### PR TITLE
Pass verbose argument to LLMChains when using *DocumentsChain

### DIFF
--- a/langchain/chains/qa_with_sources/__init__.py
+++ b/langchain/chains/qa_with_sources/__init__.py
@@ -26,9 +26,10 @@ def _load_stuff_chain(
     llm: BaseLLM,
     prompt: BasePromptTemplate = stuff_prompt.PROMPT,
     document_variable_name: str = "summaries",
+    verbose: bool = False,
     **kwargs: Any,
 ) -> StuffDocumentsChain:
-    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=kwargs.get("verbose", False))
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
     return StuffDocumentsChain(
         llm_chain=llm_chain,
         document_variable_name=document_variable_name,
@@ -47,15 +48,12 @@ def _load_map_reduce_chain(
     collapse_prompt: Optional[BasePromptTemplate] = None,
     reduce_llm: Optional[BaseLLM] = None,
     collapse_llm: Optional[BaseLLM] = None,
+    verbose: bool = False,
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
-    map_chain = LLMChain(
-        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
-    )
+    map_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
     _reduce_llm = reduce_llm or llm
-    reduce_chain = LLMChain(
-        llm=_reduce_llm, prompt=combine_prompt, verbose=kwargs.get("verbose", False)
-    )
+    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt, verbose=verbose)
     combine_document_chain = StuffDocumentsChain(
         llm_chain=reduce_chain,
         document_variable_name=combine_document_variable_name,
@@ -74,7 +72,7 @@ def _load_map_reduce_chain(
             llm_chain=LLMChain(
                 llm=_collapse_llm,
                 prompt=collapse_prompt,
-                verbose=kwargs.get("verbose", False),
+                verbose=verbose,
             ),
             document_variable_name=combine_document_variable_name,
             document_prompt=document_prompt,
@@ -96,15 +94,12 @@ def _load_refine_chain(
     document_variable_name: str = "context_str",
     initial_response_name: str = "existing_answer",
     refine_llm: Optional[BaseLLM] = None,
+    verbose: bool = False,
     **kwargs: Any,
 ) -> RefineDocumentsChain:
-    initial_chain = LLMChain(
-        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
-    )
+    initial_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
     _refine_llm = refine_llm or llm
-    refine_chain = LLMChain(
-        llm=_refine_llm, prompt=refine_prompt, verbose=kwargs.get("verbose", False)
-    )
+    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt, verbose=verbose)
     return RefineDocumentsChain(
         initial_llm_chain=initial_chain,
         refine_llm_chain=refine_chain,
@@ -116,7 +111,7 @@ def _load_refine_chain(
 
 
 def load_qa_with_sources_chain(
-    llm: BaseLLM, chain_type: str = "stuff", **kwargs: Any
+    llm: BaseLLM, chain_type: str = "stuff", verbose: bool = False, **kwargs: Any
 ) -> BaseCombineDocumentsChain:
     """Load question answering with sources chain.
 
@@ -139,4 +134,4 @@ def load_qa_with_sources_chain(
             f"Should be one of {loader_mapping.keys()}"
         )
     _func: LoadingCallable = loader_mapping[chain_type]
-    return _func(llm, **kwargs)
+    return _func(llm, verbose=verbose, **kwargs)

--- a/langchain/chains/qa_with_sources/__init__.py
+++ b/langchain/chains/qa_with_sources/__init__.py
@@ -28,7 +28,7 @@ def _load_stuff_chain(
     document_variable_name: str = "summaries",
     **kwargs: Any,
 ) -> StuffDocumentsChain:
-    llm_chain = LLMChain(llm=llm, prompt=prompt)
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=kwargs.get("verbose", False))
     return StuffDocumentsChain(
         llm_chain=llm_chain,
         document_variable_name=document_variable_name,
@@ -49,9 +49,13 @@ def _load_map_reduce_chain(
     collapse_llm: Optional[BaseLLM] = None,
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
-    map_chain = LLMChain(llm=llm, prompt=question_prompt)
+    map_chain = LLMChain(
+        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
+    )
     _reduce_llm = reduce_llm or llm
-    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt)
+    reduce_chain = LLMChain(
+        llm=_reduce_llm, prompt=combine_prompt, verbose=kwargs.get("verbose", False)
+    )
     combine_document_chain = StuffDocumentsChain(
         llm_chain=reduce_chain,
         document_variable_name=combine_document_variable_name,
@@ -67,7 +71,11 @@ def _load_map_reduce_chain(
     else:
         _collapse_llm = collapse_llm or llm
         collapse_chain = StuffDocumentsChain(
-            llm_chain=LLMChain(llm=_collapse_llm, prompt=collapse_prompt),
+            llm_chain=LLMChain(
+                llm=_collapse_llm,
+                prompt=collapse_prompt,
+                verbose=kwargs.get("verbose", False),
+            ),
             document_variable_name=combine_document_variable_name,
             document_prompt=document_prompt,
         )
@@ -90,9 +98,13 @@ def _load_refine_chain(
     refine_llm: Optional[BaseLLM] = None,
     **kwargs: Any,
 ) -> RefineDocumentsChain:
-    initial_chain = LLMChain(llm=llm, prompt=question_prompt)
+    initial_chain = LLMChain(
+        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
+    )
     _refine_llm = refine_llm or llm
-    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt)
+    refine_chain = LLMChain(
+        llm=_refine_llm, prompt=refine_prompt, verbose=kwargs.get("verbose", False)
+    )
     return RefineDocumentsChain(
         initial_llm_chain=initial_chain,
         refine_llm_chain=refine_chain,

--- a/langchain/chains/question_answering/__init__.py
+++ b/langchain/chains/question_answering/__init__.py
@@ -28,7 +28,7 @@ def _load_stuff_chain(
     document_variable_name: str = "context",
     **kwargs: Any,
 ) -> StuffDocumentsChain:
-    llm_chain = LLMChain(llm=llm, prompt=prompt)
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=kwargs.get("verbose", False))
     # TODO: document prompt
     return StuffDocumentsChain(
         llm_chain=llm_chain, document_variable_name=document_variable_name, **kwargs
@@ -46,9 +46,13 @@ def _load_map_reduce_chain(
     collapse_llm: Optional[BaseLLM] = None,
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
-    map_chain = LLMChain(llm=llm, prompt=question_prompt)
+    map_chain = LLMChain(
+        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
+    )
     _reduce_llm = reduce_llm or llm
-    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt)
+    reduce_chain = LLMChain(
+        llm=_reduce_llm, prompt=combine_prompt, verbose=kwargs.get("verbose", False)
+    )
     # TODO: document prompt
     combine_document_chain = StuffDocumentsChain(
         llm_chain=reduce_chain, document_variable_name=combine_document_variable_name
@@ -63,7 +67,11 @@ def _load_map_reduce_chain(
     else:
         _collapse_llm = collapse_llm or llm
         collapse_chain = StuffDocumentsChain(
-            llm_chain=LLMChain(llm=_collapse_llm, prompt=collapse_prompt),
+            llm_chain=LLMChain(
+                llm=_collapse_llm,
+                prompt=collapse_prompt,
+                verbose=kwargs.get("verbose", False),
+            ),
             document_variable_name=combine_document_variable_name,
         )
     return MapReduceDocumentsChain(
@@ -84,9 +92,13 @@ def _load_refine_chain(
     refine_llm: Optional[BaseLLM] = None,
     **kwargs: Any,
 ) -> RefineDocumentsChain:
-    initial_chain = LLMChain(llm=llm, prompt=question_prompt)
+    initial_chain = LLMChain(
+        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
+    )
     _refine_llm = refine_llm or llm
-    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt)
+    refine_chain = LLMChain(
+        llm=_refine_llm, prompt=refine_prompt, verbose=kwargs.get("verbose", False)
+    )
     return RefineDocumentsChain(
         initial_llm_chain=initial_chain,
         refine_llm_chain=refine_chain,

--- a/langchain/chains/question_answering/__init__.py
+++ b/langchain/chains/question_answering/__init__.py
@@ -26,9 +26,10 @@ def _load_stuff_chain(
     llm: BaseLLM,
     prompt: BasePromptTemplate = stuff_prompt.PROMPT,
     document_variable_name: str = "context",
+    verbose: bool = False,
     **kwargs: Any,
 ) -> StuffDocumentsChain:
-    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=kwargs.get("verbose", False))
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
     # TODO: document prompt
     return StuffDocumentsChain(
         llm_chain=llm_chain, document_variable_name=document_variable_name, **kwargs
@@ -44,15 +45,12 @@ def _load_map_reduce_chain(
     collapse_prompt: Optional[BasePromptTemplate] = None,
     reduce_llm: Optional[BaseLLM] = None,
     collapse_llm: Optional[BaseLLM] = None,
+    verbose: bool = False,
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
-    map_chain = LLMChain(
-        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
-    )
+    map_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
     _reduce_llm = reduce_llm or llm
-    reduce_chain = LLMChain(
-        llm=_reduce_llm, prompt=combine_prompt, verbose=kwargs.get("verbose", False)
-    )
+    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt, verbose=verbose)
     # TODO: document prompt
     combine_document_chain = StuffDocumentsChain(
         llm_chain=reduce_chain, document_variable_name=combine_document_variable_name
@@ -70,7 +68,7 @@ def _load_map_reduce_chain(
             llm_chain=LLMChain(
                 llm=_collapse_llm,
                 prompt=collapse_prompt,
-                verbose=kwargs.get("verbose", False),
+                verbose=verbose,
             ),
             document_variable_name=combine_document_variable_name,
         )
@@ -90,15 +88,12 @@ def _load_refine_chain(
     document_variable_name: str = "context_str",
     initial_response_name: str = "existing_answer",
     refine_llm: Optional[BaseLLM] = None,
+    verbose: bool = False,
     **kwargs: Any,
 ) -> RefineDocumentsChain:
-    initial_chain = LLMChain(
-        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
-    )
+    initial_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
     _refine_llm = refine_llm or llm
-    refine_chain = LLMChain(
-        llm=_refine_llm, prompt=refine_prompt, verbose=kwargs.get("verbose", False)
-    )
+    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt, verbose=verbose)
     return RefineDocumentsChain(
         initial_llm_chain=initial_chain,
         refine_llm_chain=refine_chain,
@@ -109,7 +104,7 @@ def _load_refine_chain(
 
 
 def load_qa_chain(
-    llm: BaseLLM, chain_type: str = "stuff", **kwargs: Any
+    llm: BaseLLM, chain_type: str = "stuff", verbose: bool = False, **kwargs: Any
 ) -> BaseCombineDocumentsChain:
     """Load question answering chain.
 
@@ -131,4 +126,4 @@ def load_qa_chain(
             f"Got unsupported chain type: {chain_type}. "
             f"Should be one of {loader_mapping.keys()}"
         )
-    return loader_mapping[chain_type](llm, **kwargs)
+    return loader_mapping[chain_type](llm, verbose=verbose, **kwargs)

--- a/langchain/chains/summarize/__init__.py
+++ b/langchain/chains/summarize/__init__.py
@@ -24,7 +24,7 @@ def _load_stuff_chain(
     document_variable_name: str = "text",
     **kwargs: Any,
 ) -> StuffDocumentsChain:
-    llm_chain = LLMChain(llm=llm, prompt=prompt)
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=kwargs.get("verbose", False))
     # TODO: document prompt
     return StuffDocumentsChain(
         llm_chain=llm_chain, document_variable_name=document_variable_name, **kwargs
@@ -42,9 +42,13 @@ def _load_map_reduce_chain(
     collapse_llm: Optional[BaseLLM] = None,
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
-    map_chain = LLMChain(llm=llm, prompt=map_prompt)
+    map_chain = LLMChain(
+        llm=llm, prompt=map_prompt, verbose=kwargs.get("verbose", False)
+    )
     _reduce_llm = reduce_llm or llm
-    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt)
+    reduce_chain = LLMChain(
+        llm=_reduce_llm, prompt=combine_prompt, verbose=kwargs.get("verbose", False)
+    )
     # TODO: document prompt
     combine_document_chain = StuffDocumentsChain(
         llm_chain=reduce_chain, document_variable_name=combine_document_variable_name
@@ -59,7 +63,11 @@ def _load_map_reduce_chain(
     else:
         _collapse_llm = collapse_llm or llm
         collapse_chain = StuffDocumentsChain(
-            llm_chain=LLMChain(llm=_collapse_llm, prompt=collapse_prompt),
+            llm_chain=LLMChain(
+                llm=_collapse_llm,
+                prompt=collapse_prompt,
+                verbose=kwargs.get("verbose", False),
+            ),
             document_variable_name=combine_document_variable_name,
         )
     return MapReduceDocumentsChain(
@@ -80,9 +88,14 @@ def _load_refine_chain(
     refine_llm: Optional[BaseLLM] = None,
     **kwargs: Any,
 ) -> RefineDocumentsChain:
-    initial_chain = LLMChain(llm=llm, prompt=question_prompt)
+
+    initial_chain = LLMChain(
+        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
+    )
     _refine_llm = refine_llm or llm
-    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt)
+    refine_chain = LLMChain(
+        llm=_refine_llm, prompt=refine_prompt, verbose=kwargs.get("verbose", False)
+    )
     return RefineDocumentsChain(
         initial_llm_chain=initial_chain,
         refine_llm_chain=refine_chain,

--- a/langchain/chains/summarize/__init__.py
+++ b/langchain/chains/summarize/__init__.py
@@ -22,9 +22,10 @@ def _load_stuff_chain(
     llm: BaseLLM,
     prompt: BasePromptTemplate = stuff_prompt.PROMPT,
     document_variable_name: str = "text",
+    verbose: bool = False,
     **kwargs: Any,
 ) -> StuffDocumentsChain:
-    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=kwargs.get("verbose", False))
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
     # TODO: document prompt
     return StuffDocumentsChain(
         llm_chain=llm_chain, document_variable_name=document_variable_name, **kwargs
@@ -40,15 +41,12 @@ def _load_map_reduce_chain(
     collapse_prompt: Optional[BasePromptTemplate] = None,
     reduce_llm: Optional[BaseLLM] = None,
     collapse_llm: Optional[BaseLLM] = None,
+    verbose: bool = False,
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
-    map_chain = LLMChain(
-        llm=llm, prompt=map_prompt, verbose=kwargs.get("verbose", False)
-    )
+    map_chain = LLMChain(llm=llm, prompt=map_prompt, verbose=verbose)
     _reduce_llm = reduce_llm or llm
-    reduce_chain = LLMChain(
-        llm=_reduce_llm, prompt=combine_prompt, verbose=kwargs.get("verbose", False)
-    )
+    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt, verbose=verbose)
     # TODO: document prompt
     combine_document_chain = StuffDocumentsChain(
         llm_chain=reduce_chain, document_variable_name=combine_document_variable_name
@@ -66,7 +64,7 @@ def _load_map_reduce_chain(
             llm_chain=LLMChain(
                 llm=_collapse_llm,
                 prompt=collapse_prompt,
-                verbose=kwargs.get("verbose", False),
+                verbose=verbose,
             ),
             document_variable_name=combine_document_variable_name,
         )
@@ -86,16 +84,13 @@ def _load_refine_chain(
     document_variable_name: str = "text",
     initial_response_name: str = "existing_answer",
     refine_llm: Optional[BaseLLM] = None,
+    verbose: bool = False,
     **kwargs: Any,
 ) -> RefineDocumentsChain:
 
-    initial_chain = LLMChain(
-        llm=llm, prompt=question_prompt, verbose=kwargs.get("verbose", False)
-    )
+    initial_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
     _refine_llm = refine_llm or llm
-    refine_chain = LLMChain(
-        llm=_refine_llm, prompt=refine_prompt, verbose=kwargs.get("verbose", False)
-    )
+    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt, verbose=verbose)
     return RefineDocumentsChain(
         initial_llm_chain=initial_chain,
         refine_llm_chain=refine_chain,
@@ -106,7 +101,7 @@ def _load_refine_chain(
 
 
 def load_summarize_chain(
-    llm: BaseLLM, chain_type: str = "stuff", **kwargs: Any
+    llm: BaseLLM, chain_type: str = "stuff", verbose: bool = False, **kwargs: Any
 ) -> BaseCombineDocumentsChain:
     """Load summarizing chain.
 
@@ -128,4 +123,4 @@ def load_summarize_chain(
             f"Got unsupported chain type: {chain_type}. "
             f"Should be one of {loader_mapping.keys()}"
         )
-    return loader_mapping[chain_type](llm, **kwargs)
+    return loader_mapping[chain_type](llm, verbose=verbose, **kwargs)


### PR DESCRIPTION
When using chains such as Summarization chain (`load_summarize_chain`), the verbose flag wasn't propagated to the `LLMChain`.