### PR TITLE
Improving Resilience of MRKL Agent

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -700,7 +700,7 @@ class AgentExecutor(Chain):
                 )
             elif agent_action.tool == "Invalid LLM Output":
                 # Passing the error message regarding the invalid format in llm output
-                observation = agent_action.tool_input
+                observation = str(agent_action.tool_input)
             else:
                 tool_run_kwargs = self.agent.tool_run_logging_kwargs()
                 observation = InvalidTool().run(

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -698,6 +698,9 @@ class AgentExecutor(Chain):
                     color=color,
                     **tool_run_kwargs,
                 )
+            elif agent_action.tool == "Invalid LLM Output":
+                # Passing the error message regarding the invalid format in llm output
+                observation = agent_action.tool_input
             else:
                 tool_run_kwargs = self.agent.tool_run_logging_kwargs()
                 observation = InvalidTool().run(

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -23,8 +23,12 @@ class MRKLOutputParser(AgentOutputParser):
         if not match:
             if not re.search(r"Action\s*\d*\s*:(.*?)", text, re.DOTALL):
                 error_message = "Invalid Format: Missing 'Action:' after 'Thought:'"
-            elif not re.search(r"\nAction\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL):
-                error_message = "Invalid Format: Missing 'Action Input:' after 'Action:'"
+            elif not re.search(
+                r"\nAction\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL
+            ):
+                error_message = (
+                    "Invalid Format: Missing 'Action Input:' after 'Action:'"
+                )
             else:
                 raise OutputParserException(f"Could not parse LLM output: `{text}`")
             return AgentAction("Invalid LLM Output", error_message, text)

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -21,7 +21,13 @@ class MRKLOutputParser(AgentOutputParser):
         regex = r"Action\s*\d*\s*:(.*?)\nAction\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
         match = re.search(regex, text, re.DOTALL)
         if not match:
-            raise OutputParserException(f"Could not parse LLM output: `{text}`")
+            if not re.search(r"Action\s*\d*\s*:(.*?)", text, re.DOTALL):
+                error_message = "Invalid Format: Missing 'Action:' after 'Thought:'"
+            elif not re.search(r"\nAction\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL):
+                error_message = "Invalid Format: Missing 'Action Input:' after 'Action:'"
+            else:
+                raise OutputParserException(f"Could not parse LLM output: `{text}`")
+            return AgentAction("Invalid LLM Output", error_message, text)
         action = match.group(1).strip()
         action_input = match.group(2)
         return AgentAction(action, action_input.strip(" ").strip('"'), text)

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -98,8 +98,9 @@ def test_get_final_answer_multiline() -> None:
 def test_bad_action_input_line() -> None:
     """Test handling when no action input found."""
     llm_output = "Thought: I need to search for NBA\n" "Action: Search\n" "Thought: NBA"
-    with pytest.raises(OutputParserException):
-        get_action_and_input(llm_output)
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "Invalid LLM Output"
+    assert action_input == "Invalid Format: Missing 'Action Input:' after 'Action:'"
 
 
 def test_bad_action_line() -> None:
@@ -107,8 +108,9 @@ def test_bad_action_line() -> None:
     llm_output = (
         "Thought: I need to search for NBA\n" "Thought: Search\n" "Action Input: NBA"
     )
-    with pytest.raises(OutputParserException):
-        get_action_and_input(llm_output)
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "Invalid LLM Output"
+    assert action_input == "Invalid Format: Missing 'Action:' after 'Thought:'"
 
 
 def test_from_chains() -> None:

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -2,14 +2,12 @@
 
 from typing import Tuple
 
-import pytest
-
 from langchain.agents.mrkl.base import ZeroShotAgent
 from langchain.agents.mrkl.output_parser import MRKLOutputParser
 from langchain.agents.mrkl.prompt import FORMAT_INSTRUCTIONS, PREFIX, SUFFIX
 from langchain.agents.tools import Tool
 from langchain.prompts import PromptTemplate
-from langchain.schema import AgentAction, OutputParserException
+from langchain.schema import AgentAction
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
 


### PR DESCRIPTION
Finally Solved the ```ValueError(f"Could not parse LLM output: `{llm_output}`")``` error, whenever llm (especially gpt-3.5-turbo) does not follow the format of MRKL Agent, while returning "Action:" & "Action Input:".

**Note:** If this pull request gets approved, I can then apply this feature to react, self_ask_with_search & conversational agents too.

The way I am solving this error is by responding back to the llm with the messages `"Invalid Format: Missing 'Action:' after 'Thought:'"` & `"Invalid Format: Missing 'Action Input:' after 'Action:'"` whenever `Action:` and `Action Input:` are not present in the llm output respectively.

The following are 2 errors that kept coming from the Pandas Dataframe Agent & VectorStore Agent respectively (both of them use the MRKL agent):

**Error-1:** (pandas dataframe agent - error message at the end)

`df_agent.run("How many policies do Aaron Pope have, contain 'Homeowners'?")`
````
> Entering new AgentExecutor chain...
Thought: We need to filter the dataframe to only include policies for Aaron Pope that contain 'Homeowners', and then count the number of rows.
Action: python_repl_ast
Action Input:
```
aaron_pope_df = df[(df['Insured Name'] == 'Aaron Pope') & (df['Policy Type'].str.contains('Homeowners'))]
len(aaron_pope_df)
```
Observation: KeyError: 'Insured Name'
Thought:The error message indicates that the column 'Insured Name' does not exist in the dataframe. I need to check the column names to make sure I am using the correct ones.
Action: python_repl_ast
Action Input: `print(df.columns)`
Observation: Index(['Account ID', 'Account Name', 'Policy ID', 'Policy Name',
       'Description of Risk', 'Status'],
      dtype='object')
Thought:The column name for the insured name is actually 'Policy Name'. I need to update my filter.
Action: python_repl_ast
Action Input:
```
aaron_pope_df = df[(df['Policy Name'] == 'Aaron Pope') & (df['Policy Type'].str.contains('Homeowners'))]
len(aaron_pope_df)
```
Observation: Traceback (most recent call last): KeyError: 'Policy Type'
Thought:The error message indicates that the column 'Policy Type' does not exist in the dataframe. I need to check the column names to make sure I am using the correct ones.
Action: python_repl_ast
Action Input: `print(df.columns)`
Observation: Index(['Account ID', 'Account Name', 'Policy ID', 'Policy Name',
       'Description of Risk', 'Status'],
      dtype='object')
Thought:The column name for the policy type is actually 'Description of Risk'. I need to update my filter.
Action: python_repl_ast
Action Input:
```
aaron_pope_df = df[(df['Policy Name'] == 'Aaron Pope') & (df['Description of Risk'].str.contains('Homeowners'))]
len(aaron_pope_df)
```
Observation: 0
Thought:Traceback (most recent call last):
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\IPython\core\interactiveshell.py", line 3433, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-9ff9c120b0a9>", line 1, in <module>
    df_agent.run("How many policies do Aaron Pope have, contain 'Homeowners'?")
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\chains\base.py", line 213, in run
    return self(args[0])[self.output_keys[0]]
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\chains\base.py", line 116, in __call__
    raise e
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\chains\base.py", line 113, in __call__
    outputs = self._call(inputs)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 812, in _call
    next_step_output = self._take_next_step(
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 692, in _take_next_step
    output = self.agent.plan(intermediate_steps, **inputs)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 403, in plan
    action = self._get_next_action(full_inputs)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 365, in _get_next_action
    parsed_output = self._extract_tool_and_input(full_output)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\mrkl\base.py", line 140, in _extract_tool_and_input
    return get_action_and_input(text)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\mrkl\base.py", line 48, in get_action_and_input
    raise ValueError(f"Could not parse LLM output: `{llm_output}`")
ValueError: Could not parse LLM output: `There are no policies for Aaron Pope that contain 'Homeowners'.`
````

**Error-2:** (VectorStore agent - error message at the end)

`VectorStore_agent.run("Do condo units have pools? (as mentioned in the insurance docs)")`
````
> Entering new AgentExecutor chain...

This question seems to be related to insurance coverage for condo units. I should use the insurance_quotes_faq tool to find the answer.
Action: insurance_quotes_faq
Action Input: "Are condo unit pools covered under insurance policies?"
This question seems to be related to insurance coverage for condo units. I should use the insurance_quotes_faq tool to find the answer.
Observation:  No, condo unit pools are not typically covered under insurance policies.
Thought:
Traceback (most recent call last):
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\IPython\core\interactiveshell.py", line 3433, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-7-92714a8d910d>", line 1, in <module>
    vs_agent.run("Do condo units have pools? (as mentioned in the insurance docs)")
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\chains\base.py", line 213, in run
    return self(args[0])[self.output_keys[0]]
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\chains\base.py", line 116, in __call__
    raise e
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\chains\base.py", line 113, in __call__
    outputs = self._call(inputs)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 812, in _call
    next_step_output = self._take_next_step(
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 692, in _take_next_step
    output = self.agent.plan(intermediate_steps, **inputs)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 403, in plan
    action = self._get_next_action(full_inputs)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\agent.py", line 365, in _get_next_action
    parsed_output = self._extract_tool_and_input(full_output)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\mrkl\base.py", line 140, in _extract_tool_and_input
    return get_action_and_input(text)
  File "D:\Deepak\mambaforge\envs\torch_1_13\lib\site-packages\langchain\agents\mrkl\base.py", line 48, in get_action_and_input
    raise ValueError(f"Could not parse LLM output: `{llm_output}`")
ValueError: Could not parse LLM output: `The answer was straightforward and did not require any sources.`
````

**Successful run after making this pull request change:** (pandas dataframe agent - after modifying mrkl agent):

`df_agent.run("How many policies that Aaron Pope have, contain 'Homeowners'?")`
````
> Entering new AgentExecutor chain...
Thought: We need to filter the dataframe to only include policies for Aaron Pope and then count how many of those policies contain 'Homeowners'.
Action: 
python_repl_ast
```
df[df['Account Name'] == 'Aaron Pope']['Policy Type'].str.contains('Homeowners').sum()
```
I need to provide the input for the action.
Action: python_repl_ast
Action Input: df[df['Account Name'] == 'Aaron Pope']['Policy Type'].str.contains('Homeowners').sum()
Observation: KeyError: 'Policy Type'
Thought: The column name 'Policy Type' does not exist in the dataframe. I need to check the column names to see what the correct name is.
Action: python_repl_ast
Action Input: df.columns
Observation: Index(['Account ID', 'Account Name', 'Policy ID', 'Policy Name',
       'Description of Risk', 'Status'],
      dtype='object')
Thought: The correct column name for policy type is 'Policy Name'. I need to update the input for the action.
Action: python_repl_ast
Action Input: df[df['Account Name'] == 'Aaron Pope']['Policy Name'].str.contains('Homeowners').sum()
Observation: 4
Thought: The final answer is that Aaron Pope has 4 policies that contain 'Homeowners'. 
Final Answer: 4
> Finished chain.
Out[4]: '4'
````

I also ran the callback function and **logged the final prompt** sent into the llm model (gpt-3.5-turbo) + output:
````
You are working with a pandas dataframe in Python. The name of the dataframe is `df`.
You should use the tools below to answer the question posed of you:
python_repl_ast: A Python shell. Use this to execute python commands. Input should be a valid python command. When using this tool, sometimes output is abbreviated - make sure it does not look abbreviated before using it in your answer.
Use the following format:
Question: the input question you must answer
Thought: you should always think about what to do
Action: the action to take, should be one of [python_repl_ast]
Action Input: the input to the action
Observation: the result of the action
 (this Thought/Action/Action Input/Observation can repeat N times)
Thought: I now know the final answer
Final Answer: the final answer to the original input question
This is the result of `print(df.head())`:
        Account ID  ...     Status
0  0015x00002GS9tM  ...  Cancelled
1  0015x00002GSF8u  ...     Active
2  0015x00002GSF8u  ...    Expired
3  0015x00002GSF8u  ...     Active
4  0015x000025lH0H  ...  Cancelled
[5 rows x 6 columns]
Begin!
Question: How many policies that Aaron Pope have, contain 'Homeowners'?
Thought: We need to filter the dataframe to only include policies for Aaron Pope and then count how many of those policies contain 'Homeowners'.
Action: 
python_repl_ast
```
df[df['Account Name'] == 'Aaron Pope']['Policy Type'].str.contains('Homeowners').sum()
```
Observation: Invalid Format: Missing 'Action Input:' after 'Action:'
Thought:I need to provide the input for the action.
Action: python_repl_ast
Action Input: df[df['Account Name'] == 'Aaron Pope']['Policy Type'].str.contains('Homeowners').sum()
Observation: KeyError: 'Policy Type'
Thought:The column name 'Policy Type' does not exist in the dataframe. I need to check the column names to see what the correct name is.
Action: python_repl_ast
Action Input: df.columns
Observation: Index(['Account ID', 'Account Name', 'Policy ID', 'Policy Name',
       'Description of Risk', 'Status'],
      dtype='object')
Thought:The correct column name for policy type is 'Policy Name'. I need to update the input for the action.
Action: python_repl_ast
Action Input: df[df['Account Name'] == 'Aaron Pope']['Policy Name'].str.contains('Homeowners').sum()
Observation: 4
Thought:The final answer is that Aaron Pope has 4 policies that contain 'Homeowners'. 
Final Answer: 4
````

As you can see from the prompt log above, the model made a mistake of outputting the code without the `Action Input:` keyword. But after sending the error message `Invalid Format: Missing 'Action Input:' after 'Action:'` as observation to the llm, it self-corrected the output format in it's next response, allowing the Agent to progress towards finding the final answer without errors.

Let me know your thoughts, and I can apply this feature to the other 3 agents as well, if this pull request gets approved.