### PR TITLE
Fixed typo for HuggingFaceHub

### DIFF
--- a/docs/modules/models/llms/integrations/huggingface_pipelines.ipynb
+++ b/docs/modules/models/llms/integrations/huggingface_pipelines.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "The [Hugging Face Model Hub](https://huggingface.co/models) hosts over 120k models, 20k datasets, and 50k demo apps (Spaces), all open source and publicly available, in an online platform where people can easily collaborate and build ML together.\n",
     "\n",
-    "These can be called from LangChain either through this local pipeline wrapper or by calling their hosted inference endpoints through the HuggingFaceHub class. For more information on the hosted pipelines, see the [HugigngFaceHub](huggingface_hub.ipynb) notebook."
+    "These can be called from LangChain either through this local pipeline wrapper or by calling their hosted inference endpoints through the HuggingFaceHub class. For more information on the hosted pipelines, see the [HuggingFaceHub](huggingface_hub.ipynb) notebook."
    ]
   },
   {


### PR DESCRIPTION
The current text has a typo. This PR contains the corrected spelling for HuggingFaceHub
