### PR TITLE
Fixed openai embeddings to be safe by batching them based on token size calculation.

### DIFF
--- a/tests/integration_tests/embeddings/test_openai.py
+++ b/tests/integration_tests/embeddings/test_openai.py
@@ -15,7 +15,8 @@ def test_openai_embedding_documents_multiple() -> None:
     """Test openai embeddings."""
     documents = ["foo bar", "bar foo", "foo"]
     embedding = OpenAIEmbeddings()
-    output = embedding.embed_documents(documents, chunk_size=2)
+    embedding.embedding_ctx_length = 8191
+    output = embedding.embed_documents(documents, chunk_size=1000)
     assert len(output) == 3
     assert len(output[0]) == 1536
     assert len(output[1]) == 1536

--- a/tests/integration_tests/embeddings/test_openai.py
+++ b/tests/integration_tests/embeddings/test_openai.py
@@ -16,7 +16,7 @@ def test_openai_embedding_documents_multiple() -> None:
     documents = ["foo bar", "bar foo", "foo"]
     embedding = OpenAIEmbeddings()
     embedding.embedding_ctx_length = 8191
-    output = embedding.embed_documents(documents, chunk_size=1000)
+    output = embedding.embed_documents(documents, chunk_size=2)
     assert len(output) == 3
     assert len(output[0]) == 1536
     assert len(output[1]) == 1536


### PR DESCRIPTION
I modified the logic of the batch calculation for embedding according to this cookbook
https://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb