### PR TITLE
Minor documentation update in initialize_agent

### DIFF
--- a/langchain/agents/initialize.py
+++ b/langchain/agents/initialize.py
@@ -17,12 +17,12 @@ def initialize_agent(
     agent_kwargs: Optional[dict] = None,
     **kwargs: Any,
 ) -> AgentExecutor:
-    """Load agent given tools and LLM.
+    """Load an agent executor given tools and LLM.
 
     Args:
         tools: List of tools this agent has access to.
         llm: Language model to use as the agent.
-        agent: The agent to use. Valid options are:
+        agent: A string that specified the agent type to use. Valid options are:
             `zero-shot-react-description`
             `react-docstore`
             `self-ask-with-search`
@@ -32,10 +32,11 @@ def initialize_agent(
         callback_manager: CallbackManager to use. Global callback manager is used if
             not provided. Defaults to None.
         agent_path: Path to serialized agent to use.
-        **kwargs: Additional key word arguments to pass to the agent.
+        agent_kwargs: Additional key word arguments to pass to the underlying agent
+        **kwargs: Additional key word arguments passed to the agent executor
 
     Returns:
-        An agent.
+        An agent executor
     """
     if agent is None and agent_path is None:
         agent = "zero-shot-react-description"


### PR DESCRIPTION
Updating documentation in initialize_agent.

One thing that could benefit from further clarification is the responsibility
breakdown by between an AgentExecutor vs. an Agent. The documentation for an
AgentExecutor does not clarify that. From the class attributes, it appears that
executor has access to the tools, while the agent is only aware of the tool
names. Anyway, additional clarification would be beneficial on the
AgentExecutor class.
