### PR TITLE
docs: update unstructured detectron install instructions 

### DIFF
--- a/docs/ecosystem/unstructured.md
+++ b/docs/ecosystem/unstructured.md
@@ -20,7 +20,7 @@ This page is broken into two parts: installation and setup, and then references 
     - `pandoc` (EPUBs)
 - If you are parsing PDFs using the `"hi_res"` strategy, run the following to install the `detectron2` model, which
   `unstructured` uses for layout detection:
-    - `pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@v0.6#egg=detectron2"`
+    - `pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"`
     - If `detectron2` is not installed, `unstructured` will fallback to processing PDFs
       using the `"fast"` strategy, which uses `pdfminer` directly and doesn't require
       `detectron2`.


### PR DESCRIPTION
Updated recommended `detectron2` version to install for use with `unstructured`.

Should now match version in [Unstructured README](https://github.com/Unstructured-IO/unstructured/blob/main/README.md#eight_pointed_black_star-quick-start).