### PR TITLE
Fix 'embeddings is not defined'

### DIFF
--- a/docs/modules/models/text_embedding/examples/llamacpp.ipynb
+++ b/docs/modules/models/text_embedding/examples/llamacpp.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query_result = embeddings.embed_query(text)"
+    "query_result = llama.embed_query(text)"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "doc_result = embeddings.embed_documents([text])"
+    "doc_result = llama.embed_documents([text])"
    ]
   }
  ],


### PR DESCRIPTION
Nothing major. The docs just give an error when you try to use `embeddings` instead of `llama`.