### PR TITLE
Add `clear()` method for `Memory`

### DIFF
--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -27,6 +27,10 @@ class Memory(BaseModel, ABC):
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save the context of this model run to memory."""
 
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear memory contents."""
+
 
 class Chain(BaseModel, ABC):
     """Base interface that all chains should implement."""

--- a/langchain/chains/conversation/memory.py
+++ b/langchain/chains/conversation/memory.py
@@ -46,6 +46,10 @@ class ConversationBufferMemory(Memory, BaseModel):
         ai = "AI: " + outputs[list(outputs.keys())[0]]
         self.buffer += "\n" + "\n".join([human, ai])
 
+    def clear(self) -> None:
+        """Clear memory contents."""
+        self.buffer = ""
+
 
 class ConversationalBufferWindowMemory(Memory, BaseModel):
     """Buffer for storing conversation memory."""
@@ -74,6 +78,10 @@ class ConversationalBufferWindowMemory(Memory, BaseModel):
         human = "Human: " + inputs[prompt_input_key]
         ai = "AI: " + outputs[list(outputs.keys())[0]]
         self.buffer.append("\n".join([human, ai]))
+
+    def clear(self) -> None:
+        """Clear memory contents."""
+        self.buffer = []
 
 
 class ConversationSummaryMemory(Memory, BaseModel):
@@ -118,3 +126,7 @@ class ConversationSummaryMemory(Memory, BaseModel):
         new_lines = "\n".join([human, ai])
         chain = LLMChain(llm=self.llm, prompt=self.prompt)
         self.buffer = chain.predict(summary=self.buffer, new_lines=new_lines)
+
+    def clear(self) -> None:
+        """Clear memory contents."""
+        self.buffer = ""

--- a/tests/unit_tests/chains/test_conversation.py
+++ b/tests/unit_tests/chains/test_conversation.py
@@ -4,6 +4,7 @@ import pytest
 from langchain.chains.base import Memory
 from langchain.chains.conversation.base import ConversationChain
 from langchain.chains.conversation.memory import (
+    ConversationalBufferWindowMemory,
     ConversationBufferMemory,
     ConversationSummaryMemory,
 )
@@ -66,3 +67,23 @@ def test_conversation_memory(memory: Memory) -> None:
     bad_outputs = {"foo": "bar", "foo1": "bar"}
     with pytest.raises(ValueError):
         memory.save_context(good_inputs, bad_outputs)
+
+
+@pytest.mark.parametrize(
+    "memory",
+    [
+        ConversationBufferMemory(memory_key="baz"),
+        ConversationSummaryMemory(llm=FakeLLM(), memory_key="baz"),
+        ConversationalBufferWindowMemory(memory_key="baz"),
+    ],
+)
+def test_clearing_conversation_memory(memory: Memory) -> None:
+    """Test clearing the conversation memory."""
+    # This is a good input because the input is not the same as baz.
+    good_inputs = {"foo": "bar", "baz": "foo"}
+    # This is a good output because these is one variable.
+    good_outputs = {"bar": "foo"}
+    memory.save_context(good_inputs, good_outputs)
+
+    memory.clear()
+    assert memory.load_memory_variables({}) == {"baz": ""}


### PR DESCRIPTION
a simple helper to clear the buffer in `Conversation*Memory` classes