### PR TITLE
Fix encoding issue in WebBaseLoader

### DIFF
--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -169,6 +169,7 @@ class WebBaseLoader(BaseLoader):
         self._check_parser(parser)
 
         html_doc = self.session.get(url)
+        html_doc.encoding = html_doc.apparent_encoding
         return BeautifulSoup(html_doc.text, parser)
 
     def scrape(self, parser: Union[str, None] = None) -> Any:


### PR DESCRIPTION
The character code mismatches occurred when character information was not included in the response header (In my case, a Japanese web page). 
I solved this issue by changing the encoding setting to apparent_encoding.