### PR TITLE
Allow saving summary messages in roles other than system in conversation memory

### DIFF
--- a/langchain/memory/kg.py
+++ b/langchain/memory/kg.py
@@ -52,16 +52,13 @@ class ConversationKGMemory(BaseChatMemory, BaseModel):
                 f"On {entity}: {summary}" for entity, summary in summaries.items()
             ]
             if self.return_messages:
+                context: Any
                 if self.summary_message_role == "user":
-                    context: Any = [
-                        HumanMessage(content=text) for text in summary_strings
-                    ]
+                    context = [HumanMessage(content=text) for text in summary_strings]
                 elif self.summary_message_role == "assistant":
-                    context: Any = [AIMessage(content=text) for text in summary_strings]
+                    context = [AIMessage(content=text) for text in summary_strings]
                 elif self.summary_message_role == "system":
-                    context: Any = [
-                        SystemMessage(content=text) for text in summary_strings
-                    ]
+                    context = [SystemMessage(content=text) for text in summary_strings]
                 else:
                     raise ValueError(
                         f"Invalid summary_message_role value: {self.summary_message_role}."

--- a/langchain/memory/kg.py
+++ b/langchain/memory/kg.py
@@ -61,8 +61,9 @@ class ConversationKGMemory(BaseChatMemory, BaseModel):
                     context = [SystemMessage(content=text) for text in summary_strings]
                 else:
                     raise ValueError(
-                        f"Invalid summary_message_role value: {self.summary_message_role}."
-                        " summary_message_role must be 'user', 'assistant', or 'system'."
+                        "Invalid summary_message_role value:"
+                        f" {self.summary_message_role}. summary_message_role must be"
+                        " 'user', 'assistant', or 'system'."
                     )
             else:
                 context = "\n".join(summary_strings)

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -53,12 +53,13 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin, BaseModel):
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Return history buffer."""
         if self.return_messages:
+            buffer: Any
             if self.summary_message_role == "user":
-                buffer: Any = [HumanMessage(content=self.buffer)]
+                buffer = [HumanMessage(content=self.buffer)]
             elif self.summary_message_role == "assistant":
-                buffer: Any = [AIMessage(content=self.buffer)]
+                buffer = [AIMessage(content=self.buffer)]
             elif self.summary_message_role == "system":
-                buffer: Any = [SystemMessage(content=self.buffer)]
+                buffer = [SystemMessage(content=self.buffer)]
             else:
                 raise ValueError(
                     f"Invalid summary_message_role value: {self.summary_message_role}."

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -7,8 +7,10 @@ from langchain.memory.chat_memory import BaseChatMemory
 from langchain.memory.prompt import SUMMARY_PROMPT
 from langchain.prompts.base import BasePromptTemplate
 from langchain.schema import (
+    AIMessage,
     BaseLanguageModel,
     BaseMessage,
+    HumanMessage,
     SystemMessage,
     get_buffer_string,
 )
@@ -37,6 +39,7 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin, BaseModel):
     """Conversation summarizer to memory."""
 
     buffer: str = ""
+    summary_message_role: str = "system"
     memory_key: str = "history"  #: :meta private:
 
     @property
@@ -50,7 +53,17 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin, BaseModel):
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Return history buffer."""
         if self.return_messages:
-            buffer: Any = [SystemMessage(content=self.buffer)]
+            if self.summary_message_role == "user":
+                buffer: Any = [HumanMessage(content=self.buffer)]
+            elif self.summary_message_role == "assistant":
+                buffer: Any = [AIMessage(content=self.buffer)]
+            elif self.summary_message_role == "system":
+                buffer: Any = [SystemMessage(content=self.buffer)]
+            else:
+                raise ValueError(
+                    f"Invalid summary_message_role value: {self.summary_message_role}."
+                    " summary_message_role must be 'user', 'assistant', or 'system'."
+                )
         else:
             buffer = self.buffer
         return {self.memory_key: buffer}

--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -37,18 +37,13 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
         """Return history buffer."""
         buffer = self.buffer
         if self.moving_summary_buffer != "":
+            first_messages: List[BaseMessage]
             if self.summary_message_role == "user":
-                first_messages: List[BaseMessage] = [
-                    HumanMessage(content=self.moving_summary_buffer)
-                ]
+                first_messages = [HumanMessage(content=self.moving_summary_buffer)]
             elif self.summary_message_role == "assistant":
-                first_messages: List[BaseMessage] = [
-                    AIMessage(content=self.moving_summary_buffer)
-                ]
+                first_messages = [AIMessage(content=self.moving_summary_buffer)]
             elif self.summary_message_role == "system":
-                first_messages: List[BaseMessage] = [
-                    SystemMessage(content=self.moving_summary_buffer)
-                ]
+                first_messages = [SystemMessage(content=self.moving_summary_buffer)]
             else:
                 raise ValueError(
                     f"Invalid summary_message_role value: {self.summary_message_role}."

--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -4,7 +4,13 @@ from pydantic import BaseModel, root_validator
 
 from langchain.memory.chat_memory import BaseChatMemory
 from langchain.memory.summary import SummarizerMixin
-from langchain.schema import BaseMessage, SystemMessage, get_buffer_string
+from langchain.schema import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    get_buffer_string,
+)
 
 
 class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel):
@@ -12,6 +18,7 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
 
     max_token_limit: int = 2000
     moving_summary_buffer: str = ""
+    summary_message_role: str = "system"
     memory_key: str = "history"
 
     @property
@@ -30,9 +37,23 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
         """Return history buffer."""
         buffer = self.buffer
         if self.moving_summary_buffer != "":
-            first_messages: List[BaseMessage] = [
-                SystemMessage(content=self.moving_summary_buffer)
-            ]
+            if self.summary_message_role == "user":
+                first_messages: List[BaseMessage] = [
+                    HumanMessage(content=self.moving_summary_buffer)
+                ]
+            elif self.summary_message_role == "assistant":
+                first_messages: List[BaseMessage] = [
+                    AIMessage(content=self.moving_summary_buffer)
+                ]
+            elif self.summary_message_role == "system":
+                first_messages: List[BaseMessage] = [
+                    SystemMessage(content=self.moving_summary_buffer)
+                ]
+            else:
+                raise ValueError(
+                    f"Invalid summary_message_role value: {self.summary_message_role}."
+                    " summary_message_role must be 'user', 'assistant', or 'system'."
+                )
             buffer = first_messages + buffer
         if self.return_messages:
             final_buffer: Any = buffer


### PR DESCRIPTION
In the current `ConcersationSummaryMemory`, `ConversationSummaryBufferMemory` and `ConversationKGMemory`, summarized messages are stored as `SystemMessage`.
However, according to the official documentation, gpt-3.5-turbo does not pay much attention to the `system` role message and prefers important information to be provided in the `user` role.

Quote 1 (https://github.com/openai/openai-python/blob/main/chatml.md)
> If adding instructions in the `system` message doesn't work, you can also try putting them into a `user` message. (In the near future, we will train our models to be much more steerable via the system message. But to date, we have trained only on a few system messages, so the models pay much more attention to user examples.)

Quote 2 (https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb)
> The system message can be used to prime the assistant with different personalities or behaviors.
>
> However, the model does not generally pay as much attention to the system message, and therefore we recommend placing important instructions in the user message instead.

Therefore, this PR changes the behavior to allow storing summary messages in roles other than system.
A new variable `summary_message_role` is added with a default value of `"system"`. Depending on the value of this variable, the summary will be stored as a `HumanMessage`, `AIMessage`, or `SystemMessage`.