### PR TITLE
Fix a bug that shows "KeyError 'items'"

### DIFF
--- a/langchain/utilities/google_search.py
+++ b/langchain/utilities/google_search.py
@@ -61,7 +61,7 @@ class GoogleSearchAPIWrapper(BaseModel):
             .list(q=search_term, cx=self.google_cse_id, **kwargs)
             .execute()
         )
-        return res["items"]
+        return res.get("items", [])
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:

--- a/tests/integration_tests/test_googlesearch_api.py
+++ b/tests/integration_tests/test_googlesearch_api.py
@@ -7,3 +7,13 @@ def test_call() -> None:
     search = GoogleSearchAPIWrapper()
     output = search.run("What was Obama's first name?")
     assert "Barack Hussein Obama II" in output
+
+
+def test_no_result_call() -> None:
+    """Test that call gives no result."""
+    search = GoogleSearchAPIWrapper()
+    output = search.run(
+        "NORESULTCALL_NORESULTCALL_NORESULTCALL_NORESULTCALL_NORESULTCALL_NORESULTCALL"
+    )
+    print(type(output))
+    assert "No good Google Search Result was found" == output


### PR DESCRIPTION
Fix KeyError 'items' when no result found.

## Problem

When no result found for a query, google search crashed with `KeyError 'items'`.

## Solution

I added a check for an empty response before accessing the 'items' key. It will handle the case correctly.

## Other

my twitter: yakigac
(I don't mind even if you don't mention me for this PR. But just because last time my real name was shout out :) )
