### PR TITLE
Added retry for openai.error.ServiceUnavailableError

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -163,6 +163,7 @@ class BaseOpenAI(BaseLLM, BaseModel):
                 | retry_if_exception_type(openai.error.APIError)
                 | retry_if_exception_type(openai.error.APIConnectionError)
                 | retry_if_exception_type(openai.error.RateLimitError)
+                | retry_if_exception_type(openai.error.ServiceUnavailableError)
             ),
             before_sleep=before_sleep_log(logger, logging.WARNING),
         )


### PR DESCRIPTION
Imho retries should be performed for ServiceUnavailableError (which tends to happen to me quite often).