### PR TITLE
Update and rename everynote.ipynb to evernote.ipynb

### DIFF
--- a/docs/modules/document_loaders/examples/evernote.ipynb
+++ b/docs/modules/document_loaders/examples/evernote.ipynb
@@ -5,9 +5,9 @@
    "id": "56ac1584",
    "metadata": {},
    "source": [
-    "# EveryNote\n",
+    "# EverNote\n",
     "\n",
-    "How to load EveryNote file from disk."
+    "How to load EverNote file from disk."
    ]
   },
   {
@@ -41,9 +41,9 @@
     }
    ],
    "source": [
-    "from langchain.document_loaders import EveryNoteLoader\n",
+    "from langchain.document_loaders import EverNoteLoader\n",
     "\n",
-    "loader = EveryNoteLoader(\"example_data/testing.enex\")\n",
+    "loader = EverNoteLoader(\"example_data/testing.enex\")\n",
     "loader.load()"
    ]
   },


### PR DESCRIPTION
Updating the filename and all the references from Everynote to Evernote since the actual application name is EverNote. Also updated the example file showed on the website to reflect this:

https://github.com/hwchase17/langchain/compare/master...akshayvkt:langchain:patch-2