### PR TITLE
Fix the loss of role information when saving memories externally

### DIFF
--- a/langchain/chat_models/base.py
+++ b/langchain/chat_models/base.py
@@ -9,8 +9,8 @@ from langchain.callbacks.base import BaseCallbackManager
 from langchain.schema import (
     AIMessage,
     BaseLanguageModel,
-    BaseMessage,
     ChatGeneration,
+    ChatMessage,
     ChatResult,
     HumanMessage,
     LLMResult,
@@ -44,14 +44,14 @@ class BaseChatModel(BaseLanguageModel, BaseModel, ABC):
         return callback_manager or get_callback_manager()
 
     def generate(
-        self, messages: List[List[BaseMessage]], stop: Optional[List[str]] = None
+        self, messages: List[List[ChatMessage]], stop: Optional[List[str]] = None
     ) -> LLMResult:
         """Top Level call"""
         results = [self._generate(m, stop=stop) for m in messages]
         return LLMResult(generations=[res.generations for res in results])
 
     async def agenerate(
-        self, messages: List[List[BaseMessage]], stop: Optional[List[str]] = None
+        self, messages: List[List[ChatMessage]], stop: Optional[List[str]] = None
     ) -> LLMResult:
         """Top Level call"""
         results = [await self._agenerate(m, stop=stop) for m in messages]
@@ -102,19 +102,19 @@ class BaseChatModel(BaseLanguageModel, BaseModel, ABC):
 
     @abstractmethod
     def _generate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         """Top Level call"""
 
     @abstractmethod
     async def _agenerate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         """Top Level call"""
 
     def __call__(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
-    ) -> BaseMessage:
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
+    ) -> ChatMessage:
         return self._generate(messages, stop=stop).generations[0].message
 
     def call_as_llm(self, message: str, stop: Optional[List[str]] = None) -> str:
@@ -124,7 +124,7 @@ class BaseChatModel(BaseLanguageModel, BaseModel, ABC):
 
 class SimpleChatModel(BaseChatModel):
     def _generate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         output_str = self._call(messages, stop=stop)
         message = AIMessage(text=output_str)
@@ -133,6 +133,6 @@ class SimpleChatModel(BaseChatModel):
 
     @abstractmethod
     def _call(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> str:
         """Simpler interface."""

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -17,7 +17,6 @@ from tenacity import (
 from langchain.chat_models.base import BaseChatModel
 from langchain.schema import (
     AIMessage,
-    BaseMessage,
     ChatGeneration,
     ChatMessage,
     ChatResult,
@@ -63,7 +62,7 @@ async def acompletion_with_retry(llm: ChatOpenAI, **kwargs: Any) -> Any:
     return await _completion_with_retry(**kwargs)
 
 
-def _convert_dict_to_message(_dict: dict) -> BaseMessage:
+def _convert_dict_to_message(_dict: dict) -> ChatMessage:
     role = _dict["role"]
     if role == "user":
         return HumanMessage(content=_dict["content"])
@@ -75,7 +74,7 @@ def _convert_dict_to_message(_dict: dict) -> BaseMessage:
         return ChatMessage(content=_dict["content"], role=role)
 
 
-def _convert_message_to_dict(message: BaseMessage) -> dict:
+def _convert_message_to_dict(message: ChatMessage) -> dict:
     if isinstance(message, ChatMessage):
         message_dict = {"role": message.role, "content": message.content}
     elif isinstance(message, HumanMessage):
@@ -222,7 +221,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
         return _completion_with_retry(**kwargs)
 
     def _generate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         message_dicts, params = self._create_message_dicts(messages, stop)
         if self.streaming:
@@ -247,7 +246,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
         return _create_chat_result(response)
 
     def _create_message_dicts(
-        self, messages: List[BaseMessage], stop: Optional[List[str]]
+        self, messages: List[ChatMessage], stop: Optional[List[str]]
     ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         params: Dict[str, Any] = {**{"model": self.model_name}, **self._default_params}
         if stop is not None:
@@ -258,7 +257,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
         return message_dicts, params
 
     async def _agenerate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         message_dicts, params = self._create_message_dicts(messages, stop)
         if self.streaming:

--- a/langchain/chat_models/promptlayer_openai.py
+++ b/langchain/chat_models/promptlayer_openai.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from langchain.chat_models import ChatOpenAI
-from langchain.schema import BaseMessage, ChatResult
+from langchain.schema import ChatMessage, ChatResult
 
 
 class PromptLayerChatOpenAI(ChatOpenAI, BaseModel):
@@ -30,7 +30,7 @@ class PromptLayerChatOpenAI(ChatOpenAI, BaseModel):
     pl_tags: Optional[List[str]]
 
     def _generate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         """Call ChatOpenAI generate and then call PromptLayer API to log the request."""
         from promptlayer.utils import get_api_key, promptlayer_api_request
@@ -57,7 +57,7 @@ class PromptLayerChatOpenAI(ChatOpenAI, BaseModel):
         return generated_responses
 
     async def _agenerate(
-        self, messages: List[BaseMessage], stop: Optional[List[str]] = None
+        self, messages: List[ChatMessage], stop: Optional[List[str]] = None
     ) -> ChatResult:
         """Call ChatOpenAI agenerate and then call PromptLayer to log."""
         from promptlayer.utils import get_api_key, promptlayer_api_request

--- a/langchain/memory/buffer_window.py
+++ b/langchain/memory/buffer_window.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from langchain.memory.chat_memory import BaseChatMemory
 from langchain.memory.utils import get_buffer_string
-from langchain.schema import BaseMessage
+from langchain.schema import ChatMessage
 
 
 class ConversationBufferWindowMemory(BaseChatMemory, BaseModel):
@@ -16,7 +16,7 @@ class ConversationBufferWindowMemory(BaseChatMemory, BaseModel):
     k: int = 5
 
     @property
-    def buffer(self) -> List[BaseMessage]:
+    def buffer(self) -> List[ChatMessage]:
         """String buffer of memory."""
         return self.chat_memory.messages
 

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from langchain.memory.utils import get_prompt_input_key
-from langchain.schema import AIMessage, BaseMemory, BaseMessage, HumanMessage
+from langchain.schema import AIMessage, BaseMemory, ChatMessage, HumanMessage
 
 
 class ChatMessageHistory(BaseModel):
-    messages: List[BaseMessage] = Field(default_factory=list)
+    messages: List[ChatMessage] = Field(default_factory=list)
 
     def add_user_message(self, message: str) -> None:
         self.messages.append(HumanMessage(content=message))

--- a/langchain/memory/entity.py
+++ b/langchain/memory/entity.py
@@ -10,7 +10,7 @@ from langchain.memory.prompt import (
 )
 from langchain.memory.utils import get_buffer_string, get_prompt_input_key
 from langchain.prompts.base import BasePromptTemplate
-from langchain.schema import BaseLanguageModel, BaseMessage
+from langchain.schema import BaseLanguageModel, ChatMessage
 
 
 class ConversationEntityMemory(BaseChatMemory, BaseModel):
@@ -27,7 +27,7 @@ class ConversationEntityMemory(BaseChatMemory, BaseModel):
     chat_history_key: str = "history"
 
     @property
-    def buffer(self) -> List[BaseMessage]:
+    def buffer(self) -> List[ChatMessage]:
         return self.chat_memory.messages
 
     @property

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -7,7 +7,7 @@ from langchain.memory.chat_memory import BaseChatMemory
 from langchain.memory.prompt import SUMMARY_PROMPT
 from langchain.memory.utils import get_buffer_string
 from langchain.prompts.base import BasePromptTemplate
-from langchain.schema import BaseLanguageModel, BaseMessage, SystemMessage
+from langchain.schema import BaseLanguageModel, ChatMessage, SystemMessage
 
 
 class SummarizerMixin(BaseModel):
@@ -17,7 +17,7 @@ class SummarizerMixin(BaseModel):
     prompt: BasePromptTemplate = SUMMARY_PROMPT
 
     def predict_new_summary(
-        self, messages: List[BaseMessage], existing_summary: str
+        self, messages: List[ChatMessage], existing_summary: str
     ) -> str:
         new_lines = get_buffer_string(
             messages,

--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, root_validator
 from langchain.memory.chat_memory import BaseChatMemory
 from langchain.memory.summary import SummarizerMixin
 from langchain.memory.utils import get_buffer_string
-from langchain.schema import BaseMessage, SystemMessage
+from langchain.schema import ChatMessage, SystemMessage
 
 
 class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel):
@@ -16,7 +16,7 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
     memory_key: str = "history"
 
     @property
-    def buffer(self) -> List[BaseMessage]:
+    def buffer(self) -> List[ChatMessage]:
         return self.chat_memory.messages
 
     @property
@@ -31,7 +31,7 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
         """Return history buffer."""
         buffer = self.buffer
         if self.moving_summary_buffer != "":
-            first_messages: List[BaseMessage] = [
+            first_messages: List[ChatMessage] = [
                 SystemMessage(content=self.moving_summary_buffer)
             ]
             buffer = first_messages + buffer
@@ -55,7 +55,7 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
             )
         return values
 
-    def get_num_tokens_list(self, arr: List[BaseMessage]) -> List[int]:
+    def get_num_tokens_list(self, arr: List[ChatMessage]) -> List[int]:
         """Get list of number of tokens in each string in the input array."""
         return [self.llm.get_num_tokens(get_buffer_string([x])) for x in arr]
 

--- a/langchain/memory/utils.py
+++ b/langchain/memory/utils.py
@@ -1,28 +1,25 @@
 from typing import Any, Dict, List
 
 from langchain.schema import (
-    AIMessage,
-    BaseMessage,
     ChatMessage,
-    HumanMessage,
-    SystemMessage,
 )
 
 
 def get_buffer_string(
-    messages: List[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
+    messages: List[ChatMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
 ) -> str:
     """Get buffer string of messages."""
     string_messages = []
     for m in messages:
-        if isinstance(m, HumanMessage):
-            role = human_prefix
-        elif isinstance(m, AIMessage):
-            role = ai_prefix
-        elif isinstance(m, SystemMessage):
-            role = "System"
-        elif isinstance(m, ChatMessage):
-            role = m.role
+        if isinstance(m, ChatMessage):
+            if m.role == "Human":
+                role = human_prefix
+            elif m.role == "AI":
+                role = ai_prefix
+            elif m.role == "System":
+                role = "System"
+            else:
+                role = m.role
         else:
             raise ValueError(f"Got unsupported message type: {m}")
         string_messages.append(f"{role}: {m.content}")

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -16,7 +16,7 @@ from langchain.output_parsers.list import (  # noqa: F401
     ListOutputParser,
 )
 from langchain.output_parsers.regex import RegexParser  # noqa: F401
-from langchain.schema import BaseMessage, HumanMessage, PromptValue
+from langchain.schema import ChatMessage, HumanMessage, PromptValue
 
 
 def jinja2_formatter(template: str, **kwargs: Any) -> str:
@@ -66,7 +66,7 @@ class StringPromptValue(PromptValue):
         """Return prompt as string."""
         return self.text
 
-    def to_messages(self) -> List[BaseMessage]:
+    def to_messages(self) -> List[ChatMessage]:
         """Return prompt as messages."""
         return [HumanMessage(content=self.text)]
 

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -108,13 +108,13 @@ class SystemMessagePromptTemplate(BaseStringMessagePromptTemplate):
 
 
 class ChatPromptValue(PromptValue):
-    messages: List[BaseMessage]
+    messages: List[ChatMessage]
 
     def to_string(self) -> str:
         """Return prompt as string."""
         return get_buffer_string(self.messages)
 
-    def to_messages(self) -> List[BaseMessage]:
+    def to_messages(self) -> List[ChatMessage]:
         """Return prompt as messages."""
         return self.messages
 

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -41,29 +41,35 @@ class BaseMessage(BaseModel):
     additional_kwargs: dict = Field(default_factory=dict)
 
 
-class HumanMessage(BaseMessage):
-    """Type of message that is spoken by the human."""
-
-
-class AIMessage(BaseMessage):
-    """Type of message that is spoken by the AI."""
-
-
-class SystemMessage(BaseMessage):
-    """Type of message that is a system message."""
-
-
 class ChatMessage(BaseMessage):
     """Type of message with arbitrary speaker."""
 
     role: str
 
 
+class HumanMessage(ChatMessage):
+    """Type of message that is spoken by the human."""
+
+    role: str = "Human"
+
+
+class AIMessage(ChatMessage):
+    """Type of message that is spoken by the AI."""
+
+    role: str = "AI"
+
+
+class SystemMessage(ChatMessage):
+    """Type of message that is a system message."""
+
+    role: str = "System"
+
+
 class ChatGeneration(Generation):
     """Output of a single generation."""
 
     text = ""
-    message: BaseMessage
+    message: ChatMessage
 
     @root_validator
     def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -96,7 +102,7 @@ class PromptValue(BaseModel, ABC):
         """Return prompt as string."""
 
     @abstractmethod
-    def to_messages(self) -> List[BaseMessage]:
+    def to_messages(self) -> List[ChatMessage]:
         """Return prompt as messages."""
 
 

--- a/tests/unit_tests/chains/test_memory.py
+++ b/tests/unit_tests/chains/test_memory.py
@@ -35,3 +35,17 @@ def test_readonly_memory(memory: BaseMemory) -> None:
     assert read_only_memory.load_memory_variables({}) == memory.load_memory_variables(
         {}
     )
+
+
+@pytest.mark.parametrize(
+    "memory",
+    [
+        ConversationBufferMemory(memory_key="baz"),
+        ConversationBufferWindowMemory(memory_key="baz"),
+    ],
+)
+def test_save_external_memory(memory: BaseMemory) -> None:
+    memory.save_context({"input": "bar"}, {"output": "foo"})
+    memory_copy = memory.parse_obj(memory.dict())
+
+    assert memory.load_memory_variables({}) == memory_copy.load_memory_variables({})


### PR DESCRIPTION
## Problem

The get_buffer_string function in BaseChatMemory determines the role of a message based on its instance type. However, this approach loses the role information when saving memories externally.

```python
def get_buffer_string(
    messages: List[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
) -> str:
    """Get buffer string of messages."""
    string_messages = []
    for m in messages:
        if isinstance(m, HumanMessage):
            role = human_prefix
        elif isinstance(m, AIMessage):
            role = ai_prefix
        elif isinstance(m, SystemMessage):
            role = "System"
        elif isinstance(m, ChatMessage):
            role = m.role
```


## Solution

Make HumanMessage, AIMessage, and SystemMessage inherit from ChatMessage so that the role can be passed as a parameter. Modify get_buffer_string to use the role information instead of the instance type.

The solution allows us to pass the role information when saving memories externally. Using the role parameter in get_buffer_string prevents the loss of role information.


## Impact

This change affects the inheritance hierarchy of the message classes and the get_buffer_string function. But, existing unit tests and a new test are all passed.