### PR TITLE
Convert to floats in FakeEmbeddings

### DIFF
--- a/tests/integration_tests/vectorstores/fake_embeddings.py
+++ b/tests/integration_tests/vectorstores/fake_embeddings.py
@@ -11,7 +11,7 @@ class FakeEmbeddings(Embeddings):
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return simple embeddings."""
-        return [[1.0] * 9 + [i] for i in range(len(texts))]
+        return [[1.0] * 9 + [float(i)] for i in range(len(texts))]
 
     def embed_query(self, text: str) -> List[float]:
         """Return simple embeddings."""


### PR DESCRIPTION
Some engines have strong typing and accept float vectors as embeddings only. This PR fixes that. It's related to #1098