### PR TITLE
fix: tests with Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 .venv
 .github
+.git
+.mypy_cache
+.pytest_cache
+Dockerfile

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -123,6 +123,12 @@ To run unit tests:
 make test
 ```
 
+To run unit tests in Docker:
+
+```bash
+make docker_tests
+```
+
 If you add new logic, please add a unit test.
 
 Integration tests cover logic that requires making calls to outside APIs (often integration with other services).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
+# This is a Dockerfile for running unit tests
+
 # Use the Python base image
 FROM python:3.11.2-bullseye AS builder
 
-# Print Python version
-RUN echo "Python version:" && python --version && echo ""
+# Define the version of Poetry to install (default is 1.4.2)
+ARG POETRY_VERSION=1.4.2
 
-# Install Poetry
-RUN echo "Installing Poetry..." && \
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+# Define the directory to install Poetry to (default is /opt/poetry)
+ARG POETRY_HOME=/opt/poetry
 
-# Add Poetry to PATH
-ENV PATH="${PATH}:/root/.local/bin"
+# Create a Python virtual environment for Poetry and install it
+RUN python3 -m venv ${POETRY_HOME} && \
+    $POETRY_HOME/bin/pip install --upgrade pip && \
+    $POETRY_HOME/bin/pip install poetry==${POETRY_VERSION}
 
-# Test if Poetry is added to PATH
-RUN echo "Poetry version:" && poetry --version && echo ""
+# Test if Poetry is installed in the expected path
+RUN echo "Poetry version:" && $POETRY_HOME/bin/poetry --version
 
-# Set working directory
+# Set the working directory for the app
 WORKDIR /app
 
 # Use a multi-stage build to install dependencies
@@ -23,8 +26,8 @@ FROM builder AS dependencies
 # Copy only the dependency files for installation
 COPY pyproject.toml poetry.lock poetry.toml ./
 
-# Install Poetry dependencies (this layer will be cached as long as the dependencies don't change)
-RUN poetry install --no-interaction --no-ansi
+# Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)
+RUN $POETRY_HOME/bin/poetry install --no-interaction --no-ansi
 
 # Use a multi-stage build to run tests
 FROM dependencies AS tests
@@ -32,8 +35,10 @@ FROM dependencies AS tests
 # Copy the rest of the app source code (this layer will be invalidated and rebuilt whenever the source code changes)
 COPY . .
 
-# Set entrypoint to run tests
-ENTRYPOINT ["poetry", "run", "pytest"]
+RUN /opt/poetry/bin/poetry install --no-interaction --no-ansi
 
-# Set default command to run all unit tests
+# Set the entrypoint to run tests using Poetry
+ENTRYPOINT ["/opt/poetry/bin/poetry", "run", "pytest"]
+
+# Set the default command to run all unit tests
 CMD ["tests/unit_tests"]


### PR DESCRIPTION
Update the Dockerfile to use the `$POETRY_HOME` argument to set the Poetry home directory instead of adding Poetry to the PATH environment variable.

Add instructions to the `CONTRIBUTING.md` file on how to run tests with Docker.

Closes https://github.com/hwchase17/langchain/issues/2324