### PR TITLE
IFixitLoader: support getting questions that have no answers

### DIFF
--- a/langchain/document_loaders/ifixit.py
+++ b/langchain/document_loaders/ifixit.py
@@ -99,7 +99,10 @@ class IFixitLoader(BaseLoader):
         output.append("# " + title)
         output.append(soup.select_one(".post-content .post-text").text.strip())
 
-        output.append("\n## " + soup.find("div", "post-answers-header").text.strip())
+        answersHeader = soup.find("div", "post-answers-header")
+        if (answersHeader):
+            output.append("\n## " + answersHeader.text.strip())
+
         for answer in soup.select(".js-answers-list .post.post-answer"):
             if answer.has_attr("itemprop") and "acceptedAnswer" in answer["itemprop"]:
                 output.append("\n### Accepted Answer")


### PR DESCRIPTION
Fixes the following error when retrieving a question with now answer:
```
    100         output.append(soup.select_one(".post-content .post-text").text.strip())
    101
--> 102         output.append("\n## " + soup.find("div", "post-answers-header").text.strip())
    103         for answer in soup.select(".js-answers-list .post.post-answer"):
    104             if answer.has_attr("itemprop") and "acceptedAnswer" in answer["itemprop"]:

AttributeError: 'NoneType' object has no attribute 'text'
```

CC @timothyasp
