### PR TITLE
Use OpenAI's official method to calculate the number of tokens

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -317,3 +317,38 @@ class ChatOpenAI(BaseChatModel, BaseModel):
 
         # calculate the number of tokens in the encoded text
         return len(tokenized_text)
+
+    def get_num_tokens_from_messages(
+        self, messages: List[BaseMessage], model: str = "gpt-3.5-turbo-0301"
+    ):
+        """Calculate num tokens for gpt-3.5-turbo with tiktoken package."""
+        try:
+            import tiktoken
+        except ImportError:
+            raise ValueError(
+                "Could not import tiktoken python package. "
+                "This is needed in order to calculate get_num_tokens. "
+                "Please it install it with `pip install tiktoken`."
+            )
+
+        """Returns the number of tokens used by a list of messages."""
+        try:
+            encoding = tiktoken.encoding_for_model(model)
+        except KeyError:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        if model == "gpt-3.5-turbo-0301":  # note: future models may deviate from this
+            num_tokens = 0
+            messages_dict = [_convert_message_to_dict(m) for m in messages]
+            for message in messages_dict:
+                num_tokens += 4  # every message follows <im_start>{role/name}\n{content}<im_end>\n
+                for key, value in message.items():
+                    num_tokens += len(encoding.encode(value))
+                    if key == "name":  # if there's a name, the role is omitted
+                        num_tokens += -1  # role is always required and always 1 token
+            num_tokens += 2  # every reply is primed with <im_start>assistant
+            return num_tokens
+        else:
+            raise NotImplementedError(
+                f"""get_num_tokens_from_messages() is not presently implemented for model {model}.
+    See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens."""
+            )

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -26,7 +26,15 @@ from tenacity import (
 )
 
 from langchain.llms.base import BaseLLM
-from langchain.schema import Generation, LLMResult
+from langchain.schema import (
+    AIMessage,
+    BaseMessage,
+    ChatMessage,
+    Generation,
+    HumanMessage,
+    LLMResult,
+    SystemMessage,
+)
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
@@ -110,6 +118,22 @@ async def acompletion_with_retry(
         return await llm.client.acreate(**kwargs)
 
     return await _completion_with_retry(**kwargs)
+
+
+def _convert_message_to_dict(message: BaseMessage) -> dict:
+    if isinstance(message, ChatMessage):
+        message_dict = {"role": message.role, "content": message.content}
+    elif isinstance(message, HumanMessage):
+        message_dict = {"role": "user", "content": message.content}
+    elif isinstance(message, AIMessage):
+        message_dict = {"role": "assistant", "content": message.content}
+    elif isinstance(message, SystemMessage):
+        message_dict = {"role": "system", "content": message.content}
+    else:
+        raise ValueError(f"Got unknown type {message}")
+    if "name" in message.additional_kwargs:
+        message_dict["name"] = message.additional_kwargs["name"]
+    return message_dict
 
 
 class BaseOpenAI(BaseLLM, BaseModel):
@@ -717,3 +741,38 @@ class OpenAIChat(BaseLLM, BaseModel):
 
         # calculate the number of tokens in the encoded text
         return len(tokenized_text)
+
+    def get_num_tokens_from_messages(
+        self, messages: List[BaseMessage], model: str = "gpt-3.5-turbo-0301"
+    ):
+        """Calculate num tokens for gpt-3.5-turbo with tiktoken package."""
+        try:
+            import tiktoken
+        except ImportError:
+            raise ValueError(
+                "Could not import tiktoken python package. "
+                "This is needed in order to calculate get_num_tokens. "
+                "Please it install it with `pip install tiktoken`."
+            )
+
+        """Returns the number of tokens used by a list of messages."""
+        try:
+            encoding = tiktoken.encoding_for_model(model)
+        except KeyError:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        if model == "gpt-3.5-turbo-0301":  # note: future models may deviate from this
+            num_tokens = 0
+            messages_dict = [_convert_message_to_dict(m) for m in messages]
+            for message in messages_dict:
+                num_tokens += 4  # every message follows <im_start>{role/name}\n{content}<im_end>\n
+                for key, value in message.items():
+                    num_tokens += len(encoding.encode(value))
+                    if key == "name":  # if there's a name, the role is omitted
+                        num_tokens += -1  # role is always required and always 1 token
+            num_tokens += 2  # every reply is primed with <im_start>assistant
+            return num_tokens
+        else:
+            raise NotImplementedError(
+                f"""get_num_tokens_from_messages() is not presently implemented for model {model}.
+    See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens."""
+            )

--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -57,13 +57,7 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
 
     def get_num_tokens_list(self, arr: List[BaseMessage]) -> List[int]:
         """Get list of number of tokens in the input array."""
-        if self.llm.__class__.__name__ in ["ChatOpenAI", "OpenAIChat"]:
-            num_tokens_list = [self.llm.get_num_tokens_from_messages(arr)]
-        else:
-            num_tokens_list = [
-                self.llm.get_num_tokens(get_buffer_string([x])) for x in arr
-            ]
-        return num_tokens_list
+        return self.llm.get_num_tokens_from_messages(arr)
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save context from this conversation to buffer."""

--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -56,8 +56,14 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
         return values
 
     def get_num_tokens_list(self, arr: List[BaseMessage]) -> List[int]:
-        """Get list of number of tokens in each string in the input array."""
-        return [self.llm.get_num_tokens(get_buffer_string([x])) for x in arr]
+        """Get list of number of tokens in the input array."""
+        if self.llm.__class__.__name__ in ["ChatOpenAI", "OpenAIChat"]:
+            num_tokens_list = [self.llm.get_num_tokens_from_messages(arr)]
+        else:
+            num_tokens_list = [
+                self.llm.get_num_tokens(get_buffer_string([x])) for x in arr
+            ]
+        return num_tokens_list
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save context from this conversation to buffer."""

--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -55,21 +55,17 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
             )
         return values
 
-    def get_num_tokens_list(self, arr: List[BaseMessage]) -> List[int]:
-        """Get list of number of tokens in the input array."""
-        return self.llm.get_num_tokens_from_messages(arr)
-
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save context from this conversation to buffer."""
         super().save_context(inputs, outputs)
         # Prune buffer if it exceeds max token limit
         buffer = self.chat_memory.messages
-        curr_buffer_length = sum(self.get_num_tokens_list(buffer))
+        curr_buffer_length = self.llm.get_num_tokens_from_messages(buffer)
         if curr_buffer_length > self.max_token_limit:
             pruned_memory = []
             while curr_buffer_length > self.max_token_limit:
                 pruned_memory.append(buffer.pop(0))
-                curr_buffer_length = sum(self.get_num_tokens_list(buffer))
+                curr_buffer_length = self.llm.get_num_tokens_from_messages(buffer)
             self.moving_summary_buffer = self.predict_new_summary(
                 pruned_memory, self.moving_summary_buffer
             )

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -156,7 +156,7 @@ class BaseLanguageModel(BaseModel, ABC):
 
     def get_num_tokens_from_messages(self, messages: List[BaseMessage]):
         """Get the number of tokens in the message."""
-        return [self.get_num_tokens(get_buffer_string([m])) for m in messages]
+        return sum([self.get_num_tokens(get_buffer_string([m])) for m in messages])
 
 
 class BaseMemory(BaseModel, ABC):

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -7,6 +7,26 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from pydantic import BaseModel, Extra, Field, root_validator
 
 
+def get_buffer_string(
+    messages: List[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
+) -> str:
+    """Get buffer string of messages."""
+    string_messages = []
+    for m in messages:
+        if isinstance(m, HumanMessage):
+            role = human_prefix
+        elif isinstance(m, AIMessage):
+            role = ai_prefix
+        elif isinstance(m, SystemMessage):
+            role = "System"
+        elif isinstance(m, ChatMessage):
+            role = m.role
+        else:
+            raise ValueError(f"Got unsupported message type: {m}")
+        string_messages.append(f"{role}: {m.content}")
+    return "\n".join(string_messages)
+
+
 class AgentAction(NamedTuple):
     """Agent's action to take."""
 
@@ -133,6 +153,10 @@ class BaseLanguageModel(BaseModel, ABC):
 
         # calculate the number of tokens in the tokenized text
         return len(tokenized_text)
+
+    def get_num_tokens_from_messages(self, messages: List[BaseMessage]):
+        """Get the number of tokens in the message."""
+        return [self.get_num_tokens(get_buffer_string([m])) for m in messages]
 
 
 class BaseMemory(BaseModel, ABC):


### PR DESCRIPTION
Fixes #1523 

The new `get_num_tokens_from_messages` function is the same as the one in  [this OpenAI official document](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb).
The argument is a list of messages, and since it has a different argument than the original `get_num_tokens`, the original function is kept for some compatibility.
In `ConversationSummaryBufferMemory`, it is used only when the `llm` class name is either ChatOpenAI or OpenAIChat.
This should also used in the `ConversationTokenBufferMemory` that I previously submitted in #1608 , so if there are no issues, I will also make the changes there.