### PR TITLE
docs: increase width

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,3 +1,13 @@
 pre {
-    white-space: break-spaces;
+  white-space: break-spaces;
+}
+
+@media (min-width: 1200px) {
+  .container,
+  .container-lg,
+  .container-md,
+  .container-sm,
+  .container-xl {
+    max-width: 2560px !important;
+  }
 }


### PR DESCRIPTION
This addresses #948.

I set the documentation max width to 2560px, but can be adjusted - see screenshot below.

<img width="1741" alt="Screenshot 2023-02-14 at 13 05 57" src="https://user-images.githubusercontent.com/23406704/218749076-ea51e90a-a220-4558-b4fe-5a95b39ebf15.png">
