### PR TITLE
Add guardrails.ai integration via an OutputParser

### DIFF
--- a/langchain/output_parsers/__init__.py
+++ b/langchain/output_parsers/__init__.py
@@ -3,7 +3,7 @@ from langchain.output_parsers.list import (
     CommaSeparatedListOutputParser,
     ListOutputParser,
 )
-from langchain.output_parsers.rail_parser import GuardrailOutputParser
+from langchain.output_parsers.rail_parser import GuardrailsOutputParser
 from langchain.output_parsers.regex import RegexParser
 from langchain.output_parsers.regex_dict import RegexDictParser
 from langchain.output_parsers.structured import ResponseSchema, StructuredOutputParser
@@ -16,5 +16,5 @@ __all__ = [
     "BaseOutputParser",
     "StructuredOutputParser",
     "ResponseSchema",
-    "GuardrailOutputParser",
+    "GuardrailsOutputParser",
 ]

--- a/langchain/output_parsers/__init__.py
+++ b/langchain/output_parsers/__init__.py
@@ -3,6 +3,7 @@ from langchain.output_parsers.list import (
     CommaSeparatedListOutputParser,
     ListOutputParser,
 )
+from langchain.output_parsers.rail_parser import GuardrailOutputParser
 from langchain.output_parsers.regex import RegexParser
 from langchain.output_parsers.regex_dict import RegexDictParser
 from langchain.output_parsers.structured import ResponseSchema, StructuredOutputParser
@@ -15,4 +16,5 @@ __all__ = [
     "BaseOutputParser",
     "StructuredOutputParser",
     "ResponseSchema",
+    "GuardrailOutputParser",
 ]

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -12,7 +12,7 @@ from langchain.output_parsers.base import BaseOutputParser
 
 
 class GuardrailOutputParser(BaseOutputParser):
-    guard = Guard
+    guard: Guard
 
     @property
     def _type(self) -> str:

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -14,7 +14,6 @@ class GuardrailsOutputParser(BaseOutputParser):
 
     @classmethod
     def from_rail(cls, rail_file: str, num_reasks: int = 1) -> GuardrailsOutputParser:
-
         from guardrails import Guard
 
         if Guard is None:
@@ -28,7 +27,6 @@ class GuardrailsOutputParser(BaseOutputParser):
     def from_rail_string(
         cls, rail_str: str, num_reasks: int = 1
     ) -> GuardrailsOutputParser:
-
         from guardrails import Guard
 
         if Guard is None:

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -1,25 +1,22 @@
 from __future__ import annotations
 
-from typing import Dict
-
-try:
-    from guardrails import Guard
-except ImportError:
-    Guard = None
-
+from typing import Any, Dict
 
 from langchain.output_parsers.base import BaseOutputParser
 
 
-class GuardrailOutputParser(BaseOutputParser):
-    guard: Guard
+class GuardrailsOutputParser(BaseOutputParser):
+    guard: Any
 
     @property
     def _type(self) -> str:
-        return "guardrail"
+        return "guardrails"
 
     @classmethod
-    def from_rail(cls, rail_file: str, num_reasks: int = 1) -> GuardrailOutputParser:
+    def from_rail(cls, rail_file: str, num_reasks: int = 1) -> GuardrailsOutputParser:
+
+        from guardrails import Guard
+
         if Guard is None:
             raise ImportError(
                 "guardrails-ai package not installed. "
@@ -30,7 +27,10 @@ class GuardrailOutputParser(BaseOutputParser):
     @classmethod
     def from_rail_string(
         cls, rail_str: str, num_reasks: int = 1
-    ) -> GuardrailOutputParser:
+    ) -> GuardrailsOutputParser:
+
+        from guardrails import Guard
+
         if Guard is None:
             raise ImportError(
                 "guardrails-ai package not installed. "

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -30,11 +30,5 @@ class GuardrailOutputParser(BaseOutputParser):
     def get_format_instructions(self) -> str:
         return self.guard.raw_prompt.format_instructions
 
-    def to_prompt_template(self) -> PromptTemplate:
-        return PromptTemplate(
-            template=self.guard.base_prompt,
-            input_variables=self.guard.prompt.input_variables
-        )
-
     def parse(self, text: str) -> Dict:
         return self.guard.parse(text)

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -5,11 +5,10 @@ from typing import Dict
 try:
     from guardrails import Guard
 except ImportError:
-    pass
+    Guard = None
 
 
 from langchain.output_parsers.base import BaseOutputParser
-from langchain.prompts import PromptTemplate
 
 
 class GuardrailOutputParser(BaseOutputParser):
@@ -21,10 +20,22 @@ class GuardrailOutputParser(BaseOutputParser):
 
     @classmethod
     def from_rail(cls, rail_file: str, num_reasks: int = 1) -> GuardrailOutputParser:
+        if Guard is None:
+            raise ImportError(
+                "guardrails-ai package not installed. "
+                "Install it by running `pip install guardrails-ai`."
+            )
         return cls(guard=Guard.from_rail(rail_file, num_reasks=num_reasks))
 
     @classmethod
-    def from_rail_string(cls, rail_str: str, num_reasks: int = 1) -> GuardrailOutputParser:
+    def from_rail_string(
+        cls, rail_str: str, num_reasks: int = 1
+    ) -> GuardrailOutputParser:
+        if Guard is None:
+            raise ImportError(
+                "guardrails-ai package not installed. "
+                "Install it by running `pip install guardrails-ai`."
+            )
         return cls(guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks))
 
     def get_format_instructions(self) -> str:

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from guardrails import Guard
+
+from langchain.output_parsers.base import BaseOutputParser
+from langchain.prompts import PromptTemplate
+
+
+class GuardrailOutputParser(BaseOutputParser):
+    guard = Guard
+
+    def _type(self) -> str:
+        return "guardrail"
+
+    @classmethod
+    def from_rail(cls, rail_file: str, num_reasks: int = 1) -> GuardrailOutputParser:
+        return cls(guard=Guard.from_rail(rail_file, num_reasks=num_reasks))
+
+    @classmethod
+    def from_rail_string(cls, rail_str: str, num_reasks: int = 1) -> GuardrailOutputParser:
+        return cls(guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks))
+
+    def get_format_instructions(self) -> str:
+        return self.guard.raw_prompt.format_instructions
+
+    def to_prompt_template(self) -> PromptTemplate:
+        return PromptTemplate(
+            template=self.guard.base_prompt,
+            input_variables=self.guard.prompt.input_variables
+        )
+
+    def parse(self, text: str) -> Dict:
+        return self.guard.parse(text)

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Dict
 
-from guardrails import Guard
+try:
+    from guardrails import Guard
+except ImportError:
+    pass
+
 
 from langchain.output_parsers.base import BaseOutputParser
 from langchain.prompts import PromptTemplate

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -15,6 +15,7 @@ from langchain.prompts import PromptTemplate
 class GuardrailOutputParser(BaseOutputParser):
     guard = Guard
 
+    @property
     def _type(self) -> str:
         return "guardrail"
 


### PR DESCRIPTION
This PR adds an OutputParser for guardrails.

- OutputParser can be initialized from a `rail` file
- LLM output can be parsed from the `parser.parse`