### PR TITLE
Add add_system_messsage to BaseChatMessageHistory

### DIFF
--- a/langchain/memory/chat_message_histories/dynamodb.py
+++ b/langchain/memory/chat_message_histories/dynamodb.py
@@ -6,6 +6,7 @@ from langchain.schema import (
     BaseChatMessageHistory,
     BaseMessage,
     HumanMessage,
+    SystemMessage,
     _message_to_dict,
     messages_from_dict,
     messages_to_dict,
@@ -52,6 +53,9 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
 
         messages = messages_from_dict(items)
         return messages
+
+    def add_system_message(self, message: str) -> None:
+        self.append(SystemMessage(content=message))
 
     def add_user_message(self, message: str) -> None:
         self.append(HumanMessage(content=message))

--- a/langchain/memory/chat_message_histories/in_memory.py
+++ b/langchain/memory/chat_message_histories/in_memory.py
@@ -7,11 +7,15 @@ from langchain.schema import (
     BaseChatMessageHistory,
     BaseMessage,
     HumanMessage,
+    SystemMessage,
 )
 
 
 class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
     messages: List[BaseMessage] = []
+
+    def add_system_message(self, message: str) -> None:
+        self.messages.append(SystemMessage(content=message))
 
     def add_user_message(self, message: str) -> None:
         self.messages.append(HumanMessage(content=message))

--- a/langchain/memory/chat_message_histories/redis.py
+++ b/langchain/memory/chat_message_histories/redis.py
@@ -7,6 +7,7 @@ from langchain.schema import (
     BaseChatMessageHistory,
     BaseMessage,
     HumanMessage,
+    SystemMessage,
     _message_to_dict,
     messages_from_dict,
 )
@@ -51,6 +52,9 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         items = [json.loads(m.decode("utf-8")) for m in _items[::-1]]
         messages = messages_from_dict(items)
         return messages
+
+    def add_system_message(self, message: str) -> None:
+        self.append(SystemMessage(content=message))
 
     def add_user_message(self, message: str) -> None:
         self.append(HumanMessage(content=message))

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -259,6 +259,12 @@ class BaseChatMessageHistory(ABC):
                        messages = json.loads(f.read())
                     return messages_from_dict(messages)     
                 
+               def add_system_message(self, message: str):
+                   message_ = SystemMessage(content=message)
+                   messages = self.messages.append(_message_to_dict(_message))
+                   with open(os.path.join(storage_path, session_id), 'w') as f:
+                       json.dump(f, messages)
+               
                def add_user_message(self, message: str):
                    message_ = HumanMessage(content=message)
                    messages = self.messages.append(_message_to_dict(_message))
@@ -277,6 +283,10 @@ class BaseChatMessageHistory(ABC):
     """
 
     messages: List[BaseMessage]
+
+    @abstractmethod
+    def add_system_message(self, message: str) -> None:
+        """Add a system message to the store"""
 
     @abstractmethod
     def add_user_message(self, message: str) -> None:


### PR DESCRIPTION
Adds a new method to BaseChatMessageHistory to add system messages.

I'm not sure if there's a rationale for keeping system messages out of the interface (is this too specific to OpenAI models?), but it seems useful to me to be able to sprinkle them at will.