### PR TITLE
FAISS: batch-embed in add_texts method

### DIFF
--- a/docs/use_cases/agents/baby_agi.ipynb
+++ b/docs/use_cases/agents/baby_agi.ipynb
@@ -75,7 +75,7 @@
     "import faiss\n",
     "embedding_size = 1536\n",
     "index = faiss.IndexFlatL2(embedding_size)\n",
-    "vectorstore = FAISS(embeddings_model.embed_query, index, InMemoryDocstore({}), {})"
+    "vectorstore = FAISS(embeddings_model, index, InMemoryDocstore({}), {})"
    ]
   },
   {

--- a/tests/integration_tests/vectorstores/test_faiss.py
+++ b/tests/integration_tests/vectorstores/test_faiss.py
@@ -95,7 +95,7 @@ def test_faiss_add_texts() -> None:
 
 def test_faiss_add_texts_not_supported() -> None:
     """Test adding of texts to a docstore that doesn't support it."""
-    docsearch = FAISS(FakeEmbeddings().embed_query, None, Wikipedia(), {})
+    docsearch = FAISS(FakeEmbeddings(), None, Wikipedia(), {})
     with pytest.raises(ValueError):
         docsearch.add_texts(["foo"])
 


### PR DESCRIPTION
Closes https://github.com/hwchase17/langchain/issues/2660

FAISS equivalent to https://github.com/hwchase17/langchain/pull/2657

Switches the FAISS init arguments to use an `Embeddings` object, so that in `add_texts`, we can call `embed_documents` which will batch-encode all of the passed text. This means a lot less calls to the embedding when passing a high number of new texts to `add_texts`

Made sure that `make lint` passes for this