### PR TITLE
Implementing a decorator to make Tools

### DIFF
--- a/docs/modules/agents/examples/custom_tools.ipynb
+++ b/docs/modules/agents/examples/custom_tools.ipynb
@@ -23,9 +23,9 @@
     "\n",
     "The two required components of a Tool are the name and then the tool itself. A tool description is optional, as it is needed for some agents but not all.\n",
     "\n",
-    "## Using the @tool Decorator\n",
+    "# Using the @tool Decorator\n",
     "\n",
-    "To make it easier to define custom tools, a `@tool` decorator is provided. This decorator can be used to quickly create a `Tool` from a simple function. The decorator can be used with or without arguments. The decorator uses the function name as the tool name by default, but this can be overridden by passing a string as the first argument. Additionally, the decorator uses the function's docstring as the tool's description.\n",
+    "To make it easier to define custom tools, a `@tool` decorator is provided. This decorator can be used to quickly create a `Tool` from a simple function. The decorator uses the function name as the tool name by default, but this can be overridden by passing a string as the first argument. Additionally, the decorator will use the function's docstring as the tool's description.\n",
     "\n",
     "```python\n",
     "from langchain.agents import tool\n",
@@ -44,7 +44,7 @@
     "tools = [search_api]\n",
     "```\n",
     "\n",
-    "After using the decorator, you can inspect the function and realize it's a `Tool` instead, but can still be called as if it was a function.\n",
+    "If you inspect the function, you'll see that it's a `Tool` instance instead, this tool can still be called as if it was a function.\n",
     "\n",
     "``` python\n",
     "print(search_api)\n",
@@ -52,8 +52,7 @@
     "\n",
     "search_api(query=\"123\")\n",
     "# \"Results\"\n",
-    "```\n",
-    "\n"
+    "```"
    ]
   },
   {

--- a/docs/modules/agents/examples/custom_tools.ipynb
+++ b/docs/modules/agents/examples/custom_tools.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5436020b",
    "metadata": {},
@@ -10,15 +11,49 @@
     "When constructing your own agent, you will need to provide it with a list of Tools that it can use. A Tool is defined as below.\n",
     "\n",
     "```python\n",
-    "class Tool(NamedTuple):\n",
+    "@dataclass \n",
+    "class Tool:\n",
     "    \"\"\"Interface for tools.\"\"\"\n",
     "\n",
     "    name: str\n",
     "    func: Callable[[str], str]\n",
     "    description: Optional[str] = None\n",
+    "    return_direct: bool = True\n",
     "```\n",
     "\n",
-    "The two required components of a Tool are the name and then the tool itself. A tool description is optional, as it is needed for some agents but not all."
+    "The two required components of a Tool are the name and then the tool itself. A tool description is optional, as it is needed for some agents but not all.\n",
+    "\n",
+    "## Using the @tool Decorator\n",
+    "\n",
+    "To make it easier to define custom tools, a `@tool` decorator is provided. This decorator can be used to quickly create a `Tool` from a simple function. The decorator can be used with or without arguments. The decorator uses the function name as the tool name by default, but this can be overridden by passing a string as the first argument. Additionally, the decorator uses the function's docstring as the tool's description.\n",
+    "\n",
+    "```python\n",
+    "from langchain.agents import tool\n",
+    "\n",
+    "@tool\n",
+    "def search_api(query: str) -> str:\n",
+    "    \"\"\"Searches the API for the query.\"\"\"\n",
+    "    return \"Results\"\n",
+    "\n",
+    "\n",
+    "@tool(\"search\", return_direct=True)\n",
+    "def search_api(query: str) -> str:\n",
+    "    \"\"\"Searches the API for the query.\"\"\"\n",
+    "    return \"Results\"\n",
+    "\n",
+    "tools = [search_api]\n",
+    "```\n",
+    "\n",
+    "After using the decorator, you can inspect the function and realize it's a `Tool` instead, but can still be called as if it was a function.\n",
+    "\n",
+    "``` python\n",
+    "print(search_api)\n",
+    "# Tool(name='search_api', func=<function search_api at 0x10fd7cd30>, description='search_api(query: str) -> str - Searches the API for the query.', return_direct=True)\n",
+    "\n",
+    "search_api(query=\"123\")\n",
+    "# \"Results\"\n",
+    "```\n",
+    "\n"
    ]
   },
   {
@@ -414,7 +449,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -428,11 +463,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.6 (default, Aug  5 2022, 15:21:02) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "cb23c3a7a387ab03496baa08507270f8e0861b23170e79d5edc545893cdca840"
+    "hash": "e90c8aa204a57276aa905271aff2d11799d0acb3547adabc5892e639a5e45e34"
    }
   }
  },

--- a/langchain/agents/tools.py
+++ b/langchain/agents/tools.py
@@ -27,20 +27,18 @@ def tool(
         - Function must be of type (str) -> str
         - Function must have a docstring
 
-    Usage:
-        - Without arguments the function name is used as the tool name, otherwise the name can be specified as an argument.
+    Examples:
+        .. code-block:: python
 
-    ```
-    @tool
-    def search_api(query: str) -> str:
-        # Searches the API for the query.
-        return
+            @tool
+            def search_api(query: str) -> str:
+                # Searches the API for the query.
+                return
 
-    @tool("search", return_direct=True)
-    def search_api(query: str) -> str:
-        # Searches the API for the query.
-        return
-    ```
+            @tool("search", return_direct=True)
+            def search_api(query: str) -> str:
+                # Searches the API for the query.
+                return
     """
 
     def _make_with_name(tool_name: str, return_direct: bool = False) -> Callable:

--- a/langchain/agents/tools.py
+++ b/langchain/agents/tools.py
@@ -46,7 +46,7 @@ def tool(
             assert func.__doc__, "Function must have a docstring"
             # Description example:
             #   search_api(query: str) - Searches the API for the query.
-            description = f"{tool_name}{signature(func)} - {func.__doc__}"
+            description = f"{tool_name}{signature(func)} - {func.__doc__.strip()}"
             tool = Tool(
                 name=tool_name,
                 func=func,

--- a/langchain/agents/tools.py
+++ b/langchain/agents/tools.py
@@ -1,6 +1,8 @@
 """Interface for tools."""
+import functools
 from dataclasses import dataclass
-from typing import Callable, Optional
+from inspect import getfullargspec, signature
+from typing import Callable, Optional, Union
 
 
 @dataclass
@@ -11,3 +13,66 @@ class Tool:
     func: Callable[[str], str]
     description: Optional[str] = None
     return_direct: bool = False
+
+    def __call__(self, *args: str, **kwargs: str) -> str:
+        return self.func(*args, **kwargs)
+
+
+def tool(
+    *args: Union[str, Callable], return_direct: bool = False
+) -> Union[Callable, Tool]:
+    """Decorator to make tools out of functions, can be used with or without arguments.
+
+    Requires:
+        - Function must be of type (str) -> str
+        - Function must have a docstring
+
+    Usage:
+        - Without arguments the function name is used as the tool name, otherwise the name can be specified as an argument.
+
+    ```
+    @tool
+    def search_api(query: str) -> str:
+        # Searches the API for the query.
+        return
+
+    @tool("search", return_direct=True)
+    def search_api(query: str) -> str:
+        # Searches the API for the query.
+        return
+    ```
+    """
+
+    def _make_with_name(tool_name: str, return_direct: bool = False) -> Callable:
+        def _make_tool(func: Callable[[str], str]) -> Tool:
+            assert func.__doc__, "Function must have a docstring"
+            # Description example:
+            #   search_api(query: str) - Searches the API for the query.
+            description = f"{tool_name}{signature(func)} - {func.__doc__}"
+            tool = Tool(
+                name=tool_name,
+                func=func,
+                description=description,
+                return_direct=return_direct,
+            )
+            return tool
+
+        return _make_tool
+
+    if len(args) == 1 and isinstance(args[0], str):
+        # if the argument is a string, then we use the string as the tool name
+        # Example usage: @tool("search", return_direct=True)
+        return _make_with_name(args[0], return_direct=return_direct)
+    elif len(args) == 1 and callable(args[0]):
+        # if the argument is a function, then we use the function name as the tool name
+        # Example usage: @tool
+        return _make_with_name(args[0].__name__, return_direct=return_direct)(args[0])
+    elif len(args) == 0:
+        # if there are no arguments, then we use the function name as the tool name
+        # Example usage: @tool(return_direct=True)
+        def _partial(func: Callable[[str], str]) -> Tool:
+            return _make_with_name(func.__name__, return_direct=return_direct)(func)
+
+        return _partial
+    else:
+        raise ValueError("Too many arguments for tool decorator")

--- a/tests/unit_tests/agents/test_tools.py
+++ b/tests/unit_tests/agents/test_tools.py
@@ -1,0 +1,57 @@
+import pytest
+
+from langchain.agents.tools import Tool, tool
+
+
+def test_unnamed_decorator() -> None:
+    @tool
+    def search_api(query: str) -> str:
+        """Searches the API for the query."""
+        return "API result"
+
+    assert isinstance(search_api, Tool)
+    assert search_api.name == "search_api"
+    assert search_api.return_direct == False
+    assert search_api("test") == "API result"
+
+
+def test_named_tool_decorator() -> None:
+    @tool("search")
+    def search_api(query: str) -> str:
+        """Searches the API for the query."""
+        return "API result"
+
+    assert isinstance(search_api, Tool)
+    assert search_api.name == "search"
+    assert search_api.return_direct == False
+
+
+def test_named_tool_decorator_return_direct() -> None:
+    @tool("search", return_direct=True)
+    def search_api(query: str) -> str:
+        """Searches the API for the query."""
+        return "API result"
+
+    assert isinstance(search_api, Tool)
+    assert search_api.name == "search"
+    assert search_api.return_direct == True
+
+
+def test_unnamed_tool_decorator_return_direct() -> None:
+    @tool(return_direct=True)
+    def search_api(query: str) -> str:
+        """Searches the API for the query."""
+        return "API result"
+
+    assert isinstance(search_api, Tool)
+    assert search_api.name == "search_api"
+    assert search_api.return_direct == True
+
+
+def test_missing_docstring() -> None:
+    # except to throw a value error if theres too many arguments
+    with pytest.raises(AssertionError):
+
+        @tool
+        def search_api(query: str, arg2: str) -> str:
+            return "API result"


### PR DESCRIPTION
# Decorator for Tool class

Currently, the Tool class is called with the following format:

```
Tool(name="search", func=search, description="search the internet for information")
```

To make it cleaner to define custom tools, a `@tool` decorator is provided. This decorator can be used to quickly create a `Tool` from a simple function. The decorator uses the function name as the tool name by default, but this can be overridden by passing a string as the first argument. Additionally, the decorator will use the function's docstring as the tool's description.

```python
from langchain.agents import tool


@tool
def search_api(query: str) -> str:
    """Searches the API for the query."""
    return "Results"


@tool("search", return_direct=True)
def search_api(query: str) -> str:
    """Searches the API for the query."""
    return "Results"

tools = [search_api]
```

If you inspect the function, you'll see that it's a `Tool` instance instead of some additional information in the description, this tool can still be called as if it was a function so it won't interview with users' expectations of their function being callable.

``` python
print(search_api)
# Tool(name='search_api', func=<function search_api at 0x10fd7cd30>, description='search_api(query: str) -> str - Searches the API for the query.', return_direct=True)
```

## Comments:
1. I noticed that 3 lint errors come up since it's having a hard time figuring out the type of `@tool("name")` it thinks it's a tool when it should be callable. Not sure if my annotations are incorrect 
2. I considered adding more explicit checks like "function only has one argument, and returns str". but decided not to since others might extend the functionality.