### PR TITLE
Improve chat tool prompt

### DIFF
--- a/langchain/agents/conversational_chat/prompt.py
+++ b/langchain/agents/conversational_chat/prompt.py
@@ -54,4 +54,4 @@ TEMPLATE_TOOL_RESPONSE = """TOOL RESPONSE:
 USER'S INPUT
 --------------------
 
-Okay, so what is the response to my original question? If using information from tools, you must say it explicitly - I have forgotten all TOOL RESPONSES! Remember to respond with a markdown code snippet of a json blob with a single action, and NOTHING else."""
+Okay, so what is the response to my last comment? If using information obtained from the tools you must mention it explicitly without mentioning the tool names - I have forgotten all TOOL RESPONSES! Remember to respond with a markdown code snippet of a json blob with a single action, and NOTHING else."""


### PR DESCRIPTION
I have found that when the user has not asked an explicit question the agent might have trouble answering the latest comment and might instead try to answer a question that came before in the conversation which would not be what is desired. 

I also found that the agent might get confused with the current prompt and talk about the tools themselves instead of the results obtained from them. 

I added two changes to the tool prompt so that the agent answers only the last comment/question and only returns information from tool results.