### PR TITLE
feat: Notion Integration WIP [Save to Notion functionality]

### DIFF
--- a/langchain/__init__.py
+++ b/langchain/__init__.py
@@ -27,6 +27,7 @@ from langchain.prompts import (
     PromptTemplate,
 )
 from langchain.serpapi import SerpAPIChain, SerpAPIWrapper
+from langchain.notion import NotionAPIWrapper
 from langchain.sql_database import SQLDatabase
 from langchain.vectorstores import FAISS, ElasticVectorSearch
 
@@ -63,4 +64,5 @@ __all__ = [
     "VectorDBQAWithSourcesChain",
     "QAWithSourcesChain",
     "PALChain",
+    "NotionAPIWrapper"
 ]

--- a/langchain/__init__.py
+++ b/langchain/__init__.py
@@ -20,6 +20,7 @@ from langchain.docstore import InMemoryDocstore, Wikipedia
 from langchain.llms import Cohere, HuggingFaceHub, OpenAI
 from langchain.llms.huggingface_pipeline import HuggingFacePipeline
 from langchain.logger import BaseLogger, StdOutLogger
+from langchain.notion import NotionAPIWrapper
 from langchain.prompts import (
     BasePromptTemplate,
     FewShotPromptTemplate,
@@ -27,7 +28,6 @@ from langchain.prompts import (
     PromptTemplate,
 )
 from langchain.serpapi import SerpAPIChain, SerpAPIWrapper
-from langchain.notion import NotionAPIWrapper
 from langchain.sql_database import SQLDatabase
 from langchain.vectorstores import FAISS, ElasticVectorSearch
 
@@ -64,5 +64,5 @@ __all__ = [
     "VectorDBQAWithSourcesChain",
     "QAWithSourcesChain",
     "PALChain",
-    "NotionAPIWrapper"
+    "NotionAPIWrapper",
 ]

--- a/langchain/notion.py
+++ b/langchain/notion.py
@@ -91,5 +91,5 @@ class NotionAPIWrapper(BaseModel):
         notion_client = self.notion_client(params)
 
         # TODO: change how the title is set
-        return self._write_to_notion(notion_client, document,document[0:10] + "...")
+        return self._write_to_notion(notion_client, document, document[0:10] + "...")
 

--- a/langchain/notion.py
+++ b/langchain/notion.py
@@ -22,12 +22,12 @@ class NotionAPIWrapper(BaseModel):
 
     To use, you should have the ``notion-client` python package installed,
     and the environment variable ``NOTION_TOKEN`` AND ``NOTION_DATABASE_ID`` set, or pass
-    `serpapi_api_key` as a named parameter to the constructor.
+    `notion_token` as a named parameter to the constructor.
 
     To get your token:
 
     1- Go to Notion, create a new integration and save the integration secret to NOTION_TOKEN
-    2- Create a new database in notion and copy its ID to NOTION_DATABASE_ID. 
+    2- Create a new database in notion and copy its ID to NOTION_DATABASE_ID.
     The id It is normally the last part of the URL when you have a database open.
 
     """
@@ -59,14 +59,16 @@ class NotionAPIWrapper(BaseModel):
 
         except ImportError:
             raise ValueError(
-                "Could not import serpapi python package. "
+                "Could not import notion_client python package. "
                 "Please it install it with `pip install notion-client`."
             )
         return values
 
     def _write_to_notion(self, notion_client, document: str, document_title: str):
         parent = {"database_id": self.notion_database_id}
-        properties = {"Name": {"title": [{"type": "text", "text": {"content": document_title}}]}}
+        properties = {
+            "Name": {"title": [{"type": "text", "text": {"content": document_title}}]}
+        }
         children = [
             {
                 "object": "block",
@@ -92,4 +94,3 @@ class NotionAPIWrapper(BaseModel):
 
         # TODO: change how the title is set
         return self._write_to_notion(notion_client, document, document[0:10] + "...")
-

--- a/langchain/notion.py
+++ b/langchain/notion.py
@@ -1,0 +1,95 @@
+"""NotionAPI to save a document.
+
+Future plans:
+- Improve the saving process, title, fields, properties
+- Add support for reading the database
+
+
+"""
+import os
+import sys
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Extra, root_validator
+
+from langchain.utils import get_from_dict_or_env
+
+
+class NotionAPIWrapper(BaseModel):
+    """Wrapper around Notion API.
+
+    TODO: Improve docs
+
+    To use, you should have the ``notion-client` python package installed,
+    and the environment variable ``NOTION_TOKEN`` AND ``NOTION_DATABASE_ID`` set, or pass
+    `serpapi_api_key` as a named parameter to the constructor.
+
+    To get your token:
+
+    1- Go to Notion, create a new integration and save the integration secret to NOTION_TOKEN
+    2- Create a new database in notion and copy its ID to NOTION_DATABASE_ID. 
+    The id It is normally the last part of the URL when you have a database open.
+
+    """
+
+    notion_client: Any  #: :meta private:
+
+    notion_token: Optional[str] = None
+    notion_database_id: Optional[str] = None
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        """Validate that api key and python package exists in environment."""
+        notion_token = get_from_dict_or_env(values, "notion_token", "NOTION_TOKEN")
+        values["NOTION_TOKEN"] = notion_token
+        notion_database_id = get_from_dict_or_env(
+            values, "notion_database_id", "NOTION_DATABASE_ID"
+        )
+        values["NOTION_DATABASE_ID"] = notion_database_id
+
+        try:
+            from notion_client import Client
+
+            values["notion_client"] = Client
+
+        except ImportError:
+            raise ValueError(
+                "Could not import serpapi python package. "
+                "Please it install it with `pip install notion-client`."
+            )
+        return values
+
+    def _write_to_notion(self, notion_client, document: str, document_title: str):
+        parent = {"database_id": self.notion_database_id}
+        properties = {"Name": {"title": [{"type": "text", "text": {"content": document_title}}]}}
+        children = [
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [{"type": "text", "text": {"content": document}}]
+                },
+            }
+        ]
+        try:
+            notion_client.pages.create(
+                parent=parent, properties=properties, children=children
+            )
+            return "Wrote to Notion successfully!"
+
+        except Exception as e:
+            return "Failed to write to Notion. Here is the exception message: " + str(e)
+
+    def run(self, document: str) -> str:
+        """Saves document to Notion."""
+        params = {"auth": self.notion_token}
+        notion_client = self.notion_client(params)
+
+        # TODO: change how the title is set
+        return self._write_to_notion(notion_client, document,document[0:10] + "...")
+


### PR DESCRIPTION
Currently an early WIP.

It would be awesome to ask the agent to save anything it generated to Notion. This PR implements such functionality. Meant to be used as a tool that the agent can use.

Current Tasks:
- [X] MVP of the agent saving a generation to a page in a database (given a db id)
- [ ] Improve customizability for how the agent should output to Notion
- [ ] Figure out better prompts/tool descriptions for the agent to save the entire output in Notion (sometimes it cuts out for some reason)
- [ ] Add better support for other specific types of blocks. Right now it just outputs a paragraph in a new Notion page inside a database

Future improvements:
- Add read functionality
- [Insert your ideas]

- How to use it:
You should have the notion-client  python package installed, and the environment variable ``NOTION_TOKEN`` AND ``NOTION_DATABASE_ID`` set, or pass `notion_token` as a named parameter to the constructor.

To get your token:

1- Go to Notion, create a new integration and save the integration secret to NOTION_TOKEN
2- Create a new database in notion and copy its ID to NOTION_DATABASE_ID.
The id is normally the last part of the URL when you have a database open.


- Example of a prompt working with an Agent: "Save the output of X in Notion."



I would love yall help with this one! :)