### PR TITLE
Add reflection step using EXPLAIN to SQLDatabaseChain

### DIFF
--- a/langchain/agents/agent_toolkits/sql/toolkit.py
+++ b/langchain/agents/agent_toolkits/sql/toolkit.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from langchain.agents.agent_toolkits.base import BaseToolkit
 from langchain.llms.base import BaseLLM
 from langchain.llms.openai import OpenAI
+from langchain.schema import BaseLanguageModel
 from langchain.sql_database import SQLDatabase
 from langchain.tools import BaseTool
 from langchain.tools.sql_database.tool import (
@@ -20,7 +21,7 @@ class SQLDatabaseToolkit(BaseToolkit):
     """Toolkit for interacting with SQL databases."""
 
     db: SQLDatabase = Field(exclude=True)
-    llm: BaseLLM = Field(default_factory=lambda: OpenAI(temperature=0))
+    llm: BaseLanguageModel = Field(default_factory=lambda: OpenAI(temperature=0))
 
     @property
     def dialect(self) -> str:

--- a/langchain/tools/sql_database/prompt.py
+++ b/langchain/tools/sql_database/prompt.py
@@ -1,7 +1,18 @@
-# flake8: noqa
-QUERY_CHECKER = """
-{query}
-Double check the {dialect} query above for common mistakes, including:
+QUERY_CHECKER = """You are a SQL expert tasked with reviewing and improving submitted queries. 
+You will be provided with the input the user originally provided, which describes what he wants to know from the query. 
+You receive a candidate {dialect} query that has been generated from this request, and it's corresponding EXPLAIN plan computed by the database. 
+
+Using the provided information, you will review the query in terms of its performance and accuracy.
+
+You must decide whether the query accuretely represents the user intent based on the input provided.
+You must also assess the query's performance and decide whether its performance is acceptable or not.
+If the query does not meet the above criteria, you must suggest a new optimized query, and explain your thought processs.
+
+Here is the db schema:
+
+{table_info}
+
+Some common mistakes to look out for:
 - Using NOT IN with NULL values
 - Using UNION when UNION ALL should have been used
 - Using BETWEEN for exclusive ranges
@@ -11,4 +22,10 @@ Double check the {dialect} query above for common mistakes, including:
 - Casting to the correct data type
 - Using the proper columns for joins
 
-If there are any of the above mistakes, rewrite the query. If there are no mistakes, just reproduce the original query."""
+
+Here is the query that you are reviewing:
+{query}
+
+Here is the EXPLAIN plan for the query:
+{explain}
+"""


### PR DESCRIPTION
WIP

This PR aims to add an optional step to the SQLDatabaseChain. Once the model has generated the SQL query from the prompt, we first run `EXPLAIN` on the query, and feed this output back to the LLM along the original query for the model to take a reflection step to asses the query's performance, and have it suggest a possible optimization if the plan is not looking great.

Preliminary tests seem to show promising results. I'm working with a relatively large database (100M-2B rows in tables), so a lot of queries I get on the first try have no chance of completing in a reasonable amount of time if they're triggering full table scans or similar expensive work. GPT-4 at least seems to be able to produce substantial improvements by having it reason its way around the EXPLAIN output.

This is my first nontrivial PR to langchain, so I could use some feedback with some things:
* Right now I'm including it directly in SQLDatabaseChain, but perhaps it should be moved to its own Chain in a separate file?
* Still deciding on what and how to trace / intermediate_steps, will include here a sample output before I mark it for review.
* My prompt foo is still pretty basic, so any suggestions on the prompt template are more than welcome

