### PR TITLE
Fix wrong prompt in refine chain

### DIFF
--- a/langchain/chains/question_answering/__init__.py
+++ b/langchain/chains/question_answering/__init__.py
@@ -155,7 +155,7 @@ def _load_refine_chain(
     **kwargs: Any,
 ) -> RefineDocumentsChain:
     _question_prompt = (
-        question_prompt or refine_prompts.REFINE_PROMPT_SELECTOR.get_prompt(llm)
+        question_prompt or refine_prompts.QUESTION_PROMPT_SELECTOR.get_prompt(llm)
     )
     _refine_prompt = refine_prompt or refine_prompts.REFINE_PROMPT_SELECTOR.get_prompt(
         llm


### PR DESCRIPTION
I got this during testing 

```
ValueError: Missing some input keys: {'existing_answer'}
```

Upon review, the initial prompt should be `QUESTION_PROMPT_SELECTOR`.