### PR TITLE
feat: add drop index in redis and fix prefix generate logic

### DIFF
--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from typing import Any, Callable, Iterable, List, Mapping, Optional
 
@@ -12,6 +13,8 @@ from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
 from langchain.vectorstores.base import VectorStore
+
+logger = logging.getLogger()
 
 
 def _check_redis_module_exist(client: RedisType, module: str) -> bool:
@@ -201,7 +204,7 @@ class Redis(VectorStore):
         # Check if index exists
         try:
             client.ft(index_name).info()
-            print("Index already exists")
+            logger.info("Index already exists")
         except:  # noqa
             # Create Redis Index
             client.ft(index_name).create_index(
@@ -251,7 +254,7 @@ class Redis(VectorStore):
         # Check if index exists
         try:
             client.ft(index_name).dropindex(delete_documents)
-            print("Drop index")
+            logger.info("Drop index")
             return True
         except:  # noqa
             # Index not exist


### PR DESCRIPTION
# Description

Add `drop_index` for redis

RediSearch: [RediSearch quick start](https://redis.io/docs/stack/search/quick_start/)

# How to use

```
from langchain.vectorstores.redis import Redis

Redis.drop_index(index_name="doc",delete_documents=False)
```