### PR TITLE
Fix a typo in the SQL agent prompt prefix

### DIFF
--- a/langchain/agents/agent_toolkits/sql/prompt.py
+++ b/langchain/agents/agent_toolkits/sql/prompt.py
@@ -4,7 +4,7 @@ SQL_PREFIX = """You are an agent designed to interact with a SQL database.
 Given an input question, create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer.
 Unless the user specifies a specific number of examples they wish to obtain, always limit your query to at most {top_k} results.
 You can order the results by a relevant column to return the most interesting examples in the database.
-Never query for all the columns from a specific table, only ask for a the few relevant columns given the question.
+Never query for all the columns from a specific table, only ask for the relevant columns given the question.
 You have access to tools for interacting with the database.
 Only use the below tools. Only use the information returned by the below tools to construct your final answer.
 You MUST double check your query before executing it. If you get an error while executing a query, rewrite the query and try again.


### PR DESCRIPTION
Fix the grammar in this sentence, and remove the redundant "few"

"only ask for a the few relevant columns" -> "only ask for the relevant columns"