### PR TITLE
Add link to repo for deploying LangChain to Digitalocean App Platform

### DIFF
--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -33,12 +33,17 @@ It implements a Question Answering app and contains instructions for deploying t
 
 A minimal example on how to run LangChain on Vercel using Flask.
 
+## [Digitalocean App Platform](https://github.com/homanp/digitalocean-langchain)
+
+A minimal example on how to deploy LangChain to DigitalOcean App Platform.
 
 ## [SteamShip](https://github.com/steamship-core/steamship-langchain/)
+
 This repository contains LangChain adapters for Steamship, enabling LangChain developers to rapidly deploy their apps on Steamship.
 This includes: production ready endpoints, horizontal scaling across dependencies, persistant storage of app state, multi-tenancy support, etc.
 
 ## [Langchain-serve](https://github.com/jina-ai/langchain-serve)
+
 This repository allows users to serve local chains and agents as RESTful, gRPC, or Websocket APIs thanks to [Jina](https://docs.jina.ai/). Deploy your chains & agents with ease and enjoy independent scaling, serverless and autoscaling APIs, as well as a Streamlit playground on Jina AI Cloud.
 
 ## [BentoML](https://github.com/ssheng/BentoChain)


### PR DESCRIPTION
This PR adds a link to a minimal example of deploying `LangChain` to `Digitalocean App Platform`.