### PR TITLE
Make project compatible with SQLAlchemy 1.3.*

### DIFF
--- a/langchain/vectorstores/analyticdb.py
+++ b/langchain/vectorstores/analyticdb.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import sqlalchemy
 from sqlalchemy import REAL, Index
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
-from sqlalchemy.orm import Mapped, Session, declarative_base, relationship
+from sqlalchemy.orm import Session, declarative_base, relationship
 from sqlalchemy.sql.expression import func
 
 from langchain.docstore.document import Document
@@ -70,7 +70,7 @@ class CollectionStore(BaseModel):
 class EmbeddingStore(BaseModel):
     __tablename__ = "langchain_pg_embedding"
 
-    collection_id: Mapped[UUID] = sqlalchemy.Column(
+    collection_id = sqlalchemy.Column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(
             f"{CollectionStore.__tablename__}.uuid",

--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 import sqlalchemy
 from pgvector.sqlalchemy import Vector
 from sqlalchemy.dialects.postgresql import JSON, UUID
-from sqlalchemy.orm import Mapped, Session, declarative_base, relationship
+from sqlalchemy.orm import Session, declarative_base, relationship
 
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
@@ -70,7 +70,7 @@ class CollectionStore(BaseModel):
 class EmbeddingStore(BaseModel):
     __tablename__ = "langchain_pg_embedding"
 
-    collection_id: Mapped[UUID] = sqlalchemy.Column(
+    collection_id = sqlalchemy.Column(
         UUID(as_uuid=True),
         sqlalchemy.ForeignKey(
             f"{CollectionStore.__tablename__}.uuid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ langchain-server = "langchain.server:main"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 pydantic = "^1"
-SQLAlchemy = ">1.4,<3"
+SQLAlchemy = ">=1.3,<3"
 requests = "^2"
 PyYAML = ">=5.4.1"
 numpy = "^1"


### PR DESCRIPTION
Related to [this issue.](https://github.com/hwchase17/langchain/issues/3655#issuecomment-1529415363) 

The `Mapped` SQLAlchemy class is introduced in SQLAlchemy 1.4 but the migration from 1.3 to 1.4 is quite challenging so, IMO, it's better to keep backwards compatibility and not change the SQLAlchemy requirements just because of type annotations.