### PR TITLE
Convert numpy arrays to lists in HuggingFaceEmbeddings

### DIFF
--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -54,7 +54,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         """
         texts = list(map(lambda x: x.replace("\n", " "), texts))
         embeddings = self.client.encode(texts)
-        return embeddings
+        return embeddings.tolist()
 
     def embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a HuggingFace transformer model.
@@ -67,4 +67,4 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         """
         text = text.replace("\n", " ")
         embedding = self.client.encode(text)
-        return embedding
+        return embedding.tolist()


### PR DESCRIPTION
`SentenceTransformer` returns a NumPy array, not a `List[List[float]]` or `List[float]` as specified in the interface of `Embeddings`. That PR makes it consistent with the interface. 