### PR TITLE
Add walkthrough on generating blog posts over a vector index

### DIFF
--- a/docs/modules/chains/combine_docs_examples/vector_db_text_generation.ipynb
+++ b/docs/modules/chains/combine_docs_examples/vector_db_text_generation.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vector DB Text Generation\n",
+    "\n",
+    "This notebook walks through how to use LangChain for text generation over a vector index. This is useful if we want to generate text that is able to draw from a large body of custom text, for example, generating blog posts that have an understanding of previous blog posts written, or product tutorials that can refer to product documentation."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare Data\n",
+    "\n",
+    "First, we prepare the data. For this example, we fetch a documentation site that consists of markdown files hosted on Github and split them into small enough Documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.llms import OpenAI\n",
+    "from langchain.docstore.document import Document\n",
+    "import requests\n",
+    "from langchain.embeddings.openai import OpenAIEmbeddings\n",
+    "from langchain.vectorstores.faiss import FAISS\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.prompts import PromptTemplate\n",
+    "import pathlib\n",
+    "import subprocess\n",
+    "import tempfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_github_docs(repo_owner, repo_name):\n",
+    "    with tempfile.TemporaryDirectory() as d:\n",
+    "        subprocess.check_call(\n",
+    "            f\"git clone --depth 1 https://github.com/{repo_owner}/{repo_name}.git .\",\n",
+    "            cwd=d,\n",
+    "            shell=True,\n",
+    "        )\n",
+    "        git_sha = (\n",
+    "            subprocess.check_output(\"git rev-parse HEAD\", shell=True, cwd=d)\n",
+    "            .decode(\"utf-8\")\n",
+    "            .strip()\n",
+    "        )\n",
+    "        repo_path = pathlib.Path(d)\n",
+    "        markdown_files = list(repo_path.glob(\"*/*.md\")) + list(\n",
+    "            repo_path.glob(\"*/*.mdx\")\n",
+    "        )\n",
+    "        for markdown_file in markdown_files:\n",
+    "            with open(markdown_file, \"r\") as f:\n",
+    "                relative_path = markdown_file.relative_to(repo_path)\n",
+    "                github_url = f\"https://github.com/{repo_owner}/{repo_name}/blob/{git_sha}/{relative_path}\"\n",
+    "                yield Document(page_content=f.read(), metadata={\"source\": github_url})\n",
+    "\n",
+    "sources = get_github_docs(\"yirenlu92\", \"deno-manual-forked\")\n",
+    "\n",
+    "source_chunks = []\n",
+    "splitter = CharacterTextSplitter(separator=\" \", chunk_size=1024, chunk_overlap=0)\n",
+    "for source in sources:\n",
+    "    for chunk in splitter.split_text(source.page_content):\n",
+    "        source_chunks.append(Document(page_content=chunk, metadata=source.metadata))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set Up Vector DB\n",
+    "\n",
+    "Now that we have the documentation content in chunks, let's put all this information in a vector index for easy retrieval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_index = FAISS.from_documents(source_chunks, OpenAIEmbeddings())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set Up LLM Chain with Custom Prompt\n",
+    "\n",
+    "Next, let's set up a simple LLM chain but give it a custom prompt for blog post generation. Note that the custom prompt is parameterized and takes two inputs: `context`, which will be the documents fetched from the vector search, and `topic`, which is given by the user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt_template = \"\"\"Use the context below to write a 400 word blog post about the topic below:\n",
+    "    Context: {context}\n",
+    "    Topic: {topic}\n",
+    "    Blog post:\"\"\"\n",
+    "\n",
+    "PROMPT = PromptTemplate(\n",
+    "    template=prompt_template, input_variables=[\"context\", \"topic\"]\n",
+    ")\n",
+    "\n",
+    "llm = OpenAI(temperature=0)\n",
+    "\n",
+    "chain = LLMChain(llm=llm, prompt=PROMPT)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Text\n",
+    "\n",
+    "Finally, we write a function to apply our inputs to the chain. The function takes an input parameter `topic`. We find the documents in the vector index that correspond to that `topic`, and use them as additional context in our simple LLM chain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_blog_post(topic):\n",
+    "    docs = search_index.similarity_search(topic, k=4)\n",
+    "    inputs = [{\"context\": doc.page_content, \"topic\": topic} for doc in docs]\n",
+    "    print(chain.apply(inputs))"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/modules/chains/combine_docs_how_to.rst
+++ b/docs/modules/chains/combine_docs_how_to.rst
@@ -11,6 +11,8 @@ The examples here are all end-to-end chains for working with documents.
 
 `Summarization <./combine_docs_examples/summarize.html>`_: A walkthrough of how to use LangChain for summarization over specific documents.
 
+`Vector DB Text Generation <./combine_docs_examples/vector_db_text_generation.html>`_: A walkthrough of how to use LangChain for text generation over a vector database.
+
 `Vector DB Question Answering <./combine_docs_examples/vector_db_qa.html>`_: A walkthrough of how to use LangChain for question answering over a vector database.
 
 `Vector DB Question Answering with Sources <./combine_docs_examples/vector_db_qa_with_sources.html>`_: A walkthrough of how to use LangChain for question answering (with sources) over a vector database.


### PR DESCRIPTION
- adding documentation for separate use case in addition to summarization and QA on top of combined documents
- not sure if the QA chain is actually substantially different from the LLMChain though? Maybe it's just a matter of different prompts?