### PR TITLE
improve agent ux with chatgpt

### DIFF
--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -81,7 +81,8 @@ class ConversationalAgent(Agent):
         regex = r"Action: (.*?)\nAction Input: (.*)"
         match = re.search(regex, llm_output)
         if not match:
-            raise ValueError(f"Could not parse LLM output: `{llm_output}`")
+            # assume no tool is needed
+            return self.ai_prefix, llm_output.strip()
         action = match.group(1)
         action_input = match.group(2)
         return action.strip(), action_input.strip(" ").strip('"')


### PR DESCRIPTION
This is a minor change to the agent. If "Action Input" and "Action" is not parsed from the llm_output, then assume that no tool is needed.

Frequently, ChatGPT will not put the AI prefix in front of messages, causing the entire chain to break. So this change makes the agent slightly more robust.

Happy to make further changes as necessary! 

This came up in the latest comment in https://github.com/hwchase17/langchain/issues/1358#issuecomment-1455486170