### PR TITLE
fix sql misinterpretation of % in query

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, List, Optional
 
-from sqlalchemy import MetaData, create_engine, inspect, select
+from sqlalchemy import MetaData, create_engine, inspect, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
 from sqlalchemy.schema import CreateTable
@@ -177,7 +177,7 @@ class SQLDatabase:
         with self._engine.begin() as connection:
             if self._schema is not None:
                 connection.exec_driver_sql(f"SET search_path TO {self._schema}")
-            cursor = connection.exec_driver_sql(command)
+            cursor = connection.execute(text(command))
             if cursor.returns_rows:
                 if fetch == "all":
                     result = cursor.fetchall()


### PR DESCRIPTION
% is being misinterpreted by sqlalchemy as parameter passing, so any `LIKE 'asdf%'` will result in a value error with mysql, mariadb, and maybe some others. This is one way to fix it - the alternative is to simply double up %, like `LIKE 'asdf%%'` but this seemed cleaner in terms of output.
Fixes #1383 