### PR TITLE
add: conda installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Please fill out [this form](https://forms.gle/57d8AmXBYp8PP8tZA) and we'll set u
 ## Quick Install
 
 `pip install langchain`
+or
+`conda install langchain -c conda-forge`
 
 ## 🤔 What is this?
 

--- a/docs/getting_started/getting_started.md
+++ b/docs/getting_started/getting_started.md
@@ -9,6 +9,8 @@ To get started, install LangChain with the following command:
 
 ```bash
 pip install langchain
+# or
+conda install langchain -c conda-forge
 ```
 
 


### PR DESCRIPTION
Hi, 

just wanted to mention that I added `langchain` to [conda-forge](https://github.com/conda-forge/langchain-feedstock), so that it can be installed with `conda`/`mamba` etc.
This makes it available to some corporate users with custom conda-servers and people who like to manage their python envs with conda.
