### PR TITLE
Update adding_memory_chain_multiple_inputs.ipynb

### DIFF
--- a/docs/modules/memory/examples/adding_memory_chain_multiple_inputs.ipynb
+++ b/docs/modules/memory/examples/adding_memory_chain_multiple_inputs.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# How to add memory to a Multi-Input Chain\n",
     "\n",
-    "Most memory objects assume a single output. In this notebook, we go over how to add memory to a chain that has multiple outputs. As an example of such a chain, we will add memory to a question/answering chain. This chain takes as inputs both related documents and a user question."
+    "Most memory objects assume a single input. In this notebook, we go over how to add memory to a chain that has multiple inputs. As an example of such a chain, we will add memory to a question/answering chain. This chain takes as inputs both related documents and a user question."
    ]
   },
   {


### PR DESCRIPTION
Fix misleading docs in memory chain example (used the term "outputs" instead of "inputs") 