### PR TITLE
Fixed Python repl for ChatGPT multiline commands

### DIFF
--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -28,7 +28,7 @@ class PythonREPLTool(BaseTool):
 
     def _run(self, query: str) -> str:
         """Use the tool."""
-        return self.python_repl.run(query)
+        return self.python_repl.run(query.replace('```', ''))
 
     async def _arun(self, query: str) -> str:
         """Use the tool asynchronously."""

--- a/tests/unit_tests/test_python.py
+++ b/tests/unit_tests/test_python.py
@@ -41,6 +41,20 @@ def test_functionality() -> None:
     code = "print(1 + 1)"
     output = chain.run(code)
     assert output == "2\n"
+    
+    
+def test_functionality_multiline() -> None:
+    """Test correct functionality for ChatGPT multiline commands."""
+    chain = PythonREPL()
+    code = """
+    ```
+    def multiply():
+        print(5*6)
+    multiply()
+    ```
+    """
+    output = chain.run(code)
+    assert output == "30\n"
 
 
 def test_function() -> None:


### PR DESCRIPTION
ChatGPT outputs multiline commands like this:

"""
```
def multiply():
    print(5*6)
multiply()
```
"""

which is a string that contains three times ` around the code.

This leads to the output SyntaxError because of the ```.

When these ``` are removed, the output is properly calculated and returned
