### PR TITLE
[RFC] Question of Tooling Consistency Check Between Agent<>AgentExecutor

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -629,12 +629,17 @@ class AgentExecutor(Chain):
         agent = values["agent"]
         tools = values["tools"]
         allowed_tools = agent.get_allowed_tools()
-        if allowed_tools is not None:
-            if set(allowed_tools) != set([tool.name for tool in tools]):
-                raise ValueError(
-                    f"Allowed tools ({allowed_tools}) different than "
-                    f"provided tools ({[tool.name for tool in tools]})"
-                )
+        if allowed_tools is None and len(tools) == 0:
+            return values
+        if allowed_tools is None and len(tools) != 0:
+            raise ValueError(
+                "Tools provided but no tool defined in Agent."
+            )
+        if set(allowed_tools) != set([tool.name for tool in tools]):
+            raise ValueError(
+                f"Allowed tools ({allowed_tools}) different than "
+                f"provided tools ({[tool.name for tool in tools]})"
+            )
         return values
 
     @root_validator()

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -632,9 +632,7 @@ class AgentExecutor(Chain):
         if allowed_tools is None and len(tools) == 0:
             return values
         if allowed_tools is None and len(tools) != 0:
-            raise ValueError(
-                "Tools provided but no tool defined in Agent."
-            )
+            raise ValueError("Tools provided but no tool defined in Agent.")
         if set(allowed_tools) != set([tool.name for tool in tools]):
             raise ValueError(
                 f"Allowed tools ({allowed_tools}) different than "


### PR DESCRIPTION
This is a follow up of https://github.com/hwchase17/langchain/pull/3840

Question: Why do we allow `None` `allowed_tools` in `Agent` when there are tools provided in `AgentExecutor`?

AgentExecutor is able to fetch the `allowed_tools` from `Agent` directly. It doesn’t look like we need to provide `tools` again at `AgentExecutor` entry functions when `Agent` is already provided as a parameter.

I’m new to the logics. I could be wrong. Would like to get some help here. Thank you so much.