### PR TITLE
Sql alchemy commands used in table info 

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -101,7 +101,7 @@ class SQLDatabase:
                 command = select(table).limit(self._sample_rows_in_table_info)
 
                 # save the command in string format
-                select_star = str(command.compile(compile_kwargs={"literal_binds": True}))
+                select_star = f"SELECT * FROM {table.name} LIMIT {self._sample_rows_in_table_info}"
 
                 # save the columns in string format 
                 columns_str = " ".join([col.name for col in table.columns])

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -85,8 +85,6 @@ class SQLDatabase:
                 raise ValueError(f"table_names {missing_tables} not found in database")
             all_table_names = table_names
 
-        print(all_table_names)
-
         tables = []
         meta = MetaData()
         meta.reflect(bind=self._engine)
@@ -112,7 +110,7 @@ class SQLDatabase:
 
                 # get the sample rows
                 with self._engine.connect() as connection:
-                    sample_rows = connection.execute(command, limit=2)
+                    sample_rows = connection.execute(command)
 
                 # shorten values in the smaple rows
                 sample_rows = list(

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 from typing import Any, Iterable, List, Optional
 
-from sqlalchemy.exc import ProgrammingError
-
 from sqlalchemy import MetaData, create_engine, inspect, select
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.schema import CreateTable
 
 
@@ -90,9 +89,11 @@ class SQLDatabase:
             if missing_tables:
                 raise ValueError(f"table_names {missing_tables} not found in database")
             all_table_names = table_names
-        
+
         meta_tables = [
-            tbl for tbl in self._metadata.sorted_tables if tbl.name in set(all_table_names)
+            tbl
+            for tbl in self._metadata.sorted_tables
+            if tbl.name in set(all_table_names)
         ]
 
         tables = []
@@ -105,8 +106,10 @@ class SQLDatabase:
                 command = select(table).limit(self._sample_rows_in_table_info)
 
                 # save the command in string format
-                select_star = (f"SELECT * FROM '{table.name}' LIMIT "
-                               f"{self._sample_rows_in_table_info}")
+                select_star = (
+                    f"SELECT * FROM '{table.name}' LIMIT "
+                    f"{self._sample_rows_in_table_info}"
+                )
 
                 # save the columns in string format
                 columns_str = " ".join([col.name for col in table.columns])
@@ -124,7 +127,7 @@ class SQLDatabase:
                     # save the sample rows in string format
                     sample_rows_str = "\n".join([" ".join(row) for row in sample_rows])
 
-                # in some dialects when there are no rows in the table a 
+                # in some dialects when there are no rows in the table a
                 # 'ProgrammingError' is returned
                 except ProgrammingError:
                     sample_rows_str = ""

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -1,24 +1,11 @@
 """SQLAlchemy wrapper around a database."""
 from __future__ import annotations
 
-import ast
 from typing import Any, Iterable, List, Optional
 
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, inspect, MetaData, select
 from sqlalchemy.engine import Engine
-
-_TEMPLATE_PREFIX = """Table data will be described in the following format:
-
-Table 'table name' has columns: {
-column1 name: (column1 type, [list of example values for column1]),
-column2 name: (column2 type, [list of example values for column2]),
-...
-}
-
-These are the tables you can use, together with their column information:
-
-"""
-
+from sqlalchemy.schema import CreateTable
 
 class SQLDatabase:
     """SQLAlchemy wrapper around a database."""
@@ -53,6 +40,10 @@ class SQLDatabase:
                 raise ValueError(
                     f"ignore_tables {missing_tables} not found in database"
                 )
+
+        if not isinstance(sample_rows_in_table_info, int):
+            raise TypeError("sample_rows_in_table_info must be an integer")
+
         self._sample_rows_in_table_info = sample_rows_in_table_info
 
     @classmethod
@@ -94,46 +85,40 @@ class SQLDatabase:
             all_table_names = table_names
 
         tables = []
-        for table_name in all_table_names:
-            columns = []
-            if self.dialect in ("sqlite", "duckdb"):
-                create_table = self.run(
-                    (
-                        "SELECT sql FROM sqlite_master WHERE "
-                        f"type='table' AND name='{table_name}'"
-                    ),
-                    fetch="one",
-                )
-            else:
-                create_table = self.run(
-                    f"SHOW CREATE TABLE `{table_name}`;",
-                )
+        meta = MetaData()
+        meta.reflect(bind=self._engine)
 
-            for column in self._inspector.get_columns(table_name, schema=self._schema):
-                columns.append(column["name"])
+        meta_tables = [tbl for tbl in meta.sorted_tables if tbl.name in set(all_table_names)]
+
+        for table in meta_tables:
+
+            # add create table command
+            create_table = str(CreateTable(table).compile(self._engine))
 
             if self._sample_rows_in_table_info:
-                if self.dialect in ("sqlite", "duckdb"):
-                    select_star = (
-                        f"SELECT * FROM '{table_name}' LIMIT "
-                        f"{self._sample_rows_in_table_info}"
-                    )
-                else:
-                    select_star = (
-                        f"SELECT * FROM `{table_name}` LIMIT "
-                        f"{self._sample_rows_in_table_info}"
-                    )
+                
+                # build the select command
+                command = select(table).limit(self._sample_rows_in_table_info)
 
-                sample_rows = self.run(select_star)
+                # save the command in string format
+                select_star = str(command.compile(compile_kwargs={"literal_binds": True}))
 
-                sample_rows_ls = ast.literal_eval(sample_rows)
-                sample_rows_ls = list(
-                    map(lambda ls: [str(i)[:100] for i in ls], sample_rows_ls)
+                # save the columns in string format 
+                columns_str = " ".join([col.name for col in table.columns])
+
+                # get the sample rows
+                with self._engine.connect() as connection:
+                    sample_rows = connection.execute(command, limit=2)
+                
+                # shorten values in the smaple rows
+                sample_rows = list(
+                    map(lambda ls: [str(i)[:100] for i in ls], sample_rows)
                 )
 
-                columns_str = " ".join(columns)
-                sample_rows_str = "\n".join([" ".join(row) for row in sample_rows_ls])
+                # save the sample rows in string format
+                sample_rows_str = "\n".join([" ".join(row) for row in sample_rows])
 
+                # build final info for table
                 tables.append(
                     create_table
                     + "\n\n"

--- a/tests/unit_tests/test_sql_database.py
+++ b/tests/unit_tests/test_sql_database.py
@@ -35,7 +35,7 @@ def test_table_info() -> None:
             PRIMARY KEY (user_id)
     )
 
-    SELECT * FROM 'user' LIMIT 3
+    SELECT * FROM 'user' LIMIT 3;
     user_id user_name
 
 
@@ -45,7 +45,7 @@ def test_table_info() -> None:
             PRIMARY KEY (company_id)
     )
 
-    SELECT * FROM 'company' LIMIT 3
+    SELECT * FROM 'company' LIMIT 3;
     company_id company_location
     """
 
@@ -75,7 +75,7 @@ def test_table_info_w_sample_rows() -> None:
         PRIMARY KEY (company_id)
 )
 
-        SELECT * FROM 'company' LIMIT 2
+        SELECT * FROM 'company' LIMIT 2;
         company_id company_location
 
 
@@ -85,7 +85,7 @@ def test_table_info_w_sample_rows() -> None:
         PRIMARY KEY (user_id)
         )
 
-        SELECT * FROM 'user' LIMIT 2
+        SELECT * FROM 'user' LIMIT 2;
         user_id user_name
         13 Harrison
         14 Chase

--- a/tests/unit_tests/test_sql_database.py
+++ b/tests/unit_tests/test_sql_database.py
@@ -3,7 +3,7 @@
 
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, insert
 
-from langchain.sql_database import _TEMPLATE_PREFIX, SQLDatabase
+from langchain.sql_database import SQLDatabase
 
 metadata_obj = MetaData()
 
@@ -29,7 +29,7 @@ def test_table_info() -> None:
     db = SQLDatabase(engine)
     output = db.table_info
     expected_output = """
-    CREATE TABLE user (                                                                                                                                    
+    CREATE TABLE user (
             user_id INTEGER NOT NULL,
             user_name VARCHAR(16) NOT NULL,
             PRIMARY KEY (user_id)

--- a/tests/unit_tests/test_sql_database_schema.py
+++ b/tests/unit_tests/test_sql_database_schema.py
@@ -46,7 +46,6 @@ def test_table_info() -> None:
     engine = create_engine("duckdb:///:memory:")
     metadata_obj.create_all(engine)
 
-
     db = SQLDatabase(engine, schema="schema_a", metadata=metadata_obj)
     output = db.table_info
     expected_output = """
@@ -59,7 +58,7 @@ def test_table_info() -> None:
     SELECT * FROM 'user' LIMIT 3;
     user_id user_name
     """
-    
+
     assert sorted(" ".join(output.split())) == sorted(" ".join(expected_output.split()))
 
 

--- a/tests/unit_tests/test_sql_database_schema.py
+++ b/tests/unit_tests/test_sql_database_schema.py
@@ -50,7 +50,7 @@ def test_table_info() -> None:
     expected_output = """
     CREATE TABLE schema_a."user"(user_id INTEGER, user_name VARCHAR NOT NULL, PRIMARY KEY(user_id));
 
-    SELECT * FROM 'user' LIMIT 3
+    SELECT * FROM 'user' LIMIT 3;
     user_id user_name
     """
 

--- a/tests/unit_tests/test_sql_database_schema.py
+++ b/tests/unit_tests/test_sql_database_schema.py
@@ -45,15 +45,21 @@ def test_table_info() -> None:
     """Test that table info is constructed properly."""
     engine = create_engine("duckdb:///:memory:")
     metadata_obj.create_all(engine)
-    db = SQLDatabase(engine, schema="schema_a")
+
+
+    db = SQLDatabase(engine, schema="schema_a", metadata=metadata_obj)
     output = db.table_info
     expected_output = """
-    CREATE TABLE schema_a."user"(user_id INTEGER, user_name VARCHAR NOT NULL, PRIMARY KEY(user_id));
+    CREATE TABLE schema_a."user" (
+        user_id INTEGER NOT NULL, 
+        user_name VARCHAR NOT NULL, 
+        PRIMARY KEY (user_id)
+    )
 
     SELECT * FROM 'user' LIMIT 3;
     user_id user_name
     """
-
+    
     assert sorted(" ".join(output.split())) == sorted(" ".join(expected_output.split()))
 
 


### PR DESCRIPTION
This approach has several advantages:

* it improves the readability of the code
* removes incompatibilities between SQL dialects
* fixes a bug with `datetime` values in rows and `ast.literal_eval`

Huge thanks and credits to @jzluo for finding the weaknesses in the current approach and for the thoughtful discussion on the best way to implement this.