### PR TITLE
[Integration Tests] Cast fake embeddings to ALL float values

### DIFF
--- a/tests/integration_tests/vectorstores/fake_embeddings.py
+++ b/tests/integration_tests/vectorstores/fake_embeddings.py
@@ -11,8 +11,8 @@ class FakeEmbeddings(Embeddings):
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return simple embeddings."""
-        return [[1.0] * 9 + [i] for i in range(len(texts))]
+        return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
 
     def embed_query(self, text: str) -> List[float]:
         """Return simple embeddings."""
-        return [1.0] * 9 + [0.0]
+        return [float(1.0)] * 9 + [float(0.0)]


### PR DESCRIPTION
Pydantic validation breaks tests for example (`test_qdrant.py`) because fake embeddings contain an integer.

This PR casts the embeddings array to all floats.

Now the `qdrant` test passes, `poetry run pytest tests/integration_tests/vectorstores/test_qdrant.py`