### PR TITLE
Update \docs\modules\models\text_embedding\examples\openai.ipynb

### DIFF
--- a/docs/modules/models/text_embedding/examples/openai.ipynb
+++ b/docs/modules/models/text_embedding/examples/openai.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = OpenAIEmbeddings(model_name=\"ada\")"
+    "embeddings = OpenAIEmbeddings()"
    ]
   },
   {


### PR DESCRIPTION
Single edit to: models/text_embedding/examples/openai.ipynb - Line 88: changed from: "embeddings = OpenAIEmbeddings(model_name=\"ada\")" to "embeddings = OpenAIEmbeddings()" as model_name is no longer part of the OpenAIEmbeddings class.