### PR TITLE
separate columns by tabs instead of single space in sql sample rows

### DIFF
--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -379,9 +379,17 @@
       ")\n",
       "\n",
       "SELECT * FROM 'Track' LIMIT 2;\n",
-      "TrackId Name AlbumId MediaTypeId GenreId Composer Milliseconds Bytes UnitPrice\n",
-      "1 For Those About To Rock (We Salute You) 1 1 1 Angus Young, Malcolm Young, Brian Johnson 343719 11170334 0.99\n",
-      "2 Balls to the Wall 2 2 1 None 342562 5510424 0.99\n"
+      "TrackId\tName\tAlbumId\tMediaTypeId\tGenreId\tComposer\tMilliseconds\tBytes\tUnitPrice\n",
+      "1\tFor Those About To Rock (We Salute You)\t1\t1\t1\tAngus Young, Malcolm Young, Brian Johnson\t343719\t11170334\t0.99\n",
+      "2\tBalls to the Wall\t2\t2\t1\tNone\t342562\t5510424\t0.99\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jon/projects/langchain/langchain/sql_database.py:121: SAWarning: Dialect sqlite+pysqlite does *not* support Decimal objects natively, and SQLAlchemy must convert from floating point - rounding errors and other issues may occur. Please consider storing Decimal numbers as strings or integers on this platform for lossless storage.\n",
+      "  sample_rows = connection.execute(command)\n"
      ]
     }
    ],
@@ -542,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -113,7 +113,7 @@ class SQLDatabase:
                 )
 
                 # save the columns in string format
-                columns_str = " ".join([col.name for col in table.columns])
+                columns_str = "\t".join([col.name for col in table.columns])
 
                 try:
                     # get the sample rows
@@ -125,7 +125,7 @@ class SQLDatabase:
                         )
 
                     # save the sample rows in string format
-                    sample_rows_str = "\n".join([" ".join(row) for row in sample_rows])
+                    sample_rows_str = "\n".join(["\t".join(row) for row in sample_rows])
 
                 # in some dialects when there are no rows in the table a
                 # 'ProgrammingError' is returned


### PR DESCRIPTION
Use tabs to separate columns instead of a single space - confusing when there are spaces in a cell