### PR TITLE
bugfix: return whole document when loading with ConfluenceLoader.load by label

### DIFF
--- a/langchain/document_loaders/confluence.py
+++ b/langchain/document_loaders/confluence.py
@@ -223,7 +223,7 @@ class ConfluenceLoader(BaseLoader):
             if page_ids:
                 page_ids = list(set(page_ids + ids_by_label))
             else:
-                page_ids = set(ids_by_label)
+                page_ids = list(set(ids_by_label))
 
         if cql:
             pages = self.paginate_request(

--- a/langchain/document_loaders/confluence.py
+++ b/langchain/document_loaders/confluence.py
@@ -219,9 +219,11 @@ class ConfluenceLoader(BaseLoader):
                 max_pages=max_pages,
                 expand="body.storage.value",
             )
-            docs += self.process_pages(
-                pages, include_restricted_content, include_attachments, include_comments
-            )
+            ids_by_label = [page["id"] for page in pages]
+            if page_ids:
+                page_ids = list(set(page_ids + ids_by_label))
+            else:
+                page_ids = set(ids_by_label)
 
         if cql:
             pages = self.paginate_request(


### PR DESCRIPTION
Method confluence.get_all_pages_by_label, returns only metadata about documents with a certain label (such as pageId, titles, ...). To return all documents with a certain label we need to extract all page ids given a certain label and get pages content by these ids.