### PR TITLE
Virat/add param to optionally not refresh ES indices

### DIFF
--- a/langchain/vectorstores/elastic_vector_search.py
+++ b/langchain/vectorstores/elastic_vector_search.py
@@ -132,6 +132,7 @@ class ElasticVectorSearch(VectorStore, ABC):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
+        refresh_indices: bool = True,
         **kwargs: Any,
     ) -> List[str]:
         """Run more texts through the embeddings and add to the vectorstore.
@@ -139,6 +140,7 @@ class ElasticVectorSearch(VectorStore, ABC):
         Args:
             texts: Iterable of strings to add to the vectorstore.
             metadatas: Optional list of metadatas associated with the texts.
+            refresh_indices: bool to refresh ElasticSearch indices
 
         Returns:
             List of ids from adding the texts into the vectorstore.
@@ -167,8 +169,9 @@ class ElasticVectorSearch(VectorStore, ABC):
             ids.append(_id)
             requests.append(request)
         bulk(self.client, requests)
-        # TODO: add option not to refresh
-        self.client.indices.refresh(index=self.index_name)
+
+        if refresh_indices:
+            self.client.indices.refresh(index=self.index_name)
         return ids
 
     def similarity_search(


### PR DESCRIPTION
**Context**
Noticed a TODO in `langchain/vectorstores/elastic_vector_search.py` for adding the option to NOT refresh ES indices

**Change**
Added a param to `add_texts()` called `refresh_indices` to not refresh ES indices.  The default value is `True` so that existing behavior does not break.