### PR TITLE
Update hyperlink in Custom Prompt Template page

### DIFF
--- a/docs/modules/prompts/examples/custom_prompt_template.md
+++ b/docs/modules/prompts/examples/custom_prompt_template.md
@@ -7,7 +7,7 @@ Let's suppose we want the LLM to generate English language explanations of a fun
 LangChain provides a set of default prompt templates that can be used to generate prompts for a variety of tasks. However, there may be cases where the default prompt templates do not meet your needs. For example, you may want to create a prompt template with specific dynamic instructions for your language model. In such cases, you can create a custom prompt template.
 
 :::{note}
-Take a look at the current set of default prompt templates [here](../prompt_templates.md).
+Take a look at the current set of default prompt templates [here](../getting_started.md).
 :::
 <!-- TODO(shreya): Add correct link here. -->
 


### PR DESCRIPTION
The current link points to a non-existent page. I've updated the link to match what is on the "Create a custom example selector" page.

<img width="584" alt="Screen Shot 2023-01-21 at 10 33 05 AM" src="https://user-images.githubusercontent.com/6773706/213879535-d8f2953d-ac37-448d-9b32-fdeb7b73cc32.png">
