### PR TITLE
Atempt to avoid error and thus unnecessary api calls when using maria…

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -175,8 +175,10 @@ class SQLDatabase:
         If the statement returns no rows, an empty string is returned.
         """
         with self._engine.begin() as connection:
-            if self._schema is not None:
+            if (self._schema is not None) and (("mariadb" not in self.dialect) or ("mysql" not in self.dialect)): ## added this to try improve mariadb and mysql support ## PLEASE TEST THIS MORE
                 connection.exec_driver_sql(f"SET search_path TO {self._schema}")
+            if (self._schema is not None) and (("mariadb" in self.dialect) or ("mysql" in self.dialect)):
+                connection.exec_driver_sql(f"USE {self._schema}")
             cursor = connection.execute(text(command))
             if cursor.returns_rows:
                 if fetch == "all":


### PR DESCRIPTION
Atempt to improve mariadb and mysql support as in my test case the line "connection.exec_driver_sql(f"SET search_path TO {self._schema}")" cause an unecessary error due to dialect differences and seems to cause more api calls than needed. Please check if the dialect string check is correct. And once again thank you for making this :D