### PR TITLE
do not await sync callback managers

### DIFF
--- a/langchain/chains/llm_math/base.py
+++ b/langchain/chains/llm_math/base.py
@@ -106,8 +106,8 @@ class LLMMathChain(Chain):
                     output, color="yellow", verbose=self.verbose
                 )
             else:
-                await self.callback_manager.on_text("\nAnswer: ", verbose=self.verbose)
-                await self.callback_manager.on_text(
+                self.callback_manager.on_text("\nAnswer: ", verbose=self.verbose)
+                self.callback_manager.on_text(
                     output, color="yellow", verbose=self.verbose
                 )
             answer = "Answer: " + output


### PR DESCRIPTION
This fixes a bug in the math LLM, where even the sync manager was awaited, creating a nasty `RuntimeError`