### PR TITLE
Add support for YAML Spec Plugins

### DIFF
--- a/langchain/tools/plugin.py
+++ b/langchain/tools/plugin.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import json
+
 import requests
+import yaml
 
 from langchain.tools.base import BaseTool
+
+
+def marshal_spec(txt: str) -> dict:
+    """Convert the yaml or json serialized spec to a dict."""
+    try:
+        return json.loads(txt)
+    except json.JSONDecodeError:
+        return yaml.safe_load(txt)
 
 
 class AIPluginTool(BaseTool):
@@ -17,9 +28,12 @@ class AIPluginTool(BaseTool):
             f"You should only call this ONCE! What is the "
             f"{response['name_for_human']} API useful for? "
         ) + response["description_for_human"]
+        url = response["api"]["url"]
+        open_api_spec_str = requests.get(url).text
+        open_api_spec = marshal_spec(open_api_spec_str)
         api_spec = (
             f"Usage Guide: {response['description_for_model']}\n\n"
-            f"OpenAPI Spec: {requests.get(response['api']['url']).json()}"
+            f"OpenAPI Spec: {open_api_spec}"
         )
         return cls(
             name=response["name_for_model"], description=description, api_spec=api_spec


### PR DESCRIPTION
It's common to use `yaml` for an OpenAPI spec used in the GPT plugins. 

For example: https://www.joinmilo.com/openapi.yaml  or https://api.slack.com/specs/openapi/ai-plugin.yaml (from [Wong2's ChatGPT Plugins List](https://github.com/wong2/chatgpt-plugins)) 

