### PR TITLE
Fix typo in constitutional_ai base.py

### DIFF
--- a/langchain/chains/constitutional_ai/base.py
+++ b/langchain/chains/constitutional_ai/base.py
@@ -16,7 +16,7 @@ class ConstitutionalChain(Chain):
         .. code-block:: python
 
             from langchain.llms import OpenAI
-            from langchian.chains import LLMChain, ConstitutionalChain
+            from langchain.chains import LLMChain, ConstitutionalChain
 
             qa_prompt = PromptTemplate(
                 template="Q: {question} A:",


### PR DESCRIPTION
Found a typo in the documentation code for the constitutional_ai module