### PR TITLE
Add Support for Returning Status Code and Reason

### DIFF
--- a/langchain/requests.py
+++ b/langchain/requests.py
@@ -5,12 +5,52 @@ import aiohttp
 import requests
 from pydantic import BaseModel, Extra
 
+REQUEST_RESPONSE_WITH_STATUS_CODES = "{status_code}: {reason}\n\n{text}"
+
+
+def format_response(
+    response: requests.Response,
+    template: Optional[str] = None,
+) -> str:
+    """Format the response as text."""
+    if template is None:
+        return response.text
+    else:
+        response_fields = {
+            "status_code": response.status,
+            "headers": response.headers,
+            "text": response.text,
+            "reason": response.reason,
+        }
+        return template.format(**response_fields)
+
+
+async def aformat_response(
+    response: aiohttp.ClientResponse,
+    template: Optional[str] = None,
+) -> str:
+    if isinstance(response, aiohttp.ClientResponse):
+        text = await response.text()
+    else:
+        raise TypeError("Invalid response type.")
+    if template is None:
+        return text
+    response_fields = {
+        "status_code": response.status,
+        "headers": response.headers,
+        "text": text,
+        "reason": response.reason,
+    }
+    return template.format(**response_fields)
+
 
 class RequestsWrapper(BaseModel):
     """Lightweight wrapper around requests library."""
 
     headers: Optional[Dict[str, str]] = None
     aiosession: Optional[aiohttp.ClientSession] = None
+    # If specified, must
+    response_format_template: Optional[str] = None
 
     class Config:
         """Configuration for this pydantic object."""
@@ -20,23 +60,28 @@ class RequestsWrapper(BaseModel):
 
     def get(self, url: str, **kwargs: Any) -> str:
         """GET the URL and return the text."""
-        return requests.get(url, headers=self.headers, **kwargs).text
+        res = requests.get(url, headers=self.headers, **kwargs)
+        return format_response(res, self.response_format_template)
 
     def post(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
         """POST to the URL and return the text."""
-        return requests.post(url, json=data, headers=self.headers, **kwargs).text
+        res = requests.post(url, json=data, headers=self.headers, **kwargs)
+        return format_response(res, self.response_format_template)
 
     def patch(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
         """PATCH the URL and return the text."""
-        return requests.patch(url, json=data, headers=self.headers, **kwargs).text
+        res = requests.patch(url, json=data, headers=self.headers, **kwargs)
+        return format_response(res, self.response_format_template)
 
     def put(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
         """PUT the URL and return the text."""
-        return requests.put(url, json=data, headers=self.headers, **kwargs).text
+        res = requests.put(url, json=data, headers=self.headers, **kwargs)
+        return format_response(res, self.response_format_template)
 
     def delete(self, url: str, **kwargs: Any) -> str:
         """DELETE the URL and return the text."""
-        return requests.delete(url, headers=self.headers, **kwargs).text
+        res = requests.delete(url, headers=self.headers, **kwargs)
+        return format_response(res, self.response_format_template)
 
     async def _arequest(self, method: str, url: str, **kwargs: Any) -> str:
         """Make an async request."""
@@ -45,12 +90,16 @@ class RequestsWrapper(BaseModel):
                 async with session.request(
                     method, url, headers=self.headers, **kwargs
                 ) as response:
-                    return await response.text()
+                    return await aformat_response(
+                        response, template=self.response_format_template
+                    )
         else:
             async with self.aiosession.request(
                 method, url, headers=self.headers, **kwargs
             ) as response:
-                return await response.text()
+                return await aformat_response(
+                    response, template=self.response_format_template
+                )
 
     async def aget(self, url: str, **kwargs: Any) -> str:
         """GET the URL and return the text asynchronously."""

--- a/langchain/requests.py
+++ b/langchain/requests.py
@@ -49,7 +49,6 @@ class RequestsWrapper(BaseModel):
 
     headers: Optional[Dict[str, str]] = None
     aiosession: Optional[aiohttp.ClientSession] = None
-    # If specified, must
     response_format_template: Optional[str] = None
 
     class Config:


### PR DESCRIPTION
It's common for agents to incorrectly use a tool at first, which can be handled if is able to see the status code and reason information from the server. Calling `.text` on everything strips that information.

This PR doesn't alter the defaults but rather lets the user add a format template similar to common log syntax..