### PR TITLE
add caching for embeddings

### DIFF
--- a/docs/modules/indexes/examples/embeddings_cache.ipynb
+++ b/docs/modules/indexes/examples/embeddings_cache.ipynb
@@ -1,0 +1,282 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2326605c",
+   "metadata": {},
+   "source": [
+    "# Embeddings Caching\n",
+    "\n",
+    "This notebook goes over how to cache embeddings using the Embeddings class in LangChain.\n",
+    "\n",
+    "The BaseEmbeddingsCache class is an interface for a cache that stores embeddings for given text. An embeddings cache can be provided as an optional argument when constructing an Embeddings class.\n",
+    "\n",
+    "The BaseEmbeddingsCache class in LangChain exposes two methods: `lookup` and `update`. These are analogous to the methods of the  LLMCache, except that the key only consists of the SHA256 hash of the provided text and does not include the model name. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5072bea",
+   "metadata": {},
+   "source": [
+    "## InMemoryEmbeddingsCache\n",
+    "\n",
+    "Let's look at a basic example of using the InMemoryEmbeddingsCache with the OpenAI Embeddings class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "433223e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings import OpenAIEmbeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1e31cead",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.cache import InMemoryEmbeddingsCache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "15d7bd61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cache = InMemoryEmbeddingsCache()\n",
+    "embeddings = OpenAIEmbeddings(embeddings_cache=cache)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4147fbcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5a9fa1b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3.07 ms, sys: 5.3 ms, total: 8.37 ms\n",
+      "Wall time: 295 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# The first time, it is not yet in cache, so it should take longer\n",
+    "query_result = embeddings.embed_query(text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2f2cfa69",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[-0.01273756567388773, -0.018157944083213806, 0.009503343142569065, -0.04341445863246918, -0.03418117016553879...'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(query_result[:5])[:-1] + '...'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "107c2aa0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 0 ns, sys: 9 µs, total: 9 µs\n",
+      "Wall time: 10.3 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# The second time it is, so it goes faster\n",
+    "query_result = embeddings.embed_query(text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "333bb33b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[-0.01273756567388773, -0.018157944083213806, 0.009503343142569065, -0.04341445863246918, -0.03418117016553879...'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(query_result[:5])[:-1] + '...'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d4397d2",
+   "metadata": {},
+   "source": [
+    "## RedisEmbeddingsCache\n",
+    "\n",
+    "Let's look another example of using the RedisEmbeddingsCache with the OpenAI Embeddings class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d57f030c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can do the same thing with a Redis cache\n",
+    "# (make sure your local Redis instance is running first before running this example)\n",
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from redis import Redis\n",
+    "from langchain.cache import RedisEmbeddingsCache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e88ac388",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cache = RedisEmbeddingsCache(redis_=Redis())\n",
+    "embeddings = OpenAIEmbeddings(embeddings_cache=cache)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0ffcbfd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e3db1609",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 41 ms, sys: 669 µs, total: 41.7 ms\n",
+      "Wall time: 175 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# The first time, it is not yet in cache, so it should take longer\n",
+    "query_result = embeddings.embed_query(text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5ad6cc3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[-0.012754085473716259, -0.018176019191741943, 0.009512502700090408, -0.04345264658331871, -0.034216709434986115...'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str(query_result[:5])[:-1] + '...'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2be1053c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 297 µs, sys: 0 ns, total: 297 µs\n",
+      "Wall time: 271 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# The second time it is, so it goes faster\n",
+    "query_result = embeddings.embed_query(text)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -1,6 +1,8 @@
 """Beta Feature: base interface for cache."""
 from abc import ABC, abstractmethod
+import numpy as np
 from typing import Any, Dict, List, Optional, Tuple
+import uuid
 
 from sqlalchemy import Column, Integer, String, create_engine, select
 from sqlalchemy.engine.base import Engine
@@ -137,3 +139,119 @@ class RedisCache(BaseCache):
         """Update cache based on prompt and llm_string."""
         for i, generation in enumerate(return_val):
             self.redis.set(self._key(prompt, llm_string, i), generation.text)
+
+
+class BaseEmbeddingsCache(ABC):
+    """Base interface for embeddings cache."""
+
+    @abstractmethod
+    def lookup(self, text: str) -> Optional[List[float]]:
+        """Look up based on text."""
+
+    @abstractmethod
+    def update(
+        self, text: str, embeddings: List[float]
+    ) -> None:
+        """Update cache based on text."""
+
+
+class InMemoryEmbeddingsCache(BaseEmbeddingsCache):
+    """Cache that stores things in memory."""
+
+    def __init__(self) -> None:
+        """Initialize with empty cache."""
+        self._cache: Dict[int, Optional[List[float]]] = {}
+
+    def lookup(self, text: str) -> Optional[List[float]]:
+        """Look up based on text hash."""
+        h = hash(text.encode())
+        return self._cache.get(h, None)
+
+    def update(self, text: str, embeddings: List[float]) -> None:
+        """Update cache with embeddings from text."""
+        h = hash(text.encode())
+        self._cache[h] = embeddings
+
+
+class RedisEmbeddingsCache(BaseEmbeddingsCache):
+    """Cache that uses Redis as a backend."""
+
+    index_name: str
+
+    def __init__(self, redis_: Any, index_name: Optional[str] = None):
+        """Initialize by passing in Redis instance."""
+        try:
+            from redis import Redis
+        except ImportError:
+            raise ValueError(
+                "Could not import redis python package. "
+                "Please install it with `pip install redis`."
+            )
+        if not isinstance(redis_, Redis):
+            raise ValueError("Please pass in Redis object.")
+        self.redis = redis_
+        if not index_name:
+            self.index_name = uuid.uuid4().hex
+        else:
+            self.index_name = index_name
+        self.prefix = "text"  # prefix for the text keys
+
+    def lookup(self, text: str) -> Optional[List[float]]:
+        """Look up based on text hash."""
+        res = self.redis.hget(f'{self.prefix}:{hash(text)}', "embeddings_vector")
+        if res:
+            try:
+                return np.frombuffer(res, dtype=np.float32).tolist()
+            except ValueError:
+                return None
+        return None
+
+    def update(self, text: str, embeddings: List[float]) -> None:
+        """Initialize by passing in Redis instance."""
+        try:
+            from redis.commands.search.field import VectorField
+            from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+        except ImportError:
+            raise ValueError(
+                "Could not import redis python package. "
+                "Please install it with `pip install redis`."
+            )
+        """Update cache based on text."""
+        dim = len(embeddings)
+        # Constants
+        vector_number = 1  # initial number of vectors
+        distance_metric = (
+            "COSINE"  # distance metric for the vectors (ex. COSINE, IP, L2)
+        )
+        content_embedding = VectorField(
+            "embeddings_vector",
+            "FLAT",
+            {
+                "TYPE": "FLOAT32",
+                "DIM": dim,
+                "DISTANCE_METRIC": distance_metric,
+                "INITIAL_CAP": vector_number,
+            },
+        )
+        fields = [content_embedding]
+
+        # Check if index exists
+        try:
+            self.redis.ft(self.index_name).info()
+            print(f'Index {self.index_name} already exists.')
+        except:  # noqa
+            # Create Redis Index
+            self.redis.ft(self.index_name).create_index(
+                fields=fields,
+                definition=IndexDefinition(prefix=[self.prefix], index_type=IndexType.HASH),
+            )
+
+        key = f"{self.prefix}:{hash(text)}"
+        self.redis.hset(
+            key,
+            mapping={
+                "embeddings_vector": np.array(
+                    embeddings, dtype=np.float32
+                ).tobytes(),
+            },
+        )

--- a/langchain/chains/hyde/base.py
+++ b/langchain/chains/hyde/base.py
@@ -49,7 +49,7 @@ class HypotheticalDocumentEmbedder(Chain, Embeddings, BaseModel):
         """Combine embeddings into final embeddings."""
         return list(np.array(embeddings).mean(axis=0))
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Generate a hypothetical document and embedded it."""
         var_name = self.llm_chain.input_keys[0]
         result = self.llm_chain.generate([{var_name: text}])

--- a/langchain/embeddings/base.py
+++ b/langchain/embeddings/base.py
@@ -1,15 +1,37 @@
 """Interface for embedding models."""
 from abc import ABC, abstractmethod
-from typing import List
+from pydantic import BaseModel, Extra, Field
+from typing import List, Optional
 
+from langchain.cache import BaseEmbeddingsCache
 
-class Embeddings(ABC):
+class Embeddings(BaseModel, ABC):
     """Interface for embedding models."""
+
+    embeddings_cache: Optional[BaseEmbeddingsCache] = Field()
+    """Cache for embeddings."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
 
     @abstractmethod
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Embed search docs."""
 
     @abstractmethod
+    def _embed_query(self, text: str) -> List[float]:
+        """Embed query text."""
+    
     def embed_query(self, text: str) -> List[float]:
         """Embed query text."""
+        if self.embeddings_cache is not None:
+            cached = self.embeddings_cache.lookup(text)
+            if cached is not None:
+                return cached
+        embedding = self._embed_query(text)
+        if self.embeddings_cache is not None:
+            self.embeddings_cache.update(text, embedding)
+        return embedding

--- a/langchain/embeddings/cohere.py
+++ b/langchain/embeddings/cohere.py
@@ -1,13 +1,13 @@
 """Wrapper around Cohere embedding models."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import Extra, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
 
 
-class CohereEmbeddings(BaseModel, Embeddings):
+class CohereEmbeddings(Embeddings):
     """Wrapper around Cohere embedding models.
 
     To use, you should have the ``cohere`` python package installed, and the
@@ -66,7 +66,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
         ).embeddings
         return [list(map(float, e)) for e in embeddings]
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Call out to Cohere's embedding endpoint.
 
         Args:

--- a/langchain/embeddings/fake.py
+++ b/langchain/embeddings/fake.py
@@ -1,19 +1,23 @@
 from typing import List
 
 import numpy as np
-from pydantic import BaseModel
 
 from langchain.embeddings.base import Embeddings
 
 
-class FakeEmbeddings(Embeddings, BaseModel):
+class FakeEmbeddings(Embeddings):
     size: int
 
+    # Add float precision so we can specify 32 or 64 bit floats
+    precision: str = "float64"
+
     def _get_embedding(self) -> List[float]:
+        if self.precision == "float32":
+            return list(np.random.normal(size=self.size).astype(np.float32))
         return list(np.random.normal(size=self.size))
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         return [self._get_embedding() for _ in texts]
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         return self._get_embedding()

--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -1,7 +1,7 @@
 """Wrapper around HuggingFace embedding models."""
 from typing import Any, List
 
-from pydantic import BaseModel, Extra
+from pydantic import Extra
 
 from langchain.embeddings.base import Embeddings
 
@@ -13,7 +13,7 @@ DEFAULT_QUERY_INSTRUCTION = (
 )
 
 
-class HuggingFaceEmbeddings(BaseModel, Embeddings):
+class HuggingFaceEmbeddings(Embeddings):
     """Wrapper around sentence_transformers embedding models.
 
     To use, you should have the ``sentence_transformers`` python package installed.
@@ -61,7 +61,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         embeddings = self.client.encode(texts)
         return embeddings.tolist()
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a HuggingFace transformer model.
 
         Args:
@@ -75,7 +75,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         return embedding.tolist()
 
 
-class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
+class HuggingFaceInstructEmbeddings(Embeddings):
     """Wrapper around sentence_transformers embedding models.
 
     To use, you should have the ``sentence_transformers``
@@ -125,7 +125,7 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
         embeddings = self.client.encode(instruction_pairs)
         return embeddings.tolist()
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a HuggingFace instruct model.
 
         Args:

--- a/langchain/embeddings/huggingface_hub.py
+++ b/langchain/embeddings/huggingface_hub.py
@@ -1,7 +1,7 @@
 """Wrapper around HuggingFace Hub embedding models."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import Extra, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.utils import get_from_dict_or_env
@@ -10,7 +10,7 @@ DEFAULT_REPO_ID = "sentence-transformers/all-mpnet-base-v2"
 VALID_TASKS = ("feature-extraction",)
 
 
-class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
+class HuggingFaceHubEmbeddings(Embeddings):
     """Wrapper around HuggingFaceHub embedding models.
 
     To use, you should have the ``huggingface_hub`` python package installed, and the
@@ -92,7 +92,7 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
         responses = self.client(inputs=texts, params=_model_kwargs)
         return responses
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Call out to HuggingFaceHub's embedding endpoint for embedding query text.
 
         Args:

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -53,7 +53,7 @@ def embed_with_retry(embeddings: OpenAIEmbeddings, **kwargs: Any) -> Any:
     return _completion_with_retry(**kwargs)
 
 
-class OpenAIEmbeddings(BaseModel, Embeddings):
+class OpenAIEmbeddings(Embeddings):
     """Wrapper around OpenAI embedding models.
 
     To use, you should have the ``openai`` python package installed, and the
@@ -259,7 +259,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 results += [r["embedding"] for r in response["data"]]
             return results
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Call out to OpenAI's embedding endpoint for embedding query text.
 
         Args:
@@ -268,5 +268,4 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         Returns:
             Embeddings for the text.
         """
-        embedding = self._embedding_func(text, engine=self.query_model_name)
-        return embedding
+        return self._embedding_func(text, engine=self.query_model_name)

--- a/langchain/embeddings/sagemaker_endpoint.py
+++ b/langchain/embeddings/sagemaker_endpoint.py
@@ -1,13 +1,13 @@
 """Wrapper around Sagemaker InvokeEndpoint API."""
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import Extra, root_validator
 
 from langchain.embeddings.base import Embeddings
 from langchain.llms.sagemaker_endpoint import ContentHandlerBase
 
 
-class SagemakerEndpointEmbeddings(BaseModel, Embeddings):
+class SagemakerEndpointEmbeddings(Embeddings):
     """Wrapper around custom Sagemaker Inference Endpoints.
 
     To use, you must supply the endpoint name from your deployed
@@ -182,7 +182,7 @@ class SagemakerEndpointEmbeddings(BaseModel, Embeddings):
             results.append(response)
         return results
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a SageMaker inference endpoint.
 
         Args:

--- a/langchain/embeddings/self_hosted.py
+++ b/langchain/embeddings/self_hosted.py
@@ -1,7 +1,7 @@
 """Running custom embedding models on self-hosted remote hardware."""
 from typing import Any, Callable, List
 
-from pydantic import BaseModel, Extra
+from pydantic import Extra
 
 from langchain.embeddings.base import Embeddings
 from langchain.llms import SelfHostedPipeline
@@ -16,7 +16,7 @@ def _embed_documents(pipeline: Any, *args: Any, **kwargs: Any) -> List[List[floa
     return pipeline(*args, **kwargs)
 
 
-class SelfHostedEmbeddings(SelfHostedPipeline, Embeddings, BaseModel):
+class SelfHostedEmbeddings(SelfHostedPipeline, Embeddings):
     """Runs custom embedding models on self-hosted remote hardware.
 
     Supported hardware includes auto-launched instances on AWS, GCP, Azure,
@@ -87,7 +87,7 @@ class SelfHostedEmbeddings(SelfHostedPipeline, Embeddings, BaseModel):
             return embeddings.tolist()
         return embeddings
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a HuggingFace transformer model.
 
         Args:

--- a/langchain/embeddings/self_hosted_hugging_face.py
+++ b/langchain/embeddings/self_hosted_hugging_face.py
@@ -3,8 +3,6 @@ import importlib
 import logging
 from typing import Any, Callable, List, Optional
 
-from pydantic import BaseModel
-
 from langchain.embeddings.self_hosted import SelfHostedEmbeddings
 
 DEFAULT_MODEL_NAME = "sentence-transformers/all-mpnet-base-v2"
@@ -59,7 +57,7 @@ def load_embedding_model(model_id: str, instruct: bool = False, device: int = 0)
     return client
 
 
-class SelfHostedHuggingFaceEmbeddings(SelfHostedEmbeddings, BaseModel):
+class SelfHostedHuggingFaceEmbeddings(SelfHostedEmbeddings):
     """Runs sentence_transformers embedding models on self-hosted remote hardware.
 
     Supported hardware includes auto-launched instances on AWS, GCP, Azure,
@@ -157,7 +155,7 @@ class SelfHostedHuggingFaceInstructEmbeddings(SelfHostedHuggingFaceEmbeddings):
         embeddings = self.client(self.pipeline_ref, instruction_pairs)
         return embeddings.tolist()
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a HuggingFace instruct model.
 
         Args:

--- a/langchain/embeddings/tensorflow_hub.py
+++ b/langchain/embeddings/tensorflow_hub.py
@@ -1,14 +1,14 @@
 """Wrapper around TensorflowHub embedding models."""
 from typing import Any, List
 
-from pydantic import BaseModel, Extra
+from pydantic import Extra
 
 from langchain.embeddings.base import Embeddings
 
 DEFAULT_MODEL_URL = "https://tfhub.dev/google/universal-sentence-encoder-multilingual/3"
 
 
-class TensorflowHubEmbeddings(BaseModel, Embeddings):
+class TensorflowHubEmbeddings(Embeddings):
     """Wrapper around tensorflow_hub embedding models.
 
     To use, you should have the ``tensorflow_text`` python package installed.
@@ -56,7 +56,7 @@ class TensorflowHubEmbeddings(BaseModel, Embeddings):
         embeddings = self.embed(texts).numpy()
         return embeddings.tolist()
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Compute query embeddings using a TensorflowHub embedding model.
 
         Args:

--- a/tests/integration_tests/vectorstores/fake_embeddings.py
+++ b/tests/integration_tests/vectorstores/fake_embeddings.py
@@ -14,9 +14,6 @@ class FakeEmbeddings(Embeddings):
         Embeddings encode each text as its index."""
         return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
 
-    def embed_query(self, text: str) -> List[float]:
-        """Return constant query embeddings.
-        Embeddings are identical to embed_documents(texts)[0].
-        Distance to each text will be that text's index,
-        as it was passed to embed_documents."""
+    def _embed_query(self, text: str) -> List[float]:
+        """Return simple embeddings."""
         return [float(1.0)] * 9 + [float(0.0)]

--- a/tests/unit_tests/chains/test_hyde.py
+++ b/tests/unit_tests/chains/test_hyde.py
@@ -18,7 +18,7 @@ class FakeEmbeddings(Embeddings):
         """Return random floats."""
         return [list(np.random.uniform(0, 1, 10)) for _ in range(10)]
 
-    def embed_query(self, text: str) -> List[float]:
+    def _embed_query(self, text: str) -> List[float]:
         """Return random floats."""
         return list(np.random.uniform(0, 1, 10))
 

--- a/tests/unit_tests/embeddings/test_base.py
+++ b/tests/unit_tests/embeddings/test_base.py
@@ -22,13 +22,13 @@ def test_redis_caching() -> None:
         def __init__(self) -> None:
             self.cache = {} # type: ignore
     
-        def ft(self) -> Any: # type: ignore
+        def ft(self, *args) -> Any: # type: ignore
             return self
 
         def info(self) -> None: # type: ignore
             return None
         
-        def create_index(self) -> None:
+        def create_index(self, *args, **kwargs) -> None: # type: ignore
             return None
         
         def hset(self, key, mapping) -> None: # type: ignore

--- a/tests/unit_tests/embeddings/test_base.py
+++ b/tests/unit_tests/embeddings/test_base.py
@@ -1,0 +1,52 @@
+from redis import Redis
+from typing import Any, Dict, List, Optional
+
+from langchain.cache import InMemoryEmbeddingsCache, RedisEmbeddingsCache
+from langchain.embeddings.fake import FakeEmbeddings
+
+def test_caching() -> None:
+    """Test InMemoryEmbeddingsCache."""
+    cache = InMemoryEmbeddingsCache()
+    embeddings = FakeEmbeddings(size=10, embeddings_cache=cache)
+    res = embeddings.embed_query("foo")
+    assert cache.lookup("foo") is res
+    test_data = [0.0] * 10
+    cache.update('f00', test_data)
+    res = embeddings.embed_query("f00")
+    assert res == test_data
+
+def test_redis_caching() -> None:
+    """Test RedisEmbeddingsCache."""
+    # mock redis
+    class MockRedis(Redis):
+        def __init__(self) -> None:
+            self.cache = {} # type: ignore
+    
+        def ft(self) -> Any: # type: ignore
+            return self
+
+        def info(self) -> None: # type: ignore
+            return None
+        
+        def create_index(self) -> None:
+            return None
+        
+        def hset(self, key, mapping) -> None: # type: ignore
+            self.cache[key] = mapping
+        
+        def hget(self, key, field) -> Any: # type: ignore
+            try:
+                return self.cache[key][field]
+            except KeyError:
+                return None
+    
+    _redis = MockRedis()
+    cache = RedisEmbeddingsCache(_redis)
+    embeddings = FakeEmbeddings(size=10, precision="float32", embeddings_cache=cache)
+    res = embeddings.embed_query("foo")
+    print(type(res[0]))
+    assert cache.lookup("foo") == res
+    test_data = [0.0] * 10
+    cache.update('f00', test_data)
+    res = embeddings.embed_query("f00")
+    assert res == test_data


### PR DESCRIPTION
Adds caching for embeddings using the following cache providers:
- InMemory
- Redis

Issue: [https://github.com/hwchase17/langchain/issues/851]([https://github.com/hwchase17/langchain/issues/851](https://github.com/hwchase17/langchain/pull/url))

I wasn't sure exactly how this should be added so I chose to modify the Embeddings interface to include an optional embeddings cache since the current llm_cache implementation couldn't be used. I thought about trying to refactor the llm_cache to serve as a more general caching layer but didn't want to make a monster PR for my first contribution.

Any input is welcome from maintainers, I am happy to refactor this if it needs to be implemented differently, like llm_cache or something else. 