### PR TITLE
Pass correct llm to requests tools

### DIFF
--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -115,7 +115,9 @@ def _create_api_planner_tool(
 
 def _get_llm_chain(llm):
     if isinstance(llm, AzureOpenAI) or isinstance(llm, AzureChatOpenAI):
-        llm = AzureOpenAI(**llm._identifying_params)
+        llm_args = llm._identifying_params.copy()
+        llm_args.pop("model_name")
+        llm = AzureOpenAI(**llm_args)
     else:
         llm = OpenAI()
     return LLMChain(llm=llm, prompt=PARSING_POST_PROMPT)

--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -5,8 +5,8 @@ from typing import List, Optional
 
 import yaml
 
-from langchain.llms import AzureOpenAI
-from langchain.chat_models import AzureChatOpenAI
+from pydantic import Field
+
 from langchain.agents.agent import AgentExecutor
 from langchain.agents.agent_toolkits.openapi.planner_prompt import (
     API_CONTROLLER_PROMPT,
@@ -48,6 +48,7 @@ def _get_default_llm_chain_factory(prompt):
             prompt=prompt,
         )
     return factory
+
 
 class RequestsGetToolWithParsing(BaseRequestsTool, BaseTool):
     name = "requests_get"


### PR DESCRIPTION
This fixes the error in the related issue below, which prevents from using the openapi agent with OpenAI models deployed in Azure.

It checks whether the llm is an Azure llm or not. If it is, it instantiates a new llm to be passed to the Requests Tool with the necessary parameters. This includes the deployment name (engine). I'm making sure that the model name is the default one, just like in the original code.

Closes #2546 