### PR TITLE
quick refactor: Chain -> BaseChain

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, root_validator
 
 from langchain.agents.tools import Tool
 from langchain.callbacks.base import BaseCallbackManager
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.input import get_color_mapping
 from langchain.llms.base import BaseLLM
@@ -242,7 +242,7 @@ class Agent(BaseModel):
             raise ValueError(f"{save_path} must be json or yaml")
 
 
-class AgentExecutor(Chain, BaseModel):
+class AgentExecutor(BaseChain, BaseModel):
     """Consists of an agent using tools."""
 
     agent: Agent

--- a/langchain/chains/api/base.py
+++ b/langchain/chains/api/base.py
@@ -6,14 +6,14 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field, root_validator
 
 from langchain.chains.api.prompt import API_RESPONSE_PROMPT, API_URL_PROMPT
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.llms.base import BaseLLM
 from langchain.prompts import BasePromptTemplate
 from langchain.requests import RequestsWrapper
 
 
-class APIChain(Chain, BaseModel):
+class APIChain(BaseChain, BaseModel):
     """Chain that makes API calls and summarizes the responses to answer a question."""
 
     api_request_chain: LLMChain

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -43,7 +43,7 @@ def _get_verbosity() -> bool:
     return langchain.verbose
 
 
-class Chain(BaseModel, ABC):
+class BaseChain(BaseModel, ABC):
     """Base interface that all chains should implement."""
 
     memory: Optional[Memory] = None

--- a/langchain/chains/combine_documents/base.py
+++ b/langchain/chains/combine_documents/base.py
@@ -5,11 +5,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.docstore.document import Document
 
 
-class BaseCombineDocumentsChain(Chain, BaseModel, ABC):
+class BaseCombineDocumentsChain(BaseChain, BaseModel, ABC):
     """Base interface for chains combining documents."""
 
     input_key: str = "input_documents"  #: :meta private:

--- a/langchain/chains/hyde/base.py
+++ b/langchain/chains/hyde/base.py
@@ -9,14 +9,14 @@ from typing import Dict, List
 import numpy as np
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.hyde.prompts import PROMPT_MAP
 from langchain.chains.llm import LLMChain
 from langchain.embeddings.base import Embeddings
 from langchain.llms.base import BaseLLM
 
 
-class HypotheticalDocumentEmbedder(Chain, Embeddings, BaseModel):
+class HypotheticalDocumentEmbedder(BaseChain, Embeddings, BaseModel):
     """Generate hypothetical document for query, and then embed that.
 
     Based on https://arxiv.org/abs/2212.10496

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -3,14 +3,14 @@ from typing import Any, Dict, List, Sequence, Union
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.input import get_colored_text
 from langchain.llms.base import BaseLLM
 from langchain.prompts.base import BasePromptTemplate
 from langchain.schema import LLMResult
 
 
-class LLMChain(Chain, BaseModel):
+class LLMChain(BaseChain, BaseModel):
     """Chain to run queries against LLMs.
 
     Example:

--- a/langchain/chains/llm_bash/base.py
+++ b/langchain/chains/llm_bash/base.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_bash.prompt import PROMPT
 from langchain.llms.base import BaseLLM
@@ -11,7 +11,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.utilities.bash import BashProcess
 
 
-class LLMBashChain(Chain, BaseModel):
+class LLMBashChain(BaseChain, BaseModel):
     """Chain that interprets a prompt and executes bash code to perform bash operations.
 
     Example:

--- a/langchain/chains/llm_checker/base.py
+++ b/langchain/chains/llm_checker/base.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_checker.prompt import (
     CHECK_ASSERTIONS_PROMPT,
@@ -18,7 +18,7 @@ from langchain.llms.base import BaseLLM
 from langchain.prompts import PromptTemplate
 
 
-class LLMCheckerChain(Chain, BaseModel):
+class LLMCheckerChain(BaseChain, BaseModel):
     """Chain for question-answering with self-verification.
 
     Example:

--- a/langchain/chains/llm_math/base.py
+++ b/langchain/chains/llm_math/base.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.llm_math.prompt import PROMPT
 from langchain.llms.base import BaseLLM
@@ -11,7 +11,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.python import PythonREPL
 
 
-class LLMMathChain(Chain, BaseModel):
+class LLMMathChain(BaseChain, BaseModel):
     """Chain that interprets a prompt and executes python code to do math.
 
     Example:

--- a/langchain/chains/llm_requests.py
+++ b/langchain/chains/llm_requests.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 from pydantic import BaseModel, Extra, Field, root_validator
 
 from langchain.chains import LLMChain
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.requests import RequestsWrapper
 
 DEFAULT_HEADERS = {
@@ -14,7 +14,7 @@ DEFAULT_HEADERS = {
 }
 
 
-class LLMRequestsChain(Chain, BaseModel):
+class LLMRequestsChain(BaseChain, BaseModel):
     """Chain that hits a URL and then uses an LLM to parse results."""
 
     llm_chain: LLMChain

--- a/langchain/chains/loading.py
+++ b/langchain/chains/loading.py
@@ -9,7 +9,7 @@ import requests
 import yaml
 
 from langchain.chains.api.base import APIChain
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
 from langchain.chains.combine_documents.map_rerank import MapRerankDocumentsChain
 from langchain.chains.combine_documents.refine import RefineDocumentsChain
@@ -426,7 +426,7 @@ type_to_loader_dict = {
 }
 
 
-def load_chain_from_config(config: dict, **kwargs: Any) -> Chain:
+def load_chain_from_config(config: dict, **kwargs: Any) -> BaseChain:
     """Load chain from Config Dict."""
     if "_type" not in config:
         raise ValueError("Must specify a chain Type in config")
@@ -439,7 +439,7 @@ def load_chain_from_config(config: dict, **kwargs: Any) -> Chain:
     return chain_loader(config, **kwargs)
 
 
-def load_chain(path: Union[str, Path], **kwargs: Any) -> Chain:
+def load_chain(path: Union[str, Path], **kwargs: Any) -> BaseChain:
     """Unified method for loading a chain from LangChainHub or local fs."""
     if isinstance(path, str) and path.startswith("lc://chains"):
         path = os.path.relpath(path, "lc://chains/")
@@ -448,7 +448,7 @@ def load_chain(path: Union[str, Path], **kwargs: Any) -> Chain:
         return _load_chain_from_file(path, **kwargs)
 
 
-def _load_chain_from_file(file: Union[str, Path], **kwargs: Any) -> Chain:
+def _load_chain_from_file(file: Union[str, Path], **kwargs: Any) -> BaseChain:
     """Load chain from file."""
     # Convert file to Path object.
     if isinstance(file, str):
@@ -468,7 +468,7 @@ def _load_chain_from_file(file: Union[str, Path], **kwargs: Any) -> Chain:
     return load_chain_from_config(config, **kwargs)
 
 
-def _load_from_hub(path: str, **kwargs: Any) -> Chain:
+def _load_from_hub(path: str, **kwargs: Any) -> BaseChain:
     """Load chain from hub."""
     suffix = path.split(".")[-1]
     if suffix not in {"json", "yaml"}:

--- a/langchain/chains/mapreduce.py
+++ b/langchain/chains/mapreduce.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
@@ -20,7 +20,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.text_splitter import TextSplitter
 
 
-class MapReduceChain(Chain, BaseModel):
+class MapReduceChain(BaseChain, BaseModel):
     """Map-reduce chain."""
 
     combine_documents_chain: BaseCombineDocumentsChain

--- a/langchain/chains/moderation.py
+++ b/langchain/chains/moderation.py
@@ -3,11 +3,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, root_validator
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.utils import get_from_dict_or_env
 
 
-class OpenAIModerationChain(Chain, BaseModel):
+class OpenAIModerationChain(BaseChain, BaseModel):
     """Pass input through a moderation endpoint.
 
     To use, you should have the ``openai`` python package installed, and the

--- a/langchain/chains/natbot/base.py
+++ b/langchain/chains/natbot/base.py
@@ -5,14 +5,14 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.natbot.prompt import PROMPT
 from langchain.llms.base import BaseLLM
 from langchain.llms.openai import OpenAI
 
 
-class NatBotChain(Chain, BaseModel):
+class NatBotChain(BaseChain, BaseModel):
     """Implement an LLM driven browser.
 
     Example:

--- a/langchain/chains/pal/base.py
+++ b/langchain/chains/pal/base.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.pal.colored_object_prompt import COLORED_OBJECT_PROMPT
 from langchain.chains.pal.math_prompt import MATH_PROMPT
@@ -17,7 +17,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.python import PythonREPL
 
 
-class PALChain(Chain, BaseModel):
+class PALChain(BaseChain, BaseModel):
     """Implements Program-Aided Language Models."""
 
     llm: BaseLLM

--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
@@ -23,7 +23,7 @@ from langchain.llms.base import BaseLLM
 from langchain.prompts.base import BasePromptTemplate
 
 
-class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
+class BaseQAWithSourcesChain(BaseChain, BaseModel, ABC):
     """Question answering with sources over documents."""
 
     combine_documents_chain: BaseCombineDocumentsChain

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -4,14 +4,14 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.input import get_color_mapping
 
 
-class SequentialChain(Chain, BaseModel):
+class SequentialChain(BaseChain, BaseModel):
     """Chain where the outputs of one step feed directly into next."""
 
-    chains: List[Chain]
+    chains: List[BaseChain]
     input_variables: List[str]
     output_variables: List[str]  #: :meta private:
     return_all: bool = False
@@ -80,10 +80,10 @@ class SequentialChain(Chain, BaseModel):
         return {k: known_values[k] for k in self.output_variables}
 
 
-class SimpleSequentialChain(Chain, BaseModel):
+class SimpleSequentialChain(BaseChain, BaseModel):
     """Simple chain where the outputs of one step feed directly into next."""
 
-    chains: List[Chain]
+    chains: List[BaseChain]
     strip_outputs: bool = False
     input_key: str = "input"  #: :meta private:
     output_key: str = "output"  #: :meta private:

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra, Field
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.sql_database.prompt import DECIDER_PROMPT, PROMPT
 from langchain.llms.base import BaseLLM
@@ -13,7 +13,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.sql_database import SQLDatabase
 
 
-class SQLDatabaseChain(Chain, BaseModel):
+class SQLDatabaseChain(BaseChain, BaseModel):
     """Chain for interacting with SQL Database.
 
     Example:
@@ -89,7 +89,7 @@ class SQLDatabaseChain(Chain, BaseModel):
         return "sql_database_chain"
 
 
-class SQLDatabaseSequentialChain(Chain, BaseModel):
+class SQLDatabaseSequentialChain(BaseChain, BaseModel):
     """Chain for querying SQL database that is a sequential chain.
 
     The chain is as follows:

--- a/langchain/chains/transform.py
+++ b/langchain/chains/transform.py
@@ -3,10 +3,10 @@ from typing import Callable, Dict, List
 
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 
 
-class TransformChain(Chain, BaseModel):
+class TransformChain(BaseChain, BaseModel):
     """Chain transform chain output.
 
     Example:

--- a/langchain/chains/vector_db_qa/base.py
+++ b/langchain/chains/vector_db_qa/base.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
 from langchain.chains.llm import LLMChain
@@ -16,7 +16,7 @@ from langchain.prompts import PromptTemplate
 from langchain.vectorstores.base import VectorStore
 
 
-class VectorDBQA(Chain, BaseModel):
+class VectorDBQA(BaseChain, BaseModel):
     """Chain for question-answering against a vector database.
 
     Example:

--- a/langchain/model_laboratory.py
+++ b/langchain/model_laboratory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Sequence
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.llm import LLMChain
 from langchain.input import get_color_mapping, print_text
 from langchain.llms.base import BaseLLM
@@ -13,14 +13,14 @@ from langchain.prompts.prompt import PromptTemplate
 class ModelLaboratory:
     """Experiment with different models."""
 
-    def __init__(self, chains: Sequence[Chain], names: Optional[List[str]] = None):
+    def __init__(self, chains: Sequence[BaseChain], names: Optional[List[str]] = None):
         """Initialize with chains to experiment with.
 
         Args:
             chains: list of chains to experiment with.
         """
         for chain in chains:
-            if not isinstance(chain, Chain):
+            if not isinstance(chain, BaseChain):
                 raise ValueError(
                     "ModelLaboratory should now be initialized with Chains. "
                     "If you want to initialize with LLMs, use the `from_llms` method "

--- a/tests/unit_tests/chains/test_base.py
+++ b/tests/unit_tests/chains/test_base.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import BaseModel
 
 from langchain.callbacks.base import CallbackManager
-from langchain.chains.base import Chain, Memory
+from langchain.chains.base import BaseChain, Memory
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 
@@ -30,7 +30,7 @@ class FakeMemory(Memory, BaseModel):
         pass
 
 
-class FakeChain(Chain, BaseModel):
+class FakeChain(BaseChain, BaseModel):
     """Fake chain class for testing purposes."""
 
     be_correct: bool = True

--- a/tests/unit_tests/chains/test_sequential.py
+++ b/tests/unit_tests/chains/test_sequential.py
@@ -4,11 +4,11 @@ from typing import Dict, List
 import pytest
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import BaseChain
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 
 
-class FakeChain(Chain, BaseModel):
+class FakeChain(BaseChain, BaseModel):
     """Fake Chain for testing purposes."""
 
     input_variables: List[str]


### PR DESCRIPTION
This makes the naming convention consistent (there is `BaseLLM`, `BasePromptTemplate`, `BaseCallbackHandler`, etc.)