### PR TITLE
Fix missing import in AzureOpenAI embeddings example

### DIFF
--- a/docs/modules/models/text_embedding/examples/azureopenai.ipynb
+++ b/docs/modules/models/text_embedding/examples/azureopenai.ipynb
@@ -32,6 +32,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "\n",
     "embeddings = OpenAIEmbeddings(model=\"your-embeddings-deployment-name\")"
    ]
   },


### PR DESCRIPTION
## Why this PR?

Fixes #2624
There's a missing import statement in AzureOpenAI embeddings example.

## What's new in this PR?

- Import `OpenAIEmbeddings` before creating it's object.

## How it's tested?
- By running notebook and creating embedding object.