### PR TITLE
Recursively Parse in Request Body

### DIFF
--- a/langchain/tools/openapi/utils/api_models.py
+++ b/langchain/tools/openapi/utils/api_models.py
@@ -315,8 +315,10 @@ class APIRequestBody(BaseModel):
         spec: OpenAPISpec,
     ) -> List[APIRequestBodyProperty]:
         """Process the media type of the request body."""
+        references_used = []
         schema = media_type_obj.media_type_schema
         if isinstance(schema, Reference):
+            references_used.append(schema.ref.split("/")[-1])
             schema = spec.get_referenced_schema(schema)
         if schema is None:
             raise ValueError(
@@ -341,11 +343,12 @@ class APIRequestBody(BaseModel):
             api_request_body_properties.append(
                 APIRequestBodyProperty(
                     name="body",
-                    required=schema.required,
+                    required=True,
                     type=schema.type,
                     default=schema.default,
                     description=schema.description,
                     properties=[],
+                    references_used=references_used,
                 )
             )
 

--- a/langchain/tools/openapi/utils/api_models.py
+++ b/langchain/tools/openapi/utils/api_models.py
@@ -505,9 +505,9 @@ class APIOperation(BaseModel):
         formatted_params = "\n".join(params).strip()
         description_str = f"/* {self.description} */" if self.description else ""
         typescript_definition = f"""
-    {description_str}
-    type {operation_name} = (_: {{
-    {formatted_params}
-    }}) => any;
-    """
+{description_str}
+type {operation_name} = (_: {{
+{formatted_params}
+}}) => any;
+"""
         return typescript_definition.strip()

--- a/langchain/tools/openapi/utils/api_models.py
+++ b/langchain/tools/openapi/utils/api_models.py
@@ -1,9 +1,8 @@
 """Pydantic models for parsing an OpenAPI spec."""
-
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
-from openapi_schema_pydantic import MediaType, Parameter, Reference, Schema
+from openapi_schema_pydantic import MediaType, Parameter, Reference, RequestBody, Schema
 from pydantic import BaseModel, Field
 
 from langchain.tools.openapi.utils.openapi_utils import HTTPVerb, OpenAPISpec
@@ -39,6 +38,8 @@ class APIPropertyLocation(Enum):
                 f"Invalid APIPropertyLocation. Valid values are {cls.__members__}"
             )
 
+
+_SUPPORTED_MEDIA_TYPES = ("application/json",)
 
 SUPPORTED_LOCATIONS = {
     APIPropertyLocation.QUERY,
@@ -187,18 +188,189 @@ class APIProperty(APIPropertyBase):
 class APIRequestBodyProperty(APIPropertyBase):
     """A model for a request body property."""
 
-    properties: List[APIProperty] = Field(alias="properties")
+    properties: List["APIRequestBodyProperty"] = Field(alias="properties")
     """The sub-properties of the property."""
+
+    # This is useful for handling nested property cycles.
+    # We can define separate types in that case.
+    references_used: List[str] = Field(alias="referencesUsed", default_factory=list)
+    """The references used by the property."""
+
+    @classmethod
+    def _process_object_schema(
+        cls, schema: Schema, spec: OpenAPISpec, references_used: List[str]
+    ) -> Tuple[Union[str, List[str], None], List["APIRequestBodyProperty"]]:
+        properties = []
+        required_props = schema.required or []
+        if schema.properties is None:
+            raise ValueError(
+                f"No properties found when processing object schema: {schema}"
+            )
+        for prop_name, prop_schema in schema.properties.items():
+            if isinstance(prop_schema, Reference):
+                ref_name = prop_schema.ref.split("/")[-1]
+                if ref_name not in references_used:
+                    references_used.append(ref_name)
+                    prop_schema = spec.get_referenced_schema(prop_schema)
+                else:
+                    continue
+
+            properties.append(
+                cls.from_schema(
+                    schema=prop_schema,
+                    name=prop_name,
+                    required=prop_name in required_props,
+                    spec=spec,
+                    references_used=references_used,
+                )
+            )
+        return schema.type, properties
+
+    @classmethod
+    def _process_array_schema(
+        cls, schema: Schema, name: str, spec: OpenAPISpec, references_used: List[str]
+    ) -> str:
+        items = schema.items
+        if items is not None:
+            if isinstance(items, Reference):
+                ref_name = items.ref.split("/")[-1]
+                if ref_name not in references_used:
+                    references_used.append(ref_name)
+                    items = spec.get_referenced_schema(items)
+                else:
+                    pass
+                return f"Array<{ref_name}>"
+            else:
+                pass
+
+            if isinstance(items, Schema):
+                array_type = cls.from_schema(
+                    schema=items,
+                    name=f"{name}Item",
+                    required=True,  # TODO: Add required
+                    spec=spec,
+                    references_used=references_used,
+                )
+                return f"Array<{array_type.type}>"
+
+        return "array"
+
+    @classmethod
+    def from_schema(
+        cls,
+        schema: Schema,
+        name: str,
+        required: bool,
+        spec: OpenAPISpec,
+        references_used: Optional[List[str]] = None,
+    ) -> "APIRequestBodyProperty":
+        """Recursively populate from an OpenAPI Schema."""
+        if references_used is None:
+            references_used = []
+
+        schema_type = schema.type
+        properties: List[APIRequestBodyProperty] = []
+        if schema_type == "object" and schema.properties:
+            schema_type, properties = cls._process_object_schema(
+                schema, spec, references_used
+            )
+        elif schema_type == "array":
+            schema_type = cls._process_array_schema(schema, name, spec, references_used)
+        elif schema_type in PRIMITIVE_TYPES:
+            # Use the primitive type directly
+            pass
+        elif schema_type is None:
+            # No typing specified/parsed. WIll map to 'any'
+            pass
+        else:
+            raise ValueError(f"Unsupported type: {schema_type}")
+
+        return cls(
+            name=name,
+            required=required,
+            type=schema_type,
+            default=schema.default,
+            description=schema.description,
+            properties=properties,
+            references_used=references_used,
+        )
 
 
 class APIRequestBody(BaseModel):
     """A model for a request body."""
+
+    description: Optional[str] = Field(alias="description")
+    """The description of the request body."""
 
     properties: List[APIRequestBodyProperty] = Field(alias="properties")
 
     # E.g., application/json - we only support JSON at the moment.
     media_type: str = Field(alias="media_type")
     """The media type of the request body."""
+
+    @classmethod
+    def _process_supported_media_type(
+        cls,
+        media_type_obj: MediaType,
+        spec: OpenAPISpec,
+    ) -> List[APIRequestBodyProperty]:
+        """Process the media type of the request body."""
+        schema = media_type_obj.media_type_schema
+        if isinstance(schema, Reference):
+            schema = spec.get_referenced_schema(schema)
+        if schema is None:
+            raise ValueError(
+                f"Could not resolve schema for media type: {media_type_obj}"
+            )
+        api_request_body_properties = []
+        required_properties = schema.required or []
+        if schema.type == "object" and schema.properties:
+            for prop_name, prop_schema in schema.properties.items():
+                if isinstance(prop_schema, Reference):
+                    prop_schema = spec.get_referenced_schema(prop_schema)
+
+                api_request_body_properties.append(
+                    APIRequestBodyProperty.from_schema(
+                        schema=prop_schema,
+                        name=prop_name,
+                        required=prop_name in required_properties,
+                        spec=spec,
+                    )
+                )
+        else:
+            api_request_body_properties.append(
+                APIRequestBodyProperty(
+                    name="body",
+                    required=schema.required,
+                    type=schema.type,
+                    default=schema.default,
+                    description=schema.description,
+                    properties=[],
+                )
+            )
+
+        return api_request_body_properties
+
+    @classmethod
+    def from_request_body(
+        cls, request_body: RequestBody, spec: OpenAPISpec
+    ) -> "APIRequestBody":
+        """Instantiate from an OpenAPI RequestBody."""
+        properties = []
+        for media_type, media_type_obj in request_body.content.items():
+            if media_type not in _SUPPORTED_MEDIA_TYPES:
+                continue
+            api_request_body_properties = cls._process_supported_media_type(
+                media_type_obj,
+                spec,
+            )
+            properties.extend(api_request_body_properties)
+
+        return cls(
+            description=request_body.description,
+            properties=properties,
+            media_type=media_type,
+        )
 
 
 class APIOperation(BaseModel):
@@ -226,8 +398,8 @@ class APIOperation(BaseModel):
     # """The properties of the operation."""
     # components: Dict[str, BaseModel] = Field(alias="components")
 
-    # request_body: Optional[APIRequestBody] = Field(alias="request_body")
-    # """The request body of the operation."""
+    request_body: Optional[APIRequestBody] = Field(alias="request_body")
+    """The request body of the operation."""
 
     @classmethod
     def from_openapi_url(
@@ -252,6 +424,12 @@ class APIOperation(BaseModel):
         parameters = spec.get_parameters_for_operation(operation)
         properties = [APIProperty.from_parameter(param, spec) for param in parameters]
         operation_id = OpenAPISpec.get_cleaned_operation_id(operation, path, method)
+        request_body = spec.get_request_body_for_operation(operation)
+        api_request_body = (
+            APIRequestBody.from_request_body(request_body, spec)
+            if request_body is not None
+            else None
+        )
         return cls(
             operation_id=operation_id,
             description=operation.description,
@@ -259,6 +437,7 @@ class APIOperation(BaseModel):
             path=path,
             method=method,
             properties=properties,
+            request_body=api_request_body,
         )
 
     @staticmethod
@@ -281,10 +460,40 @@ class APIOperation(BaseModel):
         else:
             return str(type_)
 
+    def _format_nested_properties(
+        self, properties: List[APIRequestBodyProperty], indent: int = 2
+    ) -> str:
+        """Format nested properties."""
+        formatted_props = []
+
+        for prop in properties:
+            prop_name = prop.name
+            prop_type = self.ts_type_from_python(prop.type)
+            prop_required = "" if prop.required else "?"
+            prop_desc = f"/* {prop.description} */" if prop.description else ""
+
+            if prop.properties:
+                nested_props = self._format_nested_properties(
+                    prop.properties, indent + 2
+                )
+                prop_type = f"{{\n{nested_props}\n{' ' * indent}}}"
+
+            formatted_props.append(
+                f"{prop_desc}\n{' ' * indent}{prop_name}{prop_required}: {prop_type},"
+            )
+
+        return "\n".join(formatted_props)
+
     def to_typescript(self) -> str:
         """Get typescript string representation of the operation."""
         operation_name = self.operation_id
         params = []
+
+        if self.request_body:
+            formatted_request_body_props = self._format_nested_properties(
+                self.request_body.properties
+            )
+            params.append(formatted_request_body_props)
 
         for prop in self.properties:
             prop_name = prop.name
@@ -296,9 +505,9 @@ class APIOperation(BaseModel):
         formatted_params = "\n".join(params).strip()
         description_str = f"/* {self.description} */" if self.description else ""
         typescript_definition = f"""
-{description_str}
-type {operation_name} = (_: {{
-{formatted_params}
-}}) => any;
-"""
+    {description_str}
+    type {operation_name} = (_: {{
+    {formatted_params}
+    }}) => any;
+    """
         return typescript_definition.strip()

--- a/langchain/tools/openapi/utils/api_models.py
+++ b/langchain/tools/openapi/utils/api_models.py
@@ -193,7 +193,7 @@ class APIRequestBodyProperty(APIPropertyBase):
 
     # This is useful for handling nested property cycles.
     # We can define separate types in that case.
-    references_used: List[str] = Field(alias="referencesUsed", default_factory=list)
+    references_used: List[str] = Field(alias="references_used")
     """The references used by the property."""
 
     @classmethod

--- a/langchain/tools/openapi/utils/openapi_utils.py
+++ b/langchain/tools/openapi/utils/openapi_utils.py
@@ -145,26 +145,29 @@ class OpenAPISpec(OpenAPI):
     def _alert_unsupported_spec(obj: dict) -> None:
         """Alert if the spec is not supported."""
         warning_message = (
-            " This may result in incompletely parsed information."
-            + " Please convert your spec to a valid OpenAPI 3.1.* spec"
-            + " for best results."
+            " This will likely result in unsupported behavior."
+            + " Please convert your spec to a valid OpenAPI 3.1.* spec."
         )
         swagger_version = obj.get("swagger")
         openapi_version = obj.get("openapi")
-        if isinstance(openapi_version, str) and openapi_version.startswith("3.1"):
-            pass
+        if isinstance(openapi_version, str):
+            if openapi_version != "3.1.0":
+                logger.warning(
+                    f"Attempting to load an OpenAPI {openapi_version}"
+                    f" spec. {warning_message}"
+                )
+            else:
+                pass
         elif isinstance(swagger_version, str):
             logger.warning(
-                f"Attempting to load a Swagger {swagger_version} spec. "
-                + warning_message
-            )
-        elif isinstance(openapi_version, str):
-            logger.warning(
-                f"Attempting to load an OpenAPI {openapi_version} spec. "
-                + warning_message
+                f"Attempting to load a Swagger {swagger_version}"
+                f" spec. {warning_message}"
             )
         else:
-            raise ValueError(f"Unsupported spec:\n\n{obj}\n" + warning_message)
+            raise ValueError(
+                "Attempting to load an unsupported spec:"
+                f"\n\n{obj}\n{warning_message}"
+            )
 
     @classmethod
     def parse_obj(cls, obj: dict) -> "OpenAPISpec":

--- a/langchain/tools/openapi/utils/openapi_utils.py
+++ b/langchain/tools/openapi/utils/openapi_utils.py
@@ -164,7 +164,7 @@ class OpenAPISpec(OpenAPI):
                 + warning_message
             )
         else:
-            raise ValueError(f"Unsupported spec:\n\n{spec}\n" + warning_messages)
+            raise ValueError(f"Unsupported spec:\n\n{obj}\n" + warning_message)
 
     @classmethod
     def parse_obj(cls, obj: dict) -> "OpenAPISpec":

--- a/langchain/tools/openapi/utils/openapi_utils.py
+++ b/langchain/tools/openapi/utils/openapi_utils.py
@@ -141,8 +141,34 @@ class OpenAPISpec(OpenAPI):
             request_body = self._get_referenced_request_body(request_body)
         return request_body
 
+    @staticmethod
+    def _alert_unsupported_spec(obj: dict) -> None:
+        """Alert if the spec is not supported."""
+        warning_message = (
+            " This may result in incompletely parsed information."
+            + " Please convert your spec to a valid OpenAPI 3.1.* spec"
+            + " for best results."
+        )
+        swagger_version = obj.get("swagger")
+        openapi_version = obj.get("openapi")
+        if isinstance(openapi_version, str) and openapi_version.startswith("3.1"):
+            pass
+        elif isinstance(swagger_version, str):
+            logger.warning(
+                f"Attempting to load a Swagger {swagger_version} spec. "
+                + warning_message
+            )
+        elif isinstance(openapi_version, str):
+            logger.warning(
+                f"Attempting to load an OpenAPI {openapi_version} spec. "
+                + warning_message
+            )
+        else:
+            raise ValueError(f"Unsupported spec:\n\n{spec}\n" + warning_messages)
+
     @classmethod
-    def parse_obj(cls, obj: Any) -> "OpenAPISpec":
+    def parse_obj(cls, obj: dict) -> "OpenAPISpec":
+        cls._alert_unsupported_spec(obj)
         try:
             return super().parse_obj(obj)
         except ValidationError as e:

--- a/langchain/tools/openapi/utils/openapi_utils.py
+++ b/langchain/tools/openapi/utils/openapi_utils.py
@@ -5,7 +5,7 @@ import logging
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import requests
 import yaml

--- a/tests/unit_tests/tools/openapi/test_api_models.py
+++ b/tests/unit_tests/tools/openapi/test_api_models.py
@@ -148,3 +148,48 @@ def test_api_request_body_from_request_body_with_schema(raw_spec: OpenAPISpec) -
         )
     ]
     assert api_request_body.media_type == "application/json"
+
+
+def test_api_request_body_property_from_schema(raw_spec: OpenAPISpec) -> None:
+    raw_spec.components = Components(
+        schemas={
+            "Bar": Schema(
+                type="number",
+            )
+        }
+    )
+    schema = Schema(
+        type="object",
+        properties={
+            "foo": Schema(type="string"),
+            "bar": Reference(ref="#/components/schemas/Bar"),
+        },
+        required=["bar"],
+    )
+    api_request_body_property = APIRequestBodyProperty.from_schema(
+        schema, "test", required=True, spec=raw_spec
+    )
+    expected_sub_properties = [
+        APIRequestBodyProperty(
+            name="foo",
+            required=False,
+            type="string",
+            default=None,
+            description=None,
+            properties=[],
+            references_used=[],
+        ),
+        APIRequestBodyProperty(
+            name="bar",
+            required=True,
+            type="number",
+            default=None,
+            description=None,
+            properties=[],
+            references_used=["Bar"],
+        ),
+    ]
+    assert api_request_body_property.properties[0] == expected_sub_properties[0]
+    assert api_request_body_property.properties[1] == expected_sub_properties[1]
+    assert api_request_body_property.type == "object"
+    assert api_request_body_property.properties[1].references_used == ["Bar"]

--- a/tests/unit_tests/tools/openapi/test_api_models.py
+++ b/tests/unit_tests/tools/openapi/test_api_models.py
@@ -3,6 +3,9 @@ import json
 import os
 from pathlib import Path
 from typing import Iterable, List, Tuple
+
+import pytest
+import yaml
 from openapi_schema_pydantic import (
     Components,
     Info,
@@ -11,9 +14,6 @@ from openapi_schema_pydantic import (
     RequestBody,
     Schema,
 )
-
-import pytest
-import yaml
 
 from langchain.tools.openapi.utils.api_models import (
     APIOperation,

--- a/tests/unit_tests/tools/openapi/test_api_models.py
+++ b/tests/unit_tests/tools/openapi/test_api_models.py
@@ -145,6 +145,7 @@ def test_api_request_body_from_request_body_with_schema(raw_spec: OpenAPISpec) -
             default=None,
             description=None,
             properties=[],
+            references_used=[],
         )
     ]
     assert api_request_body.media_type == "application/json"


### PR DESCRIPTION
This still doesn't handle the following
- non-JSON media types
- anyOf, allOf, oneOf's

And doesn't emit the typescript definitions for referred types, but that can be saved for a separate PR.