### PR TITLE
bugfix(inference): BaseOutputParser error fix (/ workaround?)

### DIFF
--- a/langchain/output_parsers/boolean.py
+++ b/langchain/output_parsers/boolean.py
@@ -4,6 +4,7 @@ from langchain.schema import BaseOutputParser
 class BooleanOutputParser(BaseOutputParser[bool]):
     true_val: str = "YES"
     false_val: str = "NO"
+    alt_false_val: str = "No"
 
     def parse(self, text: str) -> bool:
         """Parse the output of an LLM call to a boolean.
@@ -16,10 +17,10 @@ class BooleanOutputParser(BaseOutputParser[bool]):
 
         """
         cleaned_text = text.strip()
-        if cleaned_text not in (self.true_val, self.false_val):
+        if cleaned_text not in (self.true_val, self.false_val, self.alt_false_val):
             raise ValueError(
                 f"BooleanOutputParser expected output value to either be "
-                f"{self.true_val} or {self.false_val}. Received {cleaned_text}."
+                f"{self.true_val} or {self.false_val} or {self.alt_false_val}. Received {cleaned_text}."
             )
         return cleaned_text == self.true_val
 


### PR DESCRIPTION
Previously encountered an error 
`BooleanOutputParser expected output value to either be YES or NO. Received No`
when using the new LLMChainFilter.

Sorry, haven't further examined the issue/ cause, might be more of a workaround than a fix.