### PR TITLE
Chat Completions: Gather in agenerate instead of iterate

### DIFF
--- a/langchain/chat_models/base.py
+++ b/langchain/chat_models/base.py
@@ -1,5 +1,5 @@
-from abc import ABC, abstractmethod
 import asyncio
+from abc import ABC, abstractmethod
 from typing import List, Optional
 
 from pydantic import BaseModel, Extra, Field, validator

--- a/langchain/chat_models/base.py
+++ b/langchain/chat_models/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import asyncio
 from typing import List, Optional
 
 from pydantic import BaseModel, Extra, Field, validator
@@ -59,7 +60,7 @@ class BaseChatModel(BaseLanguageModel, BaseModel, ABC):
         self, messages: List[List[BaseMessage]], stop: Optional[List[str]] = None
     ) -> LLMResult:
         """Top Level call"""
-        results = [await self._agenerate(m, stop=stop) for m in messages]
+        results = await asyncio.gather(*[self._agenerate(m, stop=stop) for m in messages])
         llm_output = self._combine_llm_outputs([res.llm_output for res in results])
         generations = [res.generations for res in results]
         return LLMResult(generations=generations, llm_output=llm_output)


### PR DESCRIPTION
Lets use gather here instead of await in list comprehension for better async parallelization.