### PR TITLE
include the tool name for on_tool_end callback

### DIFF
--- a/langchain/tools/base.py
+++ b/langchain/tools/base.py
@@ -70,7 +70,7 @@ class BaseTool(BaseModel):
             self.callback_manager.on_tool_error(e, verbose=verbose)
             raise e
         self.callback_manager.on_tool_end(
-            observation, verbose=verbose, color=color, **kwargs
+            observation, verbose=verbose, color=color, name=self.name, **kwargs
         )
         return observation
 
@@ -112,10 +112,10 @@ class BaseTool(BaseModel):
             raise e
         if self.callback_manager.is_async:
             await self.callback_manager.on_tool_end(
-                observation, verbose=verbose, color=color, **kwargs
+                observation, verbose=verbose, color=color, name=self.name, **kwargs
             )
         else:
             self.callback_manager.on_tool_end(
-                observation, verbose=verbose, color=color, **kwargs
+                observation, verbose=verbose, color=color, name=self.name, **kwargs
             )
         return observation


### PR DESCRIPTION
This is useful if you rely on the `on_tool_end` callback to detect which tool has finished in a multi agents scenario.

For example, I'm working on a project where I consume the `on_tool_end` event where the event could be emitted by many agents or tools. Right now the only way to know which tool has finished would be set a marker on the `on_tool_start` and catch it on `on_tool_end`. 

I didn't want to break the signature of the function, but what would have been cleaner would be to pass the same details as in `on_tool_start`
