### PR TITLE
Fix GPT4All integration example

### DIFF
--- a/docs/modules/models/llms/integrations/gpt4all.ipynb
+++ b/docs/modules/models/llms/integrations/gpt4all.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "# You'll need to download a compatible model and convert it to ggml.\n",
     "# See: https://github.com/nomic-ai/gpt4all for more information.\n",
-    "llm = GPT4All(model_path=\"./models/gpt4all-model.bin\")"
+    "llm = GPT4All(model=\"./models/gpt4all-model.bin\")"
    ]
   },
   {


### PR DESCRIPTION
[The instructions for GPT4All integration](https://python.langchain.com/en/latest/modules/models/llms/integrations/gpt4all.html) did not work. The model path is read using `model` argument, not `model_path`. Otherwise you get the following error:
```
KeyError: 'model'
```

This PR fixes the example.