### PR TITLE
Allow engine args in SQLDatabase

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -69,9 +69,9 @@ class SQLDatabase:
         self._metadata.reflect(bind=self._engine)
 
     @classmethod
-    def from_uri(cls, database_uri: str, **kwargs: Any) -> SQLDatabase:
+    def from_uri(cls, database_uri: str, engine_args: Optional[dict] = None, **kwargs: Any) -> SQLDatabase:
         """Construct a SQLAlchemy engine from URI."""
-        return cls(create_engine(database_uri), **kwargs)
+        return cls(create_engine(database_uri, **(engine_args if engine_args is not None else {})), **kwargs)
 
     @property
     def dialect(self) -> str:


### PR DESCRIPTION
Adds a engine_args parameter to pass arbitrary kwargs to the create_engine function. Useful to set db parameters such as statement timeout.
Example:
```
engine_args = {'connect_args': {'options': '-c lock_timeout=30000 -c statement_timeout=30000'}}
db = SQLDatabase.from_uri(db_url, engine_args)
```