### PR TITLE
Add support to set up openai organizations

### DIFF
--- a/langchain/chains/moderation.py
+++ b/langchain/chains/moderation.py
@@ -38,10 +38,15 @@ class OpenAIModerationChain(Chain):
         openai_api_key = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
+        openai_organization = get_from_dict_or_env(
+            values, "openai_organization", "OPENAI_ORGANIZATION", default=None
+        )
         try:
             import openai
 
             openai.api_key = openai_api_key
+            if openai_organization:
+                openai.organization = openai_organization
             values["client"] = openai.Moderation
         except ImportError:
             raise ValueError(

--- a/langchain/chat_models/azure_openai.py
+++ b/langchain/chat_models/azure_openai.py
@@ -68,6 +68,9 @@ class AzureChatOpenAI(ChatOpenAI):
             "openai_api_type",
             "OPENAI_API_TYPE",
         )
+        openai_organization = get_from_dict_or_env(
+            values, "openai_organization", "OPENAI_ORGANIZATION", default=None
+        )
         try:
             import openai
 
@@ -75,6 +78,8 @@ class AzureChatOpenAI(ChatOpenAI):
             openai.api_base = openai_api_base
             openai.api_version = openai_api_version
             openai.api_key = openai_api_key
+            if openai_organization:
+                openai.organization = openai_organization
         except ImportError:
             raise ValueError(
                 "Could not import openai python package. "

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -151,10 +151,15 @@ class ChatOpenAI(BaseChatModel):
         openai_api_key = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
+        openai_organization = get_from_dict_or_env(
+            values, "openai_organization", "OPENAI_ORGANIZATION", default=None
+        )
         try:
             import openai
 
             openai.api_key = openai_api_key
+            if openai_organization:
+                openai.organization = openai_organization
         except ImportError:
             raise ValueError(
                 "Could not import openai python package. "

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -159,10 +159,15 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         openai_api_key = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
+        openai_organization = get_from_dict_or_env(
+            values, "openai_organization", "OPENAI_ORGANIZATION", default=None
+        )
         try:
             import openai
 
             openai.api_key = openai_api_key
+            if openai_organization:
+                openai.organization = openai_organization
             values["client"] = openai.Embedding
         except ImportError:
             raise ValueError(

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -204,10 +204,17 @@ class BaseOpenAI(BaseLLM):
         openai_api_key = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
+        openai_organization = get_from_dict_or_env(
+            values, "openai_organization", "OPENAI_ORGANIZATION", default=None
+        )
         try:
             import openai
 
             openai.api_key = openai_api_key
+            if openai_organization:
+                print("USING ORGANIZATION: ")
+                print(openai_organization)
+                openai.organization = openai_organization
             values["client"] = openai.Completion
         except ImportError:
             raise ValueError(
@@ -588,10 +595,15 @@ class OpenAIChat(BaseLLM):
         openai_api_key = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
+        openai_organization = get_from_dict_or_env(
+            values, "openai_organization", "OPENAI_ORGANIZATION", default=None
+        )
         try:
             import openai
 
             openai.api_key = openai_api_key
+            if openai_organization:
+                openai.organization = openai_organization
         except ImportError:
             raise ValueError(
                 "Could not import openai python package. "


### PR DESCRIPTION
Add support for defining the organization of OpenAI, similarly to what is done in the reference code below:

```
import os
import openai
openai.organization = os.getenv("OPENAI_ORGANIZATION")
openai.api_key = os.getenv("OPENAI_API_KEY")
```