### PR TITLE
Raise OutputParserException & implement get_format_instructions

### DIFF
--- a/langchain/agents/chat/output_parser.py
+++ b/langchain/agents/chat/output_parser.py
@@ -2,12 +2,17 @@ import json
 from typing import Union
 
 from langchain.agents.agent import AgentOutputParser
-from langchain.schema import AgentAction, AgentFinish
+from langchain.agents.chat.prompt import FORMAT_INSTRUCTIONS
+from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 FINAL_ANSWER_ACTION = "Final Answer:"
 
 
 class ChatOutputParser(AgentOutputParser):
+
+    def get_format_instructions(self) -> str:
+        return FORMAT_INSTRUCTIONS
+
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         if FINAL_ANSWER_ACTION in text:
             return AgentFinish(
@@ -19,4 +24,4 @@ class ChatOutputParser(AgentOutputParser):
             return AgentAction(response["action"], response["action_input"], text)
 
         except Exception:
-            raise ValueError(f"Could not parse LLM output: {text}")
+            raise OutputParserException(f"Could not parse LLM output: {text}")

--- a/langchain/agents/conversational/output_parser.py
+++ b/langchain/agents/conversational/output_parser.py
@@ -2,11 +2,15 @@ import re
 from typing import Union
 
 from langchain.agents.agent import AgentOutputParser
-from langchain.schema import AgentAction, AgentFinish
+from langchain.agents.conversational.prompt import FORMAT_INSTRUCTIONS
+from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 
 class ConvoOutputParser(AgentOutputParser):
     ai_prefix: str = "AI"
+
+    def get_format_instructions(self) -> str:
+        return FORMAT_INSTRUCTIONS
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         if f"{self.ai_prefix}:" in text:
@@ -16,7 +20,7 @@ class ConvoOutputParser(AgentOutputParser):
         regex = r"Action: (.*?)[\n]*Action Input: (.*)"
         match = re.search(regex, text)
         if not match:
-            raise ValueError(f"Could not parse LLM output: `{text}`")
+            raise OutputParserException(f"Could not parse LLM output: `{text}`")
         action = match.group(1)
         action_input = match.group(2)
         return AgentAction(action.strip(), action_input.strip(" ").strip('"'), text)

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -2,12 +2,17 @@ import re
 from typing import Union
 
 from langchain.agents.agent import AgentOutputParser
-from langchain.schema import AgentAction, AgentFinish
+from langchain.agents.mrkl.prompt import FORMAT_INSTRUCTIONS
+from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 FINAL_ANSWER_ACTION = "Final Answer:"
 
 
 class MRKLOutputParser(AgentOutputParser):
+
+    def get_format_instructions(self) -> str:
+        return FORMAT_INSTRUCTIONS
+
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         if FINAL_ANSWER_ACTION in text:
             return AgentFinish(
@@ -17,7 +22,7 @@ class MRKLOutputParser(AgentOutputParser):
         regex = r"Action\s*\d*\s*:(.*?)\nAction\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
         match = re.search(regex, text, re.DOTALL)
         if not match:
-            raise ValueError(f"Could not parse LLM output: `{text}`")
+            raise OutputParserException(f"Could not parse LLM output: `{text}`")
         action = match.group(1).strip()
         action_input = match.group(2)
         return AgentAction(action, action_input.strip(" ").strip('"'), text)

--- a/langchain/agents/react/output_parser.py
+++ b/langchain/agents/react/output_parser.py
@@ -2,21 +2,21 @@ import re
 from typing import Union
 
 from langchain.agents.agent import AgentOutputParser
-from langchain.schema import AgentAction, AgentFinish
+from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 
 class ReActOutputParser(AgentOutputParser):
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         action_prefix = "Action: "
         if not text.strip().split("\n")[-1].startswith(action_prefix):
-            raise ValueError(f"Could not parse LLM Output: {text}")
+            raise OutputParserException(f"Could not parse LLM Output: {text}")
         action_block = text.strip().split("\n")[-1]
 
         action_str = action_block[len(action_prefix) :]
         # Parse out the action and the directive.
         re_matches = re.search(r"(.*?)\[(.*?)\]", action_str)
         if re_matches is None:
-            raise ValueError(f"Could not parse action directive: {action_str}")
+            raise OutputParserException(f"Could not parse action directive: {action_str}")
         action, action_input = re_matches.group(1), re_matches.group(2)
         if action == "Finish":
             return AgentFinish({"output": action_input}, text)

--- a/langchain/agents/self_ask_with_search/output_parser.py
+++ b/langchain/agents/self_ask_with_search/output_parser.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from langchain.agents.agent import AgentOutputParser
-from langchain.schema import AgentAction, AgentFinish
+from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 
 class SelfAskOutputParser(AgentOutputParser):
@@ -12,7 +12,7 @@ class SelfAskOutputParser(AgentOutputParser):
         if followup not in last_line:
             finish_string = "So the final answer is: "
             if finish_string not in last_line:
-                raise ValueError(f"Could not parse output: {text}")
+                raise OutputParserException(f"Could not parse output: {text}")
             return AgentFinish({"output": last_line[len(finish_string) :]}, text)
 
         after_colon = text.split(":")[-1]

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -9,7 +9,7 @@ from langchain.agents.mrkl.output_parser import MRKLOutputParser
 from langchain.agents.mrkl.prompt import FORMAT_INSTRUCTIONS, PREFIX, SUFFIX
 from langchain.agents.tools import Tool
 from langchain.prompts import PromptTemplate
-from langchain.schema import AgentAction
+from langchain.schema import AgentAction, OutputParserException
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
 
@@ -98,7 +98,7 @@ def test_get_final_answer_multiline() -> None:
 def test_bad_action_input_line() -> None:
     """Test handling when no action input found."""
     llm_output = "Thought: I need to search for NBA\n" "Action: Search\n" "Thought: NBA"
-    with pytest.raises(ValueError):
+    with pytest.raises(OutputParserException):
         get_action_and_input(llm_output)
 
 
@@ -107,7 +107,7 @@ def test_bad_action_line() -> None:
     llm_output = (
         "Thought: I need to search for NBA\n" "Thought: Search\n" "Action Input: NBA"
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(OutputParserException):
         get_action_and_input(llm_output)
 
 


### PR DESCRIPTION
For agents class, raise `OutputParserException` instead of `ValueError`, enabling better error handling of invalid format.
Implements `get_format_instructions()` where it's missing.
This enables using `OutputFixingParser` to automatically recover from invalid formats.