### PR TITLE
pass list of strings to embed method in tf_hub

### DIFF
--- a/langchain/embeddings/tensorflow_hub.py
+++ b/langchain/embeddings/tensorflow_hub.py
@@ -66,5 +66,5 @@ class TensorflowHubEmbeddings(BaseModel, Embeddings):
             Embeddings for the text.
         """
         text = text.replace("\n", " ")
-        embedding = self.embed(text).numpy()[0]
+        embedding = self.embed([text]).numpy()[0]
         return embedding.tolist()


### PR DESCRIPTION
This fixes the below mentioned issue. Instead of simply passing the text to `tensorflow_hub`, we convert it to a list and then pass it.
https://github.com/hwchase17/langchain/issues/3282