### PR TITLE
add embeddings module which uses sentence_transformers

### DIFF
--- a/langchain/embeddings/sentence_transformer.py
+++ b/langchain/embeddings/sentence_transformer.py
@@ -1,4 +1,4 @@
-"""Wrapper around (chromadb) sentence transformer embedding models."""
+"""Wrapper around sentence transformer embedding models."""
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Extra, Field, root_validator
@@ -56,8 +56,7 @@ class SentenceTransformerEmbeddings(BaseModel, Embeddings):
             text: The text to embed.
 
         Returns:
-            Embeddings for the text.
+            Embedding for the text.
         """
-        embeddings = self.embedding_function.encode([text], convert_to_numpy=True).tolist()
-        return [list(map(float, e)) for e in embeddings][0]
+        return self.embed_documents([text])[0]
 

--- a/langchain/embeddings/sentence_transformer.py
+++ b/langchain/embeddings/sentence_transformer.py
@@ -1,0 +1,63 @@
+"""Wrapper around (chromadb) sentence transformer embedding models."""
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Extra, Field, root_validator
+
+from langchain.embeddings.base import Embeddings
+
+class SentenceTransformerEmbeddings(BaseModel, Embeddings):
+    embedding_function: Any  #: :meta private:
+
+    model: Optional[str] = Field("all-MiniLM-L6-v2", alias="model")
+    """Transformer model to use."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        """Validate that sentence_transformers library is installed."""
+        model = values["model"]
+
+        try:
+            from sentence_transformers import SentenceTransformer
+
+            values["embedding_function"] = SentenceTransformer(model)
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not import sentence_transformers library. "
+                "Please install the sentence_transformers library to "
+                "use this embedding model: pip install sentence_transformers"
+            )
+        except Exception:
+            raise NameError(f"Could not load SentenceTransformer model {model}.")
+
+        return values
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Embed a list of documents using the SentenceTransformer model.
+
+        Args:
+            texts: The list of texts to embed.
+
+        Returns:
+            List of embeddings, one for each text.
+        """
+        embeddings = self.embedding_function.encode(texts, convert_to_numpy=True).tolist()
+        return [list(map(float, e)) for e in embeddings]
+
+
+    def embed_query(self, text: str) -> List[float]:
+        """Embed a query using the SentenceTransformer model.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            Embeddings for the text.
+        """
+        embeddings = self.embedding_function.encode([text], convert_to_numpy=True).tolist()
+        return [list(map(float, e)) for e in embeddings][0]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ torch = "^1.0.0"
 chromadb = "^0.3.21"
 tiktoken = "^0.3.3"
 python-dotenv = "^1.0.0"
+sentence-transformers = "^2"
 gptcache = "^0.1.9"
 promptlayer = "^0.1.80"
 
@@ -144,7 +145,8 @@ llms = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "manifes
 qdrant = ["qdrant-client"]
 openai = ["openai"]
 cohere = ["cohere"]
-all = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "jina", "manifest-ml", "elasticsearch", "opensearch-py", "google-search-results", "faiss-cpu", "sentence_transformers", "transformers", "spacy", "nltk", "wikipedia", "beautifulsoup4", "tiktoken", "torch", "jinja2", "pinecone-client", "pinecone-text", "weaviate-client", "redis", "google-api-python-client", "wolframalpha", "qdrant-client", "tensorflow-text", "pypdf", "networkx", "nomic", "aleph-alpha-client", "deeplake", "pgvector", "psycopg2-binary", "boto3", "pyowm", "pytesseract", "html2text", "atlassian-python-api", "gptcache", "duckduckgo-search", "arxiv", "azure-identity", "clickhouse-connect"]
+embeddings = ["sentence-transformers"]
+all = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "jina", "manifest-ml", "elasticsearch", "opensearch-py", "google-search-results", "faiss-cpu", "sentence-transformers", "transformers", "spacy", "nltk", "wikipedia", "beautifulsoup4", "tiktoken", "torch", "jinja2", "pinecone-client", "pinecone-text", "weaviate-client", "redis", "google-api-python-client", "wolframalpha", "qdrant-client", "tensorflow-text", "pypdf", "networkx", "nomic", "aleph-alpha-client", "deeplake", "pgvector", "psycopg2-binary", "boto3", "pyowm", "pytesseract", "html2text", "atlassian-python-api", "gptcache", "duckduckgo-search", "arxiv", "azure-identity", "clickhouse-connect"]
 
 [tool.ruff]
 select = [

--- a/tests/integration_tests/embeddings/test_sentence_transformer.py
+++ b/tests/integration_tests/embeddings/test_sentence_transformer.py
@@ -1,0 +1,38 @@
+# flake8: noqa
+"""Test sentence_transformer embeddings."""
+
+from langchain.embeddings.sentence_transformer import SentenceTransformerEmbeddings
+from langchain.vectorstores import Chroma
+
+
+def test_sentence_transformer_embedding_documents() -> None:
+    """Test sentence_transformer embeddings."""
+    embedding = SentenceTransformerEmbeddings()
+    documents = ["foo bar"]
+    output = embedding.embed_documents(documents)
+    assert len(output) == 1
+    assert len(output[0]) == 384
+
+
+def test_sentence_transformer_embedding_query() -> None:
+    """Test sentence_transformer embeddings."""
+    embedding = SentenceTransformerEmbeddings()
+    query = "what the foo is a bar?"
+    query_vector = embedding.embed_query(query)
+    assert len(query_vector) == 384
+
+
+def test_sentence_transformer_db_query() -> None:
+    """Test sentence_transformer similarity search."""
+    embedding = SentenceTransformerEmbeddings()
+    texts = [
+            "we will foo your bar until you can't foo any more",
+            "the quick brown fox jumped over the lazy dog",
+    ]
+    query = "what the foo is a bar?"
+    query_vector = embedding.embed_query(query)
+    assert len(query_vector) == 384
+    db = Chroma(embedding_function=embedding)
+    db.add_texts(texts)
+    docs = db.similarity_search_by_vector(query_vector, k=2)
+    assert docs[0].page_content == "we will foo your bar until you can't foo any more"


### PR DESCRIPTION
sentence_transformers are used by chromadb by default under the hood if no `embedding_function` is specified.

however, adding support for them in langchain allows for more configurability and cleaner code for consumers of the langchain API.

this fix was inspired by https://github.com/hwchase17/langchain/issues/2442 and  https://github.com/abetlen/llama-cpp-python/issues/105