### PR TITLE
Cannot parse LLM Output - Chat and Conversational Fix

### DIFF
--- a/langchain/agents/chat/base.py
+++ b/langchain/agents/chat/base.py
@@ -47,8 +47,13 @@ class ChatAgent(Agent):
         if FINAL_ANSWER_ACTION in text:
             return "Final Answer", text.split(FINAL_ANSWER_ACTION)[-1].strip()
 
-        if f"{self.llm_prefix} Do I need to use a tool? No" in text:  # Check if the Thought prefix is present
-            return "Final Answer", text.split(FINAL_ANSWER_ACTION)[-1].strip()  # Return the thought text as Final Answer
+        if (
+            f"{self.llm_prefix} Do I need to use a tool? No" in text
+        ):  # Check if the Thought prefix is present
+            return (
+                "Final Answer",
+                text.split(FINAL_ANSWER_ACTION)[-1].strip(),
+            )  # Return the thought text as Final Answer
 
         try:
             _, action, _ = text.split("```")
@@ -57,7 +62,6 @@ class ChatAgent(Agent):
 
         except Exception:
             raise ValueError(f"Could not parse LLM output: {text}")
-
 
     @property
     def _stop(self) -> List[str]:

--- a/langchain/agents/chat/base.py
+++ b/langchain/agents/chat/base.py
@@ -46,6 +46,10 @@ class ChatAgent(Agent):
     def _extract_tool_and_input(self, text: str) -> Optional[Tuple[str, str]]:
         if FINAL_ANSWER_ACTION in text:
             return "Final Answer", text.split(FINAL_ANSWER_ACTION)[-1].strip()
+
+        if f"{self.llm_prefix} Do I need to use a tool? No" in text:  # Check if the Thought prefix is present
+            return "Final Answer", text.split(FINAL_ANSWER_ACTION)[-1].strip()  # Return the thought text as Final Answer
+
         try:
             _, action, _ = text.split("```")
             response = json.loads(action.strip())
@@ -53,6 +57,7 @@ class ChatAgent(Agent):
 
         except Exception:
             raise ValueError(f"Could not parse LLM output: {text}")
+
 
     @property
     def _stop(self) -> List[str]:

--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -34,6 +34,16 @@ class ConversationalAgent(Agent):
         """Prefix to append the llm call with."""
         return "Thought:"
 
+    @property
+    def alt_finish(self) -> str:
+        """String representing a finished Thought."""
+        return "Do I need to use a tool? No"
+
+    @property
+    def finished(self) -> str:
+        """String representing a finished Thought."""
+        return "Do I have the final answer? Yes."
+
     @classmethod
     def create_prompt(
         cls,
@@ -82,10 +92,10 @@ class ConversationalAgent(Agent):
         regex = r"Action: (.*?)[\n]*Action Input: (.*)"
         match = re.search(regex, llm_output)
         if not match:
-            if f"{self.llm_prefix} Do I need to use a tool? No" in llm_output:
+            if f"{self.llm_prefix} {self.alt_finish}" in llm_output:
                 return (
                     self.ai_prefix,
-                    f"Do I have the final answer? Yes. {llm_output.split('Do I need to use a tool? No')[-1].strip()}",
+                    f"{self.finished} {llm_output.split(self.alt_finish)[-1].strip()}",
                 )
             raise ValueError(f"Could not parse LLM output: `{llm_output}`")
         action = match.group(1)

--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -83,7 +83,10 @@ class ConversationalAgent(Agent):
         match = re.search(regex, llm_output)
         if not match:
             if f"{self.llm_prefix} Do I need to use a tool? No" in llm_output:
-                return f"{self.ai_prefix} Do I have the final answer? Yes. {llm_output.split(f'Do I need to use a tool? No')[-1].strip()}"
+                return (
+                    self.ai_prefix,
+                    f"Do I have the final answer? Yes. {llm_output.split('Do I need to use a tool? No')[-1].strip()}",
+                )
             raise ValueError(f"Could not parse LLM output: `{llm_output}`")
         action = match.group(1)
         action_input = match.group(2)

--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -82,6 +82,8 @@ class ConversationalAgent(Agent):
         regex = r"Action: (.*?)[\n]*Action Input: (.*)"
         match = re.search(regex, llm_output)
         if not match:
+            if f"{self.llm_prefix} Do I need to use a tool? No" in llm_output:
+                return f"{self.ai_prefix} Do I have the final answer? Yes. {llm_output.split(f'Do I need to use a tool? No')[-1].strip()}"
             raise ValueError(f"Could not parse LLM output: `{llm_output}`")
         action = match.group(1)
         action_input = match.group(2)

--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -16,6 +16,14 @@ from langchain.tools.base import BaseTool
 
 FINAL_ANSWER_ACTION = "Final Answer:"
 
+AI_PREFIX: str = "AI"
+
+LLM_PREFIX = "Thought:"
+
+ALT_FINISH = "Do I need to use a tool? No"
+
+FINISHED = "Do I have the final answer? Yes."
+
 
 class ChainConfig(NamedTuple):
     """Configuration for chain to use in MRKL system.
@@ -45,6 +53,11 @@ def get_action_and_input(llm_output: str) -> Tuple[str, str]:
     regex = r"Action: (.*?)[\n]*Action Input:[\s]*(.*)"
     match = re.search(regex, llm_output, re.DOTALL)
     if not match:
+        if f"{LLM_PREFIX} {ALT_FINISH}" in llm_output:
+            return (
+                AI_PREFIX,
+                f"{FINISHED} {llm_output.split(ALT_FINISH)[-1].strip()}",
+            )
         raise ValueError(f"Could not parse LLM output: `{llm_output}`")
     action = match.group(1).strip()
     action_input = match.group(2)


### PR DESCRIPTION
I frequently encounter the value error raised by the try, except clauses in `_extract_tool_and_input` in both `agents/chat/base.py` and `agents/conversational/base.py` due to the Agent resulting in a 'Thought' with the answer, but no 'Final Answer' tag appearing to flag that the chain should end and be passed back up to the Agent using the tool. 

Specifically, the Agent will land in `Thought: Do I need to use a Tool? No. {Answer}` which does not return a Final Answer flag, Action or Action Input and breaks the `_extract_tool_and_inputs` methods, despite often returning useful information that should be surfaced back to the main Chat Agent using that Tool and therefore, user.

This may be fairly specific to using Chat LLMs as the LLM for the custom Tool, however I think I have configured the returns to effectively end the chain in a normal way.

I have tested this locally, and so far, have avoided any further `cannot parse {llm value}:` errors.

Note, as potential other work-arounds I previously tried using lower, or 0 temperature in the tool LLM initialization, as well as trying a less intelligent model (e.g. using `gpt-3.5-turbo` vs. `gpt-4` which appears to be much more confident in its inherent knowledge, and thus more likely to land in the 'Do I need to use a Tool? No. {Answer}` pattern).