### PR TITLE
Fix: typo in custom_mrkl_agents.ipynb document

### DIFF
--- a/docs/modules/agents/agents/custom_mrkl_agent.ipynb
+++ b/docs/modules/agents/agents/custom_mrkl_agent.ipynb
@@ -20,13 +20,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6064f080",
    "metadata": {},
    "source": [
     "### Custom LLMChain\n",
     "\n",
-    "The first way to create a custom agent is to use an existing Agent class, but use a custom LLMChain. This is the simplest way to create a custom Agent. It is highly reccomended that you work with the `ZeroShotAgent`, as at the moment that is by far the most generalizable one. \n",
+    "The first way to create a custom agent is to use an existing Agent class, but use a custom LLMChain. This is the simplest way to create a custom Agent. It is highly recommended that you work with the `ZeroShotAgent`, as at the moment that is by far the most generalizable one. \n",
     "\n",
     "Most of the work in creating the custom LLMChain comes down to the prompt. Because we are using an existing agent class to parse the output, it is very important that the prompt say to produce text in that format. Additionally, we currently require an `agent_scratchpad` input variable to put notes on previous actions and observations. This should almost always be the final part of the prompt. However, besides those instructions, you can customize the prompt as you wish.\n",
     "\n",


### PR DESCRIPTION
I have noticed a typo error in the `custom_mrkl_agents.ipynb` document while trying the example from the documentation page. As a result, I have opened a pull request (PR) to address this minor issue, even though it may seem insignificant 😂.