### PR TITLE
Increase flexibility in AgentExecutor logic

### DIFF
--- a/langchain/agents/memory.py
+++ b/langchain/agents/memory.py
@@ -1,0 +1,61 @@
+"""Agent state data."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Sequence, Tuple
+
+from pydantic import BaseModel
+
+from langchain.agents.step import StepOutput
+from langchain.schema import AgentAction
+
+
+class BaseAgentMemory(BaseModel, ABC):
+    """Agent working memory, modeled off of Chain memory.
+
+    Should contain everything needed for the agent to make its next decision. After
+    all, how can what you don't remember possibly inform your decisions?
+    """
+
+    inputs: Dict[str, str]
+
+    @abstractmethod
+    def add_step(self, output: StepOutput) -> None:
+        """Add step output to memory."""
+
+    @abstractmethod
+    def steps(self) -> Sequence[StepOutput]:
+        """Return all steps so far.
+
+        Uses Sequence instead of List so that this could return subclasses of
+        StepOutput. This is because List is invariant but Sequence is covariant:
+
+        https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+        """
+
+    @abstractmethod
+    def as_intermediate_steps(self) -> List[Tuple[AgentAction, str]]:
+        """Return intermediate steps in unstructured form.
+
+        For backwards compatibility.
+        """
+
+
+class AgentMemory(BaseAgentMemory):
+    """Default Agent memory that assumes StepOutput type for all steps."""
+
+    _steps: List[StepOutput] = []
+
+    def add_step(self, output: StepOutput) -> None:
+        """Add step output to memory."""
+        self._steps.append(output)
+
+    def steps(self) -> Sequence[StepOutput]:
+        """Return all steps so far."""
+        return self._steps
+
+    def as_intermediate_steps(self) -> List[Tuple[AgentAction, str]]:
+        """Return intermediate steps in unstructured form.
+
+        For backwards compatibility.
+        """
+        return [output.as_intermediate_step() for output in self._steps]

--- a/langchain/agents/step.py
+++ b/langchain/agents/step.py
@@ -1,0 +1,53 @@
+"""Rich structured data about each iteration of the agent loop."""
+
+from typing import Any, Optional, Tuple, Union
+
+from pydantic import BaseModel
+
+from langchain.schema import AgentAction, AgentFinish
+
+
+class StepOutput(BaseModel):
+    """The output produced by a single step of the agent loop.
+
+    You can subclass this to store rich structured data instead of relying solely on
+    AgentAction's str inputs.
+    """
+
+    decision: Union[AgentAction, AgentFinish]
+    """The decision taken during the step.
+
+    This could be deciding to use a tool, or deciding to end the loop.
+    """
+    observation: Optional[str]
+    """The observed effects of the previous action.
+
+    Only present if the decision taken wasn't to end the loop.
+    """
+
+    @property
+    def is_finish(self) -> bool:
+        """Whether this step signals the end of the agent loop."""
+        return isinstance(self.decision, AgentFinish)
+
+    def log(self, **kwargs: Any) -> str:
+        """Produce a log for this step.
+
+        This is usually useful for constructing the scratchpad. The kwargs are there to
+        allow for flexibility during scratchpad construction. Subclass `StepOutput` and
+        override this function to make use of them.
+        """
+        if len(kwargs) > 0:
+            raise ValueError("The default log doesn't take any options")
+        assert self.observation is not None
+        # this is just an example because this function isn't actually used in any of
+        # the current Agent logic, but if kwargs were to contain `observation_prefix`
+        # and `llm_prefix`, then we could recreate the scratchpad logic in
+        # `Agent._construct_scratchpad`
+        return self.decision.log + "\n" + self.observation
+
+    def as_intermediate_step(self) -> Tuple[AgentAction, str]:
+        """Compatibility function for existing action-observation tuple."""
+        assert isinstance(self.decision, AgentAction)
+        assert self.observation is not None  # should follow from first assert
+        return (self.decision, self.observation)


### PR DESCRIPTION
In my experiments with multi-input Tool usage (the original impetus for #764) and now multi-output Tool usage, I continue to find the current Agent/AgentExecutor logic to be rather opinionated. As such, I would like to suggest the following changes:

-  Allow for flexibility in how the agent goes through each iteration of its loop. Right now the loop assumes that each Tool is invoked by its name, and has a single input. I would like an easier way to override this logic so that I can find a tool by array index instead of name, and then get all multiple inputs for that tool using `GetMultipleOutputsChain`.
- Allow for flexibility in the information returned by the agent in each iteration of its loop. Right now it's rather awkward to work around `Tuple[AgentAction, str]`; by creating a class for each step of the output, I can then subclass that class and have my custom loop logic return multiple, structured outputs on each pass.
- Allow for flexibility in agent memory management. Given the above two changes, this helps make the code cleaner, and also allows me to recreate the scratchpad outside of `Agent` (because currently Agent is not very useful to me given the assumptions it makes)

I've split up each suggestion into a separate commit. I've explained why I find each suggestion useful for my own personal experimentation, and I hope that the same is true for others too -- but feel free to cherry-pick any of these suggestions separately if you disagree :)

I've only limited my changes to the synchronous functions. I'm happy to add them to the async ones too, but I'd like to hear your thoughts first before spending effort on that. Thanks!