### PR TITLE
Bumping python version for read the docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.6
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Haven't checked whether things work with new python version, hoping error will
be caught with CI
