### PR TITLE
Add load json prompt example

### DIFF
--- a/docs/modules/prompts/examples/prompt_serialization.ipynb
+++ b/docs/modules/prompts/examples/prompt_serialization.ipynb
@@ -121,6 +121,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de75e959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = load_prompt(\"simple_prompt.json\")\n",
+    "print(prompt.format(adjective=\"funny\", content=\"chickens\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1d788f9",
+   "metadata": {},
+   "source": [
+    "Tell me a funny joke about chickens."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d788a83c",
    "metadata": {},


### PR DESCRIPTION
Hi, I just want to add a PR on the prompt serialization examples of loading from JSON so that it can contain the same as loading from YAML.