### PR TITLE
Update prompt_serialization.ipynb

### DIFF
--- a/docs/examples/prompts/prompt_serialization.ipynb
+++ b/docs/examples/prompts/prompt_serialization.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "At a high level, the following design principles are applied to serialization:\n",
     "\n",
-    "1. Both JSON and YAML are supported. We want to support serialization methods are human readable on disk, and YAML and JSON are two of the most popular methods for that. Note that this rule applies to prompts. For other assets, like Examples, different serialization methods may be supported.\n",
+    "1. Both JSON and YAML are supported. We want to support serialization methods that are human readable on disk, and YAML and JSON are two of the most popular methods for that. Note that this rule applies to prompts. For other assets, like Examples, different serialization methods may be supported.\n",
     "\n",
     "2. We support specifying everything in one file, or storing different components (templates, examples, etc) in different files and referencing them. For some cases, storing everything in file makes the most sense, but for others it is preferrable to split up some of the assets (long templates, large examples, reusable components). LangChain supports both.\n",
     "\n",


### PR DESCRIPTION
Fix typo.
Originally "support methods are..."
Now "support methods *that* are.."