### PR TITLE
fix: numerous broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library is aimed at assisting in the development of those types of applicat
 
 **🤖 Agents**
 
-- [Documentation](https://langchain.readthedocs.io/en/latest/use_cases/agents.html)
+- [Documentation](https://langchain.readthedocs.io/en/latest/modules/agents.html)
 - End-to-end Example: [GPT+WolframAlpha](https://huggingface.co/spaces/JavaFXpert/Chat-GPT-LangChain)
 
 ## 📖 Documentation

--- a/docs/ecosystem/cohere.md
+++ b/docs/ecosystem/cohere.md
@@ -22,4 +22,4 @@ There exists an Cohere Embeddings wrapper, which you can access with
 ```python
 from langchain.embeddings import CohereEmbeddings
 ```
-For a more detailed walkthrough of this, see [this notebook](../modules/models/text_embedding/examples/embeddings.ipynb)
+For a more detailed walkthrough of this, see [this notebook](../modules/models/text_embedding/examples/cohere.ipynb)

--- a/docs/ecosystem/huggingface.md
+++ b/docs/ecosystem/huggingface.md
@@ -47,7 +47,7 @@ To use a the wrapper for a model hosted on Hugging Face Hub:
 ```python
 from langchain.embeddings import HuggingFaceHubEmbeddings
 ```
-For a more detailed walkthrough of this, see [this notebook](../modules/models/text_embedding/examples/embeddings.ipynb)
+For a more detailed walkthrough of this, see [this notebook](../modules/models/text_embedding/examples/huggingfacehub.ipynb)
 
 ### Tokenizer
 
@@ -59,7 +59,7 @@ You can also use it to count tokens when splitting documents with
 from langchain.text_splitter import CharacterTextSplitter
 CharacterTextSplitter.from_huggingface_tokenizer(...)
 ```
-For a more detailed walkthrough of this, see [this notebook](../modules/indexes/text_splitters/examples/textsplitter.ipynb)
+For a more detailed walkthrough of this, see [this notebook](../modules/indexes/text_splitters/examples/huggingface_length_function.ipynb)
 
 
 ### Datasets

--- a/docs/ecosystem/openai.md
+++ b/docs/ecosystem/openai.md
@@ -31,7 +31,7 @@ There exists an OpenAI Embeddings wrapper, which you can access with
 ```python
 from langchain.embeddings import OpenAIEmbeddings
 ```
-For a more detailed walkthrough of this, see [this notebook](../modules/models/text_embedding/examples/embeddings.ipynb)
+For a more detailed walkthrough of this, see [this notebook](../modules/models/text_embedding/examples/openai.ipynb)
 
 
 ### Tokenizer
@@ -44,7 +44,7 @@ You can also use it to count tokens when splitting documents with
 from langchain.text_splitter import CharacterTextSplitter
 CharacterTextSplitter.from_tiktoken_encoder(...)
 ```
-For a more detailed walkthrough of this, see [this notebook](../modules/indexes/text_splitters/examples/textsplitter.ipynb)
+For a more detailed walkthrough of this, see [this notebook](../modules/indexes/text_splitters/examples/tiktoken.ipynb)
 
 ### Moderation
 You can also access the OpenAI content moderation endpoint with

--- a/docs/ecosystem/promptlayer.md
+++ b/docs/ecosystem/promptlayer.md
@@ -40,10 +40,10 @@ for res in llm_results.generations:
 ```
 You can use the PromptLayer request ID to add a prompt, score, or other metadata to your request. [Read more about it here](https://magniv.notion.site/Track-4deee1b1f7a34c1680d085f82567dab9).
 
-This LLM is identical to the [OpenAI LLM](./openai), except that
+This LLM is identical to the [OpenAI LLM](./openai.md), except that
 - all your requests will be logged to your PromptLayer account
 - you can add `pl_tags` when instantializing to tag your requests on PromptLayer
 - you can add `return_pl_id` when instantializing to return a PromptLayer request id to use [while tracking requests](https://magniv.notion.site/Track-4deee1b1f7a34c1680d085f82567dab9).
 
 
-PromptLayer also provides native wrappers for [`PromptLayerChatOpenAI`](../modules/models/chat/examples/promptlayer_chat_openai.ipynb) and `PromptLayerOpenAIChat`
+PromptLayer also provides native wrappers for [`PromptLayerChatOpenAI`](../modules/models/chat/integrations/promptlayer_chatopenai.ipynb) and `PromptLayerOpenAIChat`

--- a/docs/ecosystem/runhouse.md
+++ b/docs/ecosystem/runhouse.md
@@ -26,6 +26,4 @@ the `SelfHostedEmbedding` class.
 from langchain.llms import SelfHostedPipeline, SelfHostedHuggingFaceLLM
 ```
 
-For a more detailed walkthrough of the Self-hosted Embeddings, see [this notebook](../modules/models/text_embedding/examples/embeddings.ipynb)
-
-##
+For a more detailed walkthrough of the Self-hosted Embeddings, see [this notebook](../modules/models/text_embedding/examples/self-hosted.ipynb)

--- a/docs/getting_started/getting_started.md
+++ b/docs/getting_started/getting_started.md
@@ -74,7 +74,7 @@ print(llm(text))
 Feetful of Fun
 ```
 
-For more details on how to use LLMs within LangChain, see the [LLM getting started guide](../modules/llms/getting_started.ipynb).
+For more details on how to use LLMs within LangChain, see the [LLM getting started guide](../modules/models/llms/getting_started.ipynb).
 `````
 
 
@@ -111,7 +111,7 @@ What is a good name for a company that makes colorful socks?
 ```
 
 
-[For more details, check out the getting started guide for prompts.](../modules/prompts/getting_started.ipynb)
+[For more details, check out the getting started guide for prompts.](../modules/prompts/chat_prompt_template.ipynb)
 
 `````
 

--- a/docs/modules/prompts/prompt_templates/getting_started.md
+++ b/docs/modules/prompts/prompt_templates/getting_started.md
@@ -238,4 +238,4 @@ print(dynamic_prompt.format(input=long_string))
 <!-- TODO(shreya): Add correct link here. -->
 LangChain comes with a few example selectors that you can use. For more details on how to use them, see [Example Selectors](../example_selectors.rst).
 
-You can create custom example selectors that select examples based on any criteria you want. For more details on how to do this, see [Creating a custom example selector](prompt_templates/examples/custom_example_selector.ipynb).
+You can create custom example selectors that select examples based on any criteria you want. For more details on how to do this, see [Creating a custom example selector](../example_selectors/examples/custom_example_selector.md).


### PR DESCRIPTION
seems linkchecker isn't catching them because it runs on generated html. at that point the links are already missing.
the generation process seems to strip invalid references when they can't be re-written from md to html.

I used https://github.com/tcort/markdown-link-check to check the doc source directly. 

There are a few false positives on localhost for development.