### PR TITLE
added function for renaming variables

### DIFF
--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -42,8 +42,12 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
         document_prompt: BasePromptTemplate = EXAMPLE_PROMPT,
         question_prompt: BasePromptTemplate = QUESTION_PROMPT,
         combine_prompt: BasePromptTemplate = COMBINE_PROMPT,
+        sources_variable: Optional[str] = "source",
         **kwargs: Any,
     ) -> BaseQAWithSourcesChain:
+        # Reformat the document_prompt if needed
+        if sources_variable not in document_prompt.input_variables:
+            document_prompt.rename_variable("source", sources_variable)
         """Construct the chain from an LLM."""
         llm_question_chain = LLMChain(llm=llm, prompt=question_prompt)
         llm_combine_chain = LLMChain(llm=llm, prompt=combine_prompt)
@@ -68,6 +72,7 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
         llm: BaseLLM,
         chain_type: str = "stuff",
         chain_type_kwargs: Optional[dict] = None,
+        sources_variable: Optional[str] = "source",
         **kwargs: Any,
     ) -> BaseQAWithSourcesChain:
         """Load chain from chain type."""
@@ -75,6 +80,10 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
         combine_document_chain = load_qa_with_sources_chain(
             llm, chain_type=chain_type, **_chain_kwargs
         )
+        if sources_variable not in combine_document_chain.document_prompt.input_variables:
+            combine_document_chain.document_prompt.rename_variable(
+                "source", sources_variable
+            )
         return cls(combine_documents_chain=combine_document_chain, **kwargs)
 
     class Config:

--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -80,7 +80,10 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
         combine_document_chain: Any = load_qa_with_sources_chain(
             llm, chain_type=chain_type, **_chain_kwargs
         )
-        if sources_variable not in combine_document_chain.document_prompt.input_variables:
+        if (
+            sources_variable
+            not in combine_document_chain.document_prompt.input_variables
+        ):
             combine_document_chain.document_prompt.rename_variable(
                 "source", sources_variable
             )

--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -42,7 +42,7 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
         document_prompt: BasePromptTemplate = EXAMPLE_PROMPT,
         question_prompt: BasePromptTemplate = QUESTION_PROMPT,
         combine_prompt: BasePromptTemplate = COMBINE_PROMPT,
-        sources_variable: Optional[str] = "source",
+        sources_variable: str = "source",
         **kwargs: Any,
     ) -> BaseQAWithSourcesChain:
         # Reformat the document_prompt if needed
@@ -77,7 +77,7 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
     ) -> BaseQAWithSourcesChain:
         """Load chain from chain type."""
         _chain_kwargs = chain_type_kwargs or {}
-        combine_document_chain = load_qa_with_sources_chain(
+        combine_document_chain: Any = load_qa_with_sources_chain(
             llm, chain_type=chain_type, **_chain_kwargs
         )
         if sources_variable not in combine_document_chain.document_prompt.input_variables:

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -213,8 +213,8 @@ class BasePromptTemplate(BaseModel, ABC):
         # Find and replace variable in input_variables
         index = self.input_variables.index(variable)
         self.input_variables[index] = new_variable
-        # Find and replace variable in format_prompt
-        self.format_prompt = self.format_prompt.replace("{"+variable+"}", "{"+new_variable+"}")
+        # Find and replace variable in prompt template
+        self.template = self.template.replace("{"+variable+"}", "{"+new_variable+"}")
 
 class StringPromptTemplate(BasePromptTemplate, ABC):
     def format_prompt(self, **kwargs: Any) -> PromptValue:

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -193,7 +193,28 @@ class BasePromptTemplate(BaseModel, ABC):
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:
             raise ValueError(f"{save_path} must be json or yaml")
+    
+    def rename_variable(self, variable: str, new_variable: str) -> None:
+        """Allows us to switch the variable name in the prompt template.
 
+        Args:
+            variable: The existing variable to be renamed.
+            new_variable: The new variable name.
+        
+        Example:
+        .. code-block:: python
+
+            prompt.rename_variable(variable="old_variable", new_variable="new_variable")
+        """
+        if variable not in self.input_variables:
+            raise ValueError(f"{variable} is not an input variable.")
+        if new_variable in self.input_variables:
+            raise ValueError(f"{new_variable} is already an input variable.")
+        # Find and replace variable in input_variables
+        index = self.input_variables.index(variable)
+        self.input_variables[index] = new_variable
+        # Find and replace variable in format_prompt
+        self.format_prompt = self.format_prompt.replace("{"+variable+"}", "{"+new_variable+"}")
 
 class StringPromptTemplate(BasePromptTemplate, ABC):
     def format_prompt(self, **kwargs: Any) -> PromptValue:

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -214,7 +214,7 @@ class BasePromptTemplate(BaseModel, ABC):
         index = self.input_variables.index(variable)
         self.input_variables[index] = new_variable
         # Find and replace variable in prompt template
-        self.template = self.template.replace("{"+variable+"}", "{"+new_variable+"}")
+        self.template: str = self.template.replace("{"+variable+"}", "{"+new_variable+"}")
 
 class StringPromptTemplate(BasePromptTemplate, ABC):
     def format_prompt(self, **kwargs: Any) -> PromptValue:

--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -193,14 +193,14 @@ class BasePromptTemplate(BaseModel, ABC):
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:
             raise ValueError(f"{save_path} must be json or yaml")
-    
+
     def rename_variable(self, variable: str, new_variable: str) -> None:
         """Allows us to switch the variable name in the prompt template.
 
         Args:
             variable: The existing variable to be renamed.
             new_variable: The new variable name.
-        
+
         Example:
         .. code-block:: python
 
@@ -214,7 +214,10 @@ class BasePromptTemplate(BaseModel, ABC):
         index = self.input_variables.index(variable)
         self.input_variables[index] = new_variable
         # Find and replace variable in prompt template
-        self.template: str = self.template.replace("{"+variable+"}", "{"+new_variable+"}")
+        self.template: str = self.template.replace(
+            "{" + variable + "}", "{" + new_variable + "}"
+        )
+
 
 class StringPromptTemplate(BasePromptTemplate, ABC):
     def format_prompt(self, **kwargs: Any) -> PromptValue:


### PR DESCRIPTION
I came into the issue when using the `VectorDBQAWithSourcesChain` that because of the [example prompt](https://github.com/hwchase17/langchain/blob/master/langchain/chains/qa_with_sources/stuff_prompt.py) being used, it meant my source metadata in the vector DB (pinecone) had to be named `"source"`.

I and other users can go back and rename the document IDs, URLs, etc as `"source"` but it seems like an unnecessary restriction. Instead, being able to swap `"source"` for `"url"`, `"filename"`, etc seems like a better solution to me.

With that in mind, I'd like to add a new method to prompt templates called `rename_variable`, which simply takes an existing variable and a new variable name as input, and formats the prompt template to use the new variable name.

In the example of using `VectorDBQAWithSourcesChain`, this looks like:

```python
qa = VectorDBQAWithSourcesChain.from_chain_type(
    llm=llm,
    chain_type='stuff',
    vectorstore=vectorstore
)

qa.combine_documents_chain.document_prompt.rename_variable(
    'source', 'pdf_url'
)
```

And if we view the `qa.combine_documents_chain.document_prompt` we'll see:

```
PromptTemplate(input_variables=['page_content', 'pdf_url'], output_parser=None, partial_variables={}, template='Content: {page_content}\nSource: {pdf_url}', template_format='f-string', validate_template=True)
```

Alternatively, I added a `sources_variable` parameter to the initialization calls for `VectorDBQAWithSourcesChain`, so the following can be run with the same result:

```python
qa = VectorDBQAWithSourcesChain.from_chain_type(
    llm=llm,
    chain_type='stuff',
    vectorstore=vectorstore,
    sources_variable="pdf_url"
)
```