### PR TITLE
Add file filter param to Git loader

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/git.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/git.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,9 +103,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'GitLoader' from 'langchain.document_loaders' (/Users/apache/Library/Python/3.9/lib/python/site-packages/langchain/document_loaders/__init__.py)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mlangchain\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mdocument_loaders\u001b[39;00m \u001b[39mimport\u001b[39;00m GitLoader\n",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'GitLoader' from 'langchain.document_loaders' (/Users/apache/Library/Python/3.9/lib/python/site-packages/langchain/document_loaders/__init__.py)"
+     ]
+    }
+   ],
    "source": [
     "from langchain.document_loaders import GitLoader"
    ]
@@ -153,11 +165,24 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filtering files to load"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from langchain.document_loaders import GitLoader\n",
+    "\n",
+    "# eg. loading only python files\n",
+    "loader = GitLoader(repo_path=\"./example_data/test_repo1/\", branch=branch, file_filter=lambda file_path: file_path.endswith(\".py\"))"
+   ]
   }
  ],
  "metadata": {
@@ -176,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/docs/modules/indexes/document_loaders/examples/git.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/git.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,9 +68,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "page_content='.venv\\n.github\\n.git\\n.mypy_cache\\n.pytest_cache\\nDockerfile' metadata={'file_path': '.dockerignore', 'file_name': '.dockerignore', 'file_type': ''}\n"
+     ]
+    }
+   ],
    "source": [
     "print(data[0])"
    ]
@@ -84,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,15 +123,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1074"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(data)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -132,15 +150,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain.document_loaders import GitLoader\n",
     "\n",
     "# eg. loading only python files\n",
-    "loader = GitLoader(repo_path=\"./example_data/test_repo1/\", branch=branch, file_filter=lambda file_path: file_path.endswith(\".py\"))"
+    "loader = GitLoader(repo_path=\"./example_data/test_repo1/\", file_filter=lambda file_path: file_path.endswith(\".py\"))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -159,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/docs/modules/indexes/document_loaders/examples/git.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/git.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,37 +59,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1040"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(data)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "page_content='.venv\\n.github\\n.git\\n.mypy_cache\\n.pytest_cache\\nDockerfile' metadata={'file_path': '.dockerignore', 'file_name': '.dockerignore', 'file_type': ''}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(data[0])"
    ]
@@ -103,28 +84,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'GitLoader' from 'langchain.document_loaders' (/Users/apache/Library/Python/3.9/lib/python/site-packages/langchain/document_loaders/__init__.py)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mlangchain\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mdocument_loaders\u001b[39;00m \u001b[39mimport\u001b[39;00m GitLoader\n",
-      "\u001b[0;31mImportError\u001b[0m: cannot import name 'GitLoader' from 'langchain.document_loaders' (/Users/apache/Library/Python/3.9/lib/python/site-packages/langchain/document_loaders/__init__.py)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain.document_loaders import GitLoader"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,20 +115,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1040"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(data)"
    ]

--- a/langchain/document_loaders/git.py
+++ b/langchain/document_loaders/git.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -21,10 +21,12 @@ class GitLoader(BaseLoader):
         repo_path: str,
         clone_url: Optional[str] = None,
         branch: Optional[str] = "main",
+        file_filter: Optional[Callable[[str], bool]] = None,
     ):
         self.repo_path = repo_path
         self.clone_url = clone_url
         self.branch = branch
+        self.file_filter = file_filter
 
     def load(self) -> List[Document]:
         try:
@@ -47,28 +49,35 @@ class GitLoader(BaseLoader):
         docs: List[Document] = []
 
         for item in repo.tree().traverse():
-            if isinstance(item, Blob):
-                file_path = os.path.join(self.repo_path, item.path)
-                rel_file_path = os.path.relpath(file_path, self.repo_path)
-                try:
-                    with open(file_path, "rb") as f:
-                        content = f.read()
-                        file_type = os.path.splitext(item.name)[1]
+            if not isinstance(item, Blob):
+                continue
 
-                        # loads only text files
-                        try:
-                            text_content = content.decode("utf-8")
-                        except UnicodeDecodeError:
-                            continue
+            file_path = os.path.join(self.repo_path, item.path)
 
-                        metadata = {
-                            "file_path": rel_file_path,
-                            "file_name": item.name,
-                            "file_type": file_type,
-                        }
-                        doc = Document(page_content=text_content, metadata=metadata)
-                        docs.append(doc)
-                except Exception as e:
-                    print(f"Error reading file {file_path}: {e}")
+            # uses filter to skip files
+            if self.file_filter and not self.file_filter(file_path):
+                continue
+
+            rel_file_path = os.path.relpath(file_path, self.repo_path)
+            try:
+                with open(file_path, "rb") as f:
+                    content = f.read()
+                    file_type = os.path.splitext(item.name)[1]
+
+                    # loads only text files
+                    try:
+                        text_content = content.decode("utf-8")
+                    except UnicodeDecodeError:
+                        continue
+
+                    metadata = {
+                        "file_path": rel_file_path,
+                        "file_name": item.name,
+                        "file_type": file_type,
+                    }
+                    doc = Document(page_content=text_content, metadata=metadata)
+                    docs.append(doc)
+            except Exception as e:
+                print(f"Error reading file {file_path}: {e}")
 
         return docs


### PR DESCRIPTION
Allows users to specify what files should be loaded instead of indiscriminately loading the entire repo.

extends #2851 

NOTE: for reviewers, `hide whitespace` option recommended since I changed the indentation of an if-block to use `continue` instead so it looks less like a Christmas tree :)