### PR TITLE
add add_system_message method to ChatMessageHistory

### DIFF
--- a/langchain/memory/chat_message_histories/in_memory.py
+++ b/langchain/memory/chat_message_histories/in_memory.py
@@ -7,11 +7,15 @@ from langchain.schema import (
     BaseChatMessageHistory,
     BaseMessage,
     HumanMessage,
+    SystemMessage
 )
 
 
 class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
     messages: List[BaseMessage] = []
+
+    def add_system_message(self, message: str) -> None:
+        self.messages.append(SystemMessage(content=message))
 
     def add_user_message(self, message: str) -> None:
         self.messages.append(HumanMessage(content=message))


### PR DESCRIPTION
I added an `add_system_message` method to `ChatMessageHistory` (the default implementation of `BaseChatMessageHistory`).
Should pass linting this time!

Seems useful e.g. to be able to initialize a conversational agent with a system message in memory.

Though is there a reason I'm not thinking of that this wasn't already implemented, i.e. to go along with `add_user_message` and `add_ai_message`? (Even if not all models have this feature)

If not, should this be added as an abstract method to the base class and implemented elsewhere, e.g. for CosmosDB and DynamoDB?