### PR TITLE
Fix _extract_tool_and_input

### DIFF
--- a/langchain/agents/self_ask_with_search/base.py
+++ b/langchain/agents/self_ask_with_search/base.py
@@ -32,11 +32,11 @@ class SelfAskWithSearchAgent(Agent):
         else:
             last_line = text.split("\n")[-1]
 
-        if followup not in last_line:
-            finish_string = "So the final answer is: "
+        if followup not in last_line and "no" not in last_line.lower():
+            finish_string = "answer"
             if finish_string not in last_line:
                 raise ValueError("We should probably never get here")
-            return "Final Answer", text[len(finish_string) :]
+            return "Final Answer", last_line
 
         if ":" not in last_line:
             after_colon = last_line


### PR DESCRIPTION
Currently fails for any questions that don't need a follow up.

As it's currently written if the question asked doesn't require a follow up then we check on line 35 to see if have an answer and throw an error if not. That means that if no follow up is required it just throws an error.

The fix here is a bit hacky but works.