### PR TITLE
Add add_documents method to the Chroma class

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -117,6 +117,30 @@ class Chroma(VectorStore):
             metadatas=metadatas, embeddings=embeddings, documents=texts, ids=ids
         )
         return ids
+    
+    def add_documents(
+        self,
+        documents: Iterable[Document],
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Run more documents through the embeddings and add to the vectorstore.
+
+        Args:
+            documents (Iterable[Document]): Documents to add to the vectorstore.
+            ids (Optional[List[str]], optional): Optional list of IDs.
+
+        Returns:
+            List[str]: List of IDs of the added documents.
+        """
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+
+        if ids is None:
+            ids = [str(uuid.uuid1()) for _ in documents]
+
+        return self.add_texts(texts=texts, metadatas=metadatas, ids=ids)
+
 
     def similarity_search(
         self,


### PR DESCRIPTION
Creates the `add_documents` method to the `Chroma` class. The new method allows users to directly add Document objects to the Chroma instance, streamlining the process of incorporating documents into the vector store. Users can directly use it on a `Chroma` instance, without the need to go throught the classmethod. 

**Changes**

1. The add_documents method accepts an iterable of Document objects, optional document IDs, and other keyword arguments.
2. It extracts text content and metadata from the input documents and leverages the existing add_texts method to add them to the vector store.
3. Users can now easily add documents to the Chroma instance without the need to manually extract texts and metadata.