### PR TITLE
Fix KeyError in pinecone wrapper

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -78,8 +78,9 @@ class Pinecone(VectorStore):
         results = self._index.query([query_obj], top_k=k, include_metadata=True)
         for res in results["matches"]:
             metadata = res["metadata"]
-            text = metadata.pop(self._text_key)
-            docs.append(Document(page_content=text, metadata=metadata))
+            if self._text_key in metadata:
+                text = metadata.pop(self._text_key)
+                docs.append(Document(page_content=text, metadata=metadata))
         return docs
 
     @classmethod


### PR DESCRIPTION
Pinecone can return multiple matches with different text keys in the metadata, and the current behavior will throw a KeyError if one pops up that isn't the expected text key. This PR only selects the matches with the correct text key.