### PR TITLE
Print exception type for Python tool

### DIFF
--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -89,7 +89,7 @@ class PythonAstREPLTool(BaseTool):
                     output = str(e)
                 return output
         except Exception as e:
-            return str(e)
+            return "{}: {}".format(type(e).__name__, str(e))
 
     async def _arun(self, query: str) -> str:
         """Use the tool asynchronously."""


### PR DESCRIPTION
Useful for debugging agents e.g. KeyError in addition to just printing the missing key