### PR TITLE
Implement IpynbLoader to load ipynb files

### DIFF
--- a/langchain/document_loaders/__init__.py
+++ b/langchain/document_loaders/__init__.py
@@ -40,6 +40,7 @@ from langchain.document_loaders.s3_file import S3FileLoader
 from langchain.document_loaders.srt import SRTLoader
 from langchain.document_loaders.telegram import TelegramChatLoader
 from langchain.document_loaders.text import TextLoader
+from langchain.document_loaders.ipynb import IpynbLoader
 from langchain.document_loaders.unstructured import (
     UnstructuredFileIOLoader,
     UnstructuredFileLoader,

--- a/langchain/document_loaders/ipynb.py
+++ b/langchain/document_loaders/ipynb.py
@@ -1,0 +1,24 @@
+# pip install nbformat nbconvert
+import nbformat
+from nbconvert import MarkdownExporter
+from typing import List
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseLoader
+
+class IpynbLoader(BaseLoader):
+    """Load ipynb files and convert code to markdown"""
+
+    def __init__(self, file_path: str):
+        """Initialize with file path."""
+        self.file_path = file_path
+
+    def load(self) -> List[Document]:
+        """Load from file path."""
+        with open(self.file_path) as f:
+            nb = nbformat.read(f, as_version=4)
+
+        exporter = MarkdownExporter()
+        output, resources = exporter.from_notebook_node(nb, resources={'output_files_dir': 'output'})
+        metadata = {'source': self.file_path}
+        return [Document(page_content=output, metadata=metadata)]
+


### PR DESCRIPTION
This PR implements a new document loader IpynbLoader that can load and convert .ipynb files to Markdown. The loader utilizes nbformat and nbconvert packages to read and convert the .ipynb files respectively.

The IpynbLoader class extends the BaseLoader class and implements the load method to return a list of Document objects. The load method reads the .ipynb file, converts it to Markdown, and creates a Document object with the converted Markdown content and the source file path as metadata.

I have tested the IpynbLoader on a few sample .ipynb files, and it successfully loaded and converted them to Markdown.

Please review the changes and let me know if any further modifications are needed.