### PR TITLE
Initialize buffer for `ConversationSummaryMemory` if underlying chat messages are not empty.

### DIFF
--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -40,6 +40,14 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
     buffer: str = ""
     memory_key: str = "history"  #: :meta private:
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Prepare buffer if there is existing messages stored
+        if self.chat_memory.messages != []:
+            self.buffer = self.predict_new_summary(
+                self.chat_memory.messages[-2:], self.buffer
+            )
+
     @property
     def memory_variables(self) -> List[str]:
         """Will always return list of memory variables.

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Type
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, conint, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.llm import LLMChain
@@ -39,14 +41,22 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
 
     buffer: str = ""
     memory_key: str = "history"  #: :meta private:
+    summarize_step: conint(gt=0) = 2
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # Prepare buffer if there are existing messages stored
-        if self.chat_memory.messages != []:
-            self.buffer = self.predict_new_summary(
-                self.chat_memory.messages[-2:], self.buffer
+        if (self.chat_memory.messages != []) and (self.buffer == ""):
+            message_list = self.chat_memory.messages
+            self.buffer = self.summarize_message_list(message_list)
+
+    def summarize_message_list(self, message_list: List[BaseMessage]) -> str:
+        buffer = ""
+        for i in range(0, len(message_list), self.summarize_step):
+            buffer = self.predict_new_summary(
+                self.chat_memory.messages[i : i + 2], buffer
             )
+        return buffer
 
     @property
     def memory_variables(self) -> List[str]:

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Type
 
-from pydantic import BaseModel, conint, root_validator
+from pydantic import BaseModel, Field, root_validator
 
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.llm import LLMChain
@@ -41,7 +41,7 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
 
     buffer: str = ""
     memory_key: str = "history"  #: :meta private:
-    summarize_step: conint(gt=0) = 2
+    summarize_step: int = Field(default=2, gt=0)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -54,7 +54,7 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
         buffer = ""
         for i in range(0, len(message_list), self.summarize_step):
             buffer = self.predict_new_summary(
-                self.chat_memory.messages[i : i + 2], buffer
+                self.chat_memory.messages[i : i + self.summarize_step], buffer
             )
         return buffer
 

--- a/langchain/memory/summary.py
+++ b/langchain/memory/summary.py
@@ -40,9 +40,9 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
     buffer: str = ""
     memory_key: str = "history"  #: :meta private:
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # Prepare buffer if there is existing messages stored
+        # Prepare buffer if there are existing messages stored
         if self.chat_memory.messages != []:
             self.buffer = self.predict_new_summary(
                 self.chat_memory.messages[-2:], self.buffer


### PR DESCRIPTION
`ConversationSummaryMemory` will have an empty buffer even if the chat messages are not empty. This is because the first refresh of buffer occurs in `save_context`. 

```
from langchain.memory import ConversationSummaryMemory
from langchain.chains import ConversationChain
from langchain.chat_models import ChatOpenAI
from langchain.memory import ChatMessageHistory

# Assuming I have existing messages.
chat_history = ChatMessageHistory()
chat_history.add_user_message("Hello!")
chat_history.add_ai_message("Hey there, how may I assist you today?")
chat_history.add_user_message("Answer briefly. What are the first 3 colors of a rainbow?")
chat_history.add_ai_message("The first three colors of a rainbow are red, orange, and yellow.")

chat_model = ChatOpenAI(temperature=0)
memory = ConversationSummaryMemory(
    chat_memory=chat_history, 
    llm=ChatOpenAI(temperature=0) # <-- You need an LLM to summarize the conversation.
)
conversation = ConversationChain(
    llm=chat_model,
    memory=memory,
    verbose=True
)
conversation.run("And the next 4?")
```

Output, notice summary is empty:
```
> Entering new ConversationChain chain...
Prompt after formatting:
The following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.

Current conversation:

Human: And the next 4?
AI:

> Finished chain.
The next 4 what? Please provide more context so I can better understand your question.
```