### PR TITLE
Add chain name to verbose logging

### DIFF
--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -81,10 +81,10 @@ class Chain(BaseModel, ABC):
             inputs = dict(inputs, **external_context)
         self._validate_inputs(inputs)
         if self.verbose:
-            print("\n\n\033[1m> Entering new chain...\033[0m")
+            print(f"\n\n\033[1m> Entering new {self.__class__.__name__} chain...\033[0m")
         outputs = self._call(inputs)
         if self.verbose:
-            print("\n\033[1m> Finished chain.\033[0m")
+            print(f"\n\033[1m> Finished {self.__class__.__name__} chain.\033[0m")
         self._validate_outputs(outputs)
         if self.memory is not None:
             self.memory.save_context(inputs, outputs)

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -81,7 +81,9 @@ class Chain(BaseModel, ABC):
             inputs = dict(inputs, **external_context)
         self._validate_inputs(inputs)
         if self.verbose:
-            print(f"\n\n\033[1m> Entering new {self.__class__.__name__} chain...\033[0m")
+            print(
+                f"\n\n\033[1m> Entering new {self.__class__.__name__} chain...\033[0m"
+            )
         outputs = self._call(inputs)
         if self.verbose:
             print(f"\n\033[1m> Finished {self.__class__.__name__} chain.\033[0m")


### PR DESCRIPTION
Adds some context over what chain is running, thereby making it more obvious how different chains are entered and existed

<img width="867" alt="Screen Shot 2022-11-28 at 11 55 34 AM" src="https://user-images.githubusercontent.com/2548973/204336849-25d87b44-6f5d-487b-b583-5455f306a470.png">

(note that the `...` is because the output is too long and VSCode truncated it)