### PR TITLE
Fix spelling and grammar in multi_input_tool.ipynb

### DIFF
--- a/docs/modules/agents/tools/multi_input_tool.ipynb
+++ b/docs/modules/agents/tools/multi_input_tool.ipynb
@@ -1,17 +1,18 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "87455ddb",
    "metadata": {},
    "source": [
-    "# Multi Input Tools\n",
+    "# Multi-Input Tools\n",
     "\n",
     "This notebook shows how to use a tool that requires multiple inputs with an agent.\n",
     "\n",
-    "The difficulty in doing so comes from the fact that an agent decides it's next step from a language model, which outputs a string. So if that step requires multiple inputs, they need to be parsed from that. Therefor, the currently supported way to do this is write a smaller wrapper function that parses that a string into multiple inputs.\n",
+    "The difficulty in doing so comes from the fact that an agent decides its next step from a language model, which outputs a string. So if that step requires multiple inputs, they need to be parsed from that. Therefore, the currently supported way to do this is to write a smaller wrapper function that parses a string into multiple inputs.\n",
     "\n",
-    "For a concrete example, let's work on giving an agent access to a multiplication function, which takes as input two integers. In order to use this, we will tell the agent to generate the \"Action Input\" as a comma separated list of length two. We will then write a thin wrapper that takes a string, splits it into two around a comma, and passes both parsed sides as integers to the multiplication function."
+    "For a concrete example, let's work on giving an agent access to a multiplication function, which takes as input two integers. In order to use this, we will tell the agent to generate the \"Action Input\" as a comma-separated list of length two. We will then write a thin wrapper that takes a string, splits it into two around a comma, and passes both parsed sides as integers to the multiplication function."
    ]
   },
   {


### PR DESCRIPTION
Changes:
- Corrected the title to use hyphens instead of spaces.
- Fixed a typo in the second paragraph where "therefor" was changed to "Therefore".
- Added a hyphen between "comma" and "separated" in the last paragraph.

File link: [multi_input_tool.ipynb](https://github.com/hwchase17/langchain/blob/master/docs/modules/agents/tools/multi_input_tool.ipynb)