### PR TITLE
Fix the issue of OpenSearch index name being non-deterministic

### DIFF
--- a/langchain/vectorstores/opensearch_vector_search.py
+++ b/langchain/vectorstores/opensearch_vector_search.py
@@ -363,7 +363,8 @@ class OpenSearchVectorSearch(VectorStore):
         embeddings = embedding.embed_documents(texts)
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
-        index_name = uuid.uuid4().hex
+        # Get the index name from either from kwargs or ENV Variable before falling back to random generation
+        index_name = get_from_dict_or_env(kwargs, "index_name", "OPENSEARCH_INDEX_NAME", default=uuid.uuid4().hex)
         is_appx_search = _get_kwargs_value(kwargs, "is_appx_search", True)
         if is_appx_search:
             engine = _get_kwargs_value(kwargs, "engine", "nmslib")


### PR DESCRIPTION
- Allow to get it from kwargs (index_name) or
- Allow to get it from env var (OPENSEARCH_INDEX_NAME)
- if none available generate an uuid index name as fallback

References: https://github.com/hwchase17/langchain/issues/1900