### PR TITLE
fix(llms): update default AI21 model to j2, as j1 being deprecated

### DIFF
--- a/langchain/llms/ai21.py
+++ b/langchain/llms/ai21.py
@@ -29,10 +29,10 @@ class AI21(LLM, BaseModel):
         .. code-block:: python
 
             from langchain.llms import AI21
-            ai21 = AI21(model="j1-jumbo")
+            ai21 = AI21(model="j2-jumbo-instruct")
     """
 
-    model: str = "j1-jumbo"
+    model: str = "j2-jumbo-instruct"
     """Model name to use."""
 
     temperature: float = 0.7


### PR DESCRIPTION
the j1-* models are marked as [Legacy] in the docs and are expected to be deprecated in 2023-06-01 according to https://docs.ai21.com/docs/jurassic-1-models-legacy

ensured `tests/integration_tests/llms/test_ai21.py` pass.

empirically observed that `j2-jumbo-instruct` works better the `j2-jumbo` in various simple agent chains, as also expected given the prompt templates are mostly zero shot.