### PR TITLE
RWKV: do not propagate model_state between calls

### DIFF
--- a/langchain/llms/rwkv.py
+++ b/langchain/llms/rwkv.py
@@ -67,8 +67,6 @@ class RWKV(LLM, BaseModel):
 
     pipeline: Any = None  #: :meta private:
 
-    model_state: Any = None  #: :meta private:
-
     model_tokens: Any = None  #: :meta private:
 
     class Config:
@@ -145,7 +143,7 @@ class RWKV(LLM, BaseModel):
         tokens = self.tokenizer.encode(prompt).ids
 
         logits = None
-        state = self.model_state
+        state = None
 
         occurrence = {}
 
@@ -178,8 +176,6 @@ class RWKV(LLM, BaseModel):
                     + occurrence[n] * self.penalty_alpha_frequency
                 )
 
-        # Update state for future invocations
-        self.model_state = state
         return decoded
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:


### PR DESCRIPTION
RWKV is an RNN with a hidden state that is part of its inference. However, the model state should not be carried across uses and it's a bug to do so.

This resets the state for multiple invocations