### PR TITLE
Expand requests tool into individual methods for load_tools

### DIFF
--- a/langchain/agents/load_tools.py
+++ b/langchain/agents/load_tools.py
@@ -258,10 +258,10 @@ def load_tools(
     for name in tool_names:
         if name == "requests":
             # expand requests into various methods
-            request_method_tools = [
+            requests_method_tools = [
                 _tool for _tool in _BASE_TOOLS if _tool.startswith("requests_")
             ]
-            tool_names.extend(request_method_tools)
+            tool_names.extend(requests_method_tools)
         elif name in _BASE_TOOLS:
             tools.append(_BASE_TOOLS[name]())
         elif name in _LLM_TOOLS:

--- a/langchain/agents/load_tools.py
+++ b/langchain/agents/load_tools.py
@@ -263,7 +263,7 @@ def load_tools(
             ]
             tool_names.extend(request_method_tools)
         elif name in _BASE_TOOLS:
-            tools.extend(_BASE_TOOLS[name]())
+            tools.append(_BASE_TOOLS[name]())
         elif name in _LLM_TOOLS:
             if llm is None:
                 raise ValueError(f"Tool {name} requires an LLM to be provided")

--- a/langchain/agents/load_tools.py
+++ b/langchain/agents/load_tools.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 """Load tools."""
 from typing import Any, List, Optional
+import warnings
 
 from langchain.agents.tools import Tool
 from langchain.callbacks.base import BaseCallbackManager
@@ -70,6 +71,7 @@ def _get_terminal() -> BaseTool:
 
 _BASE_TOOLS = {
     "python_repl": _get_python_repl,
+    "requests": _get_tools_requests_get,  # preserved for backwards compatability
     "requests_get": _get_tools_requests_get,
     "requests_post": _get_tools_requests_post,
     "requests_patch": _get_tools_requests_patch,
@@ -257,6 +259,12 @@ def load_tools(
 
     for name in tool_names:
         if name == "requests":
+            warnings.warn(
+                "tool name `requests` is deprecated - "
+                "please use `requests_all` or specify the requests method"
+            )
+
+        if name == "requests_all":
             # expand requests into various methods
             requests_method_tools = [
                 _tool for _tool in _BASE_TOOLS if _tool.startswith("requests_")


### PR DESCRIPTION
### Motivation / Context

When exploring `load_tools(["requests"] )`, I would have expected all request method tools to be imported instead of just `RequestsGetTool`.

### Changes

Break `_get_requests` into multiple functions by request method. Each function returns the `BaseTool` for that particular request method.

In `load_tools`, if the tool name "requests_all" is encountered, we replace with all `_BASE_TOOLS` that starts with `requests_`. 

This way, `load_tools(["requests"])` returns:
- RequestsGetTool
- RequestsPostTool
- RequestsPatchTool
- RequestsPutTool
- RequestsDeleteTool