### PR TITLE
Fix docstring of RetrievalQA

### DIFF
--- a/langchain/chains/retrieval_qa/base.py
+++ b/langchain/chains/retrieval_qa/base.py
@@ -154,8 +154,9 @@ class RetrievalQA(BaseRetrievalQA):
             from langchain.llms import OpenAI
             from langchain.chains import RetrievalQA
             from langchain.faiss import FAISS
-            vectordb = FAISS(...)
-            retrievalQA = RetrievalQA.from_llm(llm=OpenAI(), retriever=vectordb)
+            from langchain.vectorstores.base import VectorStoreRetriever
+            retriever = VectorStoreRetriever(vectorstore=FAISS(...))
+            retrievalQA = RetrievalQA.from_llm(llm=OpenAI(), retriever=retriever)
 
     """
 


### PR DESCRIPTION
Structure changed an RetrievalQA now expects BaseRetriever not VectorStore