### PR TITLE
Allow ChatVectorDBChain to take get_chat_history as a parameter.

### DIFF
--- a/langchain/chains/chat_vector_db/base.py
+++ b/langchain/chains/chat_vector_db/base.py
@@ -33,6 +33,7 @@ class ChatVectorDBChain(Chain, BaseModel):
     output_key: str = "answer"
     return_source_documents: bool = False
     top_k_docs_for_context: int = 4
+    get_chat_history: Any = _get_chat_history
     """Return the source documents."""
 
     @property
@@ -81,7 +82,7 @@ class ChatVectorDBChain(Chain, BaseModel):
 
     def _call(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         question = inputs["question"]
-        chat_history_str = _get_chat_history(inputs["chat_history"])
+        chat_history_str = self.get_chat_history(inputs["chat_history"])
         vectordbkwargs = inputs.get("vectordbkwargs", {})
         if chat_history_str:
             new_question = self.question_generator.run(
@@ -103,7 +104,7 @@ class ChatVectorDBChain(Chain, BaseModel):
 
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         question = inputs["question"]
-        chat_history_str = _get_chat_history(inputs["chat_history"])
+        chat_history_str = self.get_chat_history(inputs["chat_history"])
         vectordbkwargs = inputs.get("vectordbkwargs", {})
         if chat_history_str:
             new_question = await self.question_generator.arun(

--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -1,6 +1,6 @@
 """Loader that loads ReadTheDocs documentation directory dump."""
 from pathlib import Path
-from typing import List
+from typing import Any, List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -9,16 +9,27 @@ from langchain.document_loaders.base import BaseLoader
 class ReadTheDocsLoader(BaseLoader):
     """Loader that loads ReadTheDocs documentation directory dump."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, **kwargs: Optional[Any]):
         """Initialize path."""
-        self.file_path = path
+        try:
+            from bs4 import BeautifulSoup
+            _ = BeautifulSoup('<html><body>Parser builder library test.</body></html>', **kwargs)
 
-    def load(self) -> List[Document]:
+        except ImportError:
+            raise ValueError(
+                "Could not import python packages. "
+                "Please install it with `pip install beautifulsoup4`. "
+            )
+
+        self.file_path = path
+        self.bs_kwargs = kwargs
+
+    def load(self, encoding=None, errors=None) -> List[Document]:
         """Load documents."""
         from bs4 import BeautifulSoup
 
         def _clean_data(data: str) -> str:
-            soup = BeautifulSoup(data)
+            soup = BeautifulSoup(data, **self.bs_kwargs)
             text = soup.find_all("main", {"id": "main-content"})
             if len(text) != 0:
                 text = text[0].get_text()
@@ -30,8 +41,9 @@ class ReadTheDocsLoader(BaseLoader):
         for p in Path(self.file_path).rglob("*"):
             if p.is_dir():
                 continue
-            with open(p) as f:
+            with open(p, encoding=encoding, errors=errors) as f:
                 text = _clean_data(f.read())
             metadata = {"source": str(p)}
             docs.append(Document(page_content=text, metadata=metadata))
         return docs
+


### PR DESCRIPTION
This change allows ChatVectorDBChain to support models that have different styles of `chat_history`. For example, the `microsoft/GODEL`* models accepts prompts in the styles:

```
query = f"{instruction} [CONTEXT] {dialog} {knowledge}"
instruction = f'Instruction: given a dialog context, you need to response empathically.'
knowledge = 'knowledge goes here'
dialog = "Hi there EOS Hello EOS Are you a bot? EOS Yes, I am"
```
ChatVectorDBChain currently has `_get_chat_history` which would generate `dialog`  based on the previous conversation in a format that isn't suitable for `microsoft/GODEL`*

With this change, developers can do the following to use their own format for `chat_history` to be inserted in their prompt:

```
def get_chat_history(chat_history: List[Tuple[str, str]]) -> str:
    buffer = ""
    for human_s, ai_s in chat_history:
        buffer += " EOS ".join([human_s, ai_s])
    return buffer

qa = ChatVectorDBChain(
    vectorstore=vectorstore,
    combine_docs_chain=doc_chain,
    question_generator=question_generator,
    callback_manager=manager,
    get_chat_history=get_chat_history
)
```
