### PR TITLE
added integration links to the ecosystem.rst

### DIFF
--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -3,6 +3,25 @@ LangChain Ecosystem
 
 Guides for how other companies/products can be used with LangChain
 
+Groups
+----------
+
+LangChain provides integration with many LLMs and systems:
+
+- `LLM Providers <./modules/models/llms/integrations.html>`_
+- `Chat Model Providers <./modules/models/chat/integrations.html>`_
+- `Text Embedding Model Providers <./modules/models/text_embedding.html>`_
+- `Document Loader Integrations <./modules/indexes/document_loaders.html>`_
+- `Text Splitter Integrations <./modules/indexes/text_splitters.html>`_
+- `Vectorstore Providers <./modules/indexes/vectorstores.html>`_
+- `Retriever Providers <./modules/indexes/retrievers.html>`_
+- `Tool Providers <./modules/agents/tools.html>`_
+- `Toolkit Integrations <./modules/agents/toolkits.html>`_
+
+Companies / Products
+----------
+
+
 .. toctree::
    :maxdepth: 1
    :glob:


### PR DESCRIPTION
Now it is hard to search for the integration points between data_loaders, retrievers, tools, etc.
I've placed links to all groups of providers and integrations on the `ecosystem` page.
So, it is easy to navigate between all integrations from a single location.