### PR TITLE
Add setup instruction in Getting Started for Indexing

### DIFF
--- a/docs/modules/indexes/getting_started.ipynb
+++ b/docs/modules/indexes/getting_started.ipynb
@@ -358,7 +358,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 64-bit ('3.9.13')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -372,11 +372,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {
-    "hash": "40979cf11f6e8028346b5c38d48dc60c34cf1f29d0a2995d6f2e5f00153647ea"
+    "hash": "b1677b440931f40d89ef8be7bf03acb108ce003de0ac9b18e8d43753ea2e7103"
    }
   }
  },

--- a/docs/modules/indexes/getting_started.ipynb
+++ b/docs/modules/indexes/getting_started.ipynb
@@ -7,6 +7,12 @@
    "source": [
     "# Getting Started\n",
     "\n",
+    "By default, LangChain uses [Chroma](../../ecosystem/chroma.md) as the vectorstore to index and search embeddings. We'll first need to install `chromedb`.\n",
+    "\n",
+    "```\n",
+    "pip install chromadb\n",
+    "```\n",
+    "\n",
     "This example showcases question answering over documents.\n",
     "We have chosen this as the example for getting started because it nicely combines a lot of different elements (Text splitters, embeddings, vectorstores) and then also shows how to use them in a chain.\n",
     "\n",
@@ -352,7 +358,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.13 64-bit ('3.9.13')",
    "language": "python",
    "name": "python3"
   },
@@ -366,11 +372,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {
-    "hash": "b1677b440931f40d89ef8be7bf03acb108ce003de0ac9b18e8d43753ea2e7103"
+    "hash": "40979cf11f6e8028346b5c38d48dc60c34cf1f29d0a2995d6f2e5f00153647ea"
    }
   }
  },

--- a/docs/modules/indexes/getting_started.ipynb
+++ b/docs/modules/indexes/getting_started.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Getting Started\n",
     "\n",
-    "By default, LangChain uses [Chroma](../../ecosystem/chroma.md) as the vectorstore to index and search embeddings. We'll first need to install `chromadb`.\n",
+    "By default, LangChain uses [Chroma](../../ecosystem/chroma.md) as the vectorstore to index and search embeddings. To walk through this tutorial, we'll first need to install `chromadb`.\n",
     "\n",
     "```\n",
     "pip install chromadb\n",

--- a/docs/modules/indexes/getting_started.ipynb
+++ b/docs/modules/indexes/getting_started.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Getting Started\n",
     "\n",
-    "By default, LangChain uses [Chroma](../../ecosystem/chroma.md) as the vectorstore to index and search embeddings. We'll first need to install `chromedb`.\n",
+    "By default, LangChain uses [Chroma](../../ecosystem/chroma.md) as the vectorstore to index and search embeddings. We'll first need to install `chromadb`.\n",
     "\n",
     "```\n",
     "pip install chromadb\n",


### PR DESCRIPTION
`VectorstoreIndexCreator` [uses Chroma as the vectorstore by default](https://github.com/hwchase17/langchain/blob/1c22657256a69ecf739134da7d9cec5e9365a75f/langchain/indexes/vectorstore.py#L49). It may be helpful to add a short note for the setup.

You can see how the notebook looks here.
https://github.com/mocobeta/langchain/blob/feat/add-setup-instruction-to-index-getting-started/docs/modules/indexes/getting_started.ipynb