### PR TITLE
docker dev and test environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,146 @@
-.venv
 .github
 .git
-.mypy_cache
-.pytest_cache
 Dockerfile
+.vscode/
+.idea/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+.venvs
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# macOS display setting files
+.DS_Store
+
+
+
+# docker
+docker/
+!docker/assets/
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -144,3 +144,4 @@ dmypy.json
 docker/
 !docker/assets/
 .dockerignore
+docker.build

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,34 +163,7 @@ When you run `poetry install`, the `langchain` package is installed as editable 
 
 ## Using Docker
 
-To quickly get started, run the command `make docker`.
-
-If docker is installed the Makefile will export extra targets in the fomrat `docker.*` to build and run the docker image. Type `make` for a list of common tasks.
-
-### Building the development image
-
-- use `make docker.run` will build the dev image if it does not exist.
-- `make docker.build` 
-
-#### Image caching
-
-The Dockerfile is optimized to cache the poetry install step. A rebuild is triggered when there a change to the source code.
-
-### Examples
-
-All commands that in the python env are available by default in the container.
-
-A few examples:
-```bash
-# run jupyter notebook
-docker run --rm -it IMG jupyter notebook
-
-# run ipython
-docker run --rm -it IMG ipython
-
-# start web server
-docker run --rm -p 8888:8888 IMG python -m http.server 8888
-```
+Refer to [DOCKER.md](docker/DOCKER.md) for more information.
 
 ## Documentation
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -161,6 +161,37 @@ poetry run jupyter notebook
 
 When you run `poetry install`, the `langchain` package is installed as editable in the virtualenv, so your new logic can be imported into the notebook.
 
+## Using Docker
+
+To quickly get started, run the command `make docker`.
+
+If docker is installed the Makefile will export extra targets in the fomrat `docker.*` to build and run the docker image. Type `make` for a list of common tasks.
+
+### Building the development image
+
+- use `make docker.run` will build the dev image if it does not exist.
+- `make docker.build` 
+
+#### Image caching
+
+The Dockerfile is optimized to cache the poetry install step. A rebuild is triggered when there a change to the source code.
+
+### Examples
+
+All commands that in the python env are available by default in the container.
+
+A few examples:
+```bash
+# run jupyter notebook
+docker run --rm -it IMG jupyter notebook
+
+# run ipython
+docker run --rm -it IMG ipython
+
+# start web server
+docker run --rm -p 8888:8888 IMG python -m http.server 8888
+```
+
 ## Documentation
 
 ### Contribute Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ celerybeat.pid
 # Environments
 .env
 .envrc
+!docker/.env
 .venv
 .venvs
 env/
@@ -150,3 +151,4 @@ wandb/
 # integration test artifacts
 data_map*
 \[('_type', 'fake'), ('stop', None)]
+docker.build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: all clean format lint test tests test_watch integration_tests docker_tests help extended_tests
 
+GIT_HASH ?= $(shell git rev-parse --short HEAD)
+LANGCHAIN_VERSION := $(shell grep '^version' pyproject.toml | cut -d '=' -f2 | tr -d '"')
+
 all: help
 
 coverage:
@@ -37,8 +40,7 @@ TEST_FILE ?= tests/unit_tests/
 test:
 	poetry run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
-tests: 
-	poetry run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+tests: test
 
 extended_tests:
 	poetry run pytest --disable-socket --allow-unix-socket --only-extended tests/unit_tests
@@ -67,4 +69,17 @@ help:
 	@echo 'extended_tests               - run only extended unit tests'
 	@echo 'test_watch                   - run unit tests in watch mode'
 	@echo 'integration_tests            - run integration tests'
+ifneq ($(shell command -v docker 2> /dev/null),)
 	@echo 'docker_tests                 - run unit tests in docker'
+	@echo 'docker                       - build and run the docker dev image'
+	@echo 'docker.run                   - run the docker dev image'
+	@echo 'docker.build                 - build the docker dev image'
+	@echo 'docker.force_build           - force a rebuild of the docker development image'
+endif
+
+# include the following makefile if the docker executable is available
+ifeq ($(shell command -v docker 2> /dev/null),)
+	$(info Docker not found, skipping docker-related targets)
+else
+include docker/Makefile
+endif

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,10 @@ ifneq ($(shell command -v docker 2> /dev/null),)
 	@echo 'docker_tests                 - run unit tests in docker'
 	@echo 'docker                       - build and run the docker dev image'
 	@echo 'docker.run                   - run the docker dev image'
+	@echo 'docker.jupyter 	            - start a jupyter notebook inside container'
 	@echo 'docker.build                 - build the docker dev image'
 	@echo 'docker.force_build           - force a rebuild of the docker development image'
+	@echo 'docker.clean 	            - remove the docker dev image'
 endif
 
 # include the following makefile if the docker executable is available

--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,15 @@ help:
 	@echo 'test_watch                   - run unit tests in watch mode'
 	@echo 'integration_tests            - run integration tests'
 ifneq ($(shell command -v docker 2> /dev/null),)
-	@echo 'docker_tests                 - run unit tests in docker'
+	@echo 'docker_tests                 - run unit tests in docker (test only image)'
 	@echo 'docker                       - build and run the docker dev image'
 	@echo 'docker.run                   - run the docker dev image'
-	@echo 'docker.jupyter 	            - start a jupyter notebook inside container'
+	@echo 'docker.jupyter               - start a jupyter notebook inside container'
 	@echo 'docker.build                 - build the docker dev image'
-	@echo 'docker.force_build           - force a rebuild of the docker development image'
-	@echo 'docker.clean 	            - remove the docker dev image'
+	@echo 'docker.force_build           - force a rebuild'
+	@echo 'docker.test                  - run unit tests in docker (full dev image)'
+	@echo 'docker.lint                  - run linters in docker'
+	@echo 'docker.clean                 - remove the docker dev image'
 endif
 
 # include the following makefile if the docker executable is available

--- a/docker/.env
+++ b/docker/.env
@@ -1,6 +1,10 @@
 # python env
-PYTHON_VERSION=3.11.2
+PYTHON_VERSION=3.10
 
-# langchain env
+# -E flag is required
+# comment the following line to only install dev dependencies
+POETRY_EXTRA_PACKAGES="-E all"
+
+# langchain env. warning: these variables will be baked into the docker image !
 OPENAI_API_KEY=${OPENAI_API_KEY:-}
 SERPAPI_API_KEY=${SERPAPI_API_KEY:-}

--- a/docker/.env
+++ b/docker/.env
@@ -5,6 +5,9 @@ PYTHON_VERSION=3.10
 # comment the following line to only install dev dependencies
 POETRY_EXTRA_PACKAGES="-E all"
 
+# at least one group needed
+POETRY_DEPENDENCIES="dev,test,lint,typing"
+
 # langchain env. warning: these variables will be baked into the docker image !
 OPENAI_API_KEY=${OPENAI_API_KEY:-}
 SERPAPI_API_KEY=${SERPAPI_API_KEY:-}

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,6 @@
+# python env
+PYTHON_VERSION=3.11.2
+
+# langchain env
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
+SERPAPI_API_KEY=${SERPAPI_API_KEY:-}

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,0 +1,39 @@
+## Using Docker
+
+To quickly get started, run the command `make docker`.
+
+If docker is installed the Makefile will export extra targets in the fomrat `docker.*` to build and run the docker image. Type `make` for a list of common tasks.
+
+### Building the development image
+
+- use `make docker.run` will build the dev image if it does not exist.
+- `make docker.build` 
+
+#### Customizing the image and installed dependencies
+
+The image is built with a default python version and all extras and dev
+dependencies. It can be customized by changing the variables in the [.env](/docker/.env)
+file. 
+
+If you don't need all the `extra` dependencies a slimmer image can be obtained by 
+commenting out `POETRY_EXTRA_PACKAGES` in the [.env](docker/.env) file.
+
+#### Image caching
+
+The Dockerfile is optimized to cache the poetry install step. A rebuild is triggered when there a change to the source code.
+
+### Example Usage
+
+All commands that in the python env are available by default in the container.
+
+A few examples:
+```bash
+# run jupyter notebook
+docker run --rm -it IMG jupyter notebook
+
+# run ipython
+docker run --rm -it IMG ipython
+
+# start web server
+docker run --rm -p 8888:8888 IMG python -m http.server 8888
+```

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,15 +1,17 @@
-## Using Docker
+# Using Docker
 
 To quickly get started, run the command `make docker`.
 
-If docker is installed the Makefile will export extra targets in the fomrat `docker.*` to build and run the docker image. Type `make` for a list of common tasks.
+If docker is installed the Makefile will export extra targets in the fomrat `docker.*` to build and run the docker image. Type `make` for a list of available tasks.
 
-### Building the development image
+There is a basic `docker-compose.yml` in the docker directory.
 
-- use `make docker.run` will build the dev image if it does not exist.
-- `make docker.build` 
+## Building the development image
 
-#### Customizing the image and installed dependencies
+Using `make docker` will build the dev image if it does not exist, then drops
+you inside the container with the langchain environment available in the shell.
+
+### Customizing the image and installed dependencies
 
 The image is built with a default python version and all extras and dev
 dependencies. It can be customized by changing the variables in the [.env](/docker/.env)
@@ -18,13 +20,13 @@ file.
 If you don't need all the `extra` dependencies a slimmer image can be obtained by 
 commenting out `POETRY_EXTRA_PACKAGES` in the [.env](docker/.env) file.
 
-#### Image caching
+### Image caching
 
 The Dockerfile is optimized to cache the poetry install step. A rebuild is triggered when there a change to the source code.
 
-### Example Usage
+## Example Usage
 
-All commands that in the python env are available by default in the container.
+All commands from langchain's python environment are available by default in the container.
 
 A few examples:
 ```bash
@@ -37,3 +39,15 @@ docker run --rm -it IMG ipython
 # start web server
 docker run --rm -p 8888:8888 IMG python -m http.server 8888
 ```
+
+## Testing / Linting
+
+Tests and lints are run using your local source directory that is mounted on the volume /src.
+
+Run unit tests in the container with `make docker.test`.
+
+Run the linting and formatting checks with `make docker.lint`.
+
+Note: this task can run in parallel using `make -j4 docker.lint`.
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,102 @@
+# vim: ft=dockerfile
+#
+# see also: https://github.com/python-poetry/poetry/discussions/1879
+#   - with https://github.com/bneijt/poetry-lock-docker
+# see https://github.com/thehale/docker-python-poetry
+# see https://github.com/max-pfeiffer/uvicorn-poetry
+
+# use by default the slim version of python
+ARG PYTHON_IMAGE_TAG=slim 
+ARG PYTHON_VERSION=${PYTHON_VERSION:-3.11.2}
+
+####################
+# Base Environment
+####################
+FROM python:$PYTHON_VERSION-$PYTHON_IMAGE_TAG AS lchain-base
+
+ARG UID=1000
+ARG USERNAME=lchain
+
+ENV USERNAME=$USERNAME
+
+RUN groupadd -g ${UID} $USERNAME
+RUN useradd -l -m -u ${UID} -g ${UID} $USERNAME
+
+# used for mounting source code
+RUN mkdir /src
+VOLUME /src
+
+
+#######################
+## Poetry Builder Image
+#######################
+FROM lchain-base AS lchain-base-builder
+
+ENV HOME=/root
+ENV POETRY_HOME=/root/.poetry
+ENV POETRY_VIRTUALENVS_IN_PROJECT=false
+ENV POETRY_NO_INTERACTION=1
+ENV CACHE_DIR=$HOME/.cache
+ENV POETRY_CACHE_DIR=$CACHE_DIR/pypoetry
+ENV PATH="$POETRY_HOME/bin:$PATH"
+
+WORKDIR /root
+
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    curl
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir -p $CACHE_DIR
+
+## setup poetry
+RUN curl -sSL -o $CACHE_DIR/pypoetry-installer.py https://install.python-poetry.org/
+RUN python3 $CACHE_DIR/pypoetry-installer.py
+
+
+# # Copy poetry files
+COPY poetry.* pyproject.toml ./
+
+RUN mkdir /pip-prefix
+
+RUN poetry export --with dev -f requirements.txt --output requirements.txt --without-hashes && \
+    pip install --no-cache-dir --disable-pip-version-check --prefix /pip-prefix -r requirements.txt
+
+
+# add custom motd message
+COPY docker/assets/etc/motd /tmp/motd
+RUN cat /tmp/motd > /etc/motd
+
+RUN printf "\n%s\n%s\n" "$(poetry version)" "$(python --version)" >> /etc/motd
+
+
+
+###################
+## Runtime Image
+###################
+FROM lchain-base AS lchain
+
+#jupyter port
+EXPOSE 8888
+
+COPY docker/assets/entry.sh /entry
+RUN chmod +x /entry
+
+COPY --from=lchain-base-builder /etc/motd /etc/motd
+COPY --from=lchain-base-builder /usr/bin/git /usr/bin/git
+
+USER ${USERNAME:-lchain}
+ENV HOME /home/$USERNAME
+WORKDIR /home/$USERNAME
+
+COPY --chown=lchain:lchain --from=lchain-base-builder /pip-prefix $HOME/.local/
+
+COPY . .
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN pip install --no-deps --disable-pip-version-check --no-cache-dir -e .
+
+
+entrypoint ["/entry"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ COPY poetry.* pyproject.toml ./
 
 RUN mkdir /pip-prefix
 
-RUN poetry export $POETRY_EXTRA_PACKAGES --with dev -f requirements.txt --output requirements.txt --without-hashes && \
+RUN poetry export $POETRY_EXTRA_PACKAGES --with dev,test,lint -f requirements.txt --output requirements.txt --without-hashes && \
     pip install --no-cache-dir --disable-pip-version-check --prefix /pip-prefix -r requirements.txt
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,9 @@ VOLUME /src
 #######################
 FROM lchain-base AS lchain-base-builder
 
+ARG POETRY_EXTRA_PACKAGES=${POETRY_EXTRA_PACKAGES}
+ENV POETRY_EXTRA_PACKAGES=$POETRY_EXTRA_PACKAGES
+
 ENV HOME=/root
 ENV POETRY_HOME=/root/.poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false
@@ -44,6 +47,7 @@ WORKDIR /root
 
 RUN apt-get update && \
     apt-get install -y \
+    build-essential \
     git \
     curl
 
@@ -61,7 +65,7 @@ COPY poetry.* pyproject.toml ./
 
 RUN mkdir /pip-prefix
 
-RUN poetry export --with dev -f requirements.txt --output requirements.txt --without-hashes && \
+RUN poetry export $POETRY_EXTRA_PACKAGES --with dev -f requirements.txt --output requirements.txt --without-hashes && \
     pip install --no-cache-dir --disable-pip-version-check --prefix /pip-prefix -r requirements.txt
 
 
@@ -70,8 +74,6 @@ COPY docker/assets/etc/motd /tmp/motd
 RUN cat /tmp/motd > /etc/motd
 
 RUN printf "\n%s\n%s\n" "$(poetry version)" "$(python --version)" >> /etc/motd
-
-
 
 ###################
 ## Runtime Image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,8 +32,8 @@ VOLUME /src
 #######################
 FROM lchain-base AS lchain-base-builder
 
-ARG POETRY_EXTRA_PACKAGES=${POETRY_EXTRA_PACKAGES}
-ENV POETRY_EXTRA_PACKAGES=$POETRY_EXTRA_PACKAGES
+ARG POETRY_EXTRA_PACKAGES=$POETRY_EXTRA_PACKAGES
+ARG POETRY_DEPENDENCIES=$POETRY_DEPENDENCIES
 
 ENV HOME=/root
 ENV POETRY_HOME=/root/.poetry
@@ -65,7 +65,7 @@ COPY poetry.* pyproject.toml ./
 
 RUN mkdir /pip-prefix
 
-RUN poetry export $POETRY_EXTRA_PACKAGES --with dev,test,lint -f requirements.txt --output requirements.txt --without-hashes && \
+RUN poetry export $POETRY_EXTRA_PACKAGES --with $POETRY_DEPENDENCIES -f requirements.txt --output requirements.txt --without-hashes && \
     pip install --no-cache-dir --disable-pip-version-check --prefix /pip-prefix -r requirements.txt
 
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,9 +1,12 @@
 #do not call this makefile it is included in the main Makefile
-.PHONY: docker docker.jupyter docker.run docker.force_build docker.clean
+.PHONY: docker docker.jupyter docker.run docker.force_build docker.clean \
+	docker.test docker.lint docker.lint.mypy docker.lint.black \
+	docker.lint.isort docker.lint.flake
 
 # read python version from .env file ignoring comments
 PYTHON_VERSION := $(shell grep PYTHON_VERSION docker/.env | cut -d '=' -f2)
 POETRY_EXTRA_PACKAGES := $(shell grep '^[^#]*POETRY_EXTRA_PACKAGES' docker/.env | cut -d '=' -f2)
+POETRY_DEPENDENCIES := $(shell grep 'POETRY_DEPENDENCIES' docker/.env | cut -d '=' -f2)
 
 
 DOCKER_SRC := $(shell find docker -type f)
@@ -20,6 +23,8 @@ DOCKER_MOTD := docker/assets/etc/motd
 
 ROOTDIR := $(shell git rev-parse --show-toplevel)
 
+DOCKER_LINT_CMD = docker run --rm -i -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH)
+
 docker: docker.run
 
 docker.run: docker.build
@@ -33,11 +38,13 @@ docker.build: $(SRC) $(DOCKER_SRC) $(DOCKER_MOTD)
 ifdef $(DOCKER_BUILDKIT)
 	docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 			--build-arg POETRY_EXTRA_PACKAGES=$(POETRY_EXTRA_PACKAGES) \
+			--build-arg POETRY_DEPENDENCIES=$(POETRY_DEPENDENCIES) \
 			--progress=$(DOCKER_BUILD_PROGRESS) \
 			$(BUILD_FLAGS) -f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
 else
 	docker build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 			--build-arg POETRY_EXTRA_PACKAGES=$(POETRY_EXTRA_PACKAGES) \
+			--build-arg POETRY_DEPENDENCIES=$(POETRY_DEPENDENCIES) \
 			$(BUILD_FLAGS) -f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
 endif
 	docker tag $(DOCKER_IMAGE_NAME):$(GIT_HASH) $(DOCKER_IMAGE_NAME):latest
@@ -55,10 +62,23 @@ docker.test: docker.build
 	docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH) \
 		pytest /src/tests/unit_tests
 
-docker.lint: docker.build
-	$(eval DOCKER_CMD = docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH))
+# this assumes that the docker image has been built 
+docker.lint: docker.lint.mypy docker.lint.black docker.lint.isort \
+	docker.lint.flake
 
-	$(DOCKER_CMD) mypy /src
-	$(DOCKER_CMD) black /src --check
-	$(DOCKER_CMD) isort /src --check
-	$(DOCKER_CMD) flake8 /src --check
+# these can run in parallel with -j[njobs]
+docker.lint.mypy:
+	@$(DOCKER_LINT_CMD) mypy /src
+	@printf "\t%s\n" "mypy ... "
+
+docker.lint.black:
+	@$(DOCKER_LINT_CMD) black /src --check
+	@printf "\t%s\n" "black ... "
+
+docker.lint.isort:
+	@$(DOCKER_LINT_CMD) isort /src --check
+	@printf "\t%s\n" "isort ... "
+
+docker.lint.flake:
+	@$(DOCKER_LINT_CMD) flake8 /src
+	@printf "\t%s\n" "flake8 ... "

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -50,3 +50,15 @@ docker.force_build: $(DOCKER_SRC)
 
 docker.clean:
 	docker rmi $(DOCKER_IMAGE_NAME):$(GIT_HASH) $(DOCKER_IMAGE_NAME):latest
+
+docker.test: docker.build
+	docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH) \
+		pytest /src/tests/unit_tests
+
+docker.lint: docker.build
+	$(eval DOCKER_CMD = docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH))
+
+	$(DOCKER_CMD) mypy /src
+	$(DOCKER_CMD) black /src --check
+	$(DOCKER_CMD) isort /src --check
+	$(DOCKER_CMD) flake8 /src --check

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,47 @@
+#do not call this makefile it is included in the main Makefile
+.PHONY: docker docker.jupyter docker.run docker.force_build
+
+# read python version from .env file
+PYTHON_VERSION := $(shell grep PYTHON_VERSION docker/.env | cut -d '=' -f2)
+
+
+DOCKER_SRC := $(shell find docker -type f -not -name .env)
+DOCKER_IMAGE_NAME = langchain/dev
+
+# SRC is all files matched by the git ls-files command
+SRC := $(shell git ls-files -- '*' ':!:docker/*')
+
+# set DOCKER_BUILD_PROGRESS=plain to see detailed build progress
+DOCKER_BUILD_PROGRESS ?= auto
+
+# extra message to show when entering the docker container
+DOCKER_MOTD := docker/assets/etc/motd
+
+ROOTDIR := $(shell git rev-parse --show-toplevel)
+
+docker: docker.run
+
+docker.run: docker.build
+	@echo "Docker image: $(DOCKER_IMAGE_NAME):$(GIT_HASH)"
+	@docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH)
+	@# $(local source mounted at $(ROOTDIR) at /src)
+
+docker.jupyter: docker.build
+	@docker run --rm -it -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH) jupyter notebook
+
+docker.build: $(SRC) $(DOCKER_SRC) $(DOCKER_MOTD)
+ifdef $(DOCKER_BUILDKIT)
+	@docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+			--progress=$(DOCKER_BUILD_PROGRESS) \
+			-f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
+else
+	@docker build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+			-f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
+endif
+	@docker tag $(DOCKER_IMAGE_NAME):$(GIT_HASH) $(DOCKER_IMAGE_NAME):latest
+	@touch $@ # this avoids docker rebuilds the build dependencies have not changed
+	@		  # you can remove the file docker_build to force a rebuild
+
+docker.force_build: $(DOCKER_SRC)
+	@docker build --no-cache -f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
+

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,11 +1,12 @@
 #do not call this makefile it is included in the main Makefile
-.PHONY: docker docker.jupyter docker.run docker.force_build
+.PHONY: docker docker.jupyter docker.run docker.force_build docker.clean
 
-# read python version from .env file
+# read python version from .env file ignoring comments
 PYTHON_VERSION := $(shell grep PYTHON_VERSION docker/.env | cut -d '=' -f2)
+POETRY_EXTRA_PACKAGES := $(shell grep '^[^#]*POETRY_EXTRA_PACKAGES' docker/.env | cut -d '=' -f2)
 
 
-DOCKER_SRC := $(shell find docker -type f -not -name .env)
+DOCKER_SRC := $(shell find docker -type f)
 DOCKER_IMAGE_NAME = langchain/dev
 
 # SRC is all files matched by the git ls-files command
@@ -23,25 +24,29 @@ docker: docker.run
 
 docker.run: docker.build
 	@echo "Docker image: $(DOCKER_IMAGE_NAME):$(GIT_HASH)"
-	@docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH)
-	@# $(local source mounted at $(ROOTDIR) at /src)
+	docker run --rm -it -u lchain -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH)
 
 docker.jupyter: docker.build
-	@docker run --rm -it -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH) jupyter notebook
+	docker run --rm -it -v $(ROOTDIR):/src  $(DOCKER_IMAGE_NAME):$(GIT_HASH) jupyter notebook
 
 docker.build: $(SRC) $(DOCKER_SRC) $(DOCKER_MOTD)
 ifdef $(DOCKER_BUILDKIT)
-	@docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+	docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+			--build-arg POETRY_EXTRA_PACKAGES=$(POETRY_EXTRA_PACKAGES) \
 			--progress=$(DOCKER_BUILD_PROGRESS) \
-			-f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
+			$(BUILD_FLAGS) -f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
 else
-	@docker build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-			-f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
+	docker build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+			--build-arg POETRY_EXTRA_PACKAGES=$(POETRY_EXTRA_PACKAGES) \
+			$(BUILD_FLAGS) -f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
 endif
-	@docker tag $(DOCKER_IMAGE_NAME):$(GIT_HASH) $(DOCKER_IMAGE_NAME):latest
-	@touch $@ # this avoids docker rebuilds the build dependencies have not changed
-	@		  # you can remove the file docker_build to force a rebuild
+	docker tag $(DOCKER_IMAGE_NAME):$(GIT_HASH) $(DOCKER_IMAGE_NAME):latest
+	@touch $@ # this prevents docker from rebuilding dependencies that have not 
+	@         #  changed. Remove the file `docker/docker.build` to force a rebuild.
 
 docker.force_build: $(DOCKER_SRC)
-	@docker build --no-cache -f docker/Dockerfile -t $(DOCKER_IMAGE_NAME):$(GIT_HASH) .
+	@rm -f docker.build
+	@$(MAKE) docker.build BUILD_FLAGS=--no-cache
 
+docker.clean:
+	docker rmi $(DOCKER_IMAGE_NAME):$(GIT_HASH) $(DOCKER_IMAGE_NAME):latest

--- a/docker/assets/entry.sh
+++ b/docker/assets/entry.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PATH=$HOME/.local/bin:$PATH
+
+if [ -z "$1" ]; then
+    cat /etc/motd
+    exec /bin/bash
+fi
+
+exec "$@"

--- a/docker/assets/etc/motd
+++ b/docker/assets/etc/motd
@@ -1,0 +1,9 @@
+The dependencies have been installed in the current shell.
+There is no virtualenv or a need for `poetry` inside the
+container.
+
+Running the command `make docker.run` at the root directory
+of the project will build the container the first time. On
+the next runs, it will use the cached image or rebuild it if
+a change is made on the source code.
+

--- a/docker/assets/etc/motd
+++ b/docker/assets/etc/motd
@@ -1,9 +1,8 @@
-The dependencies have been installed in the current shell.
-There is no virtualenv or a need for `poetry` inside the
-container.
+All dependencies have been installed in the current shell. There is no
+virtualenv or a need for `poetry` inside the container.
 
-Running the command `make docker.run` at the root directory
-of the project will build the container the first time. On
-the next runs, it will use the cached image or rebuild it if
-a change is made on the source code.
+Running the command `make docker.run` at the root directory of the project will
+build the container the first time. On the next runs it will use the cached
+image. A rebuild will happen when changes are made to the source code.
 
+You local source directory has been mounted to the /src directory.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       dockerfile: docker/Dockerfile
       args:
         PYTHON_VERSION: ${PYTHON_VERSION}
+        POETRY_EXTRA_PACKAGES: ${POETRY_EXTRA_PACKAGES}
+        POETRY_DEPENDENCIES: ${POETRY_DEPENDENCIES}
 
     restart: unless-stopped
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+
+services:
+  langchain:
+    hostname: langchain
+    image: langchain/dev:latest
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+      args:
+        PYTHON_VERSION: ${PYTHON_VERSION}
+
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:8888:8888


### PR DESCRIPTION
implements feature for  #1031 

### TODO:

- [ ~Use pyenv for setting custom python versions and virtualenvs*~
- [x] Separate makefile for docker
   -  [x] hidden from users who don't have docker installed
- [x] Virtualized python env
- [x] all python env commands available for container 
    - example launch jupyter notebook `docker run IMG jupyter notebook `
- [x]  Setup   dev-test- repl workflow
    - [x]   ipython/notebook from within container with exported ports
- [x] Documentation
    - [x] make docker commands
    - [x] docker-compose
    - [x] common tasks examples
- [x] using docker for testing / linting

_* ~pyenv might be necessary to make sure any python version can be installed. Given the multitude of dependencies some users might have issues with certain packages or missing libraries. Also useful for testing under different pythons.~

Abondonted the poetry/pyenv way and used a pure python based container. Using virtualenvs inside docker is a controversial topic and adds a lot of complexity. [long discussion here](https://github.com/python-poetry/poetry/discussions/1879)


### USAGE:
- Use `make docker`   or  just type `make` for a list of commands
- All commands that in the python env are available by default in the container.  For example:
- 
```bash
# run jupyter notebook
docker run --rm -it IMG jupyter notebook

# run ipython
docker run --rm -it IMG ipython

# start web server
docker run --rm -p 8888:8888 IMG python -m http.server 8888
```
- Running `make docker.run` or `make docker.build` will automatically rebuild the image if needed when code is changed, only the package is reinstalled. Dependencies are only built once using docker builder cache.

- linting can happen with parallel jobs using `make -j4 docker.lint`

NOTE: using docker for sandboxing untrusted code exection is tracked in #1031 
