### PR TITLE
docs: update gpt index references to LlamaIndex

### DIFF
--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -158,14 +158,14 @@ Open Source
 
     ---
 
-    .. link-button:: https://github.com/jerryjliu/gpt_index
+    .. link-button:: https://github.com/jerryjliu/llama_index
         :type: url
-        :text: GPT Index
+        :text: LlamaIndex
         :classes: stretched-link btn-lg
     
     +++
 
-    GPT Index is a project consisting of a set of data structures that are created using GPT-3 and can be traversed using GPT-3 in order to answer queries.
+    LlamaIndex (formerly GPT Index) is a project consisting of a set of data structures that are created using GPT-3 and can be traversed using GPT-3 in order to answer queries.
 
     ---
 

--- a/docs/modules/indexes.rst
+++ b/docs/modules/indexes.rst
@@ -4,7 +4,7 @@ Indexes
 Indexes refer to ways to structure documents so that LLMs can best interact with them.
 This module contains utility functions for working with documents, different types of indexes, and then examples for using those indexes in chains.
 LangChain provides common indices for working with data (most prominently support for vector databases).
-For more complicated index structures, it is worth checking out `GPTIndex <https://gpt-index.readthedocs.io/en/latest/index.html>`_.
+For more complicated index structures, it is worth checking out `LlamaIndex <https://gpt-index.readthedocs.io/en/latest/index.html>`_.
 
 The following sections of documentation are provided:
 

--- a/docs/use_cases/combine_docs.md
+++ b/docs/use_cases/combine_docs.md
@@ -76,7 +76,7 @@ Examples of vector database companies include [Pinecone](https://www.pinecone.io
 
 Although this is perhaps the most common way of document retrieval, people are starting to think about alternative
 data structures and indexing techniques specifically for working with language models. For a leading example of this,
-check out [GPT Index](https://github.com/jerryjliu/gpt_index) - a collection of data structures created by and optimized
+check out [LlamaIndex](https://github.com/jerryjliu/llama_index) - a collection of data structures created by and optimized
 for language models.
 
 ## Augmenting


### PR DESCRIPTION
The GPT Index project is transitioning to the new project name, LlamaIndex. 

I've updated a few files referencing the old project name and repository URL to the current ones.

From the [LlamaIndex repo](https://github.com/jerryjliu/llama_index):
> NOTE: We are rebranding GPT Index as LlamaIndex! We will carry out this transition gradually.
>
>    2/25/2023: By default, our docs/notebooks/instructions now reference "LlamaIndex" instead of "GPT Index".
>
>    2/19/2023: By default, our docs/notebooks/instructions now use the llama-index package. However the gpt-index package still exists as a duplicate!
>
>    2/16/2023: We have a duplicate llama-index pip package. Simply replace all imports of gpt_index with llama_index if you choose to pip install llama-index.

I'm not associated with LlamaIndex in any way. I just noticed the discrepancy when studying the lanchain documentation.