### PR TITLE
bugfix: throw exception if structured output parser doesn't get what it wants

### DIFF
--- a/langchain/output_parsers/structured.py
+++ b/langchain/output_parsers/structured.py
@@ -38,6 +38,12 @@ class StructuredOutputParser(BaseOutputParser):
         return STRUCTURED_FORMAT_INSTRUCTIONS.format(format=schema_str)
 
     def parse(self, text: str) -> Any:
+        if "```json" not in text:
+            raise OutputParserException(
+                f"Got invalid return object. Expected markdown code snippet with JSON"
+                "object, but got {text}"
+            )
+
         json_string = text.split("```json")[1].strip().strip("```").strip()
         try:
             json_obj = json.loads(json_string)

--- a/langchain/output_parsers/structured.py
+++ b/langchain/output_parsers/structured.py
@@ -40,8 +40,8 @@ class StructuredOutputParser(BaseOutputParser):
     def parse(self, text: str) -> Any:
         if "```json" not in text:
             raise OutputParserException(
-                f"Got invalid return object. Expected markdown code snippet with JSON"
-                "object, but got {text}"
+                f"Got invalid return object. Expected markdown code snippet with JSON "
+                f"object, but got:\n{text}"
             )
 
         json_string = text.split("```json")[1].strip().strip("```").strip()


### PR DESCRIPTION
allows the user to catch the issue and handle it rather than failing hard.

This happens more than you'd expect when using output parsers with chatgpt, especially if the temp is anything but 0.  Sometimes it doesn't want to listen and just does its own thing.