### PR TITLE
Update data augmented generation docs

### DIFF
--- a/docs/getting_started/data_augmented_generation.ipynb
+++ b/docs/getting_started/data_augmented_generation.ipynb
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qa = VectorDBQA.from_llm(llm=OpenAI(), vectorstore=docsearch)"
+    "qa = VectorDBQA(llm=OpenAI(), vectorstore=docsearch)"
    ]
   },
   {


### PR DESCRIPTION
I got an error locally when trying to use VectorDBQA.from_llm, looks like this method has been removed