### PR TITLE
Add `Stripe` document loader

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/stripe.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/stripe.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stripe\n",
+    "\n",
+    "This notebook covers how to load data from the Stripe REST API into a format that can be ingested into LangChain, along with example usage for vectorization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "\n",
+    "from langchain.document_loaders.stripe import StripeLoader\n",
+    "from langchain.indexes import VectorstoreIndexCreator"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Stripe API requires an access token, which can be found inside of the Stripe dashboard.\n",
+    "\n",
+    "This document loader also requires a `resource` option which defines what data you want to load.\n",
+    "\n",
+    "Following resources are available:\n",
+    "\n",
+    "`balance_transations` (Documentation)[https://stripe.com/docs/api/balance_transactions/list]\n",
+    "`charges` (Documentation)[https://stripe.com/docs/api/charges/list]\n",
+    "`customers` (Documentation)[https://stripe.com/docs/api/customers/list]\n",
+    "`events` (Documentation)[https://stripe.com/docs/api/events/list]\n",
+    "`refunds` (Documentation)[https://stripe.com/docs/api/refunds/list]\n",
+    "`disputes` (Documentation)[https://stripe.com/docs/api/disputes/list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stripe_loader = StripeLoader(os.environ[\"STRIPE_ACCESS_TOKEN\"], \"charges\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a vectorstore retriver from the loader\n",
+    "# see https://python.langchain.com/en/latest/modules/indexes/getting_started.html for more details\n",
+    "\n",
+    "index = VectorstoreIndexCreator().from_loaders([stripe_loader])\n",
+    "stripe_doc_retriever = index.vectorstore.as_retriever()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/langchain/document_loaders/stripe.py
+++ b/langchain/document_loaders/stripe.py
@@ -1,0 +1,60 @@
+"""Loader that fetches data from Stripe"""
+import json
+import urllib.request
+from typing import Any, List
+
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseLoader
+
+
+STRIPE_ENDPOINTS = {
+    "balance_transactions": "https://api.stripe.com/v1/balance_transactions",
+    "charges": "https://api.stripe.com/v1/charges",
+    "customers": "https://api.stripe.com/v1/customers",
+    "events": "https://api.stripe.com/v1/events",
+    "refunds": "https://api.stripe.com/v1/refunds",
+    "disputes": "https://api.stripe.com/v1/disputes"
+}
+
+
+def _stringify_value(val: Any) -> str:
+    if isinstance(val, str):
+        return val
+    elif isinstance(val, dict):
+        return "\n" + _stringify_dict(val)
+    elif isinstance(val, list):
+        return "\n".join(_stringify_value(v) for v in val)
+    else:
+        return str(val)
+
+
+def _stringify_dict(data: dict) -> str:
+    text = ""
+    for key, value in data.items():
+        text += key + ": " + _stringify_value(value) + "\n"
+    return text
+
+
+class StripeLoader(BaseLoader):
+    def __init__(self, access_token: str, resource: str) -> None:
+        self.access_token = access_token
+        self.resource = resource
+        self.headers = {"Authorization": f"Bearer {self.access_token}"}
+           
+    def _make_request(self, url: str) -> List[Document]:
+        request = urllib.request.Request(url, headers=self.headers)
+        
+        with urllib.request.urlopen(request) as response:
+            json_data = json.loads(response.read().decode())
+            text = _stringify_dict(json_data)
+            metadata = {"source": url}
+            return [Document(page_content=text, metadata=metadata)]
+        
+    def _get_resource(self) -> List[Document]:
+        endpoint = STRIPE_ENDPOINTS.get(self.resource)
+        if endpoint is None:
+            return []
+        return self._make_request(endpoint)
+    
+    def load(self) -> List[Document]:
+        return self._get_resource()

--- a/langchain/document_loaders/stripe.py
+++ b/langchain/document_loaders/stripe.py
@@ -6,14 +6,13 @@ from typing import Any, List
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
-
 STRIPE_ENDPOINTS = {
     "balance_transactions": "https://api.stripe.com/v1/balance_transactions",
     "charges": "https://api.stripe.com/v1/charges",
     "customers": "https://api.stripe.com/v1/customers",
     "events": "https://api.stripe.com/v1/events",
     "refunds": "https://api.stripe.com/v1/refunds",
-    "disputes": "https://api.stripe.com/v1/disputes"
+    "disputes": "https://api.stripe.com/v1/disputes",
 }
 
 
@@ -40,21 +39,21 @@ class StripeLoader(BaseLoader):
         self.access_token = access_token
         self.resource = resource
         self.headers = {"Authorization": f"Bearer {self.access_token}"}
-           
+
     def _make_request(self, url: str) -> List[Document]:
         request = urllib.request.Request(url, headers=self.headers)
-        
+
         with urllib.request.urlopen(request) as response:
             json_data = json.loads(response.read().decode())
             text = _stringify_dict(json_data)
             metadata = {"source": url}
             return [Document(page_content=text, metadata=metadata)]
-        
+
     def _get_resource(self) -> List[Document]:
         endpoint = STRIPE_ENDPOINTS.get(self.resource)
         if endpoint is None:
             return []
         return self._make_request(endpoint)
-    
+
     def load(self) -> List[Document]:
         return self._get_resource()

--- a/tests/integration_tests/document_loaders/test_stripe.py
+++ b/tests/integration_tests/document_loaders/test_stripe.py
@@ -1,8 +1,8 @@
 from langchain.document_loaders.stripe import StripeLoader
 
-
 access_token = ""
 resource = "charges"
+
 
 def test_stripe_loader() -> None:
     """Test Figma file loader."""

--- a/tests/integration_tests/document_loaders/test_stripe.py
+++ b/tests/integration_tests/document_loaders/test_stripe.py
@@ -8,6 +8,5 @@ def test_stripe_loader() -> None:
     """Test Figma file loader."""
     stripe_loader = StripeLoader(access_token, resource)
     documents = stripe_loader.load()
-    print(documents)
 
     assert len(documents) == 1

--- a/tests/integration_tests/document_loaders/test_stripe.py
+++ b/tests/integration_tests/document_loaders/test_stripe.py
@@ -1,0 +1,13 @@
+from langchain.document_loaders.stripe import StripeLoader
+
+
+access_token = ""
+resource = "charges"
+
+def test_stripe_loader() -> None:
+    """Test Figma file loader."""
+    stripe_loader = StripeLoader(access_token, resource)
+    documents = stripe_loader.load()
+    print(documents)
+
+    assert len(documents) == 1


### PR DESCRIPTION
## Summary
This PR adds a document loader for `Stripe`. 
It utilizes the `Stripe` REST Api without using any official or unofficial wrappers to keep the loader dependency free.

## Usage

```
import os

from langchain.document_loaders.stripe import StripeLoader
from langchain.indexes import VectorstoreIndexCreator


stripe_loader = StripeLoader(os.environ["STRIPE_ACCESS_TOKEN"], "charges")
index = VectorstoreIndexCreator().from_loaders([stripe_loader])
stripe_doc_retriever = index.vectorstore.as_retriever()
```