### PR TITLE
enhancement: add elements mode to `UnstructuredURLLoader`

### DIFF
--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -35,8 +35,11 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
                 "unstructured package not found, please install it with "
                 "`pip install unstructured`"
             )
-
-        self._validate_mode(mode)
+        _valid_modes = {"single", "elements"}
+        if mode not in _valid_modes:
+            raise ValueError(
+                f"Got {mode} for `mode`, but should be one of `{_valid_modes}`"
+            )
         self.mode = mode
 
         if not satisfies_min_unstructured_version("0.5.4"):
@@ -44,13 +47,6 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
                 unstructured_kwargs.pop("strategy")
 
         self.unstructured_kwargs = unstructured_kwargs
-
-    def _validate_mode(self, mode: str) -> None:
-        _valid_modes = {"single", "elements"}
-        if mode not in _valid_modes:
-            raise ValueError(
-                f"Got {mode} for `mode`, but should be one of `{_valid_modes}`"
-            )
 
     @abstractmethod
     def _get_elements(self) -> List:

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -35,11 +35,8 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
                 "unstructured package not found, please install it with "
                 "`pip install unstructured`"
             )
-        _valid_modes = {"single", "elements"}
-        if mode not in _valid_modes:
-            raise ValueError(
-                f"Got {mode} for `mode`, but should be one of `{_valid_modes}`"
-            )
+
+        self._validate_mode(mode)
         self.mode = mode
 
         if not satisfies_min_unstructured_version("0.5.4"):
@@ -47,6 +44,13 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
                 unstructured_kwargs.pop("strategy")
 
         self.unstructured_kwargs = unstructured_kwargs
+
+    def _validate_mode(self, mode: str) -> None:
+        _valid_modes = {"single", "elements"}
+        if mode not in _valid_modes:
+            raise ValueError(
+                f"Got {mode} for `mode`, but should be one of `{_valid_modes}`"
+            )
 
     @abstractmethod
     def _get_elements(self) -> List:

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -118,5 +118,4 @@ class UnstructuredURLLoader(BaseLoader):
                     continue
                 else:
                     raise e
-
         return docs

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -99,7 +99,6 @@ class UnstructuredURLLoader(BaseLoader):
                         )
                     else:
                         elements = partition_html(url=url, **self.unstructured_kwargs)
-
             except Exception as e:
                 if self.continue_on_failure:
                     logger.error(f"Error fetching or processing {url}, exeption: {e}")

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -100,22 +100,21 @@ class UnstructuredURLLoader(BaseLoader):
                     else:
                         elements = partition_html(url=url, **self.unstructured_kwargs)
 
-                if self.mode == "single":
-                    text = "\n\n".join([str(el) for el in elements])
-                    metadata = {"source": url}
-                    docs.append(Document(page_content=text, metadata=metadata))
-                elif self.mode == "elements":
-                    for element in elements:
-                        metadata = element.metadata.to_dict()
-                        metadata["category"] = element.category
-                        docs.append(
-                            Document(page_content=str(element), metadata=metadata)
-                        )
-
             except Exception as e:
                 if self.continue_on_failure:
                     logger.error(f"Error fetching or processing {url}, exeption: {e}")
                     continue
                 else:
                     raise e
+
+            if self.mode == "single":
+                text = "\n\n".join([str(el) for el in elements])
+                metadata = {"source": url}
+                docs.append(Document(page_content=text, metadata=metadata))
+            elif self.mode == "elements":
+                for element in elements:
+                    metadata = element.metadata.to_dict()
+                    metadata["category"] = element.category
+                    docs.append(Document(page_content=str(element), metadata=metadata))
+
         return docs

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -77,9 +77,6 @@ class UnstructuredURLLoader(BaseLoader):
 
         return unstructured_version >= (0, 5, 12)
 
-    def _get_metadata(self) -> dict:
-        return {}
-
     def load(self) -> List[Document]:
         """Load file."""
         from unstructured.partition.auto import partition

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, List
 
 from langchain.docstore.document import Document
-from langchain.document_loaders.unstructured import BaseLoader
+from langchain.document_loaders.base import BaseLoader
 
 logger = logging.getLogger(__name__)
 

--- a/langchain/document_loaders/url.py
+++ b/langchain/document_loaders/url.py
@@ -29,11 +29,7 @@ class UnstructuredURLLoader(UnstructuredBaseLoader):
                 "`pip install unstructured`"
             )
 
-        _valid_modes = {"single", "elements"}
-        if mode not in _valid_modes:
-            raise ValueError(
-                f"Got {mode} for `mode`, but should be one of `{_valid_modes}`"
-            )
+        self._validate_mode(mode)
         self.mode = mode
 
         headers = unstructured_kwargs.pop("headers", {})


### PR DESCRIPTION
### Summary

Updates the `UnstructuredURLLoader` to include a "elements" mode that retains additional metadata from `unstructured`. This makes `UnstructuredURLLoader` consistent with other unstructured loaders, which also support "elements" mode. Patched mode into the existing `UnstructuredURLLoader` class instead of inheriting from `UnstructuredBaseLoader` because it significantly simplified the implementation.

### Testing

This should still work and show the url in the source for the metadata

```python
from langchain.document_loaders import UnstructuredURLLoader

urls = ["https://www.understandingwar.org/sites/default/files/Russian%20Offensive%20Campaign%20Assessment%2C%20April%2011%2C%202023.pdf"]

loader = UnstructuredURLLoader(urls=urls, headers={"Accept": "application/json"}, strategy="fast")
docs = loader.load()
print(docs[0].page_content[:1000])
docs[0].metadata
``` 

This should now work and show additional metadata from `unstructured`.

This should still work and show the url in the source for the metadata

```python
from langchain.document_loaders import UnstructuredURLLoader

urls = ["https://www.understandingwar.org/sites/default/files/Russian%20Offensive%20Campaign%20Assessment%2C%20April%2011%2C%202023.pdf"]

loader = UnstructuredURLLoader(urls=urls, headers={"Accept": "application/json"}, strategy="fast", mode="elements")
docs = loader.load()
print(docs[0].page_content[:1000])
docs[0].metadata
``` 