### PR TITLE
expose pgvector in __init__.py

### DIFF
--- a/langchain/vectorstores/__init__.py
+++ b/langchain/vectorstores/__init__.py
@@ -7,6 +7,7 @@ from langchain.vectorstores.elastic_vector_search import ElasticVectorSearch
 from langchain.vectorstores.faiss import FAISS
 from langchain.vectorstores.milvus import Milvus
 from langchain.vectorstores.opensearch_vector_search import OpenSearchVectorSearch
+from langchain.vectorstores.pgvector import PGVector
 from langchain.vectorstores.pinecone import Pinecone
 from langchain.vectorstores.qdrant import Qdrant
 from langchain.vectorstores.weaviate import Weaviate
@@ -15,6 +16,7 @@ __all__ = [
     "ElasticVectorSearch",
     "FAISS",
     "VectorStore",
+    "PGVector",
     "Pinecone",
     "Weaviate",
     "Qdrant",


### PR DESCRIPTION
This allows it to be imported as:

```
from langchain.vectorstores import PGVector
```

like the other stores