### PR TITLE
Add retry logic for ChromaDB

### DIFF
--- a/langchain/utils.py
+++ b/langchain/utils.py
@@ -1,6 +1,6 @@
 """Generic utility functions."""
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 
 
 def get_from_dict_or_env(
@@ -19,3 +19,28 @@ def get_from_dict_or_env(
             f" `{env_key}` which contains it, or pass"
             f"  `{key}` as a named parameter."
         )
+
+
+def xor_args(*arg_groups: Tuple[str, ...]) -> Callable:
+    """Validate specified keyword args are mutually exclusive."""
+
+    def decorator(func: Callable) -> Callable:
+        def wrapper(*args: Any, **kwargs: Any) -> Callable:
+            """Validate exactly one arg in each group is not None."""
+            counts = [
+                sum(1 for arg in arg_group if kwargs.get(arg) is not None)
+                for arg_group in arg_groups
+            ]
+            invalid_groups = [i for i, count in enumerate(counts) if count != 1]
+            if invalid_groups:
+                invalid_group_names = [", ".join(arg_groups[i]) for i in invalid_groups]
+                raise ValueError(
+                    "Exactly one argument in each of the following"
+                    " groups must be defined:"
+                    f" {', '.join(invalid_group_names)}"
+                )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -97,7 +97,7 @@ class Chroma(VectorStore):
             metadata=collection_metadata,
         )
 
-    @xor_args(("query_texts", "query"))
+    @xor_args(("query_texts", "query_embeddings"))
     def __query_collection(
         self,
         query_texts: Optional[List[str]] = None,


### PR DESCRIPTION
Rewrite of #3368

Mainly an issue for when people are just getting started, but still nice to not throw an error if the number of docs is < k.

Add a little decorator utility to block mutually exclusive keyword arguments

