### PR TITLE
docs: fix promptlayer link typo

### DIFF
--- a/docs/modules/models/chat/integrations/promptlayer_chatopenai.ipynb
+++ b/docs/modules/models/chat/integrations/promptlayer_chatopenai.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "## Set the Environment API Key\n",
-    "You can create a PromptLayer API Key at [wwww.promptlayer.com](https://ww.promptlayer.com) by clicking the settings cog in the navbar.\n",
+    "You can create a PromptLayer API Key at [www.promptlayer.com](https://www.promptlayer.com) by clicking the settings cog in the navbar.\n",
     "\n",
     "Set it as an environment variable called `PROMPTLAYER_API_KEY`."
    ]

--- a/docs/modules/models/llms/integrations/promptlayer_openai.ipynb
+++ b/docs/modules/models/llms/integrations/promptlayer_openai.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "## Set the Environment API Key\n",
-    "You can create a PromptLayer API Key at [wwww.promptlayer.com](https://ww.promptlayer.com) by clicking the settings cog in the navbar.\n",
+    "You can create a PromptLayer API Key at [www.promptlayer.com](https://www.promptlayer.com) by clicking the settings cog in the navbar.\n",
     "\n",
     "Set it as an environment variable called `PROMPTLAYER_API_KEY`."
    ]


### PR DESCRIPTION
tiny typo, just stumbled upon it when reading the docs