### PR TITLE
Allow kwargs to be passed to SBERT

### DIFF
--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -36,7 +36,9 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         try:
             import sentence_transformers
 
-            self.client = sentence_transformers.SentenceTransformer(self.model_name)
+            self.client = sentence_transformers.SentenceTransformer(
+                self.model_name, **kwargs
+            )
         except ImportError:
             raise ValueError(
                 "Could not import sentence_transformers python package. "


### PR DESCRIPTION
Currently `kwargs` are not passed to `SentenceTransformer`  instantiation. This allows `device`, `cache_folder` and other params to be passed.