### PR TITLE
Add-github-api-utility

### DIFF
--- a/langchain/tools/github/__init__.py
+++ b/langchain/tools/github/__init__.py
@@ -1,0 +1,1 @@
+""" GitHub API wrapper toolkit. """

--- a/langchain/tools/github/tool.py
+++ b/langchain/tools/github/tool.py
@@ -1,0 +1,29 @@
+"""Tool for the GitHub API."""
+
+from langchain.tools.base import BaseTool
+from langchain.utilities import GitHubAPIWrapper
+
+
+class GitHubRepoQueryRun(BaseTool):
+    """Tool that adds the capability to query using the GitHub API."""
+
+    api_wrapper: GitHubAPIWrapper
+
+    name = "GitHub"
+    description = (
+        "A wrapper around GitHub API. "
+        "Useful for fetching repository information for a specified user. "
+        "Input should be a GitHub username (e.g. 'octocat')."
+    )
+
+    def __init__(self) -> None:
+        self.api_wrapper = GitHubAPIWrapper()
+        return
+
+    def _run(self, user: str) -> str:
+        """Use the GitHub tool."""
+        return self.api_wrapper.run(user)
+
+    async def _arun(self, user: str) -> str:
+        """Use the GitHub tool asynchronously."""
+        raise NotImplementedError("GitHubRepoQueryRun does not support async")

--- a/langchain/utilities/__init__.py
+++ b/langchain/utilities/__init__.py
@@ -14,6 +14,7 @@ from langchain.utilities.searx_search import SearxSearchWrapper
 from langchain.utilities.serpapi import SerpAPIWrapper
 from langchain.utilities.wikipedia import WikipediaAPIWrapper
 from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
+from langchain.utilities.github import GitHubAPIWrapper
 
 __all__ = [
     "ApifyWrapper",
@@ -31,4 +32,5 @@ __all__ = [
     "OpenWeatherMapAPIWrapper",
     "PythonREPL",
     "PowerBIDataset",
+    "GitHubAPIWrapper",
 ]

--- a/langchain/utilities/github.py
+++ b/langchain/utilities/github.py
@@ -1,0 +1,86 @@
+"""Util that calls GitHub API using requests."""
+from typing import Any, Dict, Optional
+
+import requests
+from pydantic import Extra, root_validator
+
+from langchain.tools.base import BaseModel
+from langchain.utils import get_from_dict_or_env
+
+""" 
+Example usage
+
+from langchain.utilities import GitHubAPIWrapper
+
+#set env variable GITHUB_API_KEY
+import os
+
+os.environ['GITHUB_API_KEY'] = ''
+
+github_api = GitHubAPIWrapper()
+
+print(github_api.run('SamPink'))
+"""
+
+
+class GitHubAPIWrapper(BaseModel):
+    """Wrapper for GitHub API using requests.
+
+    Docs for using:
+
+    1. Go to GitHub and sign up for an API key
+    2. Save your API KEY into GITHUB_API_KEY env variable
+    3. pip install requests
+    """
+
+    github_api_key: Optional[str] = None
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+
+    @root_validator(pre=True)
+    def validate_environment(cls, values: Dict) -> Dict:
+        """Validate that api key exists in environment."""
+        github_api_key = get_from_dict_or_env(
+            values, "github_api_key", "GITHUB_API_KEY"
+        )
+        values["github_api_key"] = github_api_key
+
+        try:
+            import requests
+
+        except ImportError:
+            raise ImportError(
+                "requests is not installed. "
+                "Please install it with `pip install requests`"
+            )
+
+        return values
+
+    def _format_repo_info(self, repo: Dict) -> str:
+        return (
+            f"Repo name: {repo['name']}\n"
+            f"Description: {repo['description']}\n"
+            f"URL: {repo['html_url']}\n"
+            f"Stars: {repo['stargazers_count']}\n"
+            f"Forks: {repo['forks_count']}\n"
+            f"Language: {repo['language']}\n"
+            f"Open issues: {repo['open_issues_count']}\n"
+        )
+
+    def run(self, user: str) -> str:
+        """Get the repository information for a specified user."""
+        headers = {"Authorization": f"token {self.github_api_key}"}
+        response = requests.get(
+            f"https://api.github.com/users/{user}/repos", headers=headers
+        )
+
+        if response.status_code != 200:
+            raise ValueError(f"Error: {response.status_code}, {response.text}")
+
+        repos = response.json()
+        repo_info = "\n\n".join(self._format_repo_info(repo) for repo in repos)
+
+        return f"Repositories for {user}:\n\n{repo_info}"


### PR DESCRIPTION
This PR introduces a new GitHub API Wrapper using the requests library. The new GitHubAPIWrapper class allows users to fetch repository information for a specified GitHub user. The PR includes the following changes:

Create a new GitHubAPIWrapper class that provides easy access to the GitHub API
Add a root validator to ensure the GitHub API key is present in the environment
Implement _format_repo_info method to format repository information into a readable string
Add run method to fetch and display repositories for a given user
Update requirements.txt to include requests library
With the new GitHub API Wrapper, users can now easily retrieve repository information for any GitHub user. This functionality can be useful for a variety of purposes, such as displaying user profiles, generating reports, or analyzing repositories for various metrics.

Please let me know if you have any questions or concerns. I look forward to your feedback and merging this feature into the main branch.