### PR TITLE
Modify SQLDatabaseChain prompt to prevent casing errors

### DIFF
--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -4,9 +4,9 @@ from langchain.prompts.prompt import PromptTemplate
 
 _DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results. You can order the results by a relevant column to return the most interesting examples in the database.
 
-Never query for all the columns from a specific table, only ask for a the few relevant columns given the question. Also wrap each column name in double quotes (") to prevent casing errors.
+Never query for all the columns from a specific table, only ask for a the few relevant columns given the question.
 
-Pay attention to use only the column names that you can see in the schema description. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Pay attention to use only the column names that you can see in the schema description. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table. Also wrap each column name in double quotes (") to prevent casing errors.
 
 Use the following format:
 

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -4,7 +4,7 @@ from langchain.prompts.prompt import PromptTemplate
 
 _DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results. You can order the results by a relevant column to return the most interesting examples in the database.
 
-Never query for all the columns from a specific table, only ask for a the few relevant columns given the question.
+Never query for all the columns from a specific table, only ask for a the few relevant columns given the question. Also wrap each column name in double quotes (") to prevent casing errors.
 
 Pay attention to use only the column names that you can see in the schema description. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 


### PR DESCRIPTION
Add 
```
Also wrap each column name in double quotes (") to prevent casing errors.
```
To the prompt so that the query doesn't fail when querying postgres for columns that may contain capital letters. 

Mixed case column names were made common by Prisma ORM.