### PR TITLE
Add kwargs to from_loaders

### DIFF
--- a/langchain/indexes/vectorstore.py
+++ b/langchain/indexes/vectorstore.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, Extra, Field
 from langchain.chains.qa_with_sources.vector_db import VectorDBQAWithSourcesChain
 from langchain.chains.vector_db_qa.base import VectorDBQA
 from langchain.document_loaders.base import BaseLoader
-from langchain.embeddings.base import Embeddings
 from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.llms.base import BaseLLM
 from langchain.llms.openai import OpenAI
@@ -68,12 +67,10 @@ class VectorstoreIndexCreator(BaseModel):
         super().__init__(*args, **kwargs)
 
         """backwards compatibility for embedding param"""
-        if 'embedding' in kwargs:
-            self.vectorstore_kwargs['embedding'] = kwargs['embedding']
+        if "embedding" in kwargs:
+            self.vectorstore_kwargs["embedding"] = kwargs["embedding"]
 
-    def from_loaders(
-        self, loaders: List[BaseLoader]
-    ) -> VectorStoreIndexWrapper:
+    def from_loaders(self, loaders: List[BaseLoader]) -> VectorStoreIndexWrapper:
         """Create a vectorstore index from loaders."""
         docs = []
         for loader in loaders:

--- a/langchain/indexes/vectorstore.py
+++ b/langchain/indexes/vectorstore.py
@@ -59,11 +59,15 @@ class VectorstoreIndexCreator(BaseModel):
         extra = Extra.forbid
         arbitrary_types_allowed = True
 
-    def from_loaders(self, loaders: List[BaseLoader]) -> VectorStoreIndexWrapper:
+    def from_loaders(
+        self, loaders: List[BaseLoader], **kwargs: Any
+    ) -> VectorStoreIndexWrapper:
         """Create a vectorstore index from loaders."""
         docs = []
         for loader in loaders:
             docs.extend(loader.load())
         sub_docs = self.text_splitter.split_documents(docs)
-        vectorstore = self.vectorstore_cls.from_documents(sub_docs, self.embedding)
+        vectorstore = self.vectorstore_cls.from_documents(
+            sub_docs, self.embedding, **kwargs
+        )
         return VectorStoreIndexWrapper(vectorstore=vectorstore)

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -207,6 +207,7 @@ class Chroma(VectorStore):
             embedding (Optional[Embeddings]): Embedding function. Defaults to None.
             metadatas (Optional[List[dict]]): List of metadatas. Defaults to None.
             ids (Optional[List[str]]): List of document IDs. Defaults to None.
+            client_settings (Optional[chromadb.config.Settings]): Chroma client settings
 
         Returns:
             Chroma: Chroma vectorstore.
@@ -241,7 +242,7 @@ class Chroma(VectorStore):
             persist_directory (Optional[str]): Directory to persist the collection.
             documents (List[Document]): List of documents to add to the vectorstore.
             embedding (Optional[Embeddings]): Embedding function. Defaults to None.
-
+            client_settings (Optional[chromadb.config.Settings]): Chroma client settings
         Returns:
             Chroma: Chroma vectorstore.
         """


### PR DESCRIPTION
Most of the from_documents functions have more than a few args. It's really nice using the single line loader, so lets pass along kwargs