### PR TITLE
feat: add private weaviate api_key support on from_texts

### DIFF
--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -217,7 +217,7 @@ class Weaviate(VectorStore):
         )
 
         try:
-            from weaviate import AuthApiKey, Client
+            from weaviate import Client
             from weaviate.auth import AuthApiKey
             from weaviate.util import get_valid_uuid
         except ImportError:
@@ -226,9 +226,7 @@ class Weaviate(VectorStore):
                 "Please install it with `pip instal weaviate-client`"
             )
 
-        auth = (
-            AuthApiKey(api_key=weaviate_api_key) if weaviate_api_key is not "" else None
-        )
+        auth = AuthApiKey(api_key=weaviate_api_key) if weaviate_api_key != "" else None
 
         client = Client(weaviate_url, auth_client_secret=auth)
         index_name = kwargs.get("index_name", f"LangChain_{uuid4().hex}")

--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -212,10 +212,13 @@ class Weaviate(VectorStore):
                 )
         """
         weaviate_url = get_from_dict_or_env(kwargs, "weaviate_url", "WEAVIATE_URL")
-        weaviate_api_key = get_from_dict_or_env(kwargs, "weaviate_api_key", "WEAVIATE_API_KEY")
+        weaviate_api_key = get_from_dict_or_env(
+            kwargs, "weaviate_api_key", "WEAVIATE_API_KEY", ""
+        )
 
         try:
-            from weaviate import Client
+            from weaviate import AuthApiKey, Client
+            from weaviate.auth import AuthApiKey
             from weaviate.util import get_valid_uuid
         except ImportError:
             raise ValueError(
@@ -223,7 +226,9 @@ class Weaviate(VectorStore):
                 "Please install it with `pip instal weaviate-client`"
             )
 
-        auth = weaviate.auth.AuthApiKey(api_key=weaviate_api_key) if weaviate_api_key else None
+        auth = (
+            AuthApiKey(api_key=weaviate_api_key) if weaviate_api_key is not "" else None
+        )
 
         client = Client(weaviate_url, auth_client_secret=auth)
         index_name = kwargs.get("index_name", f"LangChain_{uuid4().hex}")

--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -212,6 +212,7 @@ class Weaviate(VectorStore):
                 )
         """
         weaviate_url = get_from_dict_or_env(kwargs, "weaviate_url", "WEAVIATE_URL")
+        weaviate_api_key = get_from_dict_or_env(kwargs, "weaviate_api_key", "WEAVIATE_API_KEY")
 
         try:
             from weaviate import Client
@@ -222,7 +223,9 @@ class Weaviate(VectorStore):
                 "Please install it with `pip instal weaviate-client`"
             )
 
-        client = Client(weaviate_url)
+        auth = weaviate.auth.AuthApiKey(api_key=weaviate_api_key) if weaviate_api_key else None
+
+        client = Client(weaviate_url, auth_client_secret=auth)
         index_name = kwargs.get("index_name", f"LangChain_{uuid4().hex}")
         embeddings = embedding.embed_documents(texts) if embedding else None
         text_key = "text"


### PR DESCRIPTION
This PR adds support for providing a Weaviate API Key to the VectorStore methods `from_documents` and `from_texts`. With this addition, users can authenticate to Weaviate and make requests to private Weaviate servers when using these methods.

## Motivation
Currently, LangChain's VectorStore methods do not provide a way to authenticate to Weaviate. This limits the functionality of the library and makes it more difficult for users to take advantage of Weaviate's features.

This PR addresses this issue by adding support for providing a Weaviate API Key as extra parameter used in the `from_texts` method.

## Contributing Guidelines
I have read the [contributing guidelines](https://github.com/hwchase17/langchain/blob/72b7d76d79b0e187426787616d96257b64292119/.github/CONTRIBUTING.md) and the PR code passes the following tests:

- [x] make format
- [x] make lint
- [x] make coverage
- [x] make test