### PR TITLE
Implement MarkdownTextSplitter

### DIFF
--- a/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
+++ b/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "from langchain.text_splitter import CharacterTextSplitter, NLTKTextSplitter, SpacyTextSplitter\n",
     "# This is a long document we can split up.\n",
-    "with open('./docs/modules/state_of_the_union.txt') as f:\n",
+    "with open('../../state_of_the_union.txt') as f:\n",
     "    state_of_the_union = f.read()"
    ]
   },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "id": "1ac6376d",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "id": "6787b13b",
    "metadata": {},
    "outputs": [],
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "id": "4f0e7d9b",
    "metadata": {},
    "outputs": [
@@ -135,7 +135,7 @@
      "output_type": "stream",
      "text": [
       "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet.\n",
-      "and the Cabinet. Justices of the Supreme Court. My fellow Americans.\n"
+      "and the Cabinet. Justices of the Supreme Court. My fellow Americans. \n"
      ]
     }
    ],
@@ -605,7 +605,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -619,11 +619,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11 (main, Sep 29 2022, 13:06:15) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {
-    "hash": "6854864773d2ea47038788d8df4cd0457034d3e5d00eebb23a2d5ded8df10f21"
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
    }
   }
  },

--- a/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
+++ b/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "from langchain.text_splitter import CharacterTextSplitter, NLTKTextSplitter, SpacyTextSplitter\n",
     "# This is a long document we can split up.\n",
-    "with open('../../state_of_the_union.txt') as f:\n",
+    "with open('./docs/modules/state_of_the_union.txt') as f:\n",
     "    state_of_the_union = f.read()"
    ]
   },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "id": "1ac6376d",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "id": "6787b13b",
    "metadata": {},
    "outputs": [],
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "id": "4f0e7d9b",
    "metadata": {},
    "outputs": [
@@ -135,7 +135,7 @@
      "output_type": "stream",
      "text": [
       "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet.\n",
-      "and the Cabinet. Justices of the Supreme Court. My fellow Americans.  \n"
+      "and the Cabinet. Justices of the Supreme Court. My fellow Americans.\n"
      ]
     }
    ],
@@ -525,17 +525,87 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c24dbbb7",
+   "metadata": {},
+   "source": [
+    "# Markdown Text Splitter\n",
+    "\n",
+    "MarkdownTextSplitter splits text along Markdown headings, code blocks, or horizontal rules. It's implemented as a simple subclass of RecursiveCharacterSplitter with Markdown-specific separators. See the source code to see the Markdown syntax expected by default."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0905c1de",
+   "execution_count": 6,
+   "id": "593e490c",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from langchain.text_splitter import MarkdownTextSplitter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "89a9a3ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markdown_text = \"\"\"\n",
+    "# 🦜️🔗 LangChain\n",
+    "\n",
+    "⚡ Building applications with LLMs through composability ⚡\n",
+    "\n",
+    "## Quick Install\n",
+    "\n",
+    "```bash\n",
+    "# Hopefully this code block isn't split\n",
+    "pip install langchain\n",
+    "```\n",
+    "\n",
+    "As an open source project in a rapidly developing field, we are extremely open to contributions.\n",
+    "\"\"\"\n",
+    "markdown_splitter = MarkdownTextSplitter(chunk_size=100, chunk_overlap=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "241f0719",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# 🦜️🔗 LangChain\n",
+      "\n",
+      "⚡ Building applications with LLMs through composability ⚡\n",
+      "\n",
+      "---\n",
+      "\n",
+      "Quick Install\n",
+      "\n",
+      "```bash\n",
+      "# Hopefully this code block isn't split\n",
+      "pip install langchain\n",
+      "\n",
+      "---\n",
+      "\n",
+      "As an open source project in a rapidly developing field, we are extremely open to contributions.\n"
+     ]
+    }
+   ],
+   "source": [
+    "texts = markdown_splitter.split_text(markdown_text)\n",
+    "print('\\n\\n---\\n\\n'.join(texts))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".env",
    "language": "python",
    "name": "python3"
   },
@@ -549,11 +619,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.11 (main, Sep 29 2022, 13:06:15) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+    "hash": "6854864773d2ea47038788d8df4cd0457034d3e5d00eebb23a2d5ded8df10f21"
    }
   }
  },

--- a/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
+++ b/docs/modules/utils/combine_docs_examples/textsplitter.ipynb
@@ -135,7 +135,7 @@
      "output_type": "stream",
      "text": [
       "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet.\n",
-      "and the Cabinet. Justices of the Supreme Court. My fellow Americans. \n"
+      "and the Cabinet. Justices of the Supreme Court. My fellow Americans.  \n"
      ]
     }
    ],

--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -309,3 +309,27 @@ class SpacyTextSplitter(TextSplitter):
         """Split incoming text and return chunks."""
         splits = (str(s) for s in self._tokenizer(text).sents)
         return self._merge_splits(splits, self._separator)
+
+
+class MarkdownTextSplitter(RecursiveCharacterTextSplitter):
+    """Attempts to split the text along Markdown-formatted headings, code blocks, or horizontal rules."""
+    
+    def __init__(self, separators: Optional[List[str]] = None, **kwargs: Any):
+        """Initialize a MarkdownTextSplitter."""
+        super().__init__(**kwargs)
+        self._separators = separators or [
+            # First, try to split along Markdown headings (starting with level 2)
+            "\n## ", "\n### ", "\n#### ", "\n##### ", "\n###### ",
+            # Note the alternative syntax for headings (below) is not handled here
+            # Heading level 2
+            # ---------------
+
+            # End of code block
+            "```\n\n",
+
+            # Horizontal lines
+            "\n\n***\n\n", "\n\n---\n\n", "\n\n___\n\n",
+            # Note that this splitter doesn't handle horizontal lines defined by *three or more* of ***, ---, or ___, but this is not handled
+
+            "\n\n", "\n", " ", ""
+        ]


### PR DESCRIPTION
Create a simple MarkdownTextSplitter which tries to split along headings, code blocks, and horizontal rules. For simplicity and customizability, this is implemented as a RecursiveCharacterTextSplitter, just with different Markdown-specific separators.