### PR TITLE
Add GoogleSQL prompt

### DIFF
--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -41,6 +41,29 @@ DECIDER_PROMPT = PromptTemplate(
 )
 
 
+_googlesql_prompt = """You are a GoogleSQL expert. Given an input question, first create a syntactically correct GoogleSQL query to run, then look at the results of the query and return the answer to the input question.
+Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per GoogleSQL. You can order the results to return the most informative data in the database.
+Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
+Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+
+Use the following format:
+
+Question: "Question here"
+SQLQuery: "SQL Query to run"
+SQLResult: "Result of the SQLQuery"
+Answer: "Final answer here"
+
+Only use the following tables:
+{table_info}
+
+Question: {input}"""
+
+GOOGLESQL_PROMPT = PromptTemplate(
+    input_variables=["input", "table_info", "top_k"],
+    template=_googlesql_prompt,
+)
+
+
 _mssql_prompt = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in square brackets ([]) to denote them as delimited identifiers.
@@ -178,6 +201,7 @@ SQLITE_PROMPT = PromptTemplate(
 
 
 SQL_PROMPTS = {
+    "googlesql": GOOGLESQL_PROMPT,
     "mssql": MSSQL_PROMPT,
     "mysql": MYSQL_PROMPT,
     "mariadb": MARIADB_PROMPT,


### PR DESCRIPTION
This PR extends upon @jzluo 's PR #2748 which addressed dialect-specific issues with SQL prompts, and adds a prompt that uses backticks for column names when querying BigQuery. See [GoogleSQL quoted identifiers](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#quoted_identifiers).

Additionally, the SQL agent currently uses a generic prompt. Not sure how best to adopt the same optional dialect-specific prompts as above, but will consider making an issue and PR for that too. See [langchain/agents/agent_toolkits/sql/prompt.py](langchain/agents/agent_toolkits/sql/prompt.py).