### PR TITLE
optional youtube meta infor (title, description, thumbnail and more)

### DIFF
--- a/langchain/document_loaders/youtube.py
+++ b/langchain/document_loaders/youtube.py
@@ -20,16 +20,46 @@ class YoutubeLoader(BaseLoader):
         video_id = youtube_url.split("youtube.com/watch?v=")[-1]
         return cls(video_id)
 
-    def load(self) -> List[Document]:
+    def load(self,  add_video_infor: bool=False) -> List[Document]:
         """Load documents."""
         try:
             from youtube_transcript_api import YouTubeTranscriptApi
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import youtube_transcript_api python package. "
                 "Please it install it with `pip install youtube-transcript-api`."
             )
+        
+        metadata = {"source": self.video_id}
+
+        if add_video_infor:
+            # Get more video meta info, such as title, description, thumbnail url, publish_date， 
+            video_infor = self._get_video_infor()
+            metadata.update(video_infor)
+
         transcript_pieces = YouTubeTranscriptApi.get_transcript(self.video_id)
         transcript = " ".join([t["text"].strip(" ") for t in transcript_pieces])
-        metadata = {"source": self.video_id}
+        
         return [Document(page_content=transcript, metadata=metadata)]
+
+    def _get_video_infor(self):
+        """Get important video information: title, description, thumbnail url, publish_date, channel_author and more."""
+        try:
+            from pytube import YouTube
+
+        except ImportError:
+            raise ImportError(
+                "Could not import pytube python package. "
+                "Please it install it with `pip install pytube`."
+            )
+        yt = YouTube(f"https://www.youtube.com/watch?v={self.video_id}")
+        video_info = {
+            'title': yt.title,
+            'description': yt.description,
+            'view_count': yt.views,
+            'thumbnail_url': yt.thumbnail_url,
+            'publish_date': yt.publish_date,
+            'length': yt.length,
+            'author': yt.author,
+        }
+        return video_info


### PR DESCRIPTION
Hi team, 

Love the work you guys have done on LangChain, hope i can also contribute a tiny bit!

have done similar side project on Youtube summarization and question answering with LLM,
I find that Youtube video meta infor, especially video title and descriptions are quite helpful for model to better understand the context.

Additionally, the thumbnail image url can also be useful when build web app with this.

a sample video meta infor would be

```
{
'source': 'I845O57ZSy4',
 'title': 'John Carmack: Doom, Quake, VR, AGI, Programming, Video Games, and Rockets | Lex Fridman Podcast #309',
 'description': 'John Carmack is a legendary programmer, co-founder of id Software, and lead programmer of many revol...',
 'view_count': 1229347,
 'thumbnail_url': 'https://i.ytimg.com/vi/I845O57ZSy4/sddefault.jpg',
 'publish_date': datetime.datetime(2022, 8, 4, 0, 0),
 'length': 18890,
 'author': 'Lex Fridman',
}
```



