### PR TITLE
Fix CohereError: embed is not an available endpoint on this model

### DIFF
--- a/langchain/embeddings/cohere.py
+++ b/langchain/embeddings/cohere.py
@@ -22,7 +22,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
     """
 
     client: Any  #: :meta private:
-    model: str = "medium"
+    model: str = "large"
     """Model name to use."""
 
     cohere_api_key: Optional[str] = None


### PR DESCRIPTION
Running the Cohere embeddings example from the docs:

```python
from langchain.embeddings import CohereEmbeddings
embeddings = CohereEmbeddings(cohere_api_key= cohere_api_key)

text = "This is a test document."
query_result = embeddings.embed_query(text)
doc_result = embeddings.embed_documents([text])
```

I get the error:

```bash
CohereError(message=res['message'], http_status=response.status_code, headers=response.headers)      
cohere.error.CohereError: embed is not an available endpoint on this model
```

This is because the `model` string is set to `medium` which is not currently available.

From the Cohere docs:

> Currently available models are small and large (default)
