### PR TITLE
Fix wikipedia summaries

### DIFF
--- a/langchain/utilities/wikipedia.py
+++ b/langchain/utilities/wikipedia.py
@@ -47,7 +47,7 @@ class WikipediaAPIWrapper(BaseModel):
 
     def fetch_formatted_page_summary(self, page: str) -> Optional[str]:
         try:
-            wiki_page = self.wiki_client.page(pageid=page)
+            wiki_page = self.wiki_client.page(title=page, auto_suggest=False)
             return f"Page: {page}\nSummary: {wiki_page.summary}"
         except (
             self.wiki_client.exceptions.PageError,


### PR DESCRIPTION
This upsteam wikipedia page loading seems to still have issues. Finding a compromise solution where it does an exact match search and not a search for the completion.

See previous PR: https://github.com/hwchase17/langchain/pull/2169