### PR TITLE
[Fix] custom input_variables doesn’t work in pandas custom agent

### DIFF
--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -16,7 +16,6 @@ def create_pandas_dataframe_agent(
     callback_manager: Optional[BaseCallbackManager] = None,
     prefix: str = PREFIX,
     suffix: str = SUFFIX,
-    input_variables: Optional[List[str]] = None,
     verbose: bool = False,
     return_intermediate_steps: bool = False,
     max_iterations: Optional[int] = 15,
@@ -30,8 +29,7 @@ def create_pandas_dataframe_agent(
 
     if not isinstance(df, pd.DataFrame):
         raise ValueError(f"Expected pandas object, got {type(df)}")
-    if input_variables is None:
-        input_variables = ["df", "input", "agent_scratchpad"]
+    input_variables = ["df", "input", "agent_scratchpad"]
     tools = [PythonAstREPLTool(locals={"df": df})]
     prompt = ZeroShotAgent.create_prompt(
         tools, prefix=prefix, suffix=suffix, input_variables=input_variables

--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -1,5 +1,5 @@
 """Agent for working with pandas objects."""
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from langchain.agents.agent import AgentExecutor
 from langchain.agents.agent_toolkits.pandas.prompt import PREFIX, SUFFIX


### PR DESCRIPTION
Issue: https://github.com/hwchase17/langchain/issues/3950
Root Cause: 
- when custom `input_variables`, it will override the default values. In order to use them, a customized and relevant prompt is needed, which is however not supported in this function. Only default prompts are used everywhere, which means the default template will be used ([code pointer](langchain/agents/agent_toolkits/pandas/prompt.py), which doesn’t have any support for a different variable and all the 3 variables are mandatory. This means `input_variables` isn’t supported as a function param. It’s better to remove for now. If later we figure out a need to customize pandas prompt template, we can provide a new entry point, but so far, not seeing the needs yet.


Test:
```python3
from langchain.agents import create_pandas_dataframe_agent
from langchain.llms import OpenAI
import pandas as pd

df = pd.read_csv('titanic_train.csv')
agent = create_pandas_dataframe_agent(
    OpenAI(temperature=0.5),
    df,
    verbose=True
)
```python3
agent.run("how many people have more than 3 sibligngs")
```
<img width="540" alt="Screenshot 2023-05-01 at 10 29 30 PM" src="https://user-images.githubusercontent.com/62768671/235586105-bd08e7cc-64b7-429f-aaf5-8e8ef794b551.png">
