### PR TITLE
docs: document_loaders classification

### DIFF
--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -30,30 +30,30 @@ For detailed instructions on how to get set up with Unstructured, see installati
    :maxdepth: 1
    :glob:
 
-./document_loaders/examples/CoNLL-U.ipynb
-./document_loaders/examples/copypaste.ipynb
-./document_loaders/examples/csv.ipynb
-./document_loaders/examples/dataframe.ipynb
-./document_loaders/examples/directory_loader.ipynb
-./document_loaders/examples/email.ipynb
-./document_loaders/examples/epub.ipynb
-./document_loaders/examples/image.ipynb
-./document_loaders/examples/html.ipynb
-./document_loaders/examples/evernote.ipynb
-./document_loaders/examples/facebook_chat.ipynb
-./document_loaders/examples/markdown.ipynb
-./document_loaders/examples/notebook.ipynb
-./document_loaders/examples/pdf.ipynb
-./document_loaders/examples/powerpoint.ipynb
-./document_loaders/examples/sitemap.ipynb
-./document_loaders/examples/srt.ipynb
-./document_loaders/examples/telegram.ipynb
-./document_loaders/examples/toml.ipynb
-./document_loaders/examples/unstructured_file.ipynb
-./document_loaders/examples/url.ipynb
-./document_loaders/examples/web_base.ipynb
-./document_loaders/examples/whatsapp_chat.ipynb
-./document_loaders/examples/word_document.ipynb
+   ./document_loaders/examples/examples/CoNLL-U.ipynb
+   ./document_loaders/examples/examples/copypaste.ipynb
+   ./document_loaders/examples/examples/csv.ipynb
+   ./document_loaders/examples/examples/dataframe.ipynb
+   ./document_loaders/examples/examples/directory_loader.ipynb
+   ./document_loaders/examples/examples/email.ipynb
+   ./document_loaders/examples/examples/epub.ipynb
+   ./document_loaders/examples/examples/image.ipynb
+   ./document_loaders/examples/examples/html.ipynb
+   ./document_loaders/examples/examples/evernote.ipynb
+   ./document_loaders/examples/examples/facebook_chat.ipynb
+   ./document_loaders/examples/examples/markdown.ipynb
+   ./document_loaders/examples/examples/notebook.ipynb
+   ./document_loaders/examples/examples/pdf.ipynb
+   ./document_loaders/examples/examples/powerpoint.ipynb
+   ./document_loaders/examples/examples/sitemap.ipynb
+   ./document_loaders/examples/examples/srt.ipynb
+   ./document_loaders/examples/examples/telegram.ipynb
+   ./document_loaders/examples/examples/toml.ipynb
+   ./document_loaders/examples/examples/unstructured_file.ipynb
+   ./document_loaders/examples/examples/url.ipynb
+   ./document_loaders/examples/examples/web_base.ipynb
+   ./document_loaders/examples/examples/whatsapp_chat.ipynb
+   ./document_loaders/examples/examples/word_document.ipynb
 
 
 Public dataset or service loaders
@@ -68,17 +68,17 @@ You don't need any access permissions to these datasets and services.
    :maxdepth: 1
    :glob:
 
-./document_loaders/examples/arxiv.ipynb
-./document_loaders/examples/azlyrics.ipynb
-./document_loaders/examples/bilibili.ipynb
-./document_loaders/examples/college_confidential.ipynb
-./document_loaders/examples/gutenberg.ipynb
-./document_loaders/examples/hn.ipynb
-./document_loaders/examples/hugging_face_dataset.ipynb
-./document_loaders/examples/ifixit.ipynb
-./document_loaders/examples/imsdb.ipynb
-./document_loaders/examples/mediawikidump.ipynb
-./document_loaders/examples/youtube.ipynb
+   ./document_loaders/examples/examples/arxiv.ipynb
+   ./document_loaders/examples/examples/azlyrics.ipynb
+   ./document_loaders/examples/examples/bilibili.ipynb
+   ./document_loaders/examples/examples/college_confidential.ipynb
+   ./document_loaders/examples/examples/gutenberg.ipynb
+   ./document_loaders/examples/examples/hn.ipynb
+   ./document_loaders/examples/examples/hugging_face_dataset.ipynb
+   ./document_loaders/examples/examples/ifixit.ipynb
+   ./document_loaders/examples/examples/imsdb.ipynb
+   ./document_loaders/examples/examples/mediawikidump.ipynb
+   ./document_loaders/examples/examples/youtube.ipynb
 
 
 Proprietary dataset or service loaders
@@ -93,36 +93,36 @@ We need access tokens and sometime other parameters to get access to these datas
    :maxdepth: 1
    :glob:
 
-./document_loaders/examples/airbyte_json.ipynb
-./document_loaders/examples/apify_dataset.ipynb
-./document_loaders/examples/azure_blob_storage_container.ipynb
-./document_loaders/examples/azure_blob_storage_file.ipynb
-./document_loaders/examples/bigquery.ipynb
-./document_loaders/examples/blackboard.ipynb
-./document_loaders/examples/blockchain.ipynb
-./document_loaders/examples/chatgpt_loader.ipynb
-./document_loaders/examples/confluence.ipynb
-./document_loaders/examples/diffbot.ipynb
-./document_loaders/examples/discord_loader.ipynb
-./document_loaders/examples/duckdb.ipynb
-./document_loaders/examples/figma.ipynb
-./document_loaders/examples/gcs_directory.ipynb
-./document_loaders/examples/gcs_file.ipynb
-./document_loaders/examples/gitbook.ipynb
-./document_loaders/examples/git.ipynb
-./document_loaders/examples/googledrive.ipynb
-./document_loaders/examples/image_captions.ipynb
-./document_loaders/examples/modern_treasury.ipynb
-./document_loaders/examples/notiondb.ipynb
-./document_loaders/examples/notion.ipynb
-./document_loaders/examples/obsidian.ipynb
-./document_loaders/examples/onedrive.ipynb
-./document_loaders/examples/readthedocs_documentation.ipynb
-./document_loaders/examples/reddit.ipynb
-./document_loaders/examples/roam.ipynb
-./document_loaders/examples/s3_directory.ipynb
-./document_loaders/examples/s3_file.ipynb
-./document_loaders/examples/slack_directory.ipynb
-./document_loaders/examples/spreedly.ipynb
-./document_loaders/examples/stripe.ipynb
-./document_loaders/examples/twitter.ipynb
+   ./document_loaders/examples/examples/airbyte_json.ipynb
+   ./document_loaders/examples/examples/apify_dataset.ipynb
+   ./document_loaders/examples/examples/azure_blob_storage_container.ipynb
+   ./document_loaders/examples/examples/azure_blob_storage_file.ipynb
+   ./document_loaders/examples/examples/bigquery.ipynb
+   ./document_loaders/examples/examples/blackboard.ipynb
+   ./document_loaders/examples/examples/blockchain.ipynb
+   ./document_loaders/examples/examples/chatgpt_loader.ipynb
+   ./document_loaders/examples/examples/confluence.ipynb
+   ./document_loaders/examples/examples/diffbot.ipynb
+   ./document_loaders/examples/examples/discord_loader.ipynb
+   ./document_loaders/examples/examples/duckdb.ipynb
+   ./document_loaders/examples/examples/figma.ipynb
+   ./document_loaders/examples/examples/gcs_directory.ipynb
+   ./document_loaders/examples/examples/gcs_file.ipynb
+   ./document_loaders/examples/examples/gitbook.ipynb
+   ./document_loaders/examples/examples/git.ipynb
+   ./document_loaders/examples/examples/googledrive.ipynb
+   ./document_loaders/examples/examples/image_captions.ipynb
+   ./document_loaders/examples/examples/modern_treasury.ipynb
+   ./document_loaders/examples/examples/notiondb.ipynb
+   ./document_loaders/examples/examples/notion.ipynb
+   ./document_loaders/examples/examples/obsidian.ipynb
+   ./document_loaders/examples/examples/onedrive.ipynb
+   ./document_loaders/examples/examples/readthedocs_documentation.ipynb
+   ./document_loaders/examples/examples/reddit.ipynb
+   ./document_loaders/examples/examples/roam.ipynb
+   ./document_loaders/examples/examples/s3_directory.ipynb
+   ./document_loaders/examples/examples/s3_file.ipynb
+   ./document_loaders/examples/examples/slack_directory.ipynb
+   ./document_loaders/examples/examples/spreedly.ipynb
+   ./document_loaders/examples/examples/stripe.ipynb
+   ./document_loaders/examples/examples/twitter.ipynb

--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -30,30 +30,31 @@ For detailed instructions on how to get set up with Unstructured, see installati
    :maxdepth: 1
    :glob:
 
-   ./document_loaders/examples/CoNLL-U.ipynb
+   ./document_loaders/examples/conll-u.ipynb
    ./document_loaders/examples/copypaste.ipynb
    ./document_loaders/examples/csv.ipynb
-   ./document_loaders/examples/dataframe.ipynb
-   ./document_loaders/examples/directory_loader.ipynb
    ./document_loaders/examples/email.ipynb
    ./document_loaders/examples/epub.ipynb
-   ./document_loaders/examples/image.ipynb
-   ./document_loaders/examples/html.ipynb
    ./document_loaders/examples/evernote.ipynb
    ./document_loaders/examples/facebook_chat.ipynb
+   ./document_loaders/examples/file_directory.ipynb
+   ./document_loaders/examples/html.ipynb
+   ./document_loaders/examples/image.ipynb
+   ./document_loaders/examples/jupyter_notebook.ipynb
    ./document_loaders/examples/markdown.ipynb
-   ./document_loaders/examples/notebook.ipynb
+   ./document_loaders/examples/microsoft_powerpoint.ipynb
+   ./document_loaders/examples/microsoft_word.ipynb
+   ./document_loaders/examples/pandas_dataframe.ipynb
    ./document_loaders/examples/pdf.ipynb
-   ./document_loaders/examples/powerpoint.ipynb
    ./document_loaders/examples/sitemap.ipynb
-   ./document_loaders/examples/srt.ipynb
+   ./document_loaders/examples/subtitle.ipynb
    ./document_loaders/examples/telegram.ipynb
    ./document_loaders/examples/toml.ipynb
    ./document_loaders/examples/unstructured_file.ipynb
    ./document_loaders/examples/url.ipynb
    ./document_loaders/examples/web_base.ipynb
    ./document_loaders/examples/whatsapp_chat.ipynb
-   ./document_loaders/examples/word_document.ipynb
+
 
 
 Public dataset or service loaders
@@ -74,12 +75,12 @@ We don't need any access permissions to these datasets and services.
    ./document_loaders/examples/bilibili.ipynb
    ./document_loaders/examples/college_confidential.ipynb
    ./document_loaders/examples/gutenberg.ipynb
-   ./document_loaders/examples/hn.ipynb
+   ./document_loaders/examples/hacker_news.ipynb
    ./document_loaders/examples/hugging_face_dataset.ipynb
    ./document_loaders/examples/ifixit.ipynb
    ./document_loaders/examples/imsdb.ipynb
    ./document_loaders/examples/mediawikidump.ipynb
-   ./document_loaders/examples/youtube.ipynb
+   ./document_loaders/examples/youtube_transcript.ipynb
 
 
 Proprietary dataset or service loaders
@@ -97,9 +98,10 @@ We need access tokens and sometime other parameters to get access to these datas
 
    ./document_loaders/examples/airbyte_json.ipynb
    ./document_loaders/examples/apify_dataset.ipynb
+   ./document_loaders/examples/aws_s3_directory.ipynb
+   ./document_loaders/examples/aws_s3_file.ipynb
    ./document_loaders/examples/azure_blob_storage_container.ipynb
    ./document_loaders/examples/azure_blob_storage_file.ipynb
-   ./document_loaders/examples/bigquery.ipynb
    ./document_loaders/examples/blackboard.ipynb
    ./document_loaders/examples/blockchain.ipynb
    ./document_loaders/examples/chatgpt_loader.ipynb
@@ -108,23 +110,22 @@ We need access tokens and sometime other parameters to get access to these datas
    ./document_loaders/examples/discord_loader.ipynb
    ./document_loaders/examples/duckdb.ipynb
    ./document_loaders/examples/figma.ipynb
-   ./document_loaders/examples/gcs_directory.ipynb
-   ./document_loaders/examples/gcs_file.ipynb
    ./document_loaders/examples/gitbook.ipynb
    ./document_loaders/examples/git.ipynb
-   ./document_loaders/examples/googledrive.ipynb
+   ./document_loaders/examples/google_bigquery.ipynb
+   ./document_loaders/examples/google_cloud_storage_directory.ipynb
+   ./document_loaders/examples/google_cloud_storage_file.ipynb
+   ./document_loaders/examples/google_drive.ipynb
    ./document_loaders/examples/image_captions.ipynb
+   ./document_loaders/examples/microsoft_onedrive.ipynb
    ./document_loaders/examples/modern_treasury.ipynb
    ./document_loaders/examples/notiondb.ipynb
    ./document_loaders/examples/notion.ipynb
    ./document_loaders/examples/obsidian.ipynb
-   ./document_loaders/examples/onedrive.ipynb
    ./document_loaders/examples/readthedocs_documentation.ipynb
    ./document_loaders/examples/reddit.ipynb
    ./document_loaders/examples/roam.ipynb
-   ./document_loaders/examples/s3_directory.ipynb
-   ./document_loaders/examples/s3_file.ipynb
-   ./document_loaders/examples/slack_directory.ipynb
+   ./document_loaders/examples/slack.ipynb
    ./document_loaders/examples/spreedly.ipynb
    ./document_loaders/examples/stripe.ipynb
    ./document_loaders/examples/twitter.ipynb

--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -13,10 +13,10 @@ The document loader is aimed at making this easy.
 The following document loaders are provided:
 
 
-Transformer Loaders
+Transform Loaders
 ------------------------------
 
-These **transformer** loaders transform data from a specific format into the Document format.
+These **transform** loaders transform data from a specific format into the Document format.
 For example, there are **transformers** for CSV and SQL.
 Mostly, these loaders input data from files but sometime from URLs.
 
@@ -85,7 +85,7 @@ Proprietary dataset or service loaders
 ------------------------------
 These datasets and services are not from the public domain.
 These loaders mostly transform data from specific formats of applications or cloud services,
-for example the **Google Drive**.
+for example **Google Drive**.
 We need access tokens and sometime other parameters to get access to these datasets and services.
 
 

--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -13,7 +13,7 @@ The document loader is aimed at making this easy.
 The following document loaders are provided:
 
 
-Transform Loaders
+Transform loaders
 ------------------------------
 
 These **transform** loaders transform data from a specific format into the Document format.
@@ -61,7 +61,8 @@ Public dataset or service loaders
 These datasets and sources are created for public domain and we use queries to search there
 and download necessary documents.
 For example, **Hacker News** service.
-You don't need any access permissions to these datasets and services.
+
+We don't need any access permissions to these datasets and services.
 
 
 .. toctree::
@@ -86,6 +87,7 @@ Proprietary dataset or service loaders
 These datasets and services are not from the public domain.
 These loaders mostly transform data from specific formats of applications or cloud services,
 for example **Google Drive**.
+
 We need access tokens and sometime other parameters to get access to these datasets and services.
 
 

--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -30,30 +30,30 @@ For detailed instructions on how to get set up with Unstructured, see installati
    :maxdepth: 1
    :glob:
 
-   ./document_loaders/examples/examples/CoNLL-U.ipynb
-   ./document_loaders/examples/examples/copypaste.ipynb
-   ./document_loaders/examples/examples/csv.ipynb
-   ./document_loaders/examples/examples/dataframe.ipynb
-   ./document_loaders/examples/examples/directory_loader.ipynb
-   ./document_loaders/examples/examples/email.ipynb
-   ./document_loaders/examples/examples/epub.ipynb
-   ./document_loaders/examples/examples/image.ipynb
-   ./document_loaders/examples/examples/html.ipynb
-   ./document_loaders/examples/examples/evernote.ipynb
-   ./document_loaders/examples/examples/facebook_chat.ipynb
-   ./document_loaders/examples/examples/markdown.ipynb
-   ./document_loaders/examples/examples/notebook.ipynb
-   ./document_loaders/examples/examples/pdf.ipynb
-   ./document_loaders/examples/examples/powerpoint.ipynb
-   ./document_loaders/examples/examples/sitemap.ipynb
-   ./document_loaders/examples/examples/srt.ipynb
-   ./document_loaders/examples/examples/telegram.ipynb
-   ./document_loaders/examples/examples/toml.ipynb
-   ./document_loaders/examples/examples/unstructured_file.ipynb
-   ./document_loaders/examples/examples/url.ipynb
-   ./document_loaders/examples/examples/web_base.ipynb
-   ./document_loaders/examples/examples/whatsapp_chat.ipynb
-   ./document_loaders/examples/examples/word_document.ipynb
+   ./document_loaders/examples/CoNLL-U.ipynb
+   ./document_loaders/examples/copypaste.ipynb
+   ./document_loaders/examples/csv.ipynb
+   ./document_loaders/examples/dataframe.ipynb
+   ./document_loaders/examples/directory_loader.ipynb
+   ./document_loaders/examples/email.ipynb
+   ./document_loaders/examples/epub.ipynb
+   ./document_loaders/examples/image.ipynb
+   ./document_loaders/examples/html.ipynb
+   ./document_loaders/examples/evernote.ipynb
+   ./document_loaders/examples/facebook_chat.ipynb
+   ./document_loaders/examples/markdown.ipynb
+   ./document_loaders/examples/notebook.ipynb
+   ./document_loaders/examples/pdf.ipynb
+   ./document_loaders/examples/powerpoint.ipynb
+   ./document_loaders/examples/sitemap.ipynb
+   ./document_loaders/examples/srt.ipynb
+   ./document_loaders/examples/telegram.ipynb
+   ./document_loaders/examples/toml.ipynb
+   ./document_loaders/examples/unstructured_file.ipynb
+   ./document_loaders/examples/url.ipynb
+   ./document_loaders/examples/web_base.ipynb
+   ./document_loaders/examples/whatsapp_chat.ipynb
+   ./document_loaders/examples/word_document.ipynb
 
 
 Public dataset or service loaders
@@ -68,17 +68,17 @@ You don't need any access permissions to these datasets and services.
    :maxdepth: 1
    :glob:
 
-   ./document_loaders/examples/examples/arxiv.ipynb
-   ./document_loaders/examples/examples/azlyrics.ipynb
-   ./document_loaders/examples/examples/bilibili.ipynb
-   ./document_loaders/examples/examples/college_confidential.ipynb
-   ./document_loaders/examples/examples/gutenberg.ipynb
-   ./document_loaders/examples/examples/hn.ipynb
-   ./document_loaders/examples/examples/hugging_face_dataset.ipynb
-   ./document_loaders/examples/examples/ifixit.ipynb
-   ./document_loaders/examples/examples/imsdb.ipynb
-   ./document_loaders/examples/examples/mediawikidump.ipynb
-   ./document_loaders/examples/examples/youtube.ipynb
+   ./document_loaders/examples/arxiv.ipynb
+   ./document_loaders/examples/azlyrics.ipynb
+   ./document_loaders/examples/bilibili.ipynb
+   ./document_loaders/examples/college_confidential.ipynb
+   ./document_loaders/examples/gutenberg.ipynb
+   ./document_loaders/examples/hn.ipynb
+   ./document_loaders/examples/hugging_face_dataset.ipynb
+   ./document_loaders/examples/ifixit.ipynb
+   ./document_loaders/examples/imsdb.ipynb
+   ./document_loaders/examples/mediawikidump.ipynb
+   ./document_loaders/examples/youtube.ipynb
 
 
 Proprietary dataset or service loaders
@@ -93,36 +93,36 @@ We need access tokens and sometime other parameters to get access to these datas
    :maxdepth: 1
    :glob:
 
-   ./document_loaders/examples/examples/airbyte_json.ipynb
-   ./document_loaders/examples/examples/apify_dataset.ipynb
-   ./document_loaders/examples/examples/azure_blob_storage_container.ipynb
-   ./document_loaders/examples/examples/azure_blob_storage_file.ipynb
-   ./document_loaders/examples/examples/bigquery.ipynb
-   ./document_loaders/examples/examples/blackboard.ipynb
-   ./document_loaders/examples/examples/blockchain.ipynb
-   ./document_loaders/examples/examples/chatgpt_loader.ipynb
-   ./document_loaders/examples/examples/confluence.ipynb
-   ./document_loaders/examples/examples/diffbot.ipynb
-   ./document_loaders/examples/examples/discord_loader.ipynb
-   ./document_loaders/examples/examples/duckdb.ipynb
-   ./document_loaders/examples/examples/figma.ipynb
-   ./document_loaders/examples/examples/gcs_directory.ipynb
-   ./document_loaders/examples/examples/gcs_file.ipynb
-   ./document_loaders/examples/examples/gitbook.ipynb
-   ./document_loaders/examples/examples/git.ipynb
-   ./document_loaders/examples/examples/googledrive.ipynb
-   ./document_loaders/examples/examples/image_captions.ipynb
-   ./document_loaders/examples/examples/modern_treasury.ipynb
-   ./document_loaders/examples/examples/notiondb.ipynb
-   ./document_loaders/examples/examples/notion.ipynb
-   ./document_loaders/examples/examples/obsidian.ipynb
-   ./document_loaders/examples/examples/onedrive.ipynb
-   ./document_loaders/examples/examples/readthedocs_documentation.ipynb
-   ./document_loaders/examples/examples/reddit.ipynb
-   ./document_loaders/examples/examples/roam.ipynb
-   ./document_loaders/examples/examples/s3_directory.ipynb
-   ./document_loaders/examples/examples/s3_file.ipynb
-   ./document_loaders/examples/examples/slack_directory.ipynb
-   ./document_loaders/examples/examples/spreedly.ipynb
-   ./document_loaders/examples/examples/stripe.ipynb
-   ./document_loaders/examples/examples/twitter.ipynb
+   ./document_loaders/examples/airbyte_json.ipynb
+   ./document_loaders/examples/apify_dataset.ipynb
+   ./document_loaders/examples/azure_blob_storage_container.ipynb
+   ./document_loaders/examples/azure_blob_storage_file.ipynb
+   ./document_loaders/examples/bigquery.ipynb
+   ./document_loaders/examples/blackboard.ipynb
+   ./document_loaders/examples/blockchain.ipynb
+   ./document_loaders/examples/chatgpt_loader.ipynb
+   ./document_loaders/examples/confluence.ipynb
+   ./document_loaders/examples/diffbot.ipynb
+   ./document_loaders/examples/discord_loader.ipynb
+   ./document_loaders/examples/duckdb.ipynb
+   ./document_loaders/examples/figma.ipynb
+   ./document_loaders/examples/gcs_directory.ipynb
+   ./document_loaders/examples/gcs_file.ipynb
+   ./document_loaders/examples/gitbook.ipynb
+   ./document_loaders/examples/git.ipynb
+   ./document_loaders/examples/googledrive.ipynb
+   ./document_loaders/examples/image_captions.ipynb
+   ./document_loaders/examples/modern_treasury.ipynb
+   ./document_loaders/examples/notiondb.ipynb
+   ./document_loaders/examples/notion.ipynb
+   ./document_loaders/examples/obsidian.ipynb
+   ./document_loaders/examples/onedrive.ipynb
+   ./document_loaders/examples/readthedocs_documentation.ipynb
+   ./document_loaders/examples/reddit.ipynb
+   ./document_loaders/examples/roam.ipynb
+   ./document_loaders/examples/s3_directory.ipynb
+   ./document_loaders/examples/s3_file.ipynb
+   ./document_loaders/examples/slack_directory.ipynb
+   ./document_loaders/examples/spreedly.ipynb
+   ./document_loaders/examples/stripe.ipynb
+   ./document_loaders/examples/twitter.ipynb

--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -6,19 +6,123 @@ Document Loaders
 
 
 Combining language models with your own text data is a powerful way to differentiate them.
-The first step in doing this is to load the data into "documents" - a fancy way of say some pieces of text.
-This module is aimed at making this easy.
+The first step in doing this is to load the data into "Documents" - a fancy way of say some pieces of text.
+The document loader is aimed at making this easy.
 
-A primary driver of a lot of this is the `Unstructured <https://github.com/Unstructured-IO/unstructured>`_ python package.
-This package is a great way to transform all types of files - text, powerpoint, images, html, pdf, etc - into text data.
-
-For detailed instructions on how to get set up with Unstructured, see installation guidelines `here <https://github.com/Unstructured-IO/unstructured#coffee-getting-started>`_.
 
 The following document loaders are provided:
+
+
+Transformer Loaders
+------------------------------
+
+These **transformer** loaders transform data from a specific format into the Document format.
+For example, there are **transformers** for CSV and SQL.
+Mostly, these loaders input data from files but sometime from URLs.
+
+A primary driver of a lot of these transformers is the `Unstructured <https://github.com/Unstructured-IO/unstructured>`_ python package.
+This package transforms many types of files - text, powerpoint, images, html, pdf, etc - into text data.
+
+For detailed instructions on how to get set up with Unstructured, see installation guidelines `here <https://github.com/Unstructured-IO/unstructured#coffee-getting-started>`_.
 
 
 .. toctree::
    :maxdepth: 1
    :glob:
 
-   ./document_loaders/examples/*
+./document_loaders/examples/CoNLL-U.ipynb
+./document_loaders/examples/copypaste.ipynb
+./document_loaders/examples/csv.ipynb
+./document_loaders/examples/dataframe.ipynb
+./document_loaders/examples/directory_loader.ipynb
+./document_loaders/examples/email.ipynb
+./document_loaders/examples/epub.ipynb
+./document_loaders/examples/image.ipynb
+./document_loaders/examples/html.ipynb
+./document_loaders/examples/evernote.ipynb
+./document_loaders/examples/facebook_chat.ipynb
+./document_loaders/examples/markdown.ipynb
+./document_loaders/examples/notebook.ipynb
+./document_loaders/examples/pdf.ipynb
+./document_loaders/examples/powerpoint.ipynb
+./document_loaders/examples/sitemap.ipynb
+./document_loaders/examples/srt.ipynb
+./document_loaders/examples/telegram.ipynb
+./document_loaders/examples/toml.ipynb
+./document_loaders/examples/unstructured_file.ipynb
+./document_loaders/examples/url.ipynb
+./document_loaders/examples/web_base.ipynb
+./document_loaders/examples/whatsapp_chat.ipynb
+./document_loaders/examples/word_document.ipynb
+
+
+Public dataset or service loaders
+----------------------------------
+These datasets and sources are created for public domain and we use queries to search there
+and download necessary documents.
+For example, **Hacker News** service.
+You don't need any access permissions to these datasets and services.
+
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+./document_loaders/examples/arxiv.ipynb
+./document_loaders/examples/azlyrics.ipynb
+./document_loaders/examples/bilibili.ipynb
+./document_loaders/examples/college_confidential.ipynb
+./document_loaders/examples/gutenberg.ipynb
+./document_loaders/examples/hn.ipynb
+./document_loaders/examples/hugging_face_dataset.ipynb
+./document_loaders/examples/ifixit.ipynb
+./document_loaders/examples/imsdb.ipynb
+./document_loaders/examples/mediawikidump.ipynb
+./document_loaders/examples/youtube.ipynb
+
+
+Proprietary dataset or service loaders
+------------------------------
+These datasets and services are not from the public domain.
+These loaders mostly transform data from specific formats of applications or cloud services,
+for example the **Google Drive**.
+We need access tokens and sometime other parameters to get access to these datasets and services.
+
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+./document_loaders/examples/airbyte_json.ipynb
+./document_loaders/examples/apify_dataset.ipynb
+./document_loaders/examples/azure_blob_storage_container.ipynb
+./document_loaders/examples/azure_blob_storage_file.ipynb
+./document_loaders/examples/bigquery.ipynb
+./document_loaders/examples/blackboard.ipynb
+./document_loaders/examples/blockchain.ipynb
+./document_loaders/examples/chatgpt_loader.ipynb
+./document_loaders/examples/confluence.ipynb
+./document_loaders/examples/diffbot.ipynb
+./document_loaders/examples/discord_loader.ipynb
+./document_loaders/examples/duckdb.ipynb
+./document_loaders/examples/figma.ipynb
+./document_loaders/examples/gcs_directory.ipynb
+./document_loaders/examples/gcs_file.ipynb
+./document_loaders/examples/gitbook.ipynb
+./document_loaders/examples/git.ipynb
+./document_loaders/examples/googledrive.ipynb
+./document_loaders/examples/image_captions.ipynb
+./document_loaders/examples/modern_treasury.ipynb
+./document_loaders/examples/notiondb.ipynb
+./document_loaders/examples/notion.ipynb
+./document_loaders/examples/obsidian.ipynb
+./document_loaders/examples/onedrive.ipynb
+./document_loaders/examples/readthedocs_documentation.ipynb
+./document_loaders/examples/reddit.ipynb
+./document_loaders/examples/roam.ipynb
+./document_loaders/examples/s3_directory.ipynb
+./document_loaders/examples/s3_file.ipynb
+./document_loaders/examples/slack_directory.ipynb
+./document_loaders/examples/spreedly.ipynb
+./document_loaders/examples/stripe.ipynb
+./document_loaders/examples/twitter.ipynb


### PR DESCRIPTION

**Problem statement:** the [document_loaders](https://python.langchain.com/en/latest/modules/indexes/document_loaders.html#) section is too long and hard to comprehend.
**Proposal:** group document_loaders by 3 classes: (see `Files changed` tab)

UPDATE: I've completely reworked the document_loader classification.
Now this PR changes only one file! 

FYI @eyurtsev @hwchase17 