### PR TITLE
Update PAL to allow passing local and global context to PythonREPL

### DIFF
--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -27,7 +27,6 @@ class PALChain(Chain, BaseModel):
     python_globals: Dict[str, Any] = None
     python_locals: Dict[str, Any] = None
     output_key: str = "result"  #: :meta private:
-    code_history: List[str] = []   #: :meta private:
 
     class Config:
         """Configuration for this pydantic object."""
@@ -57,7 +56,6 @@ class PALChain(Chain, BaseModel):
         self.callback_manager.on_text(
             code, color="green", end="\n", verbose=self.verbose
         )
-        self.code_history.append(code)
         repl = PythonREPL(_globals=self.python_globals, _locals=self.python_locals)
         res = repl.run(code + f"\n{self.get_answer_expr}")
         return {self.output_key: res.strip()}

--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -24,7 +24,10 @@ class PALChain(Chain, BaseModel):
     prompt: BasePromptTemplate
     stop: str = "\n\n"
     get_answer_expr: str = "print(solution())"
+    python_globals: Dict[str, Any] = None
+    python_locals: Dict[str, Any] = None
     output_key: str = "result"  #: :meta private:
+    code_history: List[str] = None   #: :meta private:
 
     class Config:
         """Configuration for this pydantic object."""
@@ -54,7 +57,8 @@ class PALChain(Chain, BaseModel):
         self.callback_manager.on_text(
             code, color="green", end="\n", verbose=self.verbose
         )
-        repl = PythonREPL()
+        self.code_history.append(code)
+        repl = PythonREPL(_globals=self.python_globals, _locals=self.python_locals)
         res = repl.run(code + f"\n{self.get_answer_expr}")
         return {self.output_key: res.strip()}
 

--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -4,7 +4,7 @@ As in https://arxiv.org/pdf/2211.10435.pdf.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Extra
 
@@ -24,8 +24,8 @@ class PALChain(Chain, BaseModel):
     prompt: BasePromptTemplate
     stop: str = "\n\n"
     get_answer_expr: str = "print(solution())"
-    python_globals: Dict[str, Any] = None
-    python_locals: Dict[str, Any] = None
+    python_globals: Optional[Dict[str, Any]] = None
+    python_locals: Optional[Dict[str, Any]] = None
     output_key: str = "result"  #: :meta private:
 
     class Config:

--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -27,7 +27,7 @@ class PALChain(Chain, BaseModel):
     python_globals: Dict[str, Any] = None
     python_locals: Dict[str, Any] = None
     output_key: str = "result"  #: :meta private:
-    code_history: List[str] = None   #: :meta private:
+    code_history: List[str] = []   #: :meta private:
 
     class Config:
         """Configuration for this pydantic object."""


### PR DESCRIPTION
Passing additional variables to the python environment can be useful for example if you want to generate code to analyze a dataset. 

I also added a tracker for the executed code - `code_history`.