### PR TITLE
added unstructured version validation for `headers` parameter

### DIFF
--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -11,17 +11,30 @@ logger = logging.getLogger(__file__)
 class UnstructuredURLLoader(BaseLoader):
     """Loader that uses unstructured to load HTML files."""
 
-    def __init__(self, urls: List[str], continue_on_failure: bool = True):
+    def __init__(self, urls: List[str], continue_on_failure: bool = True, headers: dict = {}):
         """Initialize with file path."""
         try:
             import unstructured  # noqa:F401
+            from unstructured.__version__ import __version__ as __unstructured_version__
+            self.__version = __unstructured_version__
         except ImportError:
             raise ValueError(
                 "unstructured package not found, please install it with "
                 "`pip install unstructured`"
             )
+
+        if not self.__is_headers_available() and len(headers.keys()) != 0:
+            logger.warning("You are using old version of unstructured. The headers parameter is ignored")
+
         self.urls = urls
         self.continue_on_failure = continue_on_failure
+        self.headers = headers
+
+    def __is_headers_available(self) -> bool:
+        _unstructured_version = self.__version.split("-")[0]
+        unstructured_version = tuple([int(x) for x in _unstructured_version.split(".")])
+
+        return unstructured_version >= (0, 5, 7)
 
     def load(self) -> List[Document]:
         """Load file."""
@@ -30,7 +43,10 @@ class UnstructuredURLLoader(BaseLoader):
         docs: List[Document] = list()
         for url in self.urls:
             try:
-                elements = partition_html(url=url)
+                if self.__is_headers_available():
+                    elements = partition_html(url=url, headers=self.headers)
+                else:
+                    elements = partition_html(url=url)
             except Exception as e:
                 if self.continue_on_failure:
                     logger.error(f"Error fetching or processing {url}, exeption: {e}")


### PR DESCRIPTION
Added `headers` parameters for UnstructuredURLLoader.
If the version of `unstructured` is less than 0.5.7 and `headers` is not an empty dict, the user will see a warning (You are using old version of unstructured. The headers parameter is ignored).

Ways to reproduce:
```bash
poetry add unstructured="0.5.6"
```
```python
from langchain.document_loaders import UnstructuredURLLoader
urls = [
     "https://www.understandingwar.org/backgrounder/russian-offensive-campaign-assessment-february-8-2023",
     "https://doesnotexistithinkprobablynotverynotlikely.io",
     "https://www.understandingwar.org/backgrounder/russian-offensive-campaign-assessment-february-9-2023",
 ]
loader = UnstructuredURLLoader(urls=urls, continue_on_failure=False, headers={"User-Agent": "value"})
```
Logs:
```
You are using old version of unstructured. The headers parameter is ignored
```
In this case, headers will not be passed to `partition_html` function.
If the user will create the object of `UnstructuredURLLoader` without the `headers` parameter or with an empty dict, he will not see the warning.


If the unstructured version is equal to or more than 0.5.7, the user will not see the warning after creating the object of `UnstructuredURLLoader` with the `headers` parameter.

---

Closes issue #1944 