### PR TITLE
Fix documentation for 'model' parameter in CohereEmbeddings

### DIFF
--- a/langchain/embeddings/cohere.py
+++ b/langchain/embeddings/cohere.py
@@ -18,7 +18,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
         .. code-block:: python
 
             from langchain.embeddings import CohereEmbeddings
-            cohere = CohereEmbeddings(model_name="medium", cohere_api_key="my-api-key")
+            cohere = CohereEmbeddings(model="medium", cohere_api_key="my-api-key")
     """
 
     client: Any  #: :meta private:


### PR DESCRIPTION
Currently, the class parameter 'model_name' of the CohereEmbeddings class is not supported, but 'model' is. The class documentation is inconsistent with this, though, so I propose to either fix the documentation (this PR right now) or fix the parameter.

It will create the following error:
```
ValidationError: 1 validation error for CohereEmbeddings
model_name
  extra fields not permitted (type=value_error.extra)
```