### PR TITLE
remove default usage of openai model in SQLDatabaseToolkit

### DIFF
--- a/langchain/agents/agent_toolkits/sql/toolkit.py
+++ b/langchain/agents/agent_toolkits/sql/toolkit.py
@@ -20,7 +20,7 @@ class SQLDatabaseToolkit(BaseToolkit):
     """Toolkit for interacting with SQL databases."""
 
     db: SQLDatabase = Field(exclude=True)
-    llm: BaseLLM = Field(default_factory=lambda: OpenAI(temperature=0))
+    llm: BaseLLM = Field(exclude=True)
 
     @property
     def dialect(self) -> str:

--- a/langchain/agents/agent_toolkits/sql/toolkit.py
+++ b/langchain/agents/agent_toolkits/sql/toolkit.py
@@ -5,7 +5,6 @@ from pydantic import Field
 
 from langchain.agents.agent_toolkits.base import BaseToolkit
 from langchain.llms.base import BaseLLM
-from langchain.llms.openai import OpenAI
 from langchain.sql_database import SQLDatabase
 from langchain.tools import BaseTool
 from langchain.tools.sql_database.tool import (


### PR DESCRIPTION
#2866

This toolkit used openai LLM as the default, which could incurr unwanted cost. 