### PR TITLE
docs: add docs link to agent toolkits

### DIFF
--- a/docs/modules/agents/key_concepts.md
+++ b/docs/modules/agents/key_concepts.md
@@ -13,4 +13,4 @@ For more detailed information on tools, and different types of tools in LangChai
 Toolkits are groups of tools that are best used together.
 They allow you to logically group and initialize a set of tools that share a particular resource (such as a database connection or json object). 
 They can be used to construct an agent for a specific use-case.
-For more detailed information on toolkits and their use cases, see [this documentation](how_to_guides.rst#agent-toolkits).
+For more detailed information on toolkits and their use cases, see [this documentation](how_to_guides.rst#agent-toolkits) (the "Agent Toolkits" section).

--- a/docs/modules/agents/key_concepts.md
+++ b/docs/modules/agents/key_concepts.md
@@ -13,3 +13,4 @@ For more detailed information on tools, and different types of tools in LangChai
 Toolkits are groups of tools that are best used together.
 They allow you to logically group and initialize a set of tools that share a particular resource (such as a database connection or json object). 
 They can be used to construct an agent for a specific use-case.
+For more detailed information on toolkits and their use cases, see [this documentation](how_to_guides.rst#agent-toolkits).


### PR DESCRIPTION
New to Langchain, was a bit confused where I should find the toolkits section when I'm at `agent/key_concepts` docs. I added a short link that points to the how to section.