### PR TITLE
Fixes the import typo in the vector db text generator notebook

### DIFF
--- a/docs/modules/indexes/chain_examples/vector_db_text_generation.ipynb
+++ b/docs/modules/indexes/chain_examples/vector_db_text_generation.ipynb
@@ -28,7 +28,7 @@
     "from langchain.docstore.document import Document\n",
     "import requests\n",
     "from langchain.embeddings.openai import OpenAIEmbeddings\n",
-    "from langchain.vectorstores import Chromama\n",
+    "from langchain.vectorstores import Chroma\n",
     "from langchain.text_splitter import CharacterTextSplitter\n",
     "from langchain.prompts import PromptTemplate\n",
     "import pathlib\n",


### PR DESCRIPTION
Fixes the import typo in the vector db text generator notebook for the chroma library 