### PR TITLE
Fix #4087 by setting the correct csv dialect

### DIFF
--- a/langchain/document_loaders/csv_loader.py
+++ b/langchain/document_loaders/csv_loader.py
@@ -30,18 +30,13 @@ class CSVLoader(BaseLoader):
         self,
         file_path: str,
         source_column: Optional[str] = None,
-        csv_args: Optional[Dict] = None,
+        csv_args: Optional[Dict] = {},
         encoding: Optional[str] = None,
     ):
         self.file_path = file_path
         self.source_column = source_column
         self.encoding = encoding
-        if csv_args is None:
-            self.csv_args = {
-                "dialect": csv.excel,
-            }
-        else:
-            self.csv_args = csv_args
+        self.csv_args = csv_args
 
     def load(self) -> List[Document]:
         """Load data into document objects."""

--- a/langchain/document_loaders/csv_loader.py
+++ b/langchain/document_loaders/csv_loader.py
@@ -30,7 +30,7 @@ class CSVLoader(BaseLoader):
         self,
         file_path: str,
         source_column: Optional[str] = None,
-        csv_args: Optional[Dict] = {},
+        csv_args: Optional[Dict] = None,
         encoding: Optional[str] = None,
     ):
         self.file_path = file_path

--- a/langchain/document_loaders/csv_loader.py
+++ b/langchain/document_loaders/csv_loader.py
@@ -31,15 +31,14 @@ class CSVLoader(BaseLoader):
         file_path: str,
         source_column: Optional[str] = None,
         csv_args: Optional[Dict] = None,
-        encoding: Optional[str] = None,
+        encoding: Optional[str] = None
     ):
         self.file_path = file_path
         self.source_column = source_column
         self.encoding = encoding
-        if csv_args is None:
+        if (csv_args is None):
             self.csv_args = {
-                "delimiter": csv.Dialect.delimiter,
-                "quotechar": csv.Dialect.quotechar,
+                "dialect": csv.excel,
             }
         else:
             self.csv_args = csv_args

--- a/langchain/document_loaders/csv_loader.py
+++ b/langchain/document_loaders/csv_loader.py
@@ -36,7 +36,7 @@ class CSVLoader(BaseLoader):
         self.file_path = file_path
         self.source_column = source_column
         self.encoding = encoding
-        self.csv_args = csv_args
+        self.csv_args = csv_args or {}
 
     def load(self) -> List[Document]:
         """Load data into document objects."""

--- a/langchain/document_loaders/csv_loader.py
+++ b/langchain/document_loaders/csv_loader.py
@@ -31,12 +31,12 @@ class CSVLoader(BaseLoader):
         file_path: str,
         source_column: Optional[str] = None,
         csv_args: Optional[Dict] = None,
-        encoding: Optional[str] = None
+        encoding: Optional[str] = None,
     ):
         self.file_path = file_path
         self.source_column = source_column
         self.encoding = encoding
-        if (csv_args is None):
+        if csv_args is None:
             self.csv_args = {
                 "dialect": csv.excel,
             }

--- a/tests/unit_tests/document_loader/test_csv_loader.py
+++ b/tests/unit_tests/document_loader/test_csv_loader.py
@@ -1,8 +1,9 @@
+from io import StringIO
+
 from pytest_mock import MockerFixture
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.csv_loader import CSVLoader
-from io import StringIO
 
 
 class TestCSVLoader:
@@ -22,7 +23,9 @@ class TestCSVLoader:
         ]
 
         mock_csv_reader = mocker.patch("builtins.open")
-        mock_csv_reader.return_value = StringIO("column1,column2,column3\nvalue1,value2,value3\nvalue4,value5,value6")
+        mock_csv_reader.return_value = StringIO(
+            "column1,column2,column3\nvalue1,value2,value3\nvalue4,value5,value6"
+        )
 
         # Exercise
         loader = CSVLoader(file_path=file_path)

--- a/tests/unit_tests/document_loader/test_csv_loader.py
+++ b/tests/unit_tests/document_loader/test_csv_loader.py
@@ -1,6 +1,4 @@
-from io import StringIO
-
-from pytest_mock import MockerFixture
+from pathlib import Path
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.csv_loader import CSVLoader
@@ -8,9 +6,9 @@ from langchain.document_loaders.csv_loader import CSVLoader
 
 class TestCSVLoader:
     # Tests that a CSV file with valid data is loaded successfully.
-    def test_csv_loader_load_from_string(self, mocker: MockerFixture) -> None:
+    def test_csv_loader_load_valid_data(self) -> None:
         # Setup
-        file_path = "test.csv"
+        file_path = self._get_csv_file_path("test_nominal.csv")
         expected_docs = [
             Document(
                 page_content="column1: value1\ncolumn2: value2\ncolumn3: value3",
@@ -20,39 +18,6 @@ class TestCSVLoader:
                 page_content="column1: value4\ncolumn2: value5\ncolumn3: value6",
                 metadata={"source": file_path, "row": 1},
             ),
-        ]
-
-        mock_csv_reader = mocker.patch("builtins.open")
-        mock_csv_reader.return_value = StringIO(
-            "column1,column2,column3\nvalue1,value2,value3\nvalue4,value5,value6"
-        )
-
-        # Exercise
-        loader = CSVLoader(file_path=file_path)
-        result = loader.load()
-
-        # Assert
-        assert result == expected_docs
-
-    # Tests that a CSV file with valid data is loaded successfully.
-    def test_csv_loader_load_valid_data(self, mocker: MockerFixture) -> None:
-        # Setup
-        file_path = "test.csv"
-        expected_docs = [
-            Document(
-                page_content="column1: value1\ncolumn2: value2\ncolumn3: value3",
-                metadata={"source": file_path, "row": 0},
-            ),
-            Document(
-                page_content="column1: value4\ncolumn2: value5\ncolumn3: value6",
-                metadata={"source": file_path, "row": 1},
-            ),
-        ]
-        mocker.patch("builtins.open", mocker.mock_open())
-        mock_csv_reader = mocker.patch("csv.DictReader")
-        mock_csv_reader.return_value = [
-            {"column1": "value1", "column2": "value2", "column3": "value3"},
-            {"column1": "value4", "column2": "value5", "column3": "value6"},
         ]
 
         # Exercise
@@ -63,13 +28,10 @@ class TestCSVLoader:
         assert result == expected_docs
 
     # Tests that an empty CSV file is handled correctly.
-    def test_csv_loader_load_empty_file(self, mocker: MockerFixture) -> None:
+    def test_csv_loader_load_empty_file(self) -> None:
         # Setup
-        file_path = "test.csv"
+        file_path = self._get_csv_file_path("test_empty.csv")
         expected_docs: list = []
-        mocker.patch("builtins.open", mocker.mock_open())
-        mock_csv_reader = mocker.patch("csv.DictReader")
-        mock_csv_reader.return_value = []
 
         # Exercise
         loader = CSVLoader(file_path=file_path)
@@ -79,19 +41,14 @@ class TestCSVLoader:
         assert result == expected_docs
 
     # Tests that a CSV file with only one row is handled correctly.
-    def test_csv_loader_load_single_row_file(self, mocker: MockerFixture) -> None:
+    def test_csv_loader_load_single_row_file(self) -> None:
         # Setup
-        file_path = "test.csv"
+        file_path = self._get_csv_file_path("test_one_row.csv")
         expected_docs = [
             Document(
                 page_content="column1: value1\ncolumn2: value2\ncolumn3: value3",
                 metadata={"source": file_path, "row": 0},
             )
-        ]
-        mocker.patch("builtins.open", mocker.mock_open())
-        mock_csv_reader = mocker.patch("csv.DictReader")
-        mock_csv_reader.return_value = [
-            {"column1": "value1", "column2": "value2", "column3": "value3"}
         ]
 
         # Exercise
@@ -102,9 +59,9 @@ class TestCSVLoader:
         assert result == expected_docs
 
     # Tests that a CSV file with only one column is handled correctly.
-    def test_csv_loader_load_single_column_file(self, mocker: MockerFixture) -> None:
+    def test_csv_loader_load_single_column_file(self) -> None:
         # Setup
-        file_path = "test.csv"
+        file_path = self._get_csv_file_path("test_one_col.csv")
         expected_docs = [
             Document(
                 page_content="column1: value1",
@@ -119,13 +76,6 @@ class TestCSVLoader:
                 metadata={"source": file_path, "row": 2},
             ),
         ]
-        mocker.patch("builtins.open", mocker.mock_open())
-        mock_csv_reader = mocker.patch("csv.DictReader")
-        mock_csv_reader.return_value = [
-            {"column1": "value1"},
-            {"column1": "value2"},
-            {"column1": "value3"},
-        ]
 
         # Exercise
         loader = CSVLoader(file_path=file_path)
@@ -133,3 +83,7 @@ class TestCSVLoader:
 
         # Assert
         assert result == expected_docs
+
+    # utility functions
+    def _get_csv_file_path(self, file_name: str) -> str:
+        return str(Path(__file__).resolve().parent / "test_docs" / "csv" / file_name)

--- a/tests/unit_tests/document_loader/test_csv_loader.py
+++ b/tests/unit_tests/document_loader/test_csv_loader.py
@@ -2,9 +2,35 @@ from pytest_mock import MockerFixture
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.csv_loader import CSVLoader
+from io import StringIO
 
 
 class TestCSVLoader:
+    # Tests that a CSV file with valid data is loaded successfully.
+    def test_csv_loader_load_from_string(self, mocker: MockerFixture) -> None:
+        # Setup
+        file_path = "test.csv"
+        expected_docs = [
+            Document(
+                page_content="column1: value1\ncolumn2: value2\ncolumn3: value3",
+                metadata={"source": file_path, "row": 0},
+            ),
+            Document(
+                page_content="column1: value4\ncolumn2: value5\ncolumn3: value6",
+                metadata={"source": file_path, "row": 1},
+            ),
+        ]
+
+        mock_csv_reader = mocker.patch("builtins.open")
+        mock_csv_reader.return_value = StringIO("column1,column2,column3\nvalue1,value2,value3\nvalue4,value5,value6")
+
+        # Exercise
+        loader = CSVLoader(file_path=file_path)
+        result = loader.load()
+
+        # Assert
+        assert result == expected_docs
+
     # Tests that a CSV file with valid data is loaded successfully.
     def test_csv_loader_load_valid_data(self, mocker: MockerFixture) -> None:
         # Setup

--- a/tests/unit_tests/document_loader/test_docs/csv/test_nominal.csv
+++ b/tests/unit_tests/document_loader/test_docs/csv/test_nominal.csv
@@ -1,0 +1,3 @@
+column1,column2,column3
+value1,value2,value3
+value4,value5,value6

--- a/tests/unit_tests/document_loader/test_docs/csv/test_one_col.csv
+++ b/tests/unit_tests/document_loader/test_docs/csv/test_one_col.csv
@@ -1,0 +1,4 @@
+column1
+value1
+value2
+value3

--- a/tests/unit_tests/document_loader/test_docs/csv/test_one_row.csv
+++ b/tests/unit_tests/document_loader/test_docs/csv/test_one_row.csv
@@ -1,0 +1,2 @@
+column1,column2,column3
+value1,value2,value3


### PR DESCRIPTION
The error in #4087 was happening because of the use of csv.Dialect.* which is just an empty base class. we need to make a choice on what is our base dialect. I usually use excel so I put it as excel, if maintainers have other preferences do let me know. 

Open Questions:
1. What should be the default dialect?
2. Should we rework all tests to mock the open function rather than the csv.DictReader?
3. Should we make a separate input for `dialect` like we have for `encoding`?