### PR TITLE
added support for blockwise sitemap indexing

### DIFF
--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -1,5 +1,5 @@
 from langchain.document_loaders import SitemapLoader
-
+import pytest
 
 def test_sitemap() -> None:
     """Test sitemap loader."""
@@ -9,11 +9,34 @@ def test_sitemap() -> None:
     assert "🦜🔗" in documents[0].page_content
 
 
+def test_sitemap_block() -> None:
+    """Test sitemap loader."""
+    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1, blocknum=1)
+    documents = loader.load()
+    assert len(documents) == 1
+    assert "🦜🔗" in documents[0].page_content
+
+
+def test_sitemap_block_only_one() -> None:
+    """Test sitemap loader."""
+    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=0)
+    documents = loader.load()
+    assert len(documents) > 1
+    assert "🦜🔗" in documents[0].page_content
+
+
+def test_sitemap_block_does_not_exists() -> None:
+    """Test sitemap loader."""
+    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=15)
+    with pytest.raises(ValueError):
+        documents = loader.load()
+
+
 def test_filter_sitemap() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
         "https://langchain.readthedocs.io/sitemap.xml",
-        filter_urls=["https://langchain.readthedocs.io/en/stable/"],
+        filter_urls=["https://python.langchain.com/en/stable/"],
     )
     documents = loader.load()
     assert len(documents) == 1

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -28,7 +28,7 @@ def test_sitemap_block_only_one() -> None:
 def test_sitemap_block_does_not_exists() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=15)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Selected sitemap does not contain enough blocks for given blocknum"):
         documents = loader.load()
 
 

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -1,5 +1,7 @@
-from langchain.document_loaders import SitemapLoader
 import pytest
+
+from langchain.document_loaders import SitemapLoader
+
 
 def test_sitemap() -> None:
     """Test sitemap loader."""
@@ -11,7 +13,9 @@ def test_sitemap() -> None:
 
 def test_sitemap_block() -> None:
     """Test sitemap loader."""
-    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1, blocknum=1)
+    loader = SitemapLoader(
+        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1, blocknum=1
+    )
     documents = loader.load()
     assert len(documents) == 1
     assert "🦜🔗" in documents[0].page_content
@@ -19,17 +23,52 @@ def test_sitemap_block() -> None:
 
 def test_sitemap_block_only_one() -> None:
     """Test sitemap loader."""
-    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=0)
+    loader = SitemapLoader(
+        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=0
+    )
     documents = loader.load()
     assert len(documents) > 1
     assert "🦜🔗" in documents[0].page_content
 
 
+def test_sitemap_block_blocknum_default() -> None:
+    """Test sitemap loader."""
+    loader = SitemapLoader(
+        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000
+    )
+    documents = loader.load()
+    assert len(documents) > 1
+    assert "🦜🔗" in documents[0].page_content
+
+
+def test_sitemap_block_size_to_small() -> None:
+    """Test sitemap loader."""
+    with pytest.raises(ValueError, match="Sitemap blocksize should be at least 1"):
+        SitemapLoader(
+            "https://langchain.readthedocs.io/sitemap.xml", blocksize=0
+        )
+
+
+def test_sitemap_block_num_to_small() -> None:
+    """Test sitemap loader."""
+    with pytest.raises(ValueError, match="Sitemap blocknum can not be lower then 0"):
+        SitemapLoader(
+            "https://langchain.readthedocs.io/sitemap.xml",
+            blocksize=1000000,
+            blocknum=-1,
+        )
+
+
 def test_sitemap_block_does_not_exists() -> None:
     """Test sitemap loader."""
-    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=15)
-    with pytest.raises(ValueError, match="Selected sitemap does not contain enough blocks for given blocknum"):
-        documents = loader.load()
+    loader = SitemapLoader(
+        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=15
+    )
+    with pytest.raises(
+        ValueError,
+        match="Selected sitemap does not contain enough blocks for given blocknum",
+    ):
+        loader.load()
 
 
 def test_filter_sitemap() -> None:


### PR DESCRIPTION
I wanted to add an option to load sitemaps blockwise.

I wanted to use the sitemap importer on my local machine but since the sitemaps i wanted to ingest where pretty large my import porcess always died at the end.
So i added the option to split up loading smaller parts of a sitemap.

Since i use pgvector as my store i could then block by block import even a large sitemap. 
Maybe this is helpfull for other people.