### PR TITLE
Allow clearing cache and fix gptcache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ wandb/
 
 *.pkl
 *.bin
+
+# integration test artifacts
+data_map*
+\[('_type', 'fake'), ('stop', None)]

--- a/docs/modules/models/llms/examples/llm_caching.ipynb
+++ b/docs/modules/models/llms/examples/llm_caching.ipynb
@@ -785,7 +785,9 @@
    "id": "9df0dab8",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "!rm .langchain.db sqlite.db"
+   ]
   }
  ],
  "metadata": {

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -1,7 +1,7 @@
 """Beta Feature: base interface for cache."""
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast, no_type_check
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from sqlalchemy import Column, Integer, String, create_engine, select
 from sqlalchemy.engine.base import Engine
@@ -29,8 +29,7 @@ class BaseCache(ABC):
         """Update cache based on prompt and llm_string."""
 
     @abstractmethod
-    @no_type_check
-    def clear(self, **kwargs) -> None:
+    def clear(self, **kwargs: Any) -> None:
         """Clear cache."""
 
 
@@ -49,8 +48,7 @@ class InMemoryCache(BaseCache):
         """Update cache based on prompt and llm_string."""
         self._cache[(prompt, llm_string)] = return_val
 
-    @no_type_check
-    def clear(self, **kwargs) -> None:
+    def clear(self, **kwargs: Any) -> None:
         """Clear cache."""
         self._cache = {}
 
@@ -100,8 +98,7 @@ class SQLAlchemyCache(BaseCache):
             with Session(self.engine) as session, session.begin():
                 session.merge(item)
 
-    @no_type_check
-    def clear(self, **kwargs) -> None:
+    def clear(self, **kwargs: Any) -> None:
         """Clear cache."""
         self.cache_schema.metadata.drop_all(self.engine)
         self.cache_schema.metadata.create_all(self.engine)
@@ -155,8 +152,7 @@ class RedisCache(BaseCache):
         for i, generation in enumerate(return_val):
             self.redis.set(self._key(prompt, llm_string, i), generation.text)
 
-    @no_type_check
-    def clear(self, asynchronous: bool = False, **kwargs) -> None:
+    def clear(self, asynchronous: bool = False, **kwargs: Any) -> None:
         """Clear cache. If `asynchronous` is True, flush asynchronously."""
         self.redis.flushall(asynchronous=asynchronous, **kwargs)
 
@@ -265,12 +261,11 @@ class GPTCache(BaseCache):
         return res
 
     @staticmethod
-    @no_type_check
     def _update_cache_callback(
         llm_data: RETURN_VAL_TYPE,
         update_cache_func: Callable[[Any], None],
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         """Save the `llm_data` to cache storage"""
         handled_data = json.dumps([generation.dict() for generation in llm_data])
@@ -297,8 +292,7 @@ class GPTCache(BaseCache):
             prompt=prompt,
         )
 
-    @no_type_check
-    def clear(self, **kwargs) -> None:
+    def clear(self, **kwargs: Any) -> None:
         """Clear cache."""
         from gptcache import Cache
 

--- a/langchain/memory/entity.py
+++ b/langchain/memory/entity.py
@@ -235,4 +235,5 @@ class ConversationEntityMemory(BaseChatMemory):
     def clear(self) -> None:
         """Clear memory contents."""
         self.chat_memory.clear()
+        self.entity_cache.clear()
         self.entity_store.clear()

--- a/tests/integration_tests/cache/test_gptcache.py
+++ b/tests/integration_tests/cache/test_gptcache.py
@@ -1,61 +1,48 @@
 import os
+from typing import Any, Callable, Optional
 
 import pytest
 
 import langchain
 from langchain.cache import GPTCache
-from langchain.schema import Generation, LLMResult
+from langchain.schema import Generation
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
 try:
-    import gptcache  # noqa: F401
+    from gptcache import Cache  # noqa: F401
+    from gptcache.manager.factory import get_data_manager
+    from gptcache.processor.pre import get_prompt
 
     gptcache_installed = True
 except ImportError:
     gptcache_installed = False
 
 
+def init_gptcache_map(cache_obj: Cache) -> None:
+    i = getattr(init_gptcache_map, "_i", 0)
+    cache_path = f"data_map_{i}.txt"
+    if os.path.isfile(cache_path):
+        os.remove(cache_path)
+    cache_obj.init(
+        pre_embedding_func=get_prompt,
+        data_manager=get_data_manager(data_path=cache_path),
+    )
+    init_gptcache_map._i = i + 1  # type: ignore
+
+
 @pytest.mark.skipif(not gptcache_installed, reason="gptcache not installed")
-def test_gptcache_map_caching() -> None:
-    """Test gptcache caching behavior."""
-
-    from gptcache import Cache
-    from gptcache.manager.factory import get_data_manager
-    from gptcache.processor.pre import get_prompt
-
-    i = 0
-    file_prefix = "data_map"
-
-    def init_gptcache_map(cache_obj: Cache) -> None:
-        nonlocal i
-        cache_path = f"{file_prefix}_{i}.txt"
-        if os.path.isfile(cache_path):
-            os.remove(cache_path)
-        cache_obj.init(
-            pre_embedding_func=get_prompt,
-            data_manager=get_data_manager(data_path=cache_path),
-        )
-        i += 1
-
-    langchain.llm_cache = GPTCache(init_gptcache_map)
-
+@pytest.mark.parametrize("init_func", [None, init_gptcache_map])
+def test_gptcache_caching(init_func: Optional[Callable[[Any], None]]) -> None:
+    """Test gptcache default caching behavior."""
+    langchain.llm_cache = GPTCache(init_func)
     llm = FakeLLM()
     params = llm.dict()
     params["stop"] = None
     llm_string = str(sorted([(k, v) for k, v in params.items()]))
     langchain.llm_cache.update("foo", llm_string, [Generation(text="fizz")])
-    output = llm.generate(["foo", "bar", "foo"])
-    expected_cache_output = [Generation(text="foo")]
-    cache_output = langchain.llm_cache.lookup("bar", llm_string)
-    assert cache_output == expected_cache_output
-    langchain.llm_cache = None
-    expected_generations = [
-        [Generation(text="fizz")],
-        [Generation(text="foo")],
-        [Generation(text="fizz")],
-    ]
-    expected_output = LLMResult(
-        generations=expected_generations,
-        llm_output=None,
-    )
-    assert output == expected_output
+    _ = llm.generate(["foo", "bar", "foo"])
+    cache_output = langchain.llm_cache.lookup("foo", llm_string)
+    assert cache_output == [Generation(text="fizz")]
+
+    langchain.llm_cache.clear()
+    assert langchain.llm_cache.lookup("bar", llm_string) is None


### PR DESCRIPTION
This PR

* Adds `clear` method for `BaseCache` and implements it for various caches
* Adds the default `init_func=None` and fixes gptcache integtest
* Since right now integtest is not running in CI, I've verified the changes by running `docs/modules/models/llms/examples/llm_caching.ipynb` (until proper e2e integtest is done in CI)