### PR TITLE
Added new deployment template

### DIFF
--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -22,3 +22,9 @@ This repo serves as a template for how deploy a LangChain with Gradio.
 It implements a chatbot interface, with a "Bring-Your-Own-Token" approach (nice for not wracking up big bills).
 It also contains instructions for how to deploy this app on the Hugging Face platform.
 This is heavily influenced by James Weaver's [excellent examples](https://huggingface.co/JavaFXpert).
+
+## [Beam](https://github.com/slai-labs/get-beam/tree/main/examples/langchain-question-answering)
+
+This repo serves as a template for how deploy a LangChain with [Beam](https://beam.cloud).
+
+It implements a Question Answering app and contains instructions for deploying the app as a serverless REST API.


### PR DESCRIPTION
This PR introduces a new template for deploying LangChain apps as web endpoints. It includes template code, and links to a detailed code-walkthrough.