### PR TITLE
[Agent][Bug Fix][Enhancement] Making default implementation of _validate_tools less restrictive

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -453,12 +453,13 @@ class Agent(BaseSingleActionAgent):
 
     @classmethod
     def _validate_tools(cls, tools: Sequence[BaseTool]) -> None:
-        """Validate that appropriate tools are passed in."""
-        for tool in tools:
-            if not tool.is_single_input:
-                raise ValueError(
-                    f"{cls.__name__} does not support multi-input tool {tool.name}."
-                )
+        """
+        This class method is intended to be overridden in derived classes if necessary.
+        The default implementation does nothing and assumes that the provided tools are
+        valid.
+
+        Validate that appropriate tools are passed in.
+        """
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
#### Overview
The default implementation of `_validate_tools` is too restrictive as it raises a ValueError when multi-input tools are passed in. This does not make sense as many agents rely on tools that require some sort of multi-input and there are many other issues referencing this problem. 

The default implementation should be empty and `Agent` children classes should explicitly define their own validator if they need it.

#### References
- https://github.com/hwchase17/langchain/issues/3781
- https://github.com/hwchase17/langchain/issues/3700
- https://github.com/hwchase17/langchain/issues/3757