### PR TITLE
Fix the `create_sql_agent` instantiation

### DIFF
--- a/langchain/tools/sql_database/tool.py
+++ b/langchain/tools/sql_database/tool.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 """Tools for interacting with a SQL database."""
 from pydantic import BaseModel, Extra, Field, validator, root_validator
-from typing import (Any, Dict)
+from typing import Any, Dict
 
 from langchain.chains.llm import LLMChain
 from langchain.prompts import PromptTemplate

--- a/tests/unit_tests/agents/test_sql.py
+++ b/tests/unit_tests/agents/test_sql.py
@@ -1,8 +1,9 @@
 from langchain.agents import create_sql_agent
 from langchain.agents.agent_toolkits import SQLDatabaseToolkit
-from langchain.sql_database import SQLDatabase
 from langchain.llms.openai import OpenAI
+from langchain.sql_database import SQLDatabase
 from tests.unit_tests.llms.fake_llm import FakeLLM
+
 
 def test_create_sql_agent() -> None:
     db = SQLDatabase.from_uri("sqlite:///:memory:")
@@ -15,4 +16,4 @@ def test_create_sql_agent() -> None:
         toolkit=toolkit,
     )
 
-    assert agent_executor.run("foo") == "baz"
+    assert agent_executor.run("hello") == "baz"

--- a/tests/unit_tests/agents/test_sql.py
+++ b/tests/unit_tests/agents/test_sql.py
@@ -1,0 +1,18 @@
+from langchain.agents import create_sql_agent
+from langchain.agents.agent_toolkits import SQLDatabaseToolkit
+from langchain.sql_database import SQLDatabase
+from langchain.llms.openai import OpenAI
+from tests.unit_tests.llms.fake_llm import FakeLLM
+
+def test_create_sql_agent():
+    db = SQLDatabase.from_uri("sqlite:///:memory:")
+    queries = {"foo": "Final Answer: baz"}
+    llm = FakeLLM(queries=queries, sequential_responses=True)
+    toolkit = SQLDatabaseToolkit(db=db, llm=llm)
+
+    agent_executor = create_sql_agent(
+        llm=llm,
+        toolkit=toolkit,
+    )
+
+    assert agent_executor.run("foo") == "baz"

--- a/tests/unit_tests/agents/test_sql.py
+++ b/tests/unit_tests/agents/test_sql.py
@@ -4,7 +4,7 @@ from langchain.sql_database import SQLDatabase
 from langchain.llms.openai import OpenAI
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
-def test_create_sql_agent():
+def test_create_sql_agent() -> None:
     db = SQLDatabase.from_uri("sqlite:///:memory:")
     queries = {"foo": "Final Answer: baz"}
     llm = FakeLLM(queries=queries, sequential_responses=True)

--- a/tests/unit_tests/llms/fake_llm.py
+++ b/tests/unit_tests/llms/fake_llm.py
@@ -8,6 +8,8 @@ class FakeLLM(LLM):
     """Fake LLM wrapper for testing purposes."""
 
     queries: Optional[Mapping] = None
+    sequential_responses: Optional[bool] = False
+    response_index: int = 0
 
     @property
     def _llm_type(self) -> str:
@@ -15,7 +17,9 @@ class FakeLLM(LLM):
         return "fake"
 
     def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
-        """First try to lookup in queries, else return 'foo' or 'bar'."""
+        if self.sequential_responses:
+            return self._get_next_response_in_sequence
+
         if self.queries is not None:
             return self.queries[prompt]
         if stop is None:
@@ -26,3 +30,9 @@ class FakeLLM(LLM):
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
         return {}
+
+    @property
+    def _get_next_response_in_sequence(self):
+        response = self.queries[list(self.queries.keys())[self.response_index]]
+        self.response_index = self.response_index + 1
+        return response

--- a/tests/unit_tests/llms/fake_llm.py
+++ b/tests/unit_tests/llms/fake_llm.py
@@ -32,7 +32,7 @@ class FakeLLM(LLM):
         return {}
 
     @property
-    def _get_next_response_in_sequence(self):
+    def _get_next_response_in_sequence(self) -> str:
         response = self.queries[list(self.queries.keys())[self.response_index]]
         self.response_index = self.response_index + 1
         return response


### PR DESCRIPTION
**Original issue link**: https://github.com/hwchase17/langchain/issues/2722

I addressed the above issue by replacing the `initialize_llm_chain` method with a `@root_validator` that initializes the llm_chain field using the provided llm instance.

With these changes, the `QueryCheckerTool` class properly initializes the `llm_chain` field during instantiation. 

I also added a test and a minor modification to FakeLLM to easily fake the calls sequentially, which avoids rebuilding the template.

Feel free to let me know if you have any questions or suggestions.
