### PR TITLE
Improve redis caching, docs, and other fixes

### DIFF
--- a/docs/ecosystem/redis.md
+++ b/docs/ecosystem/redis.md
@@ -1,6 +1,6 @@
 # Redis
 
-This page covers how to use the Redis ecosystem within LangChain.
+This page covers how to use the [Redis](https://redis.com) ecosystem within LangChain.
 It is broken into two parts: installation and setup, and then references to specific Redis wrappers.
 
 ## Installation and Setup
@@ -30,7 +30,7 @@ langchain.llm_cache = RedisCache(redis_client)
 ```
 
 #### Semantic Cache
-Semantic caching allows users to retrieve cached prompts based on semantic similarity between the input and previously cached results. Under the hood it blends Redis as both a cache and a vectorstore.
+Semantic caching allows users to retrieve cached prompts based on semantic similarity between the user input and previously cached results. Under the hood it blends Redis as both a cache and a vectorstore.
 
 To import this cache:
 ```python
@@ -69,7 +69,7 @@ For a more detailed walkthrough of the Redis vectorstore wrapper, see [this note
 The Redis vector store retriever wrapper generalizes the vectorstore class to perform low-latency document retrieval. To create the retriever, simply call `.as_retriever()` on the base vectorstore class.
 
 ### Memory
-Redis can be used to cache LLM conversations.
+Redis can be used to persist LLM conversations.
 
 #### Vector Store Retriever Memory
 

--- a/docs/ecosystem/redis.md
+++ b/docs/ecosystem/redis.md
@@ -1,0 +1,79 @@
+# Redis
+
+This page covers how to use the Redis ecosystem within LangChain.
+It is broken into two parts: installation and setup, and then references to specific Redis wrappers.
+
+## Installation and Setup
+- Install the Redis Python SDK with `pip install redis`
+
+## Wrappers
+
+### Cache
+
+The Cache wrapper allows for [Redis](https://redis.io) to be used as a remote, low-latency, in-memory cache for LLM prompts and responses.
+
+#### Standard Cache
+The standard cache is the Redis bread & butter of use case in production for both [open source](https://redis.io) and [enterprise](https://redis.com) users globally.
+
+To import this cache:
+```python
+from langchain.cache import RedisCache
+```
+
+To use this cache with your LLMs:
+```python
+import langchain
+import redis
+
+redis_client = redis.Redis.from_url(...)
+langchain.llm_cache = RedisCache(redis_client)
+```
+
+#### Semantic Cache
+Semantic caching allows users to retrieve cached prompts based on semantic similarity between the input and previously cached results. Under the hood it blends Redis as both a cache and a vectorstore.
+
+To import this cache:
+```python
+from langchain.cache import RedisSemanticCache
+```
+
+To use this cache with your LLMs:
+```python
+import langchain
+import redis
+
+# use any embedding provider...
+from tests.integration_tests.vectorstores.fake_embeddings import FakeEmbeddings
+
+redis_url = "redis://localhost:6379"
+
+langchain.llm_cache = RedisSemanticCache(
+    embedding=FakeEmbeddings(),
+    redis_url=redis_url
+)
+```
+
+### VectorStore
+
+The vectorstore wrapper turns Redis into a low-latency [vector database](https://redis.com/solutions/use-cases/vector-database/) for semantic search or LLM content retrieval.
+
+To import this vectorstore:
+```python
+from langchain.vectorstores import Redis
+```
+
+For a more detailed walkthrough of the Redis vectorstore wrapper, see [this notebook](../modules/indexes/vectorstores/examples/redis.ipynb).
+
+### Retriever
+
+The Redis vector store retriever wrapper generalizes the vectorstore class to perform low-latency document retrieval. To create the retriever, simply call `.as_retriever()` on the base vectorstore class.
+
+### Memory
+Redis can be used to cache LLM conversations.
+
+#### Vector Store Retriever Memory
+
+For a more detailed walkthrough of the `VectorStoreRetrieverMemory` wrapper, see [this notebook](../modules/memory/types/vectorstore_retriever_memory.ipynb).
+
+#### Chat Message History Memory
+For a detailed example of Redis to cache conversation message history, see [this notebook](../modules/memory/examples/redis_chat_message_history.ipynb).

--- a/docs/modules/models/llms/examples/llm_caching.ipynb
+++ b/docs/modules/models/llms/examples/llm_caching.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "f69f6283",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "64005d1f",
    "metadata": {},
    "outputs": [
@@ -60,8 +60,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 14.2 ms, sys: 4.9 ms, total: 19.1 ms\n",
-      "Wall time: 1.1 s\n"
+      "CPU times: user 26.1 ms, sys: 21.5 ms, total: 47.6 ms\n",
+      "Wall time: 1.68 s\n"
      ]
     },
     {
@@ -70,7 +70,7 @@
        "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side.'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "c8a1cb2b",
    "metadata": {},
    "outputs": [
@@ -91,8 +91,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 162 µs, sys: 7 µs, total: 169 µs\n",
-      "Wall time: 175 µs\n"
+      "CPU times: user 238 µs, sys: 143 µs, total: 381 µs\n",
+      "Wall time: 1.76 ms\n"
      ]
     },
     {
@@ -101,7 +101,7 @@
        "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side.'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,8 +215,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c5c9a4d5",
+   "metadata": {},
+   "source": [
+    "### Standard Cache\n",
+    "Use [Redis](../../../../ecosystem/redis.md) to cache prompts and responses."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "39f6eb0b",
    "metadata": {},
    "outputs": [],
@@ -225,15 +234,35 @@
     "# (make sure your local Redis instance is running first before running this example)\n",
     "from redis import Redis\n",
     "from langchain.cache import RedisCache\n",
+    "\n",
     "langchain.llm_cache = RedisCache(redis_=Redis())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "28920749",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6.88 ms, sys: 8.75 ms, total: 15.6 ms\n",
+      "Wall time: 1.04 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side!'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%time\n",
     "# The first time, it is not yet in cache, so it should take longer\n",
@@ -242,14 +271,122 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "94bf9415",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.59 ms, sys: 610 µs, total: 2.2 ms\n",
+      "Wall time: 5.58 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side!'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%time\n",
     "# The second time it is, so it goes faster\n",
     "llm(\"Tell me a joke\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82be23f6",
+   "metadata": {},
+   "source": [
+    "### Semantic Cache\n",
+    "Use [Redis](../../../../ecosystem/redis.md) to cache prompts and responses and evaluate hits based on semantic similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "64df3099",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from langchain.cache import RedisSemanticCache\n",
+    "\n",
+    "\n",
+    "langchain.llm_cache = RedisSemanticCache(\n",
+    "    redis_url=\"redis://localhost:6379\",\n",
+    "    embedding=OpenAIEmbeddings()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8e91d3ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 351 ms, sys: 156 ms, total: 507 ms\n",
+      "Wall time: 3.37 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"\\n\\nWhy don't scientists trust atoms?\\nBecause they make up everything.\""
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# The first time, it is not yet in cache, so it should take longer\n",
+    "llm(\"Tell me a joke\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "df856948",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6.25 ms, sys: 2.72 ms, total: 8.97 ms\n",
+      "Wall time: 262 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"\\n\\nWhy don't scientists trust atoms?\\nBecause they make up everything.\""
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# The second time, while not a direct hit, the question is semantically similar to the original question,\n",
+    "# so it uses the cached result!\n",
+    "llm(\"Tell me one joke\")"
    ]
   },
   {

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -16,7 +16,6 @@ except ImportError:
 
 from langchain.embeddings.base import Embeddings
 from langchain.schema import Generation
-from langchain.vectorstores.redis import Redis
 
 
 RETURN_VAL_TYPE = List[Generation]
@@ -194,6 +193,8 @@ class RedisSemanticCache(BaseCache):
         # return vectorstore client for the specific llm string
         if index_name in self._cache_dict:
             return self._cache_dict[index_name]
+
+        from langchain.vectorstores.redis import Redis
 
         # create new vectorstore client for the specific llm string
         try:

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -159,9 +159,25 @@ class RedisSemanticCache(BaseCache):
         embedding: Embeddings,
         score_threshold: float = 0.2
     ):
-        """
-        Initialize by passing in Redis url, embedding generator,
-        and semantic score threshold.
+        """Initialize by passing in the `init` GPTCache func
+
+        Args:
+            redis_url (str): URL to connect to Redis.
+            embedding (Embedding): Embedding provider for semantic encoding and search.
+            score_threshold (float, 0.2):
+
+        Example:
+        .. code-block:: python
+            import langchain
+
+            from langchain.cache import RedisSemanticCache
+            from langchain.embeddings import OpenAIEmbeddings
+
+            langchain.llm_cache = RedisSemanticCache(
+                redis_url="redis://localhost:6379",
+                embedding=OpenAIEmbeddings()
+            )
+
         """
         self._cache_dict = {}
         self.redis_url = redis_url

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -198,6 +198,17 @@ class RedisSemanticCache(BaseCache):
 
         return self._cache_dict[index_name]
 
+    def clear(self, llm_string: str):
+        """Clear semantic cache for a given llm_string."""
+        index_name = self._index_name(llm_string)
+        if index_name in self._cache_dict:
+            self._cache_dict[index_name].drop_index(
+                index_name=index_name,
+                delete_documents=True,
+                redis_url=self.redis_url
+            )
+            del self._cache_dict[index_name]
+
     def lookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
         """Look up based on prompt and llm_string."""
         llm_cache = self._get_llm_cache(llm_string)

--- a/langchain/vectorstores/__init__.py
+++ b/langchain/vectorstores/__init__.py
@@ -12,11 +12,13 @@ from langchain.vectorstores.myscale import MyScale, MyScaleSettings
 from langchain.vectorstores.opensearch_vector_search import OpenSearchVectorSearch
 from langchain.vectorstores.pinecone import Pinecone
 from langchain.vectorstores.qdrant import Qdrant
+from langchain.vectorstores.redis import Redis
 from langchain.vectorstores.supabase import SupabaseVectorStore
 from langchain.vectorstores.weaviate import Weaviate
 from langchain.vectorstores.zilliz import Zilliz
 
 __all__ = [
+    "Redis",
     "ElasticVectorSearch",
     "FAISS",
     "VectorStore",

--- a/tests/integration_tests/cache/test_redis_cache.py
+++ b/tests/integration_tests/cache/test_redis_cache.py
@@ -1,0 +1,46 @@
+"""Test Redis cache functionality."""
+import langchain
+import redis
+
+from tests.integration_tests.vectorstores.fake_embeddings import FakeEmbeddings
+from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.cache import RedisCache, RedisSemanticCache
+from langchain.schema import Generation, LLMResult
+
+
+REDIS_TEST_URL = "redis://localhost:6379"
+
+
+def test_redis_cache():
+    langchain.llm_cache = RedisCache(redis_=redis.Redis.from_url(REDIS_TEST_URL))
+    llm = FakeLLM()
+    params = llm.dict()
+    params["stop"] = None
+    llm_string = str(sorted([(k, v) for k, v in params.items()]))
+    langchain.llm_cache.update("foo", llm_string, [Generation(text="fizz")])
+    output = llm.generate(["foo"])
+    print(output)
+    expected_output = LLMResult(
+        generations=[[Generation(text="fizz")]],
+        llm_output={},
+    )
+    print(expected_output)
+    assert output == expected_output
+
+def test_redis_semantic_cache():
+    langchain.llm_cache = RedisSemanticCache(
+        embedding=FakeEmbeddings(),
+        redis_url=REDIS_TEST_URL,
+        score_threshold=0.1
+    )
+    llm = FakeLLM()
+    params = llm.dict()
+    params["stop"] = None
+    llm_string = str(sorted([(k, v) for k, v in params.items()]))
+    langchain.llm_cache.update("foo", llm_string, [Generation(text="fizz")])
+    output = llm.generate(["bar"]) # foo and bar will have the same embedding produced by FakeEmbeddings
+    expected_output = LLMResult(
+        generations=[[Generation(text="fizz")]],
+        llm_output={},
+    )
+    assert output == expected_output

--- a/tests/integration_tests/cache/test_redis_cache.py
+++ b/tests/integration_tests/cache/test_redis_cache.py
@@ -50,3 +50,4 @@ def test_redis_semantic_cache():
     output = llm.generate(["bar"]) # foo and bar will have the same embedding produced by FakeEmbeddings
     # expect different output now without cached result
     assert output != expected_output
+    langchain.llm_cache.clear(llm_string)

--- a/tests/integration_tests/cache/test_redis_cache.py
+++ b/tests/integration_tests/cache/test_redis_cache.py
@@ -26,6 +26,7 @@ def test_redis_cache():
     )
     print(expected_output)
     assert output == expected_output
+    langchain.llm_cache.redis.flushall()
 
 def test_redis_semantic_cache():
     langchain.llm_cache = RedisSemanticCache(
@@ -44,3 +45,8 @@ def test_redis_semantic_cache():
         llm_output={},
     )
     assert output == expected_output
+    # clear the cache
+    langchain.llm_cache.clear(llm_string)
+    output = llm.generate(["bar"]) # foo and bar will have the same embedding produced by FakeEmbeddings
+    # expect different output now without cached result
+    assert output != expected_output

--- a/tests/integration_tests/vectorstores/test_redis.py
+++ b/tests/integration_tests/vectorstores/test_redis.py
@@ -1,26 +1,70 @@
 """Test Redis functionality."""
+import pytest
 
 from langchain.docstore.document import Document
 from langchain.vectorstores.redis import Redis
 from tests.integration_tests.vectorstores.fake_embeddings import FakeEmbeddings
 
 
+TEST_INDEX_NAME = "test"
+TEST_REDIS_URL = "redis://localhost:6379"
+TEST_SINGLE_RESULT = [Document(page_content="foo")]
+TEST_RESULT = [Document(page_content="foo"), Document(page_content="foo")]
+
+
+def drop(index_name) -> bool:
+    return Redis.drop_index(
+        index_name=index_name, delete_documents=True, redis_url=TEST_REDIS_URL
+    )
+
+
 def test_redis() -> None:
     """Test end to end construction and search."""
     texts = ["foo", "bar", "baz"]
     docsearch = Redis.from_texts(
-        texts, FakeEmbeddings(), redis_url="redis://localhost:6379"
+        texts, FakeEmbeddings(), redis_url=TEST_REDIS_URL
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == TEST_SINGLE_RESULT
+    assert drop(docsearch.index_name)
 
 
 def test_redis_new_vector() -> None:
     """Test adding a new document"""
     texts = ["foo", "bar", "baz"]
     docsearch = Redis.from_texts(
-        texts, FakeEmbeddings(), redis_url="redis://localhost:6379"
+        texts, FakeEmbeddings(), redis_url=TEST_REDIS_URL
     )
     docsearch.add_texts(["foo"])
     output = docsearch.similarity_search("foo", k=2)
-    assert output == [Document(page_content="foo"), Document(page_content="foo")]
+    assert output == TEST_RESULT
+    assert drop(docsearch.index_name)
+
+
+def test_redis_from_existing() -> None:
+    """Test adding a new document"""
+    texts = ["foo", "bar", "baz"]
+    docsearch = Redis.from_texts(
+        texts, FakeEmbeddings(), index_name=TEST_INDEX_NAME, redis_url=TEST_REDIS_URL
+    )
+    # Test creating from an existing
+    docsearch2 = Redis.from_existing_index(
+        FakeEmbeddings(), index_name=TEST_INDEX_NAME, redis_url=TEST_REDIS_URL
+    )
+    output = docsearch2.similarity_search("foo", k=1)
+    assert output == TEST_SINGLE_RESULT
+
+
+def test_redis_add_texts_to_existing() -> None:
+    """Test adding a new document"""
+    # Test creating from an existing
+    docsearch = Redis.from_existing_index(
+        FakeEmbeddings(), index_name=TEST_INDEX_NAME, redis_url=TEST_REDIS_URL
+    )
+    docsearch.add_texts(["foo"])
+    output = docsearch.similarity_search("foo", k=2)
+    assert output == TEST_RESULT
+
+
+def test_redis_drop_index() -> None:
+    assert drop(TEST_INDEX_NAME)

--- a/tests/integration_tests/vectorstores/test_redis.py
+++ b/tests/integration_tests/vectorstores/test_redis.py
@@ -64,7 +64,4 @@ def test_redis_add_texts_to_existing() -> None:
     docsearch.add_texts(["foo"])
     output = docsearch.similarity_search("foo", k=2)
     assert output == TEST_RESULT
-
-
-def test_redis_drop_index() -> None:
     assert drop(TEST_INDEX_NAME)


### PR DESCRIPTION
With Redis widely used as a cache today, we added some improvements to make better use of native datastructures including HASH objects (for standard caching) and vector indices (for semantic caching).

This PR introduces a few things:

1) Updates to use a HASH datastrcutre for the standard cache
2) Updates to use a deterministic hashing algorithm from `hashlib`
3) Adds Redis Semantic Cache as another caching variant to work with (using similarity threshold based cache hits)
4) Adds new tests
5) Fixes: https://github.com/hwchase17/langchain/issues/3111
6) Addresses: https://github.com/hwchase17/langchain/issues/2618