### PR TITLE
VectorStore Memory Module

### DIFF
--- a/docs/modules/memory/types/vectorstore_memory.ipynb
+++ b/docs/modules/memory/types/vectorstore_memory.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ff4be5f3",
+   "metadata": {},
+   "source": [
+    "# VectorStore Memory\n",
+    "\n",
+    "`VectorStoreMemory` stores interactions in a VectorDB and queries the top-K most \"salient\" interactions every type it is called.\n",
+    "\n",
+    "This differs from most of the other Memory classes in that "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "da3384db",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings.openai import OpenAIEmbeddings\n",
+    "from langchain.llms import OpenAI\n",
+    "from langchain.memory import VectorStoreMemory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2e7abdf",
+   "metadata": {},
+   "source": [
+    "### Initialize your VectorStore\n",
+    "\n",
+    "Depending on the store you choose, this step may look different. Consult the relevant VectorStore documentation for more details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eef56f65",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import faiss\n",
+    "\n",
+    "from langchain.docstore import InMemoryDocstore\n",
+    "from langchain.vectorstores import FAISS\n",
+    "\n",
+    "\n",
+    "embedding_size = 1536 # Dimensions of the OpenAIEmbeddings\n",
+    "index = faiss.IndexFlatL2(embedding_size)\n",
+    "embedding_fn = OpenAIEmbeddings().embed_query\n",
+    "vectorstore = FAISS(embedding_fn, index, InMemoryDocstore({}), {})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f4bdf92",
+   "metadata": {},
+   "source": [
+    "### Create your the VectorStoreMemory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e00d4938",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "memory = VectorStoreMemory(\n",
+    "    vectorstore=vectorstore,\n",
+    "    return_docs=False, # Makes load_memory_variables() return Dict[str, str] instead of Dict[str, List[Document]]\n",
+    "    )\n",
+    "\n",
+    "# Examples of how\n",
+    "memory.save_context({\"input\": \"hi\"}, {\"output\": \"whats up\"})\n",
+    "memory.save_context({\"input\": \"Heard of France?\"}, {\"output\": \"Undoubtedly\"})\n",
+    "memory.save_context({\"input\": \"How about Australia?\"}, {\"output\": \"Most certainly\"})\n",
+    "memory.save_context({\"input\": \"What about Montreal?\"}, {\"output\": \"Of course.\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2fe28a28",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "input: Heard of France?\n",
+      "output: Undoubtedly\n",
+      "input: What about Montreal?\n",
+      "output: Of course.\n",
+      "input: How about Australia?\n",
+      "output: Most certainly\n",
+      "input: hi\n",
+      "output: whats up\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Notice the first result discusses France, which the language model deems more semantically relevant\n",
+    "# than the other locations\n",
+    "print(memory.load_memory_variables({\"prompt\": \"Emmanuel Macron\"})[\"history\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6d2569f",
+   "metadata": {},
+   "source": [
+    "## Using in a chain\n",
+    "Let's walk through an example, again setting `verbose=True` so we can see the prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ebd68c10",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "input: hi\n",
+      "output: whats up\n",
+      "input: What about Montreal?\n",
+      "output: Of course.\n",
+      "input: How about Australia?\n",
+      "output: Most certainly\n",
+      "input: Heard of France?\n",
+      "output: Undoubtedly\n",
+      "Human: Hi, what's up?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\" Hi there! I'm doing great. How can I help you?\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.chains import ConversationChain\n",
+    "from langchain.llms import OpenAI\n",
+    "llm = OpenAI() # Can be any valid LLM\n",
+    "conversation_with_summary = ConversationChain(\n",
+    "    llm=llm, \n",
+    "    # We set a very low max_token_limit for the purposes of testing.\n",
+    "    memory=memory,\n",
+    "    verbose=True\n",
+    ")\n",
+    "conversation_with_summary.predict(input=\"Hi, what's up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "86207a61",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "input: How about Australia?\n",
+      "output: Most certainly\n",
+      "input: Heard of France?\n",
+      "output: Undoubtedly\n",
+      "input: hi\n",
+      "output: whats up\n",
+      "input: Hi, what's up?\n",
+      "response:  Hi there! I'm doing great. How can I help you?\n",
+      "Human: What do you know about Uluru?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\" Uluru is a large sandstone monolith in Australia's Northern Territory. It is also known by its English name Ayers Rock. It is considered to be sacred to the Aboriginal people and is a popular tourist destination.\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation_with_summary.predict(input=\"What do you know about Uluru?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "76a0ab39",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "input: Heard of France?\n",
+      "output: Undoubtedly\n",
+      "input: What about Montreal?\n",
+      "output: Of course.\n",
+      "input: What do you know about Uluru?\n",
+      "response:  Uluru is a large sandstone monolith in Australia's Northern Territory. It is also known by its English name Ayers Rock. It is considered to be sacred to the Aboriginal people and is a popular tourist destination.\n",
+      "input: How about Australia?\n",
+      "output: Most certainly\n",
+      "Human: Tell me more about UNESCO!\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "' UNESCO is the United Nations Educational, Scientific, and Cultural Organization. It was founded in 1945 and works to promote international cooperation in the fields of education, science, and culture. UNESCO works to advance global understanding and respect for diversity, cultural heritage, and human rights.'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conversation_with_summary.predict(input=\"Tell me more about UNESCO!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8c669db1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new ConversationChain chain...\u001b[0m\n",
+      "Prompt after formatting:\n",
+      "\u001b[32;1m\u001b[1;3mThe following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.\n",
+      "\n",
+      "Current conversation:\n",
+      "input: Tell me more about UNESCO!\n",
+      "response:  UNESCO is the United Nations Educational, Scientific, and Cultural Organization. It was founded in 1945 and works to promote international cooperation in the fields of education, science, and culture. UNESCO works to advance global understanding and respect for diversity, cultural heritage, and human rights.\n",
+      "input: What about Montreal?\n",
+      "output: Of course.\n",
+      "input: Heard of France?\n",
+      "output: Undoubtedly\n",
+      "input: How about Australia?\n",
+      "output: Most certainly\n",
+      "Human: Are there UNESCO sites in Canada?\n",
+      "AI:\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "' Yes, there are 18 UNESCO World Heritage Sites in Canada. They include the Canadian Rocky Mountain Parks, the Historic District of Old Québec, the Nahanni National Park Reserve, the Rideau Canal, and the L’Anse aux Meadows National Historic Site.'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can see here that the buffer is updated\n",
+    "conversation_with_summary.predict(input=\"Are there UNESCO sites in Canada?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c09a239",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/langchain/memory/__init__.py
+++ b/langchain/memory/__init__.py
@@ -18,6 +18,7 @@ from langchain.memory.simple import SimpleMemory
 from langchain.memory.summary import ConversationSummaryMemory
 from langchain.memory.summary_buffer import ConversationSummaryBufferMemory
 from langchain.memory.token_buffer import ConversationTokenBufferMemory
+from langchain.memory.vectorstore import VectorStoreMemory
 
 __all__ = [
     "CombinedMemory",
@@ -36,4 +37,5 @@ __all__ = [
     "ConversationTokenBufferMemory",
     "RedisChatMessageHistory",
     "DynamoDBChatMessageHistory",
+    "VectorStoreMemory",
 ]

--- a/langchain/memory/vectorstore.py
+++ b/langchain/memory/vectorstore.py
@@ -1,0 +1,95 @@
+"""Class for a VectorStore-backed memory object."""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import Field
+
+from langchain.memory.chat_memory import BaseMemory
+from langchain.memory.utils import get_prompt_input_key
+from langchain.schema import Document
+from langchain.vectorstores.base import VectorStore
+
+
+class VectorStoreMemory(BaseMemory):
+    """Class for a VectorStore-backed memory object."""
+
+    vectorstore: VectorStore = Field(exclude=True)
+    """Vector Database to connect to."""
+
+    k: int = 4
+    """Number of results to attempt to return from store."""
+
+    memory_key: str = "history"  #: :meta private:
+    """Key name to locate the memories in the result of load_memory_variables."""
+
+    input_key: Optional[str] = None
+    """Key name to index the inputs to load_memory_variables."""
+
+    search_type: str = "similarity"
+    """Method to use for searching."""
+
+    search_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    """Extra search args."""
+
+    return_docs: bool = True
+    """Whether or not to return the result of querying the database directly."""
+
+    @property
+    def memory_variables(self) -> List[str]:
+        """The list of keys emitted from the load_memory_variables method."""
+        return [self.memory_key]
+
+    def _similarity_search(self, query: str, k: int) -> List[Document]:
+        """Search the database for similar documents."""
+        # TODO: Extract vectorstores with similarity_search_with_score classes
+        # to a separate mixin and check to attempt to guarantee orderedness
+        # of the output.
+        if self.search_type == "similarity":
+            docs = self.vectorstore.similarity_search(
+                query, k=self.k, **self.search_kwargs
+            )
+        elif self.search_type == "mmr":
+            docs = self.vectorstore.max_marginal_relevance_search(
+                query, k=self.k, **self.search_kwargs
+            )
+        else:
+            raise ValueError(f"search_type of {self.search_type} not allowed.")
+        return docs
+
+    def _get_prompt_input_key(self, inputs: Dict[str, Any]) -> str:
+        """Get the input key for the prompt."""
+        if self.input_key is None:
+            return get_prompt_input_key(inputs, self.memory_variables)
+        return self.input_key
+
+    def load_memory_variables(
+        self, inputs: Dict[str, Any]
+    ) -> Dict[str, Union[List[Document], str]]:
+        """Return history buffer."""
+        input_key = self._get_prompt_input_key(inputs)
+        query = inputs[input_key]
+        docs = self._similarity_search(query, k=self.k)
+        result: Union[List[Document], str]
+        if not self.return_docs:
+            result = "\n".join([doc.page_content for doc in docs])
+        else:
+            result = docs
+        return {self.memory_key: result}
+
+    def _format_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> str:
+        """Format context from this conversation to buffer."""
+        # Each document should only include the current turn, not the chat history
+        filtered_inputs = {k: v for k, v in inputs.items() if k != self.memory_key}
+        texts = [
+            f"{k}: {v}"
+            for k, v in list(filtered_inputs.items()) + list(outputs.items())
+        ]
+        return "\n".join(texts)
+
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Save context from this conversation to buffer."""
+        formatted_text = self._format_context(inputs, outputs)
+        self.vectorstore.add_texts([formatted_text])
+
+    def clear(self) -> None:
+        """Nothing to clear."""


### PR DESCRIPTION
Adds a basic VectorStore-backed memory module.

So far doesn't inherit from ChatMemory since the initial usage is likely to be around storing intermediate steps. However it would be straightforward to alter or add an addition memory class for that.

Adds a notebook.

