### PR TITLE
Feature: AgentExecutor execution time limit

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -837,7 +837,7 @@ class AgentExecutor(Chain, BaseModel):
         # We now enter the agent loop (until it returns something).
         async with asyncio_timeout(self.max_execution_time):
             try:
-                while self._should_continue(iterations):
+                while self._should_continue(iterations, time_elapsed):
                     next_step_output = await self._atake_next_step(
                         name_to_tool_map, color_mapping, inputs, intermediate_steps
                     )
@@ -853,6 +853,7 @@ class AgentExecutor(Chain, BaseModel):
                             return await self._areturn(tool_return, intermediate_steps)
 
                     iterations += 1
+                    time_elapsed = time.time() - start_time
                 output = self.agent.return_stopped_response(
                     self.early_stopping_method, intermediate_steps, **inputs
                 )

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -637,9 +637,9 @@ class AgentExecutor(Chain, BaseModel):
         return {tool.name: tool for tool in self.tools}[name]
 
     def _should_continue(self, iterations: int, time_elapsed: float) -> bool:
-        if self.max_iterations and iterations >= self.max_iterations:
+        if self.max_iterations is not None and iterations >= self.max_iterations:
             return False
-        if self.max_execution_time and time_elapsed >= self.max_execution_time:
+        if self.max_execution_time is not None and time_elapsed >= self.max_execution_time:
             return False
 
         return True

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -90,7 +90,9 @@ class BaseSingleActionAgent(BaseModel):
         """Return response when agent has been stopped due to max iterations."""
         if early_stopping_method == "force":
             # `force` just returns a constant string
-            return AgentFinish({"output": "Agent stopped due to iteration limit or time limit."}, "")
+            return AgentFinish(
+                {"output": "Agent stopped due to iteration limit or time limit."}, ""
+            )
         else:
             raise ValueError(
                 f"Got unsupported early_stopping_method `{early_stopping_method}`"
@@ -508,7 +510,9 @@ class Agent(BaseSingleActionAgent):
         """Return response when agent has been stopped due to max iterations."""
         if early_stopping_method == "force":
             # `force` just returns a constant string
-            return AgentFinish({"output": "Agent stopped due to iteration limit or time limit."}, "")
+            return AgentFinish(
+                {"output": "Agent stopped due to iteration limit or time limit."}, ""
+            )
         elif early_stopping_method == "generate":
             # Generate does one final forward pass
             thoughts = ""

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -90,7 +90,7 @@ class BaseSingleActionAgent(BaseModel):
         """Return response when agent has been stopped due to max iterations."""
         if early_stopping_method == "force":
             # `force` just returns a constant string
-            return AgentFinish({"output": "Agent stopped due to max iterations."}, "")
+            return AgentFinish({"output": "Agent stopped due to iteration limit or time limit."}, "")
         else:
             raise ValueError(
                 f"Got unsupported early_stopping_method `{early_stopping_method}`"
@@ -508,7 +508,7 @@ class Agent(BaseSingleActionAgent):
         """Return response when agent has been stopped due to max iterations."""
         if early_stopping_method == "force":
             # `force` just returns a constant string
-            return AgentFinish({"output": "Agent stopped due to max iterations."}, "")
+            return AgentFinish({"output": "Agent stopped due to iteration limit or time limit."}, "")
         elif early_stopping_method == "generate":
             # Generate does one final forward pass
             thoughts = ""
@@ -639,7 +639,10 @@ class AgentExecutor(Chain, BaseModel):
     def _should_continue(self, iterations: int, time_elapsed: float) -> bool:
         if self.max_iterations is not None and iterations >= self.max_iterations:
             return False
-        if self.max_execution_time is not None and time_elapsed >= self.max_execution_time:
+        if (
+            self.max_execution_time is not None
+            and time_elapsed >= self.max_execution_time
+        ):
             return False
 
         return True

--- a/langchain/utilities/async.py
+++ b/langchain/utilities/async.py
@@ -1,0 +1,12 @@
+"""Shims for async features that may be missing from older python versions"""
+
+import sys
+
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout
+else:
+    from asyncio import timeout as asyncio_timeout
+
+
+__all__ = ["asyncio_timeout"]

--- a/langchain/utilities/asyncio.py
+++ b/langchain/utilities/asyncio.py
@@ -1,4 +1,4 @@
-"""Shims for async features that may be missing from older python versions"""
+"""Shims for asyncio features that may be missing from older python versions"""
 
 import sys
 

--- a/langchain/utilities/asyncio.py
+++ b/langchain/utilities/asyncio.py
@@ -2,7 +2,6 @@
 
 import sys
 
-
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout
 else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pgvector = {version = "^0.1.6", optional = true}
 psycopg2-binary = {version = "^2.9.5", optional = true}
 boto3 = {version = "^1.26.96", optional = true}
 pyowm = {version = "^3.3.0", optional = true}
+async-timeout = {version = "^4.0.0", python = "<3.11"}
 
 [tool.poetry.group.docs.dependencies]
 autodoc_pydantic = "^1.8.0"

--- a/tests/unit_tests/agents/test_agent.py
+++ b/tests/unit_tests/agents/test_agent.py
@@ -72,10 +72,16 @@ def test_agent_bad_action() -> None:
 
 
 def test_agent_stopped_early() -> None:
-    """Test react chain when bad action given."""
+    """Test react chain when max iterations or max execution time is exceeded."""
+    # iteration limit
     agent = _get_agent(max_iterations=0)
     output = agent.run("when was langchain made")
-    assert output == "Agent stopped due to max iterations."
+    assert output == "Agent stopped due to iteration limit or time limit."
+
+    # execution time limit
+    agent = _get_agent(max_execution_time=0.0)
+    output = agent.run("when was langchain made")
+    assert output == "Agent stopped due to iteration limit or time limit."
 
 
 def test_agent_with_callbacks_global() -> None:


### PR DESCRIPTION
`AgentExecutor` already has support for limiting the number of iterations.  But the amount of time taken for each iteration can vary quite a bit, so it is difficult to place limits on the execution time.  This PR adds a new field `max_execution_time` to the `AgentExecutor` model.  When called asynchronously, the agent loop is wrapped in an `asyncio.timeout()` context which triggers the early stopping response if the time limit is reached.  When called synchronously, the agent loop checks for both the max_iteration limit and the time limit after each iteration.

When used asynchronously `max_execution_time` gives really tight control over the max time for an execution chain.  When used synchronously, the chain can unfortunately exceed max_execution_time, but it still gives more control than trying to estimate the number of max_iterations needed to cap the execution time.