### PR TITLE
RFC: Improve LLMChain output type with strong parsing support

### DIFF
--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -116,7 +116,10 @@ class Chain(BaseModel, ABC):
         raise NotImplementedError("Async call not supported for this chain type.")
 
     def __call__(
-        self, inputs: Union[Dict[str, Any], Any], return_only_outputs: bool = False
+        self,
+        inputs: Union[Dict[str, Any], Any],
+        return_only_outputs: bool = False,
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         """Run the logic of this chain and add to output if desired.
 
@@ -136,7 +139,7 @@ class Chain(BaseModel, ABC):
             verbose=self.verbose,
         )
         try:
-            outputs = self._call(inputs)
+            outputs = self._call(inputs, **kwargs)
         except (KeyboardInterrupt, Exception) as e:
             self.callback_manager.on_chain_error(e, verbose=self.verbose)
             raise e

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -1,13 +1,14 @@
 """Chain that just formats a prompt and calls an LLM."""
+from types import FunctionType
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from pydantic import BaseModel, Extra
 
 from langchain.chains.base import Chain
-from langchain.chains.llm_validator import PROMPT_CORRECTION, LLMCorrectChain
+from langchain.chains.llm_validator import LLMCorrectChain
 from langchain.input import get_colored_text
 from langchain.llms.base import BaseLLM
-from langchain.prompts.base import BasePromptTemplate
+from langchain.prompts.base import BaseOutputParser, BasePromptTemplate
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import LLMResult
 
@@ -30,9 +31,9 @@ class LLMChain(Chain, BaseModel):
     """Prompt object to use."""
     llm: BaseLLM
     """LLM wrapper to use."""
-    retries: int = 0
+    parser_retries: int = 0
     """Number of times to retry the query if it fails."""
-    correct_on_error: bool = False
+    parser_correct_on_error: bool = False
     """If True, will try to correct the input if the query fails."""
     output_key: str = "text"  #: :meta private:
 
@@ -110,47 +111,31 @@ class LLMChain(Chain, BaseModel):
             outputs.append({self.output_key: response_str})
         return outputs
 
-    def apply_and_parse(
-        self, input_list: List[Dict[str, Any]]
-    ) -> Sequence[Union[str, List[str], Dict[str, str]]]:
-        """Call apply and then parse the results."""
-        result = self.apply(input_list)
-        if self.prompt.output_parser is not None:
-            new_result = []
-            for res in result:
-                text = res[self.output_key]
-                new_result.append(self.prompt.output_parser.parse(text))
-            return new_result
-        else:
-            return result
-
-    def _call(self, inputs: Dict[str, Any], parse=False) -> Dict[str, str]:
-        if not parse:
+    def _call(self, inputs: Dict[str, Any], parse: bool = True) -> Dict[str, str]:
+        if not parse or self.prompt.output_parser is None:
             return self.apply([inputs])[0]
 
-        if self.prompt.output_parser is None:
-            raise ValueError("No output parser available.")
-
-        retry_count = 0
-        for _ in range(1 + self.retries):
+        parse_last_exception: Optional[Exception] = None
+        for _ in range(1 + self.parser_retries):
+            result = self.apply([inputs])[0]
+            text = result[self.output_key]
             try:
-                result = self.apply([inputs])[0]
-                text = result[self.output_key]
-                try:
-                    result[self.output_key] = self.prompt.output_parser.parse(text)
-                    return result
-                except Exception as exc:
-                    if self.correct_on_error:
-                        result[self.output_key] = self._parser_correct_on_error(
-                            text, exc
-                        )
-                        return result
-                    raise exc
+                result[self.output_key] = self.prompt.parse_output(text)
+                return result
             except Exception as exc:
-                if retry_count < self.retries:
-                    retry_count += 1
-                    continue
-                raise exc  # raise the last exception
+                parse_last_exception = exc
+
+                if self.parser_correct_on_error:
+                    corrected = self._parser_correct_on_error(text, exc)
+                    try:
+                        result[self.output_key] = self.prompt.parse_output(corrected)
+                        return result
+                    except Exception:
+                        pass
+
+        if parse_last_exception is not None:
+            raise parse_last_exception
+        raise ValueError("parser_retries shouldn't be negative.")
 
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, str]:
         return (await self.aapply([inputs]))[0]
@@ -169,7 +154,7 @@ class LLMChain(Chain, BaseModel):
 
                 completion = llm.predict(adjective="funny")
         """
-        return self(kwargs)[self.output_key]
+        return self(kwargs, parse=False)[self.output_key]
 
     async def apredict(self, **kwargs: Any) -> str:
         """Format prompt with kwargs and pass to LLM.
@@ -189,21 +174,41 @@ class LLMChain(Chain, BaseModel):
 
     def predict_and_parse(self, **kwargs: Any) -> Union[str, List[str], Dict[str, str]]:
         """Call predict and then parse the results."""
-        return self(kwargs, parse=True)[self.output_key]
+        return self(kwargs)[self.output_key]
+
+    def apply_and_parse(
+        self, input_list: List[Dict[str, Any]]
+    ) -> Sequence[Union[str, List[str], Dict[str, str]]]:
+        """Call apply and then parse the results."""
+        result = self.apply(input_list)
+        if self.prompt.output_parser is not None:
+            new_result = []
+            for res in result:
+                text = res[self.output_key]
+                new_result.append(self.prompt.parse_output(text))
+            return new_result
+        return result
 
     def _parser_correct_on_error(self, text: str, e: Exception) -> str:
         """Try to correct the input if the parser function fails."""
         llm_correct_validator = LLMCorrectChain(llm=self.llm)
 
+        if isinstance(self.prompt.output_parser, BaseOutputParser):
+            parser_name = self.prompt.output_parser.__class__.__name__
+        elif isinstance(self.prompt.output_parser, FunctionType):
+            parser_name = self.prompt.output_parser.__name__
+        else:
+            raise ValueError("Could not determine output parser name.")
+
         response = llm_correct_validator(
             {
                 "text": text,
-                "validator_name": self.prompt.output_parser.__class__.__name__,
+                "validator_name": parser_name,
                 "error_message": str(e),
             }
         )
         corrected = response["corrected"]
-        return self.prompt.output_parser.parse(corrected)
+        return corrected
 
     @property
     def _chain_type(self) -> str:

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from pydantic import BaseModel, Extra
 
 from langchain.chains.base import Chain
+from langchain.chains.llm_validator import PROMPT_CORRECTION, LLMCorrectChain
 from langchain.input import get_colored_text
 from langchain.llms.base import BaseLLM
 from langchain.prompts.base import BasePromptTemplate
@@ -29,6 +30,10 @@ class LLMChain(Chain, BaseModel):
     """Prompt object to use."""
     llm: BaseLLM
     """LLM wrapper to use."""
+    retries: int = 0
+    """Number of times to retry the query if it fails."""
+    correct_on_error: bool = False
+    """If True, will try to correct the input if the query fails."""
     output_key: str = "text"  #: :meta private:
 
     class Config:
@@ -105,8 +110,47 @@ class LLMChain(Chain, BaseModel):
             outputs.append({self.output_key: response_str})
         return outputs
 
-    def _call(self, inputs: Dict[str, Any]) -> Dict[str, str]:
-        return self.apply([inputs])[0]
+    def apply_and_parse(
+        self, input_list: List[Dict[str, Any]]
+    ) -> Sequence[Union[str, List[str], Dict[str, str]]]:
+        """Call apply and then parse the results."""
+        result = self.apply(input_list)
+        if self.prompt.output_parser is not None:
+            new_result = []
+            for res in result:
+                text = res[self.output_key]
+                new_result.append(self.prompt.output_parser.parse(text))
+            return new_result
+        else:
+            return result
+
+    def _call(self, inputs: Dict[str, Any], parse=False) -> Dict[str, str]:
+        if not parse:
+            return self.apply([inputs])[0]
+
+        if self.prompt.output_parser is None:
+            raise ValueError("No output parser available.")
+
+        retry_count = 0
+        for _ in range(1 + self.retries):
+            try:
+                result = self.apply([inputs])[0]
+                text = result[self.output_key]
+                try:
+                    result[self.output_key] = self.prompt.output_parser.parse(text)
+                    return result
+                except Exception as exc:
+                    if self.correct_on_error:
+                        result[self.output_key] = self._parser_correct_on_error(
+                            text, exc
+                        )
+                        return result
+                    raise exc
+            except Exception as exc:
+                if retry_count < self.retries:
+                    retry_count += 1
+                    continue
+                raise exc  # raise the last exception
 
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, str]:
         return (await self.aapply([inputs]))[0]
@@ -145,25 +189,21 @@ class LLMChain(Chain, BaseModel):
 
     def predict_and_parse(self, **kwargs: Any) -> Union[str, List[str], Dict[str, str]]:
         """Call predict and then parse the results."""
-        result = self.predict(**kwargs)
-        if self.prompt.output_parser is not None:
-            return self.prompt.output_parser.parse(result)
-        else:
-            return result
+        return self(kwargs, parse=True)[self.output_key]
 
-    def apply_and_parse(
-        self, input_list: List[Dict[str, Any]]
-    ) -> Sequence[Union[str, List[str], Dict[str, str]]]:
-        """Call apply and then parse the results."""
-        result = self.apply(input_list)
-        if self.prompt.output_parser is not None:
-            new_result = []
-            for res in result:
-                text = res[self.output_key]
-                new_result.append(self.prompt.output_parser.parse(text))
-            return new_result
-        else:
-            return result
+    def _parser_correct_on_error(self, text: str, e: Exception) -> str:
+        """Try to correct the input if the parser function fails."""
+        llm_correct_validator = LLMCorrectChain(llm=self.llm)
+
+        response = llm_correct_validator(
+            {
+                "text": text,
+                "validator_name": self.prompt.output_parser.__class__.__name__,
+                "error_message": str(e),
+            }
+        )
+        corrected = response["corrected"]
+        return self.prompt.output_parser.parse(corrected)
 
     @property
     def _chain_type(self) -> str:

--- a/langchain/chains/llm_validator.py
+++ b/langchain/chains/llm_validator.py
@@ -1,0 +1,98 @@
+"""Chain to parse / validate the LLM output."""
+import json
+from typing import Any, Callable, Dict
+
+from langchain.chains.llm import LLMChain
+from langchain.prompts.prompt import PromptTemplate
+
+_PROMPT_TEMPLATE_CORRECTION = """
+Output: {output}
+Validator function: {validator_name}
+Exception failed with error: {error_message}
+
+---
+
+Please correct the output so it passes the validator function.
+Corrected output:
+"""
+
+PROMPT_CORRECTION = PromptTemplate(
+    input_variables=["output", "validator_name", "error_message"],
+    template=_PROMPT_TEMPLATE_CORRECTION,
+)
+
+
+def boolean_validator(output: str) -> bool:
+    """Convert string to boolean."""
+    if output.lower() in ("yes", "true", "t", "1"):
+        return True
+    elif output.lower() in ("no", "false", "f", "0"):
+        return False
+    else:
+        raise ValueError("could not convert string to boolean: " + output)
+
+
+def json_validator(output: str) -> Dict[str, Any]:
+    """Convert string to json."""
+    return json.loads(output)
+
+
+VALIDATORS = {
+    "boolean": boolean_validator,
+    "json": json_validator,
+}
+
+
+class LLMChainWithValidator(LLMChain):
+    """Chain that accept a validator function.
+
+    It has special parameters to handle errors in the validator function.
+    - `correct_on_error`: If True, the chain will use the output of the validator
+      function to try to correct the input.
+    - `retry`: Number of times to retry the validator function if it fails
+      (done after correcting the input if `correct_on_error` is True)
+    """
+
+    correct_on_error: bool = False
+    retry: int = 0
+    validator: Callable
+
+    def _call(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+        """
+        Apply validator function to the output of the LLM.
+
+        If the validator function fails, it will try to correct the input
+        If the validator function fails after correcting the input,
+        it will retry the validator function
+        """
+        for _ in range(1 + self.retry):
+            result = super().apply([inputs])[0]
+            try:
+                result["response"] = self._validate_output(result["response"])
+                return result
+            except Exception as exc:
+                if self.correct_on_error:
+                    try:
+                        result["response"] = self._correct_on_error(result, exc)
+                        return result
+                    except Exception:
+                        continue
+        return {}
+
+    def _validate_output(self, output: str) -> Any:
+        output = output.strip()  # remove spaces and newlines
+        return self.validator(output)
+
+    def _correct_on_error(self, result: Dict[str, str], e: Exception) -> str:
+        """Try to correct the input if the validator function fails."""
+        prompt = PROMPT_CORRECTION.format(
+            output=result["response"],
+            validator_name=self.validator.__name__,
+            error_message=str(e),
+        )
+        response = self.llm.generate(
+            prompts=[prompt],
+        )
+        output = response.generations[0][0].text
+        # apply the validator function to the corrected output
+        return self._validate_output(output)

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -115,7 +115,7 @@ class BasePromptTemplate(BaseModel, ABC):
 
     input_variables: List[str]
     """A list of the names of the variables the prompt template expects."""
-    output_parser: Optional[BaseOutputParser] = None
+    output_parser: Optional[Union[BaseOutputParser, Callable[[str], Any]]] = None
     """How to parse the output of calling an LLM on this formatted prompt."""
 
     class Config:
@@ -193,3 +193,18 @@ class BasePromptTemplate(BaseModel, ABC):
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:
             raise ValueError(f"{save_path} must be json or yaml")
+
+    @property
+    def parse_output(self) -> Callable[[str], Any]:
+        """Return a function to parse the output of an LLM call.
+
+        If output_parser is None, then the output is a string.
+        If output_parser is a BaseOutputParser object, then we call output_parser.parse
+        If output_parser is a function, then we call output_parser
+        """
+        if self.output_parser is None:
+            return lambda x: x
+        elif isinstance(self.output_parser, BaseOutputParser):
+            return self.output_parser.parse
+        else:
+            return self.output_parser


### PR DESCRIPTION
As you all know, one of the big issue with LLM is the output form (type / format / syntax...).

I propose to add a new chain, LLMChainWithValidator, that accept a validator, a function that try parse the output / validate it's syntax, and return the appropriate type.

Here are example of possible validator:
- boolean: "true" -> True
- age: "34" -> 34  (parse int + check 0 < 130)
- data structure
- json
- SQL
...

The chain also accept two others parameters: `correct_on_error` and `retry`. 
- `correct_on_error` try to correct the output with the LLM
- `retry` is the number of possible retry of the LLM

The chain return None if it didn't succeed to return a validated output.

Some notes:
- I initially wanted to add validator directly in LLMChain, but I figured that it was probably best to start with a simple custom chain.
- So far, this implementation doesn't handle multiple call / responses. It added too much complexities due to the retry / correct logic.

---

Examples
```python
import os

from langchain.chains.llm_validator import VALIDATORS, LLMChainWithValidator
from langchain.llms import OpenAI
from langchain.prompts import PromptTemplate

llm = OpenAI()

template = """What is the price of {product}?"""
prompt = PromptTemplate(
    template=template,
    input_variables=["product"],
)
chain = LLMChainWithValidator(
    llm=llm,
    prompt=prompt,
    output_key="response",
    validator=int,
    retry=2,
    correct_on_error=True,
)
chain(
    {
        "product": "an iphone",
    }
)
# > {'product': 'an iphone', 'response': 699}
```

```python
prompt = PromptTemplate(
    template="generate a json of top 3 french cities",
    input_variables=[]
)    
chain = LLMChainWithValidator(
    llm=llm,
    prompt=prompt,
    output_key="response",
    validator=VALIDATORS["json"],
    retry=2,
    correct_on_error=True
)
chain({})
# > {'response': {'Top 5 French Cities': [{'City': 'Paris', 'Population': 2244000},{'City': 'Marseille', 'Population': 861635},{'City': 'Lyon', 'Population': 495268}]}}
```
