### PR TITLE
Add get_text_separator parameter to BSHTMLLoader

### DIFF
--- a/langchain/document_loaders/html_bs.py
+++ b/langchain/document_loaders/html_bs.py
@@ -17,6 +17,7 @@ class BSHTMLLoader(BaseLoader):
         file_path: str,
         open_encoding: Union[str, None] = None,
         bs_kwargs: Union[dict, None] = None,
+        get_text_separator: str = ""
     ) -> None:
         """Initialise with path, and optionally, file encoding to use, and any kwargs
         to pass to the BeautifulSoup object."""
@@ -41,7 +42,7 @@ class BSHTMLLoader(BaseLoader):
         with open(self.file_path, "r", encoding=self.open_encoding) as f:
             soup = BeautifulSoup(f, **self.bs_kwargs)
 
-        text = soup.get_text()
+        text = soup.get_text(get_text_separator)
 
         if soup.title:
             title = str(soup.title.string)

--- a/langchain/document_loaders/html_bs.py
+++ b/langchain/document_loaders/html_bs.py
@@ -17,7 +17,7 @@ class BSHTMLLoader(BaseLoader):
         file_path: str,
         open_encoding: Union[str, None] = None,
         bs_kwargs: Union[dict, None] = None,
-        get_text_separator: str = ""
+        get_text_separator: str = "",
     ) -> None:
         """Initialise with path, and optionally, file encoding to use, and any kwargs
         to pass to the BeautifulSoup object."""
@@ -34,6 +34,7 @@ class BSHTMLLoader(BaseLoader):
         if bs_kwargs is None:
             bs_kwargs = {"features": "lxml"}
         self.bs_kwargs = bs_kwargs
+        self.get_text_separator = get_text_separator
 
     def load(self) -> List[Document]:
         from bs4 import BeautifulSoup
@@ -42,7 +43,7 @@ class BSHTMLLoader(BaseLoader):
         with open(self.file_path, "r", encoding=self.open_encoding) as f:
             soup = BeautifulSoup(f, **self.bs_kwargs)
 
-        text = soup.get_text(get_text_separator)
+        text = soup.get_text(self.get_text_separator)
 
         if soup.title:
             title = str(soup.title.string)

--- a/tests/integration_tests/document_loaders/test_bshtml.py
+++ b/tests/integration_tests/document_loaders/test_bshtml.py
@@ -15,10 +15,11 @@ def test_bs_html_loader() -> None:
     assert len(docs) == 1
 
     metadata = docs[0].metadata
+    content = docs[0].page_content
 
     assert metadata["title"] == "Chew dad's slippers"
     assert metadata["source"] == str(file_path)
-    assert docs[0].page_content[:2] == "\n|"
+    assert content[:2] == "\n|"
 
 
 @pytest.mark.skipif(

--- a/tests/integration_tests/document_loaders/test_bshtml.py
+++ b/tests/integration_tests/document_loaders/test_bshtml.py
@@ -9,7 +9,7 @@ from langchain.document_loaders.html_bs import BSHTMLLoader
 def test_bs_html_loader() -> None:
     """Test unstructured loader."""
     file_path = Path(__file__).parent.parent / "examples/example.html"
-    loader = BSHTMLLoader(str(file_path))
+    loader = BSHTMLLoader(str(file_path), get_text_separator="|")
     docs = loader.load()
 
     assert len(docs) == 1
@@ -18,6 +18,7 @@ def test_bs_html_loader() -> None:
 
     assert metadata["title"] == "Chew dad's slippers"
     assert metadata["source"] == str(file_path)
+    assert docs[0].page_content[:2] == "\n|"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
By default get_text doesn't separate content of different HTML tag.
Adding option for specifying separator helps with document splitting.