### PR TITLE
DeepLake: Pass in rest of args to self._search_helper

### DIFF
--- a/langchain/vectorstores/deeplake.py
+++ b/langchain/vectorstores/deeplake.py
@@ -437,6 +437,7 @@ class DeepLake(VectorStore):
             fetch_k=fetch_k,
             use_maximal_marginal_relevance=True,
             lambda_mult=lambda_mult,
+            **kwargs,
         )
 
     def max_marginal_relevance_search(
@@ -471,6 +472,7 @@ class DeepLake(VectorStore):
             fetch_k=fetch_k,
             use_maximal_marginal_relevance=True,
             lambda_mult=lambda_mult,
+            **kwargs,
         )
 
     @classmethod


### PR DESCRIPTION
As of right now when trying to use functions like `max_marginal_relevance_search()` or `max_marginal_relevance_search_by_vector()` the rest of the kwargs are not propagated to `self._search_helper()`. For example a user cannot explicitly state the distance_metric they want to use when calling `max_marginal_relevance_search`