### PR TITLE
Fix typo in integration with Chroma

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -64,7 +64,7 @@ class Chroma(VectorStore):
         else:
             self._collection = self._client.create_collection(
                 name=collection_name,
-                embedding_fn=self._embedding_function.embed_documents
+                embedding_function=self._embedding_function.embed_documents
                 if self._embedding_function is not None
                 else None,
             )


### PR DESCRIPTION
We introduced a breaking change but missed this call. This PR fixes `langchain` to work with upstream `chroma`.