### PR TITLE
Fix bug in svm.LinearSVC, add support for a relevancy_threshold

### DIFF
--- a/langchain/retrievers/svm.py
+++ b/langchain/retrievers/svm.py
@@ -22,7 +22,7 @@ class SVMRetriever(BaseRetriever, BaseModel):
     index: Any
     texts: List[str]
     k: int = 4
-    relevancy_threshold: float = 0.8
+    relevancy_threshold: Optional[float] = None
 
     class Config:
 
@@ -56,7 +56,10 @@ class SVMRetriever(BaseRetriever, BaseModel):
         top_k_results = []
         for row in sorted_ix[1 : self.k + 1]:
             doc = Document(page_content=self.texts[row - 1])
-             if similarities[row - 1] >= self.relevancy_threshold:
+            if self.relevancy_threshold is not None:
+                if similarities[row - 1] >= self.relevancy_threshold:
+                    top_k_results.append(doc)
+            else:
                 top_k_results.append(doc)
         return top_k_results
 

--- a/langchain/retrievers/svm.py
+++ b/langchain/retrievers/svm.py
@@ -22,7 +22,7 @@ class SVMRetriever(BaseRetriever, BaseModel):
     index: Any
     texts: List[str]
     k: int = 4
-    relevancy_threshold: Optional[float] = None
+    relevancy_threshold: float = None
 
     class Config:
 

--- a/langchain/retrievers/svm.py
+++ b/langchain/retrievers/svm.py
@@ -22,6 +22,7 @@ class SVMRetriever(BaseRetriever, BaseModel):
     index: Any
     texts: List[str]
     k: int = 4
+    relevancy_threshold: float = 0.8
 
     class Config:
 
@@ -54,7 +55,9 @@ class SVMRetriever(BaseRetriever, BaseModel):
 
         top_k_results = []
         for row in sorted_ix[1 : self.k + 1]:
-            top_k_results.append(Document(page_content=self.texts[row - 1]))
+            doc = Document(page_content=self.texts[row - 1])
+             if similarities[row - 1] >= self.relevancy_threshold:
+                top_k_results.append(doc)
         return top_k_results
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:

--- a/langchain/retrievers/svm.py
+++ b/langchain/retrievers/svm.py
@@ -53,11 +53,20 @@ class SVMRetriever(BaseRetriever, BaseModel):
         similarities = clf.decision_function(x)
         sorted_ix = np.argsort(-similarities)
 
+        # svm.LinearSVC in scikit-learn is non-deterministic.
+        # if a text is the same as a query, there is no guarantee the query will be in the first index.
+        # this performs a simple swap, this works because anything left of the 0 should be equivalent.
+        zero_index = np.where(sorted_ix == 0)[0][0]
+        if zero_index != 0:
+            sorted_ix[0], sorted_ix[zero_index] = sorted_ix[zero_index], sorted_ix[0]
+
+        normalized_similarities = (similarities - np.min(similarities)) / (np.max(similarities) - np.min(similarities))
+
         top_k_results = []
-        for row in sorted_ix[1 : self.k + 1]:
+        for row in sorted_ix[1:self.k+1]:
             doc = Document(page_content=self.texts[row - 1])
             if self.relevancy_threshold is not None:
-                if similarities[row - 1] >= self.relevancy_threshold:
+                if normalized_similarities[row] >= self.relevancy_threshold:
                     top_k_results.append(doc)
             else:
                 top_k_results.append(doc)

--- a/langchain/retrievers/svm.py
+++ b/langchain/retrievers/svm.py
@@ -60,16 +60,12 @@ class SVMRetriever(BaseRetriever, BaseModel):
         if zero_index != 0:
             sorted_ix[0], sorted_ix[zero_index] = sorted_ix[zero_index], sorted_ix[0]
 
-        normalized_similarities = (similarities - np.min(similarities)) / (np.max(similarities) - np.min(similarities))
+        normalized_similarities = (similarities - np.min(similarities)) / (np.max(similarities) - np.min(similarities) + 1e-6)
 
         top_k_results = []
         for row in sorted_ix[1:self.k+1]:
-            doc = Document(page_content=self.texts[row - 1])
-            if self.relevancy_threshold is not None:
-                if normalized_similarities[row] >= self.relevancy_threshold:
-                    top_k_results.append(doc)
-            else:
-                top_k_results.append(doc)
+            if self.relevancy_threshold is None or normalized_similarities[row] >= self.relevancy_threshold:
+                top_k_results.append(Document(page_content=self.texts[row - 1]))
         return top_k_results
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:


### PR DESCRIPTION
- Modify SVMRetriever class to add an optional relevancy_threshold
- Modify SVMRetriever.get_relevant_documents method to filter out documents with similarity scores below the relevancy threshold
- Normalized the similarities to be between 0 and 1 so the relevancy_threshold makes more sense
- The number of results are limited to the top k documents or the maximum number of relevant documents above the threshold, whichever is smaller

This code will now return the top self.k results (or less, if there are not enough results that meet the self.relevancy_threshold criteria).

The svm.LinearSVC implementation in scikit-learn is non-deterministic, which means
SVMRetriever.from_texts(["bar", "world", "foo", "hello", "foo bar"])
could return [3 0 5 4 2 1] instead of [0 3 5 4 2 1] with a query of "foo".
If you pass in multiple "foo" texts, the order could be different each time. Here, we only care if the 0 is the first element, otherwise it will offset the text and similarities.


Example:
```python
retriever = SVMRetriever.from_texts(
  ["foo", "bar", "world", "hello", "foo bar"],
  OpenAIEmbeddings(),
  k=4,
  relevancy_threshold=.25
)

result = retriever.get_relevant_documents("foo")
```
yields
```python
[Document(page_content='foo', metadata={}), Document(page_content='foo bar', metadata={})]
```