### PR TITLE
Fix Chroma integration failing when there are less than 4 items in the collection

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -111,7 +111,7 @@ class Chroma(VectorStore):
                 return self._collection.query(
                     query_texts=query_texts,
                     query_embeddings=query_embeddings,
-                    n_results=n_results,
+                    n_results=i,
                     where=where,
                 )
             except chromadb.errors.NotEnoughElementsException:


### PR DESCRIPTION
The code was failing to decrement the `n_results` kwarg passed to `query(...)`