### PR TITLE
consistently use getLogger(__name__), no root logger

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -30,7 +30,7 @@ from langchain.schema import (
 from langchain.tools.base import BaseTool
 from langchain.utilities.asyncio import asyncio_timeout
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class BaseSingleActionAgent(BaseModel):

--- a/langchain/chat_models/azure_openai.py
+++ b/langchain/chat_models/azure_openai.py
@@ -9,7 +9,7 @@ from pydantic import root_validator
 from langchain.chat_models.openai import ChatOpenAI
 from langchain.utils import get_from_dict_or_env
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class AzureChatOpenAI(ChatOpenAI):

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -26,7 +26,7 @@ from langchain.schema import (
 )
 from langchain.utils import get_from_dict_or_env
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 def _create_retry_decorator(llm: ChatOpenAI) -> Callable[[Any], Any]:

--- a/langchain/document_loaders/diffbot.py
+++ b/langchain/document_loaders/diffbot.py
@@ -7,7 +7,7 @@ import requests
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class DiffbotLoader(BaseLoader):

--- a/langchain/document_loaders/directory.py
+++ b/langchain/document_loaders/directory.py
@@ -12,7 +12,7 @@ from langchain.document_loaders.unstructured import UnstructuredFileLoader
 FILE_LOADER_TYPE = Union[
     Type[UnstructuredFileLoader], Type[TextLoader], Type[BSHTMLLoader]
 ]
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 def _is_visible(p: Path) -> bool:

--- a/langchain/document_loaders/html_bs.py
+++ b/langchain/document_loaders/html_bs.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Union
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class BSHTMLLoader(BaseLoader):

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -5,7 +5,7 @@ from typing import Any, List
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class UnstructuredURLLoader(BaseLoader):

--- a/langchain/document_loaders/url_playwright.py
+++ b/langchain/document_loaders/url_playwright.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class PlaywrightURLLoader(BaseLoader):

--- a/langchain/document_loaders/url_selenium.py
+++ b/langchain/document_loaders/url_selenium.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class SeleniumURLLoader(BaseLoader):

--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -9,7 +9,7 @@ import requests
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 default_header_template = {
     "User-Agent": "",

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -12,7 +12,7 @@ DEFAULT_MODEL_ID = "gpt2"
 DEFAULT_TASK = "text-generation"
 VALID_TASKS = ("text2text-generation", "text-generation")
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class HuggingFacePipeline(LLM):

--- a/langchain/llms/self_hosted.py
+++ b/langchain/llms/self_hosted.py
@@ -9,7 +9,7 @@ from pydantic import Extra
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def _generate_text(

--- a/langchain/llms/self_hosted_hugging_face.py
+++ b/langchain/llms/self_hosted_hugging_face.py
@@ -12,7 +12,7 @@ DEFAULT_MODEL_ID = "gpt2"
 DEFAULT_TASK = "text-generation"
 VALID_TASKS = ("text2text-generation", "text-generation")
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def _generate_text(

--- a/langchain/prompts/loading.py
+++ b/langchain/prompts/loading.py
@@ -14,7 +14,7 @@ from langchain.prompts.prompt import PromptTemplate
 from langchain.utilities.loading import try_load_from_hub
 
 URL_BASE = "https://raw.githubusercontent.com/hwchase17/langchain-hub/master/prompts/"
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 def load_prompt_from_config(config: dict) -> BasePromptTemplate:

--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -18,7 +18,7 @@ from typing import (
 
 from langchain.docstore.document import Document
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class TextSplitter(ABC):

--- a/langchain/vectorstores/atlas.py
+++ b/langchain/vectorstores/atlas.py
@@ -11,7 +11,7 @@ from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
 from langchain.vectorstores.base import VectorStore
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class AtlasDB(VectorStore):

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     import chromadb
     import chromadb.config
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def _results_to_docs(results: Any) -> List[Document]:

--- a/langchain/vectorstores/deeplake.py
+++ b/langchain/vectorstores/deeplake.py
@@ -13,7 +13,7 @@ from langchain.embeddings.base import Embeddings
 from langchain.vectorstores.base import VectorStore
 from langchain.vectorstores.utils import maximal_marginal_relevance
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 distance_metric_map = {
     "l2": lambda a, b: np.linalg.norm(a - b, axis=1, ord=2),

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -16,7 +16,7 @@ from langchain.schema import BaseRetriever
 from langchain.utils import get_from_dict_or_env
 from langchain.vectorstores.base import VectorStore
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 # required modules


### PR DESCRIPTION
re https://github.com/hwchase17/langchain/issues/439#issuecomment-1510442791

I think it's not polite for a library to use the root logger

both of these forms are also used:
```
logger = logging.getLogger(__name__)
logger = logging.getLogger(__file__)
```
I am not sure if there is any reason behind one vs the other? (...I am guessing maybe just contributed by different people)

it seems to me it'd be better to consistently use `logging.getLogger(__name__)`

this makes it easier for consumers of the library to set up log handlers, e.g. for everything with `langchain.` prefix