### PR TITLE
Docs: side menu to match the order (llms)

### DIFF
--- a/docs/modules/llms.rst
+++ b/docs/modules/llms.rst
@@ -20,8 +20,8 @@ The following sections of documentation are provided:
    :maxdepth: 1
    :name: LLMs
    :hidden:
-
-   ./llms/key_concepts.md
+   
    ./llms/getting_started.ipynb
+   ./llms/key_concepts.md
    ./llms/how_to_guides.rst
    Reference<../reference/modules/llms.rst>


### PR DESCRIPTION
Small quick fix:

Suggest making the order of the menu the same as it is written on the page (Getting Started -> Key Concepts). Before the menu order was not the same as it was on the page. Not sure if this is the only place the menu is affected.

Mismatch is found here: https://langchain.readthedocs.io/en/latest/modules/llms.html