### PR TITLE
feat: add Dockerfile to run unit tests in a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.venv
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Use the Python base image
+FROM python:3.11.2-bullseye AS builder
+
+# Print Python version
+RUN echo "Python version:" && python --version && echo ""
+
+# Install Poetry
+RUN echo "Installing Poetry..." && \
+    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+
+# Add Poetry to PATH
+ENV PATH="${PATH}:/root/.local/bin"
+
+# Test if Poetry is added to PATH
+RUN echo "Poetry version:" && poetry --version && echo ""
+
+# Set working directory
+WORKDIR /app
+
+# Use a multi-stage build to install dependencies
+FROM builder AS dependencies
+
+# Copy only the dependency files for installation
+COPY pyproject.toml poetry.lock poetry.toml ./
+
+# Install Poetry dependencies (this layer will be cached as long as the dependencies don't change)
+RUN poetry install --no-interaction --no-ansi
+
+# Use a multi-stage build to run tests
+FROM dependencies AS tests
+
+# Copy the rest of the app source code (this layer will be invalidated and rebuilt whenever the source code changes)
+COPY . .
+
+# Set entrypoint to run tests
+ENTRYPOINT ["poetry", "run", "pytest"]
+
+# Set default command to run all unit tests
+CMD ["tests/unit_tests"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: all clean format lint test tests test_watch integration_tests help
+.PHONY: all clean format lint test tests test_watch integration_tests docker_tests help
 
 all: help
-	
+
 coverage:
 	poetry run pytest --cov \
 		--cov-config=.coveragerc \
@@ -40,6 +40,10 @@ test_watch:
 integration_tests:
 	poetry run pytest tests/integration_tests
 
+docker_tests:
+	docker build -t my-langchain-image:test .
+	docker run --rm my-langchain-image:test
+
 help:
 	@echo '----'
 	@echo 'coverage            - run unit tests and generate coverage report'
@@ -51,3 +55,4 @@ help:
 	@echo 'test                - run unit tests'
 	@echo 'test_watch          - run unit tests in watch mode'
 	@echo 'integration_tests   - run integration tests'
+	@echo 'docker_tests        - run unit tests in docker'


### PR DESCRIPTION
This makes it easy to run the tests locally. Some tests may not be able to run in `Windows` environments, hence the need for a `Dockerfile`.  

The new `Dockerfile` sets up a multi-stage build to install Poetry and dependencies, and then copies the project code to a final image for tests.  

The `Makefile` has been updated to include a new 'docker_tests' target that builds the Docker image and runs the `unit tests` inside a container.

It would be beneficial to offer a local testing environment for developers by enabling them to run a Docker image on their local machines with the required dependencies, particularly for integration tests. While this is not included in the current PR, it would be straightforward to add in the future.

This pull request lacks documentation of the changes made at this moment.