### PR TITLE
🐛 fix: missing kwargs in from_agent_and_tools in dataframe agent

### DIFF
--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -18,6 +18,9 @@ def create_pandas_dataframe_agent(
     suffix: str = SUFFIX,
     input_variables: Optional[List[str]] = None,
     verbose: bool = False,
+    return_intermediate_steps: bool = False,
+    max_iterations: Optional[int] = 15,
+    early_stopping_method: str = "force",
     **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a pandas agent from an LLM and dataframe."""
@@ -39,4 +42,11 @@ def create_pandas_dataframe_agent(
     )
     tool_names = [tool.name for tool in tools]
     agent = ZeroShotAgent(llm_chain=llm_chain, allowed_tools=tool_names, **kwargs)
-    return AgentExecutor.from_agent_and_tools(agent=agent, tools=tools, verbose=verbose)
+    return AgentExecutor.from_agent_and_tools(
+        agent=agent,
+        tools=tools,
+        verbose=verbose,
+        return_intermediate_steps=return_intermediate_steps,
+        max_iterations=max_iterations,
+        early_stopping_method=early_stopping_method,
+    )


### PR DESCRIPTION
Hello! 
I've noticed a bug in `create_pandas_dataframe_agent`. When calling it with argument `return_intermediate_steps=True`, it doesn't return the intermediate step. I think the issue is that `kwargs` was not passed where it needed to be passed. It should be passed into `AgentExecutor.from_agent_and_tools`

Please correct me if my solution isn't appropriate and I will fix with the appropriate approach.