### PR TITLE
Sanitize Python tool query by removing triple backticks that include language

### DIFF
--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -31,6 +31,7 @@ class PythonREPLTool(BaseTool):
     def _run(self, query: str) -> str:
         """Use the tool."""
         if self.sanitize_input:
+            query = query.strip().removeprefix("```python")
             query = query.strip().strip("```")
         return self.python_repl.run(query)
 

--- a/langchain/tools/python/tool.py
+++ b/langchain/tools/python/tool.py
@@ -69,6 +69,7 @@ class PythonAstREPLTool(BaseTool):
         try:
             if self.sanitize_input:
                 # Remove the triple backticks from the query.
+                query = query.strip().removeprefix("```python")
                 query = query.strip().strip("```")
             tree = ast.parse(query)
             module = ast.Module(tree.body[:-1], type_ignores=[])


### PR DESCRIPTION
When using the Python REPL Tool, sometimes agents will respond with a Python command to execute that includes triple backticks with the programming language included i.e. 
```
```python
```
Triple backticks are already stripped, this PR simply also identifies and strips the above first.

I think it’s only a problem with ChatGPT model or models where temp is higher than the default 0 for agents that use the Python tool.