### PR TITLE
bugfix: fix some  bugs in conversational_chat

### DIFF
--- a/langchain/agents/conversational_chat/base.py
+++ b/langchain/agents/conversational_chat/base.py
@@ -36,6 +36,7 @@ class ConversationalChatAgent(Agent):
     """An agent designed to hold a conversation in addition to using tools."""
 
     output_parser: AgentOutputParser = Field(default_factory=ConvoOutputParser)
+    tool_response_template: str = TEMPLATE_TOOL_RESPONSE
 
     @classmethod
     def _get_default_output_parser(cls, **kwargs: Any) -> AgentOutputParser:
@@ -93,7 +94,7 @@ class ConversationalChatAgent(Agent):
         for action, observation in intermediate_steps:
             thoughts.append(AIMessage(content=action.log))
             human_message = HumanMessage(
-                content=TEMPLATE_TOOL_RESPONSE.format(observation=observation)
+                content=self.tool_response_template.format(observation=observation)
             )
             thoughts.append(human_message)
         return thoughts

--- a/langchain/agents/conversational_chat/output_parser.py
+++ b/langchain/agents/conversational_chat/output_parser.py
@@ -19,12 +19,12 @@ class ConvoOutputParser(AgentOutputParser):
         if "```" in cleaned_output:
             cleaned_output, _ = cleaned_output.split("```")
         if cleaned_output.startswith("```json"):
-            cleaned_output = cleaned_output[len("```json") :]
+            cleaned_output = cleaned_output[len("```json"):]
         if cleaned_output.startswith("```"):
-            cleaned_output = cleaned_output[len("```") :]
+            cleaned_output = cleaned_output[len("```"):]
         if cleaned_output.endswith("```"):
             cleaned_output = cleaned_output[: -len("```")]
-        
+
         # sometimes, two backquotes in text.
         cleaned_output = cleaned_output.rstrip("`").strip()
         response = json.loads(cleaned_output)

--- a/langchain/agents/conversational_chat/output_parser.py
+++ b/langchain/agents/conversational_chat/output_parser.py
@@ -24,7 +24,9 @@ class ConvoOutputParser(AgentOutputParser):
             cleaned_output = cleaned_output[len("```") :]
         if cleaned_output.endswith("```"):
             cleaned_output = cleaned_output[: -len("```")]
-        cleaned_output = cleaned_output.strip()
+        
+        # sometimes, two backquotes in text.
+        cleaned_output = cleaned_output.rstrip("`").strip()
         response = json.loads(cleaned_output)
         action, action_input = response["action"], response["action_input"]
         if action == "Final Answer":

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -142,7 +142,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate, ABC):
     ) -> ChatPromptTemplate:
         messages = [
             ChatMessagePromptTemplate(
-                content=PromptTemplate.from_template(template), role=role
+                prompt=PromptTemplate.from_template(template), role=role
             )
             for role, template in string_messages
         ]


### PR DESCRIPTION
- :bug:  bugfix: excessive backquotes sometimes in `ConvoOutputParser`  @hwchase17 
- :recycle: defect: easy to change other tool response template in `ConversationalChatAgent`
- :bug: `ChatPromptTemplate.from_role_strings`,  fix `new ChatMessagePromptTemplate` argument name typo. @agola11 