### PR TITLE
Fixed Python REPL tool validation to look at the right index in the array

### DIFF
--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -51,7 +51,7 @@ class PythonAstREPLTool(BaseTool):
     @root_validator(pre=True)
     def validate_python_version(cls, values: Dict) -> Dict:
         """Validate valid python version."""
-        if sys.version_info[0] <= 8:
+        if sys.version_info[1] <= 8:
             raise ValueError(
                 "This tool relies on Python 3.9 or higher "
                 "(as it uses new functionality in the `ast` module, "


### PR DESCRIPTION
Even with correct python version (3.9+), the error would occur.