### PR TITLE
Wli/jira tool

### DIFF
--- a/docs/modules/agents/tools/examples/jira.ipynb
+++ b/docs/modules/agents/tools/examples/jira.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "245a954a",
+   "metadata": {},
+   "source": [
+    "# Wolfram Alpha\n",
+    "\n",
+    "This notebook goes over how to use the wolfram alpha component.\n",
+    "\n",
+    "First, you need to set up your Wolfram Alpha developer account and get your APP ID:\n",
+    "\n",
+    "1. Go to wolfram alpha and sign up for a developer account [here](https://developer.wolframalpha.com/)\n",
+    "2. Create an app and get your APP ID\n",
+    "3. pip install wolframalpha\n",
+    "\n",
+    "Then we will need to set some environment variables:\n",
+    "1. Save your APP ID into WOLFRAM_ALPHA_APPID env variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "961b3689",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install wolframalpha"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "34bb5968",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"WOLFRAM_ALPHA_APPID\"] = \"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ac4910f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "84b8f773",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wolfram = WolframAlphaAPIWrapper()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "068991a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'x = 2/5'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wolfram.run(\"What is 2x+5 = -3x + 7?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "028f4cba",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "53f3bc57609c7a84333bb558594977aa5b4026b1d6070b93987956689e367341"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/modules/agents/tools/examples/jira.ipynb
+++ b/docs/modules/agents/tools/examples/jira.ipynb
@@ -6,18 +6,15 @@
    "id": "245a954a",
    "metadata": {},
    "source": [
-    "# Wolfram Alpha\n",
+    "# Jira\n",
     "\n",
-    "This notebook goes over how to use the wolfram alpha component.\n",
+    "This notebook goes over how to use the Jira tool.\n",
+    "The Jira tool allows agents to interact with a given Jira instance, performing actions such as searching for issues and creating issues, the tool wraps the atlassian-python-api library, for more see: https://atlassian-python-api.readthedocs.io/jira.html\n",
     "\n",
-    "First, you need to set up your Wolfram Alpha developer account and get your APP ID:\n",
-    "\n",
-    "1. Go to wolfram alpha and sign up for a developer account [here](https://developer.wolframalpha.com/)\n",
-    "2. Create an app and get your APP ID\n",
-    "3. pip install wolframalpha\n",
-    "\n",
-    "Then we will need to set some environment variables:\n",
-    "1. Save your APP ID into WOLFRAM_ALPHA_APPID env variable"
+    "To use this tool, you must first set as environment variables:\n",
+    "    JIRA_API_TOKEN\n",
+    "    JIRA_USERNAME\n",
+    "    JIRA_INSTANCE_URL"
    ]
   },
   {
@@ -31,7 +28,8 @@
    },
    "outputs": [],
    "source": [
-    "pip install wolframalpha"
+    "pip install atlassian-python-api\n",
+    "pip install json"
    ]
   },
   {
@@ -41,8 +39,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "os.environ[\"WOLFRAM_ALPHA_APPID\"] = \"\"\n"
+    "from langchain.agents import AgentType\n",
+    "from langchain.agents import initialize_agent\n",
+    "from langchain.agents.agent_toolkits.jira.toolkit import JiraToolkit\n",
+    "from langchain.llms import OpenAI\n",
+    "from langchain.utilities.jira import JiraAPIWrapper\n",
+    "\n",
+    "os.environ[\"JIRA_API_TOKEN\"] = \"abc\"\n",
+    "os.environ[\"JIRA_USERNAME\"] = \"123\"\n",
+    "os.environ[\"JIRA_INSTANCE_URL\"] = \"https://jira.atlassian.com\""
    ]
   },
   {
@@ -52,47 +57,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper"
+    "llm = OpenAI(temperature=0)\n",
+    "jira = JiraAPIWrapper()\n",
+    "toolkit = JiraToolkit.from_jira_api_wrapper(jira)\n",
+    "agent = initialize_agent(\n",
+    "    toolkit.get_tools(),\n",
+    "    llm,\n",
+    "    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,\n",
+    "    verbose=True\n",
+    ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "84b8f773",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wolfram = WolframAlphaAPIWrapper()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "068991a6",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'x = 2/5'"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "wolfram.run(\"What is 2x+5 = -3x + 7?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "028f4cba",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/modules/agents/tools/examples/jira.ipynb
+++ b/docs/modules/agents/tools/examples/jira.ipynb
@@ -24,37 +24,65 @@
    "metadata": {
     "vscode": {
      "languageId": "shellscript"
+    },
+    "ExecuteTime": {
+     "start_time": "2023-04-17T10:21:18.698672Z",
+     "end_time": "2023-04-17T10:21:20.168639Z"
     }
    },
    "outputs": [],
    "source": [
-    "pip install atlassian-python-api\n",
-    "pip install json"
+    "%pip install atlassian-python-api"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "34bb5968",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-17T10:21:22.911233Z",
+     "end_time": "2023-04-17T10:21:23.730922Z"
+    }
+   },
    "outputs": [],
    "source": [
+    "import os\n",
     "from langchain.agents import AgentType\n",
     "from langchain.agents import initialize_agent\n",
     "from langchain.agents.agent_toolkits.jira.toolkit import JiraToolkit\n",
     "from langchain.llms import OpenAI\n",
-    "from langchain.utilities.jira import JiraAPIWrapper\n",
-    "\n",
-    "os.environ[\"JIRA_API_TOKEN\"] = \"abc\"\n",
-    "os.environ[\"JIRA_USERNAME\"] = \"123\"\n",
-    "os.environ[\"JIRA_INSTANCE_URL\"] = \"https://jira.atlassian.com\""
+    "from langchain.utilities.jira import JiraAPIWrapper"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "os.environ[\"JIRA_API_TOKEN\"] = \"abc\"\n",
+    "os.environ[\"JIRA_USERNAME\"] = \"123\"\n",
+    "os.environ[\"JIRA_INSTANCE_URL\"] = \"https://jira.atlassian.com\"\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"xyz\""
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-17T10:22:42.499447Z",
+     "end_time": "2023-04-17T10:22:42.505412Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "ac4910f8",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-04-17T10:22:44.664481Z",
+     "end_time": "2023-04-17T10:22:44.720538Z"
+    }
+   },
    "outputs": [],
    "source": [
     "llm = OpenAI(temperature=0)\n",
@@ -67,6 +95,47 @@
     "    verbose=True\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
+      "\u001B[32;1m\u001B[1;3m I need to create an issue in project PW\n",
+      "Action: Create Issue\n",
+      "Action Input: {\"summary\": \"Make more fried rice\", \"description\": \"Reminder to make more fried rice\", \"issuetype\": {\"name\": \"Task\"}, \"priority\": {\"name\": \"Low\"}, \"project\": {\"key\": \"PW\"}}\u001B[0m\n",
+      "Observation: \u001B[38;5;200m\u001B[1;3mNone\u001B[0m\n",
+      "Thought:\u001B[32;1m\u001B[1;3m I now know the final answer\n",
+      "Final Answer: A new issue has been created in project PW with the summary \"Make more fried rice\" and description \"Reminder to make more fried rice\".\u001B[0m\n",
+      "\n",
+      "\u001B[1m> Finished chain.\u001B[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "'A new issue has been created in project PW with the summary \"Make more fried rice\" and description \"Reminder to make more fried rice\".'"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agent.run(\"make a new issue in project PW to remind me to make more fried rice\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "start_time": "2023-04-17T10:23:33.662454Z",
+     "end_time": "2023-04-17T10:23:38.121883Z"
+    }
+   }
   }
  ],
  "metadata": {

--- a/langchain/agents/agent_toolkits/__init__.py
+++ b/langchain/agents/agent_toolkits/__init__.py
@@ -20,6 +20,7 @@ from langchain.agents.agent_toolkits.vectorstore.toolkit import (
     VectorStoreToolkit,
 )
 from langchain.agents.agent_toolkits.zapier.toolkit import ZapierToolkit
+from langchain.agents.agent_toolkits.jira.toolkit import JiraToolkit
 
 __all__ = [
     "create_json_agent",
@@ -38,4 +39,5 @@ __all__ = [
     "create_pandas_dataframe_agent",
     "create_csv_agent",
     "ZapierToolkit",
+    "JiraToolkit",
 ]

--- a/langchain/agents/agent_toolkits/jira/__init__.py
+++ b/langchain/agents/agent_toolkits/jira/__init__.py
@@ -1,0 +1,1 @@
+"""Jira Toolkit."""

--- a/langchain/agents/agent_toolkits/jira/toolkit.py
+++ b/langchain/agents/agent_toolkits/jira/toolkit.py
@@ -13,7 +13,7 @@ class JiraToolkit(BaseToolkit):
     tools: List[BaseTool] = []
 
     @classmethod
-    def from_zapier_nla_wrapper(
+    def from_jira_api_wrapper(
         cls, jira_api_wrapper: JiraAPIWrapper
     ) -> "JiraToolkit":
         actions = jira_api_wrapper.list()

--- a/langchain/agents/agent_toolkits/jira/toolkit.py
+++ b/langchain/agents/agent_toolkits/jira/toolkit.py
@@ -1,0 +1,33 @@
+"""Jira Toolkit."""
+from typing import List
+
+from langchain.agents.agent_toolkits.base import BaseToolkit
+from langchain.tools import BaseTool
+from langchain.tools.jira.tool import JiraAction
+from langchain.utilities.jira import JiraAPIWrapper
+
+
+class JiraToolkit(BaseToolkit):
+    """Jira Toolkit."""
+
+    tools: List[BaseTool] = []
+
+    @classmethod
+    def from_zapier_nla_wrapper(
+        cls, jira_api_wrapper: JiraAPIWrapper
+    ) -> "JiraToolkit":
+        actions = jira_api_wrapper.list()
+        tools = [
+            JiraAction(
+                name=action["name"],
+                description=action["description"],
+                action_id=action["id"],
+                api_wrapper=jira_api_wrapper,
+            )
+            for action in actions
+        ]
+        return cls(tools=tools)
+
+    def get_tools(self) -> List[BaseTool]:
+        """Get the tools in the toolkit."""
+        return self.tools

--- a/langchain/agents/agent_toolkits/jira/toolkit.py
+++ b/langchain/agents/agent_toolkits/jira/toolkit.py
@@ -21,7 +21,7 @@ class JiraToolkit(BaseToolkit):
             JiraAction(
                 name=action["name"],
                 description=action["description"],
-                action_id=action["id"],
+                mode=action["mode"],
                 api_wrapper=jira_api_wrapper,
             )
             for action in actions

--- a/langchain/tools/jira/__init__.py
+++ b/langchain/tools/jira/__init__.py
@@ -1,0 +1,1 @@
+"""Zapier Tool."""

--- a/langchain/tools/jira/prompt.py
+++ b/langchain/tools/jira/prompt.py
@@ -1,0 +1,12 @@
+# flake8: noqa
+JIRA_CREATE_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jira issue create API. '
+                      'Useful for when you need to create a Jira issue/task/ticket. '
+                      'The input to this tool is a dictionary specifying the fields of the Jira issue, and will be passed into atlassian-python-api\'s Jira issue_create function, '
+                      'For example, to create a low priority task called "test issue" with description "test description", you would pass in the following dictionary: '
+                      '{{"summary": "test issue", "description": "test description", "issuetype": {{"name": "Task"}}, "priority": {{"name": "Low"}}}}')
+
+JIRA_JQL_PROMPT = "This tool is a wrapper around atlassian-python-api's Jira jql API. " \
+                  "Useful for when you need to search for Jira issues/tasks/tickets, or find out information about an issue. " \
+                  "The input to this tool is a JQL query string, and will be passed into atlassian-python-api's Jira jql function, " \
+                  "For example, find all the issues in project 'Test' assigned to the me, you would pass in the following string: " \
+                  "'project = Test AND assignee = currentUser()'"

--- a/langchain/tools/jira/prompt.py
+++ b/langchain/tools/jira/prompt.py
@@ -27,7 +27,8 @@ JIRA_JQL_PROMPT = \
 JIRA_CATCH_ALL_PROMPT = \
     ("""
     This tool is a wrapper around atlassian-python-api's Jira API.
-    There are other dedicated tools for creating and searching for issues, but this tool can be used to perform any other actions allowed by the atlassian-python-api Jira API.
+    There are other dedicated tools for fetching all projects, and creating and searching for issues, 
+    use this tool if you need to perform any other actions allowed by the atlassian-python-api Jira API.
     The input to this tool is line of python code that calls a function from atlassian-python-api's Jira API
     For example, to update the summary field of an issue, you would pass in the following string:
     self.jira.update_issue_field(key, {{"summary": "New summary"}})

--- a/langchain/tools/jira/prompt.py
+++ b/langchain/tools/jira/prompt.py
@@ -1,21 +1,37 @@
 # flake8: noqa
-JIRA_CREATE_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jira issue create API. '
-                      'Useful for when you need to create a Jira issue/task/ticket. '
-                      'The input to this tool is a dictionary specifying the fields of the Jira issue, and will be passed into atlassian-python-api\'s Jira issue_create function, '
-                      'For example, to create a low priority task called "test issue" with description "test description", you would pass in the following dictionary: '
-                      '{{"summary": "test issue", "description": "test description", "issuetype": {{"name": "Task"}}, "priority": {{"name": "Low"}}}}')
+JIRA_ISSUE_CREATE_PROMPT = \
+    ("""
+    This tool is a wrapper around atlassian-python-api's Jira issue_create API, useful when you need to create a Jira issue. 
+    The input to this tool is a dictionary specifying the fields of the Jira issue, and will be passed into atlassian-python-api's Jira `issue_create` function.
+    For example, to create a low priority task called "test issue" with description "test description", you would pass in the following dictionary: 
+    {{"summary": "test issue", "description": "test description", "issuetype": {{"name": "Task"}}, "priority": {{"name": "Low"}}}}
+    """)
 
-JIRA_JQL_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jira jql API. ' \
-                   'Useful for when you need to search for Jira issues/tasks/tickets, or find out information about an issue. ' \
-                   'The input to this tool is a JQL query string, and will be passed into atlassian-python-api\'s Jira jql function, ' \
-                   'For example, find all the issues in project "Test" assigned to the me, you would pass in the following string: ' \
-                   'project = Test AND assignee = currentUser()' \
-                   'or to find issues with summaries that contain the word "test", you would pass in the following string: ' \
-                   'summary ~ "test"')
+JIRA_GET_ALL_PROJECTS_PROMPT = \
+    ("""
+    This tool is a wrapper around atlassian-python-api's Jira project API, 
+    useful when you need to fetch all the projects the user has access to, find out how many projects there are, or as an intermediary step that involv searching by projects. 
+    there is no input to this tool.
+    """)
 
-JIRA_CATCH_ALL_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jira issue API. '
-                         'There are dedicated tools for creating and searching for issues, but this tool can be used to perform any other actions allowed by the atlassian python Jira API.'
-                         'The input to this tool is line of python code that calls a function from atlassian-python-api\'s Jira API, '
-                         'For example, to update the summary field of an issue, you would pass in the following string: '
-                         'self.jira.update_issue_field(key, {{"summary": "New summary"}})'
-                         'For more information on the Jira API, see https://atlassian-python-api.readthedocs.io/jira.html')
+JIRA_JQL_PROMPT = \
+    ("""
+    This tool is a wrapper around atlassian-python-api's Jira jql API, useful when you need to search for Jira issues.
+    The input to this tool is a JQL query string, and will be passed into atlassian-python-api's Jira `jql` function,
+    For example, to find all the issues in project "Test" assigned to the me, you would pass in the following string:
+    project = Test AND assignee = currentUser()
+    or to find issues with summaries that contain the word "test", you would pass in the following string:
+    summary ~ 'test'
+    """)
+
+JIRA_CATCH_ALL_PROMPT = \
+    ("""
+    This tool is a wrapper around atlassian-python-api's Jira API.
+    There are other dedicated tools for creating and searching for issues, but this tool can be used to perform any other actions allowed by the atlassian-python-api Jira API.
+    The input to this tool is line of python code that calls a function from atlassian-python-api's Jira API
+    For example, to update the summary field of an issue, you would pass in the following string:
+    self.jira.update_issue_field(key, {{"summary": "New summary"}})
+    or to find out how many projects are in the Jira instance, you would pass in the following string:
+    self.jira.projects()
+    For more information on the Jira API, refer to https://atlassian-python-api.readthedocs.io/jira.html
+    """)

--- a/langchain/tools/jira/prompt.py
+++ b/langchain/tools/jira/prompt.py
@@ -5,8 +5,17 @@ JIRA_CREATE_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jir
                       'For example, to create a low priority task called "test issue" with description "test description", you would pass in the following dictionary: '
                       '{{"summary": "test issue", "description": "test description", "issuetype": {{"name": "Task"}}, "priority": {{"name": "Low"}}}}')
 
-JIRA_JQL_PROMPT = "This tool is a wrapper around atlassian-python-api's Jira jql API. " \
-                  "Useful for when you need to search for Jira issues/tasks/tickets, or find out information about an issue. " \
-                  "The input to this tool is a JQL query string, and will be passed into atlassian-python-api's Jira jql function, " \
-                  "For example, find all the issues in project 'Test' assigned to the me, you would pass in the following string: " \
-                  "'project = Test AND assignee = currentUser()'"
+JIRA_JQL_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jira jql API. ' \
+                   'Useful for when you need to search for Jira issues/tasks/tickets, or find out information about an issue. ' \
+                   'The input to this tool is a JQL query string, and will be passed into atlassian-python-api\'s Jira jql function, ' \
+                   'For example, find all the issues in project "Test" assigned to the me, you would pass in the following string: ' \
+                   'project = Test AND assignee = currentUser()' \
+                   'or to find issues with summaries that contain the word "test", you would pass in the following string: ' \
+                   'summary ~ "test"')
+
+JIRA_CATCH_ALL_PROMPT = ('This tool is a wrapper around atlassian-python-api\'s Jira issue API. '
+                         'There are dedicated tools for creating and searching for issues, but this tool can be used to perform any other actions allowed by the atlassian python Jira API.'
+                         'The input to this tool is line of python code that calls a function from atlassian-python-api\'s Jira API, '
+                         'For example, to update the summary field of an issue, you would pass in the following string: '
+                         'self.jira.update_issue_field(key, {{"summary": "New summary"}})'
+                         'For more information on the Jira API, see https://atlassian-python-api.readthedocs.io/jira.html')

--- a/langchain/tools/jira/tool.py
+++ b/langchain/tools/jira/tool.py
@@ -7,23 +7,17 @@ from langchain.utilities.jira import JiraAPIWrapper
 
 
 class JiraAction(BaseTool):
-    """
-    Args:
-        action_id: a specific action ID (from list actions) of the action to execute
-            (the set api_key must be associated with the action owner)
-        instructions: a natural language instruction string for using the action
-            (eg. "get the latest email from Mike Knoop" for "Gmail: find email" action)
-    """
-
     api_wrapper: JiraAPIWrapper = Field(default_factory=JiraAPIWrapper)
     action_id: str
     name = ""
     description = ""
 
     def _run(self, instructions: str) -> str:
-        """Use the Zapier NLA tool to return a list of all exposed user actions."""
+        """Use the Atlassian Jira API to run an operation."""
+        print()
+        print(instructions)
         return self.api_wrapper.run(self.action_id, instructions)
 
     async def _arun(self, _: str) -> str:
-        """Use the Zapier NLA tool to return a list of all exposed user actions."""
-        raise NotImplementedError("ZapierNLAListActions does not support async")
+        """Use the Atlassian Jira API to run an operation."""
+        raise NotImplementedError("JiraAction does not support async")

--- a/langchain/tools/jira/tool.py
+++ b/langchain/tools/jira/tool.py
@@ -36,13 +36,13 @@ agent = initialize_agent(
 """
 class JiraAction(BaseTool):
     api_wrapper: JiraAPIWrapper = Field(default_factory=JiraAPIWrapper)
-    action_id: str
+    mode: str
     name = ""
     description = ""
 
     def _run(self, instructions: str) -> str:
         """Use the Atlassian Jira API to run an operation."""
-        return self.api_wrapper.run(self.action_id, instructions)
+        return self.api_wrapper.run(self.mode, instructions)
 
     async def _arun(self, _: str) -> str:
         """Use the Atlassian Jira API to run an operation."""

--- a/langchain/tools/jira/tool.py
+++ b/langchain/tools/jira/tool.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, Optional
+
+from pydantic import Field, root_validator
+
+from langchain.tools.base import BaseTool
+from langchain.utilities.jira import JiraAPIWrapper
+
+
+class JiraAction(BaseTool):
+    """
+    Args:
+        action_id: a specific action ID (from list actions) of the action to execute
+            (the set api_key must be associated with the action owner)
+        instructions: a natural language instruction string for using the action
+            (eg. "get the latest email from Mike Knoop" for "Gmail: find email" action)
+    """
+
+    api_wrapper: JiraAPIWrapper = Field(default_factory=JiraAPIWrapper)
+    action_id: str
+    name = ""
+    description = ""
+
+    def _run(self, instructions: str) -> str:
+        """Use the Zapier NLA tool to return a list of all exposed user actions."""
+        return self.api_wrapper.run(self.action_id, instructions)
+
+    async def _arun(self, _: str) -> str:
+        """Use the Zapier NLA tool to return a list of all exposed user actions."""
+        raise NotImplementedError("ZapierNLAListActions does not support async")

--- a/langchain/tools/jira/tool.py
+++ b/langchain/tools/jira/tool.py
@@ -14,8 +14,6 @@ class JiraAction(BaseTool):
 
     def _run(self, instructions: str) -> str:
         """Use the Atlassian Jira API to run an operation."""
-        print()
-        print(instructions)
         return self.api_wrapper.run(self.action_id, instructions)
 
     async def _arun(self, _: str) -> str:

--- a/langchain/tools/jira/tool.py
+++ b/langchain/tools/jira/tool.py
@@ -5,7 +5,35 @@ from pydantic import Field, root_validator
 from langchain.tools.base import BaseTool
 from langchain.utilities.jira import JiraAPIWrapper
 
+"""
+This tool allows agents to interact with the atlassian-python-api library and operate on a Jira instance.
+for more information on the atlassian-python-api library, see https://atlassian-python-api.readthedocs.io/jira.html
 
+To use this tool, you must first set as environment variables:
+    JIRA_API_TOKEN
+    JIRA_USERNAME
+    JIRA_INSTANCE_URL
+
+Below is a sample script that uses the Jira tool:
+
+```python
+from langchain.agents import AgentType
+from langchain.agents import initialize_agent
+from langchain.agents.agent_toolkits.jira.toolkit import JiraToolkit
+from langchain.llms import OpenAI
+from langchain.utilities.jira import JiraAPIWrapper
+
+llm = OpenAI(temperature=0)
+jira = JiraAPIWrapper()
+toolkit = JiraToolkit.from_jira_api_wrapper(jira)
+agent = initialize_agent(
+    toolkit.get_tools(),
+    llm,
+    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+    verbose=True
+)
+```
+"""
 class JiraAction(BaseTool):
     api_wrapper: JiraAPIWrapper = Field(default_factory=JiraAPIWrapper)
     action_id: str

--- a/langchain/utilities/jira.py
+++ b/langchain/utilities/jira.py
@@ -18,7 +18,7 @@ class JiraAPIWrapper(BaseModel):
     jira_api_token: Optional[str] = None
     jira_instance_url: Optional[str] = None
 
-    operations: List[str] = [
+    operations: List[Dict] = [
         {
             "mode": "jql",
             "name": "JQL Query",
@@ -45,7 +45,7 @@ class JiraAPIWrapper(BaseModel):
         """Configuration for this pydantic object."""
         extra = Extra.forbid
 
-    def list(self) -> List[str]:
+    def list(self) -> List[Dict]:
         return self.operations
 
     @root_validator()
@@ -105,7 +105,7 @@ class JiraAPIWrapper(BaseModel):
                  "status": status, "related_issues": rel_issues})
         return parsed
 
-    def parse_projects(self, projects):
+    def parse_projects(self, projects) -> str:
         parsed = []
         for project in projects:
             id = project['id']
@@ -137,13 +137,13 @@ class JiraAPIWrapper(BaseModel):
                 "Please install it with `pip install json`"
             )
         params = json.loads(query)
-        self.jira.create_issue(fields=dict(params))
+        return self.jira.create_issue(fields=dict(params))
 
     def other(self, query: str) -> str:
         context = {"self": self}
         exec(f"result = {query}", context)
         result = context["result"]
-        return result
+        return str(result)
 
     def run(self, mode: str, query: str) -> str:
         if mode == "jql":

--- a/langchain/utilities/jira.py
+++ b/langchain/utilities/jira.py
@@ -1,0 +1,119 @@
+"""Util that calls Jira."""
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Extra, root_validator
+
+from langchain.utils import get_from_dict_or_env
+
+
+class JiraAPIWrapper(BaseModel):
+    """Wrapper for Jira API."""
+
+    jira_client: Any  #: :meta private:
+    jira_username: Optional[str] = None
+    jira_api_token: Optional[str] = None
+    jira_instance_url: Optional[str] = None
+
+    operations: List[str] = ["create", "update", "delete", "search"]
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+
+    def list(self) -> List[str]:
+        return self.operations
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        """Validate that api key and python package exists in environment."""
+        jira_username = get_from_dict_or_env(values, "jira_username", "JIRA_USERNAME")
+        values["jira_username"] = jira_username
+
+        jira_api_token = get_from_dict_or_env(values, "jira_api_token", "JIRA_API_TOKEN")
+        values["jira_api_token"] = jira_api_token
+
+        jira_instance_url = get_from_dict_or_env(values, "jira_instance_url", "JIRA_INSTANCE_URL")
+        values["jira_instance_url"] = jira_instance_url
+
+        try:
+            from atlassian import Jira
+
+        except ImportError:
+            raise ImportError(
+                "atlassian-python-api is not installed. "
+                "Please install it with `pip install atlassian-python-api`"
+            )
+
+        jira = Jira(
+            url=jira_instance_url,
+            username=jira_username,
+            password=jira_api_token,
+            cloud=True)
+        values["jira_client"] = jira
+
+        return values
+
+    def jql_results_to_text(self, issues):
+        raw_string = json.dumps(issues, indent=4)
+        # Start string
+        parsed_string = "Returned issues:\n\n"
+        i = 0
+        # Process json
+        for issue in issues["issues"]:
+            i += 1
+            # Max ten issues
+            if i > 10:
+                break
+            # Simple fields
+            key = issue["key"]
+            summary = issue["fields"]["summary"]
+            created = issue["fields"]["created"][0:10]
+            priority = issue["fields"]["priority"]["name"]
+            status = issue["fields"]["status"]["name"]
+            try:
+                assignee = issue["fields"]["assignee"]["displayName"]
+            except:
+                assignee = "None"
+            # Related issues
+            rel_issues = ""
+            for related_issue in issue["fields"]["issuelinks"]:
+                if "inwardIssue" in related_issue.keys():
+                    rel_type = related_issue["type"]["inward"]
+                    rel_key = related_issue["inwardIssue"]["key"]
+                    rel_summary = related_issue["inwardIssue"]["fields"]["summary"]
+                if "outwardIssue" in related_issue.keys():
+                    rel_type = related_issue["type"]["outward"]
+                    rel_key = related_issue["outwardIssue"]["key"]
+                    rel_summary = related_issue["outwardIssue"]["fields"]["summary"]
+                rel_issues += f"""        {rel_type} {rel_key} {rel_summary}"""
+            # Add text
+            parsed_string += f"""{key}: {summary}\n    Created on: {created}\n    Assignee: {assignee}\n    Priority: {priority}\n    Status: {status}\n{rel_issues}\n\n"""
+        # Return parsed string
+        return parsed_string, raw_string
+
+    def search(self, query: str) -> str:
+        jql_response = self.jira_client.jql(query)
+        parsed, raw = jql_results_to_text(jql_response)
+        return parsed
+
+    def create(self, query: str) -> str:
+        try:
+            params = json.loads(query)
+            params["project"] = {"id": 10000}
+            params["labels"] = ["ai-created"]
+            print(params)
+            self.jira_client.create_issue(fields=dict(params))
+        except ValueError:
+            print("Error: JSON provided by LLM incorrect")
+
+    def run(self, mode: str, query: str) -> str:
+        """Run query through Jira and parse result."""
+        if mode == "search":
+            return self.search(query)
+        elif mode == "create":
+            return self.create(query)
+        # elif mode == "update":
+        #     return self.update(query)
+        # elif mode == "delete":
+        #     return self.delete(query)


### PR DESCRIPTION
This pr adds a basic Jira toolkit for langchain

Due to the number of different api calls jira has, this version of the toolkit only provides 3 dedicated tools (with description and examples) for the 3 most common apis, it also provides a 4th catch all tool to try guess which api call to use given just information about which underlying library the tools use. 

I'll keep working on making this toolkit more robust, keen for any feedback or ideas :) 