### PR TITLE
Fixed the link to promptlayer dashboard

### DIFF
--- a/docs/modules/models/llms/integrations/promptlayer_openai.ipynb
+++ b/docs/modules/models/llms/integrations/promptlayer_openai.ipynb
@@ -115,7 +115,7 @@
    "id": "a2d76826",
    "metadata": {},
    "source": [
-    "**The above request should now appear on your [PromptLayer dashboard](https://ww.promptlayer.com).**"
+    "**The above request should now appear on your [PromptLayer dashboard](https://www.promptlayer.com).**"
    ]
   },
   {


### PR DESCRIPTION
Fixed a simple error where in the PromptLayer LLM documentation, the "PromptLayer dashboard" hyperlink linked to "https://ww.promptlayer.com" instead of "https://www.promptlayer.com". Solved issue  #2245 