### PR TITLE
Refine Olivia Wilde's boyfriend example prompt to work better

### DIFF
--- a/docs/getting_started/agents.ipynb
+++ b/docs/getting_started/agents.ipynb
@@ -160,7 +160,7 @@
     }
    ],
    "source": [
-    "agent.run(\"What is the age of Olivia Wilde's boyfriend raised to the 0.23 power?\")"
+    "agent.run(\"How old is Olivia Wilde's boyfriend? What is that number raised to the 0.23 power?\")"
    ]
   },
   {


### PR DESCRIPTION
With the original prompt, the chain keeps trying to jump straight to doing math directly, without first looking up ages. With this two-part question, it behaves more as intended:


> Entering new ZeroShotAgent chain...
How old is Olivia Wilde's boyfriend? What is that number raised to the 0.23 power?
Thought: I need to find out how old Olivia Wilde's boyfriend is, and then use a calculator to calculate the power.
Action: Search
Action Input: Olivia Wilde's boyfriend age
Observation: While Wilde, 37, and Styles, 27, have both kept a low profile when it comes to talking about their relationship, Wilde did address their ...
Thought: Olivia Wilde's boyfriend is 27 years old.
Action: Calculator
Action Input: 27^0.23

> Entering new LLMMathChain chain...
27^0.23

```python
import math
print(math.pow(27, 0.23))
```

Answer: 2.1340945944237553

> Finished LLMMathChain chain.

Observation: Answer: 2.1340945944237553

Thought: I now know the final answer.
Final Answer: 2.1340945944237553
> Finished ZeroShotAgent chain.
