### PR TITLE
Update examples to fix execution problems

### DIFF
--- a/docs/modules/prompts/examples/custom_prompt_template.md
+++ b/docs/modules/prompts/examples/custom_prompt_template.md
@@ -54,7 +54,7 @@ class FunctionExplainerPromptTemplate(BasePromptTemplate, BaseModel):
         # Generate the prompt to be sent to the language model
         prompt = f"""
         Given the function name and source code, generate an English language explanation of the function.
-        Function Name: {kwargs["function_name"]}
+        Function Name: {kwargs["function_name"].__name__}
         Source Code:
         {source_code}
         Explanation:

--- a/docs/modules/prompts/examples/example_selectors.ipynb
+++ b/docs/modules/prompts/examples/example_selectors.ipynb
@@ -48,6 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from langchain.prompts import PromptTemplate\n",
     "from langchain.prompts.example_selector import LengthBasedExampleSelector"
    ]
   },
@@ -75,6 +76,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "example_prompt = PromptTemplate(\n",
+    "    input_variables=[\"input\", \"output\"],\n",
+    "    template=\"Input: {input}\\nOutput: {output}\",\n",
+    ")\n",
     "example_selector = LengthBasedExampleSelector(\n",
     "    # These are the examples is has available to choose from.\n",
     "    examples=examples, \n",

--- a/docs/modules/prompts/getting_started.md
+++ b/docs/modules/prompts/getting_started.md
@@ -211,7 +211,7 @@ In contrast, if we provide a very long input, the `LengthBasedExampleSelector` w
 
 ```python
 long_string = "big and huge and massive and large and gigantic and tall and much much much much much bigger than everything else"
-print(dynamic_prompt.format(adjective=long_string))
+print(dynamic_prompt.format(input=long_string))
 # -> Give the antonym of every input
 
 # -> Word: happy


### PR DESCRIPTION
On the [Getting Started page](https://langchain.readthedocs.io/en/latest/modules/prompts/getting_started.html) for prompt templates, I believe the very last example

```python
print(dynamic_prompt.format(adjective=long_string))
```

should actually be

```python
print(dynamic_prompt.format(input=long_string))
```

The existing example produces `KeyError: 'input'` as expected

***

On the [Create a custom prompt template](https://langchain.readthedocs.io/en/latest/modules/prompts/examples/custom_prompt_template.html#id1) page, I believe the line

```python
Function Name: {kwargs["function_name"]}
```

should actually be

```python
Function Name: {kwargs["function_name"].__name__}
```

The existing example produces the prompt:

```
        Given the function name and source code, generate an English language explanation of the function.
        Function Name: <function get_source_code at 0x7f907bc0e0e0>
        Source Code:
        def get_source_code(function_name):
    # Get the source code of the function
    return inspect.getsource(function_name)

        Explanation:
```

***

On the [Example Selectors](https://langchain.readthedocs.io/en/latest/modules/prompts/examples/example_selectors.html) page, the first example does not define `example_prompt`, which is also subtly different from previous example prompts used. For user convenience, I suggest including

```python
example_prompt = PromptTemplate(
    input_variables=["input", "output"],
    template="Input: {input}\nOutput: {output}",
)
```

in the code to be copy-pasted