### PR TITLE
replace forbid into ignore

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -58,7 +58,7 @@ class BaseOpenAI(BaseLLM, BaseModel):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = Extra.ignore
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
this is the second PR of #519.
in #519 I suggested deleting Extra.forbid.
I was very confused but I replaced Extra.forbid to Extra.ignore, which is the default of pydantic.


Since the [BaseLLM](https://github.com/hwchase17/langchain/blob/4b7b8229de50e5e97a2b2c12e1607f347d8ded35/langchain/llms/base.py#L20)  from which it is inherited is set in Extra.forbid, I wanted to avoid having the Extra.forbid settings inherited by simply deleting it.