### PR TITLE
add encoding to avoid UnicodeDecodeError

### DIFF
--- a/docs/modules/indexes/getting_started.ipynb
+++ b/docs/modules/indexes/getting_started.ipynb
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "from langchain.document_loaders import TextLoader\n",
-    "loader = TextLoader('../state_of_the_union.txt')"
+    "loader = TextLoader('../state_of_the_union.txt', encoding='utf8')"
    ]
   },
   {


### PR DESCRIPTION
**About**
Specify encoding to avoid UnicodeDecodeError when reading .txt for users who are following the tutorial. 

**Reference**
```
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1205: character maps to <undefined>
```

**Environment**
OS: Win 11
Python: 3.8