### PR TITLE
- load qa chain should not take prompt as an input

### DIFF
--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -180,7 +180,6 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain):
         doc_chain = load_qa_chain(
             llm,
             chain_type=chain_type,
-            prompt=qa_prompt,
         )
         condense_question_chain = LLMChain(llm=llm, prompt=condense_question_prompt)
         return cls(


### PR DESCRIPTION
### Bugfix


Reproduce via

`ConversationalRetrievalChain.from_llm(llm, retriever, chain_type="map_reduce")` 

```
pydantic.error_wrappers.ValidationError: 1 validation error for MapReduceDocumentsChain
prompt
  extra fields not permitted (type=value_error.extra)
```