### PR TITLE
feat: use raw input for agent using tool with return_direct

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -693,7 +693,7 @@ class AgentExecutor(Chain):
                     tool_run_kwargs["llm_prefix"] = ""
                 # We then call the tool on the tool input to get an observation
                 observation = tool.run(
-                    agent_action.tool_input,
+                    next(iter(inputs.values())) if return_direct else agent_action.tool_input,
                     verbose=self.verbose,
                     color=color,
                     **tool_run_kwargs,
@@ -752,7 +752,7 @@ class AgentExecutor(Chain):
                     tool_run_kwargs["llm_prefix"] = ""
                 # We then call the tool on the tool input to get an observation
                 observation = await tool.arun(
-                    agent_action.tool_input,
+                    next(iter(inputs.values())) if return_direct else agent_action.tool_input,
                     verbose=self.verbose,
                     color=color,
                     **tool_run_kwargs,

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -693,7 +693,9 @@ class AgentExecutor(Chain):
                     tool_run_kwargs["llm_prefix"] = ""
                 # We then call the tool on the tool input to get an observation
                 observation = tool.run(
-                    next(iter(inputs.values())) if return_direct else agent_action.tool_input,
+                    next(iter(inputs.values()))
+                    if return_direct
+                    else agent_action.tool_input,
                     verbose=self.verbose,
                     color=color,
                     **tool_run_kwargs,
@@ -752,7 +754,9 @@ class AgentExecutor(Chain):
                     tool_run_kwargs["llm_prefix"] = ""
                 # We then call the tool on the tool input to get an observation
                 observation = await tool.arun(
-                    next(iter(inputs.values())) if return_direct else agent_action.tool_input,
+                    next(iter(inputs.values()))
+                    if return_direct
+                    else agent_action.tool_input,
                     verbose=self.verbose,
                     color=color,
                     **tool_run_kwargs,


### PR DESCRIPTION
When we meet a tool set `return_direct=True`, we need to preserve the original information of the question or the last thoughts as much as possible. What about directly use the raw input here?