### PR TITLE
Fixed k=0 bug on ConversationBufferWindowMemory

### DIFF
--- a/langchain/memory/buffer_window.py
+++ b/langchain/memory/buffer_window.py
@@ -28,11 +28,10 @@ class ConversationBufferWindowMemory(BaseChatMemory):
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
         """Return history buffer."""
 
-        if self.return_messages:
-            buffer: Any = self.buffer[-self.k * 2 :]
-        else:
+        buffer: Any = self.buffer[-self.k * 2 :] if self.k > 0 else []
+        if not self.return_messages:
             buffer = get_buffer_string(
-                self.buffer[-self.k * 2 :],
+                buffer,
                 human_prefix=self.human_prefix,
                 ai_prefix=self.ai_prefix,
             )


### PR DESCRIPTION
Updated the "load_memory_variables" function of the ConversationBufferWindowMemory to support a window size of 0 (k=0). Previous behavior would return the full memory instead of an empty array. 