### PR TITLE
fix typos in readme and text splitter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is aimed at assisting in the development of those types of applicat
 **❓ Question Answering over specific documents**
 
 - [Documentation](https://langchain.readthedocs.io/en/latest/use_cases/question_answering.html)
-- End-to-end Example: [Question Answering over Notion Database](https://github.com/hwchase17/notion-qa>)
+- End-to-end Example: [Question Answering over Notion Database](https://github.com/hwchase17/notion-qa)
 
 **💬 Chatbots**
 

--- a/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
+++ b/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
@@ -1,13 +1,14 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b118c9dc",
    "metadata": {},
    "source": [
     "# Text Splitter\n",
     "\n",
-    "When you want to deal wit long pieces of text, it is necessary to split up that text into chunks.\n",
+    "When you want to deal with long pieces of text, it is necessary to split up that text into chunks.\n",
     "This notebook showcases several ways to do that.\n",
     "\n",
     "At a high level, text splitters work as following:\n",
@@ -486,7 +487,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -500,7 +501,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.12 (main, Mar 26 2022, 15:51:15) \n[Clang 13.1.6 (clang-1316.0.21.2)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix typos in readme and TextSplitter documentation.