### PR TITLE
Update python_repl docs

### DIFF
--- a/docs/modules/agents/tools/examples/python.ipynb
+++ b/docs/modules/agents/tools/examples/python.ipynb
@@ -65,7 +65,7 @@
     "repl_tool = Tool(\n",
     "    name=\"python_repl\",\n",
     "    description=\"A Python shell. Use this to execute python commands. Input should be a valid python command. If you want to see the output of a value, you should print it out with `print(...)`.\",\n",
-    "    func=python_repl\n",
+    "    func=python_repl.run\n",
     ")"
    ]
   }


### PR DESCRIPTION
In the example for creating a Python REPL tool under the Agent module, the ".run" was omitted in the example. I believe this is required when defining a Tool.