### PR TITLE
Fix headings in docs (ClearML and Comet)

### DIFF
--- a/docs/ecosystem/clearml_tracking.ipynb
+++ b/docs/ecosystem/clearml_tracking.ipynb
@@ -19,7 +19,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Getting API Credentials\n",
+    "## Getting API Credentials\n",
     "\n",
     "We'll be using quite some APIs in this notebook, here is a list and where to get them:\n",
     "\n",
@@ -47,7 +47,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Setting Up"
+    "## Setting Up"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Scenario 1: Just an LLM\n",
+    "## Scenario 1: Just an LLM\n",
     "\n",
     "First, let's just run a single LLM a few times and capture the resulting prompt-answer conversation in ClearML"
    ]
@@ -361,7 +361,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Scenario 2: Creating a agent with tools\n",
+    "## Scenario 2: Creating an agent with tools\n",
     "\n",
     "To show a more advanced workflow, let's create an agent with access to tools. The way ClearML tracks the results is not different though, only the table will look slightly different as there are other types of actions taken when compared to the earlier, simpler example.\n",
     "\n",
@@ -542,7 +542,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Tips and Next Steps\n",
+    "## Tips and Next Steps\n",
     "\n",
     "- Make sure you always use a unique `name` argument for the `clearml_callback.flush_tracker` function. If not, the model parameters used for a run will override the previous run!\n",
     "\n",

--- a/docs/ecosystem/comet_tracking.ipynb
+++ b/docs/ecosystem/comet_tracking.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using Comet with Langchain"
+    "# Comet"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the document structure in the [Ecosystem](https://python.langchain.com/en/latest/ecosystem.html) page. Also adds a fix for the heading on the [Comet](https://python.langchain.com/en/latest/ecosystem/comet_tracking.html) page for more consistency with other ecosystem tools.

## Screenshot

<img width="878" alt="image" src="https://user-images.githubusercontent.com/6207830/231674921-9bf25376-cf14-4dba-be3c-08e0abda6154.png">

<img width="869" alt="image" src="https://user-images.githubusercontent.com/6207830/231675105-d8e42df4-2d01-435b-9e09-3371522fd2ce.png">
