### PR TITLE
update typing for used_args

### DIFF
--- a/langchain/formatting.py
+++ b/langchain/formatting.py
@@ -1,6 +1,6 @@
 """Utilities for formatting strings."""
 from string import Formatter
-from typing import Any, List, Mapping, Sequence, Union
+from typing import Any, List, Mapping, Sequence, Set, Union
 
 
 class StrictFormatter(Formatter):
@@ -8,7 +8,7 @@ class StrictFormatter(Formatter):
 
     def check_unused_args(
         self,
-        used_args: Sequence[Union[int, str]],
+        used_args: Set[Union[int, str]],
         args: Sequence,
         kwargs: Mapping[str, Any],
     ) -> None:


### PR DESCRIPTION
this change removes the following mypy error (reproducible on 18ec22fe56049aaea446406daab6d66d172dd48f and mypy 1.2.0):

```
langchain/formatting.py:11: error: Argument 1 of "check_unused_args" is incompatible with supertype "Formatter"; supertype defines the argument type as "Set[Union[int, str]]"  [override]
langchain/formatting.py:11: note: This violates the Liskov substitution principle
langchain/formatting.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
```