### PR TITLE
Allow `max_tokens`=-1 for `ChatOpenAI` and set the default value to -1

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -128,7 +128,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
     """Whether to stream the results or not."""
     n: int = 1
     """Number of chat completions to generate for each prompt."""
-    max_tokens: int = 256
+    max_tokens: int = -1
     """Maximum number of tokens to generate."""
 
     class Config:

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -182,13 +182,17 @@ class ChatOpenAI(BaseChatModel, BaseModel):
     @property
     def _default_params(self) -> Dict[str, Any]:
         """Get the default parameters for calling OpenAI API."""
-        return {
+        params = {
             "model": self.model_name,
             "max_tokens": self.max_tokens,
             "stream": self.streaming,
             "n": self.n,
             **self.model_kwargs,
         }
+        if params.get("max_tokens") == -1:
+            # for ChatGPT api, omitting max_tokens is equivalent to having no limit
+            del params["max_tokens"]
+        return params
 
     def _create_retry_decorator(self) -> Callable[[Any], Any]:
         import openai


### PR DESCRIPTION
Resolves #1532, resolves #1652.

In the current implementation of `ChatOpenAI`, the default value for max_tokens is set to 256, and it cannot take a value of -1.
In this PR, we will allow `max_tokens` to take a value of -1. When `max_tokens`=-1, the `max_tokens` parameter will be omitted, which means there will be no token limit for the response.

Originally, the default value of `max_tokens` was set to 256, causing longer responses to be cut off and creating confusion (as in issue #1652). This PR sets the default value of `max_tokens` to -1, preventing cutoffs from occurring.

The solution was originally proposed by @adlindenberg in the issue discussion (#1532). Thank you, @adlindenberg, for providing the idea for this fix.