### PR TITLE
Add chain to get multiple inputs from the LLM

### DIFF
--- a/langchain/chains/multiple_outputs/__init__.py
+++ b/langchain/chains/multiple_outputs/__init__.py
@@ -1,0 +1,3 @@
+from .base import GetMultipleOutputsChain  # noqa
+from .config import VariableConfig  # noqa
+from .prompt import MultipleOutputsPrompter  # noqa

--- a/langchain/chains/multiple_outputs/base.py
+++ b/langchain/chains/multiple_outputs/base.py
@@ -1,0 +1,141 @@
+"""Chain that gets multiple outputs from the LLM."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Extra
+
+from langchain.chains import LLMChain, SequentialChain
+from langchain.chains.base import Chain
+from langchain.chains.multiple_outputs.config import VariableConfig
+from langchain.chains.multiple_outputs.prompt import MultipleOutputsPrompter
+from langchain.llms.base import BaseLLM
+from langchain.prompts.base import DictOutputParser
+
+
+class GetMultipleOutputsChain(Chain, BaseModel):
+    """Chain that gets multiple outputs from the LLM, one at a time by default.
+
+    Use this over manually parsing the outputs if the outputs can be hard to parse
+    (e.g. if you're looking for code blocks of indeterminate length and content, it can
+    be hard to write a regex to figure out when one block ends and the next one
+    starts). It can also be used when the LLM is having difficulty generating all
+    outputs in one go. The `one_step` setting lets you easily toggle between one-step
+    and multi-step generation for comparison.
+    """
+
+    one_step_stop: Optional[str]
+    """Stop specifically for one-step output."""
+    prompter: MultipleOutputsPrompter  #: :meta private:
+    # putting these two separately instead of a Union type because pydantic validation
+    # fails when the LLMChain does not have values["chains"]
+    one_step_chain: Optional[LLMChain]  #: :meta private:
+    multi_step_chain: Optional[SequentialChain]  #: :meta private:
+    completions: Optional[Dict[str, str]]  #: :meta private:
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+
+    def __init__(
+        self,
+        llm: BaseLLM,
+        prefix: str,
+        variables: Optional[Dict[str, str]] = None,
+        variable_configs: Optional[List[VariableConfig]] = None,
+        auto_suffix_variable_display: bool = True,
+        output_parser: Optional[DictOutputParser] = None,
+        one_step: bool = False,
+        one_step_stop: Optional[str] = None,
+        **chain_options: Any
+    ):
+        """Construct a chain that gets multiple outputs from the LLM.
+
+        By default, this chain gets the inputs one at a time, although that can be
+        toggled with the `one_step` variable.
+        """
+        prompter = MultipleOutputsPrompter(
+            prefix=prefix,
+            variables=variables,
+            variable_configs=variable_configs,
+            auto_suffix_variable_display=auto_suffix_variable_display,
+            output_parser=output_parser,
+        )
+
+        one_step_chain = None
+        multi_step_chain = None
+        if one_step:
+            one_step_chain = LLMChain(
+                llm=llm,
+                prompt=prompter.prompt_template_for_full_input(),
+                **chain_options,
+            )
+        else:
+            chains = []
+            for i, var in enumerate(prompter.variables):
+                chains.append(
+                    LLMChain(
+                        llm=llm,
+                        prompt=prompter.prompt_template_for_variable_at(i),
+                        output_key=var.output_key,
+                        **chain_options,
+                    )
+                )
+            multi_step_chain = SequentialChain(
+                chains=chains,
+                input_variables=[],
+                output_variables=prompter.output_keys,
+                **chain_options,
+            )
+
+        super().__init__(
+            prompter=prompter,
+            one_step_chain=one_step_chain,
+            multi_step_chain=multi_step_chain,
+            one_step_stop=one_step_stop,
+            **chain_options,
+        )
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Input keys for this chain.
+
+        Always empty because the prefix should have already been pre-formatted before
+        being passed into this chain.
+        """
+        return []
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Output keys produced by this whole chain."""
+        return self.prompter.output_keys
+
+    def log(self) -> str:
+        """Return entire transcript for how the LLM filled in these values."""
+        assert self.completions, "Run the chain first so we have something to log"
+        return self.prompter.log(self.completions)
+
+    def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
+        if self.one_step_chain:
+            with_stop = {**inputs, "stop": self.one_step_stop}
+            result = self.one_step_chain.apply_and_parse([with_stop])[0]
+            # typechecking above should ensure a DictOutputParser gets passed in if
+            # we're doing this in one step
+            assert isinstance(result, dict), "Please set DictOutputParser"
+            self.completions = result
+        else:
+            assert self.multi_step_chain is not None, "No chains configured"
+            self.completions = {}
+            for var, chain in zip(
+                self.prompter.variables, self.multi_step_chain.chains
+            ):
+                assert isinstance(chain, LLMChain)
+                known_values = {
+                    **inputs,
+                    **self.completions,
+                    "stop": var.stop,
+                }
+                llm_result = chain.generate([known_values])
+                self.completions[var.output_key] = llm_result.generations[0][0].text
+
+        return self.completions

--- a/langchain/chains/multiple_outputs/config.py
+++ b/langchain/chains/multiple_outputs/config.py
@@ -1,0 +1,106 @@
+"""Configuration for variables in GetMultipleOutputsChain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Type, TypeVar
+
+VC = TypeVar("VC", bound="VariableConfig")
+
+
+@dataclass
+class VariableConfig:
+    """Configuration for each variable the LLM should fill in."""
+
+    display: str
+    """The string that the LLM sees as an invitation to fill this variable in.
+
+    For example, if the value of this is "Action Input: \"", then the LLM will see the
+    prompt
+
+    ```
+    Decide on your next course of action:
+
+    Action Type: "Search"
+    Action Input: "
+    ```
+    """
+    output_key: str
+    """The key in the final output dict that the LLM-provided value will be saved to.
+
+    For example, if the value of this is "input", and the LLM prompt completion is:
+
+    ```
+    Decide on your next course of action:
+
+    Action Type: "Search"
+    Action Input: "Olivia Wilde boyfriend"
+    ```
+
+    Then the final dict returned will store "Olivia Wilde boyfriend" inside the key
+    "input":
+
+    ```
+    {
+        ...
+        "input": "Olivia Wilde boyfriend"
+        ...
+    }
+    ```
+    """
+    stop: str = '"'
+    """The character to stop at when completing the value for this variable.
+
+    This defaults to a single double-quote, so that if your prompt goes
+
+    Action Input: "
+
+    then the LLM can know to terminate its input with a double-quote. If you expect the
+    output to be multiline, then you may instead want to go with ''' or ```, and adjust
+    the display string accordingly
+
+    This exists here instead of MultipleOutputsPrompter so that each variable can have
+    its own custom stop if needed.
+    """
+    display_suffix: Optional[str] = None
+    """The string to put at the end of the display string.
+
+    For example, if you set this to ": \"", and your display is "Action Input", then
+    the whole thing will come out as "Action Input: \"" for the LLM to complete
+
+    This exists to allow easy modification of the final display string by simply
+    copying over the stopper, without polluting the display string with the stopper.
+    """
+
+    @property
+    def prompt(self) -> str:
+        """Prompt for the LLM to fill in this specific variable."""
+        if self.display_suffix:
+            return self.display + self.display_suffix
+        return self.display
+
+    @property
+    def prompt_with_value(self) -> str:
+        """Previous prompt + filled-in value for this variable.
+
+        This is a templating string, so it won't have the actual value of the variable,
+        just a marker for the template to eventually fill it in with.
+        """
+        return self.prompt + "{" + self.output_key + "}" + self.stop
+
+    @classmethod
+    def for_code(
+        cls: Type[VC],
+        output_key: str,
+        display: str,
+        language: Optional[str] = None,
+    ) -> VC:
+        """Configure a language-specific code prompt."""
+        language_str = "" if language is None else language
+        display_suffix = f": ```{language_str}\n"
+        return cls(
+            output_key=output_key,
+            display=display,
+            display_suffix=display_suffix,
+            stop="```",
+        )

--- a/langchain/chains/multiple_outputs/prompt.py
+++ b/langchain/chains/multiple_outputs/prompt.py
@@ -1,0 +1,136 @@
+"""Prompt building for GetMultipleOutputsChain."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Extra
+
+from langchain.chains.multiple_outputs.config import VariableConfig
+from langchain.prompts.base import DictOutputParser
+from langchain.prompts.prompt import PromptTemplate
+
+
+class MultipleOutputsPrompter(BaseModel):
+    """Handles the prompting logic for GetMultipleOutputsChain."""
+
+    prefix: str
+    """The preamble before we ask the LLM to fill in each variable value."""
+    variables: List[VariableConfig]
+    """Settings for how each variable is to be displayed and processed."""
+    output_parser: Optional[DictOutputParser] = None
+    """How to parse the output of calling an LLM on this formatted prompt.
+
+    Must be provided if the LLM is completing all the inputs all at once."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    def __init__(
+        self,
+        prefix: str,
+        variables: Optional[Dict[str, str]] = None,
+        variable_configs: Optional[List[VariableConfig]] = None,
+        auto_suffix_variable_display: bool = True,
+        output_parser: Optional[DictOutputParser] = None,
+    ):
+        r"""Prompt template creator for getting multiple outputs from the LLM.
+
+        Args:
+            prefix: Prompt that asks for the values of each of the variables the LLM
+                    should fill in
+            variables: A mapping from the output key of each variable to its display in
+                    the prompt. Use this instead of `variable_configs` if you don't care
+                    about customizing per-variable prompts.
+            variable_configs: Information about each variable we want the value of. Use
+                    this instead of `variables` if you want fine-grained control over
+                    the display of variables in the prompt.
+            auto_suffix_variable_display: If true, for every variable that doesn't
+                    already have a suffix, the display values provided for each
+                    variable will have a colon and the variable stop appended to the
+                    end.
+
+                    For example, if this is true, and your variable display is
+                    "Action Input", this will automatically suffix the stop to get
+                    "Action Input: \"" for the final prompt.
+            output_parser: The output parser that will be called if this is asked to
+                    let the LLM complete all the outputs at once.
+        """
+        if variables is None and variable_configs is None:
+            raise ValueError("Please set either variables or variable_configs")
+        elif variables and variable_configs:
+            raise ValueError("Please set only one of variables or variable_configs")
+
+        if not variable_configs:
+            # this assert helps tell pydantic `variables` is assured to have a value at
+            # this point
+            assert variables is not None, "Please put the ValueError's back in"
+            variable_configs = [
+                VariableConfig(display=display, output_key=output_key)
+                for output_key, display in variables.items()
+            ]
+
+        if auto_suffix_variable_display:
+            new_configs = []
+            for variable in variable_configs:
+                if variable.display_suffix is None:
+                    new_suffix = f": {variable.stop}"
+                else:
+                    new_suffix = variable.display_suffix  # keep the old one
+                new_configs.append(
+                    dataclasses.replace(variable, display_suffix=new_suffix)
+                )
+            variable_configs = new_configs
+
+        super().__init__(
+            prefix=prefix, variables=variable_configs, output_parser=output_parser
+        )
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Output keys from this whole chain."""
+        return [v.output_key for v in self.variables]
+
+    def prompt_template_for_variable_at(self, i: int) -> PromptTemplate:
+        """Prompt for a single output variable to be filled in."""
+        output = self.variables[i]
+        inputs = self.variables[:i]
+        input_keys = [v.output_key for v in inputs]
+
+        template = self.prefix
+        for input in inputs:
+            template += input.prompt_with_value + "\n"
+        template += output.prompt
+
+        return PromptTemplate(
+            input_variables=input_keys,
+            template=template,
+        )
+
+    def prompt_template_for_full_input(self) -> PromptTemplate:
+        """Prompt for all outputs to be filled in in a single step."""
+        if not self.output_parser:
+            raise ValueError(
+                "Can't prompt for full input if we don't know how to parse it!"
+            )
+
+        first_template = self.prompt_template_for_variable_at(0)
+        first_template.output_parser = self.output_parser
+        return first_template
+
+    def log(self, completions: Dict[str, str]) -> str:
+        """Output the entirety of the LLM's inputs in this chain."""
+        initial_prompt = self.prompt_template_for_variable_at(0).format()
+
+        final_prompt = self.prefix
+        for var in self.variables:
+            final_prompt += var.prompt_with_value + "\n"
+        final_prompt = final_prompt.format(**completions)
+
+        assert final_prompt.startswith(initial_prompt), "Prompt reconstruction failed"
+
+        return final_prompt[len(initial_prompt) :].strip()

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -75,6 +75,14 @@ class ListOutputParser(BaseOutputParser):
         """Parse the output of an LLM call."""
 
 
+class DictOutputParser(BaseOutputParser):
+    """Class to parse the output of an LLM call to a dict."""
+
+    @abstractmethod
+    def parse(self, text: str) -> Dict[str, str]:
+        """Parse the output of an LLM call."""
+
+
 class CommaSeparatedListOutputParser(ListOutputParser):
     """Parse out comma separated lists."""
 

--- a/tests/unit_tests/chains/multiple_outputs/__init__.py
+++ b/tests/unit_tests/chains/multiple_outputs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for multiple-output chain functionality."""

--- a/tests/unit_tests/chains/multiple_outputs/test_chain.py
+++ b/tests/unit_tests/chains/multiple_outputs/test_chain.py
@@ -1,0 +1,40 @@
+"""Test that GetMultipleOutputsChain can run successfully."""
+
+from langchain.chains.multiple_outputs.base import GetMultipleOutputsChain
+from tests.unit_tests.llms.fake_llm import FakeLLM
+from tests.unit_tests.prompts.fake_parser import FakeDictParser
+
+
+def test_multiple_outputs_can_run() -> None:
+    """Test that GetMultipleOutputsChain can run successfully with multiple steps."""
+    chain = GetMultipleOutputsChain(
+        llm=FakeLLM(
+            ensure_and_remove_stop=True,
+            sequenced_responses=['fake tool"', 'fake input"'],
+        ),
+        prefix="Figure out what to do next.\n\n",
+        variables={"tool": "Action", "tool_input": "Action Input"},
+    )
+    assert chain({}) == {
+        "tool": "fake tool",
+        "tool_input": "fake input",
+    }
+
+
+def test_multiple_outputs_can_run_in_one_step() -> None:
+    """Test that GetMultipleOutputsChain can run successfully in a single step."""
+    chain = GetMultipleOutputsChain(
+        llm=FakeLLM(
+            ensure_and_remove_stop=True,
+            sequenced_responses=["fake tool\nAction Input: fake input\nObservation:"],
+        ),
+        prefix="Figure out what to do next.\n\n",
+        variables={"tool": "Action", "tool_input": "Action Input"},
+        one_step=True,
+        one_step_stop="Observation:",
+        output_parser=FakeDictParser(),
+    )
+    assert chain({}) == {
+        "tool": "Fake tool",
+        "tool_input": "Fake input",
+    }

--- a/tests/unit_tests/chains/multiple_outputs/test_prompter.py
+++ b/tests/unit_tests/chains/multiple_outputs/test_prompter.py
@@ -1,0 +1,328 @@
+"""Test step-by-step prompting for GetMultipleOutputsChain."""
+
+from collections import OrderedDict
+
+from langchain.chains.multiple_outputs import MultipleOutputsPrompter, VariableConfig
+from tests.unit_tests.prompts.fake_parser import FakeDictParser
+
+
+def test_prompter_with_defaults() -> None:
+    """Test templating with the simplest defaults."""
+    prompter = MultipleOutputsPrompter(
+        prefix="Figure out what to do next.\n\n",
+        variables={
+            "tool": "Action",
+            "tool_input": "Action Input",
+        },
+    )
+
+    first_prompt_template = prompter.prompt_template_for_variable_at(0)
+    assert first_prompt_template.output_parser is None
+    first_prompt = first_prompt_template.format()
+    assert (
+        first_prompt
+        == """
+Figure out what to do next.
+
+Action: "
+    """.strip()
+    )
+
+    second_prompt_template = prompter.prompt_template_for_variable_at(1)
+    assert second_prompt_template.output_parser is None
+    second_prompt = second_prompt_template.format(tool="Search")
+    assert (
+        second_prompt
+        == """
+Figure out what to do next.
+
+Action: "Search"
+Action Input: "
+    """.strip()
+    )
+
+
+def test_prompter_without_auto_suffixing() -> None:
+    """Test templating without automatic suffixes applied."""
+    prompter = MultipleOutputsPrompter(
+        prefix="Figure out what to do next.\n\n",
+        variables=OrderedDict(tool='Action: "', tool_input='Action Input: "'),
+        auto_suffix_variable_display=False,
+        # also test that output parser doesn't leak into templates by default
+        output_parser=FakeDictParser(),
+    )
+
+    first_prompt_template = prompter.prompt_template_for_variable_at(0)
+    assert first_prompt_template.output_parser is None
+    first_prompt = first_prompt_template.format()
+    assert (
+        first_prompt
+        == """
+Figure out what to do next.
+
+Action: "
+    """.strip()
+    )
+
+    second_prompt_template = prompter.prompt_template_for_variable_at(1)
+    assert second_prompt_template.output_parser is None
+    second_prompt = second_prompt_template.format(tool="Search")
+    assert (
+        second_prompt
+        == """
+Figure out what to do next.
+
+Action: "Search"
+Action Input: "
+    """.strip()
+    )
+
+
+def test_prompter_with_specified_variables() -> None:
+    """Test templating when variables are specified instead of a dict."""
+    prompter = MultipleOutputsPrompter(
+        prefix="Write some code.\n\n",
+        variable_configs=[
+            VariableConfig(display="File Path", output_key="path"),
+            VariableConfig(display="Code", output_key="code", stop="```"),
+            VariableConfig(display="Tests", output_key="test_code", stop="```"),
+        ],
+        # also test that output parser doesn't leak into templates by default
+        output_parser=FakeDictParser(),
+    )
+
+    first_prompt_template = prompter.prompt_template_for_variable_at(0)
+    assert first_prompt_template.output_parser is None
+    first_prompt = first_prompt_template.format()
+    assert (
+        first_prompt
+        == """
+Write some code.
+
+File Path: "
+    """.strip()
+    )
+
+    second_prompt_template = prompter.prompt_template_for_variable_at(1)
+    assert second_prompt_template.output_parser is None
+    second_prompt = second_prompt_template.format(path="my_module/functionality.py")
+    assert (
+        second_prompt
+        == """
+Write some code.
+
+File Path: "my_module/functionality.py"
+Code: ```
+""".strip()
+    )
+
+    third_prompt_template = prompter.prompt_template_for_variable_at(2)
+    third_prompt = third_prompt_template.format(
+        path="my_module/functionality.py",
+        code="""\ndef do_something():\n    print("Hello world!")\n""",
+    )
+    assert (
+        third_prompt
+        == """
+Write some code.
+
+File Path: "my_module/functionality.py"
+Code: ```
+def do_something():
+    print("Hello world!")
+```
+Tests: ```
+""".strip()
+    )
+
+
+def test_prompter_dont_override_custom_suffix() -> None:
+    """Test templating when variables have a custom suffix applied."""
+    prompter = MultipleOutputsPrompter(
+        prefix="Write some code.\n\n",
+        variable_configs=[
+            VariableConfig(display="File Path", output_key="path"),
+            VariableConfig(display="Code", output_key="code", stop="```"),
+            VariableConfig(
+                display="Tests",
+                output_key="test_code",
+                stop="```",
+                display_suffix=": ```python",
+            ),
+        ],
+        # also test that output parser doesn't leak into templates by default
+        output_parser=FakeDictParser(),
+    )
+
+    first_prompt_template = prompter.prompt_template_for_variable_at(0)
+    assert first_prompt_template.output_parser is None
+    first_prompt = first_prompt_template.format()
+    assert (
+        first_prompt
+        == """
+Write some code.
+
+File Path: "
+    """.strip()
+    )
+
+    second_prompt_template = prompter.prompt_template_for_variable_at(1)
+    assert second_prompt_template.output_parser is None
+    second_prompt = second_prompt_template.format(path="my_module/functionality.py")
+    assert (
+        second_prompt
+        == """
+Write some code.
+
+File Path: "my_module/functionality.py"
+Code: ```
+""".strip()
+    )
+
+    third_prompt_template = prompter.prompt_template_for_variable_at(2)
+    third_prompt = third_prompt_template.format(
+        path="my_module/functionality.py",
+        code="""\ndef do_something():\n    print("Hello world!")\n""",
+    )
+    assert (
+        third_prompt
+        == """
+Write some code.
+
+File Path: "my_module/functionality.py"
+Code: ```
+def do_something():
+    print("Hello world!")
+```
+Tests: ```python
+""".strip()
+    )
+
+
+def test_prompter_with_fully_specified_variables() -> None:
+    """Test templating when all variables are fully specified.
+
+    Now we want to start the code blocks with ```python, but end them with ``` still.
+    """
+    prompter = MultipleOutputsPrompter(
+        prefix="Write some code.\n\n",
+        variable_configs=[
+            VariableConfig(
+                display="File Path",
+                display_suffix=': "',
+                output_key="path",
+                stop='"',
+            ),
+            VariableConfig.for_code(
+                display="Code",
+                output_key="code",
+                language="python",
+            ),
+            # test one config without the language specified
+            VariableConfig.for_code(
+                display="Tests",
+                output_key="test_code",
+            ),
+        ],
+        auto_suffix_variable_display=False,
+        # also test that output parser doesn't leak into templates by default
+        output_parser=FakeDictParser(),
+    )
+
+    first_prompt_template = prompter.prompt_template_for_variable_at(0)
+    assert first_prompt_template.output_parser is None
+    first_prompt = first_prompt_template.format()
+    assert (
+        first_prompt
+        == """
+Write some code.
+
+File Path: "
+    """.strip()
+    )
+
+    second_prompt_template = prompter.prompt_template_for_variable_at(1)
+    assert second_prompt_template.output_parser is None
+    second_prompt = second_prompt_template.format(path="my_module/functionality.py")
+    assert (
+        second_prompt
+        == """
+Write some code.
+
+File Path: "my_module/functionality.py"
+Code: ```python
+""".lstrip()
+    )
+
+    third_prompt_template = prompter.prompt_template_for_variable_at(2)
+    third_prompt = third_prompt_template.format(
+        path="my_module/functionality.py",
+        code="""def do_something():\n    print("Hello world!")\n""",
+    )
+    assert (
+        third_prompt
+        == """
+Write some code.
+
+File Path: "my_module/functionality.py"
+Code: ```python
+def do_something():
+    print("Hello world!")
+```
+Tests: ```
+""".lstrip()
+    )
+
+
+def test_prompter_full_input() -> None:
+    """Test prompt templating when asking for all outputs at once.
+
+    The prompt should be exactly the same as the prompt for the first step of the
+    sequential chain. The only differences should exist in the presence of an
+    output_parser, and in the lack of a stop (because now the stop would be for the
+    whole chain, not just per-variable).
+    """
+    prompter = MultipleOutputsPrompter(
+        prefix="Figure out what to do next.\n\n",
+        variables=OrderedDict(
+            tool="Action",
+            tool_input="Action Input",
+        ),
+        output_parser=FakeDictParser(),
+    )
+
+    full_input_template = prompter.prompt_template_for_full_input()
+    assert full_input_template.output_parser is prompter.output_parser
+    full_input_prompt = full_input_template.format()
+    assert (
+        full_input_prompt
+        == """
+Figure out what to do next.
+
+Action: "
+    """.strip()
+    )
+
+
+def test_prompter_log() -> None:
+    """Test reconstruction of the full LLM output from this interaction."""
+    prompter = MultipleOutputsPrompter(
+        prefix="Figure out what to do next.\n\n",
+        variables=OrderedDict(
+            tool="Action",
+            tool_input="Action Input",
+        ),
+    )
+
+    assert (
+        prompter.log(
+            {
+                "tool": "Search",
+                "tool_input": "Olivia Wilde boyfriend",
+            }
+        )
+        == """
+Search"
+Action Input: "Olivia Wilde boyfriend"
+    """.strip()
+    )

--- a/tests/unit_tests/chains/multiple_outputs/test_variable_config.py
+++ b/tests/unit_tests/chains/multiple_outputs/test_variable_config.py
@@ -1,0 +1,44 @@
+"""Configurations for variables that we want to get LLM outputs for."""
+
+from langchain.chains.multiple_outputs.config import VariableConfig
+
+
+def test_default_prompt() -> None:
+    """Test that the simplest default options for variables work as expected."""
+    config = VariableConfig(display='Action Input: "', output_key="input")
+    assert config.prompt == 'Action Input: "'
+    assert config.output_key == "input"
+    assert config.stop == '"'
+
+
+def test_prompt_with_display_suffix() -> None:
+    """Test that we can attach a suffix to the variable display."""
+    config = VariableConfig(
+        display="Action Input",
+        display_suffix=': "',
+        output_key="input",
+    )
+    assert config.prompt == 'Action Input: "'
+    assert config.output_key == "input"
+    assert config.stop == '"'
+
+
+def test_prompt_with_value() -> None:
+    """Test constructing of templating string after value filled in."""
+    config = VariableConfig(
+        display="Action Input",
+        display_suffix=': "',
+        output_key="input",
+    )
+    assert config.prompt_with_value == 'Action Input: "{input}"'
+
+
+def test_prompt_with_custom_stop() -> None:
+    """Test that templating string includes custom final stop."""
+    config = VariableConfig(
+        display="Input Code",
+        display_suffix=": ```",
+        output_key="input",
+        stop="```",
+    )
+    assert config.prompt_with_value == "Input Code: ```{input}```"

--- a/tests/unit_tests/llms/fake_llm.py
+++ b/tests/unit_tests/llms/fake_llm.py
@@ -10,16 +10,44 @@ class FakeLLM(LLM, BaseModel):
     """Fake LLM wrapper for testing purposes."""
 
     queries: Optional[Mapping] = None
+    sequenced_responses: Optional[List[str]] = None
+    """List of responses to return in order.
+
+    Useful if the prompt is too complicated to reconstruct for testing."""
+    num_calls: int = 0
+    """Keeps track of which sequenced response to return."""
+    ensure_and_remove_stop: bool = False
+    """Set to true to check that stops are being set, and being set properly.
+
+    `queries` must be modified to have the stop present.
+    """
 
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
         return "fake"
 
+    def _check_stop(self, result: str, stop: Optional[List[str]]) -> str:
+        if self.ensure_and_remove_stop:
+            assert stop is not None, "Stop has not been set"
+            # stop is apparently a list... but it's a string everywhere else in the
+            # project. Just make it a str to stop mypy complaining
+            str_stop = str(stop)
+            assert result.endswith(
+                str_stop
+            ), f"Output '{result}' does not end in {stop}"
+            result = result[: len(result) - len(stop)]
+
+        return result
+
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         """First try to lookup in queries, else return 'foo' or 'bar'."""
+        self.num_calls += 1
+
         if self.queries is not None:
-            return self.queries[prompt]
+            return self._check_stop(self.queries[prompt], stop)
+        if self.sequenced_responses is not None:
+            return self._check_stop(self.sequenced_responses[self.num_calls - 1], stop)
         if stop is None:
             return "foo"
         else:

--- a/tests/unit_tests/prompts/fake_parser.py
+++ b/tests/unit_tests/prompts/fake_parser.py
@@ -1,0 +1,21 @@
+"""Fake parsers for testing purposes."""
+
+
+from typing import Dict, Mapping, Optional
+
+from langchain.prompts.base import DictOutputParser
+
+
+class FakeDictParser(DictOutputParser):
+    """Fake dict parser for testing purposes."""
+
+    parses: Optional[Mapping] = None
+
+    def parse(self, text: str) -> Dict[str, str]:
+        """Return fake parse from input."""
+        if self.parses is not None:
+            return self.parses[text]
+        return {
+            "tool": "Fake tool",
+            "tool_input": "Fake input",
+        }


### PR DESCRIPTION
Right now, it seems that if you want to get multiple inputs from the LLM, you have to write a custom regex parser like ZeroShotAgent does with its get_action_and_input. I would like to suggest that we add an optional generic way to retrieve such inputs.

Please feel free to suggest or make changes to this PR!