### PR TITLE
FIX [FAILOVER - SEMANTIC PARSE] - Could not parse LLM output [AGENTS]

### DIFF
--- a/langchain/agents/chat_v2/base.py
+++ b/langchain/agents/chat_v2/base.py
@@ -5,16 +5,18 @@ from langchain.agents.chat_v2.prompt import (
     FORMAT_INSTRUCTIONS,
     PREFIX,
     SUFFIX,
-    ChatOutputParser,
     create_prompt,
 )
+from langchain.agents.output_parsers.chat_v2_agent_output_parser import ChatOutputParser
 from langchain.callbacks.base import BaseCallbackManager
 from langchain.chains.llm import LLMChain
-from langchain.schema import BaseLanguageModel
+from langchain.schema import BaseLanguageModel, BaseOutputParser
 from langchain.tools import BaseTool
 
 
 class ChatAgentV2(LLMSingleActionAgent):
+    output_parser: BaseOutputParser
+
     @classmethod
     def from_llm_and_tools(
         cls,
@@ -31,7 +33,7 @@ class ChatAgentV2(LLMSingleActionAgent):
     ) -> LLMSingleActionAgent:
         """Construct an agent from an LLM and tools."""
         _stop = stop or ["Observation:"]
-        _output_parser = output_parser or ChatOutputParser()
+        _output_parser = output_parser or ChatOutputParser(llm, tools, FORMAT_INSTRUCTIONS=FORMAT_INSTRUCTIONS)
         prompt = create_prompt(
             tools,
             prefix=prefix,

--- a/langchain/agents/chat_v2/prompt.py
+++ b/langchain/agents/chat_v2/prompt.py
@@ -61,24 +61,3 @@ def create_prompt(
     return AgentScratchPadChatPromptTemplate(
         input_variables=input_variables, messages=messages
     )
-
-
-class ChatOutputParser(AgentOutputParser):
-    def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        if "Final Answer:" in text:
-            return AgentFinish(
-                # Return values is generally always a dictionary with a single `output` key
-                # It is not recommended to try anything else at the moment :)
-                return_values={"output": text.split("Final Answer:")[-1].strip()},
-                log=text,
-            )
-        try:
-            _, action, _ = text.split("```")
-            response = json.loads(action.strip())
-            agent_action = AgentAction(
-                tool=response["action"], tool_input=response["action_input"], log=text
-            )
-            return agent_action
-
-        except Exception:
-            raise ValueError(f"Could not parse LLM output: {text}")

--- a/langchain/agents/conversational_chat/base.py
+++ b/langchain/agents/conversational_chat/base.py
@@ -1,16 +1,15 @@
 """An agent designed to hold a conversation in addition to using tools."""
 from __future__ import annotations
 
-import json
 from typing import Any, List, Optional, Sequence, Tuple
 
 from langchain.agents.agent import Agent
 from langchain.agents.conversational_chat.prompt import (
-    FORMAT_INSTRUCTIONS,
     PREFIX,
     SUFFIX,
-    TEMPLATE_TOOL_RESPONSE,
+    TEMPLATE_TOOL_RESPONSE, FORMAT_INSTRUCTIONS,
 )
+from langchain.agents.output_parsers.chat_agent_output_parser import ChatAgentOutputParser
 from langchain.callbacks.base import BaseCallbackManager
 from langchain.chains import LLMChain
 from langchain.prompts.base import BasePromptTemplate
@@ -29,27 +28,6 @@ from langchain.schema import (
     HumanMessage,
 )
 from langchain.tools.base import BaseTool
-
-
-class AgentOutputParser(BaseOutputParser):
-    def get_format_instructions(self) -> str:
-        return FORMAT_INSTRUCTIONS
-
-    def parse(self, text: str) -> Any:
-        cleaned_output = text.strip()
-        if "```json" in cleaned_output:
-            _, cleaned_output = cleaned_output.split("```json")
-        if "```" in cleaned_output:
-            cleaned_output, _ = cleaned_output.split("```")
-        if cleaned_output.startswith("```json"):
-            cleaned_output = cleaned_output[len("```json") :]
-        if cleaned_output.startswith("```"):
-            cleaned_output = cleaned_output[len("```") :]
-        if cleaned_output.endswith("```"):
-            cleaned_output = cleaned_output[: -len("```")]
-        cleaned_output = cleaned_output.strip()
-        response = json.loads(cleaned_output)
-        return {"action": response["action"], "action_input": response["action_input"]}
 
 
 class ConversationalChatAgent(Agent):
@@ -84,7 +62,7 @@ class ConversationalChatAgent(Agent):
             [f"> {tool.name}: {tool.description}" for tool in tools]
         )
         tool_names = ", ".join([tool.name for tool in tools])
-        _output_parser = output_parser or AgentOutputParser()
+        _output_parser = output_parser
         format_instructions = human_message.format(
             format_instructions=_output_parser.get_format_instructions()
         )
@@ -102,11 +80,7 @@ class ConversationalChatAgent(Agent):
         return ChatPromptTemplate(input_variables=input_variables, messages=messages)
 
     def _extract_tool_and_input(self, llm_output: str) -> Optional[Tuple[str, str]]:
-        try:
-            response = self.output_parser.parse(llm_output)
-            return response["action"], response["action_input"]
-        except Exception:
-            raise ValueError(f"Could not parse LLM output: {llm_output}")
+        return self.output_parser.parse(llm_output)
 
     def _construct_scratchpad(
         self, intermediate_steps: List[Tuple[AgentAction, str]]
@@ -135,7 +109,7 @@ class ConversationalChatAgent(Agent):
     ) -> Agent:
         """Construct an agent from an LLM and tools."""
         cls._validate_tools(tools)
-        _output_parser = output_parser or AgentOutputParser()
+        _output_parser = output_parser or ChatAgentOutputParser(llm, tools, FORMAT_INSTRUCTIONS=FORMAT_INSTRUCTIONS)
         prompt = cls.create_prompt(
             tools,
             system_message=system_message,

--- a/langchain/agents/output_parsers/chat_agent_output_parser.py
+++ b/langchain/agents/output_parsers/chat_agent_output_parser.py
@@ -1,0 +1,69 @@
+import ast
+import json
+from typing import List, Any
+
+from langchain.chains import RetrievalQA
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.schema import BaseLanguageModel, BaseOutputParser, Document
+from langchain.tools import BaseTool
+from langchain.vectorstores import Chroma
+
+
+class ChatAgentOutputParser(BaseOutputParser):
+    llm: BaseLanguageModel = None
+    tools: List[BaseTool] = None
+    FORMAT_INSTRUCTIONS = ""
+
+    def __init__(self, llm, tools, FORMAT_INSTRUCTIONS, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.llm = llm
+        self.tools = tools
+        self.FORMAT_INSTRUCTIONS = FORMAT_INSTRUCTIONS
+
+    def get_format_instructions(self) -> str:
+        return self.FORMAT_INSTRUCTIONS
+
+    def parse(self, text: str) -> Any:
+        try:
+            parsed_text = self.semantic_parse(text)
+        except Exception:
+            raise ValueError(f"Could not parse LLM output: {text}")
+
+        return parsed_text
+
+    def semantic_parse(self, text: str):
+        try:
+            cleaned_output = text.strip()
+
+            if "```json" in cleaned_output:
+                _, cleaned_output = cleaned_output.split("```json")
+            if "```" in cleaned_output:
+                cleaned_output, _ = cleaned_output.split("```")
+            if cleaned_output.startswith("```json"):
+                cleaned_output = cleaned_output[len("```json"):]
+            if cleaned_output.startswith("```"):
+                cleaned_output = cleaned_output[len("```"):]
+            if cleaned_output.endswith("```"):
+                cleaned_output = cleaned_output[: -len("```")]
+            cleaned_output = cleaned_output.strip()
+
+            response = json.loads(cleaned_output)
+
+        except Exception:
+            embeddings = OpenAIEmbeddings()
+            docsearch = Chroma.from_documents([Document(page_content=cleaned_output)], embeddings)
+            qa = RetrievalQA.from_chain_type(self.llm, retriever=docsearch.as_retriever(search_kwargs={"k": 1}))
+            tools_str = ",".join(["\"" + tool.name + "\"" for tool in self.tools])
+            action_rsp = qa.run(
+                F"Extract the action. Choices: [{tools_str}]. Put your answer in this textbox: []. Do not add additional text. Example Answer: [\"Example Action\"]")
+            action_input_rsp = qa.run(
+                "Extract the action_input. Hint: Should be relevant to the action. Put your answer in this textbox: []. Do not add additional text. Example Answers: [\"Example Action Input\"] or [\"\"] (for empty action inputs)")
+
+            action = ast.literal_eval(action_rsp)[0]
+            action_input = ast.literal_eval(action_input_rsp)[0]
+
+            response = {"action": action, "action_input": action_input}
+
+        return response["action"], response["action_input"]
+
+

--- a/langchain/agents/output_parsers/chat_v2_agent_output_parser.py
+++ b/langchain/agents/output_parsers/chat_v2_agent_output_parser.py
@@ -1,0 +1,56 @@
+import ast
+import json
+from typing import List, Union
+
+from langchain.agents import AgentOutputParser
+from langchain.chains import RetrievalQA
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.schema import BaseLanguageModel, AgentAction, AgentFinish, Document
+from langchain.tools import BaseTool
+from langchain.vectorstores import Chroma
+
+
+class ChatOutputParser(AgentOutputParser):
+    llm: BaseLanguageModel = None
+    tools: List[BaseTool] = None
+    FORMAT_INSTRUCTIONS = ""
+
+    def __init__(self, llm, tools, FORMAT_INSTRUCTIONS, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.llm = llm
+        self.tools = tools
+        self.FORMAT_INSTRUCTIONS = FORMAT_INSTRUCTIONS
+
+    def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
+        try:
+            if "Final Answer:" in text:
+                return AgentFinish(
+                    # Return values is generally always a dictionary with a single `output` key
+                    # It is not recommended to try anything else at the moment :)
+                    return_values={"output": text.split("Final Answer:")[-1].strip()},
+                    log=text,
+                )
+            _, llm_output, _ = text.split("```")
+
+            if self.is_json_parsable(llm_output):
+                response = json.loads(llm_output)
+                action = response["action"]
+                action_input = response["action_input"]
+            else:
+                embeddings = OpenAIEmbeddings()
+                docsearch = Chroma.from_documents([Document(page_content=llm_output)], embeddings)
+                qa = RetrievalQA.from_chain_type(self.llm, retriever=docsearch.as_retriever(search_kwargs={"k": 1}))
+                tools_str = ",".join(["\"" + tool.name + "\"" for tool in self.tools])
+                action_rsp = qa.run(
+                    F"Extract the action. Choices: [{tools_str}]. Put your answer in this textbox: []. Do not add additional text. Example Answer: [\"Example Action\"]")
+                action_input_rsp = qa.run(
+                    "Extract the action_input. Hint: Should be relevant to the action. Put your answer in this textbox: []. Do not add additional text. Example Answers: [\"Example Action Input\"] or [\"\"] (for empty action inputs)")
+
+                action = ast.literal_eval(action_rsp)[0]
+                action_input = ast.literal_eval(action_input_rsp)[0]
+
+        except Exception:
+            raise ValueError(f"Could not parse LLM output: {text}")
+
+        return AgentAction(tool=action, tool_input=action_input, log=text)
+

--- a/langchain/agents/output_parsers/conversational_agent_output_parser.py
+++ b/langchain/agents/output_parsers/conversational_agent_output_parser.py
@@ -1,0 +1,52 @@
+import ast
+import re
+from typing import List, Any
+
+from langchain.chains import RetrievalQA
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.schema import BaseOutputParser, BaseLanguageModel, Document
+from langchain.tools import BaseTool
+from langchain.vectorstores import Chroma
+
+
+class ConversationalAgentOutputParser(BaseOutputParser):
+    llm: BaseLanguageModel = None
+    tools: List[BaseTool] = None
+    FORMAT_INSTRUCTIONS = ""
+    ai_prefix: str = "AI"
+
+    def __init__(self, llm, tools, FORMAT_INSTRUCTIONS, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.llm = llm
+        self.tools = tools
+        self.FORMAT_INSTRUCTIONS = FORMAT_INSTRUCTIONS
+
+    def get_format_instructions(self) -> str:
+        return self.FORMAT_INSTRUCTIONS
+
+    def parse(self, llm_output: str) -> Any:
+        try:
+            if f"{self.ai_prefix}:" in llm_output:
+                return self.ai_prefix, llm_output.split(f"{self.ai_prefix}:")[-1].strip()
+            regex = r"Action: (.*?)[\n]*Action Input: (.*)"
+            match = re.search(regex, llm_output)
+            if match:
+                action = match.group(1).strip()
+                action_input = match.group(2).strip(" ").strip('"')
+            else:
+                embeddings = OpenAIEmbeddings()
+                docsearch = Chroma.from_documents([Document(page_content=llm_output)], embeddings)
+                qa = RetrievalQA.from_chain_type(self.llm, retriever=docsearch.as_retriever(search_kwargs={"k": 1}))
+                tools_str = ",".join(["\"" + tool.name + "\"" for tool in self.tools])
+                action_rsp = qa.run(
+                    F"Extract the Action. Choices: [{tools_str}]. Put your answer in this textbox: []. Do not add additional text. Example Answer: [\"Example Action\"]")
+                action_input_rsp = qa.run(
+                    "Extract the Action Input. Hint: Should be relevant to the action. Put your answer in this textbox: []. Do not add additional text. Example Answers: [\"Example Action Input\"] or [\"\"] (for empty action inputs)")
+
+                action = ast.literal_eval(action_rsp)[0]
+                action_input = ast.literal_eval(action_input_rsp)[0]
+        except Exception:
+            raise ValueError(f"Could not parse LLM output: {llm_output}")
+
+        return action, action_input
+

--- a/langchain/agents/output_parsers/mrkl_agent_output_parser.py
+++ b/langchain/agents/output_parsers/mrkl_agent_output_parser.py
@@ -1,0 +1,52 @@
+import ast
+import re
+from typing import List, Any
+
+from langchain.chains import RetrievalQA
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.schema import BaseOutputParser, BaseLanguageModel, Document
+from langchain.tools import BaseTool
+from langchain.vectorstores import Chroma
+
+
+class MRKLAgentOutputParser(BaseOutputParser):
+    llm: BaseLanguageModel = None
+    tools: List[BaseTool] = None
+    FORMAT_INSTRUCTIONS = ""
+    FINAL_ANSWER_ACTION = "Final Answer:"
+
+    def __init__(self, llm, tools, FORMAT_INSTRUCTIONS, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.llm = llm
+        self.tools = tools
+        self.FORMAT_INSTRUCTIONS = FORMAT_INSTRUCTIONS
+
+    def get_format_instructions(self) -> str:
+        return self.FORMAT_INSTRUCTIONS
+
+    def parse(self, llm_output: str) -> Any:
+        try:
+            if self.FINAL_ANSWER_ACTION in llm_output:
+                return "Final Answer", llm_output.split(self.FINAL_ANSWER_ACTION)[-1].strip()
+            regex = r"Action: (.*?)[\n]*Action Input: (.*)"
+            match = re.search(regex, llm_output)
+            if match:
+                action = match.group(1).strip()
+                action_input = match.group(2).strip(" ").strip('"')
+            else:
+                embeddings = OpenAIEmbeddings()
+                docsearch = Chroma.from_documents([Document(page_content=llm_output)], embeddings)
+                qa = RetrievalQA.from_chain_type(self.llm, retriever=docsearch.as_retriever(search_kwargs={"k": 1}))
+                tools_str = ",".join(["\"" + tool.name + "\"" for tool in self.tools])
+                action_rsp = qa.run(
+                    F"Extract the Action. Choices: [{tools_str}]. Put your answer in this textbox: []. Do not add additional text. Example Answer: [\"Example Action\"]")
+                action_input_rsp = qa.run(
+                    "Extract the Action Input. Hint: Should be relevant to the action. Put your answer in this textbox: []. Do not add additional text. Example Answers: [\"Example Action Input\"] or [\"\"] (for empty action inputs)")
+
+                action = ast.literal_eval(action_rsp)[0]
+                action_input = ast.literal_eval(action_input_rsp)[0]
+        except Exception:
+            raise ValueError(f"Could not parse LLM output: {llm_output}")
+
+        return action, action_input
+

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -1,6 +1,7 @@
 """Common schema objects."""
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, NamedTuple, Optional, TypeVar
 
@@ -380,6 +381,14 @@ class BaseOutputParser(BaseModel, ABC, Generic[T]):
         output_parser_dict = super().dict()
         output_parser_dict["_type"] = self._type
         return output_parser_dict
+
+    def is_json_parsable(self, s: str):
+        """Helper to validate whether LLM output is JSON Parsable."""
+        try:
+            json.loads(s)
+            return True
+        except ValueError:
+            return False
 
 
 class OutputParserException(Exception):


### PR DESCRIPTION
My approach to fix LLM Output Parsing here is to have a Fail-Over approach of Semantic Searching according to Parsing Format Instructions from the Prompt and building JSON from that.

This has proved to be much better so far from my local testing, but really happy to hear everyone's input and how this works for you. @hwchase17 @agola11 

I tried to break it by injecting wrong format instructions, but it still was able to parse it, for example:
```
Question: is xray covered

> Entering new AgentExecutor chain...
Using embedded DuckDB without persistence: data will be transient
{
Here is your response:
    "action": "User's Summary of Benefits and Coverage Document Search Tool",
    "action_input": "x-ray"
Please let me know if that works for you, i am here to help
}

Observation: For a diagnostic test (x-ray), you will pay 0% coinsurance for in-network providers and 30% coinsurance for non-network providers.
Thought:
{
Here is your response:
    "action": "Final Answer",
    "action_input": "For a diagnostic test (x-ray), you will pay 0% coinsurance for in-network providers and 30% coinsurance for non-network providers."
Please let me know if that works for you, i am here to help
}

> Finished chain.
For a diagnostic test (x-ray), you will pay 0% coinsurance for in-network providers and 30% coinsurance for non-network providers.

```

To-Do: Needs cleanup. Looking for feedback.