### PR TITLE
add token reduction to ConversationalRetrievalChain

### DIFF
--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -131,9 +131,7 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain, BaseModel):
             self.combine_docs_chain, StuffDocumentsChain
         ):
             tokens = [
-                self.combine_docs_chain.llm_chain.llm.get_num_tokens(
-                    doc.page_content
-                )
+                self.combine_docs_chain.llm_chain.llm.get_num_tokens(doc.page_content)
                 for doc in docs
             ]
             token_count = sum(tokens[:num_docs])

--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -118,16 +118,14 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain, BaseModel):
 
     retriever: BaseRetriever
     """Index to connect to."""
-    reduce_k_below_max_tokens: bool = False
-    """Reduce the number of results to return from store based on tokens limit"""
-    max_tokens_limit: int = 3375
-    """Restrict the docs to return from store based on tokens,
-    enforced only for StuffDocumentChain and if reduce_k_below_max_tokens is to true"""
+    max_tokens_limit: Optional[int] = None
+    """If set, restricts the docs to return from store based on tokens, enforced only
+    for StuffDocumentChain"""
 
     def _reduce_tokens_below_limit(self, docs: List[Document]) -> List[Document]:
         num_docs = len(docs)
 
-        if self.reduce_k_below_max_tokens and isinstance(
+        if self.max_tokens_limit and isinstance(
             self.combine_docs_chain, StuffDocumentsChain
         ):
             tokens = [


### PR DESCRIPTION
This worked for me, but I'm not sure if its the right way to approach something like this, so I'm open to suggestions.

Adds class property`max_tokens_limit: Optional[int]` to the `ConversationalRetrievalChain`. The code is basically copied from [`RetreivalQAWithSourcesChain`](https://github.com/nkov/langchain/blob/46d141c6cb6c0fdebb308336d8ae140d8368945a/langchain/chains/qa_with_sources/retrieval.py#L24)