### PR TITLE
Fix typos in arxiv.ipynb

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/arxiv.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/arxiv.ipynb
@@ -41,13 +41,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "094b5f13-7e54-4354-9d83-26d6926ecaa0",
    "metadata": {
     "tags": []
    },
    "source": [
-    "Second, you need to install `PyMuPDF` python package which transform PDF files from the `arxiv.org` site into the text fromat."
+    "Second, you need to install `PyMuPDF` python package which transform PDF files from the `arxiv.org` site into the text format."
    ]
   },
   {
@@ -71,6 +72,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e29b954c-1407-4797-ae21-6ba8937156be",
    "metadata": {},
@@ -78,12 +80,12 @@
     "`ArxivLoader` has these arguments:\n",
     "- `query`: free text which used to find documents in the Arxiv\n",
     "- optional `load_max_docs`: default=100. Use it to limit number of downloaded documents. It takes time to download all 100 documents, so use a small number for experiments.\n",
-    "- optional `load_all_available_meta`: default=False. By defaul only the most important fields downloaded: `Published` (date when document was published/last updated), `Title`, `Authors`, `Summary`. If True, other fields also downloaded."
+    "- optional `load_all_available_meta`: default=False. By default only the most important fields downloaded: `Published` (date when document was published/last updated), `Title`, `Authors`, `Summary`. If True, other fields also downloaded."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "9bfd5e46",
    "metadata": {},
    "outputs": [],
@@ -105,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "8977bac0-0042-4f23-9754-247dbd32439b",
    "metadata": {
     "tags": []
@@ -120,18 +122,18 @@
        " 'Summary': 'Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.'}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "doc[0].metadata  # meta-information of the Document"
+    "docs[0].metadata  # meta-information of the Document"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "46969806-45a9-4c4d-a61b-cfb9658fc9de",
    "metadata": {
     "tags": []
@@ -143,13 +145,13 @@
        "'arXiv:1605.08386v1  [math.CO]  26 May 2016\\nHEAT-BATH RANDOM WALKS WITH MARKOV BASES\\nCAPRICE STANLEY AND TOBIAS WINDISCH\\nAbstract. Graphs on lattice points are studied whose edges come from a ﬁnite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on ﬁbers of a\\nﬁxed integer matrix can be bounded from above by a constant. We then study the mixing\\nbehaviour of heat-b'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "doc[0].page_content[:400]  # all pages of the Document content\n"
+    "docs[0].page_content[:400]  # all pages of the Document content\n"
    ]
   }
  ],
@@ -169,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Several minor typos in the doc for the arxiv document loaders were fixed.