### PR TITLE
fix: incorrect data type when construct_path in chain

### DIFF
--- a/langchain/chains/api/openapi/chain.py
+++ b/langchain/chains/api/openapi/chain.py
@@ -61,7 +61,7 @@ class OpenAPIEndpointChain(Chain, BaseModel):
         """Construct the path from the deserialized input."""
         path = self.api_operation.base_url + self.api_operation.path
         for param in self.param_mapping.path_params:
-            path = path.replace(f"{{{param}}}", args.pop(param, ""))
+            path = path.replace(f"{{{param}}}", str(args.pop(param, "")))
         return path
 
     def _extract_query_params(self, args: Dict[str, str]) -> Dict[str, str]:


### PR DESCRIPTION
A incorrect data type error happened when executing _construct_path in `chain.py` as follows:

```python
Error with message replace() argument 2 must be str, not int
```

The path is always a string. But the result of `args.pop(param, "")` is undefined.