### PR TITLE
Parallelize LLMChain apply method with ThreadPoolExecutor

### DIFF
--- a/langchain/chains/constants.py
+++ b/langchain/chains/constants.py
@@ -1,0 +1,2 @@
+"""Constants file for LLM Chains."""
+MAX_FANOUT_PER_CALL = 4


### PR DESCRIPTION
Creates separate threads to execute parallel chains, reduces latency.