### PR TITLE
Move SerpAPI to utilities; add raw results method

### DIFF
--- a/langchain/__init__.py
+++ b/langchain/__init__.py
@@ -39,17 +39,20 @@ from langchain.prompts import (
     Prompt,
     PromptTemplate,
 )
-from langchain.serpapi import SerpAPIChain, SerpAPIWrapper
 from langchain.sql_database import SQLDatabase
 from langchain.utilities.google_search import GoogleSearchAPIWrapper
 from langchain.utilities.google_serper import GoogleSerperAPIWrapper
 from langchain.utilities.searx_search import SearxSearchWrapper
+from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 from langchain.vectorstores import FAISS, ElasticVectorSearch
 
 verbose: bool = False
 llm_cache: Optional[BaseCache] = None
 set_default_callback_manager()
+
+# For backwards compatibility
+SerpAPIChain = SerpAPIWrapper
 
 __all__ = [
     "LLMChain",

--- a/langchain/agents/load_tools.py
+++ b/langchain/agents/load_tools.py
@@ -11,7 +11,6 @@ from langchain.chains.pal.base import PALChain
 from langchain.llms.base import BaseLLM
 from langchain.python import PythonREPL
 from langchain.requests import RequestsWrapper
-from langchain.serpapi import SerpAPIWrapper
 from langchain.tools.base import BaseTool
 from langchain.tools.bing_search.tool import BingSearchRun
 from langchain.tools.google_search.tool import GoogleSearchResults, GoogleSearchRun
@@ -21,6 +20,7 @@ from langchain.utilities.bing_search import BingSearchAPIWrapper
 from langchain.utilities.google_search import GoogleSearchAPIWrapper
 from langchain.utilities.google_serper import GoogleSerperAPIWrapper
 from langchain.utilities.searx_search import SearxSearchWrapper
+from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 
 

--- a/langchain/agents/self_ask_with_search/base.py
+++ b/langchain/agents/self_ask_with_search/base.py
@@ -6,9 +6,9 @@ from langchain.agents.self_ask_with_search.prompt import PROMPT
 from langchain.agents.tools import Tool
 from langchain.llms.base import BaseLLM
 from langchain.prompts.base import BasePromptTemplate
-from langchain.serpapi import SerpAPIWrapper
 from langchain.tools.base import BaseTool
 from langchain.utilities.google_serper import GoogleSerperAPIWrapper
+from langchain.utilities.serpapi import SerpAPIWrapper
 
 
 class SelfAskWithSearchAgent(Agent):

--- a/langchain/utilities/__init__.py
+++ b/langchain/utilities/__init__.py
@@ -1,12 +1,12 @@
 """General utilities."""
 from langchain.python import PythonREPL
 from langchain.requests import RequestsWrapper
-from langchain.serpapi import SerpAPIWrapper
 from langchain.utilities.bash import BashProcess
 from langchain.utilities.bing_search import BingSearchAPIWrapper
 from langchain.utilities.google_search import GoogleSearchAPIWrapper
 from langchain.utilities.google_serper import GoogleSerperAPIWrapper
 from langchain.utilities.searx_search import SearxSearchWrapper
+from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 
 __all__ = [

--- a/langchain/utilities/serpapi.py
+++ b/langchain/utilities/serpapi.py
@@ -26,46 +26,6 @@ class HiddenPrints:
         sys.stdout = self._original_stdout
 
 
-def _get_default_params() -> dict:
-    return {
-        "engine": "google",
-        "google_domain": "google.com",
-        "gl": "us",
-        "hl": "en",
-    }
-
-
-def process_response(res: dict) -> str:
-    """Process response from SerpAPI."""
-    if "error" in res.keys():
-        raise ValueError(f"Got error from SerpAPI: {res['error']}")
-    if "answer_box" in res.keys() and "answer" in res["answer_box"].keys():
-        toret = res["answer_box"]["answer"]
-    elif "answer_box" in res.keys() and "snippet" in res["answer_box"].keys():
-        toret = res["answer_box"]["snippet"]
-    elif (
-        "answer_box" in res.keys()
-        and "snippet_highlighted_words" in res["answer_box"].keys()
-    ):
-        toret = res["answer_box"]["snippet_highlighted_words"][0]
-    elif (
-        "sports_results" in res.keys()
-        and "game_spotlight" in res["sports_results"].keys()
-    ):
-        toret = res["sports_results"]["game_spotlight"]
-    elif (
-        "knowledge_graph" in res.keys()
-        and "description" in res["knowledge_graph"].keys()
-    ):
-        toret = res["knowledge_graph"]["description"]
-    elif "snippet" in res["organic_results"][0].keys():
-        toret = res["organic_results"][0]["snippet"]
-
-    else:
-        toret = "No good search result found"
-    return toret
-
-
 class SerpAPIWrapper(BaseModel):
     """Wrapper around SerpAPI.
 
@@ -81,7 +41,14 @@ class SerpAPIWrapper(BaseModel):
     """
 
     search_engine: Any  #: :meta private:
-    params: dict = Field(default_factory=_get_default_params)
+    params: dict = Field(
+        default={
+            "engine": "google",
+            "google_domain": "google.com",
+            "gl": "us",
+            "hl": "en",
+        }
+    )
     serpapi_api_key: Optional[str] = None
     aiosession: Optional[aiohttp.ClientSession] = None
 
@@ -130,15 +97,19 @@ class SerpAPIWrapper(BaseModel):
             async with self.aiosession.get(url, params=params) as response:
                 res = await response.json()
 
-        return process_response(res)
+        return self._process_response(res)
 
     def run(self, query: str) -> str:
         """Run query through SerpAPI and parse result."""
+        return self._process_response(self.results(query))
+
+    def results(self, query: str) -> dict:
+        """Run query through SerpAPI and return the raw result"""
         params = self.get_params(query)
         with HiddenPrints():
             search = self.search_engine(params)
             res = search.get_dict()
-        return process_response(res)
+        return res
 
     def get_params(self, query: str) -> Dict[str, str]:
         """Get parameters for SerpAPI."""
@@ -149,7 +120,34 @@ class SerpAPIWrapper(BaseModel):
         params = {**self.params, **_params}
         return params
 
+    @staticmethod
+    def _process_response(res: dict) -> str:
+        """Process response from SerpAPI."""
 
-# For backwards compatibility
+        if "error" in res.keys():
+            raise ValueError(f"Got error from SerpAPI: {res['error']}")
+        if "answer_box" in res.keys() and "answer" in res["answer_box"].keys():
+            toret = res["answer_box"]["answer"]
+        elif "answer_box" in res.keys() and "snippet" in res["answer_box"].keys():
+            toret = res["answer_box"]["snippet"]
+        elif (
+            "answer_box" in res.keys()
+            and "snippet_highlighted_words" in res["answer_box"].keys()
+        ):
+            toret = res["answer_box"]["snippet_highlighted_words"][0]
+        elif (
+            "sports_results" in res.keys()
+            and "game_spotlight" in res["sports_results"].keys()
+        ):
+            toret = res["sports_results"]["game_spotlight"]
+        elif (
+            "knowledge_graph" in res.keys()
+            and "description" in res["knowledge_graph"].keys()
+        ):
+            toret = res["knowledge_graph"]["description"]
+        elif "snippet" in res["organic_results"][0].keys():
+            toret = res["organic_results"][0]["snippet"]
 
-SerpAPIChain = SerpAPIWrapper
+        else:
+            toret = "No good search result found"
+        return toret


### PR DESCRIPTION
There's a lot of valuable data that can come from SerpAPI, more than just a single snippet or answer.

Add a `results` method which returns the raw api response from serpapi.  It's very useful grabbing snippets and the answer box for crafting context summaries in quality checking answers for recent or more obscure information.

---

I did make a proactive move to move `SerpApiWrapper` into `langchain.utilities` since that was where the other Serp API utilities all were, and it seemed like it might have been a legacy thing.  I tested that backwards compatibility was maintained with `SerpApiChain`.  Also did a small amount of refactoring to bring in the `process_response` method into the class so that it was more in line with what I saw with the other utilities. 

If this is out of scope or not what you want, let me know, I'm fine pulling those changes out and just including the `results` method.