### PR TITLE
[Documents]: Add `Figma` file document loader

### DIFF
--- a/docs/modules/document_loaders/examples/figma.ipynb
+++ b/docs/modules/document_loaders/examples/figma.ipynb
@@ -1,13 +1,14 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "33205b12",
    "metadata": {},
    "source": [
-    "# Telegram\n",
+    "# Figma\n",
     "\n",
-    "This notebook covers how to load data from Telegram into a format that can be ingested into LangChain."
+    "This notebook covers how to load data from the Figma REST API into a format that can be ingested into LangChain."
    ]
   },
   {
@@ -15,18 +16,7 @@
    "execution_count": null,
    "id": "90b69c94",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mRunning cells with '/usr/bin/python3' requires the ipykernel package.\n",
-      "\u001b[1;31mRun the following command to install 'ipykernel' into the Python environment. \n",
-      "\u001b[1;31mCommand: '/usr/bin/python3 -m pip install ipykernel -U --user --force-reinstall'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -52,18 +42,7 @@
    "execution_count": null,
    "id": "9ccc1e2f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Document(page_content=\"Henry on 2020-01-01T00:00:02: It's 2020...\\n\\nHenry on 2020-01-01T00:00:04: Fireworks!\\n\\nGrace ðŸ§¤ ðŸ\\x8d’ on 2020-01-01T00:00:05: You're a minute late!\\n\\n\", lookup_str='', metadata={'source': 'example_data/telegram.json'}, lookup_index=0)]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "loader.load()"
    ]

--- a/docs/modules/document_loaders/examples/figma.ipynb
+++ b/docs/modules/document_loaders/examples/figma.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "33205b12",
+   "metadata": {},
+   "source": [
+    "# Telegram\n",
+    "\n",
+    "This notebook covers how to load data from Telegram into a format that can be ingested into LangChain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90b69c94",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mRunning cells with '/usr/bin/python3' requires the ipykernel package.\n",
+      "\u001b[1;31mRun the following command to install 'ipykernel' into the Python environment. \n",
+      "\u001b[1;31mCommand: '/usr/bin/python3 -m pip install ipykernel -U --user --force-reinstall'"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from langchain.document_loaders import FigmaFileLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "13deb0f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = FigmaFileLoader(\n",
+    "    os.environ.get('ACCESS_TOKEM'),\n",
+    "    os.environ.get('NODE_IDS'),\n",
+    "    os.environ.get('FILE_KEY')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ccc1e2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Document(page_content=\"Henry on 2020-01-01T00:00:02: It's 2020...\\n\\nHenry on 2020-01-01T00:00:04: Fireworks!\\n\\nGrace ðŸ§¤ ðŸ\\x8d’ on 2020-01-01T00:00:05: You're a minute late!\\n\\n\", lookup_str='', metadata={'source': 'example_data/telegram.json'}, lookup_index=0)]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loader.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e64cac2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/langchain/document_loaders/figma.py
+++ b/langchain/document_loaders/figma.py
@@ -1,0 +1,59 @@
+"""Loader that loads Figma files json dump."""
+import json
+import urllib.request
+from typing import Any, List
+
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseLoader
+
+
+def _stringify_value(val: Any) -> str:
+    if isinstance(val, str):
+        return val
+    elif isinstance(val, dict):
+        return "\n" + _stringify_dict(val)
+    elif isinstance(val, list):
+        return "\n".join(_stringify_value(v) for v in val)
+    else:
+        return str(val)
+
+
+def _stringify_dict(data: dict) -> str:
+    text = ""
+    for key, value in data.items():
+        text += key + ": " + _stringify_value(data[key]) + "\n"
+    return text
+
+
+class FigmaFileLoader(BaseLoader):
+    """Loader that loads local Figma file json."""
+
+    def __init__(self, acces_token: str, ids: str, key: str):
+        """Initialize with bucket and key name."""
+        self.acces_token = acces_token
+        self.ids = ids
+        self.key = key
+
+    def _construct_figma_api_url(self) -> str:
+        api_url = "https://api.figma.com/v1/files/%s/nodes?ids=%s" % (
+            self.key,
+            self.ids,
+        )
+        return api_url
+
+    def _get_fima_file(self) -> Any:
+        """Get Figma file from Figma REST API."""
+        headers = {"X-Figma-Token": self.acces_token}
+        request = urllib.request.Request(
+            self._construct_figma_api_url(), headers=headers
+        )
+        with urllib.request.urlopen(request) as response:
+            json_data = json.loads(response.read().decode())
+            return json_data
+
+    def load(self) -> List[Document]:
+        """Load file"""
+        data = self._get_fima_file()
+        text = _stringify_dict(data)
+        metadata = {"source": self._construct_figma_api_url()}
+        return [Document(page_content=text, metadata=metadata)]

--- a/tests/integration_tests/document_loaders/test_figma.py
+++ b/tests/integration_tests/document_loaders/test_figma.py
@@ -1,0 +1,13 @@
+from langchain.document_loaders.figma import FigmaFileLoader
+
+ACCESS_TOKEN = "figd_Buj8TSTDYrvH1FwIzOqT6NUNEdZ5i1Cxo2J_tEPN"
+IDS = "2:104"
+KEY = "UXKwV2DyPaXCgBSufVIXZy"
+
+
+def test_figma_file_loader() -> None:
+    """Test Figma file loader."""
+    loader = FigmaFileLoader(ACCESS_TOKEN, IDS, KEY)
+    docs = loader.load()
+
+    assert len(docs) == 1

--- a/tests/integration_tests/document_loaders/test_figma.py
+++ b/tests/integration_tests/document_loaders/test_figma.py
@@ -1,8 +1,8 @@
 from langchain.document_loaders.figma import FigmaFileLoader
 
-ACCESS_TOKEN = "figd_Buj8TSTDYrvH1FwIzOqT6NUNEdZ5i1Cxo2J_tEPN"
-IDS = "2:104"
-KEY = "UXKwV2DyPaXCgBSufVIXZy"
+ACCESS_TOKEN = ""
+IDS = ""
+KEY = ""
 
 
 def test_figma_file_loader() -> None:


### PR DESCRIPTION
## Summary
This PR ads a `Figma` document loader which fetches a specific file via the Figma REST API. The JSON payload recevied from the API call  is parsed and loaded into a `Document` for use further downstream.

## Use case
The JSON payload from the Figma REST API contains instructions on all elements for a specifc Figma design. This could also be used for analyzing or manipulating a Figma design. 

## Tests
Integration test for this PR is written and included but will fail it you one doesn't set the FIGMA authorization credentials. 