### PR TITLE
Refactoring `BaseChatMessageHistory` [wip]

### DIFF
--- a/langchain/memory/chat_message_histories/file.py
+++ b/langchain/memory/chat_message_histories/file.py
@@ -27,6 +27,7 @@ class FileChatMessageHistory(BaseChatMessageHistory):
     """
 
     file_path: Path
+    legacy: bool = False
 
     @validator('file_path')
     def initialize_file_path(cls, value) -> Path:

--- a/langchain/memory/chat_message_histories/file.py
+++ b/langchain/memory/chat_message_histories/file.py
@@ -3,6 +3,8 @@ import logging
 from pathlib import Path
 from typing import List
 
+from pydantic import validator
+
 from langchain.schema import (
     AIMessage,
     BaseChatMessageHistory,
@@ -10,6 +12,7 @@ from langchain.schema import (
     HumanMessage,
     messages_from_dict,
     messages_to_dict,
+    MessageLog
 )
 
 logger = logging.getLogger(__name__)
@@ -23,31 +26,37 @@ class FileChatMessageHistory(BaseChatMessageHistory):
         file_path: path of the local file to store the messages.
     """
 
-    def __init__(self, file_path: str):
-        self.file_path = Path(file_path)
+    file_path: Path
+
+    @validator('file_path', pre=True)
+    def initialize_file_path(cls, value) -> Path:
+        if type(value) == str:
+            file_path = Path(value)
+
+        if not file_path.exists():
+            file_path.touch()
+            file_path.write_text(json.dumps([]))  
+        
+        return file_path
+
+    def load_message_logs(self) -> List[MessageLog]:
         if not self.file_path.exists():
             self.file_path.touch()
             self.file_path.write_text(json.dumps([]))
+            return []
 
-    @property
-    def messages(self) -> List[BaseMessage]:  # type: ignore
-        """Retrieve the messages from the local file"""
-        items = json.loads(self.file_path.read_text())
-        messages = messages_from_dict(items)
-        return messages
-
-    def add_user_message(self, message: str) -> None:
-        self.append(HumanMessage(content=message))
-
-    def add_ai_message(self, message: str) -> None:
-        self.append(AIMessage(content=message))
-
-    def append(self, message: BaseMessage) -> None:
-        """Append the message to the record in the local file"""
-        messages = messages_to_dict(self.messages)
-        messages.append(messages_to_dict([message])[0])
-        self.file_path.write_text(json.dumps(messages))
-
-    def clear(self) -> None:
-        """Clear session memory from the local file"""
+        else:
+           items = json.loads(self.file_path.read_text())
+           message_logs = [MessageLog(**item) for item in items]
+           return message_logs
+    
+    def save_message_log(self, message_log: MessageLog) -> None:
+        current_message_logs = self.load_message_logs()
+        current_message_logs.append(message_log)
+        current_message_logs = [i.json() for i in current_message_logs]
+        # NOTE: Maybe we should just use JSONL?
+        current_message_logs = ",".join(current_message_logs)
+        self.file_path.write_text('[' + current_message_logs + ']')
+    
+    def _clear(self) -> None:
         self.file_path.write_text(json.dumps([]))

--- a/langchain/memory/chat_message_histories/file.py
+++ b/langchain/memory/chat_message_histories/file.py
@@ -28,10 +28,13 @@ class FileChatMessageHistory(BaseChatMessageHistory):
 
     file_path: Path
 
-    @validator('file_path', pre=True)
+    @validator('file_path')
     def initialize_file_path(cls, value) -> Path:
         if type(value) == str:
             file_path = Path(value)
+        
+        else:
+            file_path = value
 
         if not file_path.exists():
             file_path.touch()

--- a/langchain/memory/chat_message_histories/in_memory.py
+++ b/langchain/memory/chat_message_histories/in_memory.py
@@ -7,17 +7,18 @@ from langchain.schema import (
     BaseChatMessageHistory,
     BaseMessage,
     HumanMessage,
+    MessageLog
 )
 
+class ChatMessageHistory(BaseChatMessageHistory):
+    def load_message_logs(self) -> List[MessageLog]:
+        # No database to load from
+        return []
+    
+    def save_message_log(self, message_log: MessageLog) -> None:
+        # No database to save to
+        return None
 
-class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
-    messages: List[BaseMessage] = []
-
-    def add_user_message(self, message: str) -> None:
-        self.messages.append(HumanMessage(content=message))
-
-    def add_ai_message(self, message: str) -> None:
-        self.messages.append(AIMessage(content=message))
-
-    def clear(self) -> None:
-        self.messages = []
+    def _clear(self) -> None:
+        # We have no database
+        return None

--- a/langchain/memory/chat_message_histories/postgres.py
+++ b/langchain/memory/chat_message_histories/postgres.py
@@ -1,6 +1,8 @@
 import json
 import logging
-from typing import List
+from typing import List, Dict, Any
+
+from pydantic import root_validator
 
 from langchain.schema import (
     AIMessage,
@@ -9,71 +11,87 @@ from langchain.schema import (
     HumanMessage,
     _message_to_dict,
     messages_from_dict,
+    MessageLog
 )
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONNECTION_STRING = "postgresql://postgres:mypassword@localhost/chat_history"
-
+DEFAULT_CONNECTION_STRING = "postgresql://postgres:mypassword@localhost:5432/"
 
 class PostgresChatMessageHistory(BaseChatMessageHistory):
-    def __init__(
-        self,
-        session_id: str,
-        connection_string: str = DEFAULT_CONNECTION_STRING,
-        table_name: str = "message_store",
-    ):
+
+    connection_string: str = DEFAULT_CONNECTION_STRING
+    table_name: str = "message_store"
+    connection: Any
+    cursor: Any
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
         import psycopg
         from psycopg.rows import dict_row
 
         try:
-            self.connection = psycopg.connect(connection_string)
-            self.cursor = self.connection.cursor(row_factory=dict_row)
+            values["connection"] = psycopg.connect(values["connection_string"])
+            values["cursor"] = values["connection"].cursor(row_factory=dict_row)
         except psycopg.OperationalError as error:
             logger.error(error)
-
-        self.session_id = session_id
-        self.table_name = table_name
-
-        self._create_table_if_not_exists()
-
-    def _create_table_if_not_exists(self) -> None:
-        create_table_query = f"""CREATE TABLE IF NOT EXISTS {self.table_name} (
+        
+        # Create table if not exists
+        create_table_query = f"""CREATE TABLE IF NOT EXISTS {values["table_name"]} (
             id SERIAL PRIMARY KEY,
             session_id TEXT NOT NULL,
-            message JSONB NOT NULL
+            created_at TIMESTAMP NOT NULL,
+            content TEXT NOT NULL,
+            role TEXT NOT NULL,
+            message_type TEXT NOT NULL,
+            extra_variables JSONB 
         );"""
-        self.cursor.execute(create_table_query)
-        self.connection.commit()
+        values["cursor"].execute(create_table_query)
+        values["connection"].commit()
+        return values
 
-    @property
-    def messages(self) -> List[BaseMessage]:  # type: ignore
-        """Retrieve the messages from PostgreSQL"""
-        query = f"SELECT message FROM {self.table_name} WHERE session_id = %s;"
-        self.cursor.execute(query, (self.session_id,))
-        items = [record["message"] for record in self.cursor.fetchall()]
-        messages = messages_from_dict(items)
-        return messages
-
-    def add_user_message(self, message: str) -> None:
-        self.append(HumanMessage(content=message))
-
-    def add_ai_message(self, message: str) -> None:
-        self.append(AIMessage(content=message))
-
-    def append(self, message: BaseMessage) -> None:
+    
+    def save_message_log(self, message_log: MessageLog) -> None:
         """Append the message to the record in PostgreSQL"""
         from psycopg import sql
 
-        query = sql.SQL("INSERT INTO {} (session_id, message) VALUES (%s, %s);").format(
+        extra_vars_json = json.dumps(message_log.extra_variables)
+
+        # Create a SQL query using the psycopg2.sql module
+        query = sql.SQL("""
+            INSERT INTO {} (session_id, created_at, content, role, message_type, extra_variables)
+            VALUES (%s, %s, %s, %s, %s, %s)
+        """).format(
             sql.Identifier(self.table_name)
         )
+
+        # Create a tuple of values to insert into the query
+        values = (
+            message_log.session_id,
+            message_log.created_at,
+            message_log.content,
+            message_log.role,
+            message_log.message_type,
+            extra_vars_json
+        )
+
         self.cursor.execute(
-            query, (self.session_id, json.dumps(_message_to_dict(message)))
+            query, values
         )
         self.connection.commit()
 
-    def clear(self) -> None:
+    def load_message_logs(self) -> List[MessageLog]:
+        """Retrieve the messages from PostgreSQL"""
+        query = f"SELECT * FROM {self.table_name} WHERE session_id = %s;"
+        self.cursor.execute(query, (self.session_id,))
+        records = []
+        for i in self.cursor.fetchall():
+            del i["id"]
+            records.append(i)
+        message_logs = [MessageLog(**i) for i in records]
+        return message_logs
+
+    def _clear(self) -> None:
         """Clear session memory from PostgreSQL"""
         query = f"DELETE FROM {self.table_name} WHERE session_id = %s;"
         self.cursor.execute(query, (self.session_id,))

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -77,15 +77,24 @@ class BaseMessage(BaseModel):
     def type(self) -> str:
         """Type of the message, used for serialization."""
 
-    def to_message_log(self, session_id: str, created_at: Optional[datetime] = None) -> MessageLog:
+    def to_message_log(self, created_at: Optional[datetime] = None) -> MessageLog:
         """Convert BaseMessage to MessageLog"""
-        return MessageLog(
-            session_id=session_id,
-            content=self.content,
-            created_at=created_at,
-            _type=self.type,
-            role=self.type if self.role is None else self.role
-        )
+        if created_at is not None:
+            return MessageLog(
+                content=self.content,
+                created_at=created_at,
+                message_type=self.type,
+                role=self.role if hasattr(self, "role") else self.type,
+                extra_variables=self.additional_kwargs
+            )
+
+        else:
+            return MessageLog(
+                content=self.content,
+                message_type=self.type,
+                role=self.role if hasattr(self, "role") else self.type,
+                extra_variables=self.additional_kwargs
+            ) 
 
 
 class HumanMessage(BaseMessage):

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -15,7 +15,6 @@ from typing import (
 )
 
 from datetime import datetime
-from uuid import uuid4
 
 from pydantic import BaseModel, Extra, Field, root_validator
 
@@ -267,7 +266,6 @@ class BaseMemory(BaseModel, ABC):
         """Clear memory contents."""
 
 class MessageLog(BaseModel):
-    session_id: str
     created_at: datetime = Field(default_factory=datetime.now)
     content: str
     role: str
@@ -330,7 +328,6 @@ class BaseChatMessageHistory(BaseModel, ABC):
     """
 
     messages: List[BaseMessage] = []
-    session_id: str = Field(default_factory=lambda: str(uuid4()))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -352,7 +349,6 @@ class BaseChatMessageHistory(BaseModel, ABC):
     def add_user_message(self, message: str) -> None:
         """Add a user message to the store"""
         message_log = MessageLog(
-            session_id=self.session_id,
             content=message,
             role="human",
             message_type="human"
@@ -363,7 +359,6 @@ class BaseChatMessageHistory(BaseModel, ABC):
     def add_ai_message(self, message: str) -> None:
         """Add an AI message to the store"""
         message_log = MessageLog(
-            session_id=self.session_id,
             content=message,
             role="ai",
             message_type="ai"
@@ -374,7 +369,6 @@ class BaseChatMessageHistory(BaseModel, ABC):
     def add_system_message(self, message: str) -> None:
         """Add an AI message to the store"""
         message_log = MessageLog(
-            session_id=self.session_id,
             content=message,
             role="system",
             message_type="system"

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -334,16 +334,16 @@ class BaseChatMessageHistory(BaseModel, ABC):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.refresh_buffer()
+        self.refresh_cache()
 
-    def _add_to_buffer(self, message: BaseMessage) -> None:
+    def _add_to_cache(self, message: BaseMessage) -> None:
         self.messages.append(message)
 
     def _sort_message_logs(self, message_logs: List[MessageLog]) -> List[MessageLog]:
         # TODO: Test correctness of this sorting logic
         return sorted(message_logs, key=lambda message_log: message_log.created_at)
 
-    def refresh_buffer(self):
+    def refresh_cache(self):
         self.messages = []
         message_logs = self.load_message_logs()
         message_logs = self._sort_message_logs(message_logs)
@@ -358,7 +358,7 @@ class BaseChatMessageHistory(BaseModel, ABC):
             message_type="human"
         )
         self.save_message_log(message_log)
-        self._add_to_buffer(message_log.to_message())
+        self._add_to_cache(message_log.to_message())
 
     def add_ai_message(self, message: str) -> None:
         """Add an AI message to the store"""
@@ -369,7 +369,7 @@ class BaseChatMessageHistory(BaseModel, ABC):
             message_type="ai"
         )
         self.save_message_log(message_log)
-        self._add_to_buffer(message_log.to_message())
+        self._add_to_cache(message_log.to_message())
     
     def add_system_message(self, message: str) -> None:
         """Add an AI message to the store"""
@@ -380,7 +380,7 @@ class BaseChatMessageHistory(BaseModel, ABC):
             message_type="system"
         )
         self.save_message_log(message_log)
-        self._add_to_buffer(message_log.to_message())
+        self._add_to_cache(message_log.to_message())
 
     @abstractmethod
     def save_message_log(self, message_log: MessageLog) -> None:


### PR DESCRIPTION
My attempt at refactoring `BaseChatMessageHistory` and its subclasses. So far I have finished refactoring `FileChatMessageHistory`, `ChatMessageHistory` and `PostgresChatMessageHistory`, would like to ask if my approach is acceptable before proceeding.

Below are some benefits from the refactoring:

## Less boilerplate

Before this, all classes inherited from `BaseChatMessageHistory` need to specify `add_ai_message` and `add_user_message`. Now, user only has to specify the CRUD (actually without update) operation on its underlying database. More specifically, user has to specify `save_message_log`, `load_message_logs` and `_clear` methods when creating new class of chat message history. See refactored class for example.

## Caching

Before this, database backed `BaseChatMessageHistory` will query the underlying database every time `messages` property is accessed. Now read operation is only done once during initialization (or when user choose to `refresh_cache`). `messages` acts as a cache, which will get updated every time new messages are added. All of these are handled by `BaseChatMessageHistory`.

## MessageLog

`MessageLog` is a new Pydantic object that acts as an interface for chat message storage. Each `MessageLog` contains information on one chat mesage. It contains a mandatory field called `created_at`, which is needed for `BaseChatMessageHistory` to ensuring the loaded message logs are in the correct order. It also allows additions of additional fields through `extra_variables`, for example to contain user feedback on particular chat message, number of likes or whatever on a particular chat message.  During conversion from `MessageLog` to `BaseMessage`, MessageLog's `extra_variables` corresponds to BaseMessage's `additional_kwargs`.

The user has full control over how `extra_variables` are stored through `save_message_log` method in `BaseChatMessageHistory`. For example, the user can choose to ignore variables in `extra_variables` and not insert it into database.

## More intuitive (in my subjective opinion) storage format

Before this, list of chat messaages are stored as a raw JSON object in a field of a row (such as in `postgres`). Now, each message has its own row. A list of 5 chat messages, for example, are represented as 5 rows in the SQL-like database.

Doing so comes with one disadvantage. After querying all rows associated with the same `session_id`, you have to sort the messages (using `created_at` field) to ensure the messages are in the correct order. This will increase response time during initialization. 

## Backward-compatibility

No change is applied on existing APIs exposed by `BaseChatMessageHistory`, so all existing code should still work, except in two cases:

1. New `BaseChatMessageHistory` will not be able to read previously persisted chat memory due to additional mandatory fields introduced in `MessageLog` (such as `created_at`), I can probably add a `legacy` field in affected classes to handle reading from old chat messages.
2. Since `BaseChatMessageHistory` is now a Pydantic object. Previous code that initializes with positional arguments will fail.

```python
chat_memory = FileChatMessageHistory("our_conversation.txt") # Error
chat_memory = FileChatMessageHistory(file_path="our_conversation.txt") # OK
```

Thanks for reading! 
