### PR TITLE
Add missing verb

### DIFF
--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -126,7 +126,7 @@ class BasePromptTemplate(BaseModel, ABC):
 
     @root_validator()
     def validate_variable_names(cls, values: Dict) -> Dict:
-        """Validate variable names do not restricted names."""
+        """Validate variable names do not include restricted names."""
         if "stop" in values["input_variables"]:
             raise ValueError(
                 "Cannot have an input variable named 'stop', as it is used internally,"


### PR DESCRIPTION
Mini drive-by PR:

I came across this sentence in a stack trace for an error I had, and it confused me because the verb I missing. So I added the verb.