### PR TITLE
feat: Add from_existing_index function to vectorstores.redis

### DIFF
--- a/docs/modules/indexes/vectorstore_examples/redis.ipynb
+++ b/docs/modules/indexes/vectorstore_examples/redis.ipynb
@@ -156,7 +156,7 @@
    "outputs": [],
    "source": [
     "#Query\n",
-    "rds = Redis.from_existing_index(embeddings, redis_url=\"redis://localhost:6380\", index_name='link')\n",
+    "rds = Redis.from_existing_index(embeddings, redis_url=\"redis://localhost:6379\", index_name='link')\n",
     "\n",
     "query = \"What did the president say about Ketanji Brown Jackson\"\n",
     "results = rds.similarity_search(query)\n",

--- a/docs/modules/indexes/vectorstore_examples/redis.ipynb
+++ b/docs/modules/indexes/vectorstore_examples/redis.ipynb
@@ -8,10 +8,7 @@
     "This notebook shows how to use functionality related to the Redis database."
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -24,10 +21,7 @@
     "from langchain.vectorstores.redis import Redis"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -44,10 +38,7 @@
     "embeddings = OpenAIEmbeddings()"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -55,13 +46,10 @@
    "execution_count": 4,
    "outputs": [],
    "source": [
-    "rds = Redis.from_documents(docs, embeddings,redis_url=\"redis://localhost:6379\")"
+    "rds = Redis.from_documents(docs, embeddings, redis_url=\"redis://localhost:6379\",  index_name='link')"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -81,10 +69,14 @@
     "rds.index_name"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [],
+   "metadata": {
+    "collapsed": false
    }
   },
   {
@@ -115,10 +107,7 @@
     "print(results[0].page_content)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -137,10 +126,7 @@
     "print(rds.add_texts([\"Ankush went to Princeton\"]))"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -161,22 +147,23 @@
     "print(results[0].page_content)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],
-   "source": [],
+   "source": [
+    "#Query\n",
+    "rds = Redis.from_existing_index(embeddings, redis_url=\"redis://localhost:6380\", index_name='link')\n",
+    "\n",
+    "query = \"What did the president say about Ketanji Brown Jackson\"\n",
+    "results = rds.similarity_search(query)\n",
+    "print(results[0].page_content)"
+   ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   }
  ],

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -228,16 +228,14 @@ class Redis(VectorStore):
 
     @classmethod
     def from_existing_index(
-            cls,
-            embedding: Embeddings,
-            index_name: str,
-            **kwargs: Any,
+        cls,
+        embedding: Embeddings,
+        index_name: str,
+        **kwargs: Any,
     ) -> Redis:
         redis_url = get_from_dict_or_env(kwargs, "redis_url", "REDIS_URL")
         try:
             import redis
-            from redis.commands.search.field import TextField, VectorField
-            from redis.commands.search.indexDefinition import IndexDefinition, IndexType
         except ImportError:
             raise ValueError(
                 "Could not import redis python package. "

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -225,3 +225,37 @@ class Redis(VectorStore):
             )
         pipeline.execute()
         return cls(redis_url, index_name, embedding.embed_query)
+
+    @classmethod
+    def from_existing_index(
+            cls,
+            embedding: Embeddings,
+            index_name: str,
+            **kwargs: Any,
+    ) -> Redis:
+        redis_url = get_from_dict_or_env(kwargs, "redis_url", "REDIS_URL")
+        try:
+            import redis
+            from redis.commands.search.field import TextField, VectorField
+            from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+        except ImportError:
+            raise ValueError(
+                "Could not import redis python package. "
+                "Please install it with `pip install redis`."
+            )
+        try:
+            # We need to first remove redis_url from kwargs,
+            # otherwise passing it to Redis will result in an error.
+            kwargs.pop("redis_url")
+            client = redis.from_url(url=redis_url, **kwargs)
+        except ValueError as e:
+            raise ValueError(f"Your redis connected error: {e}")
+
+        # check if redis add redisearch module
+        if not _check_redis_module_exist(client, "search"):
+            raise ValueError(
+                "Could not use redis directly, you need to add search module"
+                "Please refer [RediSearch](https://redis.io/docs/stack/search/quick_start/)"  # noqa
+            )
+
+        return cls(redis_url, index_name, embedding.embed_query)


### PR DESCRIPTION
# Description
***
Add from_existing_index function to loading existing vector libraries

# How to use
***
`rds = Redis.from_existing_index(embeddings, redis_url="redis://localhost:6379", index_name='link')`