### PR TITLE
Improve error message formatting for PythonREPL tool errors

### DIFF
--- a/langchain/python.py
+++ b/langchain/python.py
@@ -24,7 +24,6 @@ class PythonREPL(BaseModel):
         except Exception:
             sys.stdout = old_stdout
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            trace_info = traceback.format_exception(
-                exc_type, exc_value, exc_traceback)
+            trace_info = traceback.format_exception(exc_type, exc_value, exc_traceback)
             output = "\n".join(trace_info)
         return output

--- a/langchain/python.py
+++ b/langchain/python.py
@@ -1,5 +1,6 @@
 """Mock Python REPL."""
 import sys
+import traceback
 from io import StringIO
 from typing import Dict, Optional
 
@@ -20,7 +21,10 @@ class PythonREPL(BaseModel):
             exec(command, self.globals, self.locals)
             sys.stdout = old_stdout
             output = mystdout.getvalue()
-        except Exception as e:
+        except Exception:
             sys.stdout = old_stdout
-            output = str(e)
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            trace_info = traceback.format_exception(
+                exc_type, exc_value, exc_traceback)
+            output = "\n".join(trace_info)
         return output

--- a/tests/unit_tests/test_python.py
+++ b/tests/unit_tests/test_python.py
@@ -32,7 +32,7 @@ def test_python_repl_no_previous_variables() -> None:
     foo = 3  # noqa: F841
     repl = PythonREPL()
     output = repl.run("print(foo)")
-    assert output == "name 'foo' is not defined"
+    assert output == "NameError: name 'foo' is not defined"
 
 
 def test_python_repl_pass_in_locals() -> None:


### PR DESCRIPTION
The current PythonREPL returns incomplete error message.
This patch returns error messages that same with actual Python interpreter, so that llm can correctly understand the error messages.