### PR TITLE
Sagemaker embeddings shape in embed_documents needs to be 2D, not 3D.

### DIFF
--- a/langchain/embeddings/sagemaker_endpoint.py
+++ b/langchain/embeddings/sagemaker_endpoint.py
@@ -179,7 +179,7 @@ class SagemakerEndpointEmbeddings(BaseModel, Embeddings):
         _chunk_size = len(texts) if chunk_size > len(texts) else chunk_size
         for i in range(0, len(texts), _chunk_size):
             response = self._embedding_func(texts[i : i + _chunk_size])
-            results.append(response)
+            results.extend(response)
         return results
 
     def embed_query(self, text: str) -> List[float]:


### PR DESCRIPTION
Using Sagemaker embeddings as defined in the [docs](https://python.langchain.com/en/latest/modules/models/text_embedding/examples/sagemaker-endpoint.html) was erroring out when used with `max_marginal_relevance_search` because `embed_documents` was adding an extra dimension onto the output of _embedding_func. Needed to change .append to .extend to maintain the dimension of `_embedding_func` in the `results` list of embeddings.