### PR TITLE
changed requests.run to requests.get

### DIFF
--- a/docs/modules/utils/examples/requests.ipynb
+++ b/docs/modules/utils/examples/requests.ipynb
@@ -48,7 +48,7 @@
     }
    ],
    "source": [
-    "requests.run(\"https://www.google.com\")"
+    "requests.get(\"https://www.google.com\")"
    ]
   },
   {


### PR DESCRIPTION
This pull request proposes an update to the Lightweight wrapper library's documentation. The current documentation provides an example of how to use the library's requests.run method, as follows: requests.run("https://www.google.com"). However, this example does not work for the 0.0.102 version of the library.

Testing:

The changes have been tested locally to ensure they are working as intended.

Thank you for considering this pull request.