### PR TITLE
Fix typo in VectorStoreIndexWrapper method

### DIFF
--- a/langchain/indexes/vectorstore.py
+++ b/langchain/indexes/vectorstore.py
@@ -33,7 +33,7 @@ class VectorStoreIndexWrapper(BaseModel):
         """Query the vectorstore."""
         llm = llm or OpenAI(temperature=0)
         chain = RetrievalQA.from_chain_type(
-            llm, retriver=self.vectorstore.as_retriever(), **kwargs
+            llm, retriever=self.vectorstore.as_retriever(), **kwargs
         )
         return chain.run(question)
 


### PR DESCRIPTION
Fixed a typo in the argument of the query method within the VectorStoreIndexWrapper class. Specifically, the argument `retriver` has been changed to `retriever`. With this correction, the correct argument name is used, and potential bugs are avoided.