### PR TITLE
fix(chain): RetrievalQA should send all inputs to combine_documents_chain

### DIFF
--- a/libs/langchain/langchain/chains/retrieval_qa/base.py
+++ b/libs/langchain/langchain/chains/retrieval_qa/base.py
@@ -136,8 +136,9 @@ class BaseRetrievalQA(Chain):
             docs = self._get_docs(question, run_manager=_run_manager)
         else:
             docs = self._get_docs(question)  # type: ignore[call-arg]
+        inputs["question"] = question
         answer = self.combine_documents_chain.run(
-            input_documents=docs, question=question, callbacks=_run_manager.get_child()
+            input_documents=docs, callbacks=_run_manager.get_child(), **inputs
         )
 
         if self.return_source_documents:
@@ -179,8 +180,9 @@ class BaseRetrievalQA(Chain):
             docs = await self._aget_docs(question, run_manager=_run_manager)
         else:
             docs = await self._aget_docs(question)  # type: ignore[call-arg]
+        inputs["question"] = question
         answer = await self.combine_documents_chain.arun(
-            input_documents=docs, question=question, callbacks=_run_manager.get_child()
+            input_documents=docs, callbacks=_run_manager.get_child(), **inputs
         )
 
         if self.return_source_documents:


### PR DESCRIPTION
https://python.langchain.com/en/latest/modules/chains/index_examples/vector_db_qa.html#custom-prompts

It says you can custom prompts for `RetrievalQA`. But `RetrievalQA` not send all inputs to `combine_documents_chain`.  This will make errors like below:

```
    prompt_template = """Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.

    {context}

    Question: {question}
    Answer in {language}:"""
    PROMPT = PromptTemplate(
        template=prompt_template, input_variables=["context", "question", "language"]
    )

    chain_type_kwargs = {"prompt": PROMPT}
    qa = RetrievalQA.from_chain_type(
        llm=OpenAI(),
        chain_type="stuff",
        retriever=docsearch.as_retriever(),
        chain_type_kwargs=chain_type_kwargs,
    )
    question = "What did the president say about Ketanji Brown Jackson"
    language = "Italian"
    qa.input_key = 'question'
    print(qa.run(question=question, language=language))
```

```
Traceback (most recent call last):
  File "test.py", line 38, in <module>
    print(qa.run(question=question, language=language))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/base.py", line 216, in run
    return self(kwargs)[self.output_keys[0]]
           ^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/base.py", line 116, in __call__
    raise e
  File "python3.11/site-packages/langchain/chains/base.py", line 113, in __call__
    outputs = self._call(inputs)
              ^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/retrieval_qa/base.py", line 110, in _call
    answer = self.combine_documents_chain.run(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/base.py", line 216, in run
    return self(kwargs)[self.output_keys[0]]
           ^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/base.py", line 116, in __call__
    raise e
  File "python3.11/site-packages/langchain/chains/base.py", line 113, in __call__
    outputs = self._call(inputs)
              ^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/combine_documents/base.py", line 56, in _call
    output, extra_return_dict = self.combine_docs(docs, **other_keys)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/combine_documents/stuff.py", line 89, in combine_docs
    return self.llm_chain.predict(**inputs), {}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/llm.py", line 151, in predict
    return self(kwargs)[self.output_key]
           ^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/base.py", line 106, in __call__
    inputs = self.prep_inputs(inputs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.11/site-packages/langchain/chains/base.py", line 195, in prep_inputs
    self._validate_inputs(inputs)
  File "python3.11/site-packages/langchain/chains/base.py", line 75, in _validate_inputs
    raise ValueError(f"Missing some input keys: {missing_keys}")
ValueError: Missing some input keys: {'language'}
```