### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/langchain/docker-compose.yaml
+++ b/langchain/docker-compose.yaml
@@ -26,4 +26,4 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
     expose:
-      - 5432:5432
+      - 5432


### PR DESCRIPTION
The following error gets returned when trying to launch langchain-server:

ERROR: The Compose file '/opt/homebrew/lib/python3.11/site-packages/langchain/docker-compose.yaml' is invalid because:
services.langchain-db.expose is invalid: should be of the format 'PORT[/PROTOCOL]'

Solution:
Change line 28 from - 5432:5432 to - 5432