### PR TITLE
Add Qdrant to ecosystem page

### DIFF
--- a/docs/ecosystem/qdrant.md
+++ b/docs/ecosystem/qdrant.md
@@ -1,0 +1,20 @@
+# Qdrant
+
+This page covers how to use the Qdrant ecosystem within LangChain.
+It is broken into two parts: installation and setup, and then references to specific Qdrant wrappers.
+
+## Installation and Setup
+- Install the Python SDK with `pip install qdrant-client`
+## Wrappers
+
+### VectorStore
+
+There exists a wrapper around Qdrant indexes, allowing you to use it as a vectorstore,
+whether for semantic search or example selection.
+
+To import this vectorstore:
+```python
+from langchain.vectorstores import Qdrant
+```
+
+For a more detailed walkthrough of the Pinecone wrapper, see [this notebook](../modules/indexes/vectorstore_examples/qdrant.ipynb)

--- a/docs/ecosystem/qdrant.md
+++ b/docs/ecosystem/qdrant.md
@@ -17,4 +17,4 @@ To import this vectorstore:
 from langchain.vectorstores import Qdrant
 ```
 
-For a more detailed walkthrough of the Pinecone wrapper, see [this notebook](../modules/indexes/vectorstore_examples/qdrant.ipynb)
+For a more detailed walkthrough of the Qdrant wrapper, see [this notebook](../modules/indexes/vectorstore_examples/qdrant.ipynb)


### PR DESCRIPTION
Add [Qdrant](https://qdrant.tech/) to [LangChain ecosystem](https://langchain.readthedocs.io/en/latest/ecosystem.html) page. 