### PR TITLE
Update reduce_openapi_spec for PATCH and DELETE

### DIFF
--- a/langchain/agents/agent_toolkits/openapi/spec.py
+++ b/langchain/agents/agent_toolkits/openapi/spec.py
@@ -68,12 +68,12 @@ def reduce_openapi_spec(spec: dict, dereference: bool = True) -> ReducedOpenAPIS
     I was hoping https://openapi.tools/ would have some useful bits
     to this end, but doesn't seem so.
     """
-    # 1. Consider only get, post endpoints.
+    # 1. Consider only get, post, patch, delete endpoints.
     endpoints = [
         (f"{operation_name.upper()} {route}", docs.get("description"), docs)
         for route, operation in spec["paths"].items()
         for operation_name, docs in operation.items()
-        if operation_name in ["get", "post"]
+        if operation_name in ["get", "post", "patch", "delete"]
     ]
 
     # 2. Replace any refs so that complete docs are retrieved.

--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -82,7 +82,7 @@ class ConversationalAgent(Agent):
         regex = r"Action: (.*?)[\n]*Action Input: (.*)"
         match = re.search(regex, llm_output)
         if not match:
-            return llm_output.strip()
+            raise ValueError(f"Could not parse LLM output: `{llm_output}`")
         action = match.group(1)
         action_input = match.group(2)
         return action.strip(), action_input.strip(" ").strip('"')

--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -82,7 +82,7 @@ class ConversationalAgent(Agent):
         regex = r"Action: (.*?)[\n]*Action Input: (.*)"
         match = re.search(regex, llm_output)
         if not match:
-            raise ValueError(f"Could not parse LLM output: `{llm_output}`")
+            return llm_output.strip()
         action = match.group(1)
         action_input = match.group(2)
         return action.strip(), action_input.strip(" ").strip('"')


### PR DESCRIPTION
My recent pull request (#2729) neglected to update the `reduce_openapi_spec` in spec.py to also accommodate PATCH and DELETE added to planner.py and prompt_planner.py.