### PR TITLE
Fix Document & Expose StringPromptTemplate as a custom-prompt-template.

### DIFF
--- a/docs/modules/prompts/examples/custom_prompt_template.ipynb
+++ b/docs/modules/prompts/examples/custom_prompt_template.ipynb
@@ -21,16 +21,17 @@
    "id": "5d56ce86",
    "metadata": {},
    "source": [
-    "## Create a custom prompt template\n",
+    "## Creating a Custom Prompt Template\n",
     "\n",
-    "The only two requirements for all prompt templates are:\n",
+    "There are essentially two distinct prompt templates available - string prompt templates and chat prompt templates. String prompt templates provides a simple prompt in string format, while chat prompt templates produces a more structured prompt to be used with a chat API.\n",
     "\n",
-    "1. They have a input_variables attribute that exposes what input variables this prompt template expects.\n",
-    "2. They expose a format method which takes in keyword arguments corresponding to the expected input_variables and returns the formatted prompt.\n",
+    "In this guide, we will create a custom prompt using a string prompt template. \n",
     "\n",
-    "Let's create a custom prompt template that takes in the function name as input, and formats the prompt template to provide the source code of the function.\n",
+    "To create a custom string prompt template, there are two requirements:\n",
+    "1. It has an input_variables attribute that exposes what input variables the prompt template expects.\n",
+    "2. It exposes a format method that takes in keyword arguments corresponding to the expected input_variables and returns the formatted prompt.\n",
     "\n",
-    "First, let's create a function that will return the source code of a function given its name."
+    "We will create a custom prompt template that takes in the function name as input and formats the prompt to provide the source code of the function. To achieve this, let's first create a function that will return the source code of a function given its name."
    ]
   },
   {
@@ -62,11 +63,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.prompts import BasePromptTemplate\n",
+    "from langchain.prompts import StringPromptTemplate\n",
     "from pydantic import BaseModel, validator\n",
     "\n",
     "\n",
-    "class FunctionExplainerPromptTemplate(BasePromptTemplate, BaseModel):\n",
+    "class FunctionExplainerPromptTemplate(StringPromptTemplate, BaseModel):\n",
     "    \"\"\" A custom prompt template that takes in the function name as input, and formats the prompt template to provide the source code of the function. \"\"\"\n",
     "\n",
     "    @validator(\"input_variables\")\n",

--- a/langchain/prompts/__init__.py
+++ b/langchain/prompts/__init__.py
@@ -1,5 +1,5 @@
 """Prompt template classes."""
-from langchain.prompts.base import BasePromptTemplate
+from langchain.prompts.base import BasePromptTemplate, StringPromptTemplate
 from langchain.prompts.chat import (
     AIMessagePromptTemplate,
     ChatMessagePromptTemplate,
@@ -15,6 +15,7 @@ from langchain.prompts.prompt import Prompt, PromptTemplate
 
 __all__ = [
     "BasePromptTemplate",
+    "StringPromptTemplate",
     "load_prompt",
     "PromptTemplate",
     "FewShotPromptTemplate",


### PR DESCRIPTION
Regarding [this issue](https://github.com/hwchase17/langchain/issues/1754), the code in the document [Creating a custom prompt template](https://langchain.readthedocs.io/en/latest/modules/prompts/examples/custom_prompt_template.html) is no longer functional and outdated. 

To address this, I have made the following changes:

1. Updated the guide in the document to use `StringPromptTemplate` instead of `BasePromptTemplate`.
2. Exposed `StringPromptTemplate` in `prompts/__init__.py` for easier importing.