### PR TITLE
Improved query, print & exception handling in REPL Tool

### DIFF
--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -71,7 +71,7 @@ class PythonAstREPLTool(BaseTool):
         try:
             if self.sanitize_input:
                 # Remove backticks & python (if llm mistakes python console as terminal) from query
-                query = re.sub(r'(?i:python)|`', '', query).strip()
+                query = re.sub(r"(?i:python)|`", "", query).strip()
             tree = ast.parse(query)
             module = ast.Module(tree.body[:-1], type_ignores=[])
             exec(ast.unparse(module), self.globals, self.locals)  # type: ignore

--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -1,10 +1,10 @@
 """A tool for running python code in a REPL."""
 
 import ast
-import sys
 import re
-from io import StringIO
+import sys
 from contextlib import redirect_stdout
+from io import StringIO
 from typing import Dict, Optional
 
 from pydantic import Field, root_validator
@@ -70,7 +70,8 @@ class PythonAstREPLTool(BaseTool):
         """Use the tool."""
         try:
             if self.sanitize_input:
-                # Remove backticks & python (if llm mistakes python console as terminal) from query
+                # Remove backticks & python from query
+                # Removes python if llm mistakes python console as terminals
                 query = re.sub(r"(?i:python)|`", "", query).strip()
             tree = ast.parse(query)
             module = ast.Module(tree.body[:-1], type_ignores=[])

--- a/tests/unit_tests/tools/python/test_python_tool.py
+++ b/tests/unit_tests/tools/python/test_python_tool.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from langchain.tools.python.tool import PythonAstREPLTool, PythonREPLTool
+
+
+def test_python_ast_repl_return():
+    program = """
+import numpy as np
+v1 = np.array([1, 2, 3])
+v2 = np.array([4, 5, 6])
+dot_product = np.dot(v1, v2)
+int(dot_product)
+    """
+    tool = PythonAstREPLTool()
+    assert tool.run(program) == 32
+
+
+def test_python_ast_repl_print():
+    program = """
+string = "racecar"
+if string == string[::-1]:
+    print(string, "is a palindrome")
+else:
+    print(string, "is not a palindrome")"""
+    tool = PythonAstREPLTool()
+    assert tool.run(program) == "racecar is a palindrome\n"
+
+
+def test_python_ast_repl_raise_exception():
+    data = {"Name": ["John", "Alice"], "Age": [30, 25]}
+    program = """
+import pandas as pd
+df = pd.DataFrame(data)
+df['Gender']
+    """
+    tool = PythonAstREPLTool(locals={"data": data})
+    expected_outputs = (
+        "KeyError: 'Gender'",
+        "ModuleNotFoundError: No module named 'pandas'",
+    )
+    assert tool.run(program) in expected_outputs
+
+
+def test_python_ast_repl_one_line_print():
+    program = 'print("The square of {} is {:.2f}".format(3, 3**2))'
+    tool = PythonAstREPLTool()
+    assert tool.run(program) == "The square of 3 is 9.00\n"
+
+
+def test_python_ast_repl_one_line_return():
+    arr = np.array([1, 2, 3, 4, 5])
+    tool = PythonAstREPLTool(locals={"arr": arr})
+    program = "(arr**2).sum()   # Returns sum of squares"
+    assert tool.run(program) == 55
+
+
+def test_python_ast_repl_one_line_exception():
+    program = "[1, 2, 3][4]"
+    tool = PythonAstREPLTool()
+    assert tool.run(program) == "IndexError: list index out of range"
+
+
+def test_python_repl_print():
+    program = """
+import numpy as np
+v1 = np.array([1, 2, 3])
+v2 = np.array([4, 5, 6])
+dot_product = np.dot(v1, v2)
+print("The dot product is {:d}.".format(dot_product))
+    """
+    tool = PythonREPLTool()
+    assert tool.run(program) == "The dot product is 32.\n"


### PR DESCRIPTION
The following improvements are made to the Python REPL Tool: 
1) Improved the sanitization of query (using regex), by removing python command (since gpt-3.5-turbo sometimes assumes python console as a terminal, and runs python command first which causes error). Also sometimes 1 line python codes contain single backticks. 
(i) Eg of python in query:
> Entering new LLMMathChain chain...
1291.25 * 6
````
```python
print(1291.25 * 6)

```
````
(ii) Eg of 1 line query with single backtick:
Thought: I have the number of unique Account IDs, but I need to count the number of active accounts Action: python_repl_ast
Action Input: ``` `len(df[df['Status'] == 'Active'])` ```

2) Improved the capturing of print by redirecting stdout to output of Python REPL Tool (without cluttering the actual stdout). Also when the return of eval() function is None, then returning stdout (in case code contains a print or info statement).

3) Made sure the exception format type is returned in all cases, when the exec() function throws an exception.