### PR TITLE
[Fix #3365]: Changed regex to cover new line before action serious

### DIFF
--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -18,7 +18,7 @@ class MRKLOutputParser(AgentOutputParser):
                 {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
             )
         # \s matches against tab/newline/whitespace
-        regex = r"Action\s*\d*\s*:(.*?)\nAction\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
+        regex = r"Action\s*\d*\s*:[\s]*(.*?)[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
         match = re.search(regex, text, re.DOTALL)
         if not match:
             raise OutputParserException(f"Could not parse LLM output: `{text}`")

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -18,7 +18,9 @@ class MRKLOutputParser(AgentOutputParser):
                 {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
             )
         # \s matches against tab/newline/whitespace
-        regex = r"Action\s*\d*\s*:[\s]*(.*?)[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
+        regex = (
+            r"Action\s*\d*\s*:[\s]*(.*?)[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
+        )
         match = re.search(regex, text, re.DOTALL)
         if not match:
             raise OutputParserException(f"Could not parse LLM output: `{text}`")

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -52,9 +52,12 @@ def test_get_action_and_input_newline() -> None:
 
 def test_get_action_and_input_newline_after_keyword() -> None:
     """Test getting an action and action input from the text
-    when there is a new line before the action (after the keywords "Action:" and "Action Input:") """
+    when there is a new line before the action
+    (after the keywords "Action:" and "Action Input:")
+    """
     llm_output = """
-    I can use the `ls` command to list the contents of the directory and `grep` to search for the specific file.
+    I can use the `ls` command to list the contents of the directory \
+    and `grep` to search for the specific file.
 
     Action:
     Terminal

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -50,6 +50,24 @@ def test_get_action_and_input_newline() -> None:
     assert action_input == "```\nimport unittest\n\nunittest.main()\n```"
 
 
+def test_get_action_and_input_newline_after_keyword() -> None:
+    """Test getting an action and action input from the text
+    when there is a new line before the action (after the keywords "Action:" and "Action Input:") """
+    llm_output = """
+    I can use the `ls` command to list the contents of the directory and `grep` to search for the specific file.
+
+    Action:
+    Terminal
+
+    Action Input:
+    ls -l ~/.bashrc.d/
+    """
+
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "Terminal"
+    assert action_input == "ls -l ~/.bashrc.d/\n"
+
+
 def test_get_final_answer() -> None:
     """Test getting final answer."""
     llm_output = (


### PR DESCRIPTION
Fix for: [Changed regex to cover new line before action serious.](https://github.com/hwchase17/langchain/issues/3365)
---

This PR fixes the issue where `ValueError: Could not parse LLM output:` was thrown on seems to be valid input.

Changed regex to cover new lines before action serious (after the keywords "Action:" and "Action Input:").

regex101: https://regex101.com/r/CXl1kB/1