### PR TITLE
Add `temperature` to ChatOpenAI

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -110,6 +110,8 @@ class ChatOpenAI(BaseChatModel, BaseModel):
     client: Any  #: :meta private:
     model_name: str = "gpt-3.5-turbo"
     """Model name to use."""
+    temperature: float = 0.7
+    """What sampling temperature to use."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not explicitly specified."""
     openai_api_key: Optional[str] = None


### PR DESCRIPTION
Just add `temperature` parameter to ChatOpenAI class.

https://python.langchain.com/en/latest/getting_started/getting_started.html#building-a-language-model-application-chat-models
There are descriptions like `chat = ChatOpenAI(temperature=0)` in the documents, but it is confusing because it is not supported as an explicit parameter.