### PR TITLE
Add search_kwargs option for VectorDBQAWithSourcesChain

### DIFF
--- a/langchain/chains/qa_with_sources/vector_db.py
+++ b/langchain/chains/qa_with_sources/vector_db.py
@@ -20,4 +20,6 @@ class VectorDBQAWithSourcesChain(BaseQAWithSourcesChain, BaseModel):
 
     def _get_docs(self, inputs: Dict[str, Any]) -> List[Document]:
         question = inputs[self.question_key]
-        return self.vectorstore.similarity_search(question, k=self.k, **self.search_kwargs)
+        return self.vectorstore.similarity_search(
+            question, k=self.k, **self.search_kwargs
+        )

--- a/langchain/chains/qa_with_sources/vector_db.py
+++ b/langchain/chains/qa_with_sources/vector_db.py
@@ -14,7 +14,10 @@ class VectorDBQAWithSourcesChain(BaseQAWithSourcesChain, BaseModel):
     vectorstore: VectorStore
     """Vector Database to connect to."""
     k: int = 4
+    """Number of results to return from store"""
+    search_kwargs: Dict[str, Any] = {}
+    """Extra search args"""
 
     def _get_docs(self, inputs: Dict[str, Any]) -> List[Document]:
         question = inputs[self.question_key]
-        return self.vectorstore.similarity_search(question, k=self.k)
+        return self.vectorstore.similarity_search(question, k=self.k, **self.search_kwargs)


### PR DESCRIPTION
Allows for passing additional vectorstore params like namespace, etc. to VectorDBQAWithSourcesChain

Example:
`chain = VectorDBQAWithSourcesChain.from_llm(OpenAI(temperature=0), vectorstore=store, search_kwargs={"namespace": namespace})`