### PR TITLE
Add similarity search with distance to chroma

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
@@ -131,6 +131,45 @@ class Chroma(VectorStore):
             # we shouldn't hard code to the 1st result
             Document(page_content=result[0], metadata=result[1])
             for result in zip(results["documents"][0], results["metadatas"][0])
+        ]
+        return docs
+
+    def similarity_search_with_distance(
+        self,
+        query: str,
+        k: int = 4,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Run similarity search with Chroma with distance.
+
+        Args:
+            query (str): Query text to search for.
+            k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+
+        Returns:
+            List[Tuple[Document, float]]: List of documents most similar to the query text with distance in float.
+        """
+        if self._embedding_function is None:
+            results = self._collection.query(
+                query_texts=[query], n_results=k, where=filter
+            )
+        else:
+            query_embedding = self._embedding_function.embed_query(query)
+            results = self._collection.query(
+                query_embeddings=[query_embedding], n_results=k, where=filter
+            )
+
+        docs = [
+            # TODO: Chroma can do batch querying,
+            # we shouldn't hard code to the 1st result
+            (Document(page_content=result[0], metadata=result[1]), result[2])
+            for result in zip(
+                results["documents"][0],
+                results["metadatas"][0],
+                distances["distances"][0],
+            )
         ]
         return docs
 

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -28,6 +28,20 @@ def test_chroma_with_metadatas() -> None:
     assert output == [Document(page_content="foo", metadata={"page": "0"})]
 
 
+def test_chroma_with_metadatas_with_distance() -> None:
+    """Test end to end construction and search."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection",
+        texts=texts,
+        embedding=FakeEmbeddings(),
+        metadatas=metadatas,
+    )
+    output = docsearch.similarity_search_with_distance("foo", k=1)
+    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 1.0)]
+
+
 def test_chroma_with_persistence() -> None:
     """Test end to end construction and search, with persistence."""
     chroma_persist_dir = "./tests/persist_dir"


### PR DESCRIPTION
# Why
- The similarity_search of chroma in vector store lacks to return similarity distance from the input document to the result documents that it is impossible to compare the result document score.

# What
- Add similarity search with distance to return the distance along with the result documents.