### PR TITLE
Use SQL dialect-specific prompts for SQLDatabaseChain

### DIFF
--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -125,7 +125,7 @@ class SQLDatabaseSequentialChain(Chain):
         cls,
         llm: BaseLanguageModel,
         database: SQLDatabase,
-        query_`prompt`: BasePromptTemplate = PROMPT,
+        query_prompt: BasePromptTemplate = PROMPT,
         decider_prompt: BasePromptTemplate = DECIDER_PROMPT,
         **kwargs: Any,
     ) -> SQLDatabaseSequentialChain:

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -1,13 +1,13 @@
 """Chain for interacting with SQL Database."""
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import Extra, Field
 
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
-from langchain.chains.sql_database.prompt import DECIDER_PROMPT, PROMPT
+from langchain.chains.sql_database.prompt import DECIDER_PROMPT, PROMPT, SQL_PROMPTS
 from langchain.prompts.base import BasePromptTemplate
 from langchain.schema import BaseLanguageModel
 from langchain.sql_database import SQLDatabase
@@ -28,7 +28,7 @@ class SQLDatabaseChain(Chain):
     """LLM wrapper to use."""
     database: SQLDatabase = Field(exclude=True)
     """SQL Database to connect to."""
-    prompt: BasePromptTemplate = PROMPT
+    prompt: Optional[BasePromptTemplate] = None
     """Prompt to use to translate natural language to SQL."""
     top_k: int = 5
     """Number of results to return from the query"""
@@ -65,8 +65,9 @@ class SQLDatabaseChain(Chain):
             return [self.output_key, "intermediate_steps"]
 
     def _call(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        llm_chain = LLMChain(llm=self.llm, prompt=self.prompt)
-        input_text = f"{inputs[self.input_key]} \nSQLQuery:"
+        prompt = self.prompt or SQL_PROMPTS[self.database.dialect]
+        llm_chain = LLMChain(llm=self.llm, prompt=prompt)
+        input_text = f"{inputs[self.input_key]}\nSQLQuery:"
         self.callback_manager.on_text(input_text, verbose=self.verbose)
         # If not present, then defaults to None which is all tables.
         table_names_to_use = inputs.get("table_names_to_use")
@@ -124,7 +125,7 @@ class SQLDatabaseSequentialChain(Chain):
         cls,
         llm: BaseLanguageModel,
         database: SQLDatabase,
-        query_prompt: BasePromptTemplate = PROMPT,
+        query_`prompt`: BasePromptTemplate = PROMPT,
         decider_prompt: BasePromptTemplate = DECIDER_PROMPT,
         **kwargs: Any,
     ) -> SQLDatabaseSequentialChain:

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -65,7 +65,11 @@ class SQLDatabaseChain(Chain):
             return [self.output_key, "intermediate_steps"]
 
     def _call(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        prompt = self.prompt or SQL_PROMPTS[self.database.dialect]
+        try:
+            prompt = self.prompt or SQL_PROMPTS[self.database.dialect]
+        except KeyError:
+            # fallback to generic prompt if dialect-specific prompt doesn't exist yet
+            prompt = PROMPT
         llm_chain = LLMChain(llm=self.llm, prompt=prompt)
         input_text = f"{inputs[self.input_key]}\nSQLQuery:"
         self.callback_manager.on_text(input_text, verbose=self.verbose)

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -1,12 +1,7 @@
 # flake8: noqa
-from langchain.chains.prompt_selector import ConditionalPromptSelector, is_chat_model
 from langchain.output_parsers.list import CommaSeparatedListOutputParser
 from langchain.prompts.prompt import PromptTemplate
-from langchain.prompts.chat import (
-    ChatPromptTemplate,
-    HumanMessagePromptTemplate,
-    SystemMessagePromptTemplate,
-)
+
 
 _DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results. You can order the results by a relevant column to return the most interesting examples in the database.
 
@@ -64,8 +59,7 @@ Only use the following tables:
 Question: {input}"""
 
 MSSQL_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_mssql_prompt
+    input_variables=["input", "table_info", "top_k"], template=_mssql_prompt
 )
 
 
@@ -156,8 +150,7 @@ Only use the following tables:
 Question: {input}"""
 
 POSTGRES_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_postgres_prompt
+    input_variables=["input", "table_info", "top_k"], template=_postgres_prompt
 )
 
 

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -45,9 +45,8 @@ DECIDER_PROMPT = PromptTemplate(
     output_parser=CommaSeparatedListOutputParser(),
 )
 
-__all__ = ("mssql", "mysql", "mariadb", "oracle", "postgresql", "sqlite")
 
-_mssql_system_template = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
+_mssql_prompt = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
@@ -60,22 +59,17 @@ SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
 Only use the following tables:
-{table_info}"""
+{table_info}
+
+Question: {input}"""
 
 MSSQL_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
-    template=_mssql_system_template + "\n\nQuestion: {input}",
-)
-
-MSSQL_CHAT_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessagePromptTemplate.from_template(_mssql_system_template),
-        HumanMessagePromptTemplate.from_template("Question: {input}")
-    ]
+    template=_mssql_prompt
 )
 
 
-_mysql_system_template = """You are a MySQL expert. Given an input question, first create a syntactically correct MySQL query to run, then look at the results of the query and return the answer to the input question.
+_mysql_prompt = """You are a MySQL expert. Given an input question, first create a syntactically correct MySQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MySQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
@@ -88,22 +82,17 @@ SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
 Only use the following tables:
-{table_info}"""
+{table_info}
+
+Question: {input}"""
 
 MYSQL_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
-    template=_mssql_system_template + "\n\nQuestion: {input}",
-)
-
-MYSQL_CHAT_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessagePromptTemplate.from_template(_mysql_system_template),
-        HumanMessagePromptTemplate.from_template("Question: {input}")
-    ]
+    template=_mysql_prompt,
 )
 
 
-_mariadb_system_template = """You are a MariaDB expert. Given an input question, first create a syntactically correct MariaDB query to run, then look at the results of the query and return the answer to the input question.
+_mariadb_prompt = """You are a MariaDB expert. Given an input question, first create a syntactically correct MariaDB query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MariaDB. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
@@ -116,22 +105,17 @@ SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
 Only use the following tables:
-{table_info}"""
+{table_info}
+
+Question: {input}"""
 
 MARIADB_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
-    template=_mssql_system_template + "\n\nQuestion: {input}",
-)
-
-MARIADB_CHAT_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessagePromptTemplate.from_template(_mariadb_system_template),
-        HumanMessagePromptTemplate.from_template("Question: {input}")
-    ]
+    template=_mariadb_prompt,
 )
 
 
-_oracle_system_template = """You are an Oracle SQL expert. Given an input question, first create a syntactically correct Oracle SQL query to run, then look at the results of the query and return the answer to the input question.
+_oracle_prompt = """You are an Oracle SQL expert. Given an input question, first create a syntactically correct Oracle SQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the FETCH FIRST n ROWS ONLY clause as per Oracle SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
@@ -144,22 +128,17 @@ SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
 Only use the following tables:
-{table_info}"""
+{table_info}
+
+Question: {input}"""
 
 ORACLE_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
-    template=_mssql_system_template + "\n\nQuestion: {input}",
-)
-
-ORACLE_CHAT_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessagePromptTemplate.from_template(_oracle_system_template),
-        HumanMessagePromptTemplate.from_template("Question: {input}")
-    ]
+    template=_oracle_prompt,
 )
 
 
-_postgres_system_template = """You are a PostgreSQL expert. Given an input question, first create a syntactically correct PostgreSQL query to run, then look at the results of the query and return the answer to the input question.
+_postgres_prompt = """You are a PostgreSQL expert. Given an input question, first create a syntactically correct PostgreSQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PostgreSQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
@@ -172,22 +151,17 @@ SQLResult: "Result of the SQLQuery"
 Answer: "Final answer here"
 
 Only use the following tables:
-{table_info}"""
+{table_info}
+
+Question: {input}"""
 
 POSTGRES_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
-    template=_mssql_system_template + "\n\nQuestion: {input}",
-)
-
-POSTGRES_CHAT_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessagePromptTemplate.from_template(_postgres_system_template),
-        HumanMessagePromptTemplate.from_template("Question: {input}")
-    ]
+    template=_postgres_prompt
 )
 
 
-_sqlite_system_template = """You are a SQLite expert. Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer to the input question.
+_sqlite_prompt = """You are a SQLite expert. Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per SQLite. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
@@ -206,14 +180,15 @@ Question: {input}"""
 
 SQLITE_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
-    template=_mssql_system_template + "\n\nQuestion: {input}",
-)
-
-SQLITE_CHAT_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessagePromptTemplate.from_template(_sqlite_system_template),
-        HumanMessagePromptTemplate.from_template("Question: {input}")
-    ]
+    template=_sqlite_prompt,
 )
 
 
+SQL_PROMPTS = {
+    "mssql": MSSQL_PROMPT,
+    "mysql": MYSQL_PROMPT,
+    "mariadb": MARIADB_PROMPT,
+    "oracle": ORACLE_PROMPT,
+    "postgresql": POSTGRES_PROMPT,
+    "sqlite": SQLITE_PROMPT,
+}

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -43,7 +43,7 @@ DECIDER_PROMPT = PromptTemplate(
 
 _mssql_prompt = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in square brackets ([]) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
 Use the following format:
@@ -65,7 +65,7 @@ MSSQL_PROMPT = PromptTemplate(
 
 _mysql_prompt = """You are a MySQL expert. Given an input question, first create a syntactically correct MySQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MySQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
 Use the following format:
@@ -88,7 +88,7 @@ MYSQL_PROMPT = PromptTemplate(
 
 _mariadb_prompt = """You are a MariaDB expert. Given an input question, first create a syntactically correct MariaDB query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MariaDB. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
 Use the following format:
@@ -111,7 +111,7 @@ MARIADB_PROMPT = PromptTemplate(
 
 _oracle_prompt = """You are an Oracle SQL expert. Given an input question, first create a syntactically correct Oracle SQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the FETCH FIRST n ROWS ONLY clause as per Oracle SQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
 Use the following format:
@@ -134,7 +134,7 @@ ORACLE_PROMPT = PromptTemplate(
 
 _postgres_prompt = """You are a PostgreSQL expert. Given an input question, first create a syntactically correct PostgreSQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PostgreSQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
 Use the following format:
@@ -156,7 +156,7 @@ POSTGRES_PROMPT = PromptTemplate(
 
 _sqlite_prompt = """You are a SQLite expert. Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per SQLite. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
 Use the following format:

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -1,6 +1,12 @@
 # flake8: noqa
+from langchain.chains.prompt_selector import ConditionalPromptSelector, is_chat_model
 from langchain.output_parsers.list import CommaSeparatedListOutputParser
 from langchain.prompts.prompt import PromptTemplate
+from langchain.prompts.chat import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    SystemMessagePromptTemplate,
+)
 
 _DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results. You can order the results by a relevant column to return the most interesting examples in the database.
 
@@ -38,3 +44,176 @@ DECIDER_PROMPT = PromptTemplate(
     template=_DECIDER_TEMPLATE,
     output_parser=CommaSeparatedListOutputParser(),
 )
+
+__all__ = ("mssql", "mysql", "mariadb", "oracle", "postgresql", "sqlite")
+
+_mssql_system_template = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}"""
+
+MSSQL_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_mssql_system_template + "\n\nQuestion: {input}",
+)
+
+MSSQL_CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        SystemMessagePromptTemplate.from_template(_mssql_system_template),
+        HumanMessagePromptTemplate.from_template("Question: {input}")
+    ]
+)
+
+
+_mysql_system_template = """You are a MySQL expert. Given an input question, first create a syntactically correct MySQL query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MySQL. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}"""
+
+MYSQL_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_mssql_system_template + "\n\nQuestion: {input}",
+)
+
+MYSQL_CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        SystemMessagePromptTemplate.from_template(_mysql_system_template),
+        HumanMessagePromptTemplate.from_template("Question: {input}")
+    ]
+)
+
+
+_mariadb_system_template = """You are a MariaDB expert. Given an input question, first create a syntactically correct MariaDB query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MariaDB. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}"""
+
+MARIADB_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_mssql_system_template + "\n\nQuestion: {input}",
+)
+
+MARIADB_CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        SystemMessagePromptTemplate.from_template(_mariadb_system_template),
+        HumanMessagePromptTemplate.from_template("Question: {input}")
+    ]
+)
+
+
+_oracle_system_template = """You are an Oracle SQL expert. Given an input question, first create a syntactically correct Oracle SQL query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the FETCH FIRST n ROWS ONLY clause as per Oracle SQL. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}"""
+
+ORACLE_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_mssql_system_template + "\n\nQuestion: {input}",
+)
+
+ORACLE_CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        SystemMessagePromptTemplate.from_template(_oracle_system_template),
+        HumanMessagePromptTemplate.from_template("Question: {input}")
+    ]
+)
+
+
+_postgres_system_template = """You are a PostgreSQL expert. Given an input question, first create a syntactically correct PostgreSQL query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PostgreSQL. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}"""
+
+POSTGRES_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_mssql_system_template + "\n\nQuestion: {input}",
+)
+
+POSTGRES_CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        SystemMessagePromptTemplate.from_template(_postgres_system_template),
+        HumanMessagePromptTemplate.from_template("Question: {input}")
+    ]
+)
+
+
+_sqlite_system_template = """You are a SQLite expert. Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per SQLite. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}
+
+Question: {input}"""
+
+SQLITE_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_mssql_system_template + "\n\nQuestion: {input}",
+)
+
+SQLITE_CHAT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        SystemMessagePromptTemplate.from_template(_sqlite_system_template),
+        HumanMessagePromptTemplate.from_template("Question: {input}")
+    ]
+)
+
+


### PR DESCRIPTION
Mentioned the idea here initially: https://github.com/hwchase17/langchain/pull/2106#issuecomment-1487509106

Since there have been dialect-specific issues, we should use dialect-specific prompts. This way, each prompt can be separately modified to best suit each dialect as needed. This adds a prompt for each dialect supported in sqlalchemy (mssql, mysql, mariadb, postgres, oracle, sqlite). For this initial implementation, the only differencse between the prompts is the instruction for the clause to use to limit the number of rows queried for, and the instruction for wrapping column names using each dialect's identifier quote character.