### PR TITLE
Prevent `kwargs` from being overwritten

### DIFF
--- a/langchain/tools/base.py
+++ b/langchain/tools/base.py
@@ -100,8 +100,8 @@ class BaseTool(ABC, BaseModel):
             **kwargs,
         )
         try:
-            args, kwargs = _to_args_and_kwargs(tool_input)
-            observation = self._run(*args, **kwargs)
+            tool_args, tool_kwargs = _to_args_and_kwargs(tool_input)
+            observation = self._run(*tool_args, **tool_kwargs)
         except (Exception, KeyboardInterrupt) as e:
             self.callback_manager.on_tool_error(e, verbose=verbose_)
             raise e


### PR DESCRIPTION
Fixes #3157. Prevents `kwargs` from being overwritten by `_to_args_and_kwargs()` and sending the wrong `kwargs` in line 109.