### PR TITLE
docs: add quotes to `unstructured[local-inference]` install instructions

### DIFF
--- a/docs/ecosystem/unstructured.md
+++ b/docs/ecosystem/unstructured.md
@@ -10,7 +10,7 @@ This page is broken into two parts: installation and setup, and then references 
 `unstructured` wrappers.
 
 ## Installation and Setup
-- Install the Python SDK with `pip install unstructured[local-inference]`
+- Install the Python SDK with `pip install "unstructured[local-inference]"`
 - Install the following system dependencies if they are not already available on your system.
   Depending on what document types you're parsing, you may not need all of these.
     - `libmagic-dev`

--- a/docs/modules/document_loaders/examples/unstructured_file.ipynb
+++ b/docs/modules/document_loaders/examples/unstructured_file.ipynb
@@ -17,7 +17,7 @@
    "outputs": [],
    "source": [
     "# # Install package\n",
-    "!pip install unstructured[local-inference]\n",
+    "!pip install \"unstructured[local-inference]\"\n",
     "!pip install \"detectron2@git+https://github.com/facebookresearch/detectron2.git@v0.6#egg=detectron2\"\n",
     "!pip install layoutparser[layoutmodels,tesseract]"
    ]
@@ -166,7 +166,7 @@
     "Processing PDF documents works exactly the same way. Unstructured detects the file type and extracts the same types of `elements`. "
    ]
   },
-  
+
   {
    "cell_type": "code",
    "execution_count": 1,
@@ -221,7 +221,7 @@
    "source": [
     "docs[:5]"
    ]
-  },  
+  },
   {
    "cell_type": "code",
    "execution_count": null,


### PR DESCRIPTION
### Summary

Corrects the install instruction for local inference to `pip install "unstructured[local-inference]"`