### PR TITLE
Add AI21Embeddings class text embeddings

### DIFF
--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -9,13 +9,14 @@ class AI21Embeddings:
         Initialize AI21Embeddings with the provided API key.
         """
         ai21.api_key = api_key
-    def __enter__(self):
+
+    def __enter__(self) -> 'AI21Embeddings':
         """
         Enable usage of the 'with' statement for this class.
         """
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """
         Close the AI21Embeddings instance when used with the 'with' statement.
         """
@@ -30,16 +31,16 @@ class AI21Embeddings:
         :return: A list of numpy arrays containing the embeddings.
         """
         prompt = "\n".join([f"Embed the following text as a 768-dimensional vector: {text}" for text in texts])
-        
+
         try:
-            response = self.client.completions.create(
+            response = ai21.Completion.execute(
                 model=model,
                 prompt=prompt,
-                num_results=1,
-                max_tokens=768 * len(texts),
+                numResults=1,
+                maxTokens=768 * len(texts),
                 temperature=0,
-                top_k_return=0,
-                top_p=1
+                topKReturn=0,
+                topP=1
             )
             tokens = response["completions"][0]["data"]["tokens"]
             embeddings = [np.array([token["generatedToken"]["logprob"] for token in tokens[i*768:(i+1)*768]]) for i in range(len(texts))]

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -1,7 +1,7 @@
 import ai21
 import numpy as np
 from scipy.spatial.distance import cosine
-from typing import List, Union
+from typing import List, Union, Any, Optional, Dict
 
 class AI21Embeddings:
     def __init__(self, api_key: str):
@@ -16,7 +16,7 @@ class AI21Embeddings:
         """
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: Optional[type], exc_val: Optional[BaseException], exc_tb: Optional[Any]) -> None:
         """
         Close the AI21Embeddings instance when used with the 'with' statement.
         """

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -2,8 +2,9 @@ from typing import Any, List, Optional, Union
 
 import ai21
 import numpy as np
-from langchain.embeddings.base import Embeddings
 from scipy.spatial.distance import cosine
+
+from langchain.embeddings.base import Embeddings
 
 
 class AI21Embeddings(Embeddings):

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -4,6 +4,7 @@ from scipy.spatial.distance import cosine
 from typing import List, Union, Any, Optional, Dict
 from langchain.embeddings.base import Embeddings
 
+
 class AI21Embeddings(Embeddings):
     def __init__(self, api_key: str):
         """
@@ -11,13 +12,18 @@ class AI21Embeddings(Embeddings):
         """
         ai21.api_key = api_key
 
-    def __enter__(self) -> 'AI21Embeddings':
+    def __enter__(self) -> "AI21Embeddings":
         """
         Enable usage of the 'with' statement for this class.
         """
         return self
 
-    def __exit__(self, exc_type: Optional[type], exc_val: Optional[BaseException], exc_tb: Optional[Any]) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[Any],
+    ) -> None:
         """
         Close the AI21Embeddings instance when used with the 'with' statement.
         """
@@ -31,7 +37,9 @@ class AI21Embeddings(Embeddings):
         embeddings = self.generate_embeddings([text])
         return embeddings[0].tolist()
 
-    def generate_embeddings(self, texts: List[str], model: str = "j2-grande-instruct") -> List[np.ndarray]:
+    def generate_embeddings(
+        self, texts: List[str], model: str = "j2-grande-instruct"
+    ) -> List[np.ndarray]:
         """
         Generate embeddings for a list of texts using the specified model.
 
@@ -39,7 +47,12 @@ class AI21Embeddings(Embeddings):
         :param model: The name of the AI21 model to use for generating embeddings.
         :return: A list of numpy arrays containing the embeddings.
         """
-        prompt = "\n".join([f"Embed the following text as a 768-dimensional vector: {text}" for text in texts])
+        prompt = "\n".join(
+            [
+                f"Embed the following text as a 768-dimensional vector: {text}"
+                for text in texts
+            ]
+        )
 
         try:
             response: dict = ai21.Completion.execute(
@@ -49,16 +62,26 @@ class AI21Embeddings(Embeddings):
                 maxTokens=768 * len(texts),
                 temperature=0,
                 topKReturn=0,
-                topP=1
+                topP=1,
             )
             tokens = response["completions"][0]["data"]["tokens"]
-            embeddings = [np.array([token["generatedToken"]["logprob"] for token in tokens[i*768:(i+1)*768]]) for i in range(len(texts))]
+            embeddings = [
+                np.array(
+                    [
+                        token["generatedToken"]["logprob"]
+                        for token in tokens[i * 768 : (i + 1) * 768]
+                    ]
+                )
+                for i in range(len(texts))
+            ]
             return embeddings
         except Exception as e:
             print(f"Error while generating embeddings: {e}")
             return []
 
-    def get_similarity(self, text1: str, text2: str, model: str = "j2-grande-instruct") -> Union[float, None]:
+    def get_similarity(
+        self, text1: str, text2: str, model: str = "j2-grande-instruct"
+    ) -> Union[float, None]:
         """
         Calculate the similarity between two texts using the specified model.
 

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -1,8 +1,9 @@
+from typing import Any, List, Optional, Union
+
 import ai21
 import numpy as np
-from scipy.spatial.distance import cosine
-from typing import List, Union, Any, Optional, Dict
 from langchain.embeddings.base import Embeddings
+from scipy.spatial.distance import cosine
 
 
 class AI21Embeddings(Embeddings):

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -1,16 +1,14 @@
-# langchain/langchain/embeddings/AI21.py
-
 import ai21
 import numpy as np
 from scipy.spatial.distance import cosine
+from typing import List, Union
 
 class AI21Embeddings:
-    def __init__(self, api_key):
+    def __init__(self, api_key: str):
         """
         Initialize AI21Embeddings with the provided API key.
         """
-        self.client = ai21.Client(api_key)
-
+        ai21.api_key = api_key
     def __enter__(self):
         """
         Enable usage of the 'with' statement for this class.
@@ -23,7 +21,7 @@ class AI21Embeddings:
         """
         pass
 
-    def generate_embeddings(self, texts, model="j2-grande-instruct"):
+    def generate_embeddings(self, texts: List[str], model: str = "j2-grande-instruct") -> List[np.ndarray]:
         """
         Generate embeddings for a list of texts using the specified model.
 
@@ -50,7 +48,7 @@ class AI21Embeddings:
             print(f"Error while generating embeddings: {e}")
             return []
 
-    def get_similarity(self, text1, text2, model="j2-grande-instruct"):
+    def get_similarity(self, text1: str, text2: str, model: str = "j2-grande-instruct") -> Union[float, None]:
         """
         Calculate the similarity between two texts using the specified model.
 

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -33,7 +33,7 @@ class AI21Embeddings:
         prompt = "\n".join([f"Embed the following text as a 768-dimensional vector: {text}" for text in texts])
 
         try:
-            response = ai21.Completion.execute(
+            response: dict = ai21.Completion.execute(
                 model=model,
                 prompt=prompt,
                 numResults=1,

--- a/langchain/embeddings/ai21.py
+++ b/langchain/embeddings/ai21.py
@@ -2,8 +2,9 @@ import ai21
 import numpy as np
 from scipy.spatial.distance import cosine
 from typing import List, Union, Any, Optional, Dict
+from langchain.embeddings.base import Embeddings
 
-class AI21Embeddings:
+class AI21Embeddings(Embeddings):
     def __init__(self, api_key: str):
         """
         Initialize AI21Embeddings with the provided API key.
@@ -21,6 +22,14 @@ class AI21Embeddings:
         Close the AI21Embeddings instance when used with the 'with' statement.
         """
         pass
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        embeddings = self.generate_embeddings(texts)
+        return [embedding.tolist() for embedding in embeddings]
+
+    def embed_query(self, text: str) -> List[float]:
+        embeddings = self.generate_embeddings([text])
+        return embeddings[0].tolist()
 
     def generate_embeddings(self, texts: List[str], model: str = "j2-grande-instruct") -> List[np.ndarray]:
         """


### PR DESCRIPTION
This pull request adds the AI21Embeddings class to the langchain/langchain/embeddings module, providing support for generating text embeddings using the AI21 language model. The new class offers a similar interface as the existing OpenAIEmbeddings class, making it easy to integrate into the existing codebase.

The AI21Embeddings class has the following main methods:

generate_embeddings(texts, model): Generates embeddings for a list of texts using the specified AI21 model.
get_similarity(text1, text2, model): Calculates the similarity between two texts using the specified AI21 model.
The implementation uses the AI21 Python SDK for interacting with the AI21 API and requires an API key for initialization. The class is designed to be flexible and easy to use, allowing users to switch between different AI21 models by simply providing the model name as an argument.

This PR addresses issue #85 and provides an alternative to the existing OpenAI-based text embeddings.

Please let me know if you have any questions or need further changes.