### PR TITLE
Add similarity_search_with_normalized_similarities

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -81,17 +81,17 @@ class VectorStore(ABC):
     ) -> List[Document]:
         """Return docs most similar to query."""
 
-    def similarity_search_with_normalized_similarities(
+    def similarity_search_with_relevance_scores(
         self,
         query: str,
         k: int = 4,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        """Return docs and similarity scores, normalized on a scale from 0 to 1.
+        """Return docs and relevance scores in the range [0, 1].
 
         0 is dissimilar, 1 is most similar.
         """
-        docs_and_similarities = self._similarity_search_with_normalized_similarities(
+        docs_and_similarities = self._similarity_search_with_relevance_scores(
             query, k=k, **kwargs
         )
         if any(
@@ -99,18 +99,18 @@ class VectorStore(ABC):
             for _, similarity in docs_and_similarities
         ):
             raise ValueError(
-                "Normalized similarity scores must be between"
+                "Relevance scores must be between"
                 f" 0 and 1, got {docs_and_similarities}"
             )
         return docs_and_similarities
 
-    def _similarity_search_with_normalized_similarities(
+    def _similarity_search_with_relevance_scores(
         self,
         query: str,
         k: int = 4,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        """Return docs and similarity scores, normalized on a scale from 0 to 1.
+        """Return docs and relevance scores, normalized on a scale from 0 to 1.
 
         0 is dissimilar, 1 is most similar.
         """

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -30,9 +30,9 @@ def dependable_faiss_import() -> Any:
     return faiss
 
 
-def _default_normalize_score_fn(score: float) -> float:
+def _default_relevance_score_fn(score: float) -> float:
     """Return a similarity score on a scale [0, 1]."""
-    # The 'correct' normalization function
+    # The 'correct' relevance function
     # may differ depending on a few things, including:
     # - the distance / similarity metric used by the VectorStore
     # - the scale of your embeddings (OpenAI's are unit normed. Many others are not!)
@@ -63,16 +63,16 @@ class FAISS(VectorStore):
         index: Any,
         docstore: Docstore,
         index_to_docstore_id: Dict[int, str],
-        normalize_score_fn: Optional[
+        relevance_score_fn: Optional[
             Callable[[float], float]
-        ] = _default_normalize_score_fn,
+        ] = _default_relevance_score_fn,
     ):
         """Initialize with necessary components."""
         self.embedding_function = embedding_function
         self.index = index
         self.docstore = docstore
         self.index_to_docstore_id = index_to_docstore_id
-        self.normalize_score_fn = normalize_score_fn
+        self.relevance_score_fn = relevance_score_fn
 
     def __add(
         self,
@@ -448,10 +448,10 @@ class FAISS(VectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs and their similarity scores on a scale from 0 to 1."""
-        if self.normalize_score_fn is None:
+        if self.relevance_score_fn is None:
             raise ValueError(
                 "normalize_score_fn must be provided to"
                 " FAISS constructor to normalize scores"
             )
         docs_and_scores = self.similarity_search_with_score(query, k=k)
-        return [(doc, self.normalize_score_fn(score)) for doc, score in docs_and_scores]
+        return [(doc, self.relevance_score_fn(score)) for doc, score in docs_and_scores]

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -441,7 +441,7 @@ class FAISS(VectorStore):
             docstore, index_to_docstore_id = pickle.load(f)
         return cls(embeddings.embed_query, index, docstore, index_to_docstore_id)
 
-    def _similarity_search_with_normalized_similarities(
+    def _similarity_search_with_relevance_scores(
         self,
         query: str,
         k: int = 4,

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -316,12 +316,7 @@ class FAISS(VectorStore):
         docstore = InMemoryDocstore(
             {index_to_id[i]: doc for i, doc in enumerate(documents)}
         )
-        return cls(
-            embedding.embed_query,
-            index,
-            docstore,
-            index_to_id,
-        )
+        return cls(embedding.embed_query, index, docstore, index_to_id, **kwargs)
 
     @classmethod
     def from_texts(

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -303,7 +303,6 @@ class FAISS(VectorStore):
         embeddings: List[List[float]],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
-        normalize_score_fn: Optional[Callable[[float], float]] = None,
         **kwargs: Any,
     ) -> FAISS:
         faiss = dependable_faiss_import()
@@ -322,7 +321,6 @@ class FAISS(VectorStore):
             index,
             docstore,
             index_to_id,
-            normalize_score_fn=normalize_score_fn,
         )
 
     @classmethod
@@ -331,7 +329,6 @@ class FAISS(VectorStore):
         texts: List[str],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
-        normalize_score_fn: Optional[Callable] = None,
         **kwargs: Any,
     ) -> FAISS:
         """Construct FAISS wrapper from raw documents.
@@ -357,7 +354,6 @@ class FAISS(VectorStore):
             embeddings,
             embedding,
             metadatas,
-            normalize_score_fn=normalize_score_fn,
             **kwargs,
         )
 
@@ -367,7 +363,6 @@ class FAISS(VectorStore):
         text_embeddings: List[Tuple[str, List[float]]],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
-        normalize_score_fn: Optional[Callable[[float], float]] = None,
         **kwargs: Any,
     ) -> FAISS:
         """Construct FAISS wrapper from raw documents.
@@ -394,14 +389,13 @@ class FAISS(VectorStore):
             embeddings,
             embedding,
             metadatas,
-            normalize_score_fn=normalize_score_fn,
             **kwargs,
         )
 
     def save_local(self, folder_path: str) -> None:
         """Save FAISS index, docstore, and index_to_docstore_id to disk.
 
-        Args:s
+        Args:
             folder_path: folder path to save index, docstore,
                 and index_to_docstore_id to.
         """

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -1,6 +1,7 @@
 """Wrapper around FAISS vector database."""
 from __future__ import annotations
 
+import math
 import pickle
 import uuid
 from pathlib import Path
@@ -29,6 +30,20 @@ def dependable_faiss_import() -> Any:
     return faiss
 
 
+def _default_normalize_score_fn(score: float) -> float:
+    """Return a similarity score on a scale [0, 1]."""
+    # The 'correct' normalization function
+    # may differ depending on a few things, including:
+    # - the distance / similarity metric used by the VectorStore
+    # - the scale of your embeddings (OpenAI's are unit normed. Many others are not!)
+    # - embedding dimensionality
+    # - etc.
+    # This function converts the euclidean norm of normalized embeddings
+    # (0 is most similar, sqrt(2) most dissimilar)
+    # to a similarity function (0 to 1)
+    return 1.0 - score / math.sqrt(2)
+
+
 class FAISS(VectorStore):
     """Wrapper around FAISS vector database.
 
@@ -48,7 +63,9 @@ class FAISS(VectorStore):
         index: Any,
         docstore: Docstore,
         index_to_docstore_id: Dict[int, str],
-        normalize_score_fn: Optional[Callable[[float], float]] = None,
+        normalize_score_fn: Optional[
+            Callable[[float], float]
+        ] = _default_normalize_score_fn,
     ):
         """Initialize with necessary components."""
         self.embedding_function = embedding_function

--- a/tests/integration_tests/vectorstores/test_faiss.py
+++ b/tests/integration_tests/vectorstores/test_faiss.py
@@ -1,4 +1,5 @@
 """Test FAISS functionality."""
+import math
 import tempfile
 
 import pytest
@@ -109,3 +110,37 @@ def test_faiss_local_save_load() -> None:
         docsearch.save_local(temp_file.name)
         new_docsearch = FAISS.load_local(temp_file.name, FakeEmbeddings())
     assert new_docsearch.index is not None
+
+
+def test_faiss_similarity_search_with_normalized_similarities() -> None:
+    """Test the similarity search with normalized similarities."""
+    texts = ["foo", "bar", "baz"]
+    docsearch = FAISS.from_texts(
+        texts,
+        FakeEmbeddings(),
+        normalize_score_fn=lambda score: 1.0 - score / math.sqrt(2),
+    )
+    outputs = docsearch.similarity_search_with_normalized_similarities("foo", k=1)
+    output, score = outputs[0]
+    assert output == Document(page_content="foo")
+    assert score == 1.0
+
+
+def test_faiss_invalid_normalize_fn() -> None:
+    """Test the similarity search with normalized similarities."""
+    texts = ["foo", "bar", "baz"]
+    docsearch = FAISS.from_texts(
+        texts, FakeEmbeddings(), normalize_score_fn=lambda _: 2.0
+    )
+    with pytest.raises(
+        ValueError, match="Normalized similarity scores must be between 0 and 1"
+    ):
+        docsearch.similarity_search_with_normalized_similarities("foo", k=1)
+
+
+def test_missing_normalize_score_fn() -> None:
+    """Test doesn't perform similarity search without a normalize score function."""
+    with pytest.raises(ValueError):
+        texts = ["foo", "bar", "baz"]
+        faiss_instance = FAISS.from_texts(texts, FakeEmbeddings())
+        faiss_instance.similarity_search_with_normalized_similarities("foo", k=2)

--- a/tests/integration_tests/vectorstores/test_faiss.py
+++ b/tests/integration_tests/vectorstores/test_faiss.py
@@ -112,7 +112,7 @@ def test_faiss_local_save_load() -> None:
     assert new_docsearch.index is not None
 
 
-def test_faiss_similarity_search_with_normalized_similarities() -> None:
+def test_faiss_similarity_search_with_relevance_scores() -> None:
     """Test the similarity search with normalized similarities."""
     texts = ["foo", "bar", "baz"]
     docsearch = FAISS.from_texts(
@@ -120,7 +120,7 @@ def test_faiss_similarity_search_with_normalized_similarities() -> None:
         FakeEmbeddings(),
         normalize_score_fn=lambda score: 1.0 - score / math.sqrt(2),
     )
-    outputs = docsearch.similarity_search_with_normalized_similarities("foo", k=1)
+    outputs = docsearch.similarity_search_with_relevance_scores("foo", k=1)
     output, score = outputs[0]
     assert output == Document(page_content="foo")
     assert score == 1.0
@@ -135,7 +135,7 @@ def test_faiss_invalid_normalize_fn() -> None:
     with pytest.raises(
         ValueError, match="Normalized similarity scores must be between 0 and 1"
     ):
-        docsearch.similarity_search_with_normalized_similarities("foo", k=1)
+        docsearch.similarity_search_with_relevance_scores("foo", k=1)
 
 
 def test_missing_normalize_score_fn() -> None:
@@ -143,4 +143,4 @@ def test_missing_normalize_score_fn() -> None:
     with pytest.raises(ValueError):
         texts = ["foo", "bar", "baz"]
         faiss_instance = FAISS.from_texts(texts, FakeEmbeddings())
-        faiss_instance.similarity_search_with_normalized_similarities("foo", k=2)
+        faiss_instance.similarity_search_with_relevance_scores("foo", k=2)


### PR DESCRIPTION
Add a method that exposes a similarity search with corresponding normalized similarity scores. Implement only for FAISS now.

### Motivation:

Some memory definitions combine `relevance` with other scores, like recency , importance, etc.

While many (but not all) of the `VectorStore`'s expose a `similarity_search_with_score` method, they don't all interpret the units of that score (depends on the distance metric and whether or not the the embeddings are normalized).

This PR proposes a `similarity_search_with_normalized_similarities` method that lets consumers of the vector store not have to worry about the metric and embedding scale.

*Most providers default to euclidean distance, with Pinecone being one exception (defaults to cosine _similarity_).*