### PR TITLE
fix: type error in OpenAPI chain

### DIFF
--- a/langchain/chains/api/openapi/chain.py
+++ b/langchain/chains/api/openapi/chain.py
@@ -61,7 +61,8 @@ class OpenAPIEndpointChain(Chain, BaseModel):
         """Construct the path from the deserialized input."""
         path = self.api_operation.base_url + self.api_operation.path
         for param in self.param_mapping.path_params:
-            path = path.replace(f"{{{param}}}", args.pop(param, ""))
+            arg = args.pop(param, "")
+            path = path.replace(f"{{{param}}}", f"{arg}")
         return path
 
     def _extract_query_params(self, args: Dict[str, str]) -> Dict[str, str]:


### PR DESCRIPTION
In some cases, when using the OpenAPI chain an error is thrown similar to:
```error: Error with message replace() argument 2 must be str, not int'```

This occurs when the LLM is forming the URL to use for the HTTP Request to the REST API defined in OpenAPI spec.  In this case the type should always be string, so the fix is simply casting the url param to string in all cases.