### PR TITLE
Add `truncate` argument for Cohere's LLM 

### DIFF
--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -46,6 +46,9 @@ class Cohere(LLM, BaseModel):
 
     presence_penalty: int = 0
     """Penalizes repeated tokens."""
+    
+    truncate: Optional[str] = None
+    """Specify how the API will handle inputs longer than the maximum token length."""
 
     cohere_api_key: Optional[str] = None
 
@@ -83,6 +86,7 @@ class Cohere(LLM, BaseModel):
             "p": self.p,
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
+            "truncate": self.truncate,
         }
 
     @property

--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -48,7 +48,7 @@ class Cohere(LLM, BaseModel):
     """Penalizes repeated tokens."""
     
     truncate: Optional[str] = None
-    """Specify how the API will handle inputs longer than the maximum token length."""
+    """Specify how the client handles inputs longer than the maximum token length: Truncate from START, END or NONE"""
 
     cohere_api_key: Optional[str] = None
 


### PR DESCRIPTION
As #798, this commit adds the option to truncate the user's inputs larger than what the model can handle.

This defaults to None in the Cohere SDK instead of directly passing "NONE", so I maintained the same default value (see: https://github.com/cohere-ai/cohere-python/blob/7f30bfd40c98b88f7d08f8c05db5b91ddb1310d1/cohere/client.py#L127)


PS: I think that both this and #798 should default to the same value.