### PR TITLE
supported async retriever

### DIFF
--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -86,9 +86,9 @@ class BaseConversationalRetrievalChain(Chain, BaseModel):
         else:
             return {self.output_key: answer}
 
+    @abstractmethod
     async def _aget_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
         """Get docs."""
-        raise NotImplementedError
 
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         question = inputs["question"]
@@ -200,6 +200,9 @@ class ChatVectorDBChain(BaseConversationalRetrievalChain, BaseModel):
         return self.vectorstore.similarity_search(
             question, k=self.top_k_docs_for_context, **full_kwargs
         )
+
+    async def _aget_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
+        raise NotImplementedError("ChatVectorDBChain does not support async")
 
     @classmethod
     def from_llm(

--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -86,6 +86,10 @@ class BaseConversationalRetrievalChain(Chain, BaseModel):
         else:
             return {self.output_key: answer}
 
+    async def _aget_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
+        """Get docs."""
+        raise NotImplementedError
+
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         question = inputs["question"]
         get_chat_history = self.get_chat_history or _get_chat_history
@@ -96,8 +100,7 @@ class BaseConversationalRetrievalChain(Chain, BaseModel):
             )
         else:
             new_question = question
-        # TODO: This blocks the event loop, but it's not clear how to avoid it.
-        docs = self._get_docs(new_question, inputs)
+        docs = await self._aget_docs(new_question, inputs)
         new_inputs = inputs.copy()
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
@@ -141,6 +144,10 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain, BaseModel):
 
     def _get_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
         docs = self.retriever.get_relevant_documents(question)
+        return self._reduce_tokens_below_limit(docs)
+
+    async def _aget_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
+        docs = await self.retriever.aget_relevant_documents(question)
         return self._reduce_tokens_below_limit(docs)
 
     @classmethod

--- a/langchain/chains/qa_with_sources/base.py
+++ b/langchain/chains/qa_with_sources/base.py
@@ -129,6 +129,7 @@ class BaseQAWithSourcesChain(Chain, BaseModel, ABC):
             result["source_documents"] = docs
         return result
 
+    @abstractmethod
     async def _aget_docs(self, inputs: Dict[str, Any]) -> List[Document]:
         """Get docs to run questioning over."""
 

--- a/langchain/chains/qa_with_sources/retrieval.py
+++ b/langchain/chains/qa_with_sources/retrieval.py
@@ -44,3 +44,8 @@ class RetrievalQAWithSourcesChain(BaseQAWithSourcesChain, BaseModel):
         question = inputs[self.question_key]
         docs = self.retriever.get_relevant_documents(question)
         return self._reduce_tokens_below_limit(docs)
+
+    async def _aget_docs(self, inputs: Dict[str, Any]) -> List[Document]:
+        question = inputs[self.question_key]
+        docs = await self.retriever.aget_relevant_documents(question)
+        return self._reduce_tokens_below_limit(docs)

--- a/langchain/chains/qa_with_sources/vector_db.py
+++ b/langchain/chains/qa_with_sources/vector_db.py
@@ -52,6 +52,9 @@ class VectorDBQAWithSourcesChain(BaseQAWithSourcesChain, BaseModel):
         )
         return self._reduce_tokens_below_limit(docs)
 
+    async def _aget_docs(self, inputs: Dict[str, Any]) -> List[Document]:
+        raise NotImplementedError("VectorDBQAWithSourcesChain does not support async")
+
     @root_validator()
     def raise_deprecation(cls, values: Dict) -> Dict:
         warnings.warn(

--- a/langchain/chains/retrieval_qa/base.py
+++ b/langchain/chains/retrieval_qa/base.py
@@ -114,6 +114,7 @@ class BaseRetrievalQA(Chain, BaseModel):
         else:
             return {self.output_key: answer}
 
+    @abstractmethod
     async def _aget_docs(self, question: str) -> List[Document]:
         """Get documents to do question answering over."""
 
@@ -207,7 +208,7 @@ class VectorDBQA(BaseRetrievalQA, BaseModel):
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
 
-    async def _aget_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
+    async def _aget_docs(self, question: str) -> List[Document]:
         raise NotImplementedError("VectorDBQA does not support async")
 
     @property

--- a/langchain/chains/retrieval_qa/base.py
+++ b/langchain/chains/retrieval_qa/base.py
@@ -207,6 +207,9 @@ class VectorDBQA(BaseRetrievalQA, BaseModel):
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
 
+    async def _aget_docs(self, question: str, inputs: Dict[str, Any]) -> List[Document]:
+        raise NotImplementedError("VectorDBQA does not support async")
+
     @property
     def _chain_type(self) -> str:
         """Return the chain type."""

--- a/langchain/chains/retrieval_qa/base.py
+++ b/langchain/chains/retrieval_qa/base.py
@@ -114,6 +114,33 @@ class BaseRetrievalQA(Chain, BaseModel):
         else:
             return {self.output_key: answer}
 
+    async def _aget_docs(self, question: str) -> List[Document]:
+        """Get documents to do question answering over."""
+
+    async def _acall(self, inputs: Dict[str, str]) -> Dict[str, Any]:
+        """Run get_relevant_text and llm on input query.
+
+        If chain has 'return_source_documents' as 'True', returns
+        the retrieved documents as well under the key 'source_documents'.
+
+        Example:
+        .. code-block:: python
+
+        res = indexqa({'query': 'This is my query'})
+        answer, docs = res['result'], res['source_documents']
+        """
+        question = inputs[self.input_key]
+
+        docs = await self._aget_docs(question)
+        answer, _ = await self.combine_documents_chain.acombine_docs(
+            docs, question=question
+        )
+
+        if self.return_source_documents:
+            return {self.output_key: answer, "source_documents": docs}
+        else:
+            return {self.output_key: answer}
+
 
 class RetrievalQA(BaseRetrievalQA, BaseModel):
     """Chain for question-answering against an index.
@@ -133,6 +160,9 @@ class RetrievalQA(BaseRetrievalQA, BaseModel):
 
     def _get_docs(self, question: str) -> List[Document]:
         return self.retriever.get_relevant_documents(question)
+
+    async def _aget_docs(self, question: str) -> List[Document]:
+        return await self.retriever.aget_relevant_documents(question)
 
 
 class VectorDBQA(BaseRetrievalQA, BaseModel):

--- a/langchain/retrievers/chatgpt_plugin_retriever.py
+++ b/langchain/retrievers/chatgpt_plugin_retriever.py
@@ -1,5 +1,6 @@
-from typing import List
+from typing import List, Optional
 
+import aiohttp
 import requests
 from pydantic import BaseModel
 
@@ -9,6 +10,7 @@ from langchain.schema import BaseRetriever, Document
 class ChatGPTPluginRetriever(BaseRetriever, BaseModel):
     url: str
     bearer_token: str
+    aiosession: Optional[aiohttp.ClientSession] = None
 
     def get_relevant_documents(self, query: str) -> List[Document]:
         response = requests.post(
@@ -20,6 +22,31 @@ class ChatGPTPluginRetriever(BaseRetriever, BaseModel):
             },
         )
         results = response.json()["results"][0]["results"]
+        docs = []
+        for d in results:
+            content = d.pop("text")
+            docs.append(Document(page_content=content, metadata=d))
+        return docs
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        url = f"{self.url}/query"
+        json = {"queries": [{"query": query}]}
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.bearer_token}",
+        }
+
+        if not self.aiosession:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json=json) as response:
+                    res = await response.json()
+        else:
+            async with self.aiosession.post(
+                url, headers=headers, json=json
+            ) as response:
+                res = await response.json()
+
+        results = res["results"][0]["results"]
         docs = []
         for d in results:
             content = d.pop("text")

--- a/langchain/retrievers/chatgpt_plugin_retriever.py
+++ b/langchain/retrievers/chatgpt_plugin_retriever.py
@@ -12,6 +12,11 @@ class ChatGPTPluginRetriever(BaseRetriever, BaseModel):
     bearer_token: str
     aiosession: Optional[aiohttp.ClientSession] = None
 
+    class Config:
+        """Configuration for this pydantic object."""
+
+        arbitrary_types_allowed = True
+
     def get_relevant_documents(self, query: str) -> List[Document]:
         response = requests.post(
             f"{self.url}/query",

--- a/langchain/retrievers/llama_index.py
+++ b/langchain/retrievers/llama_index.py
@@ -33,6 +33,9 @@ class LlamaIndexRetriever(BaseRetriever, BaseModel):
             )
         return docs
 
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        raise NotImplementedError("LlamaIndexRetriever does not support async")
+
 
 class LlamaIndexGraphRetriever(BaseRetriever, BaseModel):
     """Question-answering with sources over an LlamaIndex graph data structure."""
@@ -69,3 +72,6 @@ class LlamaIndexGraphRetriever(BaseRetriever, BaseModel):
                 Document(page_content=source_node.source_text, metadata=metadata)
             )
         return docs
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        raise NotImplementedError("LlamaIndexGraphRetriever does not support async")

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -259,6 +259,17 @@ class BaseRetriever(ABC):
             List of relevant documents
         """
 
+    @abstractmethod
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        """Get documents relevant for a query.
+
+        Args:
+            query: string to find relevant documents for
+
+        Returns:
+            List of relevant documents
+        """
+
 
 # For backwards compatibility
 

--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -159,3 +159,6 @@ class VectorStoreRetriever(BaseRetriever, BaseModel):
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        raise NotImplementedError("VectorStoreRetriever does not support async")

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -375,3 +375,6 @@ class RedisVectorStoreRetriever(BaseRetriever, BaseModel):
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        raise NotImplementedError("RedisVectorStoreRetriever does not support async")


### PR DESCRIPTION
Async support for all retrievers,

Our company (NOT A HOTEL - [@notahotel_inc](https://twitter.com/notahotel_inc)) runs LangChain in production and we have our own VectorDBQA with Async support.

Today it has been modified to use Retriever instead of that VectorDBQA. I thought some of the modifications might contribute to LangChain, so I created this PR.

Thanks for a great library.