### PR TITLE
similarity_search is not accepting filters

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -128,7 +128,7 @@ class Chroma(VectorStore):
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
-            List[Document]: List of documents most simmilar to the query text.
+            List[Document]: List of documents most similar to the query text.
         """
         docs_and_scores = self.similarity_search_with_score(query, k, where=filter)
         return [doc for doc, _ in docs_and_scores]

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -130,7 +130,7 @@ class Chroma(VectorStore):
         Returns:
             List[Document]: List of documents most similar to the query text.
         """
-        docs_and_scores = self.similarity_search_with_score(query, k, where=filter)
+        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter)
         return [doc for doc, _ in docs_and_scores]
 
     def similarity_search_by_vector(


### PR DESCRIPTION
I have changed the name of the argument from `where` to `filter` which is expected by `similarity_search_with_score`.

Fixes #1838 