### PR TITLE
Send embedding requests to OpenAI api in batches

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -75,20 +75,22 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         text = text.replace("\n", " ")
         return self.client.create(input=[text], engine=engine)["data"][0]["embedding"]
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: List[str], chunk_size=1000) -> List[List[float]]:
         """Call out to OpenAI's embedding endpoint for embedding search docs.
 
         Args:
             texts: The list of texts to embed.
+            chunk_size: The maximum number of texts to send to OpenAI at once (max 1000).
 
         Returns:
             List of embeddings, one for each text.
         """
-        responses = [
-            self._embedding_func(text, engine=self.document_model_name)
-            for text in texts
-        ]
-        return responses
+        # handle large batches of texts
+        results = []
+        if len(texts) > chunk_size:
+            for i in range(0, len(texts), chunk_size):
+                results += [r['embedding'] for r in self.client.create(input=texts[i : i + chunk_size], engine=self.document_model_name)["data"]]
+        return results
 
     def embed_query(self, text: str) -> List[float]:
         """Call out to OpenAI's embedding endpoint for embedding query text.


### PR DESCRIPTION
Previously the OpenAI embedding class was making one call to the OpenAI API for each document, but this is much slower than it needs to be and also prone to getting rate-limited and or getting a "come back later" response. OpenAI's API is not well documented, but I think this is the intended use. Their example of usage for a single doc was a bit confusing. This PR fixes that problem and it also works for large numbers of documents.