### PR TITLE
updated llm response parsing action

### DIFF
--- a/langchain/agents/chat/output_parser.py
+++ b/langchain/agents/chat/output_parser.py
@@ -14,7 +14,7 @@ class ChatOutputParser(AgentOutputParser):
                 {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
             )
         try:
-            _, action, _ = text.split("```")
+            action  = text.split("```")[1]
             response = json.loads(action.strip())
             return AgentAction(response["action"], response["action_input"], text)
 

--- a/langchain/agents/chat/output_parser.py
+++ b/langchain/agents/chat/output_parser.py
@@ -14,7 +14,7 @@ class ChatOutputParser(AgentOutputParser):
                 {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
             )
         try:
-            action  = text.split("```")[1]
+            action = text.split("```")[1]
             response = json.loads(action.strip())
             return AgentAction(response["action"], response["action_input"], text)
 


### PR DESCRIPTION
Sometimes the LLM response (generated code) tends to miss the ending ticks "```". Therefore causing the text parsing to fail due to not enough values to unpack.

The 2 extra `_` don't add value and can cause errors. Suggest to simply update the `_, action, _` to just `action` then with index. 

Fixes issue #3057 