### PR TITLE
[idea] include a _repr_markdown_ for messages

### DIFF
--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -65,6 +65,13 @@ class BaseMessage(BaseModel):
     def type(self) -> str:
         """Type of the message, used for serialization."""
 
+    def _repr_markdown_(self) -> str:
+        """Generates a markdown representation for Jupyter frontends"""
+        # Since messages are part of a dialog, indent them to make it clear
+        # that they are part of a conversation.
+        blockquoted = "\n".join(f"> {line}" for line in self.content.splitlines())
+        return f"**{self.__class__.__name__}**:\n{blockquoted}"
+
 
 class HumanMessage(BaseMessage):
     """Type of message that is spoken by the human."""


### PR DESCRIPTION
Hey all!

I enjoy viewing chat messages and responses as markdown. There's a simple way to do this in IPython-backed frontends (jupyter lab, classic notebook, colab, noteable, etc.) -- including a `_repr_markdown_`. In this PR I've added a simple addition to `BaseMessage`. 

Example:

<img width="1383" alt="image" src="https://user-images.githubusercontent.com/836375/229369508-ff25b94f-d12a-4bf9-a8be-3e5c4d91797b.png">

However, this ruins a key feature when iterating in a notebook -- the ability to copy/paste the repr output to add to the messages.

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/836375/229369695-e093caa5-811b-45ca-a099-bd32dfa0e913.png">

I'd love to hear any thoughts you have on this. Happy to decorate a lot more classes with rich representations.