### PR TITLE
Prompt fix for empty intermediate steps in summarization

### DIFF
--- a/langchain/chains/summarize/map_reduce_prompt.py
+++ b/langchain/chains/summarize/map_reduce_prompt.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from langchain.prompts import PromptTemplate
 
-prompt_template = """Write a concise summary of the following: 
+prompt_template = """Write a concise summary of the following:
 
 
 "{text}"

--- a/langchain/chains/summarize/map_reduce_prompt.py
+++ b/langchain/chains/summarize/map_reduce_prompt.py
@@ -1,10 +1,10 @@
 # flake8: noqa
 from langchain.prompts import PromptTemplate
 
-prompt_template = """Write a concise summary of the following:
+prompt_template = """Write a concise summary of the following: 
 
 
-{text}
+"{text}"
 
 
 CONCISE SUMMARY:"""

--- a/langchain/chains/summarize/refine_prompts.py
+++ b/langchain/chains/summarize/refine_prompts.py
@@ -18,7 +18,7 @@ REFINE_PROMPT = PromptTemplate(
 )
 
 
-prompt_template = """Write a concise summary of the following: 
+prompt_template = """Write a concise summary of the following:
 
 
 "{text}"

--- a/langchain/chains/summarize/refine_prompts.py
+++ b/langchain/chains/summarize/refine_prompts.py
@@ -18,10 +18,10 @@ REFINE_PROMPT = PromptTemplate(
 )
 
 
-prompt_template = """Write a concise summary of the following:
+prompt_template = """Write a concise summary of the following: 
 
 
-{text}
+"{text}"
 
 
 CONCISE SUMMARY:"""

--- a/langchain/chains/summarize/stuff_prompt.py
+++ b/langchain/chains/summarize/stuff_prompt.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from langchain.prompts import PromptTemplate
 
-prompt_template = """Write a concise summary of the following: 
+prompt_template = """Write a concise summary of the following:
 
 
 "{text}"

--- a/langchain/chains/summarize/stuff_prompt.py
+++ b/langchain/chains/summarize/stuff_prompt.py
@@ -1,10 +1,10 @@
 # flake8: noqa
 from langchain.prompts import PromptTemplate
 
-prompt_template = """Write a concise summary of the following:
+prompt_template = """Write a concise summary of the following: 
 
 
-{text}
+"{text}"
 
 
 CONCISE SUMMARY:"""


### PR DESCRIPTION
Adding quotation marks around {text} avoids generating empty or completely random responses from OpenAI davinci-003. Empty or completely unrelated intermediate responses in summarization messes up the final result or makes it very inaccurate. 
The error from OpenAI would be: "The model predicted a completion that begins with a stop sequence, resulting in no output. Consider adjusting your prompt or stop sequences." 
This fix corrects the prompting for summarization chain. This works on API too, the images are for demonstrative purposes. 
This approach can be applied to other similar prompts too. 

Examples:

1) Without quotation marks
![Screenshot from 2023-01-20 07-18-19](https://user-images.githubusercontent.com/22897470/213624365-9dfc18f9-5f3f-45d2-abe1-56de67397e22.png)

2) With quotation marks
![Screenshot from 2023-01-20 07-18-35](https://user-images.githubusercontent.com/22897470/213624478-c958e742-a4a7-46fe-a163-eca6326d9dae.png)
