### PR TITLE
Constitutional Chain: chain parameter

### DIFF
--- a/langchain/chains/constitutional_ai/base.py
+++ b/langchain/chains/constitutional_ai/base.py
@@ -38,7 +38,7 @@ class ConstitutionalChain(Chain):
             constitutional_chain.run(question="What is the meaning of life?")
     """
 
-    chain: LLMChain
+    chain: Chain 
     constitutional_principles: List[ConstitutionalPrinciple]
     critique_chain: LLMChain
     revision_chain: LLMChain

--- a/langchain/chains/constitutional_ai/base.py
+++ b/langchain/chains/constitutional_ai/base.py
@@ -56,7 +56,7 @@ class ConstitutionalChain(Chain):
     def from_llm(
         cls,
         llm: BaseLanguageModel,
-        chain: LLMChain,
+        chain: Chain,
         critique_prompt: BasePromptTemplate = CRITIQUE_PROMPT,
         revision_prompt: BasePromptTemplate = REVISION_PROMPT,
         **kwargs: Any,


### PR DESCRIPTION
Fixed issue where could not use a SequentialChain as the base chain input to a ConstitutionalChain because it required an LLMChain, when any chain should do since it just needs to call the run method on the base chain.

Fixed issue by changing base chain from LLMChain to Chain.

Happy to do more if necessary!

See below issue description:

Code to create a ConstitutionalChain from an LLM:

```
 @classmethod
    def from_llm(
        cls,
        llm: BaseLanguageModel,
        chain: LLMChain,
        critique_prompt: BasePromptTemplate = CRITIQUE_PROMPT,
        revision_prompt: BasePromptTemplate = REVISION_PROMPT,
        **kwargs: Any,
    ) -> "ConstitutionalChain":
        """Create a chain from an LLM."""
        critique_chain = LLMChain(llm=llm, prompt=critique_prompt)
        revision_chain = LLMChain(llm=llm, prompt=revision_prompt)
        return cls(
            chain=chain,
            critique_chain=critique_chain,
            revision_chain=revision_chain,
            **kwargs,
        )
```
It requires an LLMChain.

SimpleSequentialChain doesn't inherit from LLMChain. It inherits from Chain.

```
class SimpleSequentialChain(Chain, BaseModel):
    """Simple chain where the outputs of one step feed directly into next."""

    chains: List[Chain]
    strip_outputs: bool = False
    input_key: str = "input"  #: :meta private:
    output_key: str = "output"  #: :meta private:
```

Therefore we cannot pass a SimpleSequentialChain to the ConstitutionalChain.

This disrupts the workflow where we create a pipeline and want to pass it to a constitutional chain for checks.