### PR TITLE
fix: AzureChatOpenAI take base, version and type from model_kwargs

### DIFF
--- a/langchain/chat_models/azure_openai.py
+++ b/langchain/chat_models/azure_openai.py
@@ -68,17 +68,17 @@ class AzureChatOpenAI(ChatOpenAI):
             "OPENAI_API_KEY",
         )
         openai_api_base = get_from_dict_or_env(
-            values,
+            values["model_kwargs"],
             "openai_api_base",
             "OPENAI_API_BASE",
         )
         openai_api_version = get_from_dict_or_env(
-            values,
+            values["model_kwargs"],
             "openai_api_version",
             "OPENAI_API_VERSION",
         )
         openai_api_type = get_from_dict_or_env(
-            values,
+            values["model_kwargs"],
             "openai_api_type",
             "OPENAI_API_TYPE",
         )


### PR DESCRIPTION
Currently **openai_api_base**, **openai_api_version**, **openai_api_type** are not part of required fields of ChatOpenAI, So these fields are part of **model_kwargs**. This PR fix the issue #1810 