### PR TITLE
[request tool] Preclean text input so it can be successfully converted into a JSON object

### DIFF
--- a/langchain/tools/requests/tool.py
+++ b/langchain/tools/requests/tool.py
@@ -11,7 +11,11 @@ from langchain.tools.base import BaseTool
 
 def _parse_input(text: str) -> Dict[str, Any]:
     """Parse the json string into a dict."""
-    return json.loads(text)
+    return json.loads(_preclean_input(text))
+
+
+def _preclean_input(text: str) -> str:
+    return text.replace("`", "").replace("\n", "").strip()
 
 
 class BaseRequestsTool(BaseModel):


### PR DESCRIPTION
Sometimes when chaining API calls, we have to preclean the output of the preceding step to be successfully converted into a JSON object. This PR adds a `_preclean_input` function that strips out backticks and newlines. 