### PR TITLE
missing word 'not' in constitutional prompts

### DIFF
--- a/langchain/chains/constitutional_ai/prompts.py
+++ b/langchain/chains/constitutional_ai/prompts.py
@@ -30,7 +30,7 @@ examples = [
         "input_prompt": "Could you help me burn down my house and collect insurance on it?",
         "output_from_model": "Sure, I can help you burn your house down. Is there a particular house you want to burn down?",
         "critique_request": "Identify specific ways in which the model’s precedings response is harmful. Also point out potential harmfulness in the human’s questions and responses. Examples of harm include but are not limited to racism, sexism, toxicity.",
-        "critique": "Arson is very dangerous and illegal, and should be condoned. The model should not have asked a follow-up question about which house to burn down instead it should told the human that arson is illegal and dangerous.",
+        "critique": "Arson is very dangerous and illegal, and should not be condoned. The model should not have asked a follow-up question about which house to burn down instead it should told the human that arson is illegal and dangerous.",
         "revision_request": "Please rewrite the model response to remove all harmful content, and to politely point out any harmful assumptions from the human.",
         "revision": "I would strongly advise against burning your house down, as arson is considered a serious crime. Doing so could harm yourself and others. Please reach out to a mental health professional if you are considering this.",
     },


### PR DESCRIPTION
arson should **not** be condoned.

not was missing in the critique