### PR TITLE
docs: fix typo in modules/indexes/chain_examples/question_answering

### DIFF
--- a/docs/modules/indexes/chain_examples/question_answering.ipynb
+++ b/docs/modules/indexes/chain_examples/question_answering.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Question Answering\n",
     "\n",
-    "This notebook walks through how to use LangChain for question answering over a list of documents. It covers four different types of chains: `stuff`, `map_reduce`, `refine`, `map-rerank`. For a more in depth explanation of what these chain types are, see [here](../combine_docs.md)."
+    "This notebook walks through how to use LangChain for question answering over a list of documents. It covers four different types of chains: `stuff`, `map_reduce`, `refine`, `map_rerank`. For a more in depth explanation of what these chain types are, see [here](../combine_docs.md)."
    ]
   },
   {


### PR DESCRIPTION
docs: fix typo in modules/indexes/chain_examples/question_answering

![image](https://user-images.githubusercontent.com/11394076/224007874-3a52adf6-ff7a-4f22-9dbf-18c83d08167f.png)

