### PR TITLE
Add `__version__` 

### DIFF
--- a/langchain/__init__.py
+++ b/langchain/__init__.py
@@ -1,5 +1,6 @@
 """Main entrypoint into package."""
 
+from importlib import metadata
 from typing import Optional
 
 from langchain.agents import MRKLChain, ReActChain, SelfAskWithSearchChain
@@ -52,6 +53,9 @@ from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utilities.wikipedia import WikipediaAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 from langchain.vectorstores import FAISS, ElasticVectorSearch
+
+__version__ = metadata.version(__package__)
+del metadata  # optional, avoids polluting the results of dir(__package__)
 
 verbose: bool = False
 llm_cache: Optional[BaseCache] = None


### PR DESCRIPTION
# What does this PR do? 

This PR adds the `__version__` variable in the main `__init__.py` to easily retrieve the version, e.g., for debugging purposes or when a user wants to open an issue and provide information. 

Usage
```python
>>> import langchain
>>> langchain.__version__
'0.0.127'
```


![Bildschirmfoto 2023-03-31 um 10 30 18](https://user-images.githubusercontent.com/32632186/229068621-53d068b5-32f4-4154-ad2c-a3e1cc7e1ef3.png)
