### PR TITLE
OpenSearch: Add Similarity Search with Score

### DIFF
--- a/tests/integration_tests/vectorstores/test_opensearch.py
+++ b/tests/integration_tests/vectorstores/test_opensearch.py
@@ -23,6 +23,22 @@ def test_opensearch() -> None:
     assert output == [Document(page_content="foo")]
 
 
+def test_similarity_search_with_score() -> None:
+    """Test similarity search with score using Approximate Search."""
+    metadatas = [{"page": i} for i in range(len(texts))]
+    docsearch = OpenSearchVectorSearch.from_texts(
+        texts,
+        FakeEmbeddings(),
+        metadatas=metadatas,
+        opensearch_url=DEFAULT_OPENSEARCH_URL,
+    )
+    output = docsearch.similarity_search_with_score("foo", k=2)
+    assert output == [
+        (Document(page_content="foo", metadata={"page": 0}), 1.0),
+        (Document(page_content="bar", metadata={"page": 1}), 0.5),
+    ]
+
+
 def test_opensearch_with_custom_field_name() -> None:
     """Test indexing and search using custom vector field and text field name."""
     docsearch = OpenSearchVectorSearch.from_texts(
@@ -178,7 +194,7 @@ def test_appx_search_with_lucene_filter() -> None:
 
 def test_opensearch_with_custom_field_name_appx_true() -> None:
     """Test Approximate Search with custom field name appx true."""
-    text_input = ["test", "add", "text", "method"]
+    text_input = ["add", "test", "text", "method"]
     docsearch = OpenSearchVectorSearch.from_texts(
         text_input,
         FakeEmbeddings(),
@@ -191,7 +207,7 @@ def test_opensearch_with_custom_field_name_appx_true() -> None:
 
 def test_opensearch_with_custom_field_name_appx_false() -> None:
     """Test Approximate Search with custom field name appx true."""
-    text_input = ["test", "add", "text", "method"]
+    text_input = ["add", "test", "text", "method"]
     docsearch = OpenSearchVectorSearch.from_texts(
         text_input, FakeEmbeddings(), opensearch_url=DEFAULT_OPENSEARCH_URL
     )


### PR DESCRIPTION
### Description
Add `similarity_search_with_score` method for OpenSearch to return scores along with documents in the search results