### PR TITLE
propogate kwargs to cls in OpenSearchVectorSearch

### DIFF
--- a/langchain/vectorstores/opensearch_vector_search.py
+++ b/langchain/vectorstores/opensearch_vector_search.py
@@ -536,4 +536,4 @@ class OpenSearchVectorSearch(VectorStore):
         _bulk_ingest_embeddings(
             client, index_name, embeddings, texts, metadatas, vector_field, text_field
         )
-        return cls(opensearch_url, index_name, embedding)
+        return cls(opensearch_url, index_name, embedding, **kwargs)


### PR DESCRIPTION
kwargs shoud be passed into cls so that opensearch client can be properly initlized in __init__(). Otherwise logic like below will not work. as auth will not be passed into __init__

```python
docsearch = OpenSearchVectorSearch.from_documents(docs, embeddings, opensearch_url="http://localhost:9200")

query = "What did the president say about Ketanji Brown Jackson"
docs = docsearch.similarity_search(query)
```

