### PR TITLE
Suppress duckdb warning in unit tests explicitly

### DIFF
--- a/tests/unit_tests/test_sql_database_schema.py
+++ b/tests/unit_tests/test_sql_database_schema.py
@@ -3,6 +3,7 @@
 
 Using DuckDB as SQLite does not support schemas.
 """
+import pytest
 
 from sqlalchemy import (
     Column,
@@ -50,8 +51,8 @@ def test_table_info() -> None:
     output = db.table_info
     expected_output = """
     CREATE TABLE schema_a."user" (
-        user_id INTEGER NOT NULL, 
-        user_name VARCHAR NOT NULL, 
+        user_id INTEGER NOT NULL,
+        user_name VARCHAR NOT NULL,
         PRIMARY KEY (user_id)
     )
     /*
@@ -70,7 +71,21 @@ def test_sql_database_run() -> None:
     stmt = insert(user).values(user_id=13, user_name="Harrison")
     with engine.begin() as conn:
         conn.execute(stmt)
-    db = SQLDatabase(engine, schema="schema_a")
+
+    with pytest.warns(Warning) as records:
+        db = SQLDatabase(engine, schema="schema_a")
+
+    # Metadata creation with duckdb raises a warning at the moment about reflection.
+    # As a stop-gap to increase strictness of pytest to fail on warnings, we'll
+    # explicitly catch the warning and assert that it's the one we expect.
+    # We may need to revisit at a later stage and determine why a warning is being
+    # raised here.
+    assert len(records) == 1
+    assert (
+        records[0].message.args[0]
+        == "duckdb-engine doesn't yet support reflection on indices"
+    )
+
     command = 'select user_name from "user" where user_id = 13'
     output = db.run(command)
     expected_output = "[('Harrison',)]"

--- a/tests/unit_tests/test_sql_database_schema.py
+++ b/tests/unit_tests/test_sql_database_schema.py
@@ -81,6 +81,7 @@ def test_sql_database_run() -> None:
     # We may need to revisit at a later stage and determine why a warning is being
     # raised here.
     assert len(records) == 1
+    assert isinstance(records[0].message, Warning)
     assert (
         records[0].message.args[0]
         == "duckdb-engine doesn't yet support reflection on indices"


### PR DESCRIPTION
This catches the warning raised when using duckdb, asserts that it's as
expected.

The goal is to resolve all existing warnings to make unit-testing much
stricter.
