### PR TITLE
Slightly modified the docstring in `BasePromptTemplate` and `StringPromptTemplate`.

### DIFF
--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -72,7 +72,7 @@ class StringPromptValue(PromptValue):
 
 
 class BasePromptTemplate(BaseModel, ABC):
-    """Base prompt should expose the format method, returning a prompt."""
+    """Base class for all prompt templates, returning a prompt."""
 
     input_variables: List[str]
     """A list of the names of the variables the prompt template expects."""
@@ -196,6 +196,7 @@ class BasePromptTemplate(BaseModel, ABC):
 
 
 class StringPromptTemplate(BasePromptTemplate, ABC):
+    """String prompt should expose the format method, returning a prompt."""
     def format_prompt(self, **kwargs: Any) -> PromptValue:
         """Create Chat Messages."""
         return StringPromptValue(text=self.format(**kwargs))

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -197,6 +197,7 @@ class BasePromptTemplate(BaseModel, ABC):
 
 class StringPromptTemplate(BasePromptTemplate, ABC):
     """String prompt should expose the format method, returning a prompt."""
+
     def format_prompt(self, **kwargs: Any) -> PromptValue:
         """Create Chat Messages."""
         return StringPromptValue(text=self.format(**kwargs))


### PR DESCRIPTION
Regarding [this issue](https://github.com/hwchase17/langchain/issues/1754), `BasePromptTample` class docstring is a little outdated, thus it requires new method `format_prompt` for now.

As such, I have made some modifications to the docstring to bring it up to date.

I tried to adhere to the established document style, and would appreciate you for taking a look at this PR.