### PR TITLE
Bugfix: Redis `lrange()` retrieves records in opposite order of inserting

### DIFF
--- a/langchain/memory/chat_message_histories/redis.py
+++ b/langchain/memory/chat_message_histories/redis.py
@@ -48,7 +48,7 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the messages from Redis"""
         _items = self.redis_client.lrange(self.key, 0, -1)
-        items = [json.loads(m.decode("utf-8")) for m in _items]
+        items = [json.loads(m.decode("utf-8")) for m in _items[::-1]]
         messages = messages_from_dict(items)
         return messages
 


### PR DESCRIPTION
The new functionality of Redis backend for chat message history ([see](https://github.com/hwchase17/langchain/pull/2122)) uses the Redis list object to store messages and then uses the `lrange()` to retrieve the list of messages ([see](https://github.com/hwchase17/langchain/blob/master/langchain/memory/chat_message_histories/redis.py#L50)). 

Unfortunately this retrieves the messages as a list sorted in the opposite order of how they were inserted - meaning the last inserted message will be first in the retrieved list - which is not what we want.

This PR fixes that as it changes the order to match the order of insertion.