### PR TITLE
Modified api and sql prompts to shorten response length

### DIFF
--- a/docs/modules/chains/examples/api.ipynb
+++ b/docs/modules/chains/examples/api.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Api\n",
+    "This notebook showcases using LLMs and apis to retrieve relevant information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chains.api.prompt import API_RESPONSE_PROMPT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chains import APIChain\n",
+    "from langchain.chains.api import open_meteo_docs\n",
+    "from langchain.prompts.prompt import PromptTemplate\n",
+    "\n",
+    "\n",
+    "from langchain.llms import OpenAI\n",
+    "\n",
+    "llm = OpenAI(temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chain_new = APIChain.from_llm_and_api_docs(llm, open_meteo_docs.OPEN_METEO_DOCS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "' The current weather in Munich, Germany is 47.6°F with a windspeed of 9.2 mph and a winddirection of 239°. The weathercode is 3.'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain_new.run('What is the weather like right now in Munich, Germany in degrees Farenheit?')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain",
+   "language": "python",
+   "name": "langchain"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "id": "72ede462",
    "metadata": {
     "pycharm": {
@@ -53,7 +53,16 @@
    "outputs": [],
    "source": [
     "db = SQLDatabase.from_uri(\"sqlite:///../../../../notebooks/Chinook.db\")\n",
-    "llm = OpenAI(temperature=0)\n",
+    "llm = OpenAI(temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8fc8f23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "db_chain = SQLDatabaseChain(llm=llm, database=db, verbose=True)"
    ]
   },
@@ -180,12 +189,58 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "acb4e9a9",
+   "metadata": {},
+   "source": [
+    "## Choosing how to limit the number of rows returned\n",
+    "If you are querying for several rows of a table you can select the maximum number of results you want to get by using the 'top_k' parameter (default is 10). This is useful for avoiding query results that exceed the prompt max length or consume tokens unnecessarily."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e59a4740",
+   "execution_count": 7,
+   "id": "09154b87",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "db_chain = SQLDatabaseChain(llm=llm, database=db, verbose=True, top_k=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8033bd3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new SQLDatabaseChain chain...\u001b[0m\n",
+      "What are some examples songs from composer Johann Sebastian Bach? \n",
+      "SQLQuery:\u001b[32;1m\u001b[1;3m SELECT Name FROM Track WHERE Composer = 'Johann Sebastian Bach' LIMIT 3;\u001b[0m\n",
+      "SQLResult: \u001b[33;1m\u001b[1;3m[('Concerto for 2 Violins in D Minor, BWV 1043: I. Vivace',), ('Aria Mit 30 Veränderungen, BWV 988 \"Goldberg Variations\": Aria',), ('Suite for Solo Cello No. 1 in G Major, BWV 1007: I. Prélude',)]\u001b[0m\n",
+      "Answer:\u001b[32;1m\u001b[1;3m Examples of songs from composer Johann Sebastian Bach include Concerto for 2 Violins in D Minor, BWV 1043: I. Vivace, Aria Mit 30 Veränderungen, BWV 988 \"Goldberg Variations\": Aria, and Suite for Solo Cello No. 1 in G Major, BWV 1007: I. Prélude.\u001b[0m\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "' Examples of songs from composer Johann Sebastian Bach include Concerto for 2 Violins in D Minor, BWV 1043: I. Vivace, Aria Mit 30 Veränderungen, BWV 988 \"Goldberg Variations\": Aria, and Suite for Solo Cello No. 1 in G Major, BWV 1007: I. Prélude.'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db_chain.run(\"What are some examples songs from composer Johann Sebastian Bach?\")"
+   ]
   }
  ],
  "metadata": {
@@ -204,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/langchain/chains/api/prompt.py
+++ b/langchain/chains/api/prompt.py
@@ -2,12 +2,19 @@
 from langchain.prompts.prompt import PromptTemplate
 
 API_URL_PROMPT_TEMPLATE = """You are given the below API Documentation:
-
 {api_docs}
+Using this documentation, generate the full API url to call for answering the user question.
+You should build the API url so as to get a response that is as short as possible, while still getting the necessary information to answer the question. Pay attention in the following example, how there are many pieces of information that are deliberately not included in the API call. You should do the same.
 
-Using this documentation, generate the full API url to call for answering this question: {question}
+EXAMPLE
+Question: Please tell me what the weather is like right now in London?
+API url:https://api.open-meteo.com/v1/forecast?latitude=51.5074&longitude=0.1278&current_weather=true&timezone=auto
+END OF EXAMPLE
 
-API url: """
+Question:{question}
+API url:
+"""
+
 API_URL_PROMPT = PromptTemplate(
     input_variables=[
         "api_docs",

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -28,6 +28,8 @@ class SQLDatabaseChain(Chain, BaseModel):
     """SQL Database to connect to."""
     prompt: BasePromptTemplate = PROMPT
     """Prompt to use to translate natural language to SQL."""
+    top_k: int = 5
+    """Number of results to return from the query"""
     input_key: str = "query"  #: :meta private:
     output_key: str = "result"  #: :meta private:
 
@@ -60,10 +62,12 @@ class SQLDatabaseChain(Chain, BaseModel):
             self.callback_manager.on_text(input_text)
         llm_inputs = {
             "input": input_text,
+            "top_k": self.top_k,
             "dialect": self.database.dialect,
             "table_info": self.database.table_info,
             "stop": ["\nSQLResult:"],
         }
+
         sql_cmd = llm_chain.predict(**llm_inputs)
         if self.verbose:
             self.callback_manager.on_text(sql_cmd, color="green")

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from langchain.prompts.prompt import PromptTemplate
 
-_DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Always limit your query to at most {top_k} results using the LIMIT clause. You can order the results by a relevant column to return the most interesting examples in the database.
+_DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results using the LIMIT clause. You can order the results by a relevant column to return the most interesting examples in the database.
 Use the following format:
 
 Question: "Question here"

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from langchain.prompts.prompt import PromptTemplate
 
-_DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer.
+_DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Always limit your query to at most {top_k} results using the LIMIT clause. You can order the results by a relevant column to return the most interesting examples in the database.
 Use the following format:
 
 Question: "Question here"
@@ -14,6 +14,8 @@ Only use the following tables:
 {table_info}
 
 Question: {input}"""
+
 PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "dialect"], template=_DEFAULT_TEMPLATE
+    input_variables=["input", "table_info", "dialect", "top_k"],
+    template=_DEFAULT_TEMPLATE,
 )


### PR DESCRIPTION
Included in the API prompt to ask for as least information in possible in API calls. 
Asked in the SQL prompt to add a limit clause when building SQL queries. Included a 'top_k' parameter which suggests a reasonable limit size for the query.