### PR TITLE
feat: add custom prompt for QAEvalChain chain

### DIFF
--- a/docs/use_cases/evaluation/question_answering.ipynb
+++ b/docs/use_cases/evaluation/question_answering.ipynb
@@ -198,7 +198,8 @@
    "source": [
     "## Customize Prompt\n",
     "\n",
-    "You can also customize the prompt that is used. Here is an example prompting it using a score from 0 to 10."
+    "You can also customize the prompt that is used. Here is an example prompting it using a score from 0 to 10.\n",
+    "The custom prompt requires 3 input variables: \"query\", \"answer\" and \"result\". Where \"query\" is the question, \"answer\" is the ground truth answer, and \"result\" is the predicted answer."
    ]
   },
   {
@@ -212,15 +213,15 @@
     "\n",
     "_PROMPT_TEMPLATE = \"\"\"You are an expert professor specialized in grading students' answers to questions.\n",
     "You are grading the following question:\n",
-    "{question}\n",
+    "{query}\n",
     "Here is the real answer:\n",
     "{answer}\n",
     "You are grading the following predicted answer:\n",
-    "{text}\n",
+    "{result}\n",
     "What grade do you give from 0 to 10, where 0 is the lowest (very low similarity) and 10 is the highest (very high similarity)?\n",
     "\"\"\"\n",
     "\n",
-    "PROMPT = PromptTemplate(input_variables=[\"question\", \"answer\", \"text\"], template=_PROMPT_TEMPLATE)"
+    "PROMPT = PromptTemplate(input_variables=[\"query\", \"answer\", \"result\"], template=_PROMPT_TEMPLATE)"
    ]
   },
   {

--- a/docs/use_cases/evaluation/question_answering.ipynb
+++ b/docs/use_cases/evaluation/question_answering.ipynb
@@ -231,7 +231,7 @@
    "outputs": [],
    "source": [
     "evalchain = QAEvalChain.from_llm(llm=llm,prompt=PROMPT)\n",
-    "evalchain.evaluate(examples, predictions, question_key=\"question\", prediction_key=\"text\")"
+    "evalchain.evaluate(examples, predictions, question_key=\"question\", answer_key=\"answer\", prediction_key=\"text\")"
    ]
   },
   {

--- a/docs/use_cases/evaluation/question_answering.ipynb
+++ b/docs/use_cases/evaluation/question_answering.ipynb
@@ -191,6 +191,50 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "782ae8c8",
+   "metadata": {},
+   "source": [
+    "## Customize Prompt\n",
+    "\n",
+    "You can also customize the prompt that is used. Here is an example prompting it using a score from 0 to 10."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "153425c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.prompts.prompt import PromptTemplate\n",
+    "\n",
+    "_PROMPT_TEMPLATE = \"\"\"You are an expert professor specialized in grading students' answers to questions.\n",
+    "You are grading the following question:\n",
+    "{question}\n",
+    "Here is the real answer:\n",
+    "{answer}\n",
+    "You are grading the following predicted answer:\n",
+    "{text}\n",
+    "What grade do you give from 0 to 10, where 0 is the lowest (very low similarity) and 10 is the highest (very high similarity)?\n",
+    "\"\"\"\n",
+    "\n",
+    "PROMPT = PromptTemplate(input_variables=[\"question\", \"answer\", \"text\"], template=_PROMPT_TEMPLATE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a3b0fb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evalchain = QAEvalChain.from_llm(llm=llm,prompt=PROMPT)\n",
+    "evalchain.evaluate(examples, predictions, question_key=\"question\", prediction_key=\"text\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "aaa61f0c",
    "metadata": {},
@@ -271,7 +315,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -285,7 +329,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.7 (default, Sep 16 2021, 08:50:36) \n[Clang 10.0.0 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "53f3bc57609c7a84333bb558594977aa5b4026b1d6070b93987956689e367341"
+   }
   }
  },
  "nbformat": 4,

--- a/langchain/evaluation/qa/eval_chain.py
+++ b/langchain/evaluation/qa/eval_chain.py
@@ -16,7 +16,21 @@ class QAEvalChain(LLMChain):
     def from_llm(
         cls, llm: BaseLLM, prompt: PromptTemplate = PROMPT, **kwargs: Any
     ) -> QAEvalChain:
-        """Load QA Eval Chain from LLM."""
+        """Load QA Eval Chain from LLM.
+
+        Args:
+            llm (BaseLLM): the base language model to use.
+
+            prompt (PromptTemplate): A prompt template containing the input_variables:
+            'input', 'answer' and 'result' that will be used as the prompt
+            for evaluation.
+            Defaults to PROMPT.
+
+            **kwargs: additional keyword arguments.
+
+        Returns:
+            QAEvalChain: the loaded QA eval chain.
+        """
         return cls(llm=llm, prompt=prompt, **kwargs)
 
     def evaluate(
@@ -29,27 +43,12 @@ class QAEvalChain(LLMChain):
     ) -> List[dict]:
         """Evaluate question answering examples and predictions."""
         inputs = []
-        if self.prompt != PROMPT:
-            prompt_keys = self.prompt.input_variables
-            input_keys = [question_key, answer_key, prediction_key]
-            if set(prompt_keys) != set(input_keys):
-                raise ValueError(
-                    f"Input keys {input_keys} do not match prompt keys {prompt_keys}"
-                )
-            for i, example in enumerate(examples):
-                _input = {
-                    question_key: example[question_key],
-                    answer_key: example[answer_key],
-                    prediction_key: predictions[i][prediction_key],
-                }
-                inputs.append(_input)
-        else:
-            for i, example in enumerate(examples):
-                _input = {
-                    "query": example[question_key],
-                    "answer": example[answer_key],
-                    "result": predictions[i][prediction_key],
-                }
-                inputs.append(_input)
+        for i, example in enumerate(examples):
+            _input = {
+                "query": example[question_key],
+                "answer": example[answer_key],
+                "result": predictions[i][prediction_key],
+            }
+            inputs.append(_input)
 
         return self.apply(inputs)

--- a/langchain/evaluation/qa/eval_chain.py
+++ b/langchain/evaluation/qa/eval_chain.py
@@ -6,15 +6,20 @@ from typing import Any, List
 from langchain.chains.llm import LLMChain
 from langchain.evaluation.qa.eval_prompt import PROMPT
 from langchain.llms.base import BaseLLM
+from langchain.prompts.base import BasePromptTemplate
+
 
 
 class QAEvalChain(LLMChain):
     """LLM Chain specifically for evaluating question answering."""
 
+    prompt: BasePromptTemplate = PROMPT
+    """Prompt to use to evaluate."""
+
     @classmethod
     def from_llm(cls, llm: BaseLLM, **kwargs: Any) -> QAEvalChain:
         """Load QA Eval Chain from LLM."""
-        return cls(llm=llm, prompt=PROMPT, **kwargs)
+        return cls(llm=llm, prompt=cls.prompt, **kwargs)
 
     def evaluate(
         self,

--- a/langchain/evaluation/qa/eval_chain.py
+++ b/langchain/evaluation/qa/eval_chain.py
@@ -1,7 +1,7 @@
 """LLM Chain specifically for evaluating question answering."""
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, List, Optional
 
 from langchain.chains.llm import LLMChain
 from langchain.evaluation.qa.eval_prompt import PROMPT
@@ -17,9 +17,9 @@ class QAEvalChain(LLMChain):
     """Prompt to use to evaluate."""
 
     @classmethod
-    def from_llm(cls, llm: BaseLLM, **kwargs: Any) -> QAEvalChain:
+    def from_llm(cls, llm: BaseLLM, prompt=prompt, **kwargs: Any) -> QAEvalChain:
         """Load QA Eval Chain from LLM."""
-        return cls(llm=llm, prompt=cls.prompt, **kwargs)
+        return cls(llm=llm, prompt=prompt, **kwargs)
 
     def evaluate(
         self,


### PR DESCRIPTION
I originally had only modified the `from_llm` to include the prompt but I realized that if the prompt keys used on the custom prompt didn't match the default prompt, it wouldn't work because of how `apply` works.

So I made some changes to the evaluate method to check if the prompt is the default and if not, it will check if the input keys are the same as the prompt key and update the inputs appropriately. 

Let me know if there is a better way to do this.

Also added the custom prompt to the QA eval notebook.