### PR TITLE
Update gpt4all example with model param

### DIFF
--- a/docs/modules/models/llms/integrations/gpt4all.ipynb
+++ b/docs/modules/models/llms/integrations/gpt4all.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "# You'll need to download a compatible model and convert it to ggml.\n",
     "# See: https://github.com/nomic-ai/gpt4all for more information.\n",
-    "llm = GPT4All(model_path=\"./models/gpt4all-model.bin\")"
+    "llm = GPT4All(model=\"./models/gpt4all-model.bin\")"
    ]
   },
   {


### PR DESCRIPTION
I am pretty sure that the documentation here should point to `model` instead of `model_path` based on the documentation here: 

https://github.com/hwchase17/langchain/blob/master/langchain/llms/gpt4all.py#L26

