### PR TITLE
Update links in Memory getting started guide

### DIFF
--- a/docs/getting_started/memory.ipynb
+++ b/docs/getting_started/memory.ipynb
@@ -157,9 +157,9 @@
     "\n",
     "This just scratches the surface of what you can do with memory. \n",
     "\n",
-    "For more concrete examples of conversational memory, please this [this notebook](../../examples/memory/conversational_memory.ipynb)\n",
+    "For more concrete examples of conversational memory, please see [this notebook](https://langchain.readthedocs.io/en/latest/examples/memory/conversational_memory.html)\n",
     "\n",
-    "For more examples on things like how to implement custom memory classes, how to add memory to a custom LLM chain and how to use memory with an agent, please see the [How-To: Memory](../../examples/memory) section. \n",
+    "For more examples on things like how to implement custom memory classes, how to add memory to a custom LLM chain and how to use memory with an agent, please see the [How-To: Memory](https://langchain.readthedocs.io/en/latest/examples/memory.html) section. \n",
     "\n",
     "For even more advanced ideas on memory (which will hopefully be included in LangChain soon!) see the [MemPrompt](https://memprompt.com/) paper."
    ]

--- a/langchain/prompts/prompt.py
+++ b/langchain/prompts/prompt.py
@@ -80,7 +80,7 @@ class PromptTemplate(BasePromptTemplate, BaseModel):
                 set up the user's input.
             input_variables: A list of variable names the final prompt template
                 will expect.
-            example_separator: The seperator to use in between examples. Defaults
+            example_separator: The separator to use in between examples. Defaults
                 to two new line characters.
             prefix: String that should go before any examples. Generally includes
                 examples. Default to an empty string.


### PR DESCRIPTION
## Why?

Two relative links in the Get-Started "Memory" section are broken.

## Fix

Changing them to point to the latest `readthedocs` URL (absolute links) for each of them.