### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+    paths:
+      - 'langchain/**.py'
+      - 'pyproject.toml'
+      - 'README.md'
+
+jobs:
+  if_release:
+    if: |
+        ${{ github.event.pull_request.merged == true }}
+        && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Release! 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,6 @@ jobs:
       - name: Publish to PyPI
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: poetry publish
+        run: | 
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry publish -r testpypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
           commit: master
       - name: Publish to PyPI
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
         run: | 
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry publish -r testpypi
+          poetry publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@ on:
     branches:
       - master
     paths:
-      - 'langchain/**.py'
       - 'pyproject.toml'
-      - 'README.md'
 
 env:
   POETRY_VERSION: "1.3.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
       - 'pyproject.toml'
       - 'README.md'
 
+env:
+  POETRY_VERSION: "1.3.1"
+
 jobs:
   if_release:
     if: |
@@ -18,5 +21,30 @@ jobs:
         && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo Release! 
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry==$POETRY_VERSION
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Build project for distribution
+        run: poetry build
+      - name: Check Version
+        id: check-version
+        run: |
+          echo version=$(poetry version --short) >> $GITHUB_OUTPUT
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          generateReleaseNotes: true
+          tag: v${{ steps.check-version.outputs.version }}
+          commit: master
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: poetry publish

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ For more information on these concepts, please see our [full documentation](http
 
 ## 💁 Contributing
 
-As an open source project in a rapidly developing field, we are extremely open
-to contributions, whether it be in the form of a new feature, improved infra, or better documentation.
+As an open source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infra, or better documentation.
 
 For detailed information on how to contribute, see [here](CONTRIBUTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.0.38"
+version = "0.0.39"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.0.40"
+version = "0.0.38"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.0.39"
+version = "0.0.40"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"


### PR DESCRIPTION
Adds release workflow that (1) creates a GitHub release and (2) publishes built artifacts to PyPI

**Release Workflow**
1. Checkout `master` locally and cut a new branch
1. Run `poetry version <rule>` to version bump (e.g., `poetry version patch`)
1. Commit changes and push to remote branch
1. Ensure all quality check workflows pass
1. Explicitly tag PR with `release` label
1. Merge to mainline

At this point, a release workflow should be triggered because:
* The PR is closed, targeting `master`, and merged
* `pyproject.toml` has been detected as modified
* The PR had a `release` label

The workflow will then proceed to build the artifacts, create a GitHub release with release notes and uploaded artifacts, and publish to PyPI.

Example Workflow run: https://github.com/shoelsch/langchain/actions/runs/3711037455/jobs/6291076898
Example Releases: https://github.com/shoelsch/langchain/releases

--

Note, this workflow is looking for the `PYPI_API_TOKEN` secret, so that will need to be uploaded to the repository secrets. I tested uploading as far as hitting a permissions issue due to project ownership in Test PyPI.