### PR TITLE
remove quotes from sql database prompts (caused syntax error) 

### DIFF
--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -11,10 +11,10 @@ Pay attention to use only the column names that you can see in the schema descri
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the tables listed below.
 
@@ -47,10 +47,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -69,10 +69,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -92,10 +92,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -114,10 +114,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -137,10 +137,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -160,10 +160,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -183,10 +183,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}
@@ -205,10 +205,10 @@ Pay attention to use only the column names you can see in the tables below. Be c
 
 Use the following format:
 
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
+Question: Question here
+SQLQuery: SQL Query to run
+SQLResult: Result of the SQLQuery
+Answer: Final answer here
 
 Only use the following tables:
 {table_info}


### PR DESCRIPTION
fixes a syntax error mentioned in
#2027 and #3305
another PR to remedy is in #3385, but I believe that is not tacking the core problem.
Also #2027 mentions a solution that works:
add to the prompt:
'The SQL query should be outputted plainly, do not surround it in quotes or anything else.'

To me it seems strange to first ask for:

SQLQuery: "SQL Query to run"

and then to tell the LLM not to put the quotes around it. Other templates (than the sql one) do not use quotes in their steps.
This PR changes that to:

SQLQuery: SQL Query to run

