### PR TITLE
Use tiktoken for Python 3.8

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -327,8 +327,8 @@ class ChatOpenAI(BaseChatModel):
 
     def get_num_tokens(self, text: str) -> int:
         """Calculate num tokens with tiktoken package."""
-        # tiktoken NOT supported for Python 3.8 or below
-        if sys.version_info[1] <= 8:
+        # tiktoken NOT supported for Python 3.7 or below
+        if sys.version_info[1] <= 7:
             return super().get_num_tokens(text)
         try:
             import tiktoken


### PR DESCRIPTION
Fixes issue #2677

`tiktoken` is supported for Python 3.8, so there is no need to use the fallback GPT-2 tokenizer.