### PR TITLE
Update cohere.py

### DIFF
--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -123,5 +123,5 @@ class Cohere(LLM, BaseModel):
         # If stop tokens are provided, Cohere's endpoint returns them.
         # In order to make this consistent with other endpoints, we strip them.
         if stop is not None or self.stop is not None:
-            text = enforce_stop_tokens(text, stop)
+            text = enforce_stop_tokens(text, params["stop_sequences"])
         return text

--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -122,6 +122,6 @@ class Cohere(LLM, BaseModel):
         text = response.generations[0].text
         # If stop tokens are provided, Cohere's endpoint returns them.
         # In order to make this consistent with other endpoints, we strip them.
-        if stop is not None:
+        if stop is not None or self.stop is not None:
             text = enforce_stop_tokens(text, stop)
         return text


### PR DESCRIPTION
When stop tokens are set in Cohere LLM constructor, they are currently not stripped from the response, and they should be stripped