### PR TITLE
Bugfix - allow custom input variables in chat zero shot agent's prompt

### DIFF
--- a/langchain/agents/chat/base.py
+++ b/langchain/agents/chat/base.py
@@ -72,9 +72,7 @@ class ChatAgent(Agent):
         ]
         if input_variables is None:
             input_variables = ["input", "agent_scratchpad"]
-        return ChatPromptTemplate(
-            input_variables=input_variables, messages=messages
-        )
+        return ChatPromptTemplate(input_variables=input_variables, messages=messages)
 
     @classmethod
     def from_llm_and_tools(

--- a/langchain/agents/chat/base.py
+++ b/langchain/agents/chat/base.py
@@ -70,8 +70,10 @@ class ChatAgent(Agent):
             SystemMessagePromptTemplate.from_template(template),
             HumanMessagePromptTemplate.from_template("{input}\n\n{agent_scratchpad}"),
         ]
+        if input_variables is None:
+            input_variables = ["input", "agent_scratchpad"]
         return ChatPromptTemplate(
-            input_variables=["input", "agent_scratchpad"], messages=messages
+            input_variables=input_variables, messages=messages
         )
 
     @classmethod


### PR DESCRIPTION
I was trying out the `chat-zero-shot-react-description` agent for [qabot](https://github.com/hardbyte/qabot/blob/dbbd31bb2702d433ed573bb177f1d1272d36f2ae/qabot/agents/data_query_chain.py#L35-L52) but langchain 0.0.108 doesn't correctly use custom 'input_variables` in the prompt template.