### PR TITLE
LLM provider interface

### DIFF
--- a/docs/ecosystem/bananadev.md
+++ b/docs/ecosystem/bananadev.md
@@ -75,5 +75,5 @@ from langchain.llms import Banana
 You need to provide a model key located in the dashboard:
 
 ```python
-llm = Banana(model_key="YOUR_MODEL_KEY")
+llm = Banana(model_id="YOUR_MODEL_KEY")
 ```

--- a/docs/model_laboratory.ipynb
+++ b/docs/model_laboratory.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "llms = [\n",
     "    OpenAI(temperature=0), \n",
-    "    Cohere(model=\"command-xlarge-20221108\", max_tokens=20, temperature=0), \n",
+    "    Cohere(model_id=\"command-xlarge-20221108\", max_tokens=20, temperature=0), \n",
     "    HuggingFaceHub(repo_id=\"google/flan-t5-xl\", model_kwargs={\"temperature\":1})\n",
     "]"
    ]
@@ -143,7 +143,7 @@
     "search = SerpAPIWrapper()\n",
     "self_ask_with_search_openai = SelfAskWithSearchChain(llm=open_ai_llm, search_chain=search, verbose=True)\n",
     "\n",
-    "cohere_llm = Cohere(temperature=0, model=\"command-xlarge-20221108\")\n",
+    "cohere_llm = Cohere(temperature=0, model_id=\"command-xlarge-20221108\")\n",
     "search = SerpAPIWrapper()\n",
     "self_ask_with_search_cohere = SelfAskWithSearchChain(llm=cohere_llm, search_chain=search, verbose=True)"
    ]

--- a/docs/modules/agents/agent_executors/examples/agent.json
+++ b/docs/modules/agents/agent_executors/examples/agent.json
@@ -1,0 +1,41 @@
+{
+    "llm_chain": {
+        "memory": null,
+        "verbose": false,
+        "prompt": {
+            "input_variables": [
+                "input",
+                "agent_scratchpad"
+            ],
+            "output_parser": null,
+            "partial_variables": {},
+            "template": "Answer the following questions as best you can. You have access to the following tools:\n\nSearch: A search engine. Useful for when you need to answer questions about current events. Input should be a search query.\nCalculator: Useful for when you need to answer questions about math.\n\nUse the following format:\n\nQuestion: the input question you must answer\nThought: you should always think about what to do\nAction: the action to take, should be one of [Search, Calculator]\nAction Input: the input to the action\nObservation: the result of the action\n... (this Thought/Action/Action Input/Observation can repeat N times)\nThought: I now know the final answer\nFinal Answer: the final answer to the original input question\n\nBegin!\n\nQuestion: {input}\nThought:{agent_scratchpad}",
+            "template_format": "f-string",
+            "validate_template": true,
+            "_type": "prompt"
+        },
+        "llm": {
+            "model_id": "text-davinci-003",
+            "temperature": 0.0,
+            "max_tokens": 256,
+            "top_p": 1,
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "n": 1,
+            "best_of": 1,
+            "request_timeout": null,
+            "logit_bias": {},
+            "_type": "openai"
+        },
+        "output_key": "text",
+        "_type": "llm_chain"
+    },
+    "allowed_tools": [
+        "Search",
+        "Calculator"
+    ],
+    "return_values": [
+        "output"
+    ],
+    "_type": "zero-shot-react-description"
+}

--- a/docs/modules/agents/agent_executors/examples/intermediate_steps.ipynb
+++ b/docs/modules/agents/agent_executors/examples/intermediate_steps.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(temperature=0, model_name='text-davinci-002')\n",
+    "llm = OpenAI(temperature=0, model_id='text-davinci-002')\n",
     "tools = load_tools([\"serpapi\", \"llm-math\"], llm=llm)"
    ]
   },

--- a/docs/modules/agents/agents/examples/react.ipynb
+++ b/docs/modules/agents/agents/examples/react.ipynb
@@ -34,7 +34,7 @@
     "    )\n",
     "]\n",
     "\n",
-    "llm = OpenAI(temperature=0, model_name=\"text-davinci-002\")\n",
+    "llm = OpenAI(temperature=0, model_id=\"text-davinci-002\")\n",
     "react = initialize_agent(tools, llm, agent=\"react-docstore\", verbose=True)"
    ]
   },

--- a/docs/modules/agents/toolkits/examples/openai_openapi.yml
+++ b/docs/modules/agents/toolkits/examples/openai_openapi.yml
@@ -245,7 +245,7 @@ paths:
             import openai
             openai.api_key = os.getenv("OPENAI_API_KEY")
             openai.Edit.create(
-              model="VAR_model_id",
+              model_id="VAR_model_id",
               input="What day of the wek is it?",
               instruction="Fix the spelling mistakes"
             )

--- a/docs/modules/chains/examples/moderation.ipynb
+++ b/docs/modules/chains/examples/moderation.ipynb
@@ -243,7 +243,7 @@
    "outputs": [],
    "source": [
     "prompt = PromptTemplate(template=\"{text}\", input_variables=[\"text\"])\n",
-    "llm_chain = LLMChain(llm=OpenAI(temperature=0, model_name=\"text-davinci-002\"), prompt=prompt)"
+    "llm_chain = LLMChain(llm=OpenAI(temperature=0, model_id=\"text-davinci-002\"), prompt=prompt)"
    ]
   },
   {
@@ -324,7 +324,7 @@
    "outputs": [],
    "source": [
     "prompt = PromptTemplate(template=\"{setup}{new_input}Person2:\", input_variables=[\"setup\", \"new_input\"])\n",
-    "llm_chain = LLMChain(llm=OpenAI(temperature=0, model_name=\"text-davinci-002\"), prompt=prompt)"
+    "llm_chain = LLMChain(llm=OpenAI(temperature=0, model_id=\"text-davinci-002\"), prompt=prompt)"
    ]
   },
   {

--- a/docs/modules/chains/examples/pal.ipynb
+++ b/docs/modules/chains/examples/pal.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name='code-davinci-002', temperature=0, max_tokens=512)"
+    "llm = OpenAI(model_id='code-davinci-002', temperature=0, max_tokens=512)"
    ]
   },
   {
@@ -71,17 +71,17 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new PALChain chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3mdef solution():\n",
+      "\u001b[1m> Entering new PALChain chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mdef solution():\n",
       "    \"\"\"Jan has three times the number of pets as Marcia. Marcia has two more pets than Cindy. If Cindy has four pets, how many total pets do the three have?\"\"\"\n",
       "    cindy_pets = 4\n",
       "    marcia_pets = cindy_pets + 2\n",
       "    jan_pets = marcia_pets * 3\n",
       "    total_pets = cindy_pets + marcia_pets + jan_pets\n",
       "    result = total_pets\n",
-      "    return result\u001B[0m\n",
+      "    return result\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -139,8 +139,8 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new PALChain chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m# Put objects into a list to record ordering\n",
+      "\u001b[1m> Entering new PALChain chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m# Put objects into a list to record ordering\n",
       "objects = []\n",
       "objects += [('booklet', 'blue')] * 2\n",
       "objects += [('booklet', 'purple')] * 2\n",
@@ -151,9 +151,9 @@
       "\n",
       "# Count number of purple objects\n",
       "num_purple = len([object for object in objects if object[1] == 'purple'])\n",
-      "answer = num_purple\u001B[0m\n",
+      "answer = num_purple\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished PALChain chain.\u001B[0m\n"
+      "\u001b[1m> Finished PALChain chain.\u001b[0m\n"
      ]
     },
     {
@@ -212,8 +212,8 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new PALChain chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m# Put objects into a list to record ordering\n",
+      "\u001b[1m> Entering new PALChain chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m# Put objects into a list to record ordering\n",
       "objects = []\n",
       "objects += [('booklet', 'blue')] * 2\n",
       "objects += [('booklet', 'purple')] * 2\n",
@@ -224,9 +224,9 @@
       "\n",
       "# Count number of purple objects\n",
       "num_purple = len([object for object in objects if object[1] == 'purple'])\n",
-      "answer = num_purple\u001B[0m\n",
+      "answer = num_purple\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     }
    ],

--- a/docs/modules/chains/generic/llm.json
+++ b/docs/modules/chains/generic/llm.json
@@ -1,5 +1,5 @@
 {
-    "model_name": "text-davinci-003",
+    "model_id": "text-davinci-003",
     "temperature": 0.0,
     "max_tokens": 256,
     "top_p": 1,

--- a/docs/modules/chains/generic/llm_chain.json
+++ b/docs/modules/chains/generic/llm_chain.json
@@ -6,8 +6,11 @@
             "question"
         ],
         "output_parser": null,
+        "partial_variables": {},
         "template": "Question: {question}\n\nAnswer: Let's think step by step.",
-        "template_format": "f-string"
+        "template_format": "f-string",
+        "validate_template": true,
+        "_type": "prompt"
     },
     "llm": {
         "model_id": "text-davinci-003",

--- a/docs/modules/chains/generic/llm_chain.json
+++ b/docs/modules/chains/generic/llm_chain.json
@@ -10,7 +10,7 @@
         "template_format": "f-string"
     },
     "llm": {
-        "model_name": "text-davinci-003",
+        "model_id": "text-davinci-003",
         "temperature": 0.0,
         "max_tokens": 256,
         "top_p": 1,

--- a/docs/modules/chains/generic/prompt.json
+++ b/docs/modules/chains/generic/prompt.json
@@ -3,6 +3,9 @@
         "question"
     ],
     "output_parser": null,
+    "partial_variables": {},
     "template": "Question: {question}\n\nAnswer: Let's think step by step.",
-    "template_format": "f-string"
+    "template_format": "f-string",
+    "validate_template": true,
+    "_type": "prompt"
 }

--- a/docs/modules/chains/generic/serialization.ipynb
+++ b/docs/modules/chains/generic/serialization.ipynb
@@ -61,32 +61,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\r\n",
-      "    \"memory\": null,\r\n",
-      "    \"verbose\": true,\r\n",
-      "    \"prompt\": {\r\n",
-      "        \"input_variables\": [\r\n",
-      "            \"question\"\r\n",
-      "        ],\r\n",
-      "        \"output_parser\": null,\r\n",
-      "        \"template\": \"Question: {question}\\n\\nAnswer: Let's think step by step.\",\r\n",
-      "        \"template_format\": \"f-string\"\r\n",
-      "    },\r\n",
-      "    \"llm\": {\r\n",
-      "        \"model_name\": \"text-davinci-003\",\r\n",
-      "        \"temperature\": 0.0,\r\n",
-      "        \"max_tokens\": 256,\r\n",
-      "        \"top_p\": 1,\r\n",
-      "        \"frequency_penalty\": 0,\r\n",
-      "        \"presence_penalty\": 0,\r\n",
-      "        \"n\": 1,\r\n",
-      "        \"best_of\": 1,\r\n",
-      "        \"request_timeout\": null,\r\n",
-      "        \"logit_bias\": {},\r\n",
-      "        \"_type\": \"openai\"\r\n",
-      "    },\r\n",
-      "    \"output_key\": \"text\",\r\n",
-      "    \"_type\": \"llm_chain\"\r\n",
+      "{\n",
+      "    \"memory\": null,\n",
+      "    \"verbose\": true,\n",
+      "    \"prompt\": {\n",
+      "        \"input_variables\": [\n",
+      "            \"question\"\n",
+      "        ],\n",
+      "        \"output_parser\": null,\n",
+      "        \"partial_variables\": {},\n",
+      "        \"template\": \"Question: {question}\\n\\nAnswer: Let's think step by step.\",\n",
+      "        \"template_format\": \"f-string\",\n",
+      "        \"validate_template\": true,\n",
+      "        \"_type\": \"prompt\"\n",
+      "    },\n",
+      "    \"llm\": {\n",
+      "        \"model_id\": \"text-davinci-003\",\n",
+      "        \"temperature\": 0.0,\n",
+      "        \"max_tokens\": 256,\n",
+      "        \"top_p\": 1,\n",
+      "        \"frequency_penalty\": 0,\n",
+      "        \"presence_penalty\": 0,\n",
+      "        \"n\": 1,\n",
+      "        \"best_of\": 1,\n",
+      "        \"request_timeout\": null,\n",
+      "        \"logit_bias\": {},\n",
+      "        \"_type\": \"openai\"\n",
+      "    },\n",
+      "    \"output_key\": \"text\",\n",
+      "    \"_type\": \"llm_chain\"\n",
       "}"
      ]
     }
@@ -136,13 +139,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
+      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
       "Prompt after formatting:\n",
-      "\u001B[32;1m\u001B[1;3mQuestion: whats 2 + 2\n",
+      "\u001b[32;1m\u001b[1;3mQuestion: whats 2 + 2\n",
       "\n",
-      "Answer: Let's think step by step.\u001B[0m\n",
+      "Answer: Let's think step by step.\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -189,13 +192,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\r\n",
-      "    \"input_variables\": [\r\n",
-      "        \"question\"\r\n",
-      "    ],\r\n",
-      "    \"output_parser\": null,\r\n",
-      "    \"template\": \"Question: {question}\\n\\nAnswer: Let's think step by step.\",\r\n",
-      "    \"template_format\": \"f-string\"\r\n",
+      "{\n",
+      "    \"input_variables\": [\n",
+      "        \"question\"\n",
+      "    ],\n",
+      "    \"output_parser\": null,\n",
+      "    \"partial_variables\": {},\n",
+      "    \"template\": \"Question: {question}\\n\\nAnswer: Let's think step by step.\",\n",
+      "    \"template_format\": \"f-string\",\n",
+      "    \"validate_template\": true,\n",
+      "    \"_type\": \"prompt\"\n",
       "}"
      ]
     }
@@ -224,18 +230,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\r\n",
-      "    \"model_name\": \"text-davinci-003\",\r\n",
-      "    \"temperature\": 0.0,\r\n",
-      "    \"max_tokens\": 256,\r\n",
-      "    \"top_p\": 1,\r\n",
-      "    \"frequency_penalty\": 0,\r\n",
-      "    \"presence_penalty\": 0,\r\n",
-      "    \"n\": 1,\r\n",
-      "    \"best_of\": 1,\r\n",
-      "    \"request_timeout\": null,\r\n",
-      "    \"logit_bias\": {},\r\n",
-      "    \"_type\": \"openai\"\r\n",
+      "{\n",
+      "    \"model_id\": \"text-davinci-003\",\n",
+      "    \"temperature\": 0.0,\n",
+      "    \"max_tokens\": 256,\n",
+      "    \"top_p\": 1,\n",
+      "    \"frequency_penalty\": 0,\n",
+      "    \"presence_penalty\": 0,\n",
+      "    \"n\": 1,\n",
+      "    \"best_of\": 1,\n",
+      "    \"request_timeout\": null,\n",
+      "    \"logit_bias\": {},\n",
+      "    \"_type\": \"openai\"\n",
       "}"
      ]
     }
@@ -274,13 +280,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\r\n",
-      "  \"memory\": null,\r\n",
-      "  \"verbose\": true,\r\n",
-      "  \"prompt_path\": \"prompt.json\",\r\n",
-      "  \"llm_path\": \"llm.json\",\r\n",
-      "  \"output_key\": \"text\",\r\n",
-      "  \"_type\": \"llm_chain\"\r\n",
+      "{\n",
+      "  \"memory\": null,\n",
+      "  \"verbose\": true,\n",
+      "  \"prompt_path\": \"prompt.json\",\n",
+      "  \"llm_path\": \"llm.json\",\n",
+      "  \"output_key\": \"text\",\n",
+      "  \"_type\": \"llm_chain\"\n",
       "}"
      ]
     }
@@ -309,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "a99d61b9",
    "metadata": {},
    "outputs": [
@@ -319,13 +325,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
+      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
       "Prompt after formatting:\n",
-      "\u001B[32;1m\u001B[1;3mQuestion: whats 2 + 2\n",
+      "\u001b[32;1m\u001b[1;3mQuestion: whats 2 + 2\n",
       "\n",
-      "Answer: Let's think step by step.\u001B[0m\n",
+      "Answer: Let's think step by step.\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -334,7 +340,7 @@
        "' 2 + 2 = 4'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -342,14 +348,6 @@
    "source": [
     "chain.run(\"whats 2 + 2\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "822b7c12",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -368,7 +366,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/modules/models/llms/examples/custom_llm.ipynb
+++ b/docs/modules/models/llms/examples/custom_llm.ipynb
@@ -24,7 +24,9 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "a65696a0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from langchain.llms.base import LLM\n",
@@ -35,16 +37,37 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "d5ceff02",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class CustomLLM(LLM):\n",
+    "    id = \"custom\"\n",
+    "    \"\"\"Unique ID for this provider class.\"\"\"\n",
+    "\n",
+    "    model_id = \"test\"\n",
+    "    \"\"\"\n",
+    "    Model ID to invoke by this provider via generate/agenerate.\n",
+    "    For our custom LLM, this is not being used.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    models = [\"test\"]\n",
+    "    \"\"\"\n",
+    "    List of supported models by their IDs. For registry providers, this will\n",
+    "    be just [\"*\"].\n",
+    "    \"\"\"\n",
+    "\n",
+    "    pypi_package_deps = []\n",
+    "    \"\"\"List of PyPi package dependencies.\"\"\"\n",
+    "\n",
+    "    auth_strategy = None\n",
+    "    \"\"\"\n",
+    "    Authentication/authorization strategy. Declares what credentials are\n",
+    "    required to use this model provider.\n",
+    "    \"\"\"\n",
     "    \n",
     "    n: int\n",
-    "        \n",
-    "    @property\n",
-    "    def _llm_type(self) -> str:\n",
-    "        return \"custom\"\n",
     "    \n",
     "    def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:\n",
     "        if stop is not None:\n",
@@ -69,7 +92,9 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "10e5ece6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "llm = CustomLLM(n=10)"
@@ -122,14 +147,6 @@
    "source": [
     "print(llm)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6dac3f47",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -148,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/modules/models/llms/examples/llm.json
+++ b/docs/modules/models/llms/examples/llm.json
@@ -1,5 +1,5 @@
 {
-    "model_name": "text-davinci-003",
+    "model_id": "text-davinci-003",
     "temperature": 0.7,
     "max_tokens": 256,
     "top_p": 1.0,

--- a/docs/modules/models/llms/examples/llm.json
+++ b/docs/modules/models/llms/examples/llm.json
@@ -8,5 +8,6 @@
     "n": 1,
     "best_of": 1,
     "request_timeout": null,
+    "logit_bias": {},
     "_type": "openai"
 }

--- a/docs/modules/models/llms/examples/llm.yaml
+++ b/docs/modules/models/llms/examples/llm.yaml
@@ -1,6 +1,7 @@
 _type: openai
 best_of: 1
 frequency_penalty: 0.0
+logit_bias: {}
 max_tokens: 256
 model_id: text-davinci-003
 n: 1

--- a/docs/modules/models/llms/examples/llm.yaml
+++ b/docs/modules/models/llms/examples/llm.yaml
@@ -2,7 +2,7 @@ _type: openai
 best_of: 1
 frequency_penalty: 0.0
 max_tokens: 256
-model_name: text-davinci-003
+model_id: text-davinci-003
 n: 1
 presence_penalty: 0.0
 request_timeout: null

--- a/docs/modules/models/llms/examples/llm_caching.ipynb
+++ b/docs/modules/models/llms/examples/llm_caching.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# To make the caching really obvious, lets use a slower model.\n",
-    "llm = OpenAI(model_name=\"text-davinci-002\", n=2, best_of=2)"
+    "llm = OpenAI(model_id=\"text-davinci-002\", n=2, best_of=2)"
    ]
   },
   {
@@ -278,8 +278,9 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0959d640",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Custom SQLAlchemy Schemas"
    ]
@@ -287,8 +288,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac967b39",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# You can define your own declarative SQLAlchemyCache child class to customize the schema used for caching. For example, to support high-speed fulltext prompt indexing with Postgres, use:\n",
@@ -336,7 +338,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name=\"text-davinci-002\", n=2, best_of=2, cache=False)"
+    "llm = OpenAI(model_id=\"text-davinci-002\", n=2, best_of=2, cache=False)"
    ]
   },
   {
@@ -417,8 +419,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name=\"text-davinci-002\")\n",
-    "no_cache_llm = OpenAI(model_name=\"text-davinci-002\", cache=False)"
+    "llm = OpenAI(model_id=\"text-davinci-002\")\n",
+    "no_cache_llm = OpenAI(model_id=\"text-davinci-002\", cache=False)"
    ]
   },
   {

--- a/docs/modules/models/llms/examples/llm_serialization.ipynb
+++ b/docs/modules/models/llms/examples/llm_serialization.ipynb
@@ -40,17 +40,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\r\n",
-      "    \"model_name\": \"text-davinci-003\",\r\n",
-      "    \"temperature\": 0.7,\r\n",
-      "    \"max_tokens\": 256,\r\n",
-      "    \"top_p\": 1.0,\r\n",
-      "    \"frequency_penalty\": 0.0,\r\n",
-      "    \"presence_penalty\": 0.0,\r\n",
-      "    \"n\": 1,\r\n",
-      "    \"best_of\": 1,\r\n",
-      "    \"request_timeout\": null,\r\n",
-      "    \"_type\": \"openai\"\r\n",
+      "{\n",
+      "    \"model_id\": \"text-davinci-003\",\n",
+      "    \"temperature\": 0.7,\n",
+      "    \"max_tokens\": 256,\n",
+      "    \"top_p\": 1.0,\n",
+      "    \"frequency_penalty\": 0.0,\n",
+      "    \"presence_penalty\": 0.0,\n",
+      "    \"n\": 1,\n",
+      "    \"best_of\": 1,\n",
+      "    \"request_timeout\": null,\n",
+      "    \"_type\": \"openai\"\n",
       "}"
      ]
     }
@@ -79,16 +79,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "_type: openai\r\n",
-      "best_of: 1\r\n",
-      "frequency_penalty: 0.0\r\n",
-      "max_tokens: 256\r\n",
-      "model_name: text-davinci-003\r\n",
-      "n: 1\r\n",
-      "presence_penalty: 0.0\r\n",
-      "request_timeout: null\r\n",
-      "temperature: 0.7\r\n",
-      "top_p: 1.0\r\n"
+      "_type: openai\n",
+      "best_of: 1\n",
+      "frequency_penalty: 0.0\n",
+      "max_tokens: 256\n",
+      "model_id: text-davinci-003\n",
+      "n: 1\n",
+      "presence_penalty: 0.0\n",
+      "request_timeout: null\n",
+      "temperature: 0.7\n",
+      "top_p: 1.0\n"
      ]
     }
    ],
@@ -134,14 +134,6 @@
    "source": [
     "llm.save(\"llm.yaml\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68e45b1c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -160,7 +152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/modules/models/llms/examples/token_usage_tracking.ipynb
+++ b/docs/modules/models/llms/examples/token_usage_tracking.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name=\"text-davinci-002\", n=2, best_of=2)"
+    "llm = OpenAI(model_id=\"text-davinci-002\", n=2, best_of=2)"
    ]
   },
   {

--- a/docs/modules/models/llms/getting_started.ipynb
+++ b/docs/modules/models/llms/getting_started.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name=\"text-ada-001\", n=2, best_of=2)"
+    "llm = OpenAI(model_id=\"text-ada-001\", n=2, best_of=2)"
    ]
   },
   {

--- a/docs/modules/models/llms/integrations/aleph_alpha.ipynb
+++ b/docs/modules/models/llms/integrations/aleph_alpha.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = AlephAlpha(model=\"luminous-extended\", maximum_tokens=20, stop_sequences=[\"Q:\"])"
+    "llm = AlephAlpha(model_id=\"luminous-extended\", maximum_tokens=20, stop_sequences=[\"Q:\"])"
    ]
   },
   {

--- a/docs/modules/models/llms/integrations/azure_openai_example.ipynb
+++ b/docs/modules/models/llms/integrations/azure_openai_example.ipynb
@@ -69,7 +69,8 @@
    "source": [
     "# Create an instance of Azure OpenAI\n",
     "# Replace the deployment name with your own\n",
-    "llm = AzureOpenAI(deployment_name=\"text-davinci-002-prod\", model_name=\"text-davinci-002\")"
+    "deployment_name = \"text-davinci-002-prod\"\n",
+    "llm = AzureOpenAI(model_id=deployment_name)"
    ]
   },
   {

--- a/docs/modules/models/llms/integrations/banana.ipynb
+++ b/docs/modules/models/llms/integrations/banana.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = Banana(model_key=\"YOUR_MODEL_KEY\")"
+    "llm = Banana(model_id=\"YOUR_MODEL_KEY\")"
    ]
   },
   {

--- a/docs/modules/models/llms/integrations/petals_example.ipynb
+++ b/docs/modules/models/llms/integrations/petals_example.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = Petals(model_name=\"bigscience/bloom-petals\")"
+    "llm = Petals(model_id=\"bigscience/bloom-petals\")"
    ]
   },
   {

--- a/docs/use_cases/evaluation/huggingface_datasets.ipynb
+++ b/docs/use_cases/evaluation/huggingface_datasets.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name=\"text-davinci-003\", temperature=0)\n",
+    "llm = OpenAI(model_id=\"text-davinci-003\", temperature=0)\n",
     "chain = LLMChain(llm=llm, prompt=prompt)"
    ]
   },

--- a/docs/use_cases/evaluation/question_answering.ipynb
+++ b/docs/use_cases/evaluation/question_answering.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = OpenAI(model_name=\"text-davinci-003\", temperature=0)\n",
+    "llm = OpenAI(model_id=\"text-davinci-003\", temperature=0)\n",
     "chain = LLMChain(llm=llm, prompt=prompt)"
    ]
   },

--- a/langchain/chat_models/azure_openai.py
+++ b/langchain/chat_models/azure_openai.py
@@ -8,6 +8,7 @@ from pydantic import root_validator
 
 from langchain.chat_models.openai import (
     ChatOpenAI,
+    OpenAIAuthStrategy
 )
 from langchain.utils import get_from_dict_or_env
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__file__)
 
 class AzureChatOpenAI(ChatOpenAI):
     """Wrapper around Azure OpenAI Chat Completion API. To use this class you
-    must have a deployed model on Azure OpenAI. Use `deployment_name` in the
+    must have a deployed model on Azure OpenAI. Use `model_id` in the
     constructor to refer to the "Model deployment name" in the Azure portal.
 
     In addition, you should have the ``openai`` python package installed, and the
@@ -30,8 +31,9 @@ class AzureChatOpenAI(ChatOpenAI):
     `35-turbo-dev`, the constructor should look like:
 
     .. code-block:: python
+        deployment_name = "35-turbo-dev"
         AzureChatOpenAI(
-            deployment_name="35-turbo-dev",
+            model_id=deployment_name,
             openai_api_version="2023-03-15-preview",
         )
 
@@ -41,7 +43,26 @@ class AzureChatOpenAI(ChatOpenAI):
     in, even if not explicitly saved on this class.
     """
 
-    deployment_name: str = ""
+    id = "azure-openai-chat"
+    """Unique ID for this provider class."""
+
+    model_id: str
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    For AzureChatOpenAI, this is the deployment name.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = ["openai"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = OpenAIAuthStrategy
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
     openai_api_type: str = "azure"
     openai_api_base: str = ""
     openai_api_version: str = ""
@@ -101,5 +122,5 @@ class AzureChatOpenAI(ChatOpenAI):
         """Get the default parameters for calling OpenAI API."""
         return {
             **super()._default_params,
-            "engine": self.deployment_name,
+            "engine": self.model_id,
         }

--- a/langchain/chat_models/azure_openai.py
+++ b/langchain/chat_models/azure_openai.py
@@ -6,10 +6,7 @@ from typing import Any, Dict
 
 from pydantic import root_validator
 
-from langchain.chat_models.openai import (
-    ChatOpenAI,
-    OpenAIAuthStrategy
-)
+from langchain.chat_models.openai import ChatOpenAI, OpenAIAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__file__)

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -17,11 +17,11 @@ from tenacity import (
 from langchain.chat_models.base import BaseChatModel
 from langchain.schema import (
     AIMessage,
+    AuthStrategy,
     BaseMessage,
     ChatGeneration,
     ChatMessage,
     ChatResult,
-    AuthStrategy,
     EnvAuthStrategy,
     HumanMessage,
     SystemMessage,

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple
 
 from pydantic import BaseModel, Extra, Field, root_validator
 from tenacity import (
@@ -21,6 +21,7 @@ from langchain.schema import (
     ChatGeneration,
     ChatMessage,
     ChatResult,
+    AuthStrategy,
     EnvAuthStrategy,
     HumanMessage,
     SystemMessage,
@@ -130,7 +131,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
     pypi_package_deps = ["openai"]
     """List of PyPi package dependencies."""
 
-    auth_strategy = OpenAIAuthStrategy
+    auth_strategy: ClassVar[AuthStrategy] = OpenAIAuthStrategy
     """Authentication/authorization strategy. Declares what credentials are
     required to use this model provider. Generally should not be `None`."""
 
@@ -375,7 +376,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
                 "Please it install it with `pip install tiktoken`."
             )
 
-        model = self.model_name
+        model = self.model_id
         if model == "gpt-3.5-turbo":
             # gpt-3.5-turbo may change over time.
             # Returning num tokens assuming gpt-3.5-turbo-0301.

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -124,7 +124,14 @@ class ChatOpenAI(BaseChatModel, BaseModel):
     # OpenAI chat model provider supports any model available via
     # `openai.ChatCompletion`.
     # Reference: https://platform.openai.com/docs/models/model-endpoint-compatibility
-    models = ['gpt-4', 'gpt-4-0314', 'gpt-4-32k', 'gpt-4-32k-0314', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0301']
+    models = [
+        "gpt-4",
+        "gpt-4-0314",
+        "gpt-4-32k",
+        "gpt-4-32k-0314",
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0301",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 

--- a/langchain/chat_models/promptlayer_openai.py
+++ b/langchain/chat_models/promptlayer_openai.py
@@ -5,7 +5,11 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from langchain.chat_models import ChatOpenAI
-from langchain.schema import BaseMessage, ChatResult
+from langchain.schema import BaseMessage, ChatResult, MultiEnvAuthStrategy
+
+
+class PromptLayerOaiAuthStrategy(MultiEnvAuthStrategy):
+    names = ["OPENAI_API_KEY", "PROMPTLAYER_API_KEY"]
 
 
 class PromptLayerChatOpenAI(ChatOpenAI, BaseModel):
@@ -28,8 +32,21 @@ class PromptLayerChatOpenAI(ChatOpenAI, BaseModel):
         .. code-block:: python
 
             from langchain.chat_models import PromptLayerChatOpenAI
-            openai = PromptLayerChatOpenAI(model_name="gpt-3.5-turbo")
+            openai = PromptLayerChatOpenAI(model_id="gpt-3.5-turbo")
     """
+
+    id = "promptlayer-openai-chat"
+    """Unique ID for this provider class."""
+
+    pypi_package_deps = ["openai", "promptlayer"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = PromptLayerOaiAuthStrategy
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
+    pypi_package_deps = ["openai"]
+    """List of PyPi package dependencies."""
 
     pl_tags: Optional[List[str]]
     return_pl_id: Optional[bool] = False

--- a/langchain/llms/ai21.py
+++ b/langchain/llms/ai21.py
@@ -19,8 +19,10 @@ class AI21PenaltyData(BaseModel):
     applyToStopwords: bool = True
     applyToEmojis: bool = True
 
+
 class AI21AuthStrategy(EnvAuthStrategy):
     name = "AI21_API_KEY"
+
 
 class AI21(LLM, BaseModel):
     """Wrapper around AI21 large language models.
@@ -44,7 +46,17 @@ class AI21(LLM, BaseModel):
     # AI21 model provider currently only provides its prompt via the `prompt`
     # key, which limits the models that can actually be used.
     # Reference: https://docs.ai21.com/reference/j2-complete-api
-    models = ["j1-large", "j1-grande", "j1-jumbo", "j1-grande-instruct", "j2-large", "j2-grande", "j2-jumbo", "j2-grande-instruct", "j2-jumbo-instruct"]
+    models = [
+        "j1-large",
+        "j1-grande",
+        "j1-jumbo",
+        "j1-grande-instruct",
+        "j2-large",
+        "j2-grande",
+        "j2-jumbo",
+        "j2-grande-instruct",
+        "j2-jumbo-instruct",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 

--- a/langchain/llms/ai21.py
+++ b/langchain/llms/ai21.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Optional
 import requests
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 

--- a/langchain/llms/ai21.py
+++ b/langchain/llms/ai21.py
@@ -32,7 +32,7 @@ class AI21(LLM, BaseModel):
         .. code-block:: python
 
             from langchain.llms import AI21
-            ai21 = AI21(model="j1-jumbo")
+            ai21 = AI21(model_id="j1-jumbo")
     """
 
     id = "ai21"

--- a/langchain/llms/aleph_alpha.py
+++ b/langchain/llms/aleph_alpha.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 

--- a/langchain/llms/aleph_alpha.py
+++ b/langchain/llms/aleph_alpha.py
@@ -8,8 +8,10 @@ from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
 from langchain.utils import get_from_dict_or_env
 
+
 class AlephAlphaAuthStrategy(EnvAuthStrategy):
     name = "ALEPH_ALPHA_API_KEY"
+
 
 class AlephAlpha(LLM, BaseModel):
     """Wrapper around Aleph Alpha large language models.
@@ -35,7 +37,12 @@ class AlephAlpha(LLM, BaseModel):
     """Model ID to invoke by this provider via generate/agenerate."""
 
     # Reference: https://docs.aleph-alpha.com/docs/introduction/luminous/
-    models = ["luminous-base", "luminous-extended", "luminous-supreme", "luminous-supreme-control"]
+    models = [
+        "luminous-base",
+        "luminous-extended",
+        "luminous-supreme",
+        "luminous-supreme-control",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 

--- a/langchain/llms/aleph_alpha.py
+++ b/langchain/llms/aleph_alpha.py
@@ -25,7 +25,7 @@ class AlephAlpha(LLM, BaseModel):
         .. code-block:: python
 
             from langchain.llms import AlephAlpha
-            alpeh_alpha = AlephAlpha(aleph_alpha_api_key="my-api-key")
+            aleph_alpha = AlephAlpha(aleph_alpha_api_key="my-api-key")
     """
 
     id = "aleph-alpha"
@@ -227,7 +227,7 @@ class AlephAlpha(LLM, BaseModel):
         Example:
             .. code-block:: python
 
-                response = alpeh_alpha("Tell me a joke.")
+                response = aleph_alpha("Tell me a joke.")
         """
         from aleph_alpha_client import CompletionRequest, Prompt
 

--- a/langchain/llms/anthropic.py
+++ b/langchain/llms/anthropic.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Generator, List, Mapping, Optional
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 

--- a/langchain/llms/anthropic.py
+++ b/langchain/llms/anthropic.py
@@ -8,8 +8,10 @@ from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.utils import get_from_dict_or_env
 
+
 class AnthropicAuthStrategy(EnvAuthStrategy):
     name = "ANTHROPIC_API_KEY"
+
 
 class Anthropic(LLM, BaseModel):
     r"""Wrapper around Anthropic large language models.
@@ -44,7 +46,13 @@ class Anthropic(LLM, BaseModel):
     # Anthropic model provider supports any model available via
     # `anthropic.Client#completion()`.
     # Reference: https://console.anthropic.com/docs/api/reference
-    models = ["claude-v1", "claude-v1.0", "claude-v1.2", "claude-instant-v1", "claude-instant-v1.0"]
+    models = [
+        "claude-v1",
+        "claude-v1.0",
+        "claude-v1.2",
+        "claude-instant-v1",
+        "claude-instant-v1.0",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 

--- a/langchain/llms/anthropic.py
+++ b/langchain/llms/anthropic.py
@@ -22,7 +22,7 @@ class Anthropic(LLM, BaseModel):
         .. code-block:: python
             import anthropic
             from langchain.llms import Anthropic
-            model = Anthropic(model="<model_name>", anthropic_api_key="my-api-key")
+            model = Anthropic(model_id="<model_name>", anthropic_api_key="my-api-key")
 
             # Simplest invocation, automatically wrapped with HUMAN_PROMPT
             # and AI_PROMPT.

--- a/langchain/llms/anthropic.py
+++ b/langchain/llms/anthropic.py
@@ -22,7 +22,7 @@ class Anthropic(LLM, BaseModel):
         .. code-block:: python
             import anthropic
             from langchain.llms import Anthropic
-            model = Anthropic(model_id="<model_name>", anthropic_api_key="my-api-key")
+            model = Anthropic(model_id="claude-v1", anthropic_api_key="my-api-key")
 
             # Simplest invocation, automatically wrapped with HUMAN_PROMPT
             # and AI_PROMPT.

--- a/langchain/llms/bananadev.py
+++ b/langchain/llms/bananadev.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)

--- a/langchain/llms/bananadev.py
+++ b/langchain/llms/bananadev.py
@@ -11,8 +11,10 @@ from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
 
+
 class BananaAuthStrategy(EnvAuthStrategy):
     name = "BANANA_API_KEY"
+
 
 class Banana(LLM, BaseModel):
     """Wrapper around Banana large language models.
@@ -28,6 +30,7 @@ class Banana(LLM, BaseModel):
             from langchain.llms import Banana
             banana = Banana(model_id="...")
     """
+
     id = "banana"
     """Unique ID for this provider class."""
 

--- a/langchain/llms/bananadev.py
+++ b/langchain/llms/bananadev.py
@@ -105,13 +105,13 @@ class Banana(LLM, BaseModel):
             )
         params = self.model_kwargs or {}
         api_key = self.banana_api_key
-        model_key = self.model_id
+        model_id = self.model_id
         model_inputs = {
             # a json specific to your model.
             "prompt": prompt,
             **params,
         }
-        response = banana.run(api_key, model_key, model_inputs)
+        response = banana.run(api_key, model_id, model_inputs)
         try:
             text = response["modelOutputs"][0]["output"]
         except (KeyError, TypeError):

--- a/langchain/llms/base.py
+++ b/langchain/llms/base.py
@@ -255,15 +255,10 @@ class BaseLLM(BaseLanguageModel, BaseModel, ABC):
         cls_name = f"\033[1m{self.__class__.__name__}\033[0m"
         return f"{cls_name}\nParams: {self._identifying_params}"
 
-    @property
-    @abstractmethod
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-
     def dict(self, **kwargs: Any) -> Dict:
         """Return a dictionary of the LLM."""
         starter_dict = dict(self._identifying_params)
-        starter_dict["_type"] = self._llm_type
+        starter_dict["_type"] = self.id
         return starter_dict
 
     def save(self, file_path: Union[Path, str]) -> None:

--- a/langchain/llms/cerebriumai.py
+++ b/langchain/llms/cerebriumai.py
@@ -11,8 +11,10 @@ from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
 
+
 class CerebriumAuthStrategy(EnvAuthStrategy):
     name = "CEREBRIUMAI_API_KEY"
+
 
 class CerebriumAI(LLM, BaseModel):
     """Wrapper around CerebriumAI large language models.

--- a/langchain/llms/cerebriumai.py
+++ b/langchain/llms/cerebriumai.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)

--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -11,8 +11,10 @@ from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
 
+
 class CohereAuthStrategy(EnvAuthStrategy):
     name = "COHERE_API_KEY"
+
 
 class Cohere(LLM, BaseModel):
     """Wrapper around Cohere large language models.

--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)

--- a/langchain/llms/cohere.py
+++ b/langchain/llms/cohere.py
@@ -25,7 +25,7 @@ class Cohere(LLM, BaseModel):
         .. code-block:: python
 
             from langchain.llms import Cohere
-            cohere = Cohere(model="gptd-instruct-tft", cohere_api_key="my-api-key")
+            cohere = Cohere(model_id="gptd-instruct-tft", cohere_api_key="my-api-key")
     """
 
     id = "cohere"

--- a/langchain/llms/deepinfra.py
+++ b/langchain/llms/deepinfra.py
@@ -11,8 +11,10 @@ from langchain.utils import get_from_dict_or_env
 
 DEFAULT_MODEL_ID = "google/flan-t5-xl"
 
+
 class DeepInfraAuthStrategy(EnvAuthStrategy):
     name = "DEEPINFRA_API_TOKEN"
+
 
 class DeepInfra(LLM, BaseModel):
     """Wrapper around DeepInfra deployed models.

--- a/langchain/llms/deepinfra.py
+++ b/langchain/llms/deepinfra.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 DEFAULT_MODEL_ID = "google/flan-t5-xl"

--- a/langchain/llms/fake.py
+++ b/langchain/llms/fake.py
@@ -5,17 +5,30 @@ from pydantic import BaseModel
 
 from langchain.llms.base import LLM
 
-
 class FakeListLLM(LLM, BaseModel):
     """Fake LLM wrapper for testing purposes."""
 
-    responses: List
-    i: int = 0
+    id = "fake-list"
+    """Unique ID for this provider class."""
 
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake-list"
+    model_id: str = ""
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = []
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
+    responses: List[str]
+    i: int = 0
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         """First try to lookup in queries, else return 'foo' or 'bar'."""

--- a/langchain/llms/fake.py
+++ b/langchain/llms/fake.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from langchain.llms.base import LLM
 
+
 class FakeListLLM(LLM, BaseModel):
     """Fake LLM wrapper for testing purposes."""
 

--- a/langchain/llms/forefrontai.py
+++ b/langchain/llms/forefrontai.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 

--- a/langchain/llms/forefrontai.py
+++ b/langchain/llms/forefrontai.py
@@ -9,8 +9,10 @@ from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
 from langchain.utils import get_from_dict_or_env
 
+
 class ForefrontAuthStrategy(EnvAuthStrategy):
     name = "FOREFRONTAI_API_KEY"
+
 
 class ForefrontAI(LLM, BaseModel):
     """Wrapper around ForefrontAI large language models.

--- a/langchain/llms/gooseai.py
+++ b/langchain/llms/gooseai.py
@@ -10,8 +10,10 @@ from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
 
+
 class GooseAuthStrategy(EnvAuthStrategy):
     name = "GOOSEAI_API_KEY"
+
 
 class GooseAI(LLM, BaseModel):
     """Wrapper around OpenAI large language models.
@@ -39,7 +41,18 @@ class GooseAI(LLM, BaseModel):
     """
 
     # Reference: https://goose.ai/docs/api/engines
-    models = ["gpt-neo-20b", "gpt-j-6b", "gpt-neo-2-7b", "gpt-neo-1-3b", "gpt-neo-125m", "fairseq-13b", "fairseq-6-7b", "fairseq-2-7b", "fairseq-1-3b", "fairseq-125m"]
+    models = [
+        "gpt-neo-20b",
+        "gpt-j-6b",
+        "gpt-neo-2-7b",
+        "gpt-neo-1-3b",
+        "gpt-neo-125m",
+        "fairseq-13b",
+        "fairseq-6-7b",
+        "fairseq-2-7b",
+        "fairseq-1-3b",
+        "fairseq-125m",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 

--- a/langchain/llms/gooseai.py
+++ b/langchain/llms/gooseai.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)

--- a/langchain/llms/gooseai.py
+++ b/langchain/llms/gooseai.py
@@ -144,7 +144,7 @@ class GooseAI(LLM, BaseModel):
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
         """Get the identifying parameters."""
-        return {**{"model_id", self.model_id}, **self._default_params}
+        return {**{"model_id": self.model_id}, **self._default_params}
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         """Call the GooseAI API."""

--- a/langchain/llms/huggingface_endpoint.py
+++ b/langchain/llms/huggingface_endpoint.py
@@ -11,6 +11,7 @@ from langchain.utils import get_from_dict_or_env
 
 VALID_TASKS = ("text2text-generation", "text-generation")
 
+
 class HfEndpointAuthStrategy(EnvAuthStrategy):
     name = "HUGGINGFACEHUB_API_TOKEN"
 

--- a/langchain/llms/huggingface_endpoint.py
+++ b/langchain/llms/huggingface_endpoint.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 VALID_TASKS = ("text2text-generation", "text-generation")

--- a/langchain/llms/huggingface_hub.py
+++ b/langchain/llms/huggingface_hub.py
@@ -11,6 +11,7 @@ from langchain.utils import get_from_dict_or_env
 DEFAULT_MODEL_ID = "gpt2"
 VALID_TASKS = ("text2text-generation", "text-generation")
 
+
 class HfHubAuthStrategy(EnvAuthStrategy):
     name = "HUGGINGFACEHUB_API_TOKEN"
 

--- a/langchain/llms/huggingface_hub.py
+++ b/langchain/llms/huggingface_hub.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import EnvAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import EnvAuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 DEFAULT_MODEL_ID = "gpt2"

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -44,8 +44,26 @@ class HuggingFacePipeline(LLM, BaseModel):
             hf = HuggingFacePipeline(pipeline=pipe)
     """
 
-    pipeline: Any  #: :meta private:
+    id = "huggingface_pipeline"
+    """Unique ID for this provider class."""
+
     model_id: str = DEFAULT_MODEL_ID
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = ["transformers"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
+    pipeline: Any  #: :meta private:
     """Model name to use."""
     model_kwargs: Optional[dict] = None
     """Key word arguments to pass to the model."""
@@ -141,10 +159,6 @@ class HuggingFacePipeline(LLM, BaseModel):
             **{"model_id": self.model_id},
             **{"model_kwargs": self.model_kwargs},
         }
-
-    @property
-    def _llm_type(self) -> str:
-        return "huggingface_pipeline"
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         response = self.pipeline(prompt)

--- a/langchain/llms/manifest.py
+++ b/langchain/llms/manifest.py
@@ -9,6 +9,26 @@ from langchain.llms.base import LLM
 class ManifestWrapper(LLM, BaseModel):
     """Wrapper around HazyResearch's Manifest library."""
 
+    id = "manifest"
+    """Unique ID for this provider class."""
+
+    model_id: str = ""
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    Not currently supported by Manifest provider.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = ["manifest-ml"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
     client: Any  #: :meta private:
     llm_kwargs: Optional[Dict] = None
 
@@ -36,11 +56,6 @@ class ManifestWrapper(LLM, BaseModel):
     def _identifying_params(self) -> Mapping[str, Any]:
         kwargs = self.llm_kwargs or {}
         return {**self.client.client.get_model_params(), **kwargs}
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "manifest"
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         """Call out to LLM through Manifest."""

--- a/langchain/llms/modal.py
+++ b/langchain/llms/modal.py
@@ -22,12 +22,30 @@ class Modal(LLM, BaseModel):
     Example:
         .. code-block:: python
             from langchain.llms import Modal
-            modal = Modal(endpoint_url="")
+            endpoint_url = "..."
+            modal = Modal(model_id=endpoint_url)
 
     """
 
-    endpoint_url: str = ""
-    """model endpoint to use"""
+    id = "modal"
+    """Unique ID for this provider class."""
+
+    model_id: str
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    For Modal, this is the endpoint URL.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = ["modal-client"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
 
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not
@@ -60,14 +78,9 @@ class Modal(LLM, BaseModel):
     def _identifying_params(self) -> Mapping[str, Any]:
         """Get the identifying parameters."""
         return {
-            **{"endpoint_url": self.endpoint_url},
+            **{"model_id": self.model_id},
             **{"model_kwargs": self.model_kwargs},
         }
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "modal"
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         """Call to Modal endpoint."""

--- a/langchain/llms/modal.py
+++ b/langchain/llms/modal.py
@@ -86,7 +86,7 @@ class Modal(LLM, BaseModel):
         """Call to Modal endpoint."""
         params = self.model_kwargs or {}
         response = requests.post(
-            url=self.endpoint_url,
+            url=self.model_id,
             headers={
                 "Content-Type": "application/json",
             },

--- a/langchain/llms/nlpcloud.py
+++ b/langchain/llms/nlpcloud.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Mapping, Optional
 from pydantic import BaseModel, Extra, Field, root_validator
 
 from langchain.llms.base import LLM
-from langchain.utils import get_from_dict_or_env
 from langchain.schema import EnvAuthStrategy
+from langchain.utils import get_from_dict_or_env
 
 
 class NlpCloudAuthStrategy(EnvAuthStrategy):

--- a/langchain/llms/nlpcloud.py
+++ b/langchain/llms/nlpcloud.py
@@ -7,8 +7,10 @@ from langchain.llms.base import LLM
 from langchain.utils import get_from_dict_or_env
 from langchain.schema import EnvAuthStrategy
 
+
 class NlpCloudAuthStrategy(EnvAuthStrategy):
     name = "NLPCLOUD_API_KEY"
+
 
 class NLPCloud(LLM, BaseModel):
     """Wrapper around NLPCloud large language models.
@@ -44,7 +46,7 @@ class NLPCloud(LLM, BaseModel):
         "it_core_news_lg",
         "ja_ginza_electra",
         "ja_core_news_lg",
-        "lt_core_news_lg"
+        "lt_core_news_lg",
         "nb_core_news_lg",
         "pl_core_news_lg",
         "pt_core_news_lg",
@@ -67,7 +69,7 @@ class NLPCloud(LLM, BaseModel):
         "paraphrase-multilingual-mpnet-base-v2",
         "python-langdetect",
         "stable-diffusion",
-        "whisper"
+        "whisper",
     ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -113,8 +113,10 @@ async def acompletion_with_retry(
 
     return await _completion_with_retry(**kwargs)
 
+
 class OpenAIAuthStrategy(EnvAuthStrategy):
     name = "OPENAI_API_KEY"
+
 
 class BaseOpenAI(BaseLLM, BaseModel):
     """Wrapper around OpenAI large language models.
@@ -525,7 +527,17 @@ class OpenAI(BaseOpenAI):
     # OpenAI model provider supports any model available via
     # `openai.Completion`.
     # Reference: https://platform.openai.com/docs/models/model-endpoint-compatibility
-    models = ['text-davinci-003', 'text-davinci-002', 'text-curie-001', 'text-babbage-001', 'text-ada-001', 'davinci', 'curie', 'babbage', 'ada']
+    models = [
+        "text-davinci-003",
+        "text-davinci-002",
+        "text-curie-001",
+        "text-babbage-001",
+        "text-ada-001",
+        "davinci",
+        "curie",
+        "babbage",
+        "ada",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
@@ -593,7 +605,14 @@ class OpenAIChat(BaseLLM, BaseModel):
     # OpenAI chat model provider supports any model available via
     # `openai.ChatCompletion`.
     # Reference: https://platform.openai.com/docs/models/model-endpoint-compatibility
-    models = ['gpt-4', 'gpt-4-0314', 'gpt-4-32k', 'gpt-4-32k-0314', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0301']
+    models = [
+        "gpt-4",
+        "gpt-4-0314",
+        "gpt-4-32k",
+        "gpt-4-32k-0314",
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0301",
+    ]
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -7,6 +7,7 @@ import warnings
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Dict,
     Generator,
     List,
@@ -27,7 +28,7 @@ from tenacity import (
 )
 
 from langchain.llms.base import BaseLLM
-from langchain.schema import Generation, LLMResult, EnvAuthStrategy
+from langchain.schema import Generation, LLMResult, EnvAuthStrategy, AuthStrategy
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ class BaseOpenAI(BaseLLM, BaseModel):
     pypi_package_deps = ["openai"]
     """List of PyPi package dependencies."""
 
-    auth_strategy = OpenAIAuthStrategy
+    auth_strategy: ClassVar[AuthStrategy] = OpenAIAuthStrategy
     """Authentication/authorization strategy. Declares what credentials are
     required to use this model provider. Generally should not be `None`."""
 

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -28,7 +28,7 @@ from tenacity import (
 )
 
 from langchain.llms.base import BaseLLM
-from langchain.schema import Generation, LLMResult, EnvAuthStrategy, AuthStrategy
+from langchain.schema import AuthStrategy, EnvAuthStrategy, Generation, LLMResult
 from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)

--- a/langchain/llms/petals.py
+++ b/langchain/llms/petals.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Extra, Field, root_validator
 
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
-from langchain.utils import get_from_dict_or_env
 from langchain.schema import EnvAuthStrategy
+from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
 

--- a/langchain/llms/petals.py
+++ b/langchain/llms/petals.py
@@ -11,8 +11,10 @@ from langchain.schema import EnvAuthStrategy
 
 logger = logging.getLogger(__name__)
 
+
 class PetalsAuthStrategy(EnvAuthStrategy):
     name = "HUGGINGFACE_API_KEY"
+
 
 class Petals(LLM, BaseModel):
     """Wrapper around Petals Bloom models.

--- a/langchain/llms/promptlayer_openai.py
+++ b/langchain/llms/promptlayer_openai.py
@@ -11,6 +11,7 @@ from langchain.schema import LLMResult, MultiEnvAuthStrategy
 class PromptLayerOaiAuthStrategy(MultiEnvAuthStrategy):
     names = ["OPENAI_API_KEY", "PROMPTLAYER_API_KEY"]
 
+
 class PromptLayerOpenAI(OpenAI, BaseModel):
     """Wrapper around OpenAI large language models.
 

--- a/langchain/llms/promptlayer_openai.py
+++ b/langchain/llms/promptlayer_openai.py
@@ -5,8 +5,11 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from langchain.llms import OpenAI, OpenAIChat
-from langchain.schema import LLMResult
+from langchain.schema import LLMResult, MultiEnvAuthStrategy
 
+
+class PromptLayerOaiAuthStrategy(MultiEnvAuthStrategy):
+    names = ["OPENAI_API_KEY", "PROMPTLAYER_API_KEY"]
 
 class PromptLayerOpenAI(OpenAI, BaseModel):
     """Wrapper around OpenAI large language models.
@@ -28,8 +31,18 @@ class PromptLayerOpenAI(OpenAI, BaseModel):
         .. code-block:: python
 
             from langchain.llms import PromptLayerOpenAI
-            openai = PromptLayerOpenAI(model_name="text-davinci-003")
+            openai = PromptLayerOpenAI(model_id="text-davinci-003")
     """
+
+    id = "promptlayer-openai"
+    """Unique ID for this provider class."""
+
+    pypi_package_deps = ["openai", "promptlayer"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = PromptLayerOaiAuthStrategy
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
 
     pl_tags: Optional[List[str]]
     return_pl_id: Optional[bool] = False
@@ -126,8 +139,18 @@ class PromptLayerOpenAIChat(OpenAIChat, BaseModel):
         .. code-block:: python
 
             from langchain.llms import PromptLayerOpenAIChat
-            openaichat = PromptLayerOpenAIChat(model_name="gpt-3.5-turbo")
+            openaichat = PromptLayerOpenAIChat(model_id="gpt-3.5-turbo")
     """
+
+    id = "promptlayer-openai-chat"
+    """Unique ID for this provider class."""
+
+    pypi_package_deps = ["openai", "promptlayer"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = PromptLayerOaiAuthStrategy
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
 
     pl_tags: Optional[List[str]]
     return_pl_id: Optional[bool] = False

--- a/langchain/llms/sagemaker_endpoint.py
+++ b/langchain/llms/sagemaker_endpoint.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 
 from pydantic import BaseModel, Extra, root_validator
 
-from langchain.schema import AwsAuthStrategy
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema import AwsAuthStrategy
 
 
 class ContentHandlerBase(ABC):

--- a/langchain/llms/self_hosted.py
+++ b/langchain/llms/self_hosted.py
@@ -124,6 +124,26 @@ class SelfHostedPipeline(LLM, BaseModel):
             )
     """
 
+    id = "self_hosted_llm"
+    """Unique ID for this provider class."""
+
+    model_id: str = ""
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    For SelfHostedPipeline, this is not used.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = ["runhouse"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
     pipeline_ref: Any  #: :meta private:
     client: Any  #: :meta private:
     inference_fn: Callable = _generate_text  #: :meta private:
@@ -203,10 +223,6 @@ class SelfHostedPipeline(LLM, BaseModel):
         return {
             **{"hardware": self.hardware},
         }
-
-    @property
-    def _llm_type(self) -> str:
-        return "self_hosted_llm"
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         return self.client(pipeline=self.pipeline_ref, prompt=prompt, stop=stop)

--- a/langchain/llms/self_hosted_hugging_face.py
+++ b/langchain/llms/self_hosted_hugging_face.py
@@ -149,8 +149,25 @@ class SelfHostedHuggingFaceLLM(SelfHostedPipeline, BaseModel):
                 model_load_fn=get_pipeline, model_id="gpt2", hardware=gpu)
     """
 
-    model_id: str = DEFAULT_MODEL_ID
-    """Hugging Face model_id to load the model."""
+    id = "selfhosted_huggingface_pipeline"
+    """Unique ID for this provider class."""
+
+    model_id = DEFAULT_MODEL_ID
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = ["runhouse"]
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
     task: str = DEFAULT_TASK
     """Hugging Face task (either "text-generation" or "text2text-generation")."""
     device: int = 0
@@ -193,10 +210,6 @@ class SelfHostedHuggingFaceLLM(SelfHostedPipeline, BaseModel):
             **{"model_id": self.model_id},
             **{"model_kwargs": self.model_kwargs},
         }
-
-    @property
-    def _llm_type(self) -> str:
-        return "selfhosted_huggingface_pipeline"
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         return self.client(pipeline=self.pipeline_ref, prompt=prompt, stop=stop)

--- a/langchain/llms/stochasticai.py
+++ b/langchain/llms/stochasticai.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel, Extra, Field, root_validator
 
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
-from langchain.utils import get_from_dict_or_env
 from langchain.schema import EnvAuthStrategy
+from langchain.utils import get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
 

--- a/langchain/llms/stochasticai.py
+++ b/langchain/llms/stochasticai.py
@@ -13,6 +13,7 @@ from langchain.schema import EnvAuthStrategy
 
 logger = logging.getLogger(__name__)
 
+
 class StochasticAuthStrategy(EnvAuthStrategy):
     name = "STOCHASTICAI_API_KEY"
 

--- a/langchain/llms/writer.py
+++ b/langchain/llms/writer.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Extra, root_validator
 
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
-from langchain.utils import get_from_dict_or_env
 from langchain.schema import EnvAuthStrategy
+from langchain.utils import get_from_dict_or_env
 
 
 class WriterAuthStrategy(EnvAuthStrategy):

--- a/langchain/llms/writer.py
+++ b/langchain/llms/writer.py
@@ -9,8 +9,10 @@ from langchain.llms.utils import enforce_stop_tokens
 from langchain.utils import get_from_dict_or_env
 from langchain.schema import EnvAuthStrategy
 
+
 class WriterAuthStrategy(EnvAuthStrategy):
     name = "WRITER_API_KEY"
+
 
 class Writer(LLM, BaseModel):
     """Wrapper around Writer large language models.

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Literal, NamedTuple, Optional, Union
+from typing import Any, ClassVar, Dict, List, Literal, NamedTuple, Optional, Union, Type
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
@@ -184,10 +184,11 @@ class AwsAuthStrategy(BaseModel):
     """Require AWS authentication via Boto3"""
     type: ClassVar[Literal["aws"]] = 'aws'
 
-AuthStrategy = Union[
-    EnvAuthStrategy,
-    MultiEnvAuthStrategy,
-]
+AuthStrategy = Optional[Union[
+    Type[EnvAuthStrategy],
+    Type[MultiEnvAuthStrategy],
+    Type[AwsAuthStrategy],
+]]
 
 class BaseLanguageModel(BaseModel, ABC):
     id: ClassVar[str]
@@ -203,7 +204,7 @@ class BaseLanguageModel(BaseModel, ABC):
     pypi_package_deps: ClassVar[List[str]] = []
     """List of PyPi package dependencies."""
 
-    auth_strategy: ClassVar[Optional[AuthStrategy]] = None
+    auth_strategy: ClassVar[AuthStrategy] = None
     """Authentication/authorization strategy. Declares what credentials are
     required to use this model provider. Generally should not be `None`."""
 

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Literal, NamedTuple, Optional, Union, Type
+from typing import Any, ClassVar, Dict, List, Literal, NamedTuple, Optional, Type, Union
 
 from pydantic import BaseModel, Extra, Field, root_validator
 

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -170,25 +170,35 @@ class PromptValue(BaseModel, ABC):
     def to_messages(self) -> List[BaseMessage]:
         """Return prompt as messages."""
 
+
 class EnvAuthStrategy(BaseModel):
     """Require one auth token via an environment variable."""
-    type: ClassVar[Literal["env"]] = 'env'
+
+    type: ClassVar[Literal["env"]] = "env"
     name: ClassVar[str]
+
 
 class MultiEnvAuthStrategy(BaseModel):
     """Require multiple auth tokens via multiple environment variables."""
-    type: ClassVar[Literal["file"]] = 'file'
+
+    type: ClassVar[Literal["file"]] = "file"
     names: ClassVar[List[str]]
+
 
 class AwsAuthStrategy(BaseModel):
     """Require AWS authentication via Boto3"""
-    type: ClassVar[Literal["aws"]] = 'aws'
 
-AuthStrategy = Optional[Union[
-    Type[EnvAuthStrategy],
-    Type[MultiEnvAuthStrategy],
-    Type[AwsAuthStrategy],
-]]
+    type: ClassVar[Literal["aws"]] = "aws"
+
+
+AuthStrategy = Optional[
+    Union[
+        Type[EnvAuthStrategy],
+        Type[MultiEnvAuthStrategy],
+        Type[AwsAuthStrategy],
+    ]
+]
+
 
 class BaseLanguageModel(BaseModel, ABC):
     id: ClassVar[str]

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -200,10 +200,10 @@ class BaseLanguageModel(BaseModel, ABC):
     """List of supported models by their IDs. For registry providers, this will
     be just ["*"]."""
 
-    pypi_package_deps: ClassVar[List[str]]
+    pypi_package_deps: ClassVar[List[str]] = []
     """List of PyPi package dependencies."""
 
-    auth_strategy: ClassVar[Optional[AuthStrategy]]
+    auth_strategy: ClassVar[Optional[AuthStrategy]] = None
     """Authentication/authorization strategy. Declares what credentials are
     required to use this model provider. Generally should not be `None`."""
 

--- a/tests/integration_tests/chains/test_pal.py
+++ b/tests/integration_tests/chains/test_pal.py
@@ -6,7 +6,7 @@ from langchain.chains.pal.base import PALChain
 
 def test_math_prompt() -> None:
     """Test math prompt."""
-    llm = OpenAI(model_name="code-davinci-002", temperature=0, max_tokens=512)
+    llm = OpenAI(model_id="code-davinci-002", temperature=0, max_tokens=512)
     pal_chain = PALChain.from_math_prompt(llm)
     question = (
         "Jan has three times the number of pets as Marcia. "
@@ -19,7 +19,7 @@ def test_math_prompt() -> None:
 
 def test_colored_object_prompt() -> None:
     """Test colored object prompt."""
-    llm = OpenAI(model_name="code-davinci-002", temperature=0, max_tokens=512)
+    llm = OpenAI(model_id="code-davinci-002", temperature=0, max_tokens=512)
     pal_chain = PALChain.from_colored_object_prompt(llm)
     question = (
         "On the desk, you see two blue booklets, "

--- a/tests/integration_tests/chains/test_react.py
+++ b/tests/integration_tests/chains/test_react.py
@@ -7,7 +7,7 @@ from langchain.llms.openai import OpenAI
 
 def test_react() -> None:
     """Test functionality on a prompt."""
-    llm = OpenAI(temperature=0, model_name="text-davinci-002")
+    llm = OpenAI(temperature=0, model_id="text-davinci-002")
     react = ReActChain(llm=llm, docstore=Wikipedia())
     question = (
         "Author David Chanoff has collaborated with a U.S. Navy admiral "

--- a/tests/integration_tests/chat_models/test_openai.py
+++ b/tests/integration_tests/chat_models/test_openai.py
@@ -79,22 +79,22 @@ def test_chat_openai_streaming() -> None:
     assert isinstance(response, BaseMessage)
 
 
-def test_chat_openai_llm_output_contains_model_name() -> None:
-    """Test llm_output contains model_name."""
+def test_chat_openai_llm_output_contains_model_id() -> None:
+    """Test llm_output contains model_id."""
     chat = ChatOpenAI(max_tokens=10)
     message = HumanMessage(content="Hello")
     llm_result = chat.generate([[message]])
     assert llm_result.llm_output is not None
-    assert llm_result.llm_output["model_name"] == chat.model_name
+    assert llm_result.llm_output["model_id"] == chat.model_id
 
 
-def test_chat_openai_streaming_llm_output_contains_model_name() -> None:
-    """Test llm_output contains model_name."""
+def test_chat_openai_streaming_llm_output_contains_model_id() -> None:
+    """Test llm_output contains model_id."""
     chat = ChatOpenAI(max_tokens=10, streaming=True)
     message = HumanMessage(content="Hello")
     llm_result = chat.generate([[message]])
     assert llm_result.llm_output is not None
-    assert llm_result.llm_output["model_name"] == chat.model_name
+    assert llm_result.llm_output["model_id"] == chat.model_id
 
 
 def test_chat_openai_invalid_streaming_params() -> None:

--- a/tests/integration_tests/llms/test_ai21.py
+++ b/tests/integration_tests/llms/test_ai21.py
@@ -15,7 +15,7 @@ def test_ai21_call() -> None:
 
 def test_ai21_call_experimental() -> None:
     """Test valid call to ai21 with an experimental model."""
-    llm = AI21(maxTokens=10, model="j1-grande-instruct")
+    llm = AI21(maxTokens=10, model_id="j1-grande-instruct")
     output = llm("Say foo:")
     assert isinstance(output, str)
 

--- a/tests/integration_tests/llms/test_anthropic.py
+++ b/tests/integration_tests/llms/test_anthropic.py
@@ -7,14 +7,14 @@ from langchain.llms.anthropic import Anthropic
 
 def test_anthropic_call() -> None:
     """Test valid call to anthropic."""
-    llm = Anthropic(model="bare-nano-0")
+    llm = Anthropic(model_id="bare-nano-0")
     output = llm("Say foo:")
     assert isinstance(output, str)
 
 
 def test_anthropic_streaming() -> None:
     """Test streaming tokens from anthropic."""
-    llm = Anthropic(model="bare-nano-0")
+    llm = Anthropic(model_id="bare-nano-0")
     generator = llm.stream("I'm Pickle Rick")
 
     assert isinstance(generator, Generator)

--- a/tests/integration_tests/llms/test_gooseai.py
+++ b/tests/integration_tests/llms/test_gooseai.py
@@ -12,7 +12,7 @@ def test_gooseai_call() -> None:
 
 def test_gooseai_call_fairseq() -> None:
     """Test valid call to gooseai with fairseq model."""
-    llm = GooseAI(model_name="fairseq-1-3b", max_tokens=10)
+    llm = GooseAI(model_id="fairseq-1-3b", max_tokens=10)
     output = llm("Say foo:")
     assert isinstance(output, str)
 

--- a/tests/integration_tests/llms/test_openai.py
+++ b/tests/integration_tests/llms/test_openai.py
@@ -35,12 +35,12 @@ def test_openai_extra_kwargs() -> None:
         OpenAI(foo=3, model_kwargs={"foo": 2})
 
 
-def test_openai_llm_output_contains_model_name() -> None:
-    """Test llm_output contains model_name."""
+def test_openai_llm_output_contains_model_id() -> None:
+    """Test llm_output contains model_id."""
     llm = OpenAI(max_tokens=10)
     llm_result = llm.generate(["Hello, how are you?"])
     assert llm_result.llm_output is not None
-    assert llm_result.llm_output["model_name"] == llm.model_name
+    assert llm_result.llm_output["model_id"] == llm.model_id
 
 
 def test_openai_stop_valid() -> None:

--- a/tests/integration_tests/llms/test_openai.py
+++ b/tests/integration_tests/llms/test_openai.py
@@ -154,7 +154,7 @@ async def test_openai_async_streaming_callback() -> None:
 
 def test_openai_chat_wrong_class() -> None:
     """Test OpenAIChat with wrong class still works."""
-    llm = OpenAI(model_name="gpt-3.5-turbo")
+    llm = OpenAI(model_id="gpt-3.5-turbo")
     output = llm("Say foo:")
     assert isinstance(output, str)
 

--- a/tests/unit_tests/agents/test_agent.py
+++ b/tests/unit_tests/agents/test_agent.py
@@ -1,38 +1,12 @@
 """Unit tests for agents."""
 
-from typing import Any, List, Mapping, Optional
-
-from pydantic import BaseModel
+from typing import Any
 
 from langchain.agents import AgentExecutor, initialize_agent
 from langchain.agents.tools import Tool
 from langchain.callbacks.base import CallbackManager
-from langchain.llms.base import LLM
+from langchain.llms.fake import FakeListLLM
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
-
-
-class FakeListLLM(LLM, BaseModel):
-    """Fake LLM for testing that outputs elements of a list."""
-
-    responses: List[str]
-    i: int = -1
-
-    def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
-        """Increment counter, and then return response in that index."""
-        self.i += 1
-        print(f"=== Mock Response #{self.i} ===")
-        print(self.responses[self.i])
-        return self.responses[self.i]
-
-    @property
-    def _identifying_params(self) -> Mapping[str, Any]:
-        return {}
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake_list"
-
 
 def _get_agent(**kwargs: Any) -> AgentExecutor:
     """Get agent for testing."""

--- a/tests/unit_tests/agents/test_agent.py
+++ b/tests/unit_tests/agents/test_agent.py
@@ -8,6 +8,7 @@ from langchain.callbacks.base import CallbackManager
 from langchain.llms.fake import FakeListLLM
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
+
 def _get_agent(**kwargs: Any) -> AgentExecutor:
     """Get agent for testing."""
     bad_action_name = "BadAction"

--- a/tests/unit_tests/agents/test_react.py
+++ b/tests/unit_tests/agents/test_react.py
@@ -17,6 +17,7 @@ What isn't there to love about langchain?
 
 Made in 2022."""
 
+
 class FakeDocstore(Docstore):
     """Fake docstore for testing purposes."""
 

--- a/tests/unit_tests/agents/test_react.py
+++ b/tests/unit_tests/agents/test_react.py
@@ -1,16 +1,13 @@
 """Unit tests for ReAct."""
 
-from typing import Any, List, Mapping, Optional, Union
-
-from pydantic import BaseModel
+from typing import Union
 
 from langchain.agents.react.base import ReActChain, ReActDocstoreAgent
 from langchain.agents.tools import Tool
 from langchain.docstore.base import Docstore
 from langchain.docstore.document import Document
-from langchain.llms.base import LLM
-from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import AgentAction
+from langchain.llms.fake import FakeListLLM
 
 _PAGE_CONTENT = """This is a page about LangChain.
 
@@ -19,30 +16,6 @@ It is a really cool framework.
 What isn't there to love about langchain?
 
 Made in 2022."""
-
-_FAKE_PROMPT = PromptTemplate(input_variables=["input"], template="{input}")
-
-
-class FakeListLLM(LLM, BaseModel):
-    """Fake LLM for testing that outputs elements of a list."""
-
-    responses: List[str]
-    i: int = -1
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake_list"
-
-    def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
-        """Increment counter, and then return response in that index."""
-        self.i += 1
-        return self.responses[self.i]
-
-    @property
-    def _identifying_params(self) -> Mapping[str, Any]:
-        return {}
-
 
 class FakeDocstore(Docstore):
     """Fake docstore for testing purposes."""

--- a/tests/unit_tests/agents/test_react.py
+++ b/tests/unit_tests/agents/test_react.py
@@ -6,8 +6,8 @@ from langchain.agents.react.base import ReActChain, ReActDocstoreAgent
 from langchain.agents.tools import Tool
 from langchain.docstore.base import Docstore
 from langchain.docstore.document import Document
-from langchain.schema import AgentAction
 from langchain.llms.fake import FakeListLLM
+from langchain.schema import AgentAction
 
 _PAGE_CONTENT = """This is a page about LangChain.
 

--- a/tests/unit_tests/chains/test_hyde.py
+++ b/tests/unit_tests/chains/test_hyde.py
@@ -1,14 +1,12 @@
 """Test HyDE."""
-from typing import List, Optional
+from typing import List
 
 import numpy as np
-from pydantic import BaseModel
 
 from langchain.chains.hyde.base import HypotheticalDocumentEmbedder
 from langchain.chains.hyde.prompts import PROMPT_MAP
 from langchain.embeddings.base import Embeddings
-from langchain.llms.base import BaseLLM
-from langchain.schema import Generation, LLMResult
+from tests.unit_tests.llms.fake_llm import FakeLLM
 
 
 class FakeEmbeddings(Embeddings):
@@ -21,27 +19,6 @@ class FakeEmbeddings(Embeddings):
     def embed_query(self, text: str) -> List[float]:
         """Return random floats."""
         return list(np.random.uniform(0, 1, 10))
-
-
-class FakeLLM(BaseLLM, BaseModel):
-    """Fake LLM wrapper for testing purposes."""
-
-    n: int = 1
-
-    def _generate(
-        self, prompts: List[str], stop: Optional[List[str]] = None
-    ) -> LLMResult:
-        return LLMResult(generations=[[Generation(text="foo") for _ in range(self.n)]])
-
-    async def _agenerate(
-        self, prompts: List[str], stop: Optional[List[str]] = None
-    ) -> LLMResult:
-        return LLMResult(generations=[[Generation(text="foo") for _ in range(self.n)]])
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake"
 
 
 def test_hyde_from_llm() -> None:

--- a/tests/unit_tests/chains/test_natbot.py
+++ b/tests/unit_tests/chains/test_natbot.py
@@ -1,14 +1,13 @@
 """Test functionality related to natbot."""
 
-from typing import Any, List, Mapping, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
 
 from langchain.chains.natbot.base import NatBotChain
-from langchain.llms.base import LLM
+from tests.unit_tests.llms.fake_llm import FakeLLM as BaseFakeLLM
 
 
-class FakeLLM(LLM, BaseModel):
+class FakeLLM(BaseFakeLLM):
     """Fake LLM wrapper for testing purposes."""
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
@@ -17,15 +16,6 @@ class FakeLLM(LLM, BaseModel):
             return "foo"
         else:
             return "bar"
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake"
-
-    @property
-    def _identifying_params(self) -> Mapping[str, Any]:
-        return {}
 
 
 def test_proper_inputs() -> None:

--- a/tests/unit_tests/chains/test_natbot.py
+++ b/tests/unit_tests/chains/test_natbot.py
@@ -2,7 +2,6 @@
 
 from typing import List, Optional
 
-
 from langchain.chains.natbot.base import NatBotChain
 from tests.unit_tests.llms.fake_llm import FakeLLM as BaseFakeLLM
 

--- a/tests/unit_tests/llms/fake_llm.py
+++ b/tests/unit_tests/llms/fake_llm.py
@@ -9,12 +9,28 @@ from langchain.llms.base import LLM
 class FakeLLM(LLM, BaseModel):
     """Fake LLM wrapper for testing purposes."""
 
-    queries: Optional[Mapping] = None
+    id = "fake"
+    """Unique ID for this provider class."""
 
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake"
+    model_id: str = ""
+    """
+    Model ID to invoke by this provider via generate/agenerate.
+    """
+
+    models = ["*"]
+    """List of supported models by their IDs. For registry providers, this will
+    be just ["*"]."""
+
+    pypi_package_deps = []
+    """List of PyPi package dependencies."""
+
+    auth_strategy = None
+    """Authentication/authorization strategy. Declares what credentials are
+    required to use this model provider. Generally should not be `None`."""
+
+    n: Optional[int] = None
+
+    queries: Optional[Mapping] = None
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
         """First try to lookup in queries, else return 'foo' or 'bar'."""


### PR DESCRIPTION
# Description

This PR implements a standard interface for LLM providers as proposed in #1797. This interface intends to **take the guesswork out of using models via LangChain**. 

- All LLM providers now accept their model ID via the `model_id` kwarg. No more guessing between `model`, `model_name`, `model_id`, `model_key`, or having to reference documentation.

```
hf = HuggingFaceHub(model_id="google/flan-t5-xxl")
```

- Furthermore, providers now directly expose the list of models they support via a class attribute. No more need to read the provider implementation, determine what upstream API is being called, and then referencing the upstream API docs.

```
>>> from langchain.llms import OpenAI
>>> OpenAI.models
['text-davinci-003', 'text-davinci-002', 'text-curie-001', 'text-babbage-001', 'text-ada-001', 'davinci', 'curie', 'babbage', 'ada']
```

- Some providers don’t have a static, well-defined list of models available. For example, in HuggingFaceHub, new models are being uploaded daily. We call these providers **registry providers**, as they mimic the behavior of a package registry. In this case, the list of models is the wildcard specifier:

```
>>> from langchain.llms import HuggingFaceHub
>>> HuggingFaceHub.models
['*']
```

- The standard interface also allows users to do the following **prior to provider instantiation**:
    - Get provider ID by querying `LLM.id`
    - Get list of package dependencies by querying `LLM.pypi_package_deps`
    - Get required authentication by querying `LLM.auth_strategy`, dispatching on `LLM.auth_strategy.type`.
        - For example, a developer determining if some authentication is required would first query `LLM.auth_strategy`. If it’s not `None`, query `LLM.auth_strategy.type`. If this is equal to `"env"`, then the required environment variable is under `LLM.auth_strategy.name`.
        - This can then be used to consolidate the auth validation logic into a single method on the base class, e.g. `BaseLLM#validate_auth()`.

This is how the interface is declared on `BaseLanguageModel`:

```py
class BaseLanguageModel(BaseModel, ABC):
    id: ClassVar[str]
    """Unique ID for this provider class."""

    model_id: str
    """Model ID to invoke by this provider via generate/agenerate."""

    models: ClassVar[List[str]]
    """List of supported models by their IDs. For registry providers, this will
    be just ["*"]."""

    pypi_package_deps: ClassVar[List[str]] = []
    """List of PyPi package dependencies."""

    auth_strategy: ClassVar[AuthStrategy] = None
    """Authentication/authorization strategy. Declares what credentials are
    required to use this model provider. Generally should not be `None`."""
```

# Other changes

- Removes `_llm_type` property in favor of `id`
- Edits most existing documentation to use new provider interface
    - Not yet implemented for `azure_openai_example.ipynb` and `manifest.ipynb`
- Corrects `AlephAlpha` provider ID from `alpeh_alpha` to `aleph_alpha`
- Removes duplicate definitions of `FakeLLM` and `FakeListLLM` providers used in tests

# Related issues

- Closes #1797

# Next steps

- Review and iterate on this PR. I need some help with doing local integration testing, as I don't have all the API keys available to me as of yet.
- Ensure we inform users of this change as much as possible, as it is a large breaking interface change for most providers. (changelog, blog post, Twitter?)
- Decide what to do with `langchain.llms.manifest`
    - The Manifest provider isn’t really describable via this interface because it is a “provider of providers”, and different models and auth strategies exist depending on the value of `client_name`, e.g. `"openai"` or `"cohere"`.
    - Manifest duplicates a lot of the work LangChain does. All of its sub-providers are already implemented in LangChain. **Hence, I think we should remove this provider, as all of its functionality is already available in LangChain today.**
- Consolidate auth validation logic into some base class
- Implement this interface for embeddings
- Update `azure_openai_example.ipynb` and `manifest.ipynb`