### PR TITLE
Add openai-chat to type_to_cls_dict

### DIFF
--- a/langchain/llms/__init__.py
+++ b/langchain/llms/__init__.py
@@ -66,6 +66,7 @@ type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
     "modal": Modal,
     "nlpcloud": NLPCloud,
     "openai": OpenAI,
+    "openai-chat": OpenAIChat,
     "petals": Petals,
     "huggingface_pipeline": HuggingFacePipeline,
     "azure": AzureOpenAI,


### PR DESCRIPTION
It enables loading chains with `openai-chat`.