### PR TITLE
#3555 Add support for a routing chain configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ wandb/
 # integration test artifacts
 data_map*
 \[('_type', 'fake'), ('stop', None)]
+
+.chroma

--- a/langchain/chains/llm_router_chain/__init__.py
+++ b/langchain/chains/llm_router_chain/__init__.py
@@ -1,0 +1,1 @@
+"""Chain pipeline that models a gateway pattern for selecting the most relevant chain based on a vector collection"""

--- a/langchain/chains/llm_router_chain/__init__.py
+++ b/langchain/chains/llm_router_chain/__init__.py
@@ -1,1 +1,1 @@
-"""Chain pipeline that models a gateway pattern for selecting the most relevant chain based on a vector collection"""
+"""Chain pipeline that models a gateway pattern for selecting the most relevant chain based on a function parameter passed by the caller"""

--- a/langchain/chains/llm_router_chain/base.py
+++ b/langchain/chains/llm_router_chain/base.py
@@ -1,0 +1,103 @@
+import re
+from types import FunctionType
+from typing import Dict, List, Any
+from pydantic import Extra, root_validator
+
+from langchain import LLMChain, BasePromptTemplate
+from langchain.chains.base import Chain
+from langchain.chains.conversation.prompt import PROMPT
+from langchain.input import get_color_mapping
+from langchain.memory import ConversationBufferWindowMemory
+from langchain.schema import BaseMemory
+
+
+class RouterChain(LLMChain):
+    """
+    Router chain that picks the most relevant model to call based on vector queries.
+    The chain includes support for memory
+    """
+
+    memory: BaseMemory = ConversationBufferWindowMemory(k=1)
+    fuzzy_match_threshold = 1.5
+    """Default memory store."""
+    prompt: BasePromptTemplate = PROMPT
+    """Default conversation prompt to use."""
+    last_chain: Chain = None
+    chains: Dict[str, Chain]
+    strip_outputs: bool = False
+    input_key: str = "input"  #: :meta private:
+    output_key: str = "output"  #: :meta private:
+    vector_lookup_fn: FunctionType = None
+
+    class Config:
+        """Configuration for this pydantic object."""
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Expect input key.
+
+        :meta private:
+        """
+        return [self.input_key]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Return output key.
+
+        :meta private:
+        """
+        return [self.output_key]
+
+    @property
+    def _chain_type(self) -> str:
+        return "conversational_router_chain"
+
+    def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
+        _input = inputs[self.input_key]
+        last_chain_name = re.compile('Responding Chain - (.*?):').findall(inputs['history'])
+        if last_chain_name and len(last_chain_name) > 0:
+            self.last_chain = self.chains.get(last_chain_name[0])
+        color_mapping = get_color_mapping([str(x) for x in self.chains.keys()])
+        if not self.vector_lookup_fn:
+            raise ValueError("Vector lookup function not provided for this router chain.")
+        m_name, distance = self.vector_lookup_fn(query=[_input])
+        # picking a guardrail where if the LLM response is way off - then just use the same model as the previous
+        # one to continue conversing.
+        if self.chains.get(m_name) and distance <= self.fuzzy_match_threshold:
+            _input = self.chains[m_name](_input)
+        else:
+            if self.last_chain:
+                m_name = last_chain_name[0]
+                _input = self.last_chain(_input)
+            else:
+                raise ValueError(
+                    "Suitable destination chain not found for this question. Distance computed from nearest match: " +
+                    str(distance))
+        self.callback_manager.on_text(
+            str(_input['text']), color=color_mapping[m_name], end="\n", verbose=self.verbose
+        )
+        return {
+            self.output_key: 'Responding Chain - ' + m_name + ':' + _input['text']
+        }
+
+    @root_validator()
+    def validate_prompt_input_variables(cls, values: Dict) -> Dict:
+        """Validate that prompt input variables are consistent."""
+        memory_keys = values["memory"].memory_variables
+        input_key = values["input_key"]
+        if input_key in memory_keys:
+            raise ValueError(
+                f"The input key {input_key} was also found in the memory keys "
+                f"({memory_keys}) - please provide keys that don't overlap."
+            )
+        prompt_variables = values["prompt"].input_variables
+        expected_keys = memory_keys + [input_key]
+        if set(expected_keys) != set(prompt_variables):
+            raise ValueError(
+                "Got unexpected prompt input variables. The prompt expects "
+                f"{prompt_variables}, but got {memory_keys} as inputs from "
+                f"memory, and {input_key} as the normal input key."
+            )
+        return values

--- a/langchain/chains/llm_router_chain/base.py
+++ b/langchain/chains/llm_router_chain/base.py
@@ -12,7 +12,7 @@ from langchain.memory import ConversationBufferWindowMemory
 from langchain.schema import BaseMemory
 
 
-class RouterChain(Chain):
+class ConditionalRouterChain(Chain):
     """
     Router chain that picks the most relevant model to call based on a lookup function the caller would pass in.
     The function for example could be a vector query to do the determination of the destination
@@ -62,7 +62,7 @@ class RouterChain(Chain):
 
     @property
     def _chain_type(self) -> str:
-        return "vector_based_router_chain"
+        return "conditional_router_chain"
 
     def extract_dict_for_output_keys(self, val):
         if not val:

--- a/langchain/chains/llm_router_chain/base.py
+++ b/langchain/chains/llm_router_chain/base.py
@@ -52,7 +52,7 @@ class RouterChain(LLMChain):
 
     @property
     def _chain_type(self) -> str:
-        return "conversational_router_chain"
+        return "router_chain"
 
     def _call(self, inputs: Dict[str, str]) -> Dict[str, str]:
         _input = inputs[self.input_key]

--- a/tests/unit_tests/chains/test_router_chain.py
+++ b/tests/unit_tests/chains/test_router_chain.py
@@ -1,0 +1,116 @@
+"""Test conversational router chain and memory."""
+import chromadb
+from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+import pytest
+import yaml
+from langchain.chains.llm_router_chain.base import RouterChain
+from langchain import LLMChain, PromptTemplate
+from tests.unit_tests.llms.fake_llm import FakeLLM
+
+LLM_MAP_CONFIG = '''
+    models:
+      - Space:
+          qa_maker:
+            - How far is the earth from the moon?
+            - What's the temperature of the sun?
+            - How does the air smell in venus?
+          template: |
+            Assume that your Elon musk and are very concerned about future of human civilization beyond Earth. 
+
+            Answer the following question keeping this in mind and provide answers that help in clarifying how 
+            would humans survive as an interplanetary species. If the question is not relevant then say "I don't know" and do not make up any answer.
+            Question related to space and how humans could survive:         
+            {question}
+          input_vars:
+            - question
+      - Architecture:
+          qa_maker:
+            - What's the best way to do sampling for statistical analysis?
+            - Which technologies would make most sense for distributed work?
+          template: |
+            Assume the role of a software architect who's really experienced in dealing with and scaling large scale distributed systems. 
+            Answer the questions specifically on software design problems as indicated below. If the question is not relevant then say "I don't know" and do not make up any answer. 
+
+            Question related to distributed systems and large scale software design
+            {question}
+
+            Please also include references in your answers to popular websites where more we can get more context.
+          input_vars:
+            - question
+      - Biotechnology:
+          qa_maker:
+            - What's the best way to tap into genetic memory?
+          template: |
+            Assume the role of a genetic expert who has unlocked the secrets of our genetic make up and is able to provide clear answers to questions below.
+            Optimize for answers that provide directions for improving current problems around genetic defects and how we can overcome them.  If the question is not relevant then say "I don't know" and do not make up any answer.
+
+            Question related to bio technology and related use cases.                 
+            {question}
+          input_vars:
+            - question
+    '''
+LLM = FakeLLM()
+
+
+class RouterConfig:
+    def __init__(self, llm):
+        self.chain_map = {}
+        chroma_client = chromadb.Client()
+        sentence_transformer_ef = SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        self.router_coll = chroma_client.create_collection(name='router', embedding_function=sentence_transformer_ef)
+        content = yaml.safe_load(LLM_MAP_CONFIG)
+        for model in content.get('models'):
+            for m_name, m_content in model.items():
+                m_name = m_name.lower()
+                self.router_coll.add(ids=[str(x) for x in range(len(m_content.get('qa_maker')))],
+                                     documents=m_content.get('qa_maker'),
+                                     metadatas=[{'classification': m_name} for x in
+                                                range(len(m_content.get('qa_maker')))])
+                self.chain_map[m_name] = LLMChain(llm=llm, prompt=PromptTemplate(template=m_content.get('template'),
+                                                                                 input_variables=m_content.get(
+                                                                                     'input_vars')))
+
+    def get_chains(self):
+        return self.chain_map
+
+    def get_embedding(self):
+        return self.router_coll
+
+
+@pytest.fixture()
+def router_config() -> RouterChain:
+    config = RouterConfig(llm=LLM)
+
+    def vector_lookup(query):
+        x = config.get_embedding().query(query_texts=query, n_results=3)
+        return x['metadatas'][0][0].get('classification'), x['distances'][0][0]
+
+    return RouterChain(llm=LLM,
+                       chains=config.get_chains(),
+                       vector_lookup_fn=vector_lookup)
+
+
+def test_vector_selection_and_routing(router_config: RouterChain) -> None:
+    """Test that the vector search has a hit and is able to pick a destination chain."""
+    output = router_config.predict(input="How far is the moon from the earth?")
+    assert output == 'Responding Chain - space:foo'
+
+
+def test_vector_memory_state(router_config: RouterChain) -> None:
+    """Test that the conversational router chain is able to maintain historical context"""
+    output1 = router_config.predict(input="How far is the moon from th earth?")
+    output2 = router_config.predict(input="Tell me more!")
+    assert output1 == 'Responding Chain - space:foo'
+    assert output2.startswith('Responding Chain - space')
+
+
+def test_memory_context_switch_across_chains(router_config: RouterChain) -> None:
+    """Test that the history is maintained even if the conversation spans across chains"""
+    output1 = router_config.predict(input="How far is the moon from th earth?")
+    output2 = router_config.predict(input="How do you scale databases for large scale software development?")
+    output3 = router_config.predict(input="How do you solve genetic problems through AI/ML?")
+    output4 = router_config.predict(input="Tell me more about it!")
+    assert output1 == 'Responding Chain - space:foo'
+    assert output2.startswith('Responding Chain - architecture')
+    assert output3.startswith('Responding Chain - biotechnology')
+    assert output4.startswith('Responding Chain - biotechnology')


### PR DESCRIPTION
The change provides an implementation for a 'Map' semantics for model chaining. Similar to `Sequential` chains which can model fixed chain sequence implementation, the idea here is to enable consumers to be able to provide a map of chains and dynamically choose the right chain (or its variations) based on input. 

The decision of which chain to use will rely on a vector store lookup function that consumers can provide as a parameter to the chain definition. This will allow callers to use their own type of vector store and does not force a specific tech. 

To maintain the interface requirements of the chain, the chain attribution is added in the response text to indicate to the caller the downstream chain that's actually processing the request. 