### PR TITLE
Remove extra markdown if included in Python REPL from LLM

### DIFF
--- a/langchain/python.py
+++ b/langchain/python.py
@@ -6,14 +6,25 @@ from typing import Dict, Optional
 from pydantic import BaseModel, Field
 
 
+def remove_backticks_if_they_exist(command: str) -> str:
+    if (len(command) >= 6 and command[:3] == "```" and command[:3] == "```"):
+        command = command[3:-3]
+    return command
+
+
 class PythonREPL(BaseModel):
     """Simulates a standalone Python REPL."""
 
     globals: Optional[Dict] = Field(default_factory=dict, alias="_globals")
     locals: Optional[Dict] = Field(default_factory=dict, alias="_locals")
 
+    
+    
     def run(self, command: str) -> str:
         """Run command with own globals/locals and returns anything printed."""
+        # Ignore any backticks if provided by chat models, ChatGPT does this
+        command = remove_backticks_if_they_exist(command)
+            
         old_stdout = sys.stdout
         sys.stdout = mystdout = StringIO()
         try:

--- a/tests/unit_tests/test_python.py
+++ b/tests/unit_tests/test_python.py
@@ -1,6 +1,25 @@
 """Test functionality of Python REPL."""
+import pytest
 
-from langchain.python import PythonREPL
+from langchain.python import PythonREPL, remove_enclosing_markdown_for_python
+
+
+@pytest.mark.parametrize(
+    "enclosing_markdown",
+    [
+        "`{}`",
+        "```{}```",
+        "```python\n{}\n```",
+    ],
+)
+def test_markdown_removal(enclosing_markdown: str) -> None:
+    cmd = 'a="```"'  # Set a to be three backticks
+    enclosing_markdown = enclosing_markdown.format(cmd)
+    assert remove_enclosing_markdown_for_python(enclosing_markdown) == cmd
+    repl = PythonREPL()
+    repl.run(cmd)
+    assert repl.locals is not None
+    assert repl.locals["a"] == "```"
 
 
 def test_python_repl() -> None:


### PR DESCRIPTION
I tested with ChatGPT and the code gets wrapped in the markdown backticks so needs to be removed