### PR TITLE
Fixed `ValueError: Could not parse LLM output`

### DIFF
--- a/langchain/agents/conversational_chat/base.py
+++ b/langchain/agents/conversational_chat/base.py
@@ -64,6 +64,7 @@ class AgentOutputParser(BaseOutputParser):
                 response["action"] = cleaned_output.split('"action": "', 1)[1].split('",', 1)[0].strip()
                 response["action_input"] = cleaned_output.split('"action_input": "', 1)[1].split('"}', 1)[0].strip()
             except IndexError:
+
                 raise ValueError("Invalid input format. Unable to extract 'action' and 'action_input' from the text.")
 
         return {"action": response["action"], "action_input": response["action_input"]}
@@ -123,7 +124,7 @@ class ConversationalChatAgent(Agent):
             response = self.output_parser.parse(llm_output)
             return response["action"], response["action_input"]
         except Exception:
-            raise ValueError(f"Could not parse LLM output: {llm_output}")
+            return "Final Answer", llm_output
 
     def _construct_scratchpad(
         self, intermediate_steps: List[Tuple[AgentAction, str]]


### PR DESCRIPTION
Sometimes a conversational agent produces a noisy JSON with `action` and `action_input` keys that has hard time to be parsed even after cleaning, for example:
```
Here's a response in the second format, as I don't think using any of the tools would be helpful in this case:

``json
{
    "action": "Final Answer",
    "action_input": "I'm sorry to hear that you're feeling sad. If you'd like, I'm here to chat and listen if you want to talk about what's been bothering you."
}
``

Remember that it's important to take care of your mental health, and it's okay to not be okay sometimes. If you're feeling overwhelmed or need someone to talk to, there are resources available to help you.
```

This causes a `ValueError: Could not parse LLM output`. 

Related issues: #1657 #1477 #1358 

I just added a simple fallback parsing that instead of using `json.loads()` relies on detecting `"action": "` and `"action_input": "` and parsing the value with `split()`. Also in case LLM failed to produce any JSON at all, I made the agent to return `llm_output` as a `Final Answer` instead of raising an error