### PR TITLE
langchain-server: Do not expose postgresql port to host

### DIFF
--- a/langchain/docker-compose.yaml
+++ b/langchain/docker-compose.yaml
@@ -25,5 +25,5 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
-    ports:
+    expose:
       - 5432:5432


### PR DESCRIPTION
Apart from being unnecessary, postgresql is run on its default port, which means that the langchain-server will fail to start if there is already a postgresql server running on the host. This is obviously less than ideal.

(Yeah, I don't understand why "expose" is the syntax that does not expose the ports to the host...)

Tested by running langchain-server and trying out debugging on a host that already has postgresql bound to the port 5432.