### PR TITLE
Fix self query pinecone translation

### DIFF
--- a/langchain/retrievers/self_query/pinecone.py
+++ b/langchain/retrievers/self_query/pinecone.py
@@ -30,7 +30,7 @@ class PineconeTranslator(Visitor):
                     f"Received disallowed comparator {func}. Allowed "
                     f"comparators are {self.allowed_comparators}"
                 )
-        return f"${func}"
+        return f"${func.value}"
 
     def visit_operation(self, operation: Operation) -> Dict:
         args = [arg.accept(self) for arg in operation.arguments]

--- a/tests/unit_tests/retrievers/self_query/test_pinecone.py
+++ b/tests/unit_tests/retrievers/self_query/test_pinecone.py
@@ -1,0 +1,29 @@
+from langchain.chains.query_constructor.ir import (
+    Comparator,
+    Comparison,
+    Operation,
+    Operator,
+)
+from langchain.retrievers.self_query.pinecone import PineconeTranslator
+
+DEFAULT_TRANSLATOR = PineconeTranslator()
+
+
+def test_visit_comparison() -> None:
+    comp = Comparison(comparator=Comparator.LT, attribute="foo", value=["1", "2"])
+    expected = {"foo": {"$lt": ["1", "2"]}}
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_operation() -> None:
+    op = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.LT, attribute="foo", value=2),
+            Comparison(comparator=Comparator.EQ, attribute="bar", value="baz"),
+        ],
+    )
+    expected = {"$and": [{"foo": {"$lt": 2}}, {"bar": {"$eq": "baz"}}]}
+    actual = DEFAULT_TRANSLATOR.visit_operation(op)
+    assert expected == actual


### PR DESCRIPTION
Enum to string conversion handled differently between python 3.9 and 3.11, currently breaking in 3.11 (see #3788). Thanks @peter-brady for catching this!