### PR TITLE
Return either the response object or the string itself

### DIFF
--- a/langchain/chains/api/base.py
+++ b/langchain/chains/api/base.py
@@ -9,7 +9,7 @@ from langchain.chains.api.prompt import API_RESPONSE_PROMPT, API_URL_PROMPT
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
 from langchain.prompts import BasePromptTemplate
-from langchain.requests import RequestsWrapper
+from langchain.requests import RequestsWrapper, get_text_from_response
 from langchain.schema import BaseLanguageModel
 
 
@@ -70,8 +70,9 @@ class APIChain(Chain, BaseModel):
             api_url, color="green", end="\n", verbose=self.verbose
         )
         api_response = self.requests_wrapper.get(api_url)
+        response_text = get_text_from_response(api_response)
         self.callback_manager.on_text(
-            api_response, color="yellow", end="\n", verbose=self.verbose
+            response_text, color="yellow", end="\n", verbose=self.verbose
         )
         answer = self.api_answer_chain.predict(
             question=question,

--- a/langchain/requests.py
+++ b/langchain/requests.py
@@ -6,6 +6,24 @@ import requests
 from pydantic import BaseModel, Extra
 
 
+def get_text_from_response(response: Union[str, requests.Response]) -> str:
+    """Return the text from the response."""
+    if isinstance(response, str):
+        return response
+    else:
+        return response.text
+
+
+async def get_text_from_response_async(
+    response: Union[str, aiohttp.ClientResponse]
+) -> str:
+    """Return the text from the response."""
+    if isinstance(response, str):
+        return response
+    else:
+        return await response.text()
+
+
 class RequestsWrapper(BaseModel):
     """Lightweight wrapper around requests library."""
 
@@ -67,7 +85,7 @@ class RequestsWrapper(BaseModel):
 
         Result type is determined by the return_response attribute."""
 
-        async def _get_response():
+        async def _get_response() -> aiohttp.ClientResponse:
             if not self.aiosession:
                 async with aiohttp.ClientSession() as session:
                     async with session.request(

--- a/langchain/requests.py
+++ b/langchain/requests.py
@@ -30,40 +30,42 @@ class RequestsWrapper(BaseModel):
             return response.text
 
     def get(self, url: str, **kwargs: Any) -> Union[str, requests.Response]:
-        """GET the URL and return the text or the response object based on return_response."""
+        """GET the URL and return the text or the response object."""
         response = requests.get(url, headers=self.headers, **kwargs)
         return self._process_response(response)
 
     def post(
         self, url: str, data: Dict[str, Any], **kwargs: Any
     ) -> Union[str, requests.Response]:
-        """POST to the URL and return the text or the response object based on return_response."""
+        """POST to the URL and return the text or the response object."""
         response = requests.post(url, json=data, headers=self.headers, **kwargs)
         return self._process_response(response)
 
     def patch(
         self, url: str, data: Dict[str, Any], **kwargs: Any
     ) -> Union[str, requests.Response]:
-        """PATCH the URL and return the text or the response object based on return_response."""
+        """PATCH the URL and return the text or the response object."""
         response = requests.patch(url, json=data, headers=self.headers, **kwargs)
         return self._process_response(response)
 
     def put(
         self, url: str, data: Dict[str, Any], **kwargs: Any
     ) -> Union[str, requests.Response]:
-        """PUT the URL and return the text or the response object based on return_response."""
+        """PUT the URL and return the text or the response object."""
         response = requests.put(url, json=data, headers=self.headers, **kwargs)
         return self._process_response(response)
 
     def delete(self, url: str, **kwargs: Any) -> Union[str, requests.Response]:
-        """DELETE the URL and return the text or the response object based on return_response."""
+        """DELETE the URL and return the text or the response object."""
         response = requests.delete(url, headers=self.headers, **kwargs)
         return self._process_response(response)
 
     async def _arequest(
         self, method: str, url: str, **kwargs: Any
     ) -> Union[aiohttp.ClientResponse, str]:
-        """Make an async request and return the appropriate result based on the return_response attribute."""
+        """Make an async request and return the appropriate result.
+
+        Result type is determined by the return_response attribute."""
 
         async def _get_response():
             if not self.aiosession:

--- a/langchain/requests.py
+++ b/langchain/requests.py
@@ -1,5 +1,5 @@
 """Lightweight wrapper around requests library, with async support."""
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import aiohttp
 import requests
@@ -11,6 +11,8 @@ class RequestsWrapper(BaseModel):
 
     headers: Optional[Dict[str, str]] = None
     aiosession: Optional[aiohttp.ClientSession] = None
+    return_response: bool = False
+    """Whether to return the response object directly."""
 
     class Config:
         """Configuration for this pydantic object."""
@@ -18,56 +20,95 @@ class RequestsWrapper(BaseModel):
         extra = Extra.forbid
         arbitrary_types_allowed = True
 
-    def get(self, url: str, **kwargs: Any) -> str:
-        """GET the URL and return the text."""
-        return requests.get(url, headers=self.headers, **kwargs).text
+    def _process_response(
+        self, response: requests.Response
+    ) -> Union[str, requests.Response]:
+        """Return the appropriate result based on the return_response attribute."""
+        if self.return_response:
+            return response
+        else:
+            return response.text
 
-    def post(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        """POST to the URL and return the text."""
-        return requests.post(url, json=data, headers=self.headers, **kwargs).text
+    def get(self, url: str, **kwargs: Any) -> Union[str, requests.Response]:
+        """GET the URL and return the text or the response object based on return_response."""
+        response = requests.get(url, headers=self.headers, **kwargs)
+        return self._process_response(response)
 
-    def patch(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        """PATCH the URL and return the text."""
-        return requests.patch(url, json=data, headers=self.headers, **kwargs).text
+    def post(
+        self, url: str, data: Dict[str, Any], **kwargs: Any
+    ) -> Union[str, requests.Response]:
+        """POST to the URL and return the text or the response object based on return_response."""
+        response = requests.post(url, json=data, headers=self.headers, **kwargs)
+        return self._process_response(response)
 
-    def put(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        """PUT the URL and return the text."""
-        return requests.put(url, json=data, headers=self.headers, **kwargs).text
+    def patch(
+        self, url: str, data: Dict[str, Any], **kwargs: Any
+    ) -> Union[str, requests.Response]:
+        """PATCH the URL and return the text or the response object based on return_response."""
+        response = requests.patch(url, json=data, headers=self.headers, **kwargs)
+        return self._process_response(response)
 
-    def delete(self, url: str, **kwargs: Any) -> str:
-        """DELETE the URL and return the text."""
-        return requests.delete(url, headers=self.headers, **kwargs).text
+    def put(
+        self, url: str, data: Dict[str, Any], **kwargs: Any
+    ) -> Union[str, requests.Response]:
+        """PUT the URL and return the text or the response object based on return_response."""
+        response = requests.put(url, json=data, headers=self.headers, **kwargs)
+        return self._process_response(response)
 
-    async def _arequest(self, method: str, url: str, **kwargs: Any) -> str:
-        """Make an async request."""
-        if not self.aiosession:
-            async with aiohttp.ClientSession() as session:
-                async with session.request(
+    def delete(self, url: str, **kwargs: Any) -> Union[str, requests.Response]:
+        """DELETE the URL and return the text or the response object based on return_response."""
+        response = requests.delete(url, headers=self.headers, **kwargs)
+        return self._process_response(response)
+
+    async def _arequest(
+        self, method: str, url: str, **kwargs: Any
+    ) -> Union[aiohttp.ClientResponse, str]:
+        """Make an async request and return the appropriate result based on the return_response attribute."""
+
+        async def _get_response():
+            if not self.aiosession:
+                async with aiohttp.ClientSession() as session:
+                    async with session.request(
+                        method, url, headers=self.headers, **kwargs
+                    ) as response:
+                        return response
+            else:
+                async with self.aiosession.request(
                     method, url, headers=self.headers, **kwargs
                 ) as response:
-                    return await response.text()
-        else:
-            async with self.aiosession.request(
-                method, url, headers=self.headers, **kwargs
-            ) as response:
-                return await response.text()
+                    return response
 
-    async def aget(self, url: str, **kwargs: Any) -> str:
+        response = await _get_response()
+
+        if self.return_response:
+            return response
+        else:
+            return await response.text()
+
+    async def aget(self, url: str, **kwargs: Any) -> Union[aiohttp.ClientResponse, str]:
         """GET the URL and return the text asynchronously."""
         return await self._arequest("GET", url, **kwargs)
 
-    async def apost(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
+    async def apost(
+        self, url: str, data: Dict[str, Any], **kwargs: Any
+    ) -> Union[aiohttp.ClientResponse, str]:
         """POST to the URL and return the text asynchronously."""
         return await self._arequest("POST", url, json=data, **kwargs)
 
-    async def apatch(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
+    async def apatch(
+        self, url: str, data: Dict[str, Any], **kwargs: Any
+    ) -> Union[aiohttp.ClientResponse, str]:
         """PATCH the URL and return the text asynchronously."""
         return await self._arequest("PATCH", url, json=data, **kwargs)
 
-    async def aput(self, url: str, data: Dict[str, Any], **kwargs: Any) -> str:
+    async def aput(
+        self, url: str, data: Dict[str, Any], **kwargs: Any
+    ) -> Union[aiohttp.ClientResponse, str]:
         """PUT the URL and return the text asynchronously."""
         return await self._arequest("PUT", url, json=data, **kwargs)
 
-    async def adelete(self, url: str, **kwargs: Any) -> str:
+    async def adelete(
+        self, url: str, **kwargs: Any
+    ) -> Union[aiohttp.ClientResponse, str]:
         """DELETE the URL and return the text asynchronously."""
         return await self._arequest("DELETE", url, **kwargs)

--- a/langchain/tools/requests/tool.py
+++ b/langchain/tools/requests/tool.py
@@ -30,7 +30,7 @@ async def _get_text_async(response: Union[str, aiohttp.ClientResponse]) -> str:
     if isinstance(response, str):
         return response
     else:
-        return await response.text
+        return await response.text()
 
 
 class BaseRequestsTool(BaseModel):
@@ -51,7 +51,8 @@ class RequestsGetTool(BaseRequestsTool, BaseTool):
 
     async def _arun(self, url: str) -> str:
         """Run the tool asynchronously."""
-        return await _get_text_async(self.requests_wrapper.aget(url))
+        res = await self.requests_wrapper.aget(url)
+        return await _get_text_async(res)
 
 
 class RequestsPostTool(BaseRequestsTool, BaseTool):
@@ -78,9 +79,8 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):
         """Run the tool asynchronously."""
         try:
             data = _parse_input(text)
-            return await _get_text_async(
-                self.requests_wrapper.apost(data["url"], data["data"])
-            )
+            res = await self.requests_wrapper.apost(data["url"], data["data"])
+            return await _get_text_async(res)
         except Exception as e:
             return repr(e)
 
@@ -101,7 +101,7 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return _get_text_async(
+            return _get_text(
                 _get_text(self.requests_wrapper.patch(data["url"], data["data"]))
             )
         except Exception as e:
@@ -111,9 +111,8 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):
         """Run the tool asynchronously."""
         try:
             data = _parse_input(text)
-            return await _get_text_async(
-                self.requests_wrapper.apatch(data["url"], data["data"])
-            )
+            res = await self.requests_wrapper.apatch(data["url"], data["data"])
+            return await _get_text_async(res)
         except Exception as e:
             return repr(e)
 
@@ -142,9 +141,8 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):
         """Run the tool asynchronously."""
         try:
             data = _parse_input(text)
-            return await _get_text_async(
-                self.requests_wrapper.aput(data["url"], data["data"])
-            )
+            res = await self.requests_wrapper.aput(data["url"], data["data"])
+            return await _get_text_async(res)
         except Exception as e:
             return repr(e)
 
@@ -161,4 +159,5 @@ class RequestsDeleteTool(BaseRequestsTool, BaseTool):
 
     async def _arun(self, url: str) -> str:
         """Run the tool asynchronously."""
-        return await _get_text_async(self.requests_wrapper.adelete(url))
+        res = await self.requests_wrapper.adelete(url)
+        return await _get_text_async(res)

--- a/langchain/tools/requests/tool.py
+++ b/langchain/tools/requests/tool.py
@@ -8,29 +8,17 @@ import aiohttp
 from pydantic import BaseModel
 import requests
 
-from langchain.requests import RequestsWrapper
+from langchain.requests import (
+    RequestsWrapper,
+    get_text_from_response,
+    get_text_from_response_async,
+)
 from langchain.tools.base import BaseTool
 
 
 def _parse_input(text: str) -> Dict[str, Any]:
     """Parse the json string into a dict."""
     return json.loads(text)
-
-
-def _get_text(response: Union[str, requests.Response]) -> str:
-    """Return the text from the response."""
-    if isinstance(response, str):
-        return response
-    else:
-        return response.text
-
-
-async def _get_text_async(response: Union[str, aiohttp.ClientResponse]) -> str:
-    """Return the text from the response."""
-    if isinstance(response, str):
-        return response
-    else:
-        return await response.text()
 
 
 class BaseRequestsTool(BaseModel):
@@ -47,12 +35,12 @@ class RequestsGetTool(BaseRequestsTool, BaseTool):
 
     def _run(self, url: str) -> str:
         """Run the tool."""
-        return _get_text(self.requests_wrapper.get(url))
+        return get_text_from_response(self.requests_wrapper.get(url))
 
     async def _arun(self, url: str) -> str:
         """Run the tool asynchronously."""
         res = await self.requests_wrapper.aget(url)
-        return await _get_text_async(res)
+        return await get_text_from_response_async(res)
 
 
 class RequestsPostTool(BaseRequestsTool, BaseTool):
@@ -71,7 +59,9 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return _get_text(self.requests_wrapper.post(data["url"], data["data"]))
+            return get_text_from_response(
+                self.requests_wrapper.post(data["url"], data["data"])
+            )
         except Exception as e:
             return repr(e)
 
@@ -80,7 +70,7 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):
         try:
             data = _parse_input(text)
             res = await self.requests_wrapper.apost(data["url"], data["data"])
-            return await _get_text_async(res)
+            return await get_text_from_response_async(res)
         except Exception as e:
             return repr(e)
 
@@ -101,8 +91,10 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return _get_text(
-                _get_text(self.requests_wrapper.patch(data["url"], data["data"]))
+            return get_text_from_response(
+                get_text_from_response(
+                    self.requests_wrapper.patch(data["url"], data["data"])
+                )
             )
         except Exception as e:
             return repr(e)
@@ -112,7 +104,7 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):
         try:
             data = _parse_input(text)
             res = await self.requests_wrapper.apatch(data["url"], data["data"])
-            return await _get_text_async(res)
+            return await get_text_from_response_async(res)
         except Exception as e:
             return repr(e)
 
@@ -133,7 +125,9 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return _get_text(self.requests_wrapper.put(data["url"], data["data"]))
+            return get_text_from_response(
+                self.requests_wrapper.put(data["url"], data["data"])
+            )
         except Exception as e:
             return repr(e)
 
@@ -142,7 +136,7 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):
         try:
             data = _parse_input(text)
             res = await self.requests_wrapper.aput(data["url"], data["data"])
-            return await _get_text_async(res)
+            return await get_text_from_response_async(res)
         except Exception as e:
             return repr(e)
 
@@ -155,9 +149,9 @@ class RequestsDeleteTool(BaseRequestsTool, BaseTool):
 
     def _run(self, url: str) -> str:
         """Run the tool."""
-        return _get_text(self.requests_wrapper.delete(url))
+        return get_text_from_response(self.requests_wrapper.delete(url))
 
     async def _arun(self, url: str) -> str:
         """Run the tool asynchronously."""
         res = await self.requests_wrapper.adelete(url)
-        return await _get_text_async(res)
+        return await get_text_from_response_async(res)

--- a/langchain/tools/requests/tool.py
+++ b/langchain/tools/requests/tool.py
@@ -1,9 +1,12 @@
 # flake8: noqa
 """Tools for making requests to an API endpoint."""
+import asyncio
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Union
+import aiohttp
 
 from pydantic import BaseModel
+import requests
 
 from langchain.requests import RequestsWrapper
 from langchain.tools.base import BaseTool
@@ -12,6 +15,22 @@ from langchain.tools.base import BaseTool
 def _parse_input(text: str) -> Dict[str, Any]:
     """Parse the json string into a dict."""
     return json.loads(text)
+
+
+def _get_text(response: Union[str, requests.Response]) -> str:
+    """Return the text from the response."""
+    if isinstance(response, str):
+        return response
+    else:
+        return response.text
+
+
+async def _get_text_async(response: Union[str, aiohttp.ClientResponse]) -> str:
+    """Return the text from the response."""
+    if isinstance(response, str):
+        return response
+    else:
+        return await response.text
 
 
 class BaseRequestsTool(BaseModel):
@@ -28,11 +47,11 @@ class RequestsGetTool(BaseRequestsTool, BaseTool):
 
     def _run(self, url: str) -> str:
         """Run the tool."""
-        return self.requests_wrapper.get(url)
+        return _get_text(self.requests_wrapper.get(url))
 
     async def _arun(self, url: str) -> str:
         """Run the tool asynchronously."""
-        return await self.requests_wrapper.aget(url)
+        return await _get_text_async(self.requests_wrapper.aget(url))
 
 
 class RequestsPostTool(BaseRequestsTool, BaseTool):
@@ -51,7 +70,7 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return self.requests_wrapper.post(data["url"], data["data"])
+            return _get_text(self.requests_wrapper.post(data["url"], data["data"]))
         except Exception as e:
             return repr(e)
 
@@ -59,7 +78,9 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):
         """Run the tool asynchronously."""
         try:
             data = _parse_input(text)
-            return await self.requests_wrapper.apost(data["url"], data["data"])
+            return await _get_text_async(
+                self.requests_wrapper.apost(data["url"], data["data"])
+            )
         except Exception as e:
             return repr(e)
 
@@ -80,7 +101,9 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return self.requests_wrapper.patch(data["url"], data["data"])
+            return _get_text_async(
+                _get_text(self.requests_wrapper.patch(data["url"], data["data"]))
+            )
         except Exception as e:
             return repr(e)
 
@@ -88,7 +111,9 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):
         """Run the tool asynchronously."""
         try:
             data = _parse_input(text)
-            return await self.requests_wrapper.apatch(data["url"], data["data"])
+            return await _get_text_async(
+                self.requests_wrapper.apatch(data["url"], data["data"])
+            )
         except Exception as e:
             return repr(e)
 
@@ -109,7 +134,7 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return self.requests_wrapper.put(data["url"], data["data"])
+            return _get_text(self.requests_wrapper.put(data["url"], data["data"]))
         except Exception as e:
             return repr(e)
 
@@ -117,7 +142,9 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):
         """Run the tool asynchronously."""
         try:
             data = _parse_input(text)
-            return await self.requests_wrapper.aput(data["url"], data["data"])
+            return await _get_text_async(
+                self.requests_wrapper.aput(data["url"], data["data"])
+            )
         except Exception as e:
             return repr(e)
 
@@ -130,8 +157,8 @@ class RequestsDeleteTool(BaseRequestsTool, BaseTool):
 
     def _run(self, url: str) -> str:
         """Run the tool."""
-        return self.requests_wrapper.delete(url)
+        return _get_text(self.requests_wrapper.delete(url))
 
     async def _arun(self, url: str) -> str:
         """Run the tool asynchronously."""
-        return await self.requests_wrapper.adelete(url)
+        return await _get_text_async(self.requests_wrapper.adelete(url))

--- a/langchain/tools/requests/tool.py
+++ b/langchain/tools/requests/tool.py
@@ -1,12 +1,9 @@
 # flake8: noqa
 """Tools for making requests to an API endpoint."""
-import asyncio
 import json
-from typing import Any, Dict, Union
-import aiohttp
+from typing import Any, Dict
 
 from pydantic import BaseModel
-import requests
 
 from langchain.requests import (
     RequestsWrapper,


### PR DESCRIPTION
It's often desired to obtain the response object to look at the status code / reason before processing further.

If we don't want to lose the typing, we could either create a sibling class or do something like [in this draft](https://github.com/hinthornw/lckg/blob/william/request_wrapper_status/langchain/requests.py) to let one specify a format string instead of a boolean, since it seems likely the user would want to pass the response to an LLM