### PR TITLE
GuessedAtParserWarning from RTD document loader documentation example

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/readthedocs_documentation.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/readthedocs_documentation.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = ReadTheDocsLoader(\"rtdocs\")"
+    "loader = ReadTheDocsLoader(\"rtdocs\", features='html.parser')"
    ]
   },
   {


### PR DESCRIPTION
Addresses #3396 by adding 

`features='html.parser'` in example
