### PR TITLE
Add more results using snippets, titles, and links metadata

### DIFF
--- a/docs/modules/utils/examples/bing_search.ipynb
+++ b/docs/modules/utils/examples/bing_search.ipynb
@@ -104,10 +104,51 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metadata Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run query through BingSearch and return snippet, title, and link metadata.\n",
+    "\n",
+    "- Snippet: The description of the result.\n",
+    "- Title: The title of the result.\n",
+    "- Link: The link to the result."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "search = BingSearchAPIWrapper()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search.results(\"apples\", 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[{'snippet': 'Lady Alice. Pink Lady <b>apples</b> aren’t the only lady in the apple family. Lady Alice <b>apples</b> were discovered growing, thanks to bees pollinating, in Washington. They are smaller and slightly more stout in appearance than other varieties. Their skin color appears to have red and yellow stripes running from stem to butt.', 'title': '25 Types of Apples - Jessica Gavin', 'link': 'https://www.jessicagavin.com/types-of-apples/'}, {'snippet': '<b>Apples</b> boast many vitamins and minerals, though not in high amounts. However, <b>apples</b> are usually a good source of vitamin C. Vitamin C. Also called ascorbic acid, this vitamin is a common ...', 'title': 'Apples 101: Nutrition Facts and Health Benefits', 'link': 'https://www.healthline.com/nutrition/foods/apples'}, {'snippet': 'As <b>apples</b> ripen, they give off ethylene gas, which shortens the storage life of some other vegetables, so keep them in a bag in your refrigerator’s crisper and remember to wash <b>apples</b> before eating them. Bill Zirkle, fourth-generation family grower (left) and Mark Zirkle, fifth-generation family grower (right). ...', 'title': 'A Guide to Apples and How to Enjoy Them | Whole Foods Market', 'link': 'https://www.wholefoodsmarket.com/tips-and-ideas/food-guides/apples'}, {'snippet': 'Weight management. The fibers in <b>apples</b> can slow digestion, helping one to feel greater satisfaction after eating. After following three large prospective cohorts of 133,468 men and women for 24 years, researchers found that higher intakes of fiber-rich fruits with a low glycemic load, particularly <b>apples</b> and pears, were associated with the least amount of weight gain over time.', 'title': 'Apples | The Nutrition Source | Harvard T.H. Chan School of Public Health', 'link': 'https://www.hsph.harvard.edu/nutritionsource/food-features/apples/'}]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],
@@ -127,7 +168,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/modules/utils/examples/google_search.ipynb
+++ b/docs/modules/utils/examples/google_search.ipynb
@@ -68,17 +68,100 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "074b7f07",
+   "metadata": {},
+   "source": [
+    "## Number of Results\n",
+    "You can use the `k` parameter to set the number of results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5083fbdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search = GoogleSearchAPIWrapper(k=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77aaa857",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search.run(\"python\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11c8d94f",
+   "metadata": {},
+   "source": [
+    "'The official home of the Python Programming Language.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73473110",
+   "metadata": {},
+   "source": [
+    "## Metadata Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "109fe796",
+   "metadata": {},
+   "source": [
+    "Run query through GoogleSearch and return snippet, title, and link metadata.\n",
+    "\n",
+    "- Snippet: The description of the result.\n",
+    "- Title: The title of the result.\n",
+    "- Link: The link to the result."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "028f4cba",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "search = GoogleSearchAPIWrapper()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d8f734f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search.results(\"apples\", 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "990191db",
+   "metadata": {},
+   "source": [
+    "[{'snippet': 'Discover the innovative world of Apple and shop everything iPhone, iPad, Apple Watch, Mac, and Apple TV, plus explore accessories, entertainment,\\xa0...', 'title': 'Apple', 'link': 'https://www.apple.com/'}, {'snippet': \"Jul 10, 2022 ... Whether or not you're up on your apple trivia, no doubt you know how delicious this popular fruit is, and how nutritious. Apples are rich in\\xa0...\", 'title': '25 Types of Apples and What to Make With Them - Parade ...', 'link': 'https://parade.com/1330308/bethlipton/types-of-apples/'}, {'snippet': 'An apple is an edible fruit produced by an apple tree (Malus domestica). Apple trees are cultivated worldwide and are the most widely grown species in the\\xa0...', 'title': 'Apple - Wikipedia', 'link': 'https://en.wikipedia.org/wiki/Apple'}, {'snippet': 'Apples are a popular fruit. They contain antioxidants, vitamins, dietary fiber, and a range of other nutrients. Due to their varied nutrient content,\\xa0...', 'title': 'Apples: Benefits, nutrition, and tips', 'link': 'https://www.medicalnewstoday.com/articles/267290'}, {'snippet': \"An apple is a crunchy, bright-colored fruit, one of the most popular in the United States. You've probably heard the age-old saying, “An apple a day keeps\\xa0...\", 'title': 'Apples: Nutrition & Health Benefits', 'link': 'https://www.webmd.com/food-recipes/benefits-apples'}]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65d9c945",
+   "metadata": {},
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.12 ('palm')",
    "language": "python",
    "name": "python3"
   },
@@ -92,7 +175,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "a0a0263b650d907a3bfe41c0f8d6a63a071b884df3cfdc1579f00cdc1aed6b03"
+   }
   }
  },
  "nbformat": 4,

--- a/langchain/utilities/bing_search.py
+++ b/langchain/utilities/bing_search.py
@@ -54,7 +54,7 @@ class BingSearchAPIWrapper(BaseModel):
             values,
             "bing_search_url",
             "BING_SEARCH_URL",
-            default="https://api.bing.microsoft.com/v7.0/search",
+            #default="https://api.bing.microsoft.com/v7.0/search",
         )
 
         values["bing_search_url"] = bing_search_url
@@ -71,3 +71,26 @@ class BingSearchAPIWrapper(BaseModel):
             snippets.append(result["snippet"])
 
         return " ".join(snippets)
+
+    def results(self, query: str, num_results: int) -> List[Dict]:
+        """
+        Run query through BingSearch and return snippet, title, and link metadata.
+        query - The query to search for.
+        num_results - The number of results to return.
+        snippet - The description of the result.
+        title - The title of the result.
+        link - The link to the result.
+        """
+        metadata_results = []
+        results = self._bing_search_results(query, count=num_results)
+        if len(results) == 0:
+            return "No good Bing Search Result was found"
+        for result in results:
+            metadata_result = {
+                "snippet": result["snippet"],
+                "title": result["name"],
+                "link": result["url"],
+            }
+            metadata_results.append(metadata_result)
+
+        return metadata_results

--- a/langchain/utilities/google_search.py
+++ b/langchain/utilities/google_search.py
@@ -48,6 +48,7 @@ class GoogleSearchAPIWrapper(BaseModel):
     search_engine: Any  #: :meta private:
     google_api_key: Optional[str] = None
     google_cse_id: Optional[str] = None
+    k: int = 10
 
     class Config:
         """Configuration for this pydantic object."""
@@ -91,10 +92,33 @@ class GoogleSearchAPIWrapper(BaseModel):
     def run(self, query: str) -> str:
         """Run query through GoogleSearch and parse result."""
         snippets = []
-        results = self._google_search_results(query, num=10)
+        results = self._google_search_results(query, num=self.k)
         if len(results) == 0:
             return "No good Google Search Result was found"
         for result in results:
             snippets.append(result["snippet"])
 
         return " ".join(snippets)
+
+    def results(self, query: str, num_results: int) -> List[Dict]:
+        """
+        Run query through GoogleSearch and return snippet, title, and link metadata.
+        query - The query to search for.
+        num_results - The number of results to return.
+        snippet - The description of the result.
+        title - The title of the result.
+        link - The link to the result.
+        """
+        metadata_results = []
+        results = self._google_search_results(query, num=num_results)
+        if len(results) == 0:
+            return "No good Google Search Result was found"
+        for result in results:
+            metadata_result = {
+                "snippet": result["snippet"],
+                "title": result["title"],
+                "link": result["link"],
+            }
+            metadata_results.append(metadata_result)
+
+        return metadata_results


### PR DESCRIPTION
Hi @hwchase17,

Per our previous discussion, I am updating the Google and Bing Search API utilities to include a method for returning metadata in the form `[{'snippet':'hello world', 'title': 'foo', 'link': 'bar'}]`.

Usage:
```python
search = GoogleSearchAPIWrapper()
search.results(query="apples", num_results=2)
```
Output:
```
[{'snippet': 'Lady Alice. Pink Lady <b>apples</b> aren’t the only lady in the apple family. Lady Alice <b>apples</b> were discovered growing, thanks to bees pollinating, in Washington. They are smaller and slightly more stout in appearance than other varieties. Their skin color appears to have red and yellow stripes running from stem to butt.', 'title': '25 Types of Apples - Jessica Gavin', 'link': 'https://www.jessicagavin.com/types-of-apples/'}, {'snippet': '<b>Apples</b> boast many vitamins and minerals, though not in high amounts. However, <b>apples</b> are usually a good source of vitamin C. Vitamin C. Also called ascorbic acid, this vitamin is a common ...', 'title': 'Apples 101: Nutrition Facts and Health Benefits', 'link': 'https://www.healthline.com/nutrition/foods/apples'}]
```

I also standardized the GoogleSearchAPIWrapper to allow you to select `k` number of results similar to the BingSearchAPIWrapper.

Usage:
```python
search = GoogleSearchAPIWrapper(k=1)
search.run("python")
```
Output:
```'The official home of the Python Programming Language.'```

I commented out the line, `default="https://api.bing.microsoft.com/v7.0/search"`, in the Bing Search API Wrapper and think it may be worth investigating as this was throwing an error for me.

I updated the documentation to include newer examples as well.

Let me know what you think.

Thank you,

Enrico Shippole