### PR TITLE
[Docs] minor fixes to loaders links and rst warnings

### DIFF
--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -1,5 +1,5 @@
 LangChain Gallery
-=============
+=================
 
 Lots of people have built some pretty awesome stuff with LangChain.
 This is a collection of our favorites.
@@ -223,7 +223,7 @@ Open Source
     Answer questions about the documentation of any project    
 
 Misc. Colab Notebooks
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. panels::
     :body: text-center

--- a/docs/modules/indexes/document_loaders/examples/csv.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/csv.ipynb
@@ -106,7 +106,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Specify a column to be used identify the document source\n",
+    "## Specify a column to be used identify the document source\n",
     "\n",
     "Use the `source_column` argument to specify a column to be set as the source for the document created from each row. Otherwise `file_path` will be used as the source for all documents created from the csv file.\n",
     "\n",

--- a/docs/modules/indexes/document_loaders/examples/web_base.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/web_base.ipynb
@@ -89,7 +89,7 @@
    "id": "150988e6",
    "metadata": {},
    "source": [
-    "# Loading multiple webpages\n",
+    "## Loading multiple webpages\n",
     "\n",
     "You can also load multiple webpages at once by passing in a list of urls to the loader. This will return a list of documents in the same order as the urls passed in."
    ]
@@ -123,7 +123,7 @@
    "id": "641be294",
    "metadata": {},
    "source": [
-    "## Load multiple urls concurrently\n",
+    "### Load multiple urls concurrently\n",
     "\n",
     "You can speed up the scraping process by scraping and parsing multiple urls concurrently.\n",
     "\n",

--- a/docs/use_cases/evaluation.rst
+++ b/docs/use_cases/evaluation.rst
@@ -1,5 +1,5 @@
 Evaluation
-==============
+==========
 
 .. note::
    `Conceptual Guide <https://docs.langchain.com/docs/use-cases/evaluation>`_
@@ -83,7 +83,7 @@ The existing examples we have are:
 
 
 Other Examples
-------------
+--------------
 
 In addition, we also have some more generic resources for evaluation.
 


### PR DESCRIPTION
The doc loaders index was picking up a bunch of subheadings because I mistakenly made the MD titles H1s.  Fixed that.

Before:
![image](https://user-images.githubusercontent.com/707699/231843254-3dd0cb06-d30b-4bdf-8f46-0d7c01837678.png)

After:
![image](https://user-images.githubusercontent.com/707699/231843180-a665e81b-e228-4e5e-bba9-04cbb450bed6.png)

also the easy minor warnings from docs_build