### PR TITLE
WIP - Sequentail chain with previous context

### DIFF
--- a/langchain/chains/__init__.py
+++ b/langchain/chains/__init__.py
@@ -18,7 +18,11 @@ from langchain.chains.moderation import OpenAIModerationChain
 from langchain.chains.pal.base import PALChain
 from langchain.chains.qa_with_sources.base import QAWithSourcesChain
 from langchain.chains.qa_with_sources.vector_db import VectorDBQAWithSourcesChain
-from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
+from langchain.chains.sequential import (
+    SequentailChainWithPreviousContext,
+    SequentialChain,
+    SimpleSequentialChain,
+)
 from langchain.chains.sql_database.base import (
     SQLDatabaseChain,
     SQLDatabaseSequentialChain,
@@ -37,6 +41,7 @@ __all__ = [
     "QAWithSourcesChain",
     "SQLDatabaseChain",
     "SequentialChain",
+    "SequentailChainWithPreviousContext",
     "SimpleSequentialChain",
     "VectorDBQA",
     "VectorDBQAWithSourcesChain",


### PR DESCRIPTION
I tried to do something I thought would be trivial but couldn't figure a way to do it.

I wanted to be able to have my successive call keep the previous query (prompt & response)

first call
"""
queryA
-> ResponseA
"""

second call
"""
queryA
-> ResponseA 

query B
-> ResponseB
"""


Test code
```python
llm = OpenAI(temperature=0.9)

chains = []
templateA = """query A {title}: """
promptA = PromptTemplate(
    template=template,
    input_variables=["title"],
)
chainA = LLMChain(llm=llm, prompt=promptA, output_key="responseA")
chains.append(chainA)

templateB = """query B {description}: """
promptB = PromptTemplate(
    template=template,
    input_variables=["description"],
)
chainB = LLMChain(llm=llm, prompt=promptB, output_key="responseB")
chains.append(chainB)

fchain = SequentailChainWithPreviousContext(
    chains=chains,
    verbose=True,
    input_variables=["title", "description"],
    output_variables=["responseA", "responseB"],
)
```
