### PR TITLE
Fix the unset argument in calling llama model

### DIFF
--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -177,6 +177,8 @@ class LlamaCpp(LLM):
             raise ValueError("`stop` found in both the input and default params.")
         elif self.stop:
             params["stop_sequences"] = self.stop
+        elif stop:
+            params["stop_sequences"] = stop
         else:
             params["stop_sequences"] = []
 


### PR DESCRIPTION
When using the llama.cpp together with agent like zero-shot-react-description, the missing branch will cause the parameter `stop` left empty, resulting in unexpected output format from the model.

This patch fixes that issue.