### PR TITLE
Small fix: Remove unused variable `summary_message_role`

### DIFF
--- a/langchain/memory/summary_buffer.py
+++ b/langchain/memory/summary_buffer.py
@@ -12,7 +12,6 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin, BaseModel
 
     max_token_limit: int = 2000
     moving_summary_buffer: str = ""
-    summary_message_role: str = "system"
     memory_key: str = "history"
 
     @property


### PR DESCRIPTION
After the changes in #1783, `summary_message_role` is no longer used in `ConversationSummaryBufferMemory`, so this PR removes it.