### PR TITLE
Add Async abilities to Sequential and Transform Chain

### DIFF
--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -163,7 +163,7 @@ class SimpleSequentialChain(Chain, BaseModel):
         _input = inputs[self.input_key]
         color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])
         for i, chain in enumerate(self.chains):
-            _input = chain.arun(_input)
+            _input = await chain.arun(_input)
             if self.strip_outputs:
                 _input = _input.strip()
             if self.callback_manager.is_async:

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -93,6 +93,12 @@ class SequentialChain(Chain, BaseModel):
             known_values.update(outputs)
         return {k: known_values[k] for k in self.output_variables}
 
+    async def _acall(self, inputs: Dict[str, str]) -> Dict[str, str]:
+        known_values = inputs.copy()
+        for _, chain in enumerate(self.chains):
+            outputs = await chain.acall(known_values, return_only_outputs=True)
+            known_values.update(outputs)
+        return {k: known_values[k] for k in self.output_variables}
 
 class SimpleSequentialChain(Chain, BaseModel):
     """Simple chain where the outputs of one step feed directly into next."""

--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -159,7 +159,7 @@ class SimpleSequentialChain(Chain, BaseModel):
             )
         return {self.output_key: _input}
 
-    def _acall(self, inputs: Dict[str, str]) -> Dict[str, str]:
+    async def _acall(self, inputs: Dict[str, str]) -> Dict[str, str]:
         _input = inputs[self.input_key]
         color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])
         for i, chain in enumerate(self.chains):

--- a/langchain/chains/transform.py
+++ b/langchain/chains/transform.py
@@ -47,4 +47,3 @@ class TransformChain(Chain, BaseModel):
         else:
             transformed = self.transform(inputs)
         return transformed
-

--- a/langchain/chains/transform.py
+++ b/langchain/chains/transform.py
@@ -1,5 +1,6 @@
 """Chain that runs an arbitrary python function."""
 from typing import Callable, Dict, List
+from asyncio import iscoroutinefunction
 
 from pydantic import BaseModel
 
@@ -42,5 +43,8 @@ class TransformChain(Chain, BaseModel):
 
     async def _acall(self, inputs: Dict[str, str]) -> Dict[str, str]:
         if iscoroutinefunction(self.transform):
-            return await self.transform(inputs)
-        return self.transform(inputs)
+            transformed = await self.transform(inputs)
+        else:
+            transformed = self.transform(inputs)
+        return transformed
+

--- a/langchain/chains/transform.py
+++ b/langchain/chains/transform.py
@@ -39,3 +39,8 @@ class TransformChain(Chain, BaseModel):
 
     def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
         return self.transform(inputs)
+
+    async def _acall(self, inputs: Dict[str, str]) -> Dict[str, str]:
+        if iscoroutinefunction(self.transform):
+            return await self.transform(inputs)
+        return self.transform(inputs)


### PR DESCRIPTION
Adding the `_acall` function to `SimpleSequentialChain`, `SequentialChain`, and `TransformChain` classes is a valuable enhancement for a couple reasons:

Asynchronous support: By incorporating the `_acall` method, the implementation now allows for asynchronous calls to be executed within the chain. This can help to improve performance.

Integration with `AsyncCallbackManager`: The addition of `_acall` opens the door for using `AsyncCallbackManager`, which is capable of streaming LLM outputs. This can lead to more efficient and responsive systems by allowing data to be processed as soon as it is available.

Compatibility preservation: Despite the change (implementation) of the `_acall` method, the changes will not break compatibility with existing code. The synchronous _call method is still available and can be used interchangeably with the new asynchronous implementation. This may only make previously broken code work.

Lastly, I added the check for transform to see if a function is async since not all transform may be async, but it is still nice to be able to call `_acall` on Sequential Chain using transform chains.

Note: I do not have much experience with `asyncio` but needed some type of method to stream responses while using transform and sequential chains. So, open to feedback.