### PR TITLE
feat(tools): `PythonAstREPLTool` handles variants of python code more robustly

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8486,10 +8486,10 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "jina", "manifest-ml", "elasticsearch", "opensearch-py", "google-search-results", "faiss-cpu", "sentence-transformers", "transformers", "spacy", "nltk", "wikipedia", "beautifulsoup4", "tiktoken", "torch", "jinja2", "pinecone-client", "weaviate-client", "redis", "google-api-python-client", "wolframalpha", "qdrant-client", "tensorflow-text", "pypdf", "networkx", "nomic", "aleph-alpha-client", "deeplake", "pgvector", "psycopg2-binary"]
+all = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "jina", "manifest-ml", "elasticsearch", "opensearch-py", "google-search-results", "faiss-cpu", "sentence-transformers", "transformers", "spacy", "nltk", "wikipedia", "beautifulsoup4", "tiktoken", "torch", "jinja2", "pinecone-client", "weaviate-client", "redis", "google-api-python-client", "wolframalpha", "qdrant-client", "tensorflow-text", "pypdf", "networkx", "nomic", "aleph-alpha-client", "deeplake", "pgvector", "psycopg2-binary", "boto3", "pyowm"]
 llms = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "manifest-ml", "torch", "transformers"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "3dd7ff0edb145aff1ba1ea7e35ffa4b224fb71f934be0e13d4427fd796e54869"
+content-hash = "21b4c921a39d9372567dc85b641cb415f13289d5438b4ddb50b277e7d24015fe"

--- a/tests/unit_tests/test_python.py
+++ b/tests/unit_tests/test_python.py
@@ -1,6 +1,7 @@
 """Test functionality of Python REPL."""
 
 from langchain.python import PythonREPL
+from langchain.tools.python.tool import PythonAstREPLTool
 
 
 def test_python_repl() -> None:
@@ -53,3 +54,33 @@ def test_function() -> None:
     code = "print(add(1, 2))"
     output = chain.run(code)
     assert output == "3\n"
+
+# TODO(jon-chuang): add new file and pytest skipif version < (3, 9, 0)?
+def test_tool_object_output() -> None:
+    """Test returning an object from an expression."""
+    chain  = PythonAstREPLTool()
+    code = "class A:\n  def __init__(self, x):\n    print(x); self.x = x\nA(1+122).x"
+    output = chain.run(code)
+    # Only return the final output
+    assert output == "123"
+
+def test_tool_stdout_output() -> None:
+    """Test returning an object from an expression."""
+    chain  = PythonAstREPLTool()
+    code = "def f(x): print(x+1)\nf(123)"
+    output = chain.run(code)
+    assert output == "124\n"
+
+def test_tool_throw_exception() -> None:
+    """Test returning an object from an expression."""
+    chain  = PythonAstREPLTool()
+    code = "def f(x): raise ValueError(f'{x}')\nf(123)"
+    output = chain.run(code)
+    assert output == "ValueError: 123"
+
+def test_tool_invalid_stmt() -> None:
+    """Test returning an object from an expression."""
+    chain  = PythonAstREPLTool()
+    code = "x = 5"
+    output = chain.run(code)
+    assert output == "SyntaxError: invalid syntax (<string>, line 1)"


### PR DESCRIPTION
We can't do something similar for non ast version. So this is best effort.

Part of: https://github.com/hwchase17/langchain/issues/586
