### PR TITLE
[WIP] Add SingleInputChain and MultiInputChain base classes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 exclude =
     .venv
+    venv
     __pycache__
     notebooks
 # Recommend matching the black line length (default 88),

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from langchain.agents.input import ChainedInput
 from langchain.agents.tools import Tool
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.input import get_color_mapping
 from langchain.llms.base import LLM
@@ -16,7 +16,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.schema import AgentAction
 
 
-class Agent(Chain, BaseModel, ABC):
+class Agent(SingleVariableChain, BaseModel, ABC):
     """Agent that uses an LLM."""
 
     prompt: ClassVar[BasePromptTemplate]

--- a/langchain/chains/api/base.py
+++ b/langchain/chains/api/base.py
@@ -6,14 +6,14 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, root_validator
 
 from langchain.chains.api.prompt import API_RESPONSE_PROMPT, API_URL_PROMPT
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.input import print_text
 from langchain.llms.base import LLM
 from langchain.requests import RequestsWrapper
 
 
-class APIChain(Chain, BaseModel):
+class APIChain(SingleVariableChain, BaseModel):
     """Chain that makes API calls and summarizes the responses to answer a question."""
 
     api_request_chain: LLMChain

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -129,7 +129,7 @@ class SingleVariableChain(Chain, BaseModel, ABC):
 
 
 class MultiVariableChain(Chain, BaseModel, ABC):
-    """Base interface for chains that take in multiple inputs and/or multiple outputs."""
+    """Base interface for chains that take in multiple inputs and/or outputs."""
 
     def apply(self, input_list: List[Dict[str, Any]]) -> List[Dict[str, str]]:
         """Call the chain on all inputs in the list."""

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -116,51 +116,25 @@ class Chain(BaseModel, ABC):
             return {**inputs, **outputs}
 
 
-class SingleInputChain(Chain, BaseModel, ABC):
-    """Base interface for chains that take in a single input."""
-
-    input_key: str = Field(default="input")  #: :meta private:
-    output_key: str = Field(default="output")  #: :meta private:
-
-    @property
-    def input_keys(self) -> List[str]:
-        """Input keys this chain expects."""
-        return [self.input_key]
-
-    @property
-    def output_keys(self) -> List[str]:
-        """Output keys this chain expects."""
-        return [self.output_key]
+class SingleVariableChain(Chain, BaseModel, ABC):
+    """Base interface for chains that take in a single input and single output."""
 
     def apply(self, input_list: List[str]) -> List[str]:
         """Call the chain on all inputs in the list."""
-        return [self({self.input_key: i})[self.output_key] for i in input_list]
+        return [self({self.input_keys[0]: i})[self.output_keys[0]] for i in input_list]
 
     def run(self, text: str) -> str:
         """Run text in, text out (if applicable)."""
-        return self({self.input_key: text})[self.output_key]
+        return self({self.input_keys[0]: text})[self.output_keys[0]]
 
 
-class MultiInputChain(Chain, BaseModel, ABC):
-    """Base interface for chains that take in multiple inputs."""
-
-    input_keys: List[str]
-    output_keys: List[str]
-
-    @property
-    def input_keys(self) -> List[str]:
-        """Input keys this chain expects."""
-        return self.input_keys
-
-    @property
-    def output_keys(self) -> List[str]:
-        """Output keys this chain expects."""
-        return self.output_keys
+class MultiVariableChain(Chain, BaseModel, ABC):
+    """Base interface for chains that take in multiple inputs and/or multiple outputs."""
 
     def apply(self, input_list: List[Dict[str, Any]]) -> List[Dict[str, str]]:
         """Call the chain on all inputs in the list."""
         return [self(inputs) for inputs in input_list]
 
-    def run(self, return_only_outputs: bool = False, **kwargs) -> Dict[str, str]:
+    def run(self, return_only_outputs: bool = False, **kwargs: str) -> Dict[str, str]:
         """Run text in, text out (if applicable)."""
         return self(kwargs, return_only_outputs=return_only_outputs)

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -44,7 +44,7 @@ class Chain(BaseModel, ABC):
     memory: Optional[Memory] = None
 
     verbose: bool = Field(default_factory=_get_verbosity)
-    """Whether to print out response text."""\
+    """Whether to print out response text."""
 
     @property
     @abstractmethod

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -144,8 +144,8 @@ class SingleInputChain(Chain, BaseModel, ABC):
 class MultiInputChain(Chain, BaseModel, ABC):
     """Base interface for chains that take in multiple inputs."""
 
-    input_keys: List[str] = Field(default=["input"])  #: :meta private:
-    output_keys: List[str] = Field(default=["output"])  #: :meta private:
+    input_keys: List[str]
+    output_keys: List[str]
 
     @property
     def input_keys(self) -> List[str]:

--- a/langchain/chains/combine_documents/base.py
+++ b/langchain/chains/combine_documents/base.py
@@ -5,11 +5,11 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.docstore.document import Document
 
 
-class BaseCombineDocumentsChain(Chain, BaseModel, ABC):
+class BaseCombineDocumentsChain(SingleVariableChain, BaseModel, ABC):
     """Base interface for chains combining documents."""
 
     input_key: str = "input_documents"  #: :meta private:

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -4,12 +4,12 @@ from typing import Any, Dict, List, Union
 from pydantic import BaseModel, Extra
 
 import langchain
-from langchain.chains.base import Chain
+from langchain.chains.base import MultiVariableChain
 from langchain.llms.base import LLM
 from langchain.prompts.base import BasePromptTemplate
 
 
-class LLMChain(Chain, BaseModel):
+class LLMChain(MultiVariableChain, BaseModel):
     """Chain to run queries against LLMs.
 
     Example:

--- a/langchain/chains/llm_bash/base.py
+++ b/langchain/chains/llm_bash/base.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_bash.prompt import PROMPT
 from langchain.input import print_text
@@ -11,7 +11,7 @@ from langchain.llms.base import LLM
 from langchain.utilities.bash import BashProcess
 
 
-class LLMBashChain(Chain, BaseModel):
+class LLMBashChain(SingleVariableChain, BaseModel):
     """Chain that interprets a prompt and executes bash code to perform bash operations.
 
     Example:

--- a/langchain/chains/llm_checker/base.py
+++ b/langchain/chains/llm_checker/base.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_checker.prompt import (
     CHECK_ASSERTIONS_PROMPT,
@@ -18,7 +18,7 @@ from langchain.llms.base import LLM
 from langchain.prompts import PromptTemplate
 
 
-class LLMCheckerChain(Chain, BaseModel):
+class LLMCheckerChain(SingleVariableChain, BaseModel):
     """Chain for question-answering with self-verification.
 
     Example:

--- a/langchain/chains/llm_math/base.py
+++ b/langchain/chains/llm_math/base.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import SingleInputChain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_math.prompt import PROMPT
 from langchain.input import print_text
@@ -11,7 +11,7 @@ from langchain.llms.base import LLM
 from langchain.python import PythonREPL
 
 
-class LLMMathChain(SingleInputChain, BaseModel):
+class LLMMathChain(SingleVariableChain, BaseModel):
     """Chain that interprets a prompt and executes python code to do math.
 
     Example:

--- a/langchain/chains/llm_math/base.py
+++ b/langchain/chains/llm_math/base.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleInputChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_math.prompt import PROMPT
 from langchain.input import print_text
@@ -11,7 +11,7 @@ from langchain.llms.base import LLM
 from langchain.python import PythonREPL
 
 
-class LLMMathChain(Chain, BaseModel):
+class LLMMathChain(SingleInputChain, BaseModel):
     """Chain that interprets a prompt and executes python code to do math.
 
     Example:

--- a/langchain/chains/llm_requests.py
+++ b/langchain/chains/llm_requests.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 from pydantic import BaseModel, Extra, Field, root_validator
 
 from langchain.chains import LLMChain
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.requests import RequestsWrapper
 
 DEFAULT_HEADERS = {
@@ -14,7 +14,7 @@ DEFAULT_HEADERS = {
 }
 
 
-class LLMRequestsChain(Chain, BaseModel):
+class LLMRequestsChain(SingleVariableChain, BaseModel):
     """Chain that hits a URL and then uses an LLM to parse results."""
 
     llm_chain: LLMChain

--- a/langchain/chains/mapreduce.py
+++ b/langchain/chains/mapreduce.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
@@ -20,7 +20,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.text_splitter import TextSplitter
 
 
-class MapReduceChain(Chain, BaseModel):
+class MapReduceChain(SingleVariableChain, BaseModel):
     """Map-reduce chain."""
 
     combine_documents_chain: BaseCombineDocumentsChain

--- a/langchain/chains/moderation.py
+++ b/langchain/chains/moderation.py
@@ -3,11 +3,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, root_validator
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.utils import get_from_dict_or_env
 
 
-class OpenAIModerationChain(Chain, BaseModel):
+class OpenAIModerationChain(SingleVariableChain, BaseModel):
     """Pass input through a moderation endpoint.
 
     To use, you should have the ``openai`` python package installed, and the

--- a/langchain/chains/natbot/base.py
+++ b/langchain/chains/natbot/base.py
@@ -5,14 +5,14 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import MultiVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.natbot.prompt import PROMPT
 from langchain.llms.base import LLM
 from langchain.llms.openai import OpenAI
 
 
-class NatBotChain(Chain, BaseModel):
+class NatBotChain(MultiVariableChain, BaseModel):
     """Implement an LLM driven browser.
 
     Example:

--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.pal.colored_object_prompt import COLORED_OBJECT_PROMPT
 from langchain.chains.pal.math_prompt import MATH_PROMPT
@@ -18,7 +18,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.python import PythonREPL
 
 
-class PALChain(Chain, BaseModel):
+class PALChain(SingleVariableChain, BaseModel):
     """Implements Program-Aided Language Models."""
 
     llm: LLM

--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.chains.base import Chain
+from langchain.chains.base import MultiVariableChain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
@@ -22,7 +22,7 @@ from langchain.llms.base import LLM
 from langchain.prompts.base import BasePromptTemplate
 
 
-class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
+class BaseQAWithSourcesChain(MultiVariableChain, BaseModel, ABC):
     """Question answering with sources over documents."""
 
     combine_document_chain: BaseCombineDocumentsChain

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -109,22 +109,6 @@ class SimpleSequentialChain(SingleVariableChain, BaseModel):
         """
         return [self.output_key]
 
-    @root_validator()
-    def validate_chains(cls, values: Dict) -> Dict:
-        """Validate that chains are all single input/output."""
-        for chain in values["chains"]:
-            if len(chain.input_keys) != 1:
-                raise ValueError(
-                    "Chains used in SimplePipeline should all have one input, got "
-                    f"{chain} with {len(chain.input_keys)} inputs."
-                )
-            if len(chain.output_keys) != 1:
-                raise ValueError(
-                    "Chains used in SimplePipeline should all have one output, got "
-                    f"{chain} with {len(chain.output_keys)} outputs."
-                )
-        return values
-
     def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
         _input = inputs[self.input_key]
         color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.chains.base import SingleVariableChain, MultiVariableChain
+from langchain.chains.base import MultiVariableChain, SingleVariableChain
 from langchain.input import get_color_mapping, print_text
 
 

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import SingleVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.sql_database.prompt import PROMPT
 from langchain.input import print_text
@@ -11,7 +11,7 @@ from langchain.llms.base import LLM
 from langchain.sql_database import SQLDatabase
 
 
-class SQLDatabaseChain(Chain, BaseModel):
+class SQLDatabaseChain(SingleVariableChain, BaseModel):
     """Chain for interacting with SQL Database.
 
     Example:

--- a/langchain/chains/transform.py
+++ b/langchain/chains/transform.py
@@ -3,10 +3,10 @@ from typing import Callable, Dict, List
 
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import MultiVariableChain
 
 
-class TransformChain(Chain, BaseModel):
+class TransformChain(MultiVariableChain, BaseModel):
     """Chain transform chain output.
 
     Example:

--- a/langchain/model_laboratory.py
+++ b/langchain/model_laboratory.py
@@ -1,7 +1,7 @@
 """Experiment with different models."""
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Dict
+from typing import Dict, List, Optional, Sequence
 
 from langchain.chains.base import MultiVariableChain
 from langchain.chains.llm import LLMChain
@@ -13,7 +13,9 @@ from langchain.prompts.prompt import PromptTemplate
 class ModelLaboratory:
     """Experiment with different models."""
 
-    def __init__(self, chains: Sequence[MultiVariableChain], names: Optional[List[str]] = None):
+    def __init__(
+        self, chains: Sequence[MultiVariableChain], names: Optional[List[str]] = None
+    ):
         """Initialize with chains to experiment with.
 
         Args:

--- a/langchain/model_laboratory.py
+++ b/langchain/model_laboratory.py
@@ -24,7 +24,7 @@ class ModelLaboratory:
         for chain in chains:
             if not isinstance(chain, MultiVariableChain):
                 raise ValueError(
-                    "ModelLaboratory should now be initialized with SingleVariableChains. "
+                    "ModelLaboratory should be initialized with MultiVariableChains. "
                     "If you want to initialize with LLMs, use the `from_llms` method "
                     "instead (`ModelLaboratory.from_llms(...)`)"
                 )

--- a/langchain/model_laboratory.py
+++ b/langchain/model_laboratory.py
@@ -1,9 +1,9 @@
 """Experiment with different models."""
 from __future__ import annotations
 
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Dict
 
-from langchain.chains.base import Chain
+from langchain.chains.base import MultiVariableChain
 from langchain.chains.llm import LLMChain
 from langchain.input import get_color_mapping, print_text
 from langchain.llms.base import LLM
@@ -13,16 +13,16 @@ from langchain.prompts.prompt import PromptTemplate
 class ModelLaboratory:
     """Experiment with different models."""
 
-    def __init__(self, chains: Sequence[Chain], names: Optional[List[str]] = None):
+    def __init__(self, chains: Sequence[MultiVariableChain], names: Optional[List[str]] = None):
         """Initialize with chains to experiment with.
 
         Args:
             chains: list of chains to experiment with.
         """
         for chain in chains:
-            if not isinstance(chain, Chain):
+            if not isinstance(chain, MultiVariableChain):
                 raise ValueError(
-                    "ModelLaboratory should now be initialized with Chains. "
+                    "ModelLaboratory should now be initialized with SingleVariableChains. "
                     "If you want to initialize with LLMs, use the `from_llms` method "
                     "instead (`ModelLaboratory.from_llms(...)`)"
                 )
@@ -61,7 +61,7 @@ class ModelLaboratory:
         names = [str(llm) for llm in llms]
         return cls(chains, names=names)
 
-    def compare(self, text: str) -> None:
+    def compare(self, chain_input: Dict[str, str]) -> None:
         """Compare model outputs on an input text.
 
         If a prompt was provided with starting the laboratory, then this text will be
@@ -69,14 +69,14 @@ class ModelLaboratory:
         entire prompt.
 
         Args:
-            text: input text to run all models on.
+            chain_input: input dictionary to run all models on.
         """
-        print(f"\033[1mInput:\033[0m\n{text}\n")
+        print(f"\033[1mInput:\033[0m\n{chain_input}\n")
         for i, chain in enumerate(self.chains):
             if self.names is not None:
                 name = self.names[i]
             else:
                 name = str(chain)
             print_text(name, end="\n")
-            output = chain.run(text)
-            print_text(output, color=self.chain_colors[str(i)], end="\n\n")
+            output = chain.run(return_only_outputs=True, **chain_input)
+            print_text(str(output), color=self.chain_colors[str(i)], end="\n\n")

--- a/tests/unit_tests/chains/test_conversation.py
+++ b/tests/unit_tests/chains/test_conversation.py
@@ -18,7 +18,7 @@ def test_conversation_chain_works() -> None:
     prompt = PromptTemplate(input_variables=["foo", "bar"], template="{foo} {bar}")
     memory = ConversationBufferMemory(memory_key="foo")
     chain = ConversationChain(llm=llm, prompt=prompt, memory=memory, input_key="bar")
-    chain.run("foo")
+    chain.run(foo="foo", bar="bar")
 
 
 def test_conversation_chain_errors_bad_prompt() -> None:

--- a/tests/unit_tests/chains/test_sequential.py
+++ b/tests/unit_tests/chains/test_sequential.py
@@ -8,13 +8,16 @@ from langchain.chains.base import MultiVariableChain, SingleVariableChain
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 
 
-def fake_call(inputs: Dict[str, str], input_keys: List[str], output_keys: List[str]) -> Dict[str, str]:
+def fake_call(
+    inputs: Dict[str, str], input_keys: List[str], output_keys: List[str]
+) -> Dict[str, str]:
     """Fake call function."""
     outputs = {}
     for var in output_keys:
         variables = [inputs[k] for k in input_keys]
         outputs[var] = f"{' '.join(variables)}foo"
     return outputs
+
 
 class FakeMultiChain(MultiVariableChain, BaseModel):
     """Fake Chain for testing purposes."""
@@ -147,6 +150,6 @@ def test_simple_sequential_functionality() -> None:
     expected_output = "123foofoo"
     assert output == expected_output
 
-    output = chain({"input": "123"})
-    expected_output = {"output": "123foofoo", "input": "123"}
-    assert output == expected_output
+    output_direct = chain({"input": "123"})
+    expected_output_direct = {"output": "123foofoo", "input": "123"}
+    assert output_direct == expected_output_direct

--- a/tests/unit_tests/chains/test_sequential.py
+++ b/tests/unit_tests/chains/test_sequential.py
@@ -4,11 +4,19 @@ from typing import Dict, List
 import pytest
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import MultiVariableChain, SingleVariableChain
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 
 
-class FakeChain(Chain, BaseModel):
+def fake_call(inputs: Dict[str, str], input_keys: List[str], output_keys: List[str]) -> Dict[str, str]:
+    """Fake call function."""
+    outputs = {}
+    for var in output_keys:
+        variables = [inputs[k] for k in input_keys]
+        outputs[var] = f"{' '.join(variables)}foo"
+    return outputs
+
+class FakeMultiChain(MultiVariableChain, BaseModel):
     """Fake Chain for testing purposes."""
 
     input_variables: List[str]
@@ -25,27 +33,43 @@ class FakeChain(Chain, BaseModel):
         return self.output_variables
 
     def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
-        outputs = {}
-        for var in self.output_variables:
-            variables = [inputs[k] for k in self.input_variables]
-            outputs[var] = f"{' '.join(variables)}foo"
-        return outputs
+        return fake_call(inputs, self.input_keys, self.output_keys)
+
+
+class FakeSingleChain(SingleVariableChain, BaseModel):
+    """Fake Chain for testing purposes."""
+
+    input_variable: str
+    output_variable: str
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Input keys this chain returns."""
+        return [self.input_variable]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Input keys this chain returns."""
+        return [self.output_variable]
+
+    def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
+        return fake_call(inputs, self.input_keys, self.output_keys)
 
 
 def test_sequential_usage_single_inputs() -> None:
     """Test sequential on single input chains."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo"], output_variables=["bar"])
+    chain_2 = FakeMultiChain(input_variables=["bar"], output_variables=["baz"])
     chain = SequentialChain(chains=[chain_1, chain_2], input_variables=["foo"])
-    output = chain({"foo": "123"})
+    output = chain.run(foo="123")
     expected_output = {"baz": "123foofoo", "foo": "123"}
     assert output == expected_output
 
 
 def test_sequential_usage_multiple_inputs() -> None:
     """Test sequential on multiple input chains."""
-    chain_1 = FakeChain(input_variables=["foo", "test"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar", "foo"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo", "test"], output_variables=["bar"])
+    chain_2 = FakeMultiChain(input_variables=["bar", "foo"], output_variables=["baz"])
     chain = SequentialChain(chains=[chain_1, chain_2], input_variables=["foo", "test"])
     output = chain({"foo": "123", "test": "456"})
     expected_output = {
@@ -58,8 +82,8 @@ def test_sequential_usage_multiple_inputs() -> None:
 
 def test_sequential_usage_multiple_outputs() -> None:
     """Test sequential usage on multiple output chains."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar", "test"])
-    chain_2 = FakeChain(input_variables=["bar", "foo"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo"], output_variables=["bar", "test"])
+    chain_2 = FakeMultiChain(input_variables=["bar", "foo"], output_variables=["baz"])
     chain = SequentialChain(chains=[chain_1, chain_2], input_variables=["foo"])
     output = chain({"foo": "123"})
     expected_output = {
@@ -71,8 +95,8 @@ def test_sequential_usage_multiple_outputs() -> None:
 
 def test_sequential_missing_inputs() -> None:
     """Test error is raised when input variables are missing."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar", "test"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo"], output_variables=["bar"])
+    chain_2 = FakeMultiChain(input_variables=["bar", "test"], output_variables=["baz"])
     with pytest.raises(ValueError):
         # Also needs "test" as an input
         SequentialChain(chains=[chain_1, chain_2], input_variables=["foo"])
@@ -80,8 +104,8 @@ def test_sequential_missing_inputs() -> None:
 
 def test_sequential_bad_outputs() -> None:
     """Test error is raised when bad outputs are specified."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo"], output_variables=["bar"])
+    chain_2 = FakeMultiChain(input_variables=["bar"], output_variables=["baz"])
     with pytest.raises(ValueError):
         # "test" is not present as an output variable.
         SequentialChain(
@@ -93,8 +117,8 @@ def test_sequential_bad_outputs() -> None:
 
 def test_sequential_valid_outputs() -> None:
     """Test chain runs when valid outputs are specified."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo"], output_variables=["bar"])
+    chain_2 = FakeMultiChain(input_variables=["bar"], output_variables=["baz"])
     chain = SequentialChain(
         chains=[chain_1, chain_2],
         input_variables=["foo"],
@@ -107,8 +131,8 @@ def test_sequential_valid_outputs() -> None:
 
 def test_sequential_overlapping_inputs() -> None:
     """Test error is raised when input variables are overlapping."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar", "test"])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
+    chain_1 = FakeMultiChain(input_variables=["foo"], output_variables=["bar", "test"])
+    chain_2 = FakeMultiChain(input_variables=["bar"], output_variables=["baz"])
     with pytest.raises(ValueError):
         # "test" is specified as an input, but also is an output of one step
         SequentialChain(chains=[chain_1, chain_2], input_variables=["foo", "test"])
@@ -116,25 +140,13 @@ def test_sequential_overlapping_inputs() -> None:
 
 def test_simple_sequential_functionality() -> None:
     """Test simple sequential functionality."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
+    chain_1 = FakeSingleChain(input_variable="foo", output_variable="bar")
+    chain_2 = FakeSingleChain(input_variable="bar", output_variable="baz")
     chain = SimpleSequentialChain(chains=[chain_1, chain_2])
+    output = chain.run("123")
+    expected_output = "123foofoo"
+    assert output == expected_output
+
     output = chain({"input": "123"})
     expected_output = {"output": "123foofoo", "input": "123"}
     assert output == expected_output
-
-
-def test_multi_input_errors() -> None:
-    """Test simple sequential errors if multiple input variables are expected."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
-    chain_2 = FakeChain(input_variables=["bar", "foo"], output_variables=["baz"])
-    with pytest.raises(ValueError):
-        SimpleSequentialChain(chains=[chain_1, chain_2])
-
-
-def test_multi_output_errors() -> None:
-    """Test simple sequential errors if multiple output variables are expected."""
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar", "grok"])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
-    with pytest.raises(ValueError):
-        SimpleSequentialChain(chains=[chain_1, chain_2])


### PR DESCRIPTION
Add two new interfaces: `SingleVariableChain` and `MultiVariableChain`

This fixes a couple of problems:
1) It was inconsistent to call single input chains with `run` and multiple input chains with `__call__`
2) The `apply` function for single input chains expected a `List[Dict[str, Any]]`, which broke the convention of keeping `input` and `output` keys abstracted away from the user.
3) Allows `run` to be called with `**kwargs` instead using `__call__` directly with a `Dict`, which is a bit cleaner.
4) No more need for validation logic for certain chains (i.e. no need for `SimpleSequentialChain` to validate that all chains are single in/out, just make all the chains `SingleVariableChains`)