### PR TITLE
Don't use dynamic api endpoint for Zapier NLA

### DIFF
--- a/langchain/tools/zapier/tool.py
+++ b/langchain/tools/zapier/tool.py
@@ -1,6 +1,6 @@
 """## Zapier Natural Language Actions API
 \
-Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
+Full docs here: https://nla.zapier.com/api/v1/docs
 
 **Zapier Natural Language Actions** gives you access to the 5k+ apps, 20k+ actions
 on Zapier's platform through a natural language API interface.
@@ -24,7 +24,7 @@ NLA offers both API Key and OAuth for signing NLA API requests.
     connected accounts on Zapier.com
 
 This quick start will focus on the server-side use case for brevity.
-Review [full docs](https://nla.zapier.com/api/v1/dynamic/docs) or reach out to
+Review [full docs](https://nla.zapier.com/api/v1/docs) or reach out to
 nla@zapier.com for user-facing oauth developer support.
 
 Typically you'd use SequentialChain, here's a basic example:
@@ -92,7 +92,7 @@ class ZapierNLARunAction(BaseTool):
             (eg. "get the latest email from Mike Knoop" for "Gmail: find email" action)
         params: a dict, optional. Any params provided will *override* AI guesses
             from `instructions` (see "understanding the AI guessing flow" here:
-            https://nla.zapier.com/api/v1/dynamic/docs)
+            https://nla.zapier.com/api/v1/docs)
     """
 
     api_wrapper: ZapierNLAWrapper = Field(default_factory=ZapierNLAWrapper)

--- a/langchain/tools/zapier/tool.py
+++ b/langchain/tools/zapier/tool.py
@@ -1,6 +1,6 @@
 """## Zapier Natural Language Actions API
 \
-Full docs here: https://nla.zapier.com/api/v1/docs
+Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
 
 **Zapier Natural Language Actions** gives you access to the 5k+ apps, 20k+ actions
 on Zapier's platform through a natural language API interface.
@@ -24,7 +24,7 @@ NLA offers both API Key and OAuth for signing NLA API requests.
     connected accounts on Zapier.com
 
 This quick start will focus on the server-side use case for brevity.
-Review [full docs](https://nla.zapier.com/api/v1/docs) or reach out to
+Review [full docs](https://nla.zapier.com/api/v1/dynamic/docs) or reach out to
 nla@zapier.com for user-facing oauth developer support.
 
 Typically you'd use SequentialChain, here's a basic example:
@@ -92,7 +92,7 @@ class ZapierNLARunAction(BaseTool):
             (eg. "get the latest email from Mike Knoop" for "Gmail: find email" action)
         params: a dict, optional. Any params provided will *override* AI guesses
             from `instructions` (see "understanding the AI guessing flow" here:
-            https://nla.zapier.com/api/v1/docs)
+            https://nla.zapier.com/api/v1/dynamic/docs)
     """
 
     api_wrapper: ZapierNLAWrapper = Field(default_factory=ZapierNLAWrapper)

--- a/langchain/utilities/zapier.py
+++ b/langchain/utilities/zapier.py
@@ -1,6 +1,6 @@
 """Util that can interact with Zapier NLA.
 
-Full docs here: https://nla.zapier.com/api/v1/docs
+Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
 
 Note: this wrapper currently only implemented the `api_key` auth method for testing
 and server-side production use cases (using the developer's connected accounts on
@@ -24,7 +24,7 @@ from langchain.utils import get_from_dict_or_env
 class ZapierNLAWrapper(BaseModel):
     """Wrapper for Zapier NLA.
 
-    Full docs here: https://nla.zapier.com/api/v1/docs
+    Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
 
     Note: this wrapper currently only implemented the `api_key` auth method for
     testingand server-side production use cases (using the developer's connected
@@ -97,7 +97,7 @@ class ZapierNLAWrapper(BaseModel):
         `params` will always contain an `instructions` key, the only required
         param. All others optional and if provided will override any AI guesses
         (see "understanding the AI guessing flow" here:
-        https://nla.zapier.com/api/v1/docs)
+        https://nla.zapier.com/api/v1/dynamic/docs)
         """
         session = self._get_session()
         response = session.get(self.zapier_nla_api_base + "exposed/")

--- a/langchain/utilities/zapier.py
+++ b/langchain/utilities/zapier.py
@@ -1,6 +1,6 @@
 """Util that can interact with Zapier NLA.
 
-Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
+Full docs here: https://nla.zapier.com/api/v1/docs
 
 Note: this wrapper currently only implemented the `api_key` auth method for testing
 and server-side production use cases (using the developer's connected accounts on
@@ -24,7 +24,7 @@ from langchain.utils import get_from_dict_or_env
 class ZapierNLAWrapper(BaseModel):
     """Wrapper for Zapier NLA.
 
-    Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
+    Full docs here: https://nla.zapier.com/api/v1/docs
 
     Note: this wrapper currently only implemented the `api_key` auth method for
     testingand server-side production use cases (using the developer's connected
@@ -38,7 +38,6 @@ class ZapierNLAWrapper(BaseModel):
 
     zapier_nla_api_key: str
     zapier_nla_api_base: str = "https://nla.zapier.com/api/v1/"
-    zapier_nla_api_dynamic_base: str = "https://nla.zapier.com/api/v1/dynamic/"
 
     class Config:
         """Configuration for this pydantic object."""
@@ -98,10 +97,10 @@ class ZapierNLAWrapper(BaseModel):
         `params` will always contain an `instructions` key, the only required
         param. All others optional and if provided will override any AI guesses
         (see "understanding the AI guessing flow" here:
-        https://nla.zapier.com/api/v1/dynamic/docs)
+        https://nla.zapier.com/api/v1/docs)
         """
         session = self._get_session()
-        response = session.get(self.zapier_nla_api_dynamic_base + "exposed/")
+        response = session.get(self.zapier_nla_api_base + "exposed/")
         response.raise_for_status()
         return response.json()["results"]
 
@@ -148,8 +147,8 @@ class ZapierNLAWrapper(BaseModel):
         data = self.preview(*args, **kwargs)
         return json.dumps(data)
 
-    def list_as_str(self, *args, **kwargs) -> str:  # type: ignore[no-untyped-def]
+    def list_as_str(self) -> str:  # type: ignore[no-untyped-def]
         """Same as list, but returns a stringified version of the JSON for
         insertting back into an LLM."""
-        actions = self.list(*args, **kwargs)
+        actions = self.list()
         return json.dumps(actions)


### PR DESCRIPTION
From Robert "Right now the dynamic/ route for specifically the above endpoints is acting on all providers a user has set up, not just the provider for the supplied API key."