### PR TITLE
Confluence: Add page status filter for spaces

### DIFF
--- a/langchain/document_loaders/confluence.py
+++ b/langchain/document_loaders/confluence.py
@@ -156,7 +156,7 @@ class ConfluenceLoader(BaseLoader):
         page_ids: Optional[List[str]] = None,
         label: Optional[str] = None,
         cql: Optional[str] = None,
-        status: Optional[str] = "current",
+        include_archived_content: bool = False,
         include_attachments: bool = False,
         include_comments: bool = False,
         limit: Optional[int] = 50,
@@ -171,8 +171,8 @@ class ConfluenceLoader(BaseLoader):
         :type label: Optional[str], optional
         :param cql: CQL Expression, defaults to None
         :type cql: Optional[str], optional
-        :param status: Page status to filter in a space, defaults to current
-        :type status: str, optional
+        :param include_archived_content: Whether to include archived content, defaults to False
+        :type include_archived_content: bool, optional
         :param include_attachments: defaults to False
         :type include_attachments: bool, optional
         :param include_comments: defaults to False
@@ -200,7 +200,7 @@ class ConfluenceLoader(BaseLoader):
                 space=space_key,
                 limit=limit,
                 max_pages=max_pages,
-                status=status,
+                status="any" if include_archived_content else "current",
                 expand="body.storage.value",
             )
             for page in pages:
@@ -225,6 +225,7 @@ class ConfluenceLoader(BaseLoader):
                 cql=cql,
                 limit=limit,
                 max_pages=max_pages,
+                include_archived_spaces=include_archived_content,
                 expand="body.storage.value",
             )
             for page in pages:

--- a/langchain/document_loaders/confluence.py
+++ b/langchain/document_loaders/confluence.py
@@ -171,7 +171,8 @@ class ConfluenceLoader(BaseLoader):
         :type label: Optional[str], optional
         :param cql: CQL Expression, defaults to None
         :type cql: Optional[str], optional
-        :param include_archived_content: Whether to include archived content, defaults to False
+        :param include_archived_content: Whether to include archived content,
+                                         defaults to False
         :type include_archived_content: bool, optional
         :param include_attachments: defaults to False
         :type include_attachments: bool, optional

--- a/langchain/document_loaders/confluence.py
+++ b/langchain/document_loaders/confluence.py
@@ -156,6 +156,7 @@ class ConfluenceLoader(BaseLoader):
         page_ids: Optional[List[str]] = None,
         label: Optional[str] = None,
         cql: Optional[str] = None,
+        status: Optional[str] = "current",
         include_attachments: bool = False,
         include_comments: bool = False,
         limit: Optional[int] = 50,
@@ -170,6 +171,8 @@ class ConfluenceLoader(BaseLoader):
         :type label: Optional[str], optional
         :param cql: CQL Expression, defaults to None
         :type cql: Optional[str], optional
+        :param status: Page status to filter in a space, defaults to current
+        :type status: str, optional
         :param include_attachments: defaults to False
         :type include_attachments: bool, optional
         :param include_comments: defaults to False
@@ -197,6 +200,7 @@ class ConfluenceLoader(BaseLoader):
                 space=space_key,
                 limit=limit,
                 max_pages=max_pages,
+                status=status,
                 expand="body.storage.value",
             )
             for page in pages:


### PR DESCRIPTION
At the moment all content in Confluence is retrieved by default, including archived content.

Often, this is undesired as the content is not relevant anymore.

**Notes**
Fetching pages by label does not support excluding archived content. This may lead to unexpected results.