### PR TITLE
 HuggingFace(Instruct)Embeddings client kwargs

### DIFF
--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -24,7 +24,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
             from langchain.embeddings import HuggingFaceEmbeddings
             model_name = "sentence-transformers/all-mpnet-base-v2"
             model_kwargs = {'device': 'cpu'}
-            hf = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kargs)
+            hf = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kwargs)
     """
 
     client: Any  #: :meta private:
@@ -93,7 +93,7 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
             from langchain.embeddings import HuggingFaceInstructEmbeddings
             model_name = "hkunlp/instructor-large"
             model_kwargs = {'device': 'cpu'}
-            hf = HuggingFaceInstructEmbeddings(model_name=model_name, model_kwargs=model_kargs)
+            hf = HuggingFaceInstructEmbeddings(model_name=model_name, model_kwargs=model_kwargs)
     """
 
     client: Any  #: :meta private:

--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -37,6 +37,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
     def __init__(self, model_kwargs: Optional[dict] = None, **kwargs: Any):
         """Initialize the sentence_transformer."""
         super().__init__(**kwargs)
+        model_kwargs = model_kwargs or {}
         try:
             import sentence_transformers
 
@@ -110,6 +111,7 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
     def __init__(self, model_kwargs: Optional[dict] = None, **kwargs: Any):
         """Initialize the sentence_transformer."""
         super().__init__(**kwargs)
+        model_kwargs = model_kwargs or {}
         try:
             from InstructorEmbedding import INSTRUCTOR
 

--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -23,7 +23,8 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
 
             from langchain.embeddings import HuggingFaceEmbeddings
             model_name = "sentence-transformers/all-mpnet-base-v2"
-            hf = HuggingFaceEmbeddings(model_name=model_name)
+            model_kwargs = {'device': 'cpu'}
+            hf = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kargs)
     """
 
     client: Any  #: :meta private:
@@ -33,14 +34,14 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
     """Path to store models. 
     Can be also set by SENTENCE_TRANSFORMERS_HOME enviroment variable."""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, model_kwargs: Optional[dict] = None, **kwargs: Any):
         """Initialize the sentence_transformer."""
         super().__init__(**kwargs)
         try:
             import sentence_transformers
 
             self.client = sentence_transformers.SentenceTransformer(
-                self.model_name, self.cache_folder
+                self.model_name, cache_folder=self.cache_folder, **model_kwargs
             )
         except ImportError:
             raise ValueError(
@@ -91,24 +92,28 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
 
             from langchain.embeddings import HuggingFaceInstructEmbeddings
             model_name = "hkunlp/instructor-large"
-            hf = HuggingFaceInstructEmbeddings(model_name=model_name)
+            model_kwargs = {'device': 'cpu'}
+            hf = HuggingFaceInstructEmbeddings(model_name=model_name, model_kwargs=model_kargs)
     """
 
     client: Any  #: :meta private:
     model_name: str = DEFAULT_INSTRUCT_MODEL
     """Model name to use."""
+    cache_folder: Optional[str] = None
+    """Path to store models. 
+    Can be also set by SENTENCE_TRANSFORMERS_HOME enviroment variable."""
     embed_instruction: str = DEFAULT_EMBED_INSTRUCTION
     """Instruction to use for embedding documents."""
     query_instruction: str = DEFAULT_QUERY_INSTRUCTION
     """Instruction to use for embedding query."""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, model_kwargs: Optional[dict] = None, **kwargs: Any):
         """Initialize the sentence_transformer."""
         super().__init__(**kwargs)
         try:
             from InstructorEmbedding import INSTRUCTOR
 
-            self.client = INSTRUCTOR(self.model_name)
+            self.client = INSTRUCTOR(self.model_name, cache_folder=self.cache_folder, **model_kwargs)
         except ImportError as e:
             raise ValueError("Dependencies for InstructorEmbedding not found.") from e
 

--- a/langchain/embeddings/huggingface.py
+++ b/langchain/embeddings/huggingface.py
@@ -113,7 +113,9 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
         try:
             from InstructorEmbedding import INSTRUCTOR
 
-            self.client = INSTRUCTOR(self.model_name, cache_folder=self.cache_folder, **model_kwargs)
+            self.client = INSTRUCTOR(
+                self.model_name, cache_folder=self.cache_folder, **model_kwargs
+            )
         except ImportError as e:
             raise ValueError("Dependencies for InstructorEmbedding not found.") from e
 


### PR DESCRIPTION
# What does this PR do?

Make it possible to control the HuggingFaceEmbeddings and HuggingFaceInstructEmbeddings client model kwargs. Additionally, the cache folder was added for HuggingFaceInstructEmbedding as the client inherits from SentenceTransformer (client of HuggingFaceEmbeddings).

It can be useful, especially to control the client device, as it will be defaulted to GPU by sentence_transformers if there is any.

Use case:
```python
from langchain.embeddings import HuggingFaceEmbeddings
model_name = "sentence-transformers/all-mpnet-base-v2"
model_kwargs = {'device': 'cpu'}
hf = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kwargs)
```

## Before submitting

- [ ] This PR passes tests
- [ ] This PR was discussed/approved

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
