### PR TITLE
Fix: Updated links for in depth explanation of chain types in the Question Answering notebooks

### DIFF
--- a/docs/modules/chains/index_examples/qa_with_sources.ipynb
+++ b/docs/modules/chains/index_examples/qa_with_sources.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Question Answering with Sources\n",
     "\n",
-    "This notebook walks through how to use LangChain for question answering with sources over a list of documents. It covers four different chain types: `stuff`, `map_reduce`, `refine`,`map-rerank`. For a more in depth explanation of what these chain types are, see [here](../combine_docs.md)."
+    "This notebook walks through how to use LangChain for question answering with sources over a list of documents. It covers four different chain types: `stuff`, `map_reduce`, `refine`,`map-rerank`. For a more in depth explanation of what these chain types are, see [here](https://docs.langchain.com/docs/components/chains/index_related_chains)."
    ]
   },
   {

--- a/docs/modules/chains/index_examples/question_answering.ipynb
+++ b/docs/modules/chains/index_examples/question_answering.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Question Answering\n",
     "\n",
-    "This notebook walks through how to use LangChain for question answering over a list of documents. It covers four different types of chains: `stuff`, `map_reduce`, `refine`, `map_rerank`. For a more in depth explanation of what these chain types are, see [here](../combine_docs.md)."
+    "This notebook walks through how to use LangChain for question answering over a list of documents. It covers four different types of chains: `stuff`, `map_reduce`, `refine`, `map_rerank`. For a more in depth explanation of what these chain types are, see [here](https://docs.langchain.com/docs/components/chains/index_related_chains)."
    ]
   },
   {


### PR DESCRIPTION
In the notebook question_answering.ipynb ([link](https://github.com/hwchase17/langchain/blob/master/docs/modules/chains/index_examples/question_answering.ipynb)), and the notebook qa_with_sources.ipynb ([link](https://github.com/hwchase17/langchain/blob/master/docs/modules/chains/index_examples/qa_with_sources.ipynb)), the first paragraph contains a dead link:

> This notebook walks through how to use LangChain for question answering over a list of documents. It covers four different types of chains: stuff, map_reduce, refine, map_rerank. For a more in depth explanation of what these chain types are, see [here](https://github.com/hwchase17/langchain/blob/32793f94fd6da0bb36311e1af4051f7883dd12c5/docs/modules/chains/combine_docs.md).

The file combine_docs.md doesn't exist anymore and thus provide 404 - Page not found.

I updated the links so it redirect to https://docs.langchain.com/docs/components/chains/index_related_chains as in the summarize notebook ([link](https://github.com/hwchase17/langchain/blob/master/docs/modules/chains/index_examples/summarize.ipynb)) present in the same folder.