### PR TITLE
Align table info

### DIFF
--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "id": "9a22ee47",
    "metadata": {},
    "outputs": [],
@@ -338,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 4,
    "id": "9de86267",
    "metadata": {},
    "outputs": [
@@ -346,9 +346,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Table 'Track' has columns: TrackId (INTEGER), Name (NVARCHAR(200)), AlbumId (INTEGER), MediaTypeId (INTEGER), GenreId (INTEGER), Composer (NVARCHAR(220)), Milliseconds (INTEGER), Bytes (INTEGER), UnitPrice (NUMERIC(10, 2)). Here is an example of 2 rows from this table (long strings are truncated):\n",
-      "1 For Those About To Rock (We Salute You) 1 1 1 Angus Young, Malcolm Young, Brian Johnson 343719 11170334 0.99\n",
-      "2 Balls to the Wall 2 2 1 None 342562 5510424 0.99\n"
+      "\n",
+      "            Table data will be described in the following format:\n",
+      "\n",
+      "            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]), column2 name: (column2 type, [list of example values for column2], ...)\n",
+      "\n",
+      "            These are the tables you can use, together with their column information:\n",
+      "\n",
+      "            Table 'Track' has columns: {'TrackId': ['INTEGER', ['1', '2']], 'Name': ['NVARCHAR(200)', ['For Those About To Rock (We Salute You)', 'Balls to the Wall']], 'AlbumId': ['INTEGER', ['1', '2']], 'MediaTypeId': ['INTEGER', ['1', '2']], 'GenreId': ['INTEGER', ['1', '1']], 'Composer': ['NVARCHAR(220)', ['Angus Young, Malcolm Young, Brian Johnson', 'None']], 'Milliseconds': ['INTEGER', ['343719', '342562']], 'Bytes': ['INTEGER', ['11170334', '5510424']], 'UnitPrice': ['NUMERIC(10, 2)', ['0.99', '0.99']]}\n"
      ]
     }
    ],
@@ -486,9 +491,9 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "langchain",
    "language": "python",
-   "name": "python3"
+   "name": "langchain"
   },
   "language_info": {
    "codemirror_mode": {
@@ -500,7 +505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -317,15 +317,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "9a22ee47",
    "metadata": {},
    "outputs": [],
    "source": [
     "db = SQLDatabase.from_uri(\n",
-    "    \"sqlite:///../../../../notebooks/Chinook.db\", \n",
+    "    \"sqlite:///../../chains/examples/Chinook.db\", \n",
     "    include_tables=['Track'], # we include only one table to save tokens in the prompt :)\n",
     "    sample_rows_in_table_info=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "64b9e494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# db = SQLDatabase.from_uri(\n",
+    "#     \"sqlite:///../../../../notebooks/Chinook.db\", \n",
+    "#     include_tables=['Track'], # we include only one table to save tokens in the prompt :)\n",
+    "#     sample_rows_in_table_info=2)"
    ]
   },
   {
@@ -338,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "9de86267",
    "metadata": {},
    "outputs": [
@@ -349,7 +362,8 @@
       "\n",
       "            Table data will be described in the following format:\n",
       "\n",
-      "            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]), column2 name: (column2 type, [list of example values for column2], ...)\n",
+      "            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]),\n",
+      "            column2 name: (column2 type, [list of example values for column2], ...)\n",
       "\n",
       "            These are the tables you can use, together with their column information:\n",
       "\n",

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -15,7 +15,7 @@ SQLQuery: "SQL Query to run"
 SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
-Only use the following tables:
+Only use the tables listed below.
 
 {table_info}
 

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -82,7 +82,8 @@ class SQLDatabase:
         template_prefix = """
             Table data will be described in the following format:
 
-            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]), column2 name: (column2 type, [list of example values for column2], ...)
+            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]),
+            column2 name: (column2 type, [list of example values for column2], ...)
 
             These are the tables you can use, together with their column information:
 
@@ -106,7 +107,9 @@ class SQLDatabase:
                 )
 
                 for e, col in enumerate(columns):
-                    columns[col].append([row[e] for row in sample_rows_ls]) # type: ignore
+                    columns[col].append(
+                        [row[e] for row in sample_rows_ls]  # type: ignore
+                    )
 
                 table_str = f"Table '{table_name}' has columns: " + str(dict(columns))
 

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -82,7 +82,7 @@ class SQLDatabase:
         template_prefix = """
             Table data will be described in the following format so you can understand what the data looks like:
 
-            table name, {column1 name: (column1 type, [list of example values for column1]), column2 name: (column2 type, [list of example values for column2], ...)
+            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]), column2 name: (column2 type, [list of example values for column2], ...)
 
             These are the tables you can use, together with their column information:
 
@@ -95,11 +95,6 @@ class SQLDatabase:
                 columns[f"{column['name']}"].append(str(column["type"]))
 
             if self._sample_rows_in_table_info:
-                row_template = (
-                    " Here is an example of {n_rows} rows from this table "
-                    "(long strings are truncated):\n"
-                    "{sample_rows}"
-                )
                 sample_rows = self.run(
                     f"SELECT * FROM '{table_name}' LIMIT "
                     f"{self._sample_rows_in_table_info}"
@@ -113,7 +108,7 @@ class SQLDatabase:
                 for e, col in enumerate(columns):
                     columns[col].append([row[e] for row in sample_rows_ls]) # type: ignore
 
-                table_str = table_name + ", " + str(dict(columns))
+                table_str = f"Table '{table_name}' has columns: " + str(dict(columns))
 
             tables.append(table_str)
 

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -80,7 +80,7 @@ class SQLDatabase:
             all_table_names = table_names
 
         template_prefix = """
-            Table data will be described in the following format so you can understand what the data looks like:
+            Table data will be described in the following format:
 
             Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]), column2 name: (column2 type, [list of example values for column2], ...)
 


### PR DESCRIPTION
Currently the chain is getting the column names and types on the one side and the example rows on the other. It is easier for the llm to read the table information if the column name and examples are shown together so that it can easily understand to which columns do the examples refer to. For an instantiation of this, please refer to the changes in the `sqlite.ipynb` notebook.

Also changed `eval` for `ast.literal_eval` when interpreting the results from the sample row query since it is a better practice.