### PR TITLE
Fix pytest collection warning

### DIFF
--- a/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -24,7 +24,7 @@ class TestModel(BaseModel):
 
 
 # Prevent pytest from trying to run tests on TestModel
-TestModel.__test__ = False
+TestModel.__test__ = False  # type: ignore[attr-defined]
 
 
 DEF_RESULT = """{

--- a/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -23,6 +23,10 @@ class TestModel(BaseModel):
     )
 
 
+# Prevent pytest from trying to run tests on TestModel
+TestModel.__test__ = False
+
+
 DEF_RESULT = """{
     "action": "Update",
     "action_input": "The PydanticOutputParser class is powerful",


### PR DESCRIPTION
Fixes a pytest collection warning because the test class starts with the prefix "Test"
