### PR TITLE
Support SQLAlchemy 2.0

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -180,7 +180,7 @@ class SQLDatabase:
 
     def _get_sample_rows(self, table: Table) -> str:
         # build the select command
-        command = select([table]).limit(self._sample_rows_in_table_info)
+        command = select(table).limit(self._sample_rows_in_table_info)
 
         # save the columns in string format
         columns_str = "\t".join([col.name for col in table.columns])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ langchain-server = "langchain.server:main"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 pydantic = "^1"
-SQLAlchemy = "^1"
+SQLAlchemy = ">1.3,<3"
 requests = "^2"
 PyYAML = ">=5.4.1"
 numpy = "^1"


### PR DESCRIPTION
With https://github.com/executablebooks/jupyter-cache/pull/93 merged and `MyST-NB` updated, we can now support SQLAlchemy 2. Closes #1766