### PR TITLE
fix: :bug: SQLAlchemy import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ langchain-server = "langchain.server:main"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 pydantic = "^1"
-SQLAlchemy = ">1.3,<3"
+SQLAlchemy = ">1.4,<3"
 requests = "^2"
 PyYAML = ">=5.4.1"
 numpy = "^1"


### PR DESCRIPTION
During the import of langchain, SQLAlchemy was throeing an errror `ImportError: cannot import name 'Mapped' from 'sqlalchemy.orm'`. This is becaue the Mapped name was introduced in v1.4