### PR TITLE
Add new iFixit document loader

### DIFF
--- a/docs/modules/document_loaders/examples/ifixit.ipynb
+++ b/docs/modules/document_loaders/examples/ifixit.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# iFixit Loader\n",
+    "\n",
+    "[iFixit](https://www.ifixit.com) is the largest, open repair community on the web. The site contains nearly 100k repair manuals, 200k Questions & Answers on 42k devices, and all the data is licensed under CC-BY-NC-SA 3.0.\n",
+    "\n",
+    "This loader will allow you to download the text of a repair guide, text of Q&A's and wikis from devices on iFixit using their open APIs.  It's incredibly useful for context related to technical documents and answers to questions about devices in the corpus of data on iFixit."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders import IFixitLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = IFixitLoader(\"https://www.ifixit.com/Teardown/Banana+Teardown/811\")\n",
+    "data = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[Document(page_content=\"# Banana Teardown\\nIn this teardown, we open a banana to see what's inside.  Yellow and delicious, but most importantly, yellow.\\n\\n\\n###Tools Required:\\n\\n - Fingers\\n\\n - Teeth\\n\\n - Thumbs\\n\\n\\n###Parts Required:\\n\\n - None\\n\\n\\n## Step 1\\nTake one banana from the bunch.\\nDon't squeeze too hard!\\n\\n\\n## Step 2\\nHold the banana in your left hand and grip the stem between your right thumb and forefinger.\\n\\n\\n## Step 3\\nPull the stem downward until the peel splits.\\n\\n\\n## Step 4\\nInsert your thumbs into the split of the peel and pull the two sides apart.\\nExpose the top of the banana.  It may be slightly squished from pulling on the stem, but this will not affect the flavor.\\n\\n\\n## Step 5\\nPull open the peel, starting from your original split, and opening it along the length of the banana.\\n\\n\\n## Step 6\\nRemove fruit from peel.\\n\\n\\n## Step 7\\nEat and enjoy!\\nThis is where you'll need your teeth.\\nDo not choke on banana!\\n\", lookup_str='', metadata={'source': 'https://www.ifixit.com/Teardown/Banana+Teardown/811', 'title': 'Banana Teardown'}, lookup_index=0)]"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "loader = IFixitLoader(\"https://www.ifixit.com/Answers/View/318583/My+iPhone+6+is+typing+and+opening+apps+by+itself\")\n",
+    "data = loader.load()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[Document(page_content='# My iPhone 6 is typing and opening apps by itself\\nmy iphone 6 is typing and opening apps by itself. How do i fix this. I just bought it last week.\\nI restored as manufactures cleaned up the screen\\nthe problem continues\\n\\n## 27 Answers\\n\\nFilter by: \\n\\nMost Helpful\\nNewest\\nOldest\\n\\n### Accepted Answer\\nHi,\\nWhere did you buy it? If you bought it from Apple or from an official retailer like Carphone warehouse etc. Then you\\'ll have a year warranty and can get it replaced free.\\nIf you bought it second hand, from a third part repair shop or online, then it may still have warranty, unless it is refurbished and has been repaired elsewhere.\\nIf this is the case, it may be the screen that needs replacing to solve your issue.\\nEither way, wherever you got it, it\\'s best to return it and get a refund or a replacement device. :-)\\n\\n\\n\\n### Most Helpful Answer\\nI had the same issues, screen freezing, opening apps by itself, selecting the screens and typing on it\\'s own. I first suspected aliens and then ghosts and then hackers.\\niPhone 6 is weak physically and tend to bend on pressure. And my phone had no case or cover.\\nI took the phone to apple stores and they said sensors need to be replaced and possibly screen replacement as well. My phone is just 17 months old.\\nHere is what I did two days ago and since then it is working like a charm..\\nHold the phone in portrait (as if watching a movie). Twist it very very gently. do it few times.Rest the phone for 10 mins (put it on a flat surface). You can now notice those self typing things gone and screen getting stabilized.\\nThen, reset the hardware (hold the power and home button till the screen goes off and comes back with apple logo). release the buttons when you see this.\\nThen, connect to your laptop and log in to iTunes and reset your phone completely. (please take a back-up first).\\nAnd your phone should be good to use again.\\nWhat really happened here for me is that the sensors might have stuck to the screen and with mild twisting, they got disengaged/released.\\nI posted this in Apple Community and the moderators deleted it, for the best reasons known to them.\\nInstead of throwing away your phone (or selling cheaply), try this and you could be saving your phone.\\nLet me know how it goes.\\n\\n\\n\\n### Other Answer\\nIt was the charging cord! I bought a gas station braided cord and it was the culprit. Once I plugged my OEM cord into the phone the GHOSTS went away.\\n\\n\\n\\n### Other Answer\\nI\\'ve same issue that I just get resolved.  I first tried to restore it from iCloud back, however it was not a software issue or any virus issue, so after restore same problem continues. Then I get my phone to local area iphone repairing lab, and they detected that it is an LCD issue. LCD get out of order without any reason (It was neither hit or nor slipped, but LCD get out of order all and sudden, while using it) it started opening things at random. I get LCD replaced with new one, that cost me $80.00 in total  ($70.00 LCD charges + $10.00 as labor charges to fix it). iPhone is back to perfect mode now.  It was iphone 6s. Thanks.\\n\\n\\n\\n### Other Answer\\nI was having the same issue with my 6 plus, I took it to a repair shop, they opened the phone, disconnected the three ribbons the screen has, blew up and cleaned the connectors and connected the screen again and it solved the issue… it’s hardware, not software.\\n\\n\\n\\n### Other Answer\\nHey.\\nJust had this problem now. As it turns out, you just need to plug in your phone. I use a case and when I took it off I noticed that there was a lot of dust and dirt around the areas that the case didn\\'t cover. I shined a light in my ports and noticed they were filled with dust. Tomorrow I plan on using pressurized air to clean it out and the problem should be solved.  If you plug in your phone and unplug it and it stops the issue, I recommend cleaning your phone thoroughly.\\n\\n\\n\\n### Other Answer\\nI simply changed the power supply and problem was gone. The block that plugs in the wall not the sub cord. The cord was fine but not the block.\\n\\n\\n\\n### Other Answer\\nSomeone ask!  I purchased my iPhone 6s Plus for 1000 from at&t.  Before I touched it, I purchased a otter defender case.  I read where at&t said touch desease was due to dropping!  Bullshit!!  I am 56 I have never dropped it!! Looks brand new!  Never dropped or abused any way!  I have my original charger.  I am going to clean it and try everyone’s advice.  It really sucks!  I had 40,000,000 on my heart of Vegas slots!  I play every day.  I would be spinning and my fingers were no where max buttons and it would light up and switch to max.  It did it 3 times before I caught it light up by its self.  It sucks. Hope I can fix it!!!!\\n\\n\\n\\n### Other Answer\\nNo answer, but same problem with iPhone 6 plus--random, self-generated jumping amongst apps and typing on its own--plus freezing regularly (aha--maybe that\\'s what the \"plus\" in \"6 plus\" refers to?).  An Apple Genius recommended upgrading to iOS 11.3.1 from 11.2.2, to see if that fixed the trouble.  If it didn\\'t, Apple will sell me a new phone for $168!  Of couese the OS upgrade didn\\'t fix the problem.  Thanks for helping me figure out that it\\'s most likely a hardware problem--which the \"genius\" probably knows too.\\nI\\'m getting ready to go Android.\\n\\n\\n\\n### Other Answer\\nI experienced similar ghost touches.  Two weeks ago, I changed my iPhone 6 Plus shell (I had forced the phone into it because it’s pretty tight), and also put a new glass screen protector (the edges of the protector don’t stick to the screen, weird, so I brushed pressure on the edges at times to see if they may smooth out one day miraculously).  I’m not sure if I accidentally bend the phone when I installed the shell,  or, if I got a defective glass protector that messes up the touch sensor. Well, yesterday was the worse day, keeps dropping calls and ghost pressing keys for me when I was on a call.  I got fed up, so I removed the screen protector, and so far problems have not reoccurred yet. I’m crossing my fingers that problems indeed solved.\\n\\n\\n\\n### Other Answer\\nthank you so much for this post! i was struggling doing the reset because i cannot type userids and passwords correctly because the iphone 6 plus i have kept on typing letters incorrectly. I have been doing it for a day until i come across this article. Very helpful! God bless you!!\\n\\n\\n\\n### Other Answer\\nI just turned it off, and turned it back on.\\n\\n\\n\\n### Other Answer\\nMy problem has not gone away completely but its better now i changed my charger and turned off prediction ....,,,now it rarely happens\\n\\n\\n\\n### Other Answer\\nI tried all of the above. I then turned off my home cleaned it with isopropyl alcohol 90%. Then I baked it in my oven on warm for an hour and a half over foil. Took it out and set it cool completely on the glass top stove. Then I turned on and it worked.\\n\\n\\n\\n### Other Answer\\nI think at& t should man up and fix your phone for free!  You pay a lot for a Apple they should back it.  I did the next 30 month payments and finally have it paid off in June.  My iPad sept.  Looking forward to a almost 100 drop in my phone bill!  Now this crap!!! Really\\n\\n\\n\\n### Other Answer\\nIf your phone is JailBroken, suggest downloading a virus.  While all my symptoms were similar, there was indeed a virus/malware on the phone which allowed for remote control of my iphone (even while in lock mode).  My mistake for buying a third party iphone i suppose.  Anyway i have since had the phone restored to factory and everything is working as expected for now.  I will of course keep you posted if this changes.  Thanks to all for the helpful posts, really helped me narrow a few things down.\\n\\n\\n\\n### Other Answer\\nWhen my phone was doing this, it ended up being the screen protector that i got from 5 below. I took it off and it stopped. I ordered more protectors from amazon and replaced it\\n\\n\\n\\n### Other Answer\\niPhone 6 Plus first generation….I had the same issues as all above, apps opening by themselves, self typing, ultra sensitive screen, items jumping around all over….it even called someone on FaceTime twice by itself when I was not in the room…..I thought the phone was toast and i’d have to buy a new one took me a while to figure out but it was the extra cheap block plug I bought at a dollar store for convenience of an extra charging station when I move around the house from den to living room…..cord was fine but bought a new Apple brand block plug…no more problems works just fine now. This issue was a recent event so had to narrow things down to what had changed recently to my phone so I could figure it out.\\nI even had the same problem on a laptop with documents opening up by themselves…..a laptop that was plugged in to the same wall plug as my phone charger with the dollar store block plug….until I changed the block plug.\\n\\n\\n\\n### Other Answer\\nHad the problem: Inherited a 6s Plus from my wife. She had no problem with it.\\nLooks like it was merely the cheap phone case I purchased on Amazon. It was either pinching the edges or torquing the screen/body of the phone. Problem solved.\\n\\n\\n\\n### Other Answer\\nI bought my phone on march 6 and it was a brand new, but It sucks me uo because it freezing, shaking and control by itself. I went to the store where I bought this and I told them to replacr it, but they told me I have to pay it because Its about lcd issue. Please help me what other ways to fix it. Or should I try to remove the screen or should I follow your step above.\\n\\n\\n\\n### Other Answer\\nI tried everything and it seems to come back to needing the original iPhone cable…or at least another 1 that would have come with another iPhone…not the $5 Store fast charging cables.  My original cable is pretty beat up - like most that I see - but I’ve been beaten up much MUCH less by sticking with its use!  I didn’t find that the casing/shell around it or not made any diff.\\n\\n\\n\\n### Other Answer\\ngreat now I have to wait one more hour to reset my phone and while I was tryin to connect my phone to my computer the computer also restarted smh does anyone else knows how I can get my phone to work… my problem is I have a black dot on the bottom left of my screen an it wont allow me to touch a certain part of my screen unless I rotate my phone and I know the password but the first number is a 2 and it won\\'t let me touch 1,2, or 3 so now I have to find a way to get rid of my password and all of a sudden my phone wants to touch stuff on its own which got my phone disabled many times to the point where I have to wait a whole hour and I really need to finish something on my phone today PLEASE HELPPPP\\n\\n\\n\\n### Other Answer\\nIn my case , iphone 6 screen was faulty. I got it replaced at local repair shop, so far phone is working fine.\\n\\n\\n\\n### Other Answer\\nthis problem in iphone 6 has many different scenarios and solutions, first try to reconnect the lcd screen to the motherboard again, if didnt solve, try to replace the lcd connector on the motherboard, if not solved, then remains two issues, lcd screen it self or touch IC. in my country some repair shops just change them all for almost 40$ since they dont want to troubleshoot one by one. readers of this comment also should know that partial screen not responding in other iphone models might also have an issue in LCD connector on the motherboard, specially if you lock/unlock screen and screen works again for sometime. lcd connectors gets disconnected lightly from the motherboard due to multiple falls and hits after sometime. best of luck for all\\n\\n\\n\\n### Other Answer\\nI am facing the same issue whereby these ghost touches type and open apps , I am using an original Iphone cable , how to I fix this issue.\\n\\n\\n\\n### Other Answer\\nThere were two issues with the phone I had troubles with. It was my dads and turns out he carried it in his pocket. The phone itself had a little bend in it as a result. A little pressure in the opposite direction helped the issue. But it also had a tiny crack in the screen which wasnt obvious, once we added a screen protector this fixed the issues entirely.\\n\\n\\n\\n### Other Answer\\nI had the same problem with my 64Gb iPhone 6+. Tried a lot of things and eventually downloaded all my images and videos to my PC and restarted the phone - problem solved. Been working now for two days.', lookup_str='', metadata={'source': 'https://www.ifixit.com/Answers/View/318583/My+iPhone+6+is+typing+and+opening+apps+by+itself', 'title': 'My iPhone 6 is typing and opening apps by itself'}, lookup_index=0)]"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [],
+   "source": [
+    "loader = IFixitLoader(\"https://www.ifixit.com/Device/Standard_iPad\")\n",
+    "data = loader.load()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[Document(page_content=\"Standard iPad\\nThe standard edition of the tablet computer made by Apple.\\n== Background Information ==\\n\\nOriginally introduced in January 2010, the iPad is Apple's standard edition of their tablet computer. In total, there have been ten generations of the standard edition of the iPad.\\n\\n== Additional Information ==\\n\\n* [link|https://www.apple.com/ipad-select/|Official Apple Product Page]\\n* [link|https://en.wikipedia.org/wiki/IPad#iPad|Official iPad Wikipedia]\", lookup_str='', metadata={'source': 'https://www.ifixit.com/Device/Standard_iPad', 'title': 'Standard iPad'}, lookup_index=0)]"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Searching iFixit using /suggest\n",
+    "\n",
+    "If you're looking for a more general way to search iFixit based on a keyword or phrase, the /suggest endpoint will return content related to the search term, then the loader will load the content from each of the suggested items and prep and return the documents."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "data = IFixitLoader.load_suggestions(\"Banana\")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[Document(page_content='Banana\\nTasty fruit. Good source of potassium. Yellow.\\n== Background Information ==\\n\\nCommonly misspelled, this wildly popular, phone shaped fruit serves as nutrition and an obstacle to slow down vehicles racing close behind you. Also used commonly as a synonym for “crazy” or “insane”.\\n\\nBotanically, the banana is considered a berry, although it isn’t included in the culinary berry category containing strawberries and raspberries. Belonging to the genus Musa, the banana originated in Southeast Asia and Australia. Now largely cultivated throughout South and Central America, bananas are largely available throughout the world. They are especially valued as a staple food group in developing countries due to the banana tree’s ability to produce fruit year round.\\n\\nThe banana can be easily opened. Simply remove the outer yellow shell by cracking the top of the stem. Then, with the broken piece, peel downward on each side until the fruity components on the inside are exposed. Once the shell has been removed it cannot be put back together.\\n\\n== Technical Specifications ==\\n\\n* Dimensions: Variable depending on genetics of the parent tree\\n* Color: Variable depending on ripeness, region, and season\\n\\n== Additional Information ==\\n\\n[link|https://en.wikipedia.org/wiki/Banana|Wiki: Banana]', lookup_str='', metadata={'source': 'https://www.ifixit.com/Device/Banana', 'title': 'Banana'}, lookup_index=0),\n Document(page_content=\"# Banana Teardown\\nIn this teardown, we open a banana to see what's inside.  Yellow and delicious, but most importantly, yellow.\\n\\n\\n###Tools Required:\\n\\n - Fingers\\n\\n - Teeth\\n\\n - Thumbs\\n\\n\\n###Parts Required:\\n\\n - None\\n\\n\\n## Step 1\\nTake one banana from the bunch.\\nDon't squeeze too hard!\\n\\n\\n## Step 2\\nHold the banana in your left hand and grip the stem between your right thumb and forefinger.\\n\\n\\n## Step 3\\nPull the stem downward until the peel splits.\\n\\n\\n## Step 4\\nInsert your thumbs into the split of the peel and pull the two sides apart.\\nExpose the top of the banana.  It may be slightly squished from pulling on the stem, but this will not affect the flavor.\\n\\n\\n## Step 5\\nPull open the peel, starting from your original split, and opening it along the length of the banana.\\n\\n\\n## Step 6\\nRemove fruit from peel.\\n\\n\\n## Step 7\\nEat and enjoy!\\nThis is where you'll need your teeth.\\nDo not choke on banana!\\n\", lookup_str='', metadata={'source': 'https://www.ifixit.com/Teardown/Banana+Teardown/811', 'title': 'Banana Teardown'}, lookup_index=0)]"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/docs/modules/document_loaders/examples/ifixit.ipynb
+++ b/docs/modules/document_loaders/examples/ifixit.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "# iFixit Loader\n",
+    "# iFixit\n",
     "\n",
     "[iFixit](https://www.ifixit.com) is the largest, open repair community on the web. The site contains nearly 100k repair manuals, 200k Questions & Answers on 42k devices, and all the data is licensed under CC-BY-NC-SA 3.0.\n",
     "\n",

--- a/docs/modules/document_loaders/how_to_guides.rst
+++ b/docs/modules/document_loaders/how_to_guides.rst
@@ -59,6 +59,8 @@ There are a lot of different document loaders that LangChain supports. Below are
 
 `CoNLL-U <./examples/CoNLL-U.html>`_: A walkthrough of how to load data from a ConLL-U file.
 
+`iFixit <./examples/ifixit.html>`_: A walkthrough of how to search and load data like guides, technical Q&A's, and device wikis from iFixit.com
+
 .. toctree::
    :maxdepth: 1
    :glob:

--- a/langchain/document_loaders/__init__.py
+++ b/langchain/document_loaders/__init__.py
@@ -17,6 +17,7 @@ from langchain.document_loaders.gutenberg import GutenbergLoader
 from langchain.document_loaders.hn import HNLoader
 from langchain.document_loaders.html import UnstructuredHTMLLoader
 from langchain.document_loaders.image import UnstructuredImageLoader
+from langchain.document_loaders.ifixit import IFixitLoader
 from langchain.document_loaders.imsdb import IMSDbLoader
 from langchain.document_loaders.notebook import NotebookLoader
 from langchain.document_loaders.notion import NotionDirectoryLoader
@@ -70,6 +71,7 @@ __all__ = [
     "IMSDbLoader",
     "AZLyricsLoader",
     "CollegeConfidentialLoader",
+    "IFixitLoader",
     "GutenbergLoader",
     "PagedPDFSplitter",
     "EverNoteLoader",

--- a/langchain/document_loaders/__init__.py
+++ b/langchain/document_loaders/__init__.py
@@ -16,8 +16,8 @@ from langchain.document_loaders.googledrive import GoogleDriveLoader
 from langchain.document_loaders.gutenberg import GutenbergLoader
 from langchain.document_loaders.hn import HNLoader
 from langchain.document_loaders.html import UnstructuredHTMLLoader
-from langchain.document_loaders.image import UnstructuredImageLoader
 from langchain.document_loaders.ifixit import IFixitLoader
+from langchain.document_loaders.image import UnstructuredImageLoader
 from langchain.document_loaders.imsdb import IMSDbLoader
 from langchain.document_loaders.notebook import NotebookLoader
 from langchain.document_loaders.notion import NotionDirectoryLoader

--- a/langchain/document_loaders/ifixit.py
+++ b/langchain/document_loaders/ifixit.py
@@ -1,0 +1,203 @@
+"""Loader that loads iFixit data."""
+from typing import List, Optional
+
+import requests
+
+from langchain.docstore.document import Document
+from langchain.document_loaders.web_base import WebBaseLoader
+from langchain.document_loaders.base import BaseLoader
+
+IFIXIT_BASE_URL = "https://www.ifixit.com/api/2.0"
+
+
+class IFixitLoader(BaseLoader):
+    """Load iFixit repair guides, device wikis and answers.
+
+    iFixit is the largest, open repair community on the web. The site contains nearly
+    100k repair manuals, 200k Questions & Answers on 42k devices, and all the data is
+    licensed under CC-BY.
+
+    This loader will allow you to download the text of a repair guide, text of Q&A's
+    and wikis from devices on iFixit using their open APIs and web scraping.
+    """
+
+    def __init__(self, web_path: str):
+        """Initialize with web path."""
+        if not web_path.startswith("https://www.ifixit.com"):
+            raise ValueError("web path must start with 'https://www.ifixit.com'")
+
+        path = web_path.replace("https://www.ifixit.com", "")
+
+        allowed_paths = ["/Device", "/Guide", "/Answers", "/Teardown"]
+
+        """ TODO: Add /Wiki """
+        if not any(path.startswith(allowed_path) for allowed_path in allowed_paths):
+            raise ValueError(
+                "web path must start with /Device, /Guide, /Teardown or /Answers"
+            )
+
+        pieces = [x for x in path.split("/") if x]
+
+        """Teardowns are just guides by a different name"""
+        self.page_type = pieces[0] if pieces[0] != "Teardown" else "Guide"
+
+        if self.page_type == "Guide" or self.page_type == "Answers":
+            self.id = pieces[2]
+        else:
+            self.id = pieces[1]
+
+        self.web_path = web_path
+
+    def load(self) -> List[Document]:
+        if self.page_type == "Device":
+            return self.load_device()
+        elif self.page_type == "Guide" or self.page_type == "Teardown":
+            return self.load_guide()
+        elif self.page_type == "Answers":
+            return self.load_questions_and_answers()
+        else:
+            raise ValueError("Unknown page type: " + self.page_type)
+
+    @staticmethod
+    def load_suggestions(
+            query: str = "", doc_type: str = "all"
+    ) -> List[Document]:
+        res = requests.get(
+            IFIXIT_BASE_URL + "/suggest/" + query + "?doctypes=" + doc_type
+        )
+
+        if res.status_code != 200:
+            raise ValueError(
+                "Could not load suggestions for \"" + query + "\"\n" + res.json()
+            )
+
+        data = res.json()
+
+        results = data["results"]
+        output = []
+
+        for result in results:
+            try:
+                loader = IFixitLoader(result['url'])
+                if loader.page_type == "Device":
+                    output += loader.load_device(include_guides=False)
+                else:
+                    output += loader.load()
+            except ValueError:
+                continue
+
+        return output
+
+    def load_questions_and_answers(
+            self, url_override: Optional[str] = None
+    ) -> List[Document]:
+        loader = WebBaseLoader(self.web_path if url_override is None else url_override)
+        soup = loader.scrape()
+
+        output = []
+
+        title = soup.find("h1", "post-title").text
+
+        output.append("# " + title)
+        output.append(soup.select_one(".post-content .post-text").text.strip())
+
+        output.append("\n## " + soup.find("div", "post-answers-header").text.strip())
+        for answer in soup.select(".js-answers-list .post.post-answer"):
+            if answer.has_attr("itemprop") and "acceptedAnswer" in answer["itemprop"]:
+                output.append("\n### Accepted Answer")
+            elif "post-helpful" in answer["class"]:
+                output.append("\n### Most Helpful Answer")
+            else:
+                output.append("\n### Other Answer")
+
+            output += [
+                a.text.strip() for a in answer.select(".post-content .post-text")
+            ]
+            output.append("\n")
+
+        text = "\n".join(output).strip()
+
+        metadata = {"source": self.web_path, "title": title}
+
+        return [Document(page_content=text, metadata=metadata)]
+
+    def load_device(self, url_override: Optional[str] = None,
+                    include_guides: bool = True) -> List[Document]:
+        documents = []
+        if url_override is None:
+            url = IFIXIT_BASE_URL + "/wikis/CATEGORY/" + self.id
+        else:
+            url = url_override
+
+        res = requests.get(url)
+        data = res.json()
+        text = "\n".join(
+            [
+                data[key]
+                for key in ["title", "description", "contents_raw"]
+                if key in data
+            ]
+        ).strip()
+
+        metadata = {"source": self.web_path, "title": data["title"]}
+        documents.append(Document(page_content=text, metadata=metadata))
+
+        if include_guides:
+            """ Load and return documents for each guide linked to from the device """
+            guide_urls = [guide["url"] for guide in data["guides"]]
+            for guide_url in guide_urls:
+                documents.append(IFixitLoader(guide_url).load()[0])
+
+        return documents
+
+    def load_guide(self, url_override: Optional[str] = None) -> List[Document]:
+        if url_override is None:
+            url = IFIXIT_BASE_URL + "/guides/" + self.id
+        else:
+            url = url_override
+
+        res = requests.get(url)
+
+        if res.status_code != 200:
+            raise ValueError(
+                "Could not load guide: " + self.web_path + "\n" + res.json()
+            )
+
+        data = res.json()
+
+        doc_parts = ["# " + data["title"], data["introduction_raw"]]
+
+        doc_parts.append("\n\n###Tools Required:")
+        if len(data["tools"]) == 0:
+            doc_parts.append("\n - None")
+        else:
+            for tool in data["tools"]:
+                doc_parts.append("\n - " + tool["text"])
+
+        doc_parts.append("\n\n###Parts Required:")
+        if len(data["parts"]) == 0:
+            doc_parts.append("\n - None")
+        else:
+            for part in data["parts"]:
+                doc_parts.append("\n - " + part["text"])
+
+        for row in data["steps"]:
+            doc_parts.append(
+                "\n\n## "
+                + (
+                    row["title"]
+                    if row["title"] != ""
+                    else "Step {}".format(row["orderby"])
+                )
+            )
+
+            for line in row["lines"]:
+                doc_parts.append(line["text_raw"])
+
+        doc_parts.append(data["conclusion_raw"])
+
+        text = "\n".join(doc_parts)
+
+        metadata = {"source": self.web_path, "title": data["title"]}
+
+        return [Document(page_content=text, metadata=metadata)]

--- a/langchain/document_loaders/ifixit.py
+++ b/langchain/document_loaders/ifixit.py
@@ -4,8 +4,8 @@ from typing import List, Optional
 import requests
 
 from langchain.docstore.document import Document
-from langchain.document_loaders.web_base import WebBaseLoader
 from langchain.document_loaders.base import BaseLoader
+from langchain.document_loaders.web_base import WebBaseLoader
 
 IFIXIT_BASE_URL = "https://www.ifixit.com/api/2.0"
 

--- a/langchain/document_loaders/ifixit.py
+++ b/langchain/document_loaders/ifixit.py
@@ -59,16 +59,14 @@ class IFixitLoader(BaseLoader):
             raise ValueError("Unknown page type: " + self.page_type)
 
     @staticmethod
-    def load_suggestions(
-            query: str = "", doc_type: str = "all"
-    ) -> List[Document]:
+    def load_suggestions(query: str = "", doc_type: str = "all") -> List[Document]:
         res = requests.get(
             IFIXIT_BASE_URL + "/suggest/" + query + "?doctypes=" + doc_type
         )
 
         if res.status_code != 200:
             raise ValueError(
-                "Could not load suggestions for \"" + query + "\"\n" + res.json()
+                'Could not load suggestions for "' + query + '"\n' + res.json()
             )
 
         data = res.json()
@@ -78,7 +76,7 @@ class IFixitLoader(BaseLoader):
 
         for result in results:
             try:
-                loader = IFixitLoader(result['url'])
+                loader = IFixitLoader(result["url"])
                 if loader.page_type == "Device":
                     output += loader.load_device(include_guides=False)
                 else:
@@ -89,7 +87,7 @@ class IFixitLoader(BaseLoader):
         return output
 
     def load_questions_and_answers(
-            self, url_override: Optional[str] = None
+        self, url_override: Optional[str] = None
     ) -> List[Document]:
         loader = WebBaseLoader(self.web_path if url_override is None else url_override)
         soup = loader.scrape()
@@ -121,8 +119,9 @@ class IFixitLoader(BaseLoader):
 
         return [Document(page_content=text, metadata=metadata)]
 
-    def load_device(self, url_override: Optional[str] = None,
-                    include_guides: bool = True) -> List[Document]:
+    def load_device(
+        self, url_override: Optional[str] = None, include_guides: bool = True
+    ) -> List[Document]:
         documents = []
         if url_override is None:
             url = IFIXIT_BASE_URL + "/wikis/CATEGORY/" + self.id
@@ -143,7 +142,7 @@ class IFixitLoader(BaseLoader):
         documents.append(Document(page_content=text, metadata=metadata))
 
         if include_guides:
-            """ Load and return documents for each guide linked to from the device """
+            """Load and return documents for each guide linked to from the device"""
             guide_urls = [guide["url"] for guide in data["guides"]]
             for guide_url in guide_urls:
                 documents.append(IFixitLoader(guide_url).load()[0])

--- a/tests/integration_tests/document_loaders/__init__.py
+++ b/tests/integration_tests/document_loaders/__init__.py
@@ -1,0 +1,1 @@
+"""Test document loader integrations."""

--- a/tests/integration_tests/document_loaders/test_ifixit.py
+++ b/tests/integration_tests/document_loaders/test_ifixit.py
@@ -1,0 +1,37 @@
+from langchain.document_loaders.ifixit import IFixitLoader
+
+
+def test_ifixit_loader() -> None:
+    """Test iFixit loader."""
+    web_path = "https://www.ifixit.com/Guide/iPad+9+Battery+Replacement/151279"
+    loader = IFixitLoader(web_path)
+    assert loader.page_type == "Guide"
+    assert loader.id == "151279"
+    assert loader.web_path == web_path
+
+
+def test_ifixit_loader_teardown() -> None:
+    web_path = "https://www.ifixit.com/Teardown/Banana+Teardown/811"
+    loader = IFixitLoader(web_path)
+    """ Teardowns are just guides by a different name """
+    assert loader.page_type == "Guide"
+    assert loader.id == "811"
+
+
+def test_ifixit_loader_device() -> None:
+    web_path = "https://www.ifixit.com/Device/Standard_iPad"
+    loader = IFixitLoader(web_path)
+    """ Teardowns are just guides by a different name """
+    assert loader.page_type == "Device"
+    assert loader.id == "Standard_iPad"
+
+
+def test_ifixit_loader_answers() -> None:
+    web_path = (
+        "https://www.ifixit.com/Answers/View/318583/My+iPhone+6+is+typing+and+"
+        "opening+apps+by+itself"
+    )
+    loader = IFixitLoader(web_path)
+
+    assert loader.page_type == "Answers"
+    assert loader.id == "318583"


### PR DESCRIPTION
iFixit is a wikipedia-like site that has a huge amount of open content on how to fix things, questions/answers for common troubleshooting and "things" related content that is more technical in nature.  All content is licensed under CC-BY-SA-NC 3.0

Adding docs from iFixit as context for user questions like "I dropped my phone in water, what do I do?" or "My macbook pro is making a whining noise, what's wrong with it?"  can yield significantly better responses than context free response from LLMs.