### PR TITLE
docs: Update langchain link to PyPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ good code into the codebase.
 ### 🏭Release process
 
 As of now, LangChain has an ad hoc release process: releases are cut with high frequency via by
-a developer and published to [PyPI](https://pypi.org/project/ruff/).
+a developer and published to [PyPI](https://pypi.org/project/langchain/).
 
 LangChain follows the [semver](https://semver.org/) versioning standard. However, as pre-1.0 software,
 even patch releases may contain [non-backwards-compatible changes](https://semver.org/#spec-item-4).


### PR DESCRIPTION
Simple one-line fix

CONTRIBUTING used a link that pointed to the `ruff` project.

