### PR TITLE
Extend OpenAIChat to track token usage

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -515,7 +515,7 @@ class AzureOpenAI(BaseOpenAI):
         return {**{"engine": self.deployment_name}, **super()._invocation_params}
 
 
-class OpenAIChat(LLM, BaseModel):
+class OpenAIChat(BaseLLM, BaseModel):
     """Wrapper around OpenAI Chat large language models.
 
     To use, you should have the ``openai`` python package installed, and the
@@ -621,15 +621,28 @@ class OpenAIChat(LLM, BaseModel):
 
         return _completion_with_retry(**kwargs)
 
-    def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
-        messages = self.prefix_messages + [{"role": "user", "content": prompt}]
+    def _generate(
+        self, prompts: List[str], stop: Optional[List[str]] = None
+    ) -> LLMResult:
+        messages = self.prefix_messages + [{"role": "user", "content": prompts[0]}]
         params: Dict[str, Any] = {**{"model": self.model_name}, **self._default_params}
         if stop is not None:
             if "stop" in params:
                 raise ValueError("`stop` found in both the input and default params.")
             params["stop"] = stop
         response = self.completion_with_retry(messages=messages, **params)
-        return response["choices"][0]["message"]["content"]
+        return LLMResult(
+            generations=[
+                [Generation(text=response["choices"][0]["message"]["content"])]
+            ],
+            llm_output={"token_usage": response["usage"]},
+        )
+
+    async def _agenerate(
+        self, prompts: List[str], stop: Optional[List[str]] = None
+    ) -> LLMResult:
+        """Run the LLM on the given prompt and input."""
+        raise NotImplementedError("Async generation not implemented for this LLM.")
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:


### PR DESCRIPTION
This change supports the use of `get_openai_callback`, as in https://langchain.readthedocs.io/en/latest/modules/llms/examples/token_usage_tracking.html, for tracking token usage.