### PR TITLE
use correct model name as engine with Azure deployments

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -222,7 +222,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 response = embed_with_retry(
                     self,
                     input=tokens[i : i + _chunk_size],
-                    engine=self.document_model_name,
+                    engine=self.query_model_name,
                 )
                 batched_embeddings += [r["embedding"] for r in response["data"]]
 


### PR DESCRIPTION
Seems that wrong name was passed to the engine. AFAIK this only affects embedding model deployments in Azure. At least this way it's backward compatible to older releases.