### PR TITLE
fixed index name error found at redis new vector test

### DIFF
--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -69,7 +69,7 @@ class Redis(VectorStore):
         ids = []
         # Check if index exists
         for i, text in enumerate(texts):
-            _key = keys[i] if keys else uuid.uuid4().hex
+            _key = keys[i] if keys else self.index_name
             key = f"{prefix}:{_key}"
             metadata = metadatas[i] if metadatas else {}
             self.client.hset(


### PR DESCRIPTION
This PR fixes a logic error in the Redis VectorStore class
Creating a redis vector store `from_texts` creates 1:1 mapping between the object and its respected index, created in the function. The index will index only documents adhering to the `doc:{index_name}` prefix.
Calling `add_texts` should use the same prefix, unless stated otherwise in `keys` dictionary, and not create a new random uuid. 