### PR TITLE
Get elements of ActionInput on newlines

### DIFF
--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -40,7 +40,7 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     if FINAL_ANSWER_ACTION in llm_output:
         return "Final Answer", llm_output.split(FINAL_ANSWER_ACTION)[-1].strip()
     regex = r"Action: (.*?)\nAction Input: (.*)"
-    match = re.search(regex, llm_output)
+    match = re.search(regex, llm_output, re.DOTALL)
     if not match:
         raise ValueError(f"Could not parse LLM output: `{llm_output}`")
     action = match.group(1).strip()


### PR DESCRIPTION
The re.DOTALL flag in Python's re (regular expression) module makes the . (dot) metacharacter match newline characters as well as any other character.

Without re.DOTALL, the . metacharacter only matches any character except for a newline character. With re.DOTALL, the . metacharacter matches any character, including newline characters.