### PR TITLE
Updated incorrect link to Weaviate notebook

### DIFF
--- a/docs/ecosystem/weaviate.md
+++ b/docs/ecosystem/weaviate.md
@@ -30,4 +30,4 @@ To import this vectorstore:
 from langchain.vectorstores import Weaviate
 ```
 
-For a more detailed walkthrough of the Weaviate wrapper, see [this notebook](../modules/indexes/vectorstores/getting_started.ipynb)
+For a more detailed walkthrough of the Weaviate wrapper, see [this notebook](../modules/indexes/vectorstores/examples/weaviate.ipynb)


### PR DESCRIPTION
The detailed walkthrough of the Weaviate wrapper was pointing to the getting-started notebook. Fixed it to point to the Weaviable notebook in the examples folder.