### PR TITLE
Upper bound on number of iterations

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -199,7 +199,7 @@ class AgentExecutor(Chain, BaseModel):
     agent: Agent
     tools: List[Tool]
     return_intermediate_steps: bool = False
-    max_iterations: Optional[int] = None
+    max_iterations: Optional[int] = 15
     early_stopping_method: str = "force"
 
     @classmethod


### PR DESCRIPTION
Some custom agents might continue to iterate until they find the correct answer, getting stuck on loops that generate request after request and are really expensive for the end user. Putting an upper bound for the number of iterations 
 by default controls this and can be explicitly tweaked by the user if necessary.