### PR TITLE
Standardize the ChatResult and LLMResult types

### DIFF
--- a/langchain/callbacks/base.py
+++ b/langchain/callbacks/base.py
@@ -4,7 +4,7 @@ import functools
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Union
 
-from langchain.schema import AgentAction, AgentFinish, LLMResult
+from langchain.schema import AgentAction, AgentFinish, BaseResult, LLMResult
 
 
 class BaseCallbackHandler(ABC):
@@ -41,7 +41,7 @@ class BaseCallbackHandler(ABC):
         """Run on new LLM token. Only available when streaming is enabled."""
 
     @abstractmethod
-    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> Any:
+    def on_llm_end(self, response: BaseResult, **kwargs: Any) -> Any:
         """Run when LLM ends running."""
 
     @abstractmethod
@@ -150,7 +150,7 @@ class CallbackManager(BaseCallbackManager):
                     handler.on_llm_new_token(token, **kwargs)
 
     def on_llm_end(
-        self, response: LLMResult, verbose: bool = False, **kwargs: Any
+        self, response: BaseResult, verbose: bool = False, **kwargs: Any
     ) -> None:
         """Run when LLM ends running."""
         for handler in self.handlers:

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -252,7 +252,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
             message = _convert_dict_to_message(
                 {"content": inner_completion, "role": role}
             )
-            return ChatResult(generations=[ChatGeneration(message=message)])
+            return ChatResult(generations=[[ChatGeneration(message=message)]])
         response = self.completion_with_retry(messages=message_dicts, **params)
         return self._create_chat_result(response)
 
@@ -268,13 +268,13 @@ class ChatOpenAI(BaseChatModel, BaseModel):
         return message_dicts, params
 
     def _create_chat_result(self, response: Mapping[str, Any]) -> ChatResult:
-        generations = []
+        generations: list[ChatGeneration] = []
         for res in response["choices"]:
             message = _convert_dict_to_message(res["message"])
             gen = ChatGeneration(message=message)
             generations.append(gen)
         llm_output = {"token_usage": response["usage"], "model_name": self.model_name}
-        return ChatResult(generations=generations, llm_output=llm_output)
+        return ChatResult(generations=[generations], llm_output=llm_output)
 
     async def _agenerate(
         self, messages: List[BaseMessage], stop: Optional[List[str]] = None
@@ -303,7 +303,7 @@ class ChatOpenAI(BaseChatModel, BaseModel):
             message = _convert_dict_to_message(
                 {"content": inner_completion, "role": role}
             )
-            return ChatResult(generations=[ChatGeneration(message=message)])
+            return ChatResult(generations=[[ChatGeneration(message=message)]])
         else:
             response = await acompletion_with_retry(
                 self, messages=message_dicts, **params

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -141,24 +141,23 @@ class ChatGeneration(Generation):
         values["text"] = values["message"].content
         return values
 
-
-class ChatResult(BaseModel):
-    """Class that contains all relevant information for a Chat Result."""
-
-    generations: List[ChatGeneration]
-    """List of the things generated."""
+class BaseResult(BaseModel):
     llm_output: Optional[dict] = None
     """For arbitrary LLM provider specific output."""
 
 
-class LLMResult(BaseModel):
+class ChatResult(BaseResult):
+    """Class that contains all relevant information for a Chat Result."""
+
+    generations: List[List[ChatGeneration]]
+    """List of the things generated. It contains a list-of-prompts list-of-responses."""
+
+class LLMResult(BaseResult):
     """Class that contains all relevant information for an LLM Result."""
 
     generations: List[List[Generation]]
     """List of the things generated. This is List[List[]] because
     each input could have multiple generations."""
-    llm_output: Optional[dict] = None
-    """For arbitrary LLM provider specific output."""
 
 
 class PromptValue(BaseModel, ABC):


### PR DESCRIPTION
There are divergences between ChatResult and LLMResult in what gets returned in various places, and this intends to standardize them. It does mean we need to return list-of-list-of-chatresults now, to provide parity with LLMResult. (Though I find list-of-list to be an annoying API when in most cases you're using a single prompt with a single response, especially since anyone streaming never gets multi-response anyway)