### PR TITLE
Reduce number of documents to return for Pinecone

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -90,7 +90,7 @@ class Pinecone(VectorStore):
     def similarity_search_with_score(
         self,
         query: str,
-        k: int = 5,
+        k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
     ) -> List[Tuple[Document, float]]:
@@ -125,7 +125,7 @@ class Pinecone(VectorStore):
     def similarity_search(
         self,
         query: str,
-        k: int = 5,
+        k: int = 4,
         filter: Optional[dict] = None,
         namespace: Optional[str] = None,
         **kwargs: Any,


### PR DESCRIPTION
Minor change: Currently, Pinecone is returning 5 documents instead of the 4 seen in other vectorstores, and the comments this Pinecone script itself. Adjusted it from 5 to 4.