### PR TITLE
Fix bug with chunks all having shallow metadatas

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -1,6 +1,7 @@
 """Functionality for splitting text."""
 from __future__ import annotations
 
+import copy
 import logging
 from abc import ABC, abstractmethod
 from typing import (
@@ -51,7 +52,7 @@ class TextSplitter(ABC):
         documents = []
         for i, text in enumerate(texts):
             for chunk in self.split_text(text):
-                documents.append(Document(page_content=chunk, metadata=_metadatas[i]))
+                documents.append(Document(page_content=chunk, metadata=copy.deepcopy(_metadatas[i])))
         return documents
 
     def split_documents(self, documents: List[Document]) -> List[Document]:


### PR DESCRIPTION
Man, this took forever to find. Right now, when you chunk up a document, the metadata for all the chunks are all shallow copies of the document's metadata.

This means when you update one, it updates across all the chunks.

As a result, there are a bunch of mysterious bugs. For example, with the Pinecone vector store, the metadata text ends up being the same for a bunch of nodes since they're all getting successively overwritten.