### PR TITLE
[annotation] Updated arg types in llmchain & extraction logics.

### DIFF
--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -13,6 +13,7 @@ from langchain.schema import BaseLanguageModel, LLMResult, PromptValue
 
 TLLMChainInitKwargs = Any
 
+
 class LLMChain(Chain):
     """Chain to run queries against LLMs.
 
@@ -167,7 +168,9 @@ class LLMChain(Chain):
         """
         return (await self.acall(kwargs))[self.output_key]
 
-    def predict_and_parse(self, **kwargs: TLLMChainInitKwargs) -> Union[str, List[str], Dict[str, str]]:
+    def predict_and_parse(
+        self, **kwargs: TLLMChainInitKwargs
+    ) -> Union[str, List[str], Dict[str, str]]:
         """Call predict and then parse the results."""
         result = self.predict(**kwargs)
         if self.prompt.output_parser is not None:

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -11,6 +11,7 @@ from langchain.prompts.base import BasePromptTemplate
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import BaseLanguageModel, LLMResult, PromptValue
 
+TLLMChainInitKwargs = Any
 
 class LLMChain(Chain):
     """Chain to run queries against LLMs.
@@ -134,7 +135,7 @@ class LLMChain(Chain):
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, str]:
         return (await self.aapply([inputs]))[0]
 
-    def predict(self, **kwargs: Any) -> str:
+T    def predict(self, **kwargs: TLLMChainInitKwargs) -> str:
         """Format prompt with kwargs and pass to LLM.
 
         Args:
@@ -150,7 +151,7 @@ class LLMChain(Chain):
         """
         return self(kwargs)[self.output_key]
 
-    async def apredict(self, **kwargs: Any) -> str:
+T    async def apredict(self, **kwargs: TLLMChainInitKwargs) -> str:
         """Format prompt with kwargs and pass to LLM.
 
         Args:
@@ -166,7 +167,7 @@ class LLMChain(Chain):
         """
         return (await self.acall(kwargs))[self.output_key]
 
-    def predict_and_parse(self, **kwargs: Any) -> Union[str, List[str], Dict[str, str]]:
+T    def predict_and_parse(self, **kwargs: TLLMChainInitKwargs) -> Union[str, List[str], Dict[str, str]]:
         """Call predict and then parse the results."""
         result = self.predict(**kwargs)
         if self.prompt.output_parser is not None:
@@ -175,7 +176,7 @@ class LLMChain(Chain):
             return result
 
     async def apredict_and_parse(
-        self, **kwargs: Any
+T        self, **kwargs: TLLMChainInitKwargs
     ) -> Union[str, List[str], Dict[str, str]]:
         """Call apredict and then parse the results."""
         result = await self.apredict(**kwargs)

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -135,7 +135,7 @@ class LLMChain(Chain):
     async def _acall(self, inputs: Dict[str, Any]) -> Dict[str, str]:
         return (await self.aapply([inputs]))[0]
 
-T    def predict(self, **kwargs: TLLMChainInitKwargs) -> str:
+    def predict(self, **kwargs: TLLMChainInitKwargs) -> str:
         """Format prompt with kwargs and pass to LLM.
 
         Args:
@@ -151,7 +151,7 @@ T    def predict(self, **kwargs: TLLMChainInitKwargs) -> str:
         """
         return self(kwargs)[self.output_key]
 
-T    async def apredict(self, **kwargs: TLLMChainInitKwargs) -> str:
+    async def apredict(self, **kwargs: TLLMChainInitKwargs) -> str:
         """Format prompt with kwargs and pass to LLM.
 
         Args:
@@ -167,7 +167,7 @@ T    async def apredict(self, **kwargs: TLLMChainInitKwargs) -> str:
         """
         return (await self.acall(kwargs))[self.output_key]
 
-T    def predict_and_parse(self, **kwargs: TLLMChainInitKwargs) -> Union[str, List[str], Dict[str, str]]:
+    def predict_and_parse(self, **kwargs: TLLMChainInitKwargs) -> Union[str, List[str], Dict[str, str]]:
         """Call predict and then parse the results."""
         result = self.predict(**kwargs)
         if self.prompt.output_parser is not None:
@@ -176,7 +176,7 @@ T    def predict_and_parse(self, **kwargs: TLLMChainInitKwargs) -> Union[str, Li
             return result
 
     async def apredict_and_parse(
-T        self, **kwargs: TLLMChainInitKwargs
+        self, **kwargs: TLLMChainInitKwargs
     ) -> Union[str, List[str], Dict[str, str]]:
         """Call apredict and then parse the results."""
         result = await self.apredict(**kwargs)

--- a/langchain/retrievers/document_compressors/chain_extract.py
+++ b/langchain/retrievers/document_compressors/chain_extract.py
@@ -1,7 +1,7 @@
 """DocumentFilter that uses an LLM chain to extract the relevant parts of documents."""
 from typing import Any, Callable, Dict, Optional, Sequence
 
-from langchain import LLMChain, PromptTemplate
+from langchain import LLMChain, PromptTemplate, TLLMChainInitKwargs
 from langchain.retrievers.document_compressors.base import (
     BaseDocumentCompressor,
 )
@@ -11,7 +11,7 @@ from langchain.retrievers.document_compressors.chain_extract_prompt import (
 from langchain.schema import BaseLanguageModel, BaseOutputParser, Document
 
 
-def default_get_input(query: str, doc: Document) -> Dict[str, Any]:
+def default_get_input(query: str, doc: Document) -> TLLMChainInitKwargs:
     """Return the compression chain input."""
     return {"question": query, "context": doc.page_content}
 
@@ -38,11 +38,14 @@ def _get_default_chain_prompt() -> PromptTemplate:
     )
 
 
+TQuery = str
+TConvQueryDocToLLMChainKwargs = Callable[[Query, Document], TLLMChainInitKwargs]
+
 class LLMChainExtractor(BaseDocumentCompressor):
     llm_chain: LLMChain
     """LLM wrapper to use for compressing documents."""
 
-    get_input: Callable[[str, Document], dict] = default_get_input
+    get_input: TConvQueryDocToLLMChainKwargs = default_get_input
     """Callable for constructing the chain input from the query and a Document."""
 
     def compress_documents(

--- a/langchain/retrievers/document_compressors/chain_extract.py
+++ b/langchain/retrievers/document_compressors/chain_extract.py
@@ -1,5 +1,7 @@
 """DocumentFilter that uses an LLM chain to extract the relevant parts of documents."""
-from typing import Any, Callable, Dict, Optional, Sequence
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence
 
 from langchain import LLMChain, PromptTemplate
 from langchain.chains.llm import TLLMChainInitKwargs

--- a/langchain/retrievers/document_compressors/chain_extract.py
+++ b/langchain/retrievers/document_compressors/chain_extract.py
@@ -1,7 +1,8 @@
 """DocumentFilter that uses an LLM chain to extract the relevant parts of documents."""
 from typing import Any, Callable, Dict, Optional, Sequence
 
-from langchain import LLMChain, PromptTemplate, TLLMChainInitKwargs
+from langchain import LLMChain, PromptTemplate
+from langchain.chains.llm import TLLMChainInitKwargs
 from langchain.retrievers.document_compressors.base import (
     BaseDocumentCompressor,
 )
@@ -39,7 +40,7 @@ def _get_default_chain_prompt() -> PromptTemplate:
 
 
 TQuery = str
-TConvQueryDocToLLMChainKwargs = Callable[[Query, Document], TLLMChainInitKwargs]
+TConvQueryDocToLLMChainKwargs = Callable[[TQuery, Document], TLLMChainInitKwargs]
 
 class LLMChainExtractor(BaseDocumentCompressor):
     llm_chain: LLMChain
@@ -72,7 +73,7 @@ class LLMChainExtractor(BaseDocumentCompressor):
         llm: BaseLanguageModel,
         prompt: Optional[PromptTemplate] = None,
         get_input: Optional[Callable[[str, Document], str]] = None,
-    ) -> "LLMChainExtractor":
+    ) -> LLMChainExtractor:
         """Initialize from LLM."""
         _prompt = prompt if prompt is not None else _get_default_chain_prompt()
         _get_input = get_input if get_input is not None else default_get_input

--- a/langchain/retrievers/document_compressors/chain_extract.py
+++ b/langchain/retrievers/document_compressors/chain_extract.py
@@ -42,6 +42,7 @@ def _get_default_chain_prompt() -> PromptTemplate:
 TQuery = str
 TConvQueryDocToLLMChainKwargs = Callable[[TQuery, Document], TLLMChainInitKwargs]
 
+
 class LLMChainExtractor(BaseDocumentCompressor):
     llm_chain: LLMChain
     """LLM wrapper to use for compressing documents."""


### PR DESCRIPTION
We have `Kwargs` and `Any` in many places. It’s not easy for new people (like myself) to understand which is pointing to which, so that it’s hard to figure out which key<>value pair to set up. In this PR, 
- it explicitly pointed out the target usage of Kwargs is for LLMChain init usage, esp. when it’s used outside of the LLMChain main file.
- also make the input function type easier to read as so many keys and variables are str…
please lmk if this makes sense. Thank you.