### PR TITLE
Support similarity search by vector as well as string

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -27,7 +27,7 @@ class VectorStore(ABC):
 
     @abstractmethod
     def similarity_search(
-        self, query: str, k: int = 4, **kwargs: Any
+        self, query: Union[str, List[float]], k: int = 4, **kwargs: Any
     ) -> List[Document]:
         """Return docs most similar to query."""
 

--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable, List, Union, Optional
 
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings

--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -32,7 +32,7 @@ class VectorStore(ABC):
         """Return docs most similar to query."""
 
     def max_marginal_relevance_search(
-        self, query: str, k: int = 4, fetch_k: int = 20
+        self, query: Union[str, List[float]], k: int = 4, fetch_k: int = 20
     ) -> List[Document]:
         """Return docs selected using the maximal marginal relevance.
 

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -93,7 +93,7 @@ class FAISS(VectorStore):
         return [_id for _, _id, _ in full_info]
 
     def similarity_search_with_score(
-        self, query: str, k: int = 4
+        self, query: Union[str, List[float]], k: int = 4
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query.
 
@@ -104,7 +104,13 @@ class FAISS(VectorStore):
         Returns:
             List of Documents most similar to the query and score for each
         """
-        embedding = self.embedding_function(query)
+        if isinstance(query, str):
+            embedding = self.embedding_function(query)
+        elif isinstance(query, list):
+            embedding = query
+        else:
+            raise ValueError(f"Got unexpected query type {type(query)}")
+        #embedding = self.embedding_function(query)
         scores, indices = self.index.search(np.array([embedding], dtype=np.float32), k)
         docs = []
         for j, i in enumerate(indices[0]):
@@ -119,7 +125,7 @@ class FAISS(VectorStore):
         return docs
 
     def similarity_search(
-        self, query: str, k: int = 4, **kwargs: Any
+        self, query: Union[str, List[float]], k: int = 4, **kwargs: Any
     ) -> List[Document]:
         """Return docs most similar to query.
 

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pickle
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -110,7 +110,6 @@ class FAISS(VectorStore):
             embedding = query
         else:
             raise ValueError(f"Got unexpected query type {type(query)}")
-        #embedding = self.embedding_function(query)
         scores, indices = self.index.search(np.array([embedding], dtype=np.float32), k)
         docs = []
         for j, i in enumerate(indices[0]):
@@ -140,7 +139,7 @@ class FAISS(VectorStore):
         return [doc for doc, _ in docs_and_scores]
 
     def max_marginal_relevance_search(
-        self, query: str, k: int = 4, fetch_k: int = 20
+        self, query: Union[str, List[float]], k: int = 4, fetch_k: int = 20
     ) -> List[Document]:
         """Return docs selected using the maximal marginal relevance.
 
@@ -155,7 +154,12 @@ class FAISS(VectorStore):
         Returns:
             List of Documents selected by maximal marginal relevance.
         """
-        embedding = self.embedding_function(query)
+        if isinstance(query, str):
+            embedding = self.embedding_function(query)
+        elif isinstance(query, list):
+            embedding = query
+        else:
+            raise ValueError(f"Got unexpected query type {type(query)}")
         _, indices = self.index.search(np.array([embedding], dtype=np.float32), fetch_k)
         # -1 happens when not enough docs are returned.
         embeddings = [self.index.reconstruct(int(i)) for i in indices[0] if i != -1]


### PR DESCRIPTION
Not sure if this sort of API change (doing similarity search on vectorstores with a vector instead of a string as input) is desirable or not but it has been useful for some experimental vector memory I have been working on. I wanted to offer this PR first to see if the API change makes sense or not. (Note I have only implemented for FAISS - not all the other vectorstores.)