### PR TITLE
Fix typo in Getting Started / LLM Chains docs

### DIFF
--- a/docs/getting_started/llm_chain.md
+++ b/docs/getting_started/llm_chain.md
@@ -27,7 +27,7 @@ from langchain.chains import LLMChain
 chain = LLMChain(llm=llm, prompt=prompt)
 ```
 
-Now we can run that can only specifying the product!
+Now we can run that chain only specifying the product!
 
 ```python
 chain.run("colorful socks")


### PR DESCRIPTION
I noticed this typo when reading the getting started guide, hope this fix makes sense.