### PR TITLE
Add Chain equivalents of Map() and Reduce()

### DIFF
--- a/langchain/chains/functional/MapChain.py
+++ b/langchain/chains/functional/MapChain.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain.chains.base import Chain
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.prompts.prompt import PromptTemplate
+from langchain.callbacks.stdout import StdOutCallbackHandler
+
+
+class MapChain(Chain):
+    """ This chain operates on a list of input values (input_values) and maps them using the mapper_chain
+    The functionality is similar to map() in functional programming
+    """
+
+    # input/output keys
+    input_values_key: str = "input_values"
+    output_values_keys: str = "output_values"
+
+    mapper_chain: Chain
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Will be whatever keys the prompt expects.
+
+        :meta private:
+        """
+        return [self.input_values_key]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Will always return text key.
+
+        :meta private:
+        """
+        return [self.output_values_keys]
+
+    def _call(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, str]:
+
+        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        input_values = inputs[self.input_values_key]
+
+        other_keys: Dict = {k: v for k, v in inputs.items() if k not in self.input_keys}
+
+        output_values = []
+        for input in input_values:
+
+            other_keys["input"] = input
+            output = self.mapper_chain(other_keys, callbacks=_run_manager.get_child())
+            output_value = output["output"]
+            output_values.append(output_value)
+
+        return {
+            self.output_values_keys: output_values
+        }
+
+    @property
+    def _chain_type(self) -> str:
+        return "MapChain"

--- a/langchain/chains/functional/ReduceChain.py
+++ b/langchain/chains/functional/ReduceChain.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain.chains.base import Chain
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+
+from langchain.prompts.prompt import PromptTemplate
+from langchain.callbacks.stdout import StdOutCallbackHandler
+
+
+class ReduceChain(Chain):
+    """ This chain operates on a list of input values (input_values)
+    Each item in the input_values is passed to the reducer_chain with two keys accumulated_value, current_value
+    The behaviour is similar to reduce() in functional programming
+    """
+
+    # input/output keys
+    input_values_key: str = "input_values"
+    initial_value_key: str = "initial_value"
+    output_value_key: str = "output_value"
+
+    reducer_chain: Chain
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Will be whatever keys the prompt expects.
+
+        :meta private:
+        """
+        return [self.input_values_key, self.initial_value_key]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Will always return text key.
+
+        :meta private:
+        """
+        return [self.output_value_key]
+
+    def _call(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, str]:
+
+        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        input_values = inputs[self.input_values_key]
+        initial_value = inputs[self.initial_value_key]
+
+        accumulated_value = initial_value
+
+        other_keys: Dict = {k: v for k, v in inputs.items() if k not in self.input_keys}
+
+        for current_value in input_values:
+
+            other_keys["accumulated_value"] = accumulated_value
+            other_keys["current_value"] = current_value
+
+            output = self.reducer_chain(other_keys, callbacks=_run_manager.get_child())
+            accumulated_value = output["output_value"]
+
+        return {
+            self.output_value_key: accumulated_value
+        }
+
+    @property
+    def _chain_type(self) -> str:
+        return "ReduceChain"

--- a/langchain/chains/functional/__init__.py
+++ b/langchain/chains/functional/__init__.py
@@ -1,0 +1,1 @@
+""" Chains that give a functional interface equivalent to map, reduce, filter(todo)"""


### PR DESCRIPTION
These are two chains which provide map() and reduce() behaviour. I used them as follows

Setup:
```
# this is a 'reducer' chain - similar to the callbackFn here  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
extraction_chain = ExtractionChain(llm=llm) 

# this is a 'mapper' chain
transform_chain = TransformChain(input_variables=["input"], output_variables=["output"], transform=transform_func)

reduce_chain = ReduceChain(llm=llm, reducer_chain=extraction_chain)
map_chain = MapChain(llm=llm, mapper_chain=transform_chain)
```


Usage:
```
# I want to extract facts from multiple documents and transform them into a certain format

docs = ["a.pdf", "b.pdf"]

doc_list = [PyPDFLoader(doc).load_and_split() for doc in docs]
texts = [item.page_content for sublist in doc_list for item in sublist]

reduce_response = reduce_chain.run(input_values=texts, initial_value=[])
map_response = map_chain.run(input_values=reduce_response)

```

If you think this is useful I'll polish it up + add docs and tests. 

Thank you for this amazing project!


