### PR TITLE
AIPluginTool: reduce token usage, fix context window error

### DIFF
--- a/langchain/tools/plugin.py
+++ b/langchain/tools/plugin.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import json
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
-from typing import List, Dict, Tuple, Optional
 
 import requests
 import yaml
 from pydantic import BaseModel
 
+from langchain.requests import TextRequestsWrapper
 from langchain.tools.base import BaseTool
 from langchain.tools.openapi.utils.api_models import APIOperation, OpenAPISpec
 from langchain.tools.requests.tool import BaseRequestsTool
-from langchain.requests import TextRequestsWrapper
 
 
 class ApiConfig(BaseModel):

--- a/langchain/tools/plugin.py
+++ b/langchain/tools/plugin.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
+from urllib.parse import urlparse
+from typing import List, Dict, Tuple, Optional
 
 import requests
 import yaml
 from pydantic import BaseModel
 
 from langchain.tools.base import BaseTool
-
+from langchain.tools.openapi.utils.api_models import APIOperation, OpenAPISpec
+from langchain.tools.requests.tool import BaseRequestsTool
+from langchain.requests import TextRequestsWrapper
 
 class ApiConfig(BaseModel):
     type: str
@@ -45,37 +48,97 @@ def marshal_spec(txt: str) -> dict:
         return yaml.safe_load(txt)
 
 
-class AIPluginTool(BaseTool):
+class AIPluginTool(BaseRequestsTool, BaseTool):
     plugin: AIPlugin
     api_spec: str
+    base_url: str
+    operations: Dict[Tuple[str, str], APIOperation]
 
     @classmethod
     def from_plugin_url(cls, url: str) -> AIPluginTool:
         plugin = AIPlugin.from_url(url)
+
+        # Strip the URL's ending path to get the base URL to send queries against
+        parsed_url = urlparse(url)
+        base_url = f"{parsed_url.scheme}://{parsed_url.hostname}{':' + str(parsed_url.port) if parsed_url.port != '80' else ''}{parsed_url.path.strip('./well-known/ai-plugin.json')}"
+
         description = (
-            f"Call this tool to get the OpenAPI spec (and usage guide) "
-            f"for interacting with the {plugin.name_for_human} API. "
-            f"You should only call this ONCE! What is the "
-            f"{plugin.name_for_human} API useful for? "
-        ) + plugin.description_for_human
+            f"""Call this tool to get the OpenAPI spec (and usage guide) """
+            f"""for interacting with the {plugin.name_for_human} API. """
+            f"""Input should be either "usage_guide" or json string with three keys: "path", "method", and if the method is a POST request, include "data" """
+            f"""The "data" value should be a dictionary of key-value pairs you want to POST to the url. Please check the usage guide for POST parameters """
+            f"""You should only call "usage_guide" ONCE! """
+            f"""This plugin is useful for {plugin.description_for_human}"""
+        )
         open_api_spec_str = requests.get(plugin.api.url).text
         open_api_spec = marshal_spec(open_api_spec_str)
+        openapi_schema = OpenAPISpec.from_spec_dict(open_api_spec)
+
+        spec_description = cls.generate_api_spec(cls, openapi_schema)        
         api_spec = (
             f"Usage Guide: {plugin.description_for_model}\n\n"
-            f"OpenAPI Spec: {open_api_spec}"
+            f"OpenAPI Spec: {spec_description}"
         )
 
+        operations = {}
+        # TODO: Add support for other HTTP methods
+        for (path, info) in openapi_schema.paths.items():
+            if info.get:
+                operations[(path, "get")] = APIOperation.from_openapi_spec(openapi_schema, path, "get")
+            if info.post:
+                operations[(path, "post")] = APIOperation.from_openapi_spec(openapi_schema, path, "post")
+
+        print("Description: ", description)
         return cls(
             name=plugin.name_for_model,
             description=description,
             plugin=plugin,
             api_spec=api_spec,
+            base_url=base_url,
+            operations=operations,
+            requests_wrapper=TextRequestsWrapper()
         )
+
+    @staticmethod
+    def generate_api_spec(cls, openapi_schema: OpenAPISpec) -> str:
+        """Generate a token-optimized API spec for using the tool."""
+        operations: List[APIOperation] = []
+        for (path, info) in openapi_schema.paths.items():
+            if info.get:
+                operations.append(APIOperation.from_openapi_spec(openapi_schema, path, "get"))
+            if info.post:
+                operations.append(APIOperation.from_openapi_spec(openapi_schema, path, "post"))
+
+        base_str = ""
+        for op in operations:
+            op_str = f"{op.path}: ({op.method}) {op.description}\n"
+            # TODO: add support and tests for query_params
+            if op.query_params:
+                op_str += f"""Query Params: {op.query_params}\n"""
+            if op.method == "post" and op.request_body:
+                request_params = []
+                for param in op.request_body.properties:
+                    request_params.append(f"{param.name} ({param.type}{' required' if param.required else ''})")
+                op_str += f"""Body Params: {', '.join(request_params)}\n"""
+            base_str += op_str + "\n\n"
+        return base_str
 
     def _run(self, tool_input: str) -> str:
         """Use the tool."""
-        return self.api_spec
+        if tool_input == "usage_guide":
+            return self.api_spec
+        try:
+            request_info = json.loads(tool_input)
+            method = request_info['method'].lower()
+            path = request_info['path'] if request_info['path'].startswith("/") else "/" + request_info['path']
+            if method == "post":
+                return self.requests_wrapper.post(self.base_url + path, data=request_info['data'])
+            elif method == "get":
+                return self.requests_wrapper.get(self.base_url + path)
+            raise ValueError("Model method could not be parsed. Must be either 'get' or 'post'")
+        except json.JSONDecodeError:
+            raise ValueError("Model input must be either 'usage_guide' or a json string with three keys: 'path', 'method', and 'data'")
 
     async def _arun(self, tool_input: str) -> str:
         """Use the tool asynchronously."""
-        return self.api_spec
+        return self._run(tool_input)


### PR DESCRIPTION
Using the AIPluginTool fails when the targeted ChatGPT Plugin server's YAML has more than 5 well-documented endpoints.
This causes the context length to overflow for most LLMs very quickly while using AIPluginTool. (See #2140 ).

This PR introduces 2 changes to AIPluginTool to make it more usable.

1. Instead of returning the entire YAML file of the plugin, only return the parsed schemas necessary to execute get & post requests against the plugin. I've chosen to represent the schema in a human readable way, (e.g. "/myEndpoint: (post) my description. Request body: message (string required)". However this should probably be configurable by developers going forward.

2. Instead of using the YAML to construct proper HTTP requests using the `requests_*` tools, I've changed the tool to accept `get` and `post` requests against the endpoints described by the YAML. This reduces the token length needed to communicate with the plugin as well.

Let me know what you think & how I can improve this PR! 🥂 