### PR TITLE
Add `LMQL` llm [wip]

### DIFF
--- a/langchain/llms/__init__.py
+++ b/langchain/llms/__init__.py
@@ -16,6 +16,7 @@ from langchain.llms.huggingface_endpoint import HuggingFaceEndpoint
 from langchain.llms.huggingface_hub import HuggingFaceHub
 from langchain.llms.huggingface_pipeline import HuggingFacePipeline
 from langchain.llms.llamacpp import LlamaCpp
+from langchain.llms.lmql import LMQL
 from langchain.llms.modal import Modal
 from langchain.llms.nlpcloud import NLPCloud
 from langchain.llms.openai import AzureOpenAI, OpenAI, OpenAIChat
@@ -61,6 +62,7 @@ __all__ = [
     "Writer",
     "RWKV",
     "PredictionGuard",
+    "LMQL"
 ]
 
 type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
@@ -90,4 +92,5 @@ type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
     "stochasticai": StochasticAI,
     "writer": Writer,
     "rwkv": RWKV,
+    "lmql": LMQL
 }

--- a/langchain/llms/lmql.py
+++ b/langchain/llms/lmql.py
@@ -1,0 +1,76 @@
+"""Wrapper around LMQL"""
+import logging
+from typing import Dict, Optional, List, Any
+import asyncio
+
+from langchain.llms.base import BaseLLM
+from langchain.schema import LLMResult, Generation
+from pydantic import Extra, root_validator
+
+logger = logging.getLogger(__name__)
+
+class LMQL(BaseLLM):
+    """Wrapper around LMQL (Language Model Query Language)
+
+    To use this, you need to have `lmql` Python library installed. 
+    Check out: https://github.com/eth-sri/lmql
+    
+    Example:
+        .. code-block:: python
+
+            from langchain.llms import LMQL
+            llm = LMQL()
+    """
+
+    class Config:
+        extra = Extra.forbid
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "lmql"
+    
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        try:
+            import lmql
+        
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not import lmql python package."
+                "Please install with `pip install lmql`."
+            )
+        return values
+    
+    def _generate(
+        self, prompts: List[str], stop: Optional[List[str]] = None
+    ) -> LLMResult:
+        """Run the LLM on the given prompt and input."""
+        return asyncio.run(self.agenerate(prompts=prompts, stop=stop))
+    
+    async def _agenerate(
+        self, prompts: List[str], stop: Optional[List[str]] = None
+    ) -> LLMResult:
+        """Run the LLM on the given prompt and input."""
+        generations = []
+        for prompt in prompts:
+            result = await self._call_lmql(prompt)
+            generation = []
+            for i in result:
+                cur = Generation(text=i.prompt, generation_info=i.variables)
+                generation.append(cur)
+            generations.append(generation)
+        return LLMResult(generations=generations)
+
+    
+    async def _call_lmql(self, query_str: str) -> List[Dict[str, Any]]:
+        import lmql
+        query_func = lmql.query(query_str)
+        # LMQL can return a list of LMQLResult or just LMQLResult
+        result = await query_func()
+        if type(result) != list:
+            result = [result]
+        return result
+
+    
+


### PR DESCRIPTION
My attempt at integrating `LMQL` as an LLM class in `langchain`. Example usage will be like:

```python
from langchain.llms import LMQL
from langchain.chains import LLMChain
from langchain.prompts import PromptTemplate

lmql_str = '''lmql
argmax
    """
    A list of things to not forget when going to sea (not travelling):
    """
    backpack = []
    for i in range(5):
        "-[THING]"
        backpack.append(THING.strip())
    print(backpack)
from
    "openai/text-davinci-003"
where
    STOPS_AT(THING, "\\n")
'''

lmql = LMQL()
result = lmql.generate([lmql_str])
print(result)
# -> generations=[[Generation(text='\nA list of things to not forget when going to sea (not travelling):\n- Life jackets\n- Emergency flares\n- First aid kit\n- Navigation equipment\n- Anchor and chain\n', generation_info={'THING': ' Anchor and chain\n'})]] llm_output=None
```

You can use it in an `LLMChain`.

```python
prompt = PromptTemplate.from_template(lmql_str)
chain = LLMChain(llm=lmql, prompt=prompt)
print(chain.run({}))
# -> A list of things to not forget when going to sea (not travelling):
# -> - Life jackets
# -> - Emergency flares
# -> - First aid kit
# -> - Navigation equipment
# -> - Anchor and chain
```