### PR TITLE
Give some memory to sequential chains

### DIFF
--- a/docs/modules/chains/generic/sequential_chains.ipynb
+++ b/docs/modules/chains/generic/sequential_chains.ipynb
@@ -36,6 +36,18 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "outputs": [],
+   "source": [
+    "%load_ext dotenv\n",
+    "%dotenv"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "3f2f9b8c",
    "metadata": {},
    "outputs": [],
@@ -47,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "b8237d1a",
    "metadata": {},
    "outputs": [],
@@ -64,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "4a391730",
    "metadata": {},
    "outputs": [],
@@ -82,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "9368bd63",
    "metadata": {},
    "outputs": [],
@@ -94,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "d39e15f5",
    "metadata": {},
    "outputs": [
@@ -104,25 +116,25 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new SimpleSequentialChain chain...\u001b[0m\n",
-      "\u001b[36;1m\u001b[1;3m\n",
+      "\u001B[1m> Entering new SimpleSequentialChain chain...\u001B[0m\n",
+      "\u001B[36;1m\u001B[1;3m\n",
       "\n",
-      "Tragedy at Sunset on the Beach follows the story of a young couple, Jack and Annie, who have just started to explore the possibility of a relationship together. After a day spent in the sun and sand, they decide to take a romantic stroll down the beach as the sun sets. \n",
+      "Tragedy at sunset on the beach is a heartfelt drama about two couples whose lives and relationships intersect in unexpected ways on a summer evening at the beach. \n",
       "\n",
-      "However, their romantic evening quickly turns tragic when they stumble upon a body lying in the sand. As they approach to investigate, they are shocked to discover that it is Jack's long-lost brother, who has been missing for several years. \n",
+      "The play centers around the couple David and Julia, who are visiting the beach for a romantic evening. As they watch the sun set, they are joined by two unexpected visitors: their friends, John and Sarah. As the four converse, they quickly realize that their relationships and lives are intertwined in ways that they never expected. \n",
       "\n",
-      "The story follows Jack and Annie as they navigate their way through the tragedy and their newfound relationship. With the help of their friends, family, and the beach's inhabitants, Jack and Annie must come to terms with their deep-seated emotions and the reality of the situation. \n",
+      "As the evening progresses, secrets are revealed and tensions rise as it becomes clear that David and Sarah had a past relationship. In the end, the four of them must grapple with the consequences of their secrets and the complex emotions that their relationships have created. \n",
       "\n",
-      "Ultimately, the play explores themes of family, love, and loss, as Jack and Annie's story unfolds against the beautiful backdrop of the beach at sunset.\u001b[0m\n",
-      "\u001b[33;1m\u001b[1;3m\n",
+      "Tragedy at sunset on the beach is a story of love, loss, and the power of secrets. It is a story of how the past can come back to haunt us and how we must confront our choices and the consequences of them.\u001B[0m\n",
+      "\u001B[33;1m\u001B[1;3m\n",
       "\n",
-      "Tragedy at Sunset on the Beach is an emotionally complex tale of family, love, and loss. Told against the beautiful backdrop of a beach at sunset, the story follows Jack and Annie, a young couple just beginning to explore a relationship together. When they stumble upon the body of Jack's long-lost brother on the beach, they must face the reality of the tragedy and come to terms with their deep-seated emotions. \n",
+      "Tragedy at Sunset on the Beach is a powerful drama that explores the complexity of relationships and the power of secrets. The story follows two couples, David and Julia, and John and Sarah, as their lives and relationships intertwine on a summer evening at the beach. As the sun sets and secrets are revealed, tensions rise as the four must grapple with the consequences of their choices and their past.\n",
       "\n",
-      "The playwright has crafted a heartfelt and thought-provoking story, one that probes into the depths of the human experience. The cast of characters is well-rounded and fully realized, and the dialogue is natural and emotional. The direction and choreography are top-notch, and the scenic design is breathtaking. \n",
+      "The writing is gripping and the performances are captivating. The actors bring the relationships to life in an honest and nuanced way, making the characters and their struggles feel real. The audience is taken on an emotional journey as they watch the characters confront their past, their choices, and the complex emotions that their relationships have created.\n",
       "\n",
-      "Overall, Tragedy at Sunset on the Beach is a powerful and moving story about the fragility of life and the strength of love. It is sure to tug at your heartstrings and leave you with a newfound appreciation of life's precious moments. Highly recommended.\u001b[0m\n",
+      "Tragedy at Sunset on the Beach is a beautifully written and performed drama that will leave audiences thinking long after the curtain has closed. It is a story of love, loss, and the power of secrets that will stay with you long after the lights have dimmed.\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished SimpleSequentialChain chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     }
    ],
@@ -132,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c6649a01",
    "metadata": {},
    "outputs": [
@@ -142,11 +154,11 @@
      "text": [
       "\n",
       "\n",
-      "Tragedy at Sunset on the Beach is an emotionally complex tale of family, love, and loss. Told against the beautiful backdrop of a beach at sunset, the story follows Jack and Annie, a young couple just beginning to explore a relationship together. When they stumble upon the body of Jack's long-lost brother on the beach, they must face the reality of the tragedy and come to terms with their deep-seated emotions. \n",
+      "Tragedy at Sunset on the Beach is a powerful drama that explores the complexity of relationships and the power of secrets. The story follows two couples, David and Julia, and John and Sarah, as their lives and relationships intertwine on a summer evening at the beach. As the sun sets and secrets are revealed, tensions rise as the four must grapple with the consequences of their choices and their past.\n",
       "\n",
-      "The playwright has crafted a heartfelt and thought-provoking story, one that probes into the depths of the human experience. The cast of characters is well-rounded and fully realized, and the dialogue is natural and emotional. The direction and choreography are top-notch, and the scenic design is breathtaking. \n",
+      "The writing is gripping and the performances are captivating. The actors bring the relationships to life in an honest and nuanced way, making the characters and their struggles feel real. The audience is taken on an emotional journey as they watch the characters confront their past, their choices, and the complex emotions that their relationships have created.\n",
       "\n",
-      "Overall, Tragedy at Sunset on the Beach is a powerful and moving story about the fragility of life and the strength of love. It is sure to tug at your heartstrings and leave you with a newfound appreciation of life's precious moments. Highly recommended.\n"
+      "Tragedy at Sunset on the Beach is a beautifully written and performed drama that will leave audiences thinking long after the curtain has closed. It is a story of love, loss, and the power of secrets that will stay with you long after the lights have dimmed.\n"
      ]
     }
    ],
@@ -167,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "02016a51",
    "metadata": {},
    "outputs": [],
@@ -185,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8bd38cc2",
    "metadata": {},
    "outputs": [],
@@ -203,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "524523af",
    "metadata": {},
    "outputs": [],
@@ -220,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "3fd3a7be",
    "metadata": {},
    "outputs": [
@@ -230,15 +242,9 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new SequentialChain chain...\u001b[0m\n",
-      "\u001b[1mChain 0\u001b[0m:\n",
-      "{'synopsis': \" \\n\\nTragedy at Sunset on the Beach is a dark and gripping drama set in Victorian England. The play follows the story of two lovers, Emma and Edward, whose passionate relationship is threatened by the strict rules and regulations of the time.\\n\\nThe two are deeply in love, but Edward is from a wealthy family and Emma is from a lower class background. Despite the obstacles, the two are determined to be together and decide to elope.\\n\\nOn the night of their planned escape, Emma and Edward meet at the beach at sunset to declare their love for one another and begin a new life together. However, their plans are disrupted when Emma's father discovers their plan and appears on the beach with a gun.\\n\\nIn a heartbreaking scene, Emma's father orders Edward to leave, but Edward refuses and fights for their love. In a fit of rage, Emma's father shoots Edward, killing him instantly. \\n\\nThe tragedy of the play lies in the fact that Emma and Edward are denied their chance at a happy ending due to the rigid social conventions of Victorian England. The audience is left with a heavy heart as the play ends with Emma standing alone on the beach, mourning the loss of her beloved.\"}\n",
+      "\u001B[1m> Entering new SequentialChain chain...\u001B[0m\n",
       "\n",
-      "\u001b[1mChain 1\u001b[0m:\n",
-      "{'review': \"\\n\\nTragedy at Sunset on the Beach is an emotionally charged production that will leave audiences heartsick. The play follows the ill-fated love story of Emma and Edward, two star-crossed lovers whose passionate relationship is tragically thwarted by Victorian England's societal conventions. The performance is captivating from start to finish, as the audience is taken on an emotional rollercoaster of love, loss, and heartbreak.\\n\\nThe acting is powerful and sincere, and the performances of the two leads are particularly stirring. Emma and Edward are both portrayed with such tenderness and emotion that it's hard not to feel their pain as they fight for their forbidden love. The climactic scene, in which Edward is shot by Emma's father, is especially heartbreaking and will leave audience members on the edge of their seats.\\n\\nOverall, Tragedy at Sunset on the Beach is a powerful and moving work of theatre. It is a tragedy of impossible love, and a vivid reminder of the devastating consequences of social injustice. The play is sure to leave a lasting impression on anyone who experiences it.\"}\n",
-      "\n",
-      "\n",
-      "\u001b[1m> Finished SequentialChain chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     }
    ],
@@ -247,12 +253,100 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Memory in Sequential Chains\n",
+    "Sometimes you may want to pass along some context to use in each step of the chain or in a later part of the chain, but maintaining and chaining together the input/output variables can quickly get messy.  Using `SimpleMemory` is a convenient way to do manage this and clean up your chains.\n",
+    "\n",
+    "For example, using the previous playwright SequentialChain, lets say you wanted to include some context about date, time and location of the play, and using the generated synopsis and review, create some social media post text.  You could add these new context variables as `input_variables`, or we can add a `SimpleMemory` to the chain to manage this context:"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6be70d27",
-   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001B[1m> Entering new SequentialChain chain...\u001B[0m\n",
+      "\n",
+      "\u001B[1m> Finished chain.\u001B[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "{'title': 'Tragedy at sunset on the beach',\n 'era': 'Victorian England',\n 'time': 'December 25th, 8pm PST',\n 'location': 'Theater in the Park',\n 'social_post_text': 'This Christmas, come to Theater in the Park to watch the powerful story of young love in \"Fate\\'s Tide\". The play follows the story of two star-crossed lovers, Sally and John, as they fight against fate to be together. You won\\'t want to miss the incredible performances and impressive set design that bring this tragedy to life! Get your tickets now! #FatesTide #YoungLove #TheaterInThePark #ChristmasShow'}"
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.chains import SequentialChain\n",
+    "from langchain.chains.base import SimpleMemory\n",
+    "\n",
+    "llm = OpenAI(temperature=.7)\n",
+    "template = \"\"\"You are a social media manager for a theater company.  Given the title of play, the era it is set in, the date,time and location, the synopsis of the play, and the review of the play, it is your job to write a social media post for that play.\n",
+    "\n",
+    "Here is some context about the time and location of the play:\n",
+    "Date and Time: {time}\n",
+    "Location: {location}\n",
+    "\n",
+    "Play Synopsis:\n",
+    "{synopsis}\n",
+    "Review from a New York Times play critic of the above play:\n",
+    "{review}\n",
+    "\n",
+    "Social Media Post:\n",
+    "\"\"\"\n",
+    "prompt_template = PromptTemplate(input_variables=[\"synopsis\", \"review\", \"time\", \"location\"], template=template)\n",
+    "social_chain = LLMChain(llm=llm, prompt=prompt_template, output_key=\"social_post_text\")\n",
+    "\n",
+    "overall_chain = SequentialChain(\n",
+    "    memory=SimpleMemory(memories={\"time\": \"December 25th, 8pm PST\", \"location\": \"Theater in the Park\"}),\n",
+    "    chains=[synopsis_chain, review_chain, social_chain],\n",
+    "    input_variables=[\"era\", \"title\"],\n",
+    "    # Here we return multiple variables\n",
+    "    output_variables=[\"social_post_text\"],\n",
+    "    verbose=True)\n",
+    "\n",
+    "overall_chain({\"title\":\"Tragedy at sunset on the beach\", \"era\": \"Victorian England\"})"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "outputs": [],
-   "source": []
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
   }
  ],
  "metadata": {

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -27,8 +27,11 @@ class Memory(BaseModel, ABC):
         """Input keys this memory class will load dynamically."""
 
     @abstractmethod
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
-        """Return key-value pairs given the text input to the chain."""
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        """Return key-value pairs given the text input to the chain.
+
+        If None, return all memories
+        """
 
     @abstractmethod
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
@@ -40,14 +43,16 @@ class Memory(BaseModel, ABC):
 
 
 class SimpleMemory(Memory, BaseModel):
-    """ Simple memory for storing context or other bits of information that shouldn't ever change between prompts."""
+    """ Simple memory for storing context or other bits of information that shouldn't
+    ever change between prompts.
+    """
     memories: Dict[str, Any] = dict()
 
     @property
     def memory_variables(self) -> List[str]:
         return list(self.memories.keys())
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         return self.memories
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -27,7 +27,9 @@ class Memory(BaseModel, ABC):
         """Input keys this memory class will load dynamically."""
 
     @abstractmethod
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Return key-value pairs given the text input to the chain.
 
         If None, return all memories
@@ -43,16 +45,19 @@ class Memory(BaseModel, ABC):
 
 
 class SimpleMemory(Memory, BaseModel):
-    """ Simple memory for storing context or other bits of information that shouldn't
+    """Simple memory for storing context or other bits of information that shouldn't
     ever change between prompts.
     """
+
     memories: Dict[str, Any] = dict()
 
     @property
     def memory_variables(self) -> List[str]:
         return list(self.memories.keys())
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         return self.memories
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:

--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -39,6 +39,24 @@ class Memory(BaseModel, ABC):
         """Clear memory contents."""
 
 
+class SimpleMemory(Memory, BaseModel):
+    """ Simple memory for storing context or other bits of information that shouldn't ever change between prompts."""
+    memories: Dict[str, Any] = dict()
+
+    @property
+    def memory_variables(self) -> List[str]:
+        return list(self.memories.keys())
+
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+        return self.memories
+
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Nothing should be saved or changed, my memory is set in stone."""
+
+    def clear(self) -> None:
+        """Nothing to clear, got a memory like a vault."""
+
+
 def _get_verbosity() -> bool:
     return langchain.verbose
 

--- a/langchain/chains/conversation/memory.py
+++ b/langchain/chains/conversation/memory.py
@@ -92,7 +92,7 @@ class ConversationBufferMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         """Return history buffer."""
         return {self.memory_key: self.buffer}
 
@@ -137,7 +137,7 @@ class ConversationBufferWindowMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         """Return history buffer."""
         return {self.memory_key: "\n".join(self.buffer[-self.k :])}
 
@@ -187,7 +187,7 @@ class ConversationSummaryMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         """Return history buffer."""
         return {self.memory_key: self.buffer}
 
@@ -251,7 +251,7 @@ class ConversationEntityMemory(Memory, BaseModel):
         """
         return ["entities", self.chat_history_key]
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Return history buffer."""
         chain = LLMChain(llm=self.llm, prompt=self.entity_extraction_prompt)
         if self.input_key is None:
@@ -332,7 +332,7 @@ class ConversationSummaryBufferMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
         """Return history buffer."""
         if self.moving_summary_buffer == "":
             return {self.memory_key: "\n".join(self.buffer)}
@@ -410,7 +410,7 @@ class ConversationKGMemory(Memory, BaseModel):
     input_key: Optional[str] = None
     memory_key: str = "history"  #: :meta private:
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Return history buffer."""
         entities = self._get_current_entities(inputs)
         summaries = {}

--- a/langchain/chains/conversation/memory.py
+++ b/langchain/chains/conversation/memory.py
@@ -47,7 +47,9 @@ class CombinedMemory(Memory, BaseModel):
 
         return memory_variables
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Load all vars from sub-memories."""
         memory_data: Dict[str, Any] = {}
 
@@ -92,7 +94,9 @@ class ConversationBufferMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Return history buffer."""
         return {self.memory_key: self.buffer}
 
@@ -137,7 +141,9 @@ class ConversationBufferWindowMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Return history buffer."""
         return {self.memory_key: "\n".join(self.buffer[-self.k :])}
 
@@ -187,7 +193,9 @@ class ConversationSummaryMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Return history buffer."""
         return {self.memory_key: self.buffer}
 
@@ -251,7 +259,15 @@ class ConversationEntityMemory(Memory, BaseModel):
         """
         return ["entities", self.chat_history_key]
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if inputs is None:
+            raise ValueError(
+                "Inputs must be provided to load memory variables from "
+                "ConversationEntityMemory."
+            )
+
         """Return history buffer."""
         chain = LLMChain(llm=self.llm, prompt=self.entity_extraction_prompt)
         if self.input_key is None:
@@ -276,6 +292,12 @@ class ConversationEntityMemory(Memory, BaseModel):
         }
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        if inputs is None:
+            raise ValueError(
+                "Inputs must be provided to save context from "
+                "ConversationEntityMemory."
+            )
+
         """Save context from this conversation to buffer."""
         if self.input_key is None:
             prompt_input_key = _get_prompt_input_key(inputs, self.memory_variables)
@@ -332,7 +354,9 @@ class ConversationSummaryBufferMemory(Memory, BaseModel):
         """
         return [self.memory_key]
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Return history buffer."""
         if self.moving_summary_buffer == "":
             return {self.memory_key: "\n".join(self.buffer)}
@@ -410,7 +434,15 @@ class ConversationKGMemory(Memory, BaseModel):
     input_key: Optional[str] = None
     memory_key: str = "history"  #: :meta private:
 
-    def load_memory_variables(self, inputs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if inputs is None:
+            raise ValueError(
+                "Inputs must be provided to load memory variables from "
+                "ConversationKGMemory."
+            )
+
         """Return history buffer."""
         entities = self._get_current_entities(inputs)
         summaries = {}

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -131,10 +131,12 @@ class LLMChain(Chain, BaseModel):
         ]
 
     def _call(self, inputs: Dict[str, Any]) -> Dict[str, str]:
-        return self.apply([inputs])[0]
+        known_values = self.prep_inputs(inputs.copy())
+        return self.apply([known_values])[0]
 
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, str]:
-        return (await self.aapply([inputs]))[0]
+        known_values = self.prep_inputs(inputs.copy())
+        return (await self.aapply([known_values]))[0]
 
     def predict(self, **kwargs: Any) -> str:
         """Format prompt with kwargs and pass to LLM.

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -50,8 +50,9 @@ class SequentialChain(Chain, BaseModel):
             if any(input_variables) in memory_keys:
                 overlapping_keys = input_variables & memory_keys
                 raise ValueError(
-                    f"The the input key(s) {''.join(overlapping_keys)} are found in the Memory keys "
-                    f"({memory_keys}) - please use input and memory keys that don't overlap."
+                    f"The the input key(s) {''.join(overlapping_keys)} are found "
+                    f"in the Memory keys ({memory_keys}) - please use input and "
+                    f"memory keys that don't overlap."
                 )
 
         known_variables = set(input_variables + memory_keys)

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -43,7 +43,18 @@ class SequentialChain(Chain, BaseModel):
         """Validate that the correct inputs exist for all chains."""
         chains = values["chains"]
         input_variables = values["input_variables"]
-        known_variables = set(input_variables)
+        memory_keys = list()
+        if 'memory' in values and values['memory'] is not None:
+            """Validate that prompt input variables are consistent."""
+            memory_keys = values["memory"].memory_variables
+            if any(input_variables) in memory_keys:
+                overlapping_keys = input_variables & memory_keys
+                raise ValueError(
+                    f"The the input key(s) {''.join(overlapping_keys)} are found in the Memory keys "
+                    f"({memory_keys}) - please use input and memory keys that don't overlap."
+                )
+
+        known_variables = set(input_variables + memory_keys)
         for chain in chains:
             missing_vars = set(chain.input_keys).difference(known_variables)
             if missing_vars:

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -44,7 +44,7 @@ class SequentialChain(Chain, BaseModel):
         chains = values["chains"]
         input_variables = values["input_variables"]
         memory_keys = list()
-        if 'memory' in values and values['memory'] is not None:
+        if "memory" in values and values["memory"] is not None:
             """Validate that prompt input variables are consistent."""
             memory_keys = values["memory"].memory_variables
             if any(input_variables) in memory_keys:

--- a/tests/integration_tests/chains/test_memory.py
+++ b/tests/integration_tests/chains/test_memory.py
@@ -39,4 +39,4 @@ def test_simple_memory() -> None:
     output = memory.load_memory_variables({})
 
     assert output == {"baz": "foo"}
-    assert ['baz'] == memory.memory_variables
+    assert ["baz"] == memory.memory_variables

--- a/tests/integration_tests/chains/test_memory.py
+++ b/tests/integration_tests/chains/test_memory.py
@@ -1,4 +1,5 @@
 """Test memory functionality."""
+from langchain.chains.base import SimpleMemory
 from langchain.chains.conversation.memory import ConversationSummaryBufferMemory
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
@@ -29,3 +30,13 @@ def test_summary_buffer_memory_summary() -> None:
     assert memory.buffer == ["Human: bar1\nAI: foo1"]
     output = memory.load_memory_variables({})
     assert output == {"baz": "foo\nHuman: bar1\nAI: foo1"}
+
+
+def test_simple_memory() -> None:
+    """Test SimpleMemory."""
+    memory = SimpleMemory(memories={"baz": "foo"})
+
+    output = memory.load_memory_variables({})
+
+    assert output == {"baz": "foo"}
+    assert ['baz'] == memory.memory_variables

--- a/tests/unit_tests/chains/test_base.py
+++ b/tests/unit_tests/chains/test_base.py
@@ -1,5 +1,5 @@
 """Test logic on base chain class."""
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 from pydantic import BaseModel
@@ -17,7 +17,9 @@ class FakeMemory(Memory, BaseModel):
         """Return baz variable."""
         return ["baz"]
 
-    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
+    def load_memory_variables(
+        self, inputs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
         """Return baz variable."""
         return {"baz": "foo"}
 

--- a/tests/unit_tests/chains/test_memory.py
+++ b/tests/unit_tests/chains/test_memory.py
@@ -1,0 +1,16 @@
+from langchain.chains.base import Chain, Memory, SimpleMemory
+from pydantic import BaseModel
+
+from tests.unit_tests.chains.test_base import FakeChain
+
+
+def test_simple_memory() -> None:
+    """Test simple memory."""
+    memory = SimpleMemory(memories={"baz": "zab"})
+    chain = FakeChain(memory=memory)
+    output = chain.run("bar")
+
+    assert output == "baz"
+    assert memory.memories == {"baz": "zab"}
+    assert memory.memory_variables == ["baz"]
+    assert memory.load_memory_variables() == {"baz": "zab"}

--- a/tests/unit_tests/chains/test_memory.py
+++ b/tests/unit_tests/chains/test_memory.py
@@ -1,6 +1,4 @@
-from langchain.chains.base import Chain, Memory, SimpleMemory
-from pydantic import BaseModel
-
+from langchain.chains.base import SimpleMemory
 from tests.unit_tests.chains.test_base import FakeChain
 
 

--- a/tests/unit_tests/chains/test_sequential.py
+++ b/tests/unit_tests/chains/test_sequential.py
@@ -61,8 +61,9 @@ def test_sequential_usage_memory() -> None:
     memory = SimpleMemory(memories={"zab": "rab"})
     chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
     chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
-    chain = SequentialChain(memory=memory, chains=[chain_1, chain_2],
-                            input_variables=["foo"])
+    chain = SequentialChain(
+        memory=memory, chains=[chain_1, chain_2], input_variables=["foo"]
+    )
     output = chain({"foo": "123"})
     expected_output = {"baz": "123foofoo", "foo": "123", "zab": "rab"}
     assert output == expected_output

--- a/tests/unit_tests/chains/test_sequential.py
+++ b/tests/unit_tests/chains/test_sequential.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 import pytest
 from pydantic import BaseModel
 
-from langchain.chains.base import Chain
+from langchain.chains.base import Chain, SimpleMemory
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 
 
@@ -53,6 +53,18 @@ def test_sequential_usage_multiple_inputs() -> None:
         "foo": "123",
         "test": "456",
     }
+    assert output == expected_output
+
+
+def test_sequential_usage_memory() -> None:
+    """Test sequential usage with memory."""
+    memory = SimpleMemory(memories={"zab": "rab"})
+    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"])
+    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"])
+    chain = SequentialChain(memory=memory, chains=[chain_1, chain_2],
+                            input_variables=["foo"])
+    output = chain({"foo": "123"})
+    expected_output = {"baz": "123foofoo", "foo": "123", "zab": "rab"}
     assert output == expected_output
 
 


### PR DESCRIPTION
Pulled out of #1240 

Working with memory a little bit, it's extremely helpful to attach memory to a sequential chain to pass along unchanging data.  The use case I found was passing along the original text to use as context in each prompt when doing rewrites of text. 

It's a lot easier to have a central data store than having to pass along each value as input/output.