### PR TITLE
Fix: unstructured package not found with UnstructuredBaseLoader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ psycopg2-binary = {version = "^2.9.5", optional = true}
 boto3 = {version = "^1.26.96", optional = true}
 pyowm = {version = "^3.3.0", optional = true}
 async-timeout = {version = "^4.0.0", python = "<3.11"}
+unstructured = {version = "^0.5.11", optional = true}
 
 [tool.poetry.group.docs.dependencies]
 autodoc_pydantic = "^1.8.0"


### PR DESCRIPTION
Fix error when using UnstructuredBaseLoader without unstructured package.

Previously, when using UnstructuredBaseLoader without having the unstructured package installed, an error would occur:: 

```
File "/opt/homebrew/lib/python3.11/site-packages/langchain/document_loaders/unstructured.py", line 34, in __init__
    raise ValueError(
ValueError: unstructured package not found, please install it with `pip install unstructured`
```