### PR TITLE
Add human_prefix param to conversation memory

### DIFF
--- a/langchain/chains/conversation/memory.py
+++ b/langchain/chains/conversation/memory.py
@@ -21,7 +21,7 @@ def _get_prompt_input_key(inputs: Dict[str, Any], memory_variables: List[str]) -
 
 class ConversationBufferMemory(Memory, BaseModel):
     """Buffer for storing conversation memory."""
-
+    human_prefix: str = "Human"
     ai_prefix: str = "AI"
     """Prefix to use for AI generated responses."""
     buffer: str = ""
@@ -53,7 +53,7 @@ class ConversationBufferMemory(Memory, BaseModel):
             output_key = list(outputs.keys())[0]
         else:
             output_key = self.output_key
-        human = "Human: " + inputs[prompt_input_key]
+        human = f"{self.human_prefix}: " + inputs[prompt_input_key]
         ai = f"{self.ai_prefix}: " + outputs[output_key]
         self.buffer += "\n" + "\n".join([human, ai])
 
@@ -64,7 +64,7 @@ class ConversationBufferMemory(Memory, BaseModel):
 
 class ConversationBufferWindowMemory(Memory, BaseModel):
     """Buffer for storing conversation memory."""
-
+    human_prefix: str = "Human"
     ai_prefix: str = "AI"
     """Prefix to use for AI generated responses."""
     buffer: List[str] = Field(default_factory=list)
@@ -97,7 +97,7 @@ class ConversationBufferWindowMemory(Memory, BaseModel):
             output_key = list(outputs.keys())[0]
         else:
             output_key = self.output_key
-        human = "Human: " + inputs[prompt_input_key]
+        human = f"{self.human_prefix}: " + inputs[prompt_input_key]
         ai = f"{self.ai_prefix}: " + outputs[output_key]
         self.buffer.append("\n".join([human, ai]))
 
@@ -114,6 +114,7 @@ class ConversationSummaryMemory(Memory, BaseModel):
     """Conversation summarizer to memory."""
 
     buffer: str = ""
+    human_prefix: str = "Human"
     ai_prefix: str = "AI"
     """Prefix to use for AI generated responses."""
     llm: BaseLLM
@@ -158,7 +159,7 @@ class ConversationSummaryMemory(Memory, BaseModel):
             output_key = list(outputs.keys())[0]
         else:
             output_key = self.output_key
-        human = f"Human: {inputs[prompt_input_key]}"
+        human = f"{self.human_prefix}: {inputs[prompt_input_key]}"
         ai = f"{self.ai_prefix}: {outputs[output_key]}"
         new_lines = "\n".join([human, ai])
         chain = LLMChain(llm=self.llm, prompt=self.prompt)
@@ -178,6 +179,7 @@ class ConversationSummaryBufferMemory(Memory, BaseModel):
     llm: BaseLLM
     prompt: BasePromptTemplate = SUMMARY_PROMPT
     memory_key: str = "history"
+    human_prefix: str = "Human"
     ai_prefix: str = "AI"
     """Prefix to use for AI generated responses."""
     output_key: Optional[str] = None
@@ -226,7 +228,7 @@ class ConversationSummaryBufferMemory(Memory, BaseModel):
             output_key = list(outputs.keys())[0]
         else:
             output_key = self.output_key
-        human = f"Human: {inputs[prompt_input_key]}"
+        human = f"{self.human_prefix}: {inputs[prompt_input_key]}"
         ai = f"{self.ai_prefix}: {outputs[output_key]}"
         new_lines = "\n".join([human, ai])
         self.buffer.append(new_lines)

--- a/tests/unit_tests/chains/test_conversation.py
+++ b/tests/unit_tests/chains/test_conversation.py
@@ -19,6 +19,13 @@ def test_memory_ai_prefix() -> None:
     assert memory.buffer == "\nHuman: bar\nAssistant: foo"
 
 
+def test_memory_human_prefix() -> None:
+    """Test that human_prefix in the memory component works."""
+    memory = ConversationBufferMemory(memory_key="foo", human_prefix="Friend")
+    memory.save_context({"input": "bar"}, {"output": "foo"})
+    assert memory.buffer == "\nFriend: bar\nAI: foo"
+
+
 def test_conversation_chain_works() -> None:
     """Test that conversation chain works in basic setting."""
     llm = FakeLLM()


### PR DESCRIPTION
I think it'd be useful to allow people to customize the human_prefix in conversation memory as it can change the results of the AI's response. In my case I'm setting the ai_prefix to be a historical figure (who's also supposed to be a 'human') and want to have different responses based on who they're talking to (i.e. friend, solider, etc)