### PR TITLE
add missing `source` field to pymupdf output

### DIFF
--- a/langchain/document_loaders/pdf.py
+++ b/langchain/document_loaders/pdf.py
@@ -156,6 +156,7 @@ class PyMuPDFLoader(BasePDFLoader):
                 page_content=page.get_text(**kwargs).encode("utf-8"),
                 metadata=dict(
                     {
+                        "source": file_path,
                         "file_path": file_path,
                         "page_number": page.number + 1,
                         "total_pages": len(doc),


### PR DESCRIPTION
To be consistent with other loaders for use with the `Sources` vector workflows.