### PR TITLE
Align table info (#999)

### DIFF
--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -317,15 +317,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "id": "9a22ee47",
    "metadata": {},
    "outputs": [],
    "source": [
     "db = SQLDatabase.from_uri(\n",
-    "    \"sqlite:///../../../../notebooks/Chinook.db\", \n",
+    "    \"sqlite:///../../chains/examples/Chinook.db\", \n",
     "    include_tables=['Track'], # we include only one table to save tokens in the prompt :)\n",
     "    sample_rows_in_table_info=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "64b9e494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# db = SQLDatabase.from_uri(\n",
+    "#     \"sqlite:///../../../../notebooks/Chinook.db\", \n",
+    "#     include_tables=['Track'], # we include only one table to save tokens in the prompt :)\n",
+    "#     sample_rows_in_table_info=2)"
    ]
   },
   {
@@ -338,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "9de86267",
    "metadata": {},
    "outputs": [
@@ -346,9 +359,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Table 'Track' has columns: TrackId (INTEGER), Name (NVARCHAR(200)), AlbumId (INTEGER), MediaTypeId (INTEGER), GenreId (INTEGER), Composer (NVARCHAR(220)), Milliseconds (INTEGER), Bytes (INTEGER), UnitPrice (NUMERIC(10, 2)). Here is an example of 2 rows from this table (long strings are truncated):\n",
-      "1 For Those About To Rock (We Salute You) 1 1 1 Angus Young, Malcolm Young, Brian Johnson 343719 11170334 0.99\n",
-      "2 Balls to the Wall 2 2 1 None 342562 5510424 0.99\n"
+      "\n",
+      "            Table data will be described in the following format:\n",
+      "\n",
+      "            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]),\n",
+      "            column2 name: (column2 type, [list of example values for column2], ...)\n",
+      "\n",
+      "            These are the tables you can use, together with their column information:\n",
+      "\n",
+      "            Table 'Track' has columns: {'TrackId': ['INTEGER', ['1', '2']], 'Name': ['NVARCHAR(200)', ['For Those About To Rock (We Salute You)', 'Balls to the Wall']], 'AlbumId': ['INTEGER', ['1', '2']], 'MediaTypeId': ['INTEGER', ['1', '2']], 'GenreId': ['INTEGER', ['1', '1']], 'Composer': ['NVARCHAR(220)', ['Angus Young, Malcolm Young, Brian Johnson', 'None']], 'Milliseconds': ['INTEGER', ['343719', '342562']], 'Bytes': ['INTEGER', ['11170334', '5510424']], 'UnitPrice': ['NUMERIC(10, 2)', ['0.99', '0.99']]}\n"
      ]
     }
    ],
@@ -486,9 +505,9 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "langchain",
    "language": "python",
-   "name": "python3"
+   "name": "langchain"
   },
   "language_info": {
    "codemirror_mode": {
@@ -500,7 +519,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "id": "d0e27d88",
    "metadata": {
     "pycharm": {
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "id": "72ede462",
    "metadata": {
     "pycharm": {
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "id": "a8fc8f23",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
+   "id": "1cb0baa1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Album',\n",
+       " 'Artist',\n",
+       " 'Customer',\n",
+       " 'Employee',\n",
+       " 'Genre',\n",
+       " 'Invoice',\n",
+       " 'InvoiceLine',\n",
+       " 'MediaType',\n",
+       " 'Playlist',\n",
+       " 'PlaylistTrack',\n",
+       " 'Track'}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.get_table_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "15ff81df",
    "metadata": {
     "pycharm": {
@@ -104,7 +135,7 @@
        "' There are 8 employees.'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -317,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "9a22ee47",
    "metadata": {},
    "outputs": [],
@@ -338,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "9de86267",
    "metadata": {},
    "outputs": [
@@ -500,7 +531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -15,7 +15,7 @@ SQLQuery: "SQL Query to run"
 SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
-Only use the following tables:
+Only use the tables listed below.
 
 {table_info}
 

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -1,6 +1,8 @@
 """SQLAlchemy wrapper around a database."""
 from __future__ import annotations
 
+import ast
+from collections import defaultdict
 from typing import Any, Iterable, List, Optional
 
 from sqlalchemy import create_engine, inspect
@@ -77,38 +79,44 @@ class SQLDatabase:
                 raise ValueError(f"table_names {missing_tables} not found in database")
             all_table_names = table_names
 
-        template = "Table '{table_name}' has columns: {columns}."
+        template_prefix = """
+            Table data will be described in the following format:
+
+            Table 'table name' has columns: {column1 name: (column1 type, [list of example values for column1]),
+            column2 name: (column2 type, [list of example values for column2], ...)
+
+            These are the tables you can use, together with their column information:
+
+            """
 
         tables = []
         for table_name in all_table_names:
-            columns = []
+            columns = defaultdict(list)
             for column in self._inspector.get_columns(table_name, schema=self._schema):
-                columns.append(f"{column['name']} ({str(column['type'])})")
-            column_str = ", ".join(columns)
-            table_str = template.format(table_name=table_name, columns=column_str)
+                columns[f"{column['name']}"].append(str(column["type"]))
 
             if self._sample_rows_in_table_info:
-                row_template = (
-                    " Here is an example of {n_rows} rows from this table "
-                    "(long strings are truncated):\n"
-                    "{sample_rows}"
-                )
                 sample_rows = self.run(
                     f"SELECT * FROM '{table_name}' LIMIT "
                     f"{self._sample_rows_in_table_info}"
                 )
-                sample_rows = eval(sample_rows)
-                if len(sample_rows) > 0:
-                    n_rows = len(sample_rows)
-                    sample_rows = "\n".join(
-                        [" ".join([str(i)[:100] for i in row]) for row in sample_rows]
-                    )
-                    table_str += row_template.format(
-                        n_rows=n_rows, sample_rows=sample_rows
+
+                sample_rows_ls = ast.literal_eval(sample_rows)
+                sample_rows_ls = list(
+                    map(lambda ls: [str(i)[:100] for i in ls], sample_rows_ls)
+                )
+
+                for e, col in enumerate(columns):
+                    columns[col].append(
+                        [row[e] for row in sample_rows_ls]  # type: ignore
                     )
 
+                table_str = f"Table '{table_name}' has columns: " + str(dict(columns))
+
             tables.append(table_str)
-        return "\n".join(tables)
+
+        final_str = template_prefix + "\n".join(tables)
+        return final_str
 
     def run(self, command: str) -> str:
         """Execute a SQL command and return a string representing the results.

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -8,7 +8,7 @@ from typing import Any, Iterable, List, Optional
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine import Engine
 
-_template_prefix = """Table data will be described in the following format:
+_TEMPLATE_PREFIX = """Table data will be described in the following format:
 
 Table 'table name' has columns: {
 column1 name: (column1 type, [list of example values for column1]),
@@ -116,7 +116,7 @@ class SQLDatabase:
             table_str = f"Table '{table_name}' has columns: " + str(dict(columns))
             tables.append(table_str)
 
-        final_str = _template_prefix + "\n".join(tables)
+        final_str = _TEMPLATE_PREFIX + "\n".join(tables)
         return final_str
 
     def run(self, command: str) -> str:

--- a/tests/unit_tests/test_sql_database_schema.py
+++ b/tests/unit_tests/test_sql_database_schema.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     schema,
 )
 
-from langchain.sql_database import SQLDatabase
+from langchain.sql_database import _TEMPLATE_PREFIX, SQLDatabase
 
 metadata_obj = MetaData()
 
@@ -46,10 +46,11 @@ def test_table_info() -> None:
     metadata_obj.create_all(engine)
     db = SQLDatabase(engine, schema="schema_a")
     output = db.table_info
+    output = output[len(_TEMPLATE_PREFIX) :]
     expected_output = (
-        "Table 'user' has columns: user_id (INTEGER), user_name (VARCHAR).",
+        "Table 'user' has columns: {'user_id': ['INTEGER'], 'user_name': ['VARCHAR']}"
     )
-    assert sorted(output.split("\n")) == sorted(expected_output)
+    assert output == expected_output
 
 
 def test_sql_database_run() -> None:


### PR DESCRIPTION
Currently the chain is getting the column names and types on the one side and the example rows on the other. It is easier for the llm to read the table information if the column name and examples are shown together so that it can easily understand to which columns do the examples refer to. For an instantiation of this, please refer to the changes in the `sqlite.ipynb` notebook.

Also changed `eval` for `ast.literal_eval` when interpreting the results from the sample row query since it is a better practice.

---------

Co-authored-by: Francisco Ingham <>