### PR TITLE
allow partial prompt formatting

### DIFF
--- a/docs/modules/prompts/getting_started.md
+++ b/docs/modules/prompts/getting_started.md
@@ -73,12 +73,39 @@ multiple_input_prompt.format(adjective="funny", content="chickens")
 You can create custom prompt templates that format the prompt in any way you want. For more information, see [Custom Prompt Templates](examples/custom_prompt_template.ipynb).
 
 
-<!-- TODO(shreya): Add link to Jinja -->
 
-:::{note}
-Currently, the template should be formatted as a Python f-string. We also support Jinja2 templates (see [Using Jinja templates](examples/custom_prompt_template.ipynb)). In the future, we will support more templating languages such as Mako.
-:::
+Currently, the default template format is Python f-string. We also support [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/) templates (see example below). In the future, we will support more templating languages such as Mako.
 
+```python
+from langchain import PromptTemplate
+
+multiple_input_prompt = PromptTemplate(
+    input_variables=["adjective", "content"], 
+    template="Tell me a {{ adjective }} joke about {{ content }}.",
+    template_format="jinja2",
+)
+
+multiple_input_prompt.format(adjective="funny", content="chickens")
+# -> "Tell me a funny joke about chickens."
+```
+
+You can also apply partial formatting to a `PromptTemplate` object:
+
+```python
+from langchain import PromptTemplate
+
+multiple_input_prompt = PromptTemplate(
+    input_variables=["adjective", "content"], 
+    template="Tell me a {adjective} joke about {content}.",
+)
+
+# Format the prompt with only the adjective
+multiple_input_prompt.pformat(adjective="funny")
+
+# Format the prompt with the content
+multiple_input_prompt.format(content="chickens")
+# -> "Tell me a funny joke about chickens."
+```
 
 ## Load a prompt template from LangChainHub
 

--- a/docs/modules/prompts/getting_started.md
+++ b/docs/modules/prompts/getting_started.md
@@ -89,7 +89,7 @@ multiple_input_prompt.format(adjective="funny", content="chickens")
 # -> "Tell me a funny joke about chickens."
 ```
 
-You can also apply partial formatting to a `PromptTemplate` object:
+You can also apply partial formatting to a `PromptTemplate` object via `pformat`:
 
 ```python
 from langchain import PromptTemplate

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -151,6 +151,10 @@ class BasePromptTemplate(BaseModel, ABC):
             prompt.format(variable1="foo")
         """
 
+    @abstractmethod
+    def pformat(self, **kwargs: Any) -> None:
+        """Apply partial formatting to the prompt with the inputs, in place."""
+
     @property
     @abstractmethod
     def _prompt_type(self) -> str:

--- a/langchain/prompts/few_shot.py
+++ b/langchain/prompts/few_shot.py
@@ -113,6 +113,12 @@ class FewShotPromptTemplate(BasePromptTemplate, BaseModel):
         # Format the template with the input variables.
         return DEFAULT_FORMATTER_MAPPING[self.template_format](template, **kwargs)
 
+    def pformat(self, **kwargs: Any) -> None:
+        """Apply partial formatting to the prompt with the inputs, in place."""
+        raise NotImplementedError(
+            "pformat is currently not supported for FewShotPromptTemplate"
+        )
+
     @property
     def _prompt_type(self) -> str:
         """Return the prompt type key."""

--- a/langchain/prompts/few_shot_with_templates.py
+++ b/langchain/prompts/few_shot_with_templates.py
@@ -133,6 +133,12 @@ class FewShotPromptWithTemplates(BasePromptTemplate, BaseModel):
         # Format the template with the input variables.
         return DEFAULT_FORMATTER_MAPPING[self.template_format](template, **kwargs)
 
+    def pformat(self, **kwargs: Any) -> None:
+        """Apply partial formatting to the prompt with the inputs, in place."""
+        raise NotImplementedError(
+            "pformat is not currently implemented for FewShotPromptWithTemplates"
+        )
+
     @property
     def _prompt_type(self) -> str:
         """Return the prompt type key."""

--- a/langchain/prompts/prompt.py
+++ b/langchain/prompts/prompt.py
@@ -62,6 +62,17 @@ class PromptTemplate(BasePromptTemplate, BaseModel):
         """
         return DEFAULT_FORMATTER_MAPPING[self.template_format](self.template, **kwargs)
 
+    def pformat(self, **kwargs: Any) -> None:
+        """Apply partial formatting to the prompt with the inputs, in place."""
+        missing_variables = set(self.input_variables) - set(kwargs.keys())
+        for var in missing_variables:
+            if self.template_format == "f-string":
+                kwargs[var] = "{" + var + "}"
+            elif self.template_format == "jinja2":
+                kwargs[var] = "{{" + var + "}}"
+        self.template = self.format(**kwargs)
+        self.input_variables = list(missing_variables)
+
     @root_validator()
     def template_is_valid(cls, values: Dict) -> Dict:
         """Check that template and input variables are consistent."""

--- a/tests/unit_tests/prompts/test_prompt.py
+++ b/tests/unit_tests/prompts/test_prompt.py
@@ -102,9 +102,57 @@ def test_prompt_invalid_template_format() -> None:
         )
 
 
+def test_no_input_variables() -> None:
+    """Test prompt template with no input variables."""
+    template = "This is a test."
+    input_variables: list = []
+    prompt = PromptTemplate(input_variables=input_variables, template=template)
+    assert prompt.format() == template
+
+
 def test_prompt_from_file() -> None:
     """Test prompt can be successfully constructed from a file."""
     template_file = "tests/unit_tests/data/prompt_file.txt"
     input_variables = ["question"]
     prompt = PromptTemplate.from_file(template_file, input_variables)
     assert prompt.template == "Question: {question}\nAnswer:"
+
+
+def test_pformat() -> None:
+    """Test prompt can be partially formatted."""
+    template = "This is a {foo} {bar} {baz} test."
+    input_variables = ["foo", "bar", "baz"]
+    prompt = PromptTemplate(input_variables=input_variables, template=template)
+
+    prompt.pformat(foo="foo")
+    assert prompt.template == "This is a foo {bar} {baz} test."
+    assert sorted(prompt.input_variables) == ["bar", "baz"]
+
+    prompt.pformat(bar="bar")
+    assert prompt.template == "This is a foo bar {baz} test."
+    assert prompt.input_variables == ["baz"]
+
+    prompt.pformat(baz="baz")
+    assert prompt.template == "This is a foo bar baz test."
+    assert prompt.input_variables == []
+
+
+def test_pformat_jinja2() -> None:
+    """Test prompt can be partially formatted."""
+    template = "This is a {{foo}} {{bar}} {{baz}} test."
+    input_variables = ["foo", "bar", "baz"]
+    prompt = PromptTemplate(
+        input_variables=input_variables, template=template, template_format="jinja2"
+    )
+
+    prompt.pformat(foo="foo")
+    assert prompt.template == "This is a foo {{bar}} {{baz}} test."
+    assert sorted(prompt.input_variables) == ["bar", "baz"]
+
+    prompt.pformat(bar="bar")
+    assert prompt.template == "This is a foo bar {{baz}} test."
+    assert prompt.input_variables == ["baz"]
+
+    prompt.pformat(baz="baz")
+    assert prompt.template == "This is a foo bar baz test."
+    assert prompt.input_variables == []


### PR DESCRIPTION
Add a method `pformat` that takes in a subset of `input_variables` and adjusts the `PromptTemplate`'s `template` and `input_variables`