### PR TITLE
Add verbose field in the LlamaCpp clients

### DIFF
--- a/langchain/embeddings/llamacpp.py
+++ b/langchain/embeddings/llamacpp.py
@@ -53,7 +53,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
     """Number of tokens to process in parallel.
     Should be a number between 1 and n_ctx."""
 
-    verbose: Optional[bool] = True
+    client_verbose: Optional[bool] = True
     """A flag to indicate whether to print detailed information during the execution of the program."""
 
     class Config:
@@ -74,7 +74,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
         use_mlock = values["use_mlock"]
         n_threads = values["n_threads"]
         n_batch = values["n_batch"]
-        verbose = values["verbose"]
+        client_verbose = values["client_verbose"]
 
         try:
             from llama_cpp import Llama
@@ -90,7 +90,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
                 use_mlock=use_mlock,
                 n_threads=n_threads,
                 n_batch=n_batch,
-                verbose=verbose,
+                verbose=client_verbose,
                 embedding=True,
             )
         except ImportError:

--- a/langchain/embeddings/llamacpp.py
+++ b/langchain/embeddings/llamacpp.py
@@ -54,7 +54,8 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
     Should be a number between 1 and n_ctx."""
 
     client_verbose: Optional[bool] = True
-    """A flag to indicate whether to print detailed information during the execution of the program."""
+    """A flag to indicate whether to print detailed information 
+    during the execution of the program."""
 
     class Config:
         """Configuration for this pydantic object."""

--- a/langchain/embeddings/llamacpp.py
+++ b/langchain/embeddings/llamacpp.py
@@ -53,6 +53,9 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
     """Number of tokens to process in parallel.
     Should be a number between 1 and n_ctx."""
 
+    verbose: Optional[bool] = True
+    """A flag to indicate whether to print detailed information during the execution of the program."""
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -71,6 +74,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
         use_mlock = values["use_mlock"]
         n_threads = values["n_threads"]
         n_batch = values["n_batch"]
+        verbose = values["verbose"]
 
         try:
             from llama_cpp import Llama
@@ -86,6 +90,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
                 use_mlock=use_mlock,
                 n_threads=n_threads,
                 n_batch=n_batch,
+                verbose=verbose,
                 embedding=True,
             )
         except ImportError:

--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -87,6 +87,9 @@ class LlamaCpp(LLM):
     last_n_tokens_size: Optional[int] = 64
     """The number of tokens to look back when applying the repeat_penalty."""
 
+    verbose: Optional[bool] = True
+    """A flag to indicate whether to print detailed information during the execution of the program."""
+
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that llama-cpp-python library is installed."""
@@ -101,6 +104,7 @@ class LlamaCpp(LLM):
         n_threads = values["n_threads"]
         n_batch = values["n_batch"]
         last_n_tokens_size = values["last_n_tokens_size"]
+        verbose = values["verbose"]
 
         try:
             from llama_cpp import Llama
@@ -117,6 +121,7 @@ class LlamaCpp(LLM):
                 n_threads=n_threads,
                 n_batch=n_batch,
                 last_n_tokens_size=last_n_tokens_size,
+                verbose=verbose,
             )
         except ImportError:
             raise ModuleNotFoundError(

--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -87,7 +87,7 @@ class LlamaCpp(LLM):
     last_n_tokens_size: Optional[int] = 64
     """The number of tokens to look back when applying the repeat_penalty."""
 
-    verbose: Optional[bool] = True
+    client_verbose: Optional[bool] = True
     """A flag to indicate whether to print detailed information during the execution of the program."""
 
     @root_validator()
@@ -104,7 +104,7 @@ class LlamaCpp(LLM):
         n_threads = values["n_threads"]
         n_batch = values["n_batch"]
         last_n_tokens_size = values["last_n_tokens_size"]
-        verbose = values["verbose"]
+        client_verbose = values["client_verbose"]
 
         try:
             from llama_cpp import Llama
@@ -121,7 +121,7 @@ class LlamaCpp(LLM):
                 n_threads=n_threads,
                 n_batch=n_batch,
                 last_n_tokens_size=last_n_tokens_size,
-                verbose=verbose,
+                verbose=client_verbose,
             )
         except ImportError:
             raise ModuleNotFoundError(

--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -88,7 +88,8 @@ class LlamaCpp(LLM):
     """The number of tokens to look back when applying the repeat_penalty."""
 
     client_verbose: Optional[bool] = True
-    """A flag to indicate whether to print detailed information during the execution of the program."""
+    """A flag to indicate whether to print detailed information 
+    during the execution of the program."""
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:


### PR DESCRIPTION
It adds the verbose parameter to the class to be able to pass it to the Llama client and remove all the annoying prints. 

See the definition of the original Llama object in the wrapper to check the missing field: https://github.com/abetlen/llama-cpp-python/blob/main/llama_cpp/llama.py#L31