### PR TITLE
Add example on deploying LangChain to `Cloud Run`

### DIFF
--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -37,6 +37,10 @@ A minimal example on how to run LangChain on Vercel using Flask.
 
 A minimal example on how to deploy LangChain to DigitalOcean App Platform.
 
+## [Google Cloud Run](https://github.com/homanp/gcp-langchain)
+
+A minimal example on how to deploy LangChain to Google Cloud Run.
+
 ## [SteamShip](https://github.com/steamship-core/steamship-langchain/)
 
 This repository contains LangChain adapters for Steamship, enabling LangChain developers to rapidly deploy their apps on Steamship.


### PR DESCRIPTION
## Summary

Adds a link to a minimal example of running LangChain on Google Cloud Run. 