### PR TITLE
Add some packages to `docs/requirements.txt` that I had to install

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,16 @@
 autodoc_pydantic==1.8.0
+duckdb-engine
+freezegun
 myst_parser
 nbsphinx==0.8.9
+responses
 sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 sphinx_book_theme
 sphinx_rtd_theme==1.0.0
 sphinx-typlog-theme==0.8.0
 sphinx-panels
+tenacity
 toml
 myst_nb
+numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 autodoc_pydantic==1.8.0
+dataclasses_json
 duckdb-engine
 freezegun
 myst_parser


### PR DESCRIPTION
…after running `pip install -r requirements.txt` with the existing `requirements.txt`.

Potentially this is not necessary, because potentially `poetry` uses a different store of dependencies?

cc: @hwchase17 