### PR TITLE
explicitly set global verbosity flag in unit tests that test callbacks

### DIFF
--- a/tests/unit_tests/agents/test_agent.py
+++ b/tests/unit_tests/agents/test_agent.py
@@ -68,6 +68,7 @@ def test_agent_stopped_early() -> None:
 def test_agent_with_callbacks_global() -> None:
     """Test react chain with callbacks by setting verbose globally."""
     import langchain
+
     langchain.verbose = True
     handler = FakeCallbackHandler()
     manager = CallbackManager([handler])
@@ -101,6 +102,7 @@ def test_agent_with_callbacks_global() -> None:
 def test_agent_with_callbacks_local() -> None:
     """Test react chain with callbacks by setting verbose locally."""
     import langchain
+
     langchain.verbose = False
     handler = FakeCallbackHandler()
     manager = CallbackManager([handler])
@@ -136,6 +138,7 @@ def test_agent_with_callbacks_local() -> None:
 def test_agent_with_callbacks_not_verbose() -> None:
     """Test react chain with callbacks but not verbose."""
     import langchain
+
     langchain.verbose = False
     handler = FakeCallbackHandler()
     manager = CallbackManager([handler])

--- a/tests/unit_tests/agents/test_agent.py
+++ b/tests/unit_tests/agents/test_agent.py
@@ -65,8 +65,10 @@ def test_agent_stopped_early() -> None:
     assert output == "Agent stopped due to max iterations."
 
 
-def test_agent_with_callbacks() -> None:
-    """Test react chain with callbacks."""
+def test_agent_with_callbacks_global() -> None:
+    """Test react chain with callbacks by setting verbose globally."""
+    import langchain
+    langchain.verbose = True
     handler = FakeCallbackHandler()
     manager = CallbackManager([handler])
     tool = "Search"
@@ -85,6 +87,40 @@ def test_agent_with_callbacks() -> None:
         verbose=True,
         callback_manager=manager,
     )
+
+    output = agent.run("when was langchain made")
+    assert output == "curses foiled again"
+
+    # 1 top level chain run, 2 LLMChain runs, 2 LLM runs, 1 tool run
+    assert handler.starts == 6
+    # 1 extra agent end
+    assert handler.ends == 7
+    assert handler.errors == 0
+
+
+def test_agent_with_callbacks_local() -> None:
+    """Test react chain with callbacks by setting verbose locally."""
+    import langchain
+    langchain.verbose = False
+    handler = FakeCallbackHandler()
+    manager = CallbackManager([handler])
+    tool = "Search"
+    responses = [
+        f"FooBarBaz\nAction: {tool}\nAction Input: misalignment",
+        "Oh well\nAction: Final Answer\nAction Input: curses foiled again",
+    ]
+    fake_llm = FakeListLLM(responses=responses, callback_manager=manager, verbose=True)
+    tools = [
+        Tool("Search", lambda x: x, "Useful for searching"),
+    ]
+    agent = initialize_agent(
+        tools,
+        fake_llm,
+        agent="zero-shot-react-description",
+        verbose=True,
+        callback_manager=manager,
+    )
+
     agent.agent.llm_chain.verbose = True
 
     output = agent.run("when was langchain made")
@@ -99,6 +135,8 @@ def test_agent_with_callbacks() -> None:
 
 def test_agent_with_callbacks_not_verbose() -> None:
     """Test react chain with callbacks but not verbose."""
+    import langchain
+    langchain.verbose = False
     handler = FakeCallbackHandler()
     manager = CallbackManager([handler])
     tool = "Search"

--- a/tests/unit_tests/chains/test_base.py
+++ b/tests/unit_tests/chains/test_base.py
@@ -151,6 +151,7 @@ def test_run_with_callback() -> None:
 def test_run_with_callback_not_verbose() -> None:
     """Test run method works when callback manager is passed and not verbose."""
     import langchain
+
     langchain.verbose = False
 
     handler = FakeCallbackHandler()

--- a/tests/unit_tests/chains/test_base.py
+++ b/tests/unit_tests/chains/test_base.py
@@ -150,6 +150,9 @@ def test_run_with_callback() -> None:
 
 def test_run_with_callback_not_verbose() -> None:
     """Test run method works when callback manager is passed and not verbose."""
+    import langchain
+    langchain.verbose = False
+
     handler = FakeCallbackHandler()
     chain = FakeChain(callback_manager=CallbackManager([handler]))
     output = chain.run("bar")

--- a/tests/unit_tests/llms/test_callbacks.py
+++ b/tests/unit_tests/llms/test_callbacks.py
@@ -18,6 +18,7 @@ def test_llm_with_callbacks() -> None:
 def test_llm_with_callbacks_not_verbose() -> None:
     """Test LLM callbacks but not verbose."""
     import langchain
+
     langchain.verbose = False
 
     handler = FakeCallbackHandler()

--- a/tests/unit_tests/llms/test_callbacks.py
+++ b/tests/unit_tests/llms/test_callbacks.py
@@ -17,6 +17,9 @@ def test_llm_with_callbacks() -> None:
 
 def test_llm_with_callbacks_not_verbose() -> None:
     """Test LLM callbacks but not verbose."""
+    import langchain
+    langchain.verbose = False
+
     handler = FakeCallbackHandler()
     llm = FakeLLM(callback_manager=CallbackManager([handler]))
     output = llm("foo")


### PR DESCRIPTION
If another file anywhere in `unit_tests` sets `langchain.verbose = True`, it messes up all of the tests that check for no callbacks because the `None` for verbose gets overridden by the global verbosity flag. By explicitly setting it in unit tests, we bypass that potential issue