### PR TITLE
RFC - Rename DuckDuckGoSearchTool to use -Run postfix to be consistent with other classes.

### DIFF
--- a/docs/modules/agents/tools/examples/ddg.ipynb
+++ b/docs/modules/agents/tools/examples/ddg.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.tools import DuckDuckGoSearchTool"
+    "from langchain.tools import DuckDuckGoSearchRun"
    ]
   },
   {
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "search = DuckDuckGoSearchTool()"
+    "search = DuckDuckGoSearchRun()"
    ]
   },
   {

--- a/langchain/agents/load_tools.py
+++ b/langchain/agents/load_tools.py
@@ -15,7 +15,7 @@ from langchain.requests import TextRequestsWrapper
 from langchain.tools.arxiv.tool import ArxivQueryRun
 from langchain.tools.base import BaseTool
 from langchain.tools.bing_search.tool import BingSearchRun
-from langchain.tools.ddg_search.tool import DuckDuckGoSearchTool
+from langchain.tools.ddg_search.tool import DuckDuckGoSearchRun
 from langchain.tools.google_search.tool import GoogleSearchResults, GoogleSearchRun
 from langchain.tools.human.tool import HumanInputRun
 from langchain.tools.python.tool import PythonREPLTool
@@ -219,7 +219,7 @@ def _get_bing_search(**kwargs: Any) -> BaseTool:
 
 
 def _get_ddg_search(**kwargs: Any) -> BaseTool:
-    return DuckDuckGoSearchTool(api_wrapper=DuckDuckGoSearchAPIWrapper(**kwargs))
+    return DuckDuckGoSearchRun(api_wrapper=DuckDuckGoSearchAPIWrapper(**kwargs))
 
 
 def _get_human_tool(**kwargs: Any) -> BaseTool:

--- a/langchain/tools/__init__.py
+++ b/langchain/tools/__init__.py
@@ -1,7 +1,7 @@
 """Core toolkit implementations."""
 
 from langchain.tools.base import BaseTool
-from langchain.tools.ddg_search.tool import DuckDuckGoSearchTool
+from langchain.tools.ddg_search.tool import DuckDuckGoSearchRun
 from langchain.tools.google_places.tool import GooglePlacesTool
 from langchain.tools.ifttt import IFTTTWebhook
 from langchain.tools.openapi.utils.api_models import APIOperation
@@ -15,5 +15,5 @@ __all__ = [
     "OpenAPISpec",
     "APIOperation",
     "GooglePlacesTool",
-    "DuckDuckGoSearchTool",
+    "DuckDuckGoSearchRun",
 ]

--- a/langchain/tools/ddg_search/__init__.py
+++ b/langchain/tools/ddg_search/__init__.py
@@ -1,5 +1,5 @@
 """DuckDuckGo Search API toolkit."""
 
-from langchain.tools.ddg_search.tool import DuckDuckGoSearchTool
+from langchain.tools.ddg_search.tool import DuckDuckGoSearchRun
 
-__all__ = ["DuckDuckGoSearchTool"]
+__all__ = ["DuckDuckGoSearchRun"]

--- a/langchain/tools/ddg_search/tool.py
+++ b/langchain/tools/ddg_search/tool.py
@@ -6,7 +6,7 @@ from langchain.tools.base import BaseTool
 from langchain.utilities.duckduckgo_search import DuckDuckGoSearchAPIWrapper
 
 
-class DuckDuckGoSearchTool(BaseTool):
+class DuckDuckGoSearchRun(BaseTool):
     """Tool that adds the capability to query the DuckDuckGo search API."""
 
     name = "DuckDuckGo Search"

--- a/langchain/utilities/duckduckgo_search.py
+++ b/langchain/utilities/duckduckgo_search.py
@@ -23,6 +23,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
 
     class Config:
         """Configuration for this pydantic object."""
+
         extra = Extra.forbid
 
     @root_validator()

--- a/langchain/utilities/duckduckgo_search.py
+++ b/langchain/utilities/duckduckgo_search.py
@@ -23,7 +23,6 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
 
     class Config:
         """Configuration for this pydantic object."""
-
         extra = Extra.forbid
 
     @root_validator()
@@ -41,7 +40,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
     def run(self, query: str) -> str:
         from duckduckgo_search import ddg
 
-        """Run query through DuckDuckGo and return results."""
+        """Run query through DuckDuckGo and return concatenated results."""
         results = ddg(
             query,
             region=self.region,
@@ -54,7 +53,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
         snippets = [result["body"] for result in results]
         return " ".join(snippets)
 
-    def results(self, query: str, num_results: int) -> List[Dict]:
+    def results(self, query: str, num_results: int) -> List[Dict[str, str]]:
         """Run query through DuckDuckGo and return metadata.
 
         Args:
@@ -80,7 +79,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
         if results is None or len(results) == 0:
             return [{"Result": "No good DuckDuckGo Search Result was found"}]
 
-        def to_metadata(result: Dict) -> Dict:
+        def to_metadata(result: Dict) -> Dict[str, str]:
             return {
                 "snippet": result["body"],
                 "title": result["title"],

--- a/tests/integration_tests/utilities/test_duckduckdgo_search_api.py
+++ b/tests/integration_tests/utilities/test_duckduckdgo_search_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from langchain.tools.ddg_search.tool import DuckDuckGoSearchTool
+from langchain.tools.ddg_search.tool import DuckDuckGoSearchRun
 
 
 def ddg_installed() -> bool:
@@ -16,7 +16,7 @@ def ddg_installed() -> bool:
 @pytest.mark.skipif(not ddg_installed(), reason="requires duckduckgo-search package")
 def test_ddg_search_tool() -> None:
     keywords = "Bella Ciao"
-    tool = DuckDuckGoSearchTool()
+    tool = DuckDuckGoSearchRun()
     result = tool(keywords)
     print(result)
     assert len(result.split()) > 20


### PR DESCRIPTION
I found most other search classes are using -Run postfix except DuckDuckGo. It might be good to keep them consistent. (screenshot below)
- Updated all places (using big search and following the original PR https://github.com/hwchase17/langchain/pull/3206)
- lint and text passed on local
- Retested jupyter example. (btw, for anyone who’s not familiar jupyter + virtual env. Here are the steps to run Jupyter in a selected Virtual Env) — screenshot below.
```
reference: https://www.geeksforgeeks.org/using-jupyter-notebook-in-virtual-environment/#
- Activate the Virtual Env
- ipython kernel install --user —name=<your virtual env name>
- In Jupyter, change Kernel. (in menu)
```

Please let me know if this makes sense. I’m new here and still ramping up. I can remove it if this doesn’t help. Thanks so much!

reference 1 - Most search classes are using -Run postfix.

<img width="708" alt="Screenshot 2023-04-25 at 12 45 56 PM" src="https://user-images.githubusercontent.com/62768671/234387596-86cf69c8-79b7-45ac-87ea-41d6f07db32d.png">

reference 2 - Jupyter example is also verified.

<img width="1191" alt="Screenshot 2023-04-25 at 12 39 17 PM" src="https://user-images.githubusercontent.com/62768671/234387759-9b615e44-d3e7-4397-b7cf-72c53784df59.png">
