### PR TITLE
Support inference of `input_variables` from `jinja2` template

### DIFF
--- a/langchain/prompts/prompt.py
+++ b/langchain/prompts/prompt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from string import Formatter
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Set, Union
 
 from jinja2 import Environment, meta
 from pydantic import Extra, root_validator
@@ -15,11 +15,11 @@ from langchain.prompts.base import (
 )
 
 
-def _get_jinja2_variables_from_template(template: str) -> List[str]:
+def _get_jinja2_variables_from_template(template: str) -> Set[str]:
     env = Environment()
     ast = env.parse(template)
     variables = meta.find_undeclared_variables(ast)
-    return list(variables)
+    return variables
 
 
 class PromptTemplate(StringPromptTemplate):

--- a/langchain/prompts/prompt.py
+++ b/langchain/prompts/prompt.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from string import Formatter
 from typing import Any, Dict, List, Union
 
+from jinja2 import Environment, meta
 from pydantic import Extra, root_validator
 
 from langchain.prompts.base import (
@@ -12,6 +13,13 @@ from langchain.prompts.base import (
     StringPromptTemplate,
     check_valid_template,
 )
+
+
+def _get_jinja2_variables_from_template(template: str) -> List[str]:
+    env = Environment()
+    ast = env.parse(template)
+    variables = meta.find_undeclared_variables(ast)
+    return list(variables)
 
 
 class PromptTemplate(StringPromptTemplate):
@@ -125,9 +133,15 @@ class PromptTemplate(StringPromptTemplate):
     @classmethod
     def from_template(cls, template: str, **kwargs: Any) -> PromptTemplate:
         """Load a prompt template from a template."""
-        input_variables = {
-            v for _, v, _, _ in Formatter().parse(template) if v is not None
-        }
+        if "template_format" in kwargs and kwargs["template_format"] == "jinja2":
+            # Get the variables for the template
+            input_variables = _get_jinja2_variables_from_template(template)
+
+        else:
+            input_variables = {
+                v for _, v, _, _ in Formatter().parse(template) if v is not None
+            }
+
         return cls(
             input_variables=list(sorted(input_variables)), template=template, **kwargs
         )

--- a/tests/unit_tests/prompts/test_prompt.py
+++ b/tests/unit_tests/prompts/test_prompt.py
@@ -211,7 +211,4 @@ Your variable again: {{ var }}
         input_variables=["dummy_list", "var", "verbose"],
         template_format="jinja2",
     )
-    # Ordering is not enforced
-    assert set(prompt.input_variables) == set(expected_prompt.input_variables)
-    prompt.input_variables = expected_prompt.input_variables
     assert prompt == expected_prompt

--- a/tests/unit_tests/prompts/test_prompt.py
+++ b/tests/unit_tests/prompts/test_prompt.py
@@ -145,3 +145,73 @@ def test_partial() -> None:
     assert new_result == "This is a 3 test."
     result = prompt.format(foo="foo")
     assert result == "This is a foo test."
+
+
+def test_prompt_from_jinja2_template() -> None:
+    """Test prompts can be constructed from a jinja2 template."""
+    # Empty input variable.
+    template = """Hello there
+There is no variable here
+Cool huh?
+    """
+    prompt = PromptTemplate.from_template(template, template_format="jinja2")
+    expected_prompt = PromptTemplate(
+        template=template, input_variables=[], template_format="jinja2"
+    )
+    assert prompt == expected_prompt
+
+    # Multiple input variables.
+    template = """\
+Hello world
+
+Your variable: {{ var }}
+
+{# This will not get rendered #}
+
+{% if verbose %}
+Congrats! You just turned on verbose mode and got extra messages!
+{% endif %}
+
+{% for i in dummy_list %}
+The value in dummy_list is {{ i }}
+{% endfor %}
+"""
+    prompt = PromptTemplate.from_template(template, template_format="jinja2")
+    expected_prompt = PromptTemplate(
+        template=template,
+        input_variables=["dummy_list", "var", "verbose"],
+        template_format="jinja2",
+    )
+
+    assert prompt == expected_prompt
+
+    # Multiple input variables with repeats.
+    template = """\
+Hello world
+
+Your variable: {{ var }}
+
+{# This will not get rendered #}
+
+{% if verbose %}
+Congrats! You just turned on verbose mode and got extra messages!
+{% endif %}
+
+{% for i in dummy_list %}
+The value in dummy_list is {{ i }}
+{% endfor %}
+
+{% if verbose %}
+Your variable again: {{ var }}
+{% endif %}
+"""
+    prompt = PromptTemplate.from_template(template, template_format="jinja2")
+    expected_prompt = PromptTemplate(
+        template=template,
+        input_variables=["dummy_list", "var", "verbose"],
+        template_format="jinja2",
+    )
+    # Ordering is not enforced
+    assert set(prompt.input_variables) == set(expected_prompt.input_variables)
+    prompt.input_variables = expected_prompt.input_variables
+    assert prompt == expected_prompt

--- a/tests/unit_tests/prompts/test_prompt.py
+++ b/tests/unit_tests/prompts/test_prompt.py
@@ -151,8 +151,8 @@ def test_prompt_from_jinja2_template() -> None:
     """Test prompts can be constructed from a jinja2 template."""
     # Empty input variable.
     template = """Hello there
-There is no variable here
-Cool huh?
+There is no variable here {
+Will it get confused{ }? 
     """
     prompt = PromptTemplate.from_template(template, template_format="jinja2")
     expected_prompt = PromptTemplate(
@@ -164,22 +164,22 @@ Cool huh?
     template = """\
 Hello world
 
-Your variable: {{ var }}
+Your variable: {{ foo }}
 
 {# This will not get rendered #}
 
-{% if verbose %}
-Congrats! You just turned on verbose mode and got extra messages!
+{% if bar %}
+You just set bar boolean variable to true
 {% endif %}
 
-{% for i in dummy_list %}
-The value in dummy_list is {{ i }}
+{% for i in foo_list %}
+{{ i }}
 {% endfor %}
 """
     prompt = PromptTemplate.from_template(template, template_format="jinja2")
     expected_prompt = PromptTemplate(
         template=template,
-        input_variables=["dummy_list", "var", "verbose"],
+        input_variables=["bar", "foo", "foo_list"],
         template_format="jinja2",
     )
 
@@ -189,26 +189,26 @@ The value in dummy_list is {{ i }}
     template = """\
 Hello world
 
-Your variable: {{ var }}
+Your variable: {{ foo }}
 
 {# This will not get rendered #}
 
-{% if verbose %}
-Congrats! You just turned on verbose mode and got extra messages!
+{% if bar %}
+You just set bar boolean variable to true
 {% endif %}
 
-{% for i in dummy_list %}
-The value in dummy_list is {{ i }}
+{% for i in foo_list %}
+{{ i }}
 {% endfor %}
 
-{% if verbose %}
-Your variable again: {{ var }}
+{% if bar %}
+Your variable again: {{ foo }}
 {% endif %}
 """
     prompt = PromptTemplate.from_template(template, template_format="jinja2")
     expected_prompt = PromptTemplate(
         template=template,
-        input_variables=["dummy_list", "var", "verbose"],
+        input_variables=["bar", "foo", "foo_list"],
         template_format="jinja2",
     )
     assert prompt == expected_prompt


### PR DESCRIPTION
`langchain.prompts.PromptTemplate` is unable to infer `input_variables` from jinja2 template. 

```python
# Using langchain v0.0.141
template_string = """\
Hello world
Your variable: {{ var }}
{# This will not get rendered #}

{% if verbose %}
Congrats! You just turned on verbose mode and got extra messages!
{% endif %}
"""

template = PromptTemplate.from_template(template_string, template_format="jinja2")
print(template.input_variables) # Output ['# This will not get rendered #', '% endif %', '% if verbose %']
```
