### PR TITLE
Improve credential handing to allow passing in constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ⚡ Building applications with LLMs through composability ⚡
 
-[![lint](https://github.com/hwchase17/langchain/actions/workflows/lint.yml/badge.svg)](https://github.com/hwchase17/langchain/actions/workflows/lint.yml) [![test](https://github.com/hwchase17/langchain/actions/workflows/test.yml/badge.svg)](https://github.com/hwchase17/langchain/actions/workflows/test.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/langchainai.svg?style=social&label=Follow%20%40LangChainAI)](https://twitter.com/langchainai) [![](https://dcbadge.vercel.app/api/server/6adMQxSpJS?compact=true&style=flat)](https://discord.gg/6adMQxSpJS) 
-
-
+[![lint](https://github.com/hwchase17/langchain/actions/workflows/lint.yml/badge.svg)](https://github.com/hwchase17/langchain/actions/workflows/lint.yml) [![test](https://github.com/hwchase17/langchain/actions/workflows/test.yml/badge.svg)](https://github.com/hwchase17/langchain/actions/workflows/test.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/langchainai.svg?style=social&label=Follow%20%40LangChainAI)](https://twitter.com/langchainai) [![](https://dcbadge.vercel.app/api/server/6adMQxSpJS?compact=true&style=flat)](https://discord.gg/6adMQxSpJS)
 
 ## Quick Install
 
@@ -20,6 +18,7 @@ combine them with other sources of computation or knowledge.
 
 This library is aimed at assisting in the development of those types of applications.
 It aims to create:
+
 1. a comprehensive collection of pieces you would ever want to combine
 2. a flexible interface for combining pieces into a single comprehensive "chain"
 3. a schema for easily saving and sharing those chains
@@ -30,23 +29,23 @@ Besides the installation of this python package, you will also need to install p
 
 Note: the reason these packages are not included in the dependencies by default is that as we imagine scaling this package, we do not want to force dependencies that are not needed.
 
-The following use cases require specific installs and environment variables:
+The following use cases require specific installs and api keys:
 
-- *OpenAI*:
+- _OpenAI_:
   - Install requirements with `pip install openai`
-  - Set the following environment variable: `OPENAI_API_KEY`
-- *Cohere*:
+  - Get an OpenAI api key and either set it as an environment variable (`OPENAI_API_KEY`) or pass it to the LLM constructor as `openai_api_key`.
+- _Cohere_:
   - Install requirements with `pip install cohere`
-  - Set the following environment variable: `COHERE_API_KEY`
-- *HuggingFace Hub*
+  - Get a Cohere api key and either set it as an environment variable (`COHERE_API_KEY`) or pass it to the LLM constructor as `cohere_api_key`.
+- _HuggingFace Hub_
   - Install requirements with `pip install huggingface_hub`
-  - Set the following environment variable: `HUGGINGFACEHUB_API_TOKEN`
-- *SerpAPI*:
+  - Get a HuggingFace Hub api token and either set it as an environment variable (`HUGGINGFACEHUB_API_TOKEN`) or pass it to the LLM constructor as `huggingfacehub_api_token`.
+- _SerpAPI_:
   - Install requirements with `pip install google-search-results`
-  - Set the following environment variable: `SERPAPI_API_KEY`
-- *NatBot*:
+  - Get a SerpAPI api key and either set it as an environment variable (`SERPAPI_API_KEY`) or pass it to the LLM constructor as `serpapi_api_key`.
+- _NatBot_:
   - Install requirements with `pip install playwright`
-- *Wikipedia*:
+- _Wikipedia_:
   - Install requirements with `pip install wikipedia`
 
 ## 🚀 What can I do with this

--- a/langchain/chains/self_ask_with_search/base.py
+++ b/langchain/chains/self_ask_with_search/base.py
@@ -92,6 +92,7 @@ class SelfAskWithSearchChain(Chain, BaseModel):
     input_key: str = "question"  #: :meta private:
     output_key: str = "answer"  #: :meta private:
 
+
     class Config:
         """Configuration for this pydantic object."""
 

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -38,6 +38,8 @@ class OpenAI(BaseModel, LLM):
     best_of: int = 1
     """Generates best_of completions server-side and returns the "best"."""
 
+    openai_api_key: Optional[str] = os.environ.get("OPENAI_API_KEY")
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -46,14 +48,18 @@ class OpenAI(BaseModel, LLM):
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
-        if "OPENAI_API_KEY" not in os.environ:
+        openai_api_key = values.get("openai_api_key")
+
+        if openai_api_key is None or openai_api_key == "":
             raise ValueError(
                 "Did not find OpenAI API key, please add an environment variable"
-                " `OPENAI_API_KEY` which contains it."
+                " `OPENAI_API_KEY` which contains it, or pass `openai_api_key`"
+                " as a named parameter."
             )
         try:
             import openai
 
+            openai.api_key = openai_api_key
             values["client"] = openai.Completion
         except ImportError:
             raise ValueError(


### PR DESCRIPTION
Addresses the issue in #76 by either using the relevant environment variable if set or using a string passed in the constructor.

Prefers the constructor string over the environment variable, which seemed like the natural choice to me.