### PR TITLE
update sql chain docs to clarify use of SQLAlchemy for connections

### DIFF
--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -9,9 +9,9 @@
     }
    },
    "source": [
-    "# SQLite example\n",
+    "# SQL Chain example\n",
     "\n",
-    "This example showcases hooking up an LLM to answer questions over a database."
+    "This example demonstrates the use of the `SQLDatabaseChain` for answering questions over a database."
    ]
   },
   {
@@ -23,8 +23,10 @@
     }
    },
    "source": [
-    "This uses the example Chinook database.\n",
-    "To set it up follow the instructions on https://database.guide/2-sample-databases-sqlite/, placing the `.db` file in a notebooks folder at the root of this repository."
+    "Under the hood, LangChain uses SQLAlchemy to connect to SQL databases. The `SQLDatabaseChain` can therefore be used with any SQL dialect supported by SQLAlchemy, such as MS SQL, MySQL, MariaDB, PostgreSQL, Oracle SQL, and SQLite. Please refer to the SQLAlchemy documentation for more information about requirements for connecting to your database. For example, a connection to MySQL requires an appropriate connector such as PyMySQL. A URI for a MySQL connection might look like: `mysql+pymysql://user:pass@some_mysql_db_address/db_name`\n",
+    "\n",
+    "This demonstration uses SQLite and the example Chinook database.\n",
+    "To set it up, follow the instructions on https://database.guide/2-sample-databases-sqlite/, placing the `.db` file in a notebooks folder at the root of this repository."
    ]
   },
   {
@@ -679,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Have seen questions about whether or not the `SQLDatabaseChain` supports more than just sqlite, which was unclear in the docs, so tried to clarify that and how to connect to other dialects.