### PR TITLE
Fix broken Cerebrium link in documentation

### DIFF
--- a/docs/modules/models/llms/integrations/cerebriumai_example.ipynb
+++ b/docs/modules/models/llms/integrations/cerebriumai_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# CerebriumAI\n",
     "\n",
-    "`Cerebrium` is an AWS Sagemaker alternative. It also provides API access to [several LLM models](https://docs.cerebrium.ai/cerebrium/prebuilt-models/deploymen).\n",
+    "`Cerebrium` is an AWS Sagemaker alternative. It also provides API access to [several LLM models](https://docs.cerebrium.ai/cerebrium/prebuilt-models/deployment).\n",
     "\n",
     "This notebook goes over how to use Langchain with [CerebriumAI](https://docs.cerebrium.ai/introduction)."
    ]


### PR DESCRIPTION
The current hyperlink has a typo. This PR contains the corrected hyperlink to Cerebrium docs