### PR TITLE
Add lint_diff command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all clean format lint test tests test_watch integration_tests docker_tests help
 
+
 all: help
 
 coverage:
@@ -23,9 +24,13 @@ format:
 	poetry run black .
 	poetry run ruff --select I --fix .
 
-lint:
-	poetry run mypy .
-	poetry run black . --check
+PYTHON_FILES=.
+lint: PYTHON_FILES=.
+lint_diff: PYTHON_FILES=$(shell git diff --name-only --diff-filter=d master | grep -E '\.py$$')
+
+lint lint_diff:
+	poetry run mypy $(PYTHON_FILES)
+	poetry run black $(PYTHON_FILES) --check
 	poetry run ruff .
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: all clean format lint test tests test_watch integration_tests docker_tests help
 
-
 all: help
 
 coverage:


### PR DESCRIPTION
It's helpful for developers to run the linter locally on just the changed files.

This PR adds support for a `lint_diff` command.

Ruff is still run over the entire directory since it's very fast.