### PR TITLE
Add callback to preprocess agent scratchpad data

### DIFF
--- a/langchain/callbacks/base.py
+++ b/langchain/callbacks/base.py
@@ -160,6 +160,16 @@ class RunManagerMixin:
     ) -> Any:
         """Run on arbitrary text."""
 
+    def on_selected_inputs_preprocess_for_prompt(
+        self,
+        text: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run while passing agent scratchpad input to prompts."""
+
 
 class BaseCallbackHandler(
     LLMManagerMixin,
@@ -321,6 +331,16 @@ class AsyncCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """Run on agent end."""
+
+    async def on_selected_inputs_preprocess_for_prompt(
+        self,
+        text: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run while passing agent scratchpad input to prompts."""
 
 
 class BaseCallbackManager(CallbackManagerMixin):

--- a/langchain/callbacks/base.py
+++ b/langchain/callbacks/base.py
@@ -162,7 +162,7 @@ class RunManagerMixin:
 
     def on_selected_inputs_preprocess_for_prompt(
         self,
-        text: str,
+        text: Dict[str, Any],
         *,
         run_id: UUID,
         parent_run_id: Optional[UUID] = None,
@@ -334,7 +334,7 @@ class AsyncCallbackHandler(BaseCallbackHandler):
 
     async def on_selected_inputs_preprocess_for_prompt(
         self,
-        text: str,
+        text: Dict[str, Any],
         *,
         run_id: UUID,
         parent_run_id: Optional[UUID] = None,

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -155,7 +155,7 @@ class RunManager(BaseRunManager):
             **kwargs,
         )
 
-    def on_selected_inputs_preprocess_for_prompt(self, text: str, **kwargs: Any) -> Any:
+    def on_selected_inputs_preprocess_for_prompt(self, text: Dict[str, Any], **kwargs: Any) -> Any:
         """Run while passing agent scratchpad input to prompts."""
         _handle_event(
             self.handlers,
@@ -188,7 +188,7 @@ class AsyncRunManager(BaseRunManager):
         )
 
     async def on_selected_inputs_preprocess_for_prompt(
-        self, text: str, **kwargs: Any
+        self, text: Dict[str, Any], **kwargs: Any
     ) -> Any:
         """Run while passing agent scratchpad input to prompts."""
         await _ahandle_event(

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -155,7 +155,9 @@ class RunManager(BaseRunManager):
             **kwargs,
         )
 
-    def on_selected_inputs_preprocess_for_prompt(self, text: Dict[str, Any], **kwargs: Any) -> Any:
+    def on_selected_inputs_preprocess_for_prompt(
+        self, text: Dict[str, Any], **kwargs: Any
+    ) -> Any:
         """Run while passing agent scratchpad input to prompts."""
         _handle_event(
             self.handlers,

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -155,6 +155,18 @@ class RunManager(BaseRunManager):
             **kwargs,
         )
 
+    def on_selected_inputs_preprocess_for_prompt(self, text: str, **kwargs: Any) -> Any:
+        """Run while passing agent scratchpad input to prompts."""
+        _handle_event(
+            self.handlers,
+            "on_selected_inputs_preprocess_for_prompt",
+            None,
+            text,
+            run_id=self.run_id,
+            parent_run_id=self.parent_run_id,
+            **kwargs,
+        )
+
 
 class AsyncRunManager(BaseRunManager):
     """Async Run Manager."""
@@ -168,6 +180,20 @@ class AsyncRunManager(BaseRunManager):
         await _ahandle_event(
             self.handlers,
             "on_text",
+            None,
+            text,
+            run_id=self.run_id,
+            parent_run_id=self.parent_run_id,
+            **kwargs,
+        )
+
+    async def on_selected_inputs_preprocess_for_prompt(
+        self, text: str, **kwargs: Any
+    ) -> Any:
+        """Run while passing agent scratchpad input to prompts."""
+        await _ahandle_event(
+            self.handlers,
+            "on_selected_inputs_preprocess_for_prompt",
             None,
             text,
             run_id=self.run_id,

--- a/langchain/chains/llm.py
+++ b/langchain/chains/llm.py
@@ -103,6 +103,11 @@ class LLMChain(Chain):
         prompts = []
         for inputs in input_list:
             selected_inputs = {k: inputs[k] for k in self.prompt.input_variables}
+            # selected input preprocessing e.g., for sensitive data
+            if run_manager:
+                run_manager.on_selected_inputs_preprocess_for_prompt(
+                    selected_inputs, verbose=self.verbose
+                )
             prompt = self.prompt.format_prompt(**selected_inputs)
             _colored_text = get_colored_text(prompt.to_string(), "green")
             _text = "Prompt after formatting:\n" + _colored_text


### PR DESCRIPTION
**Requirement**

Invoke data scan & mask guardrails before agent scratchpad data is included in the prompt. This would be useful to either mask different sensitive data or to maintain audit logs of the agent generated data in prompts 

**Proposed Changes**

Invoke preprocess callback method during preparation of prompt.

**How to use** 

Sample data mask callback manager to mask AWS account numbers included as agent output

````
class BaseMaskerHandler(BaseCallbackHandler):
  ....
  def on_selected_inputs_preprocess_for_prompt(
            self, 
            text: str,
            **kwargs: Optional[str],
    ) -> Any:
        if 'agent_scratchpad' in text:
            if text['agent_scratchpad']:
                text_of_interest = text['agent_scratchpad']
                import re
                # replace AWS account number
                to_mask = re.findall(r"(\d{12})", text_of_interest)
                for i, item in enumerate(to_mask):
                    lookup_name = f"aws_account_{i+1}"
                    text_of_interest = text_of_interest.replace(item, lookup_name)
                text['agent_scratchpad'] = text_of_interest
