### PR TITLE
Doc - Update google_search.ipynb - more explicit reference to places where to create API keys

### DIFF
--- a/docs/modules/agents/tools/examples/google_search.ipynb
+++ b/docs/modules/agents/tools/examples/google_search.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook goes over how to use the google search component.\n",
     "\n",
-    "First, you need to set up the proper API keys and environment variables. To set it up, follow the instructions found [here](https://stackoverflow.com/questions/37083058/programmatically-searching-google-in-python-using-custom-search).\n",
+    "First, you need to set up the proper API keys and environment variables. To set it up, create the GOOGLE_API_KEY in the Google Cloud credential console (https://console.cloud.google.com/apis/credentials) and a GOOGLE_CSE_ID using the Programmable Search Enginge (https://programmablesearchengine.google.com/controlpanel/create). Next, it is good to follow the instructions found [here](https://stackoverflow.com/questions/37083058/programmatically-searching-google-in-python-using-custom-search).\n",
     "\n",
     "Then we will need to set some environment variables."
    ]


### PR DESCRIPTION
Took me a bit to find the proper places to get the API keys. The link earlier provided to setup search is still good, but why not provide direct link to the Google cloud tools that give you ability to create keys?