### PR TITLE
Deleted  importing Document from document_loaders.base because Documen…

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/arxiv.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/arxiv.ipynb
@@ -88,7 +88,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.document_loaders.base import Document\n",
     "from langchain.document_loaders import ArxivLoader"
    ]
   },


### PR DESCRIPTION
Hi,

- Modification: https://python.langchain.com/en/latest/modules/indexes/document_loaders/examples/arxiv.html
- Reason: In this example, the first line is unnecessary because the Document class does not exist in the base. 
- Resolves: Issue #4052

--------
P.S: This pull-request is my first time, so please let me know if I need to correct or write more explanation.