### PR TITLE
Update `query_checker_sql_db` description

### DIFF
--- a/langchain/tools/sql_database/tool.py
+++ b/langchain/tools/sql_database/tool.py
@@ -85,6 +85,7 @@ class QueryCheckerTool(BaseSQLDatabaseTool, BaseTool):
     llm_chain: LLMChain = Field(init=False)
     name = "query_checker_sql_db"
     description = """
+    Input to this tool is a SQL query string, output is a validated SQL query string.
     Use this tool to double check if your query is correct before executing it.
     Always use this tool before executing a query with query_sql_db!
     """


### PR DESCRIPTION
Added input and output description to the `query_checker_sql_db`. Otherwise, the `SQLDatabaseToolkit` will often skip the `query_checker_sql_db` step, even though the prompt instructs it to always use it. Tested with `gpt-3.5-turbo`.