### PR TITLE
Agents: update create_prompt to be a staticmethod

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -177,9 +177,9 @@ class Agent(BaseModel):
     def llm_prefix(self) -> str:
         """Prefix to append the LLM call with."""
 
-    @classmethod
+    @staticmethod
     @abstractmethod
-    def create_prompt(cls, tools: Sequence[BaseTool]) -> BasePromptTemplate:
+    def create_prompt(tools: Sequence[BaseTool]) -> BasePromptTemplate:
         """Create a prompt for this class."""
 
     @classmethod

--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -33,9 +33,8 @@ class ConversationalAgent(Agent):
         """Prefix to append the llm call with."""
         return "Thought:"
 
-    @classmethod
+    @staticmethod
     def create_prompt(
-        cls,
         tools: Sequence[BaseTool],
         prefix: str = PREFIX,
         suffix: str = SUFFIX,
@@ -51,6 +50,7 @@ class ConversationalAgent(Agent):
                 prompt.
             prefix: String to put before the list of tools.
             suffix: String to put after the list of tools.
+            format_instructions: String that includes format instructions.
             ai_prefix: String to use before AI output.
             human_prefix: String to use before human output.
             input_variables: List of input variables the final prompt will expect.

--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -67,9 +67,8 @@ class ZeroShotAgent(Agent):
         """Prefix to append the llm call with."""
         return "Thought:"
 
-    @classmethod
+    @staticmethod
     def create_prompt(
-        cls,
         tools: Sequence[BaseTool],
         prefix: str = PREFIX,
         suffix: str = SUFFIX,
@@ -155,7 +154,7 @@ class MRKLChain(AgentExecutor):
     @classmethod
     def from_chains(
         cls, llm: BaseLLM, chains: List[ChainConfig], **kwargs: Any
-    ) -> AgentExecutor:
+    ) -> "MRKLChain":
         """User friendly way to initialize the MRKL chain.
 
         This is intended to be an easy way to get up and running with the

--- a/langchain/agents/react/base.py
+++ b/langchain/agents/react/base.py
@@ -23,8 +23,8 @@ class ReActDocstoreAgent(Agent, BaseModel):
         """Return Identifier of agent type."""
         return "react-docstore"
 
-    @classmethod
-    def create_prompt(cls, tools: Sequence[BaseTool]) -> BasePromptTemplate:
+    @staticmethod
+    def create_prompt(tools: Sequence[BaseTool]) -> BasePromptTemplate:
         """Return default prompt."""
         return WIKI_PROMPT
 
@@ -108,8 +108,8 @@ class DocstoreExplorer:
 class ReActTextWorldAgent(ReActDocstoreAgent, BaseModel):
     """Agent for the ReAct TextWorld chain."""
 
-    @classmethod
-    def create_prompt(cls, tools: Sequence[BaseTool]) -> BasePromptTemplate:
+    @staticmethod
+    def create_prompt(tools: Sequence[BaseTool]) -> BasePromptTemplate:
         """Return default prompt."""
         return TEXTWORLD_PROMPT
 

--- a/langchain/agents/self_ask_with_search/base.py
+++ b/langchain/agents/self_ask_with_search/base.py
@@ -19,8 +19,8 @@ class SelfAskWithSearchAgent(Agent):
         """Return Identifier of agent type."""
         return "self-ask-with-search"
 
-    @classmethod
-    def create_prompt(cls, tools: Sequence[BaseTool]) -> BasePromptTemplate:
+    @staticmethod
+    def create_prompt(tools: Sequence[BaseTool]) -> BasePromptTemplate:
         """Prompt does not depend on tools."""
         return PROMPT
 


### PR DESCRIPTION
This PR updates `create_prompt` method to be a staticmethod rather than a
classmethod. 

It is a bit unclear on whether the `classmethod` was intentionally to provide
the code with access to class level attributes.

If that's the case, it may be better to instead provide a way for the prompt
generator to access instance level attributes rather than class level
attributes. 

In addition, there's a minor documentation update and type annotation fix.

I haven't tested the code locally -- relying on tests working in CI (will try to get testing to work)
