### PR TITLE
Add argument for recursive loading of Google Drive documents

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/googledrive.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/googledrive.ipynb
@@ -44,7 +44,11 @@
    },
    "outputs": [],
    "source": [
-    "loader = GoogleDriveLoader(folder_id=\"1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5\")"
+    "loader = GoogleDriveLoader(\n",
+    "    folder_id=\"1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5\",\n",
+    "    # Optional: configure whether to recursively fetch files from subfolders. Defaults to False.\n",
+    "    recursive=False\n",
+    ")"
    ]
   },
   {

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -10,7 +10,7 @@
 #   https://cloud.google.com/iam/docs/service-accounts-create
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -190,8 +190,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 pass
 
         return returns
-
-    def _fetch_files_recursive(self, service, folder_id):
+    
+    def _fetch_files_recursive(self, service, folder_id) -> List[Dict[str, Union[str, List[str]]]]:
         """Fetch all files and subfolders recursively."""
         results = (
             service.files()

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -29,6 +29,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
     folder_id: Optional[str] = None
     document_ids: Optional[List[str]] = None
     file_ids: Optional[List[str]] = None
+    recursive: bool = False
 
     @root_validator
     def validate_folder_id_or_document_ids(
@@ -176,29 +177,41 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
 
         creds = self._load_credentials()
         service = build("drive", "v3", credentials=creds)
+        files = self._fetch_files_recursive(service, self.folder_id)
+        returns = []
+        for file in files:
+            if file["mimeType"] == "application/vnd.google-apps.document":
+                returns.append(self._load_document_from_id(file["id"]))
+            elif file["mimeType"] == "application/vnd.google-apps.spreadsheet":
+                returns.extend(self._load_sheet_from_id(file["id"]))
+            elif file["mimeType"] == "application/pdf":
+                returns.extend(self._load_file_from_id(file["id"]))
+            else:
+                pass
 
+        return returns
+
+    def _fetch_files_recursive(self, service, folder_id):
+        """Fetch all files and subfolders recursively."""
         results = (
             service.files()
             .list(
-                q=f"'{self.folder_id}' in parents",
+                q=f"'{folder_id}' in parents",
                 pageSize=1000,
                 includeItemsFromAllDrives=True,
                 supportsAllDrives=True,
-                fields="nextPageToken, files(id, name, mimeType)",
+                fields="nextPageToken, files(id, name, mimeType, parents)",
             )
             .execute()
         )
-        items = results.get("files", [])
+        files = results.get("files", [])
         returns = []
-        for item in items:
-            if item["mimeType"] == "application/vnd.google-apps.document":
-                returns.append(self._load_document_from_id(item["id"]))
-            elif item["mimeType"] == "application/vnd.google-apps.spreadsheet":
-                returns.extend(self._load_sheet_from_id(item["id"]))
-            elif item["mimeType"] == "application/pdf":
-                returns.extend(self._load_file_from_id(item["id"]))
+        for file in files:
+            if file["mimeType"] == "application/vnd.google-apps.folder":
+                if self.recursive:
+                    returns.extend(self._fetch_files_recursive(service, file["id"]))
             else:
-                pass
+                returns.append(file)
 
         return returns
 


### PR DESCRIPTION
This PR adds an argument to `GoogleDriveLoader` for recursive loading of Google Drive documents, set to False by default.