### PR TITLE
Fix for redis LLM cache not persisting between sessions

### DIFF
--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -1,4 +1,5 @@
 """Beta Feature: base interface for cache."""
+import hashlib
 import json
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
@@ -132,7 +133,8 @@ class RedisCache(BaseCache):
 
     def _key(self, prompt: str, llm_string: str, idx: int) -> str:
         """Compute key from prompt, llm_string, and idx."""
-        return str(hash(prompt + llm_string)) + "_" + str(idx)
+        hashed_value = hashlib.sha1((prompt + llm_string).encode("utf-8")).hexdigest()
+        return f"{hashed_value}_{idx}"
 
     def lookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
         """Look up based on prompt and llm_string."""

--- a/tests/integration_tests/cache/test_redis_cache.py
+++ b/tests/integration_tests/cache/test_redis_cache.py
@@ -1,0 +1,19 @@
+import pytest
+
+import langchain
+from langchain.cache import RedisCache
+from tests.integration_tests.cache.test_gptcache import basic_llm_caching_behavior
+
+try:
+    from redis import Redis
+
+    redis_installed = True
+except ImportError:
+    redis_installed = False
+
+
+@pytest.mark.skipif(not redis_installed, reason="redis not installed")
+def test_redis_caching() -> None:
+    """Test Redis LLM caching."""
+    langchain.llm_cache = langchain.llm_cache = RedisCache(redis_=Redis())
+    basic_llm_caching_behavior()


### PR DESCRIPTION
This is due to python hash randomization. Python's `hash` function uses a random seed which is set on startup.
It is enabled by default in Python 3.3 and up.
See: https://stackoverflow.com/questions/27522626/hash-function-in-python-3-3-returns-different-results-between-sessions

This causes the Redis cache keys to vary depending on the session- making it so that there are no cache hits for a subsequent session.

We can use a deterministic hash function instead, like `hashlib.sha1`