### PR TITLE
Fix WhatsAppChatLoader regex pattern for 24 hour time format

### DIFF
--- a/langchain/document_loaders/whatsapp_chat.py
+++ b/langchain/document_loaders/whatsapp_chat.py
@@ -28,7 +28,7 @@ class WhatsAppChatLoader(BaseLoader):
 
         for line in lines:
             result = re.match(
-                r"(\d{1,2}/\d{1,2}/\d{2,4}, \d{1,2}:\d{1,2} (?:AM|PM)) - (.*?): (.*)",
+                r"(\d{1,2}/\d{1,2}/\d{2,4}, \d{1,2}:\d{1,2}(?: AM| PM)?) - (.*?): (.*)",
                 line.strip(),
             )
             if result:


### PR DESCRIPTION
Fix for 24 hour time format bug. Now whatsapp regex is able to parse either 12 or 24 hours time format.

Linked [issue](https://github.com/hwchase17/langchain/issues/2457).