### PR TITLE
Fix the env variable for OpenAI Base Url

### DIFF
--- a/docs/modules/llms/integrations/azure_openai_example.ipynb
+++ b/docs/modules/llms/integrations/azure_openai_example.ipynb
@@ -20,7 +20,7 @@
     "# The API version you want to use: set this to `2022-12-01` for the released version.\n",
     "export OPENAI_API_VERSION=2022-12-01\n",
     "# The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource.\n",
-    "export OPENAI_API_BASE_URL=https://your-resource-name.openai.azure.com\n",
+    "export OPENAI_API_BASE=https://your-resource-name.openai.azure.com\n",
     "# The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource.\n",
     "export OPENAI_API_KEY=<your Azure OpenAI API key>\n",
     "```\n",


### PR DESCRIPTION
For using Azure OpenAI API, we need to set multiple env vars. But as can be seen in openai package [here](https://github.com/openai/openai-python/blob/48b69293a3dff649165c1d0e0f9d77d1b52436c5/openai/__init__.py#L35), the env var for setting base url is named `OPENAI_API_BASE` and not `OPENAI_API_BASE_URL`. This PR fixes that part in the documentation.