### PR TITLE
Persist database regardless of notebook or script context

### DIFF
--- a/docs/modules/indexes/vectorstores/examples/chroma.ipynb
+++ b/docs/modules/indexes/vectorstores/examples/chroma.ipynb
@@ -170,12 +170,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f568a322",
    "metadata": {},
    "source": [
     "### Persist the Database\n",
-    "In a notebook, we should call persist() to ensure the embeddings are written to disk. This isn't necessary in a script - the database will be automatically persisted when the client object is destroyed."
+    "We should call persist() to ensure the embeddings are written to disk."
    ]
   },
   {


### PR DESCRIPTION
`persist()` is required even if it's invoked in a script.

Without this, an error is thrown:

```
chromadb.errors.NoIndexException: Index is not initialized
```