### PR TITLE
Fix issue#1645: Parse llm_output even there's newline

### DIFF
--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -40,7 +40,8 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     """
     if FINAL_ANSWER_ACTION in llm_output:
         return "Final Answer", llm_output.split(FINAL_ANSWER_ACTION)[-1].strip()
-    regex = r"Action: (.*?)[\n]*Action Input:[\s]*(.*)"  # \s matches against tab/newline/whitespace
+    # \s matches against tab/newline/whitespace
+    regex = r"Action: (.*?)[\n]*Action Input:[\s]*(.*)"
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
         raise ValueError(f"Could not parse LLM output: `{llm_output}`")

--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -40,7 +40,7 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     """
     if FINAL_ANSWER_ACTION in llm_output:
         return "Final Answer", llm_output.split(FINAL_ANSWER_ACTION)[-1].strip()
-    regex = r"Action: (.*?)[\n]*Action Input: (.*)"
+    regex = r"Action: (.*?)[\n]*Action Input:[\s]*(.*)"  # \s matches against tab/newline/whitespace
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
         raise ValueError(f"Could not parse LLM output: `{llm_output}`")

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -27,6 +27,14 @@ def test_get_action_and_input_whitespace() -> None:
     assert action_input == "NBA"
 
 
+def test_get_action_and_input_newline() -> None:
+    """Test getting an action from text where Action Input is a code snippet."""
+    llm_output = "Now I need to write a unittest for the function.\n\nAction: Python\nAction Input:\n```\nimport unittest\n\nunittest.main()\n```"
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "Python"
+    assert action_input == "```\nimport unittest\n\nunittest.main()\n```"
+
+
 def test_get_final_answer() -> None:
     """Test getting final answer."""
     llm_output = (

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -29,7 +29,10 @@ def test_get_action_and_input_whitespace() -> None:
 
 def test_get_action_and_input_newline() -> None:
     """Test getting an action from text where Action Input is a code snippet."""
-    llm_output = "Now I need to write a unittest for the function.\n\nAction: Python\nAction Input:\n```\nimport unittest\n\nunittest.main()\n```"
+    llm_output = (
+        "Now I need to write a unittest for the function.\n\n"
+        "Action: Python\nAction Input:\n```\nimport unittest\n\nunittest.main()\n```"
+    )
     action, action_input = get_action_and_input(llm_output)
     assert action == "Python"
     assert action_input == "```\nimport unittest\n\nunittest.main()\n```"


### PR DESCRIPTION
Fix issue#1645: Parse either whitespace or newline after 'Action Input:' in llm_output in mrkl agent.
Unittests added accordingly.