### PR TITLE
Add Selenium tool to let autogpt agent use Chrome interactively

### DIFF
--- a/docs/modules/agents/tools/examples/selenium.ipynb
+++ b/docs/modules/agents/tools/examples/selenium.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Selenium: Let AutoGPT Use Chrome Interactively\n",
+    "\n",
+    "This notebook goes over how to use the `selenium` tool. \n",
+    "\n",
+    "First, you need to install `selenium` python package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install selenium"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.utilities import SeleniumWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selenium = SeleniumWrapper()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Heading Output: \\n\\nParagraph: \\n\\nInteractable Elements: Interactable Element: a, Text: About, Location: {'x': 21, 'y': 17}\\nInteractable Element: a, Text: Store, Location: {'x': 78, 'y': 17}\\nInteractable Element: a, Text: Gmail, Location: {'x': 1163, 'y': 18}\\nInteractable Element: a, Text: Images, Location: {'x': 1212, 'y': 18}\\nInteractable Element: a, Text: Sign in, Location: {'x': 1326, 'y': 12}\\nInteractable Element: a, Text: in your community, Location: {'x': 649, 'y': 411}\\nInteractable Element: a, Text: Advertising, Location: {'x': 20, 'y': 704}\\nInteractable Element: a, Text: Business, Location: {'x': 119, 'y': 704}\\nInteractable Element: a, Text: How Search works, Location: {'x': 206, 'y': 704}\\nInteractable Element: a, Text: Carbon neutral since 2007, Location: {'x': 614, 'y': 704}\\nInteractable Element: a, Text: Privacy, Location: {'x': 1195, 'y': 704}\\nInteractable Element: a, Text: Terms, Location: {'x': 1271, 'y': 704}\\n\""
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs = selenium.describe_website(\"https://google.com\")\n",
+    "docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Clicked interactable element with text: About\\n'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs = selenium.click_button_by_text(\"About\")\n",
+    "docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del selenium"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/langchain/utilities/__init__.py
+++ b/langchain/utilities/__init__.py
@@ -10,6 +10,7 @@ from langchain.utilities.google_serper import GoogleSerperAPIWrapper
 from langchain.utilities.openweathermap import OpenWeatherMapAPIWrapper
 from langchain.utilities.python import PythonREPL
 from langchain.utilities.searx_search import SearxSearchWrapper
+from langchain.utilities.selenium import SeleniumWrapper
 from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utilities.wikipedia import WikipediaAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
@@ -25,6 +26,7 @@ __all__ = [
     "WolframAlphaAPIWrapper",
     "SerpAPIWrapper",
     "SearxSearchWrapper",
+    "SeleniumWrapper",
     "BingSearchAPIWrapper",
     "WikipediaAPIWrapper",
     "OpenWeatherMapAPIWrapper",

--- a/langchain/utilities/selenium.py
+++ b/langchain/utilities/selenium.py
@@ -1,0 +1,106 @@
+"""Util that calls Selenium."""
+
+import re
+import time
+from typing import Optional
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+
+
+class SeleniumWrapper:
+    """Wrapper around Selenium.
+
+    To use, you should have the ``selenium`` python package installed.
+
+    Example:
+        .. code-block:: python
+
+            from langchain import SeleniumWrapper
+            selenium = SeleniumWrapper()
+    """
+
+    def __init__(self) -> None:
+        """Initialize Selenium and start interactive session."""
+        chrome_options = Options()
+        chrome_options.add_argument("--start-maximized")
+        self.driver = webdriver.Chrome(options=chrome_options)
+
+    def __del__(self) -> None:
+        """Close Selenium session."""
+        self.driver.close()
+
+    def describe_website(self, url: Optional[str] = None) -> str:
+        """Describe the website."""
+        if url:
+            try:
+                self.driver.get(url)
+            except Exception:
+                return f"Cannot load website {url}."
+        # Extract headings
+        heading_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
+        heading_output = "Heading Output: "
+        for tag in heading_tags:
+            headings = self.driver.find_elements(By.XPATH, f"//{tag}")
+            for heading in headings:
+                heading_text = heading.text.strip()
+                if heading_text:
+                    heading_output += f"{tag.upper()}: {heading_text}  "
+
+        # Extract paragraphs
+        paragraphs = self.driver.find_elements(By.XPATH, "//p")
+        paragraph_output = "Paragraph: "
+        for paragraph in paragraphs:
+            paragraph_text = re.sub(r"\s+", " ", paragraph.text.strip())
+            if paragraph_text:
+                paragraph_output += f"{paragraph_text}  "
+
+        # Extract interactable components (buttons and links)
+        buttons = self.driver.find_elements(By.XPATH, "//button")
+        links = self.driver.find_elements(By.XPATH, "//a")
+
+        interactable_output = "Interactable Elements: "
+        for element in buttons + links:
+            element_tag = element.tag_name
+            element_text = element.text.strip()
+            element_location = element.location
+            if element_text and "\n" not in element_text:
+                interactable_output += (
+                    f"Interactable Element: {element_tag}, "
+                    f"Text: {element_text}, "
+                    f"Location: {element_location}\n"
+                )
+
+        return f"{heading_output}\n\n{paragraph_output}\n\n{interactable_output}"
+
+    def click_button_by_text(self, element_text: str) -> str:
+        """Click a button element with text."""
+        try:
+            # Find both buttons and links
+            xpath = (
+                "//button[translate(normalize-space(.//text()), "
+                "'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='"
+                f"{element_text.lower()}'] | //a[translate(normalize-space(.//text()), "
+                "'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='"
+                f"{element_text.lower()}']"
+            )
+            elements = self.driver.find_elements(By.XPATH, xpath)
+
+            if not elements:
+                return f"No interactable element found with text: {element_text}"
+
+            element = elements[0]
+
+            # Scroll the element into view
+            self.driver.execute_script("arguments[0].scrollIntoView();", element)
+            time.sleep(1)  # Allow some time for the page to settle
+
+            # Click the element using JavaScript
+            self.driver.execute_script("arguments[0].click();", element)
+            output = f"Clicked interactable element with text: {element_text}\n"
+            return output
+        except Exception as e:
+            return (
+                f"Error clicking interactable element with text '{element_text}': {e}"
+            )

--- a/tests/integration_tests/test_selenium.py
+++ b/tests/integration_tests/test_selenium.py
@@ -1,0 +1,24 @@
+"""Integration test for Selenium API Wrapper."""
+import pytest
+
+from langchain.utilities import SeleniumWrapper
+
+
+@pytest.fixture
+def client() -> SeleniumWrapper:
+    return SeleniumWrapper()
+
+
+def test_describe_website(client: SeleniumWrapper) -> None:
+    """Test that SeleniumWrapper returns correct website"""
+
+    output = client.describe_website("https://example.com")
+    assert "Example Domain" in output
+
+
+def test_click(client: SeleniumWrapper) -> None:
+    """Test that SeleniumWrapper click works"""
+
+    client.describe_website("https://example.com")
+    output = client.click_button_by_text("More information...")
+    assert "Clicked interactable element with text" in output


### PR DESCRIPTION
Adds a functionality to let autogpt agents use Chrome interactively. Now AutoGPT can browse the internet and click on buttons.

See an example video below of the agent booking a restaurant on Chrome:

Given a prompt "Find me a French restaurant that have availability on Apr 24th". It was able to go to Resy and click on the correct dates and see that there is no availability.
![DEMO_AdobeExpress_AdobeExpress](https://user-images.githubusercontent.com/14324698/233713933-53d52da3-092b-4a42-a141-52d81ec2fc62.gif)
