### PR TITLE
add support for GPT-4

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -163,7 +163,7 @@ class BaseOpenAI(BaseLLM, BaseModel):
 
     def __new__(cls, **data: Any) -> Union[OpenAIChat, BaseOpenAI]:  # type: ignore
         """Initialize the OpenAI object."""
-        if data.get("model_name", "").startswith("gpt-3.5-turbo"):
+        if data.get("model_name", "").startswith(("gpt-3.5", "gpt-4")):
             return OpenAIChat(**data)
         return super().__new__(cls)
 


### PR DESCRIPTION
GPT-4 uses the same ChatCompletion API as `gpt-3.5` before it. However, this API is only "switched to" by llms/openai.py when the model starts with `"gpt-3.5-turbo"`. This makes it impossible to set the model to GPT-4 and have it work properly.

My PR fixes this by changing the starts-with checker to accept all 3.5- and 4- versions.

source on model APIs: https://platform.openai.com/docs/models/gpt-4