### PR TITLE
chore: move coverage config to pyproject

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,11 @@ ignore_missing_imports = "True"
 disallow_untyped_defs = "True"
 exclude = ["notebooks"]
 
+[tool.coverage.run]
+omit = [
+    "tests/*",
+]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR aims to move the contents of `.coveragerc` to `pyproject.toml` to make the overall file structure more minimal.