### PR TITLE
feat: adds support for MSFT Outlook files in `UnstructuredEmailLoader`

### DIFF
--- a/langchain/document_loaders/email.py
+++ b/langchain/document_loaders/email.py
@@ -5,7 +5,8 @@ from typing import List
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 from langchain.document_loaders.unstructured import (
-    UnstructuredFileLoader, satisfies_min_unstructured_version
+    UnstructuredFileLoader,
+    satisfies_min_unstructured_version,
 )
 
 
@@ -26,8 +27,9 @@ class UnstructuredEmailLoader(UnstructuredFileLoader):
 
             return partition_msg(filename=self.file_path)
         else:
-            raise ValueError(f"Filetype {filetype} is not supported in UnstructuredEmailLoader.")
-
+            raise ValueError(
+                f"Filetype {filetype} is not supported in UnstructuredEmailLoader."
+            )
 
 
 class OutlookMessageLoader(BaseLoader):


### PR DESCRIPTION
### Summary

Adds support for MSFT Outlook emails saved in `.msg` format to `UnstructuredEmailLoader`. Works if the user has `unstructured>=0.5.8` installed.

### Testing

The following tests use the example files under `example-docs` in the Unstructured repo.

```python
from langchain.document_loaders import UnstructuredEmailLoader

loader = UnstructuredEmailLoader("fake-email.eml")
loader.load()

loader = UnstructuredEmailLoader("fake-email.msg")
loader.load()
```