### PR TITLE
Fix typo in ChatGPT plugins

### DIFF
--- a/docs/modules/agents/tools/examples/chatgpt_plugins.ipynb
+++ b/docs/modules/agents/tools/examples/chatgpt_plugins.ipynb
@@ -84,7 +84,7 @@
     "tools = load_tools([\"requests\"] )\n",
     "tools += [tool]\n",
     "\n",
-    "agent_chain = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION verbose=True)\n",
+    "agent_chain = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True)\n",
     "agent_chain.run(\"what t shirts are available in klarna?\")"
    ]
   },


### PR DESCRIPTION
This PR adds a `,` that was missing in the ChatGPT plugins examples.