### PR TITLE
Replace custom parser with regex in parse function for conversational…

### DIFF
--- a/langchain/agents/conversational_chat/output_parser.py
+++ b/langchain/agents/conversational_chat/output_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Union
 
 from langchain.agents import AgentOutputParser
@@ -14,18 +15,29 @@ class ConvoOutputParser(AgentOutputParser):
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         cleaned_output = text.strip()
-        if "```json" in cleaned_output:
-            _, cleaned_output = cleaned_output.split("```json")
-        if "```" in cleaned_output:
-            cleaned_output, _ = cleaned_output.split("```")
-        if cleaned_output.startswith("```json"):
-            cleaned_output = cleaned_output[len("```json") :]
-        if cleaned_output.startswith("```"):
-            cleaned_output = cleaned_output[len("```") :]
-        if cleaned_output.endswith("```"):
-            cleaned_output = cleaned_output[: -len("```")]
-        cleaned_output = cleaned_output.strip()
-        response = json.loads(cleaned_output)
+
+        action_pattern = r'"action":\s*"([^"]*)"'
+        action_input_pattern = r'"action_input":\s*"([^"]*)"'
+
+        action_match = re.search(action_pattern, cleaned_output)
+        action_input_match = re.search(action_input_pattern, cleaned_output)
+
+        try:
+            if action_match is None or action_input_match is None:
+                raise ValueError(
+                    "Failed to parse values from the LLM output: ", cleaned_output
+                )
+
+            action = action_match.group(1)
+            action_input = action_input_match.group(1)
+
+            parsed = {"action": action, "action_input": action_input}
+            parsed_output = json.dumps(parsed)
+
+        except AttributeError:
+            print("Failed to parse LLM output: ", cleaned_output)
+
+        response = json.loads(parsed_output)
         action, action_input = response["action"], response["action_input"]
         if action == "Final Answer":
             return AgentFinish({"output": action_input}, text)


### PR DESCRIPTION
**_BUG:_**

The output_parser of conversational_chat agent has a parse function that tries to split LLM output string for parsing and extracting "action" and "action_input":
```
class ConvoOutputParser(AgentOutputParser):
    def get_format_instructions(self) -> str:
        return FORMAT_INSTRUCTIONS

    def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
        cleaned_output = text.strip()
        if "```json" in cleaned_output:
            _, cleaned_output = cleaned_output.split("```json")
        if "```" in cleaned_output:
            cleaned_output, _ = cleaned_output.split("```")
        if cleaned_output.startswith("```json"):
            cleaned_output = cleaned_output[len("```json") :]
        if cleaned_output.startswith("```"):
            cleaned_output = cleaned_output[len("```") :]
        if cleaned_output.endswith("```"):
            cleaned_output = cleaned_output[: -len("```")]
        
        cleaned_output = cleaned_output.strip()
        response = json.loads(cleaned_output)
        action, action_input = response["action"], response["action_input"]
        if action == "Final Answer":
            return AgentFinish({"output": action_input}, text)
        else:
            return AgentAction(action, action_input, text)


```
However, when the output of LLM does not contain ```, current parser cannot extract "action" and "action_input" information. Thus, it gives an error: 

`JSONDecodeError: Expecting value: line 1 column 1 (char 0)
`

There are also open [issues](https://github.com/hwchase17/langchain/issues/2488) related to this bug.

**_Contribution:_**

I change the way that parse function try to extract "action" and "action_input" information. Instead of using splitting the entire string, regex is used to directly extract "action" and "action_input". After extracted these information, they will be put in a json format thus the working scheme of the parse function is not changed. If the information cannot be extracted, function throws an exception error.
```

class ConvoOutputParser(AgentOutputParser):
    def get_format_instructions(self) -> str:
        return FORMAT_INSTRUCTIONS

    def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
        cleaned_output = text.strip()

        action_pattern = r'"action":\s*"([^"]*)"'
        action_input_pattern = r'"action_input":\s*"([^"]*)"'

        action_match = re.search(action_pattern, cleaned_output)
        action_input_match = re.search(action_input_pattern, cleaned_output)

        try:
            if action_match is None or action_input_match is None:
                raise ValueError(
                    "Failed to parse values from the LLM output: ", cleaned_output
                )

            action = action_match.group(1)
            action_input = action_input_match.group(1)

            parsed = {"action": action, "action_input": action_input}
            parsed_output = json.dumps(parsed)

        except AttributeError:
            print("Failed to parse LLM output: ", cleaned_output)

        response = json.loads(parsed_output)
        action, action_input = response["action"], response["action_input"]
        if action == "Final Answer":
            return AgentFinish({"output": action_input}, text)
        else:
            return AgentAction(action, action_input, text)

```

