### PR TITLE
Stringify `AgentType` before saving to yaml

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -117,7 +117,7 @@ class BaseSingleActionAgent(BaseModel):
     def dict(self, **kwargs: Any) -> Dict:
         """Return dictionary representation of agent."""
         _dict = super().dict()
-        _dict["_type"] = self._agent_type
+        _dict["_type"] = str(self._agent_type)
         return _dict
 
     def save(self, file_path: Union[Path, str]) -> None:
@@ -229,7 +229,7 @@ class BaseMultiActionAgent(BaseModel):
     def dict(self, **kwargs: Any) -> Dict:
         """Return dictionary representation of agent."""
         _dict = super().dict()
-        _dict["_type"] = self._agent_type
+        _dict["_type"] = str(self._agent_type)
         return _dict
 
     def save(self, file_path: Union[Path, str]) -> None:


### PR DESCRIPTION
Code to reproduce the issue (with `langchain==0.0.141`):

```python
from langchain.agents import initialize_agent, load_tools
from langchain.llms import OpenAI

llm = OpenAI(temperature=0.9, verbose=True)
tools = load_tools(["llm-math"], llm=llm)
agent = initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)
agent.save_agent("agent.yaml")
with open("agent.yaml") as f:
    print(f.read())
```

Output:

```
_type: !!python/object/apply:langchain.agents.agent_types.AgentType
- zero-shot-react-description
allowed_tools:
- Calculator
...
```

I expected `_type` to be `zero-shot-react-description` but it's actually not. This PR fixes it by stringifying `AgentType` (`Enum`).