### PR TITLE
Improve ReadTheDocsLoader

### DIFF
--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -24,7 +24,7 @@ class ReadTheDocsLoader(BaseLoader):
         self.file_path = path
         self.bs_kwargs = kwargs
 
-    def load(self, encoding:str =None, error:str =None) -> List[Document]:
+    def load(self, encoding:Optional[str] =None, error:Optional[str] =None) -> List[Document]:
         """Load documents."""
         from bs4 import BeautifulSoup
 

--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -1,6 +1,6 @@
 """Loader that loads ReadTheDocs documentation directory dump."""
 from pathlib import Path
-from typing import List
+from typing import Any, List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -9,16 +9,27 @@ from langchain.document_loaders.base import BaseLoader
 class ReadTheDocsLoader(BaseLoader):
     """Loader that loads ReadTheDocs documentation directory dump."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, **kwargs: Optional[Any]):
         """Initialize path."""
-        self.file_path = path
+        try:
+            from bs4 import BeautifulSoup
+            _ = BeautifulSoup('<html><body>Parser builder library test.</body></html>', **kwargs)
 
-    def load(self) -> List[Document]:
+        except ImportError:
+            raise ValueError(
+                "Could not import python packages. "
+                "Please install it with `pip install beautifulsoup4`. "
+            )
+
+        self.file_path = path
+        self.bs_kwargs = kwargs
+
+    def load(self, encoding=None, errors=None) -> List[Document]:
         """Load documents."""
         from bs4 import BeautifulSoup
 
         def _clean_data(data: str) -> str:
-            soup = BeautifulSoup(data)
+            soup = BeautifulSoup(data, **self.bs_kwargs)
             text = soup.find_all("main", {"id": "main-content"})
             if len(text) != 0:
                 text = text[0].get_text()
@@ -30,8 +41,9 @@ class ReadTheDocsLoader(BaseLoader):
         for p in Path(self.file_path).rglob("*"):
             if p.is_dir():
                 continue
-            with open(p) as f:
+            with open(p, encoding=encoding, errors=errors) as f:
                 text = _clean_data(f.read())
             metadata = {"source": str(p)}
             docs.append(Document(page_content=text, metadata=metadata))
         return docs
+

--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -24,7 +24,7 @@ class ReadTheDocsLoader(BaseLoader):
         self.file_path = path
         self.bs_kwargs = kwargs
 
-    def load(self, encoding=None, errors=None) -> List[Document]:
+    def load(self, encoding:str =None, error:str =None) -> List[Document]:
         """Load documents."""
         from bs4 import BeautifulSoup
 


### PR DESCRIPTION
This change improves ReadTheDocsLoader

1. Pass initialization args to BeautifulSoup. This allows selection of parser library - eg. `features='html5lib'` 
2. `load` method gets an optional `encoding` and `error` for the file `open` method.

This allows developers to do things like:

Original:
```
    # The following line produces a BeautifulSoup warning that parser library is not specified
    loader = ReadTheDocsLoader('langchain.readthedocs.io/en/latest/') 
    
    # The following could fail if encoding is not current OS encoding
    raw_documents = loader.load()
```

New:
```
    # features='html5lib' is passed down to BeautifulSoup allowing standard parser library
    # across environments - still Optional to maintain backward compatibility
    loader = ReadTheDocsLoader('langchain.readthedocs.io/en/latest/', features='html5lib')
    
    # Specify document encoding (optional to maintain compat) 
    # also support errors='ignore', defaulting to None for file open function
    raw_documents = loader.load(encoding='utf-8') 
```