### PR TITLE
Update OpenAPI Planner to use params and shared memory

### DIFF
--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -26,12 +26,12 @@ from langchain.agents.mrkl.base import ZeroShotAgent
 from langchain.agents.tools import Tool
 from langchain.chains.llm import LLMChain
 from langchain.llms.openai import OpenAI
+from langchain.memory import ReadOnlySharedMemory
 from langchain.prompts import PromptTemplate
 from langchain.requests import RequestsWrapper
 from langchain.schema import BaseLanguageModel
 from langchain.tools.base import BaseTool
 from langchain.tools.requests.tool import BaseRequestsTool
-from langchain.memory import ReadOnlySharedMemory
 
 #
 # Requests tools with LLM-instructed extraction of truncated responses.

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -190,7 +190,7 @@ def create_openapi_agent(
     api_spec: ReducedOpenAPISpec,
     requests_wrapper: RequestsWrapper,
     llm: BaseLanguageModel,
-    shared_memory: ReadOnlySharedMemory = None,
+    shared_memory: Optional[ReadOnlySharedMemory] = None,
 ) -> AgentExecutor:
     """Instantiate API planner and controller for a given spec.
 

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -60,7 +60,7 @@ class RequestsGetToolWithParsing(BaseRequestsTool, BaseTool):
             data_params = data["params"]
         except KeyError:
             data_params = None
-        response = self.requests_wrapper.get(data["url"], params = data_params)
+        response = self.requests_wrapper.get(data["url"], params=data_params)
         response = response[: self.response_length]
         return self.llm_chain.predict(
             response=response, instructions=data["output_instructions"]
@@ -215,7 +215,7 @@ def create_openapi_agent(
         },
     )
     agent = ZeroShotAgent(
-        llm_chain=LLMChain(llm=llm, prompt=prompt, memory = shared_memory),
+        llm_chain=LLMChain(llm=llm, prompt=prompt, memory=shared_memory),
         allowed_tools=[tool.name for tool in tools],
     )
     return AgentExecutor.from_agent_and_tools(agent=agent, tools=tools, verbose=True)

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -190,7 +190,7 @@ def create_openapi_agent(
     api_spec: ReducedOpenAPISpec,
     requests_wrapper: RequestsWrapper,
     llm: BaseLanguageModel,
-    shared_memory: ReadOnlySharedMemory,
+    shared_memory: ReadOnlySharedMemory = None,
 ) -> AgentExecutor:
     """Instantiate API planner and controller for a given spec.
 

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -56,7 +56,11 @@ class RequestsGetToolWithParsing(BaseRequestsTool, BaseTool):
             data = json.loads(text)
         except json.JSONDecodeError as e:
             raise e
-        response = self.requests_wrapper.get(data["url"])
+        try:
+            data_params = data["params"]
+        except KeyError:
+            data_params = None
+        response = self.requests_wrapper.get(data["url"], params = data_params)
         response = response[: self.response_length]
         return self.llm_chain.predict(
             response=response, instructions=data["output_instructions"]
@@ -158,7 +162,7 @@ def _create_api_controller_tool(
     base_url = api_spec.servers[0]["url"]  # TODO: do better.
 
     def _create_and_run_api_controller_agent(plan_str: str) -> str:
-        pattern = r"\b(GET|POST)\s+(/\S+)*"
+        pattern = r"\b(GET|POST|PATCH)\s+(/\S+)*"
         matches = re.findall(pattern, plan_str)
         endpoint_names = [
             "{method} {route}".format(method=method, route=route.split("?")[0])

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -162,7 +162,7 @@ def _create_api_controller_tool(
     base_url = api_spec.servers[0]["url"]  # TODO: do better.
 
     def _create_and_run_api_controller_agent(plan_str: str) -> str:
-        pattern = r"\b(GET|POST|PATCH)\s+(/\S+)*"
+        pattern = r"\b(GET|POST)\s+(/\S+)*"
         matches = re.findall(pattern, plan_str)
         endpoint_names = [
             "{method} {route}".format(method=method, route=route.split("?")[0])

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -31,6 +31,7 @@ from langchain.requests import RequestsWrapper
 from langchain.schema import BaseLanguageModel
 from langchain.tools.base import BaseTool
 from langchain.tools.requests.tool import BaseRequestsTool
+from langchain.memory import ReadOnlySharedMemory
 
 #
 # Requests tools with LLM-instructed extraction of truncated responses.
@@ -185,6 +186,7 @@ def create_openapi_agent(
     api_spec: ReducedOpenAPISpec,
     requests_wrapper: RequestsWrapper,
     llm: BaseLanguageModel,
+    shared_memory: ReadOnlySharedMemory,
 ) -> AgentExecutor:
     """Instantiate API planner and controller for a given spec.
 
@@ -209,7 +211,7 @@ def create_openapi_agent(
         },
     )
     agent = ZeroShotAgent(
-        llm_chain=LLMChain(llm=llm, prompt=prompt),
+        llm_chain=LLMChain(llm=llm, prompt=prompt, memory = shared_memory),
         allowed_tools=[tool.name for tool in tools],
     )
     return AgentExecutor.from_agent_and_tools(agent=agent, tools=tools, verbose=True)

--- a/langchain/agents/agent_toolkits/openapi/planner_prompt.py
+++ b/langchain/agents/agent_toolkits/openapi/planner_prompt.py
@@ -41,11 +41,11 @@ Here are endpoints you can use. Do not reference any of the endpoints above.
 User query: {query}
 Plan:"""
 API_PLANNER_TOOL_NAME = "api_planner"
-API_PLANNER_TOOL_DESCRIPTION = f"Can be used to generate the right API calls to assist with a user query, like {API_PLANNER_TOOL_NAME}(query). Should always be called before trying to calling the API controller."
+API_PLANNER_TOOL_DESCRIPTION = f"Can be used to generate the right API calls to assist with a user query, like {API_PLANNER_TOOL_NAME}(query). Should always be called before trying to call the API controller."
 
 # Execution.
 API_CONTROLLER_PROMPT = """You are an agent that gets a sequence of API calls and given their documentation, should execute them and return the final response.
-If you cannot complete them and run into issues, you should explain the issue. If you're able to resolve an API call call, you can retry the API call. When interacting with API objects, you should extract ids for inputs to other API calls but ids and names for outputs returned to the User.
+If you cannot complete them and run into issues, you should explain the issue. If you're able to resolve an API call, you can retry the API call. When interacting with API objects, you should extract ids for inputs to other API calls but ids and names for outputs returned to the User.
 
 
 Here is documentation on the API:
@@ -124,8 +124,8 @@ Thought: I should generate a plan to help with this query and then copy that pla
 {agent_scratchpad}"""
 
 REQUESTS_GET_TOOL_DESCRIPTION = """Use this to GET content from a website.
-Input to the tool should be a json string with 2 keys: "url" and "output_instructions".
-The value of "url" should be a string. The value of "output_instructions" should be instructions on what information to extract from the response, for example the id(s) for a resource(s) that the GET request fetches.
+Input to the tool should be a json string with 3 keys: "url", "params" and "output_instructions".
+The value of "url" should be a string. The value of "params" should be a dict and left empty if not needed. The value of "output_instructions" should be instructions on what information to extract from the response, for example the id(s) for a resource(s) that the GET request fetches.
 """
 
 PARSING_GET_PROMPT = PromptTemplate(

--- a/langchain/agents/agent_toolkits/openapi/planner_prompt.py
+++ b/langchain/agents/agent_toolkits/openapi/planner_prompt.py
@@ -107,12 +107,12 @@ User query: can you add some trendy stuff to my shopping cart.
 Thought: I should plan API calls first.
 Action: api_planner
 Action Input: I need to find the right API calls to add trendy items to the users shopping cart
-Observation: 1) GET /items with params = {'trending':'True'} to get trending item ids
+Observation: 1) GET /items with params 'trending' is 'True' to get trending item ids
 2) GET /user to get user
 3) POST /cart to post the trending items to the user's cart
 Thought: I'm ready to execute the API calls.
 Action: api_controller
-Action Input: 1) GET /items params = {'trending':'True'} to get trending item ids
+Action Input: 1) GET /items params 'trending' is 'True' to get trending item ids
 2) GET /user to get user
 3) POST /cart to post the trending items to the user's cart
 ...

--- a/langchain/agents/agent_toolkits/openapi/planner_prompt.py
+++ b/langchain/agents/agent_toolkits/openapi/planner_prompt.py
@@ -82,7 +82,7 @@ API_CONTROLLER_TOOL_DESCRIPTION = f"Can be used to execute a plan of API calls, 
 # The goal is to have an agent at the top-level (e.g. so it can recover from errors and re-plan) while
 # keeping planning (and specifically the planning prompt) simple.
 API_ORCHESTRATOR_PROMPT = """You are an agent that assists with user queries against API, things like querying information or creating resources.
-Some user queries can be resolved in a single API call though some require several API call.
+Some user queries can be resolved in a single API call, particularly if you can find appropriate params from the OpenAPI spec; though some require several API call.
 You should always plan your API calls first, and then execute the plan second.
 You should never return information without executing the api_controller tool.
 
@@ -107,12 +107,12 @@ User query: can you add some trendy stuff to my shopping cart.
 Thought: I should plan API calls first.
 Action: api_planner
 Action Input: I need to find the right API calls to add trendy items to the users shopping cart
-Observation: 1) GET /items/trending to get trending item ids
+Observation: 1) GET /items with params = {'trending':'True'} to get trending item ids
 2) GET /user to get user
 3) POST /cart to post the trending items to the user's cart
 Thought: I'm ready to execute the API calls.
 Action: api_controller
-Action Input: 1) GET /items/trending to get trending item ids
+Action Input: 1) GET /items params = {'trending':'True'} to get trending item ids
 2) GET /user to get user
 3) POST /cart to post the trending items to the user's cart
 ...
@@ -125,7 +125,11 @@ Thought: I should generate a plan to help with this query and then copy that pla
 
 REQUESTS_GET_TOOL_DESCRIPTION = """Use this to GET content from a website.
 Input to the tool should be a json string with 3 keys: "url", "params" and "output_instructions".
-The value of "url" should be a string. The value of "params" should be a dict and left empty if not needed. The value of "output_instructions" should be instructions on what information to extract from the response, for example the id(s) for a resource(s) that the GET request fetches.
+The value of "url" should be a string. 
+The value of "params" should be a dict of the needed and available parameters from the OpenAPI spec related to the endpoint. 
+If parameters are not needed, or not available, leave it empty.
+The value of "output_instructions" should be instructions on what information to extract from the response, 
+for example the id(s) for a resource(s) that the GET request fetches.
 """
 
 PARSING_GET_PROMPT = PromptTemplate(


### PR DESCRIPTION
The main change proposed here is to introduce params as a third argument for the class `RequestsGetToolWithParsing` as well as the corresponding instruction prompt, `REQUESTS_GET_TOOL_DESCRIPTION`. 

I've tested this on a fork and it appears to be working. Previously I had observed behaviour in which the Agent would attempt to return/list all results then follow up with a filter or truncation (when a GET list endpoint is available). However, due to the `RESPONSE_LENGTH`, any paginated or long responses perform poorly in this approach. Therefore, adding the params query allows the Agent to default to params when available (and `None` if not applicable).

Additionally, I have experimented with shared memory for the planner Agent. It's unclear if it is having the desired effect, however it doesn't throw errors and in theory should give the Planner more context on the entire conversation.