### PR TITLE
Support loading examples in few-shot template from yaml

### DIFF
--- a/docs/modules/prompts/examples/examples.yaml
+++ b/docs/modules/prompts/examples/examples.yaml
@@ -1,0 +1,4 @@
+- input: happy
+  output: sad
+- input: tall
+  output: short

--- a/docs/modules/prompts/examples/few_shot_prompt_yaml_examples.yaml
+++ b/docs/modules/prompts/examples/few_shot_prompt_yaml_examples.yaml
@@ -1,0 +1,14 @@
+_type: few_shot
+input_variables:
+    ["adjective"]
+prefix: 
+    Write antonyms for the following words.
+example_prompt:
+    input_variables:
+        ["input", "output"]
+    template:
+        "Input: {input}\nOutput: {output}"
+examples:
+    examples.yaml
+suffix:
+    "Input: {adjective}\nOutput:"

--- a/docs/modules/prompts/examples/prompt_serialization.ipynb
+++ b/docs/modules/prompts/examples/prompt_serialization.ipynb
@@ -20,10 +20,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "id": "2c8d7587",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'langchain'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[1;32m/Users/vincetrost/work/plastic/langchain/docs/modules/prompts/examples/prompt_serialization.ipynb Cell 2\u001b[0m in \u001b[0;36m<cell line: 2>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/vincetrost/work/plastic/langchain/docs/modules/prompts/examples/prompt_serialization.ipynb#W1sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39m# All prompts are loaded through the `load_prompt` function.\u001b[39;00m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/vincetrost/work/plastic/langchain/docs/modules/prompts/examples/prompt_serialization.ipynb#W1sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mlangchain\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mprompts\u001b[39;00m \u001b[39mimport\u001b[39;00m load_prompt\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'langchain'"
+     ]
+    }
+   ],
    "source": [
     "# All prompts are loaded through the `load_prompt` function.\n",
     "from langchain.prompts import load_prompt"
@@ -226,6 +238,36 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d3052850",
+   "metadata": {},
+   "source": [
+    "And here is what the same examples stored as yaml might look like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "901385d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- input: happy\n",
+      "  output: sad\n",
+      "- input: tall\n",
+      "  output: short\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat examples.yaml"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "8e300335",
    "metadata": {},
@@ -290,6 +332,69 @@
    ],
    "source": [
     "prompt = load_prompt(\"few_shot_prompt.yaml\")\n",
+    "print(prompt.format(adjective=\"funny\"))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "13620324",
+   "metadata": {},
+   "source": [
+    "The same would work if you loaded examples from the yaml file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "831e5e4a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_type: few_shot\n",
+      "input_variables:\n",
+      "    [\"adjective\"]\n",
+      "prefix: \n",
+      "    Write antonyms for the following words.\n",
+      "example_prompt:\n",
+      "    input_variables:\n",
+      "        [\"input\", \"output\"]\n",
+      "    template:\n",
+      "        \"Input: {input}\\nOutput: {output}\"\n",
+      "examples:\n",
+      "    examples.yaml\n",
+      "suffix:\n",
+      "    \"Input: {adjective}\\nOutput:\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat few_shot_prompt_yaml_examples.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6f0a7eaa",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'load_prompt' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/Users/vincetrost/work/plastic/langchain/docs/modules/prompts/examples/prompt_serialization.ipynb Cell 23\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/vincetrost/work/plastic/langchain/docs/modules/prompts/examples/prompt_serialization.ipynb#X44sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m prompt \u001b[39m=\u001b[39m load_prompt(\u001b[39m\"\u001b[39m\u001b[39mfew_shot_prompt_yaml_examples.yaml\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/vincetrost/work/plastic/langchain/docs/modules/prompts/examples/prompt_serialization.ipynb#X44sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m \u001b[39mprint\u001b[39m(prompt\u001b[39m.\u001b[39mformat(adjective\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mfunny\u001b[39m\u001b[39m\"\u001b[39m))\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'load_prompt' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = load_prompt(\"few_shot_prompt_yaml_examples.yaml\")\n",
     "print(prompt.format(adjective=\"funny\"))"
    ]
   },
@@ -512,7 +617,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.3 64-bit ('3.10.3')",
    "language": "python",
    "name": "python3"
   },
@@ -526,11 +631,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.3"
   },
   "vscode": {
    "interpreter": {
-    "hash": "b1677b440931f40d89ef8be7bf03acb108ce003de0ac9b18e8d43753ea2e7103"
+    "hash": "8eb71adebe840dca1185e9603533462bc47eb1b1a73bf7dab2d0a8a4c932882e"
    }
   }
  },

--- a/langchain/prompts/loading.py
+++ b/langchain/prompts/loading.py
@@ -52,11 +52,17 @@ def _load_examples(config: dict) -> dict:
         pass
     elif isinstance(config["examples"], str):
         with open(config["examples"]) as f:
-            examples = json.load(f)
+            if config["examples"].endswith(".json"):
+                examples = json.load(f)
+            elif config["examples"].endswith(".yaml") or config["examples"].endswith(".yml"):
+                examples = yaml.safe_load(f)
+            else:
+                raise ValueError("Invalid file format. Only json or yaml formats are supported.")
         config["examples"] = examples
     else:
-        raise ValueError
+        raise ValueError("Invalid examples format. Only list or string are supported.")
     return config
+
 
 
 def _load_few_shot_prompt(config: dict) -> FewShotPromptTemplate:


### PR DESCRIPTION
The examples I want to load are long-ish passages with plenty of characters that weren't working with JSON formatting, so I added support for loading examples in a few-shot prompt template in yaml format.

I also added examples to the prompt serialization section of the docs to show people how to do this. The YAML formatting is important so that it gets loaded correctly as a list for the FewShotPromptTemplate to be happy.

I was having env issues so I didn't run _all_ of the contributing tests, but I don't think this is a huge update. It just made my QOL better -- I want my non-technical colleagues to be able to provide examples that I can select dynamically and YAML seemed like a better copy+paste option to teach them.