### PR TITLE
Remove request_timeout param from openai requests

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -52,8 +52,6 @@ class BaseOpenAI(BaseLLM, BaseModel):
     openai_api_key: Optional[str] = None
     batch_size: int = 20
     """Batch size to use when passing multiple documents to generate."""
-    request_timeout: Optional[Union[float, Tuple[float, float]]] = None
-    """Timeout for requests to OpenAI completion API. Default is 600 seconds."""
     logit_bias: Optional[Dict[str, float]] = Field(default_factory=dict)
     """Adjust the probability of specific tokens being generated."""
 
@@ -110,7 +108,6 @@ class BaseOpenAI(BaseLLM, BaseModel):
             "presence_penalty": self.presence_penalty,
             "n": self.n,
             "best_of": self.best_of,
-            "request_timeout": self.request_timeout,
             "logit_bias": self.logit_bias,
         }
         return {**normal_params, **self.model_kwargs}


### PR DESCRIPTION
OpenAI's completion endpoint doesn't support a `request_timeout` param. Example stack trace:

```
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/base.py", line 172, in run
    return self(args[0])[self.output_keys[0]]
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/base.py", line 146, in __call__
    raise e
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/base.py", line 142, in __call__
    outputs = self._call(inputs)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/sql_database/base.py", line 64, in _call
    sql_cmd = llm_chain.predict(**llm_inputs)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/llm.py", line 103, in predict
    return self(kwargs)[self.output_key]
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/base.py", line 146, in __call__
    raise e
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/base.py", line 142, in __call__
    outputs = self._call(inputs)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/llm.py", line 87, in _call
    return self.apply([inputs])[0]
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/llm.py", line 78, in apply
    response = self.generate(input_list)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/chains/llm.py", line 73, in generate
    response = self.llm.generate(prompts, stop=stop)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/llms/base.py", line 81, in generate
    raise e
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/llms/base.py", line 77, in generate
    output = self._generate(prompts, stop=stop)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/langchain/llms/openai.py", line 158, in _generate
    response = self.client.create(prompt=_prompts, **params)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/openai/api_resources/completion.py", line 31, in create
    return super().create(*args, **kwargs)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 100, in create
    response, _, api_key = requestor.request(
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/openai/api_requestor.py", line 122, in request
    resp, got_stream = self._interpret_response(result, stream)
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/openai/api_requestor.py", line 329, in _interpret_response
    self._interpret_response_line(
  File "/Users/jwang/code/functionalai/venv/lib/python3.9/site-packages/openai/api_requestor.py", line 362, in _interpret_response_line
    raise self.handle_error_response(
openai.error.InvalidRequestError: Unrecognized request argument supplied: request_timeout
```