### PR TITLE
[WIP][RFC] Add a method to construct vector store from existing index for Pinecone

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -145,3 +145,10 @@ class Pinecone(VectorStore):
             # upsert to Pinecone
             index.upsert(vectors=list(to_upsert))
         return cls(index, embedding.embed_query, text_key)
+
+    @classmethod
+    def from_existing_index(cls,
+                            index_name: str,
+                            embedding: Embeddings,
+                            text_key: str = "text"):
+        return cls(pinecone.Index(index_name), embedding.embed_query, text_key)


### PR DESCRIPTION
This is a sample PR to construct `VectorStore` from the existing index for Pinecone; I am happy to implement similar methods for the rest of the implementations.

While I used `index_name`  here, a consistent implementation would be to pass the `index` instead, especially for stores like `FAISS`. 

Let me know your thoughts.

**Usecase**:

- For caching/long-term purposes
- Using in a serverless environment, etc