### PR TITLE
Bump Metal to use index_id

### DIFF
--- a/docs/modules/indexes/retrievers/examples/metal.ipynb
+++ b/docs/modules/indexes/retrievers/examples/metal.ipynb
@@ -32,9 +32,9 @@
     "from metal_sdk.metal import Metal\n",
     "API_KEY = \"\"\n",
     "CLIENT_ID = \"\"\n",
-    "APP_ID = \"\"\n",
+    "INDEX_ID = \"\"\n",
     "\n",
-    "metal = Metal(API_KEY, CLIENT_ID, APP_ID);\n"
+    "metal = Metal(API_KEY, CLIENT_ID, INDEX_ID);\n"
    ]
   },
   {


### PR DESCRIPTION
## Use `index_id` over `app_id`
We made a major update to index + retrieve based on Metal Indexes (instead of apps). With this change, we accept an index instead of an app in each of our respective core apis. [More details here](https://docs.getmetal.io/api-reference/core/indexing).