### PR TITLE
remove legacy embedding model name

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -18,7 +18,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         .. code-block:: python
 
             from langchain.embeddings import OpenAIEmbeddings
-            openai = OpenAIEmbeddings(model_name="davinci", openai_api_key="my-api-key")
+            openai = OpenAIEmbeddings(openai_api_key="my-api-key")
     """
 
     client: Any  #: :meta private:


### PR DESCRIPTION
Now that OpenAI has deprecated all embeddings models except text-embedding-ada-002, we should stop specifying a legacy embedding model in the example. This will also avoid confusion from people (like me) trying to specify model="text-embedding-ada-002" and having that erroneously expanded to text-search-text-embedding-ada-002-query-001