### PR TITLE
Allow ChatVectorDBChain to take get_chat_history as a parameter.

### DIFF
--- a/langchain/chains/chat_vector_db/base.py
+++ b/langchain/chains/chat_vector_db/base.py
@@ -33,6 +33,7 @@ class ChatVectorDBChain(Chain, BaseModel):
     output_key: str = "answer"
     return_source_documents: bool = False
     top_k_docs_for_context: int = 4
+    get_chat_history: Any = _get_chat_history
     """Return the source documents."""
 
     @property
@@ -81,7 +82,7 @@ class ChatVectorDBChain(Chain, BaseModel):
 
     def _call(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         question = inputs["question"]
-        chat_history_str = _get_chat_history(inputs["chat_history"])
+        chat_history_str = self.get_chat_history(inputs["chat_history"])
         vectordbkwargs = inputs.get("vectordbkwargs", {})
         if chat_history_str:
             new_question = self.question_generator.run(
@@ -103,7 +104,7 @@ class ChatVectorDBChain(Chain, BaseModel):
 
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         question = inputs["question"]
-        chat_history_str = _get_chat_history(inputs["chat_history"])
+        chat_history_str = self.get_chat_history(inputs["chat_history"])
         vectordbkwargs = inputs.get("vectordbkwargs", {})
         if chat_history_str:
             new_question = await self.question_generator.arun(


### PR DESCRIPTION
This change allows ChatVectorDBChain to support models that have different styles of `chat_history`. For example, the `microsoft/GODEL`* models accepts prompts in the styles:

```
query = f"{instruction} [CONTEXT] {dialog} {knowledge}"
instruction = f'Instruction: given a dialog context, you need to response empathically.'
knowledge = 'knowledge goes here'
dialog = "Hi there EOS Hello EOS Are you a bot? EOS Yes, I am"
```
ChatVectorDBChain currently has `_get_chat_history` which would generate `dialog`  based on the previous conversation in a format that isn't suitable for `microsoft/GODEL`*

With this change, developers can do the following to use their own format for `chat_history` to be inserted in their prompt:

```
def get_chat_history(chat_history: List[Tuple[str, str]]) -> str:
    buffer = ""
    for human_s, ai_s in chat_history:
        buffer += " EOS ".join([human_s, ai_s])
    return buffer

qa = ChatVectorDBChain(
    vectorstore=vectorstore,
    combine_docs_chain=doc_chain,
    question_generator=question_generator,
    callback_manager=manager,
    get_chat_history=get_chat_history
)
```
