### PR TITLE
fix sqlite internal tables breaking table_info

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -94,6 +94,7 @@ class SQLDatabase:
             tbl
             for tbl in self._metadata.sorted_tables
             if tbl.name in set(all_table_names)
+            and not (self.dialect == "sqlite" and tbl.name.startswith("sqlite_"))
         ]
 
         tables = []


### PR DESCRIPTION
With the current method used to get the SQL table info, sqlite internal schema tables are being included and are not being handled correctly by sqlalchemy because the columns have no types. This is easy to see with the Chinook database:
```python
db = SQLDatabase.from_uri("sqlite:///Chinook.db")
print(db.table_info)
```
```python
...
sqlalchemy.exc.CompileError: (in table 'sqlite_sequence', column 'name'): Can't generate DDL for NullType(); did you forget to specify a type on this Column?
```

SQLAlchemy 2.0 [ignores these by default](https://github.com/sqlalchemy/sqlalchemy/blob/63d90b0f44016b15bed6c4108d90a71c15f05a09/lib/sqlalchemy/dialects/sqlite/base.py#L856-L880): 
https://github.com/sqlalchemy/sqlalchemy/blob/63d90b0f44016b15bed6c4108d90a71c15f05a09/lib/sqlalchemy/dialects/sqlite/base.py#L2096-L2123