### PR TITLE
Strange behavior with LLM import requirements

### DIFF
--- a/langchain/llms/ai21.py
+++ b/langchain/llms/ai21.py
@@ -28,7 +28,7 @@ class AI21(LLM, BaseModel):
     Example:
         .. code-block:: python
 
-            from langchain import AI21
+            from langchain.llms import AI21
             ai21 = AI21(model="j1-jumbo")
     """
 


### PR DESCRIPTION
This import works fine:
```python
from langchain import Anthropic
```
This import does not:
```python
from langchain import AI21
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'AI21' from 'langchain' (/opt/anaconda3/envs/fed_nlp/lib/python3.9/site-packages/langchain/__init__.py)
```

I think there is a slight documentation inconsistency here: https://langchain.readthedocs.io/en/latest/reference/modules/llms.html

This PR starts to solve that. Should all the import examples be
`from langchain.llms import X` instead of `from langchain import X`?