### PR TITLE
Don't create a new Pinecone index if doesn't exist

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -21,7 +21,7 @@ class Pinecone(VectorStore):
             from langchain.embeddings.openai import OpenAIEmbeddings
             import pinecone
 
-            # The environment should be the one specified next to the API key 
+            # The environment should be the one specified next to the API key
             # in your Pinecone console
             pinecone.init(api_key="***", environment="...")
             index = pinecone.Index("langchain-demo")
@@ -188,7 +188,7 @@ class Pinecone(VectorStore):
                 from langchain.embeddings import OpenAIEmbeddings
                 import pinecone
 
-                # The environment should be the one specified next to the API key 
+                # The environment should be the one specified next to the API key
                 # in your Pinecone console
                 pinecone.init(api_key="***", environment="...")
                 embeddings = OpenAIEmbeddings()

--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -21,7 +21,8 @@ class Pinecone(VectorStore):
             from langchain.embeddings.openai import OpenAIEmbeddings
             import pinecone
 
-            # The environment should be the one specified next to the API key in your Pinecone console
+            # The environment should be the one specified next to the API key 
+            # in your Pinecone console
             pinecone.init(api_key="***", environment="...")
             index = pinecone.Index("langchain-demo")
             embeddings = OpenAIEmbeddings()
@@ -187,7 +188,8 @@ class Pinecone(VectorStore):
                 from langchain.embeddings import OpenAIEmbeddings
                 import pinecone
 
-                # The environment should be the one specified next to the API key in your Pinecone console
+                # The environment should be the one specified next to the API key 
+                # in your Pinecone console
                 pinecone.init(api_key="***", environment="...")
                 embeddings = OpenAIEmbeddings()
                 pinecone = Pinecone.from_texts(
@@ -210,11 +212,13 @@ class Pinecone(VectorStore):
             index = pinecone.Index(index_name)
         elif len(indexes) == 0:
             raise ValueError(
-                f"No active indexes found in your Pinecone project, are you sure you're using the right API key and environment?"
+                "No active indexes found in your Pinecone project, "
+                "are you sure you're using the right API key and environment?"
             )
         else:
             raise ValueError(
-                f"Index '{index_name}' not found in your Pinecone project. Did you mean one of the following indexes: {', '.join(indexes)}"
+                f"Index '{index_name}' not found in your Pinecone project. "
+                "Did you mean one of the following indexes: {', '.join(indexes)}"
             )
 
         for i in range(0, len(texts), batch_size):


### PR DESCRIPTION
In the case no pinecone index is specified, or a wrong one is, do not create a new one. Creating new indexes can cause unexpected costs to users, and some code paths could cause a new one to be created on each invocation.
This PR solves #2413.