### PR TITLE
Added retry executor

### DIFF
--- a/langchain/agents/executors.py
+++ b/langchain/agents/executors.py
@@ -1,0 +1,30 @@
+from typing import Dict, List, Tuple, Union
+
+from langchain.agents import AgentExecutor
+from langchain.agents.agent import AgentExecutor
+from langchain.schema import AgentAction, AgentFinish, OutputParserException
+from langchain.tools import BaseTool
+from langchain.tools.base import BaseTool
+
+
+class RetryAgentExecutor(AgentExecutor):
+    """Agent executor that retries on output parser exceptions."""
+
+    def _take_next_step(
+        self,
+        name_to_tool_map: Dict[str, BaseTool],
+        color_mapping: Dict[str, str],
+        inputs: Dict[str, str],
+        intermediate_steps: List[Tuple[AgentAction, str]],
+    ) -> Union[AgentFinish, List[Tuple[AgentAction, str]]]:
+        # call super method
+        try:
+            return super()._take_next_step(
+                name_to_tool_map, color_mapping, inputs, intermediate_steps
+            )
+        except OutputParserException as e:
+            agent_action = AgentAction("_Exception", "", str(e))
+            self.callback_manager.on_agent_action(
+                agent_action, verbose=self.verbose, color="red"
+            )
+            return [(agent_action, "Invalid or incomplete response. Please try again.")]

--- a/langchain/agents/executors.py
+++ b/langchain/agents/executors.py
@@ -1,10 +1,8 @@
 from typing import Dict, List, Tuple, Union
 
 from langchain.agents import AgentExecutor
-from langchain.agents.agent import AgentExecutor
 from langchain.schema import AgentAction, AgentFinish, OutputParserException
 from langchain.tools import BaseTool
-from langchain.tools.base import BaseTool
 
 
 class RetryAgentExecutor(AgentExecutor):


### PR DESCRIPTION
This adds a retry executor that gives the agent the exception as an observation. It uses a fake tool that has no side-effects called `_Exception` - similar to how `InvalidTool()` works. This simplifies things like making sure iteration counts are tracked and the outputs will be returned in intermediate steps. 

Gonna wait for feedback before writing a test/example :)

This can be be instantiated with:
```py
agent_executor = RetryAgentExecutor.from_agent_and_tools(
    tools=tools,
    agent=ZeroShotAgent.from_llm_and_tools(llm, tools),
    verbose=True,
    max_iterations=max_iterations,
    return_intermediate_steps=True,
)
```