### PR TITLE
Minor fix for google search util: it's uncertain if "snippet" in results exists 

### DIFF
--- a/langchain/utilities/google_search.py
+++ b/langchain/utilities/google_search.py
@@ -96,7 +96,8 @@ class GoogleSearchAPIWrapper(BaseModel):
         if len(results) == 0:
             return "No good Google Search Result was found"
         for result in results:
-            snippets.append(result["snippet"])
+            if "snippet" in result:
+                snippets.append(result["snippet"])
 
         return " ".join(snippets)
 
@@ -119,10 +120,11 @@ class GoogleSearchAPIWrapper(BaseModel):
             return [{"Result": "No good Google Search Result was found"}]
         for result in results:
             metadata_result = {
-                "snippet": result["snippet"],
                 "title": result["title"],
                 "link": result["link"],
             }
+            if "snippet" in result:
+                metadata_result["snippet"] = result["snippet"]
             metadata_results.append(metadata_result)
 
         return metadata_results


### PR DESCRIPTION
The results from Google search may not always contain a "snippet". 

Example:
`{'kind': 'customsearch#result', 'title': 'FEMA Flood Map', 'htmlTitle': 'FEMA Flood Map', 'link': 'https://msc.fema.gov/portal/home', 'displayLink': 'msc.fema.gov', 'formattedUrl': 'https://msc.fema.gov/portal/home', 'htmlFormattedUrl': 'https://<b>msc</b>.fema.gov/portal/home'}`

This will cause a KeyError at line 99 `snippets.append(result["snippet"])`.

