### PR TITLE
added ability to override default verbose and memory when load chain …

### DIFF
--- a/langchain/chains/loading.py
+++ b/langchain/chains/loading.py
@@ -466,9 +466,9 @@ def _load_chain_from_file(file: Union[str, Path], **kwargs: Any) -> Chain:
 
     # Override default 'verbose' and 'memory' for the chain
     if "verbose" in kwargs:
-        config["verbose"] = kwargs["verbose"]
+        config["verbose"] = kwargs.pop("verbose")
     if "memory" in kwargs:
-        config["memory"] = kwargs["memory"]
+        config["memory"] = kwargs.pop("memory")
 
     # Load the chain from the config now.
     return load_chain_from_config(config, **kwargs)

--- a/langchain/chains/loading.py
+++ b/langchain/chains/loading.py
@@ -463,5 +463,12 @@ def _load_chain_from_file(file: Union[str, Path], **kwargs: Any) -> Chain:
             config = yaml.safe_load(f)
     else:
         raise ValueError("File type must be json or yaml")
+
+    # Override default 'verbose' and 'memory' for the chain
+    if "verbose" in kwargs:
+        config["verbose"] = kwargs["verbose"]
+    if "memory" in kwargs:
+        config["memory"] = kwargs["memory"]
+
     # Load the chain from the config now.
     return load_chain_from_config(config, **kwargs)


### PR DESCRIPTION
It is useful to be able to specify `verbose` or `memory` while still keeping the chain's overall structure.