### PR TITLE
fix: add informative error message for anthropic completion

### DIFF
--- a/langchain/llms/anthropic.py
+++ b/langchain/llms/anthropic.py
@@ -180,6 +180,8 @@ class Anthropic(LLM, _AnthropicCommon):
             stop_sequences=stop,
             **self._default_params,
         )
+        if "detail" in response:
+            raise RuntimeError(response["detail"])
         return response["completion"]
 
     async def _acall(self, prompt: str, stop: Optional[List[str]] = None) -> str:
@@ -209,6 +211,8 @@ class Anthropic(LLM, _AnthropicCommon):
             stop_sequences=stop,
             **self._default_params,
         )
+        if "detail" in response:
+            raise RuntimeError(response["detail"])
         return response["completion"]
 
     def stream(self, prompt: str, stop: Optional[List[str]] = None) -> Generator:


### PR DESCRIPTION
Fixes #3170. `response` is a dict containing only `detail` when an error occurs, which was leading to the uninformative `KeyError`.  `detail` is not present when an error does not occur.

Now, we get:
```
RuntimeError: Number of concurrent connections to Claude exceeds your rate limit. Please try again, or contact sales@anthropic.com to discuss your options for a rate limit increase.
```
 
or
```
RuntimeError: Invalid API Key
```