### PR TITLE
fix: invalid escape sequence error in regex pattern

### DIFF
--- a/langchain/output_parsers/pydantic.py
+++ b/langchain/output_parsers/pydantic.py
@@ -17,7 +17,7 @@ class PydanticOutputParser(BaseOutputParser[T]):
         try:
             # Greedy search for 1st json candidate.
             match = re.search(
-                "\{.*\}", text.strip(), re.MULTILINE | re.IGNORECASE | re.DOTALL
+                r"\{.*\}", text.strip(), re.MULTILINE | re.IGNORECASE | re.DOTALL
             )
             json_str = ""
             if match:


### PR DESCRIPTION
This PR fixes the "SyntaxError: invalid escape sequence" error in the pydantic.py file. The issue was caused by the backslashes in the regular expression pattern being treated as escape characters. By using a raw string literal for the regex pattern (e.g., r"\{.*\}"), this fix ensures that backslashes are treated as literal characters, thus preventing the error.