### PR TITLE
Fix type hint of 'vectorstore_cls' arg in `SemanticSimilarityExampleSelector`

### DIFF
--- a/langchain/prompts/example_selector/semantic_similarity.py
+++ b/langchain/prompts/example_selector/semantic_similarity.py
@@ -1,7 +1,7 @@
 """Example selector that selects examples based on SemanticSimilarity."""
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseModel, Extra
 
@@ -65,7 +65,7 @@ class SemanticSimilarityExampleSelector(BaseExampleSelector, BaseModel):
         cls,
         examples: List[dict],
         embeddings: Embeddings,
-        vectorstore_cls: VectorStore,
+        vectorstore_cls: Type[VectorStore],
         k: int = 4,
         input_keys: Optional[List[str]] = None,
         **vectorstore_cls_kwargs: Any,
@@ -131,7 +131,7 @@ class MaxMarginalRelevanceExampleSelector(SemanticSimilarityExampleSelector, Bas
         cls,
         examples: List[dict],
         embeddings: Embeddings,
-        vectorstore_cls: VectorStore,
+        vectorstore_cls: Type[VectorStore],
         k: int = 4,
         input_keys: Optional[List[str]] = None,
         fetch_k: int = 20,


### PR DESCRIPTION
Hello! Thank you for the amazing library you've created!

While following the tutorial at [the link(`Using an example selector`)](https://langchain.readthedocs.io/en/latest/modules/prompts/examples/few_shot_examples.html#using-an-example-selector), I noticed that passing Chroma as an argument to from_examples results in a type hint error.

Error message(mypy):
```
Argument 3 to "from_examples" of "SemanticSimilarityExampleSelector" has incompatible type "Type[Chroma]"; expected "VectorStore"  [arg-type]mypy(error)
```

This pull request fixes the type hint and allows the VectorStore class to be specified as an argument.
