### PR TITLE
Add macOS .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# macOS display setting files
+.DS_Store


### PR DESCRIPTION
These are macOS specific files left around in directories (to save user's display settings)
