### PR TITLE
Suggestion: Add filenames to Refine method

### DIFF
--- a/langchain/chains/combine_documents/refine.py
+++ b/langchain/chains/combine_documents/refine.py
@@ -17,7 +17,7 @@ from langchain.prompts.prompt import PromptTemplate
 
 
 def _get_default_document_prompt() -> PromptTemplate:
-    return PromptTemplate(input_variables=["page_content"], template="{page_content}")
+    return PromptTemplate(input_variables=["page_content", "file_path"], template="File:\n{file_path}\nContent:\n{page_content}")
 
 
 class RefineDocumentsChain(BaseCombineDocumentsChain):


### PR DESCRIPTION
I found the refine method when you add the filenames as part of the context. Often the filenames provide very useful information about the file in question, and help the agent get an idea for the structure of the repo you are summarizing (or whatever).

If you like this suggestion I can add more details about how I use it, something like:
```
text_docs = [Document(d, extra_info={"filepath": str(f.absolute())}) for d, f in zip(data_list, self.input_files)]
```