### PR TITLE
correct the llm type of AzureOpenAI

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -584,6 +584,10 @@ class AzureOpenAI(BaseOpenAI):
     def _invocation_params(self) -> Dict[str, Any]:
         return {**{"engine": self.deployment_name}, **super()._invocation_params}
 
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "azure"
 
 class OpenAIChat(BaseLLM):
     """Wrapper around OpenAI Chat large language models.

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -589,6 +589,7 @@ class AzureOpenAI(BaseOpenAI):
         """Return type of llm."""
         return "azure"
 
+
 class OpenAIChat(BaseLLM):
     """Wrapper around OpenAI Chat large language models.
 


### PR DESCRIPTION
The llm type of AzureOpenAI was previously set to default, which is openai. But since AzureOpenAI has different API from openai, it creates problems when doing chain saving and loading. This PR corrected the llm type of AzureOpenAI to "azure"