### PR TITLE
Optimize ConversationEntityMemory save_context function

### DIFF
--- a/langchain/memory/entity.py
+++ b/langchain/memory/entity.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
+from functools import partial
 
 from langchain.chains.llm import LLMChain
 from langchain.memory.chat_memory import BaseChatMemory
@@ -71,30 +72,28 @@ class ConversationEntityMemory(BaseChatMemory, BaseModel):
             "entities": entity_summaries,
         }
 
-    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+    def save_context_optimized(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save context from this conversation to buffer."""
         super().save_context(inputs, outputs)
+
         if self.input_key is None:
             prompt_input_key = get_prompt_input_key(inputs, self.memory_variables)
         else:
             prompt_input_key = self.input_key
-        for entity in self.entity_cache:
-            chain = LLMChain(llm=self.llm, prompt=self.entity_summarization_prompt)
-            # key value store for entity
-            existing_summary = self.store.get(entity, "")
-            buffer_string = get_buffer_string(
-                self.buffer[-self.k * 2 :],
-                human_prefix=self.human_prefix,
-                ai_prefix=self.ai_prefix,
-            )
 
-            output = chain.predict(
-                summary=existing_summary,
-                history=buffer_string,
-                input=inputs[prompt_input_key],
-                entity=entity,
-            )
-            self.store[entity] = output.strip()
+        buffer_string = get_buffer_string(
+            self.buffer[-self.k * 2:],
+            human_prefix=self.human_prefix,
+            ai_prefix=self.ai_prefix,
+        )
+        input_data = inputs[prompt_input_key]
+        chain = LLMChain(llm=self.llm, prompt=self.entity_summarization_prompt)
+        predict_summary = partial(chain.predict, history=buffer_string, input=input_data)
+
+        for entity in self.entity_cache:
+            existing_summary = self.store.get(entity, "")
+            output = predict_summary(summary=existing_summary, entity=entity).strip()
+            self.store[entity] = output
 
     def clear(self) -> None:
         """Clear memory contents."""

--- a/langchain/memory/entity.py
+++ b/langchain/memory/entity.py
@@ -72,7 +72,7 @@ class ConversationEntityMemory(BaseChatMemory, BaseModel):
             "entities": entity_summaries,
         }
 
-    def save_context_optimized(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save context from this conversation to buffer."""
         super().save_context(inputs, outputs)
 


### PR DESCRIPTION
Optimizations made:
1. Moved the `buffer_string` and `chain` initialization outside of the loop to avoid redundant computations.
2. Used the `functools.partial` function to create a `predict_summary` function that already includes common arguments such as `history` and `input_data`. This improves readability and might have a minor performance improvement.

@agihouse