### PR TITLE
Pandas agent: Pass forward callback manager

### DIFF
--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -42,7 +42,12 @@ def create_pandas_dataframe_agent(
         callback_manager=callback_manager,
     )
     tool_names = [tool.name for tool in tools]
-    agent = ZeroShotAgent(llm_chain=llm_chain, allowed_tools=tool_names, **kwargs)
+    agent = ZeroShotAgent(
+        llm_chain=llm_chain,
+        allowed_tools=tool_names,
+        callback_manager=callback_manager,
+        **kwargs,
+    )
     return AgentExecutor.from_agent_and_tools(
         agent=agent,
         tools=tools,
@@ -51,4 +56,5 @@ def create_pandas_dataframe_agent(
         max_iterations=max_iterations,
         max_execution_time=max_execution_time,
         early_stopping_method=early_stopping_method,
+        callback_manager=callback_manager,
     )


### PR DESCRIPTION
The Pandas agent fails to pass callback_manager forward, making it
impossible to use custom callbacks with it. Fix that.
