### PR TITLE
skip unit tests that fails in Windows

### DIFF
--- a/tests/unit_tests/chains/test_llm_bash.py
+++ b/tests/unit_tests/chains/test_llm_bash.py
@@ -1,4 +1,5 @@
 """Test LLM Bash functionality."""
+import sys
 
 import pytest
 
@@ -17,6 +18,9 @@ def fake_llm_bash_chain() -> LLMBashChain:
     return LLMBashChain(llm=fake_llm, input_key="q", output_key="a")
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test not supported on Windows"
+)
 def test_simple_question(fake_llm_bash_chain: LLMBashChain) -> None:
     """Test simple question that should not need python."""
     question = "Please write a bash script that prints 'Hello World' to the console."

--- a/tests/unit_tests/test_bash.py
+++ b/tests/unit_tests/test_bash.py
@@ -1,11 +1,17 @@
 """Test the bash utility."""
 import re
 import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 from langchain.utilities.bash import BashProcess
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test not supported on Windows"
+)
 def test_pwd_command() -> None:
     """Test correct functionality."""
     session = BashProcess()
@@ -15,6 +21,9 @@ def test_pwd_command() -> None:
     assert output == subprocess.check_output("pwd", shell=True).decode()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test not supported on Windows"
+)
 def test_incorrect_command() -> None:
     """Test handling of incorrect command."""
     session = BashProcess()
@@ -22,6 +31,9 @@ def test_incorrect_command() -> None:
     assert output == "Command 'invalid_command' returned non-zero exit status 127."
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test not supported on Windows"
+)
 def test_incorrect_command_return_err_output() -> None:
     """Test optional returning of shell output on incorrect command."""
     session = BashProcess(return_err_output=True)
@@ -29,6 +41,9 @@ def test_incorrect_command_return_err_output() -> None:
     assert re.match(r"^/bin/sh:.*invalid_command.*not found.*$", output)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test not supported on Windows"
+)
 def test_create_directory_and_files(tmp_path: Path) -> None:
     """Test creation of a directory and files in a temporary directory."""
     session = BashProcess(strip_newlines=True)


### PR DESCRIPTION
closes #2174
Several unit tests fail in Windows.
Added pytest attribute to skip these tests automatically.