### PR TITLE
handling ValueError: Could not parse LLM output:

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -64,13 +64,23 @@ class Agent(BaseModel):
 
     def _get_next_action(self, full_inputs: Dict[str, str]) -> AgentAction:
         full_output = self.llm_chain.predict(**full_inputs)
-        parsed_output = self._extract_tool_and_input(full_output)
+        try:
+            parsed_output = self._extract_tool_and_input(full_output)
+        except Exception as e:
+            print ('type:' + str(type(e)))
+            print =  'args:' + str(e.args)
+            print (str(e))
         while parsed_output is None:
             full_output = self._fix_text(full_output)
             full_inputs["agent_scratchpad"] += full_output
             output = self.llm_chain.predict(**full_inputs)
             full_output += output
-            parsed_output = self._extract_tool_and_input(full_output)
+            try:
+                parsed_output = self._extract_tool_and_input(full_output)
+            except Exception as e:
+                print ('type:' + str(type(e)))
+                print =  'args:' + str(e.args)
+                print (str(e))
         return AgentAction(
             tool=parsed_output[0], tool_input=parsed_output[1], log=full_output
         )


### PR DESCRIPTION
Sometime I meet ValueError: Could not parse LLM output: 
I think I can fix this.