### PR TITLE
Add workaround for debugpy install issue to contrib docs.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,6 +73,8 @@ poetry install -E all
 
 This will install all requirements for running the package, examples, linting, formatting, tests, and coverage. Note the `-E all` flag will install all optional dependencies necessary for integration testing.
 
+❗Note: If you're running Poetry 1.4.1 and receive a `WheelFileValidationError` for `debugpy` during installation, you can try either downgrading to Poetry 1.4.0 or disabling "modern installation" (`poetry config installer.modern-installation false`) and re-install requirements. See [this `debugpy` issue](https://github.com/microsoft/debugpy/issues/1246) for more details.
+
 Now, you should be able to run the common tasks in the following section.
 
 ## ✅Common Tasks


### PR DESCRIPTION
When following the Quick Start instructions in the contributing docs, I was getting a "WheelFileValidationError" on installation of debugpy which was blocking the installation of a number of other deps. Google turned up this [GitHub issue](https://github.com/microsoft/debugpy/issues/1246) indicating a regression in Poetry 1.4.1 and workarounds.

This PR updates the contrib docs noting the issue and the workarounds.