### PR TITLE
[FR] Add TomlLoader document loader

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/directory_loader.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/directory_loader.ipynb
@@ -233,9 +233,48 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "b2ae0578",
+   "metadata": {},
+   "source": [
+    "If you need to load Toml files, use the `TomlLoader`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7f6e0eae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders import TomlLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5eb0ced",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = TomlLoader('example_data/fake_rule.toml')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc62d1c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rule = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a91a0bc",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/modules/indexes/document_loaders/examples/example_data/fake_rule.toml
+++ b/docs/modules/indexes/document_loaders/examples/example_data/fake_rule.toml
@@ -1,0 +1,22 @@
+[internal]
+creation_date = "2023-05-01"
+updated_date = "2022-05-01"
+release = ["release_type"]
+min_endpoint_version = "some_semantic_version"
+os_list = ["operating_system_list"]
+
+[rule]
+uuid = "some_uuid"
+name = "Fake Rule Name"
+description = "Fake description of rule"
+query = '''
+process where process.name : "somequery"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+  [rule.threat.tactic]
+  name = "Execution"
+  id = "TA0002"
+  reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/langchain/document_loaders/__init__.py
+++ b/langchain/document_loaders/__init__.py
@@ -74,6 +74,7 @@ from langchain.document_loaders.srt import SRTLoader
 from langchain.document_loaders.stripe import StripeLoader
 from langchain.document_loaders.telegram import TelegramChatLoader
 from langchain.document_loaders.text import TextLoader
+from langchain.document_loaders.toml import TomlLoader
 from langchain.document_loaders.twitter import TwitterTweetLoader
 from langchain.document_loaders.unstructured import (
     UnstructuredFileIOLoader,
@@ -159,6 +160,7 @@ __all__ = [
     "SlackDirectoryLoader",
     "TelegramChatLoader",
     "TextLoader",
+    "TomlLoader",
     "TwitterTweetLoader",
     "UnstructuredEPubLoader",
     "UnstructuredEmailLoader",

--- a/langchain/document_loaders/toml.py
+++ b/langchain/document_loaders/toml.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Iterable, List, Union
+
+import toml
+
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseLoader
+
+
+class TomlLoader(BaseLoader):
+    """
+    A TOML document loader that inherits from the BaseLoader class.
+
+    This class can be initialized with either a single source file or a source
+    directory containing TOML files.
+    """
+
+    def __init__(self, source: Union[str, Path]):
+        """Initialize the TomlLoader with a source file or directory."""
+        self.source = Path(source)
+
+    def load(self) -> List[Document]:
+        """Load and return all documents."""
+        return list(self.lazy_load())
+
+    def lazy_load(self) -> Iterable[Document]:
+        """Lazily load the TOML documents from the source file or directory."""
+        if self.source.is_file() and self.source.suffix == ".toml":
+            files = [self.source]
+        elif self.source.is_dir():
+            files = list(self.source.glob("**/*.toml"))
+        else:
+            raise ValueError("Invalid source path or file type")
+
+        for file_path in files:
+            with file_path.open("r", encoding="utf-8") as file:
+                content = file.read()
+                try:
+                    data = toml.loads(content)
+                    doc = Document(data=data, metadata={"path": str(file_path)})
+                    yield doc
+                except toml.TomlDecodeError as e:
+                    print(f"Error parsing TOML file {file_path}: {e}")

--- a/langchain/document_loaders/toml.py
+++ b/langchain/document_loaders/toml.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Iterable, List, Union
 
@@ -37,7 +38,8 @@ class TomlLoader(BaseLoader):
                 content = file.read()
                 try:
                     data = toml.loads(content)
-                    doc = Document(data=data, metadata={"path": str(file_path)})
+                    doc = Document(page_content=json.dumps(data),
+                                   metadata={"source": str(file_path)})
                     yield doc
                 except toml.TomlDecodeError as e:
                     print(f"Error parsing TOML file {file_path}: {e}")

--- a/langchain/document_loaders/toml.py
+++ b/langchain/document_loaders/toml.py
@@ -38,8 +38,10 @@ class TomlLoader(BaseLoader):
                 content = file.read()
                 try:
                     data = toml.loads(content)
-                    doc = Document(page_content=json.dumps(data),
-                                   metadata={"source": str(file_path)})
+                    doc = Document(
+                        page_content=json.dumps(data),
+                        metadata={"source": str(file_path)},
+                    )
                     yield doc
                 except toml.TomlDecodeError as e:
                     print(f"Error parsing TOML file {file_path}: {e}")

--- a/langchain/document_loaders/toml.py
+++ b/langchain/document_loaders/toml.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Iterable, List, Union
 
-import toml
+import tomli
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -37,11 +37,11 @@ class TomlLoader(BaseLoader):
             with file_path.open("r", encoding="utf-8") as file:
                 content = file.read()
                 try:
-                    data = toml.loads(content)
+                    data = tomli.loads(content)
                     doc = Document(
                         page_content=json.dumps(data),
                         metadata={"source": str(file_path)},
                     )
                     yield doc
-                except toml.TomlDecodeError as e:
+                except tomli.TOMLDecodeError as e:
                     print(f"Error parsing TOML file {file_path}: {e}")


### PR DESCRIPTION
# Summary 

Adds a new document loader called `TomlLoader` which loads toml files (either file or directory of toml files).

## Usage

```python
from from langchain.document_loaders import TomlLoader

# Initialize with a single source file
source_file = "/path/to/your/toml/file.toml"
toml_loader_file = TomlLoader(source_file)
toml_loader_file.load()

# Initialize with a source directory
source_dir = "/path/to/your/toml/files"
toml_loader_dir = TomlLoader(source_dir)

for doc in toml_loader_dir.lazy_load():
    print(doc)

```
 