### PR TITLE
Add Zapier NLA OAuth access_token to be used

### DIFF
--- a/langchain/tools/zapier/tool.py
+++ b/langchain/tools/zapier/tool.py
@@ -31,8 +31,8 @@ Typically you'd use SequentialChain, here's a basic example:
 
     1. Use NLA to find an email in Gmail
     2. Use LLMChain to generate a draft reply to (1)
-    3. Use NLA to send the draft reply (2) to someone in Slack via direct mesage
-    
+    3. Use NLA to send the draft reply (2) to someone in Slack via direct message
+
 In code, below:
 
 ```python
@@ -61,6 +61,9 @@ from langchain.utilities.zapier import ZapierNLAWrapper
 
 llm = OpenAI(temperature=0)
 zapier = ZapierNLAWrapper()
+## To leverage a nla_oauth_access_token you may pass the value to the ZapierNLAWrapper
+## If you do this there is no need to initialize the ZAPIER_NLA_API_KEY env variable
+# zapier = ZapierNLAWrapper(zapier_nla_oauth_access_token="TOKEN_HERE")
 toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier)
 agent = initialize_agent(
     toolkit.get_tools(),

--- a/langchain/utilities/zapier.py
+++ b/langchain/utilities/zapier.py
@@ -56,9 +56,7 @@ class ZapierNLAWrapper(BaseModel):
 
         if self.zapier_nla_oauth_access_token:
             session.headers.update(
-                {
-                    "Authorization": f"Bearer {self.zapier_nla_oauth_access_token}"
-                }
+                {"Authorization": f"Bearer {self.zapier_nla_oauth_access_token}"}
             )
         else:
             session.params = {"api_key": self.zapier_nla_api_key}
@@ -98,7 +96,7 @@ class ZapierNLAWrapper(BaseModel):
             values,
             "zapier_nla_api_key",
             "ZAPIER_NLA_API_KEY",
-            zapier_nla_api_key_default
+            zapier_nla_api_key_default,
         )
 
         values["zapier_nla_api_key"] = zapier_nla_api_key

--- a/langchain/utilities/zapier.py
+++ b/langchain/utilities/zapier.py
@@ -37,6 +37,7 @@ class ZapierNLAWrapper(BaseModel):
     """
 
     zapier_nla_api_key: str
+    zapier_nla_oauth_access_token: str
     zapier_nla_api_base: str = "https://nla.zapier.com/api/v1/"
 
     class Config:
@@ -52,7 +53,16 @@ class ZapierNLAWrapper(BaseModel):
                 "Content-Type": "application/json",
             }
         )
-        session.params = {"api_key": self.zapier_nla_api_key}
+
+        if self.zapier_nla_oauth_access_token:
+            session.headers.update(
+                {
+                    "Authorization": f"Bearer {self.zapier_nla_oauth_access_token}"
+                }
+            )
+        else:
+            session.params = {"api_key": self.zapier_nla_api_key}
+
         return session
 
     def _get_action_request(
@@ -73,9 +83,24 @@ class ZapierNLAWrapper(BaseModel):
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key exists in environment."""
+
+        zapier_nla_api_key_default = None
+
+        # If there is a oauth_access_key passed in the values
+        # we don't need a nla_api_key it can be blank
+        if "zapier_nla_oauth_access_token" in values:
+            zapier_nla_api_key_default = ""
+        else:
+            values["zapier_nla_oauth_access_token"] = ""
+
+        # we require at least one API Key
         zapier_nla_api_key = get_from_dict_or_env(
-            values, "zapier_nla_api_key", "ZAPIER_NLA_API_KEY"
+            values,
+            "zapier_nla_api_key",
+            "ZAPIER_NLA_API_KEY",
+            zapier_nla_api_key_default
         )
+
         values["zapier_nla_api_key"] = zapier_nla_api_key
 
         return values


### PR DESCRIPTION
This change allows the user to initialize the ZapierNLAWrapper with a valid Zapier NLA OAuth Access_Token, which would be used to make requests back to the Zapier NLA API.

When a `zapier_nla_oauth_access_token` is passed to the ZapierNLAWrapper it is no longer required for the `ZAPIER_NLA_API_KEY ` environment variable to be set, still having it set will not affect the behavior as the `zapier_nla_oauth_access_token` will be used over the `ZAPIER_NLA_API_KEY`