### PR TITLE
Use gpu for huggingface pipeline

### DIFF
--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -89,12 +89,12 @@ class HuggingFacePipeline(LLM, BaseModel):
                 import torch
 
                 cuda_device_count = torch.cuda.device_count()
-                if device < -1 or (device > cuda_device_count - 1):
+                if device < -1 or (device >= cuda_device_count):
                     raise ValueError(
                         f"Got device=={device}, "
-                        f"device is required to be within [-1, {cuda_device_count}]"
+                        f"device is required to be within [-1, {cuda_device_count})"
                     )
-                if device < 0:
+                if device < 0 and cuda_device_count > 0:
                     logger.warning(
                         "Device has %d GPUs available. "
                         "Provide device={deviceId} to `from_model_id` to use available GPUs"

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -97,9 +97,9 @@ class HuggingFacePipeline(LLM, BaseModel):
                 if device < 0 and cuda_device_count > 0:
                     logger.warning(
                         "Device has %d GPUs available. "
-                        "Provide device={deviceId} to `from_model_id` to use available GPUs"
-                        " for execution. deviceId is -1 (default) for CPU and can be a "
-                        "positive integer associated with CUDA device id.",
+                        "Provide device={deviceId} to `from_model_id` to use available"
+                        "GPUs for execution. deviceId is -1 (default) for CPU and "
+                        "can be a positive integer associated with CUDA device id.",
                         cuda_device_count,
                     )
 


### PR DESCRIPTION
1. Allow HuggingFace pipeline to use local GPUs if available.
2. If `transformers` is installed but `torch` is not, the existing `ImportError` still insisted that `transformers` is not installed.