### PR TITLE
Updating YoutubeLoader.from_youtube_channel name and doc to reflect actual usage

### DIFF
--- a/langchain/document_loaders/youtube.py
+++ b/langchain/document_loaders/youtube.py
@@ -106,8 +106,8 @@ class YoutubeLoader(BaseLoader):
         self.language = language
 
     @classmethod
-    def from_youtube_channel(cls, youtube_url: str, **kwargs: Any) -> YoutubeLoader:
-        """Given a channel name, load all videos."""
+    def from_youtube_url(cls, youtube_url: str, **kwargs: Any) -> YoutubeLoader:
+        """Given youtube URL, load video."""
         video_id = youtube_url.split("youtube.com/watch?v=")[-1]
         return cls(video_id, **kwargs)
 


### PR DESCRIPTION
the function actually updates video_id from URL not channel.

The docs still reflect the previous old function name `from_youtube_url`. Resolves #1962

https://python.langchain.com/en/latest/modules/indexes/document_loaders/examples/youtube.html