### PR TITLE
Use regex match for bash process error output test assertion.

### DIFF
--- a/tests/unit_tests/test_bash.py
+++ b/tests/unit_tests/test_bash.py
@@ -1,4 +1,5 @@
 """Test the bash utility."""
+import re
 import subprocess
 from pathlib import Path
 
@@ -25,7 +26,7 @@ def test_incorrect_command_return_err_output() -> None:
     """Test optional returning of shell output on incorrect command."""
     session = BashProcess(return_err_output=True)
     output = session.run(["invalid_command"])
-    assert output == "/bin/sh: 1: invalid_command: not found\n"
+    assert re.match(r'^/bin/sh:.*invalid_command.*not found.*$', output)
 
 
 def test_create_directory_and_files(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_bash.py
+++ b/tests/unit_tests/test_bash.py
@@ -26,7 +26,7 @@ def test_incorrect_command_return_err_output() -> None:
     """Test optional returning of shell output on incorrect command."""
     session = BashProcess(return_err_output=True)
     output = session.run(["invalid_command"])
-    assert re.match(r'^/bin/sh:.*invalid_command.*not found.*$', output)
+    assert re.match(r"^/bin/sh:.*invalid_command.*not found.*$", output)
 
 
 def test_create_directory_and_files(tmp_path: Path) -> None:


### PR DESCRIPTION
I was getting the same issue reported in #1339 by [MacYang555](https://github.com/MacYang555) when running the test suite on my Mac. I implemented the fix they suggested to use a regex match in the output assertion for the scenario under test.

Resolves #1339