### PR TITLE
pass agent verbosity through to llmchain

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -168,11 +168,16 @@ class AgentExecutor(Chain, BaseModel):
         agent: Agent,
         tools: List[Tool],
         callback_manager: Optional[BaseCallbackManager] = None,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> AgentExecutor:
         """Create from agent and tools."""
         return cls(
-            agent=agent, tools=tools, callback_manager=callback_manager, **kwargs
+            agent=agent,
+            tools=tools,
+            callback_manager=callback_manager,
+            verbose=verbose,
+            **kwargs,
         )
 
     @property

--- a/langchain/agents/loading.py
+++ b/langchain/agents/loading.py
@@ -20,6 +20,7 @@ def initialize_agent(
     tools: List[Tool],
     llm: BaseLLM,
     agent: str = "zero-shot-react-description",
+    verbose: bool = False,
     callback_manager: Optional[BaseCallbackManager] = None,
     **kwargs: Any,
 ) -> AgentExecutor:
@@ -30,6 +31,7 @@ def initialize_agent(
         llm: Language model to use as the agent.
         agent: The agent to use. Valid options are:
             `zero-shot-react-description`, `react-docstore`, `self-ask-with-search`.
+        verbose: Whether to or not to initiate callbacks and print verbose output.
         callback_manager: CallbackManager to use. Global callback manager is used if
             not provided. Defaults to None.
         **kwargs: Additional key word arguments to pass to the agent.
@@ -44,11 +46,12 @@ def initialize_agent(
         )
     agent_cls = AGENT_TO_CLASS[agent]
     agent_obj = agent_cls.from_llm_and_tools(
-        llm, tools, callback_manager=callback_manager
+        llm, tools, callback_manager=callback_manager, verbose=verbose
     )
     return AgentExecutor.from_agent_and_tools(
         agent=agent_obj,
         tools=tools,
         callback_manager=callback_manager,
+        verbose=verbose,
         **kwargs,
     )

--- a/tests/unit_tests/agents/test_agent.py
+++ b/tests/unit_tests/agents/test_agent.py
@@ -85,7 +85,6 @@ def test_agent_with_callbacks() -> None:
         verbose=True,
         callback_manager=manager,
     )
-    agent.agent.llm_chain.verbose = True
 
     output = agent.run("when was langchain made")
     assert output == "curses foiled again"


### PR DESCRIPTION
before this change, you had to do `agent.agent.llm_chain.verbose = True` to get the same behavior