### PR TITLE
Fix #2837 validation errors in qdrant.add_texts

### DIFF
--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -83,7 +83,7 @@ class Qdrant(VectorStore):
             collection_name=self.collection_name,
             points=rest.Batch(
                 ids=ids,
-                vectors=[self.embedding_function(text) for text in texts],
+                vectors=self.embedding_function(texts),
                 payloads=self._build_payloads(
                     texts,
                     metadatas,


### PR DESCRIPTION
To fix https://github.com/hwchase17/langchain/issues/2837

Update vectors generation of `add_texts` , keeping the same as `from_texts` which works fine:

`vectors=[self.embedding_function(text) for text in texts],`
to
`vectors=self.embedding_function(texts)`
