### PR TITLE
Fix typo in documentation: vectorstore-retriever.ipynb

### DIFF
--- a/docs/modules/indexes/retrievers/examples/vectorstore-retriever.ipynb
+++ b/docs/modules/indexes/retrievers/examples/vectorstore-retriever.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docs = retriever.get_relevant_documents(\"what did he say abotu ketanji brown jackson\")"
+    "docs = retriever.get_relevant_documents(\"what did he say about ketanji brown jackson\")"
    ]
   },
   {


### PR DESCRIPTION
There is a typo in the documentation. 
Fixed it!