### PR TITLE
fix argument passing and import errors in chat_vector_db.ipynb

### DIFF
--- a/docs/modules/chat/examples/chat_vector_db.ipynb
+++ b/docs/modules/chat/examples/chat_vector_db.ipynb
@@ -169,7 +169,7 @@
    },
    "outputs": [],
    "source": [
-    "qa = ConversationalRetrievalChain.from_llm(ChatOpenAI(temperature=0), vectorstore,qa_prompt=prompt)"
+    "qa = ConversationalRetrievalChain.from_llm(ChatOpenAI(temperature=0), vectorstore.as_retriever(), qa_prompt=prompt)"
    ]
   },
   {
@@ -205,7 +205,7 @@
     {
      "data": {
       "text/plain": [
-       "\"The President nominated Circuit Court of Appeals Judge Ketanji Brown Jackson to serve on the United States Supreme Court. He described her as one of the nation's top legal minds, a former top litigator in private practice, a former federal public defender, and a consensus builder. She has received a broad range of support from the Fraternal Order of Police to former judges appointed by Democrats and Republicans.\""
+       "\"The President nominated Circuit Court of Appeals Judge Ketanji Brown Jackson to serve on the United States Supreme Court. He described her as one of the nation's top legal minds, a former top litigator in private practice, a former federal public defender, and a consensus builder. He also mentioned that she has received a broad range of support from the Fraternal Order of Police to former judges appointed by Democrats and Republicans.\""
       ]
      },
      "execution_count": 9,
@@ -250,7 +250,7 @@
     {
      "data": {
       "text/plain": [
-       "\"The President mentioned Circuit Court of Appeals Judge Ketanji Brown Jackson as the nominee for the United States Supreme Court. He described her as one of the nation's top legal minds who will continue Justice Breyer's legacy of excellence. The President did not mention any specific sources of support for Judge Jackson, but he did note that advancing immigration reform is supported by everyone from labor unions to religious leaders to the U.S. Chamber of Commerce.\""
+       "'The President did not mention anyone who came before Ketanji Brown Jackson.'"
       ]
      },
      "execution_count": 11,
@@ -285,7 +285,7 @@
     "from langchain.llms import OpenAI\n",
     "from langchain.callbacks.base import CallbackManager\n",
     "from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler\n",
-    "from langchain.chains.chat_index.prompts import CONDENSE_QUESTION_PROMPT\n",
+    "from langchain.chains.conversational_retrieval.prompts import CONDENSE_QUESTION_PROMPT\n",
     "from langchain.chains.question_answering import load_qa_chain\n",
     "\n",
     "# Construct a ChatVectorDBChain with a streaming llm for combine docs\n",
@@ -311,14 +311,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The President nominated Circuit Court of Appeals Judge Ketanji Brown Jackson to serve on the United States Supreme Court. He described her as one of the nation's top legal minds, a former top litigator in private practice, a former federal public defender, and a consensus builder. He also mentioned that she has received a broad range of support from the Fraternal Order of Police to former judges appointed by Democrats and Republicans."
+      "The President nominated Circuit Court of Appeals Judge Ketanji Brown Jackson to serve on the United States Supreme Court. He described her as one of the nation's top legal minds, a former top litigator in private practice, a former federal public defender, and a consensus builder. She has received a broad range of support from the Fraternal Order of Police to former judges appointed by Democrats and Republicans."
      ]
     }
    ],
    "source": [
     "chat_history = []\n",
     "query = \"What did the president say about Ketanji Brown Jackson\"\n",
-    "result = qa({\"question\": query, \"chat_history\": chat_history})"
+    "result = qa({\"question\": query, \"chat_history\": chat_history})\n"
    ]
   },
   {


### PR DESCRIPTION
Fix #1986 

I had the same issue and fixed it along with another minor issue in chat_vector_db.ipynb:

- Change argument of `ConversationalRetrievalChain.from_llm()` to resolve pydantic.error_wrappers.ValidationError
- Change import source of `CONDENSE_QUESTION_PROMPT` to appropriate one