### PR TITLE
Added support for BaseChatModel in initialize_agent

### DIFF
--- a/langchain/agents/initialize.py
+++ b/langchain/agents/initialize.py
@@ -4,14 +4,13 @@ from typing import Any, Optional, Sequence, Union
 from langchain.agents.agent import AgentExecutor
 from langchain.agents.loading import AGENT_TO_CLASS, load_agent
 from langchain.callbacks.base import BaseCallbackManager
-from langchain.llms.base import BaseLLM
-from langchain.chat_models.base import BaseChatModel
+from langchain.chat_models.base import BaseLanguageModel
 from langchain.tools.base import BaseTool
 
 
 def initialize_agent(
     tools: Sequence[BaseTool],
-    llm: Union[BaseLLM, BaseChatModel],
+    llm: BaseLanguageModel,
     agent: Optional[str] = None,
     callback_manager: Optional[BaseCallbackManager] = None,
     agent_path: Optional[str] = None,

--- a/langchain/agents/initialize.py
+++ b/langchain/agents/initialize.py
@@ -1,16 +1,17 @@
 """Load agent."""
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Union
 
 from langchain.agents.agent import AgentExecutor
 from langchain.agents.loading import AGENT_TO_CLASS, load_agent
 from langchain.callbacks.base import BaseCallbackManager
 from langchain.llms.base import BaseLLM
+from langchain.chat_models.base import BaseChatModel
 from langchain.tools.base import BaseTool
 
 
 def initialize_agent(
     tools: Sequence[BaseTool],
-    llm: BaseLLM,
+    llm: Union[BaseLLM, BaseChatModel],
     agent: Optional[str] = None,
     callback_manager: Optional[BaseCallbackManager] = None,
     agent_path: Optional[str] = None,


### PR DESCRIPTION
**Description of Change:**

Add support for BaseChatModel as a type hint in **`initialize_agent`** function definition. There are tutorials in the Quickstart guide among others that will throw warnings based on recent updates. This should help with that. 

**Note: I am not very experienced with contributing and pull requests but I did read the document about contributing and hope I did everything right. I know this is a small change but hopefully, if I get this right I can work on larger changes in the future. Please feel free to help me improve or remedy any mistakes I make.**

---

**Change Steps**
1. To allow the function to accept both **`BaseLLM`** and **`BaseChatModel`** classes, you can use Python's typing module to define a **`Union`** type hint. Here's how you can update the function signature:

```python
from typing import Any, Optional, Sequence, Union
```

2. Next, update the type hint for the **`llm`** parameter in the function signature to accept both classes:

```python
def initialize_agent(
    tools: Sequence[BaseTool],
    llm: Union[BaseLLM, BaseChatModel],
    agent: Optional[str] = None,
    callback_manager: Optional[BaseCallbackManager] = None,
    agent_path: Optional[str] = None,
    agent_kwargs: Optional[dict] = None,
    **kwargs: Any,
) -> AgentExecutor:
    ...
```

---

**Outcome**

Now, the function accepts both **`BaseLLM`** and **`BaseChatModel`** instances without raising warnings for the **`llm`** parameter.