### PR TITLE
Add type inference for output parsers

### DIFF
--- a/langchain/output_parsers/fix.py
+++ b/langchain/output_parsers/fix.py
@@ -1,30 +1,32 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TypeVar
 
 from langchain.chains.llm import LLMChain
 from langchain.output_parsers.prompts import NAIVE_FIX_PROMPT
 from langchain.prompts.base import BasePromptTemplate
 from langchain.schema import BaseLanguageModel, BaseOutputParser, OutputParserException
 
+T = TypeVar("T")
 
-class OutputFixingParser(BaseOutputParser):
+
+class OutputFixingParser(BaseOutputParser[T]):
     """Wraps a parser and tries to fix parsing errors."""
 
-    parser: BaseOutputParser
+    parser: BaseOutputParser[T]
     retry_chain: LLMChain
 
     @classmethod
     def from_llm(
         cls,
         llm: BaseLanguageModel,
-        parser: BaseOutputParser,
+        parser: BaseOutputParser[T],
         prompt: BasePromptTemplate = NAIVE_FIX_PROMPT,
-    ) -> OutputFixingParser:
+    ) -> OutputFixingParser[T]:
         chain = LLMChain(llm=llm, prompt=prompt)
         return cls(parser=parser, retry_chain=chain)
 
-    def parse(self, completion: str) -> Any:
+    def parse(self, completion: str) -> T:
         try:
             parsed_completion = self.parser.parse(completion)
         except OutputParserException as e:

--- a/langchain/output_parsers/pydantic.py
+++ b/langchain/output_parsers/pydantic.py
@@ -1,17 +1,19 @@
 import json
 import re
-from typing import Any
+from typing import Type, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
 from langchain.output_parsers.format_instructions import PYDANTIC_FORMAT_INSTRUCTIONS
 from langchain.schema import BaseOutputParser, OutputParserException
 
+T = TypeVar("T", bound=BaseModel)
 
-class PydanticOutputParser(BaseOutputParser):
-    pydantic_object: Any
 
-    def parse(self, text: str) -> BaseModel:
+class PydanticOutputParser(BaseOutputParser[T]):
+    pydantic_object: Type[T]
+
+    def parse(self, text: str) -> T:
         try:
             # Greedy search for 1st json candidate.
             match = re.search(

--- a/langchain/output_parsers/pydantic.py
+++ b/langchain/output_parsers/pydantic.py
@@ -40,6 +40,6 @@ class PydanticOutputParser(BaseOutputParser[T]):
         if "type" in reduced_schema:
             del reduced_schema["type"]
         # Ensure json in context is well-formed with double quotes.
-        schema = json.dumps(reduced_schema)
+        schema_str = json.dumps(reduced_schema)
 
-        return PYDANTIC_FORMAT_INSTRUCTIONS.format(schema=schema)
+        return PYDANTIC_FORMAT_INSTRUCTIONS.format(schema=schema_str)

--- a/langchain/output_parsers/structured.py
+++ b/langchain/output_parsers/structured.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import List
+from typing import Any, List
 
 from pydantic import BaseModel
 
@@ -37,7 +37,7 @@ class StructuredOutputParser(BaseOutputParser):
         )
         return STRUCTURED_FORMAT_INSTRUCTIONS.format(format=schema_str)
 
-    def parse(self, text: str) -> BaseModel:
+    def parse(self, text: str) -> Any:
         json_string = text.split("```json")[1].strip().strip("```").strip()
         try:
             json_obj = json.loads(json_string)

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, Generic, List, NamedTuple, Optional, TypeVar
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
@@ -327,15 +327,17 @@ class BaseRetriever(ABC):
 
 Memory = BaseMemory
 
+T = TypeVar("T")
 
-class BaseOutputParser(BaseModel, ABC):
+
+class BaseOutputParser(BaseModel, ABC, Generic[T]):
     """Class to parse the output of an LLM call.
 
     Output parsers help structure language model responses.
     """
 
     @abstractmethod
-    def parse(self, text: str) -> Any:
+    def parse(self, text: str) -> T:
         """Parse the output of an LLM call.
 
         A method which takes in a string (assumed output of language model )

--- a/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -46,7 +46,9 @@ DEF_EXPECTED_RESULT = TestModel(
 def test_pydantic_output_parser() -> None:
     """Test PydanticOutputParser."""
 
-    pydantic_parser = PydanticOutputParser(pydantic_object=TestModel)
+    pydantic_parser: PydanticOutputParser[TestModel] = PydanticOutputParser(
+        pydantic_object=TestModel
+    )
 
     result = pydantic_parser.parse(DEF_RESULT)
     print("parse_result:", result)
@@ -56,7 +58,9 @@ def test_pydantic_output_parser() -> None:
 def test_pydantic_output_parser_fail() -> None:
     """Test PydanticOutputParser where completion result fails schema validation."""
 
-    pydantic_parser = PydanticOutputParser(pydantic_object=TestModel)
+    pydantic_parser: PydanticOutputParser[TestModel] = PydanticOutputParser(
+        pydantic_object=TestModel
+    )
 
     try:
         pydantic_parser.parse(DEF_RESULT_FAIL)


### PR DESCRIPTION
Currently, the output type of a number of OutputParser's `parse` methods is `Any` when it can in fact be inferred.

This PR makes BaseOutputParser use a generic type and fixes the output types of the following parsers:
- `PydanticOutputParser`
- `OutputFixingParser`
- `RetryOutputParser`
- `RetryWithErrorOutputParser`

The output of the `StructuredOutputParser` is corrected from `BaseModel` to `Any` since there are no type guarantees provided by the parser.

Fixes issue #2715