### PR TITLE
Enforce maximum Wikipedia query length

### DIFF
--- a/langchain/utilities/wikipedia.py
+++ b/langchain/utilities/wikipedia.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Extra, root_validator
 
+WIKIPEDIA_MAX_QUERY_LENGTH = 300
+
 
 class WikipediaAPIWrapper(BaseModel):
     """Wrapper around WikipediaAPI.
@@ -37,7 +39,7 @@ class WikipediaAPIWrapper(BaseModel):
 
     def run(self, query: str) -> str:
         """Run Wikipedia search and get page summaries."""
-        search_results = self.wiki_client.search(query)
+        search_results = self.wiki_client.search(query[:WIKIPEDIA_MAX_QUERY_LENGTH])
         summaries = []
         len_search_results = len(search_results)
         if len_search_results == 0:


### PR DESCRIPTION
I got the following stacktrace when the agent was trying to search Wikipedia with a huge query:

```
Thought:{
    "action": "Wikipedia",
    "action_input": "Outstanding is a song originally performed by the Gap Band and written by member Raymond Calhoun. The song originally appeared on the group's platinum-selling 1982 album Gap Band IV. It is one of their signature songs and biggest hits, reaching the number one spot on the U.S. R&B Singles Chart in February 1983.  \"Outstanding\" peaked at number 51 on the Billboard Hot 100."
}
Traceback (most recent call last):
  File "/usr/src/app/tests/chat.py", line 121, in <module>
    answer = agent_chain.run(input=question)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/chains/base.py", line 216, in run
    return self(kwargs)[self.output_keys[0]]
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/chains/base.py", line 116, in __call__
    raise e
  File "/usr/local/lib/python3.11/site-packages/langchain/chains/base.py", line 113, in __call__
    outputs = self._call(inputs)
              ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/agents/agent.py", line 828, in _call
    next_step_output = self._take_next_step(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/agents/agent.py", line 725, in _take_next_step
    observation = tool.run(
                  ^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/tools/base.py", line 73, in run
    raise e
  File "/usr/local/lib/python3.11/site-packages/langchain/tools/base.py", line 70, in run
    observation = self._run(tool_input)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/agents/tools.py", line 17, in _run
    return self.func(tool_input)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/utilities/wikipedia.py", line 40, in run
    search_results = self.wiki_client.search(query)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wikipedia/util.py", line 28, in __call__
    ret = self._cache[key] = self.fn(*args, **kwargs)
                             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wikipedia/wikipedia.py", line 109, in search
    raise WikipediaException(raw_results['error']['info'])
wikipedia.exceptions.WikipediaException: An unknown error occured: "Search request is longer than the maximum allowed length. (Actual: 373; allowed: 300)". Please report it on GitHub!
```

This commit limits the maximum size of the query passed to Wikipedia to avoid this issue.