### PR TITLE
Documentation Error - Typo in Docs - Update custom_mrkl_agent.ipynb

### DIFF
--- a/docs/modules/agents/agents/custom_mrkl_agent.ipynb
+++ b/docs/modules/agents/agents/custom_mrkl_agent.ipynb
@@ -13,7 +13,7 @@
     "    \n",
     "    - Tools: The tools the agent has available to use.\n",
     "    - LLMChain: The LLMChain that produces the text that is parsed in a certain way to determine which action to take.\n",
-    "    - The agent class itself: this parses the output of the LLMChain to determin which action to take.\n",
+    "    - The agent class itself: this parses the output of the LLMChain to determine which action to take.\n",
     "        \n",
     "        \n",
     "In this notebook we walk through how to create a custom MRKL agent by creating a custom LLMChain."


### PR DESCRIPTION
Just a small typo in the documentation.