### PR TITLE
Make logger instance local to each instance that uses it

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, root_validator
 
-import langchain
 from langchain.agents.tools import Tool
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
@@ -190,13 +189,13 @@ class AgentExecutor(Chain, BaseModel):
             # If the tool chosen is the finishing tool, then we end and return.
             if isinstance(output, AgentFinish):
                 if self.verbose:
-                    langchain.logger.log_agent_end(output, color="green")
+                    self.logger.log_agent_end(output, color="green")
                 final_output = output.return_values
                 if self.return_intermediate_steps:
                     final_output["intermediate_steps"] = intermediate_steps
                 return final_output
             if self.verbose:
-                langchain.logger.log_agent_action(output, color="green")
+                self.logger.log_agent_action(output, color="green")
             # And then we lookup the tool
             if output.tool in name_to_tool_map:
                 chain = name_to_tool_map[output.tool]
@@ -207,7 +206,7 @@ class AgentExecutor(Chain, BaseModel):
                 observation = f"{output.tool} is not a valid tool, try another one."
                 color = None
             if self.verbose:
-                langchain.logger.log_agent_observation(
+                self.logger.log_agent_observation(
                     observation,
                     color=color,
                     observation_prefix=self.agent.observation_prefix,

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, Extra, Field
 
 import langchain
+from langchain.logger import BaseLogger
 
 
 class Memory(BaseModel, ABC):
@@ -38,12 +39,17 @@ def _get_verbosity() -> bool:
     return langchain.verbose
 
 
+def _get_logger() -> BaseLogger:
+    return langchain.logger
+
+
 class Chain(BaseModel, ABC):
     """Base interface that all chains should implement."""
 
     memory: Optional[Memory] = None
 
     verbose: bool = Field(default_factory=_get_verbosity)
+    logger: BaseLogger = Field(default_factory=_get_logger)
     """Whether to print out response text."""
 
     @property

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Sequence, Union
 
 from pydantic import BaseModel, Extra
 
-import langchain
 from langchain.chains.base import Chain
 from langchain.llms.base import BaseLLM, LLMResult
 from langchain.prompts.base import BasePromptTemplate
@@ -61,7 +60,7 @@ class LLMChain(Chain, BaseModel):
             selected_inputs = {k: inputs[k] for k in self.prompt.input_variables}
             prompt = self.prompt.format(**selected_inputs)
             if self.verbose:
-                langchain.logger.log_llm_inputs(selected_inputs, prompt)
+                self.logger.log_llm_inputs(selected_inputs, prompt)
             if "stop" in inputs and inputs["stop"] != stop:
                 raise ValueError(
                     "If `stop` is present in any inputs, should be present in all."
@@ -78,7 +77,7 @@ class LLMChain(Chain, BaseModel):
             # Get the text of the top generated string.
             response_str = generation[0].text
             if self.verbose:
-                langchain.logger.log_llm_response(response_str)
+                self.logger.log_llm_response(response_str)
             outputs.append({self.output_key: response_str})
         return outputs
 

--- a/langchain/logger.py
+++ b/langchain/logger.py
@@ -1,11 +1,13 @@
 """BETA: everything in here is highly experimental, do not rely on."""
 from typing import Any, Optional
 
+from pydantic import BaseModel
+
 from langchain.input import print_text
 from langchain.schema import AgentAction, AgentFinish
 
 
-class BaseLogger:
+class BaseLogger(BaseModel):
     """Base logging interface."""
 
     def log_agent_start(self, text: str, **kwargs: Any) -> None:


### PR DESCRIPTION
Any class with `verbose` property should now implement an (optional) `logger` prop (which if not specified defaults to global logger as before).

BaseLogger now inherits from pydantic.BaseModel so that it can easily be used as the type of a property on the other classes which inherit from BaseModel.