### PR TITLE
adding add_documents and aadd_documents to class RedisVectorStoreRetriever

### DIFF
--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -461,3 +461,13 @@ class RedisVectorStoreRetriever(BaseRetriever, BaseModel):
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:
         raise NotImplementedError("RedisVectorStoreRetriever does not support async")
+    
+    def add_documents(self, documents: List[Document], **kwargs: Any) -> List[str]:
+        """Add documents to vectorstore."""
+        return self.vectorstore.add_documents(documents, **kwargs)
+
+    async def aadd_documents(
+        self, documents: List[Document], **kwargs: Any
+    ) -> List[str]:
+        """Add documents to vectorstore."""
+        return await self.vectorstore.aadd_documents(documents, **kwargs)

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -461,7 +461,7 @@ class RedisVectorStoreRetriever(BaseRetriever, BaseModel):
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:
         raise NotImplementedError("RedisVectorStoreRetriever does not support async")
-    
+
     def add_documents(self, documents: List[Document], **kwargs: Any) -> List[str]:
         """Add documents to vectorstore."""
         return self.vectorstore.add_documents(documents, **kwargs)


### PR DESCRIPTION
Ran into this issue In vectorstores/redis.py when trying to use the AutoGPT agent with redis vector store. The error I received was 

`
langchain/experimental/autonomous_agents/autogpt/agent.py", line 134, in run
    self.memory.add_documents([Document(page_content=memory_to_add)])
AttributeError: 'RedisVectorStoreRetriever' object has no attribute 'add_documents'
`

Added the needed function to the class RedisVectorStoreRetriever which did not have the functionality like the base VectorStoreRetriever in vectorstores/base.py that, for example, vectorstores/faiss.py has