### PR TITLE
Use `pull_request` not `pull_request_target` in GitHub Actions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: lint
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
`pull_request` runs on the merge commit between the opened PR and the target branch where the PR is to be merged — `master` in this case. This is desirable because that way the new changes get linted and tested.

The existing `pull_request_target` specifier causes lint and test to run _on the target branch itself_ (i.e. `master` in this case). That way the new code in the PR doesn't get linted and tested at all. This can also lead to security vulnerabilities, as described in the GitHub docs:
![image](https://user-images.githubusercontent.com/2348618/201735153-c5dd0c03-2490-45e9-b7f9-f0d47eb0109f.png)

Screenshot from here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
Link from the screenshot: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/