### PR TITLE
add llamaindex retrievers

### DIFF
--- a/langchain/retrievers/llama_retriever.py
+++ b/langchain/retrievers/llama_retriever.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, List, cast
+
+import requests
+from pydantic import BaseModel, Field
+
+from langchain.schema import BaseRetriever, Document
+
+
+class LlamaIndexRetriever(BaseRetriever, BaseModel):
+    """Question-answering with sources over an LlamaIndex data structure."""
+
+    index: Any
+    query_kwargs: Dict = Field(default_factory=dict)
+
+    def get_relevant_documents(self, query: str) -> List[Document]:
+        """Get documents relevant for a query."""
+        try:
+            from llama_index.indices.base import BaseGPTIndex
+            from llama_index.response.schema import Response
+        except ImportError:
+            raise ImportError(
+                "You need to install `pip install llama-index` to use this retriever."
+            )
+        index = cast(BaseGPTIndex, self.index)
+
+        response = index.query(query, response_mode="no_text", **self.query_kwargs)
+        response = cast(Response, response)
+        # parse source nodes
+        docs = []
+        for source_node in response.source_nodes:
+            metadata = source_node.extra_info or {}
+            docs.append(
+                Document(page_content=source_node.source_text, metadata=metadata)
+            )
+        return docs
+
+
+class LlamaGraphRetriever(BaseRetriever, BaseModel):
+    """Question-answering with sources over an LlamaIndex graph data structure."""
+
+    graph: Any
+    query_configs: List[Dict] = Field(default_factory=list)
+
+    def get_relevant_documents(self, query: str) -> List[Document]:
+        """Get documents relevant for a query."""
+        try:
+            from llama_index.composability.graph import (
+                QUERY_CONFIG_TYPE,
+                ComposableGraph,
+            )
+            from llama_index.response.schema import Response
+        except ImportError:
+            raise ImportError(
+                "You need to install `pip install llama-index` to use this retriever."
+            )
+        graph = cast(ComposableGraph, self.graph)
+
+        # for now, inject response_mode="no_text" into query configs
+        for query_config in self.query_configs:
+            query_config["response_mode"] = "no_text"
+        query_configs = cast(List[QUERY_CONFIG_TYPE], self.query_configs)
+        response = graph.query(query, query_configs=query_configs)
+        response = cast(Response, response)
+
+        # parse source nodes
+        docs = []
+        for source_node in response.source_nodes:
+            metadata = source_node.extra_info or {}
+            docs.append(
+                Document(page_content=source_node.source_text, metadata=metadata)
+            )
+        return docs


### PR DESCRIPTION
Adds retrievers for both an index data structure and graph data structure (ideally they could use the same class with roughly similar configurations, but that's a tech debt item on our end).

Set response_mode="no_text" for now, to only retrieve the source nodes. 

Lmk if this makes sense + anything else I'd need to add! 