### PR TITLE
Add ids parameter for pinecone from_texts / add_texts

### DIFF
--- a/langchain/chains/qa_with_sources/vector_db.py
+++ b/langchain/chains/qa_with_sources/vector_db.py
@@ -20,4 +20,6 @@ class VectorDBQAWithSourcesChain(BaseQAWithSourcesChain, BaseModel):
 
     def _get_docs(self, inputs: Dict[str, Any]) -> List[Document]:
         question = inputs[self.question_key]
-        return self.vectorstore.similarity_search(question, k=self.k, **self.search_kwargs)
+        return self.vectorstore.similarity_search(
+            question, k=self.k, **self.search_kwargs
+        )

--- a/langchain/chains/qa_with_sources/vector_db.py
+++ b/langchain/chains/qa_with_sources/vector_db.py
@@ -14,7 +14,10 @@ class VectorDBQAWithSourcesChain(BaseQAWithSourcesChain, BaseModel):
     vectorstore: VectorStore
     """Vector Database to connect to."""
     k: int = 4
+    """Number of results to return from store"""
+    search_kwargs: Dict[str, Any] = {}
+    """Extra search args"""
 
     def _get_docs(self, inputs: Dict[str, Any]) -> List[Document]:
         question = inputs[self.question_key]
-        return self.vectorstore.similarity_search(question, k=self.k)
+        return self.vectorstore.similarity_search(question, k=self.k, **self.search_kwargs)

--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -53,16 +53,16 @@ class Pinecone(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        ids: Optional[List[str]] = None,
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         namespace: Optional[str] = None,
     ) -> List[str]:
         """Run more texts through the embeddings and add to the vectorstore.
 
         Args:
             texts: Iterable of strings to add to the vectorstore.
-            ids: Optional list of ids to associate with the texts.
             metadatas: Optional list of metadatas associated with the texts.
+            ids: Optional list of ids to associate with the texts.
             namespace: Optional pinecone namespace to add the texts to.
 
         Returns:
@@ -152,8 +152,8 @@ class Pinecone(VectorStore):
         cls,
         texts: List[str],
         embedding: Embeddings,
-        ids: Optional[List[str]] = None,
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         batch_size: int = 32,
         text_key: str = "text",
         index_name: Optional[str] = None,


### PR DESCRIPTION
Allow optionally specifying a list of ids for pinecone rather than having them randomly generated. 
This also permits editing the embedding/metadata of existing pinecone entries, by id. 