### PR TITLE
add acceptable LLM output pattern

### DIFF
--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -43,7 +43,9 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     regex = r"Action: (.*?)Action Input: (.*)"
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
-        if "Action:(.*?)None" in llm_output:
+        regex = r"Action:(.*?)None"
+        match = re.search(regex, llm_output, re.DOTALL)
+        if match:
             return action, ""
         else:
             raise ValueError(f"Could not parse LLM output: `{llm_output}`")

--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -40,12 +40,17 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     """
     if FINAL_ANSWER_ACTION in llm_output:
         return "Final Answer", llm_output.split(FINAL_ANSWER_ACTION)[-1].strip()
-    regex = r"Action: (.*?)\nAction Input: (.*)"
+    regex = r"Action: (.*?)Action Input: (.*)"
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
-        raise ValueError(f"Could not parse LLM output: `{llm_output}`")
+        if "Action:(.*?)None" in llm_output:
+            return action, ""
+        else:
+            raise ValueError(f"Could not parse LLM output: `{llm_output}`")
     action = match.group(1).strip()
     action_input = match.group(2)
+    if "Speak" in action:
+        return "Final Answer", action_input.strip(" ").strip('"')
     return action, action_input.strip(" ").strip('"')
 
 

--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -43,7 +43,7 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     regex = r"Action: (.*?)Action Input: (.*)"
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
-        regex = r"Action: ?None"
+        regex = r"Action: *None"
         match = re.search(regex, llm_output, re.DOTALL)
         if match:
             return "None", ""

--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -43,10 +43,10 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     regex = r"Action: (.*?)Action Input: (.*)"
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
-        regex = r"Action:(.*?)None"
+        regex = r"Action: ?None"
         match = re.search(regex, llm_output, re.DOTALL)
         if match:
-            return action, ""
+            return "None", ""
         else:
             raise ValueError(f"Could not parse LLM output: `{llm_output}`")
     action = match.group(1).strip()


### PR DESCRIPTION
When LLM generates Action: Speak, Final Answer usually contains in Action Input.(not in FinalAnswer)
Action: Speak is not defined in tools, so it results in raising  "Speak is not a valid tool, try another one."
Also, when Action:None is generated, there is often no Action Input. This causes "Could not parse LLM output:" error.
 
I admit that this can be thought as Exception,  but I also think there might be some behaviors that we should treat as right answer because output of LLM is too fuzzy to parse strictly.

Also, I fixed regex because there is often no "\n" before Action Input.