### PR TITLE
support setting environment variables in `.env` file

### DIFF
--- a/docs/getting_started/getting_started.md
+++ b/docs/getting_started/getting_started.md
@@ -35,6 +35,12 @@ import os
 os.environ["OPENAI_API_KEY"] = "..."
 ```
 
+You may also set the environment variable in a `.env` file in the working directory:
+
+```
+OPENAI_API_KEY=...
+```
+
 
 ## Building a Language Model Application: LLMs
 

--- a/langchain/utils.py
+++ b/langchain/utils.py
@@ -1,6 +1,12 @@
 """Generic utility functions."""
 import os
 from typing import Any, Dict, Optional
+from dotenv import dotenv_values
+
+_environ = {
+    **dotenv_values(),  # load .env file
+    **os.environ,       # override loaded values with environment variables
+}
 
 
 def get_from_dict_or_env(
@@ -9,13 +15,13 @@ def get_from_dict_or_env(
     """Get a value from a dictionary or an environment variable."""
     if key in data and data[key]:
         return data[key]
-    elif env_key in os.environ and os.environ[env_key]:
-        return os.environ[env_key]
+    elif env_key in _environ and _environ[env_key]:
+        return _environ[env_key]
     elif default is not None:
         return default
     else:
         raise ValueError(
             f"Did not find {key}, please add an environment variable"
-            f" `{env_key}` which contains it, or pass"
+            f" `{env_key}` which contains it, add `{env_key}=...` to .env file or pass"
             f"  `{key}` as a named parameter."
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -8655,4 +8655,4 @@ qdrant = ["qdrant-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "56e8666167102cc23b605c8d91b26a62c0858216637cc281b866315da766ad71"
+content-hash = "22b250be30011356fc36a18e212be684c6670dfbd7e684ac4b713d14bfa82d50"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ psycopg2-binary = {version = "^2.9.5", optional = true}
 #boto3 = {version = "^1.26.96", optional = true} # TODO: fix it, commented because the version failed with deeplake
 pyowm = {version = "^3.3.0", optional = true}
 async-timeout = {version = "^4.0.0", python = "<3.11"}
+python-dotenv = "^1.0.0"
 
 [tool.poetry.group.docs.dependencies]
 autodoc_pydantic = "^1.8.0"


### PR DESCRIPTION
Intention of change: setting API keys from the shell or `os.environ` is a tedious step. With this change, user can store API keys in a `.env` file and forget about it. `LangChain` will load the keys from the `.env` file automatically.
Note: for backward-compatibility, explicitly set local environment variables and `os.environ` will override the settings in `.env` file.