### PR TITLE
Include API Error messages in huggingface endpoint

### DIFF
--- a/langchain/llms/huggingface_endpoint.py
+++ b/langchain/llms/huggingface_endpoint.py
@@ -121,12 +121,13 @@ class HuggingFaceEndpoint(LLM, BaseModel):
             )
         except requests.exceptions.RequestException as e:  # This is the correct syntax
             raise ValueError(f"Error raised by inference endpoint: {e}")
+        generated_text = response.json()
+        if "error" in generated_text:
+            raise ValueError(f"Error raised by inference API: {generated_text['error']}")           
         if self.task == "text-generation":
             # Text generation return includes the starter text.
-            generated_text = response.json()
             text = generated_text[0]["generated_text"][len(prompt) :]
         elif self.task == "text2text-generation":
-            generated_text = response.json()
             text = generated_text[0]["generated_text"]
         else:
             raise ValueError(


### PR DESCRIPTION
To make this Error message from the API visible:
ValueError: Error raised by inference API: A valid user token is required

Without the change I get this Error, which is not very informative: KeyError: 0
because generated_text[0] is inexistent.

The change I made in the code is similar to something already present in huggingface_hub.py