### PR TITLE
doc: change comment with correct name

### DIFF
--- a/docs/modules/chains/index_examples/chat_vector_db.ipynb
+++ b/docs/modules/chains/index_examples/chat_vector_db.ipynb
@@ -466,7 +466,7 @@
     "from langchain.chains.chat_index.prompts import CONDENSE_QUESTION_PROMPT, QA_PROMPT\n",
     "from langchain.chains.question_answering import load_qa_chain\n",
     "\n",
-    "# Construct a ChatVectorDBChain with a streaming llm for combine docs\n",
+    "# Construct a ConversationalRetrievalChain with a streaming llm for combine docs\n",
     "# and a separate, non-streaming llm for question generation\n",
     "llm = OpenAI(temperature=0)\n",
     "streaming_llm = OpenAI(streaming=True, callback_manager=CallbackManager([StreamingStdOutCallbackHandler()]), verbose=True, temperature=0)\n",


### PR DESCRIPTION
In this comment, it should be **ConversationalRetrievalChain** instead of **ChatVectorDBChain**