### PR TITLE
added keys to return values of from_texts redis method

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -265,7 +265,7 @@ class VectorStore(ABC):
         documents: List[Document],
         embedding: Embeddings,
         **kwargs: Any,
-    ) -> VST | Tuple[VST, List[str]]:
+    ) -> VST:
         """Return VectorStore initialized from documents and embeddings."""
         texts = [d.page_content for d in documents]
         metadatas = [d.metadata for d in documents]
@@ -291,8 +291,19 @@ class VectorStore(ABC):
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
         **kwargs: Any,
-    ) -> Tuple[VST, List[str]]:
+    ) -> VST:
         """Return VectorStore initialized from texts and embeddings."""
+
+    @classmethod
+    @abstractmethod
+    def from_texts_return_keys(
+        cls: Type[VST],
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> Tuple[VST, List[str]]:
+        """Return VectorStore and matching keys initialized from texts and embeddings."""
 
     @classmethod
     async def afrom_texts(

--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -265,7 +265,7 @@ class VectorStore(ABC):
         documents: List[Document],
         embedding: Embeddings,
         **kwargs: Any,
-    ) -> VST:
+    ) -> VST | Tuple[VST, List[str]]:
         """Return VectorStore initialized from documents and embeddings."""
         texts = [d.page_content for d in documents]
         metadatas = [d.metadata for d in documents]
@@ -291,7 +291,7 @@ class VectorStore(ABC):
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
         **kwargs: Any,
-    ) -> VST:
+    ) -> Tuple[VST, List[str]]:
         """Return VectorStore initialized from texts and embeddings."""
 
     @classmethod

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -355,7 +355,7 @@ class Redis(VectorStore):
         return [(doc, self.relevance_score_fn(score)) for doc, score in docs_and_scores]
 
     @classmethod
-    def from_texts(
+    def from_texts_return_keys(
         cls: Type[Redis],
         texts: List[str],
         embedding: Embeddings,
@@ -412,6 +412,47 @@ class Redis(VectorStore):
         # Add data to Redis
         keys = instance.add_texts(texts, metadatas, embeddings)
         return instance, keys
+
+    @classmethod
+    def from_texts(
+        cls: Type[Redis],
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        index_name: Optional[str] = None,
+        content_key: str = "content",
+        metadata_key: str = "metadata",
+        vector_key: str = "content_vector",
+        **kwargs: Any,
+    ) -> Redis:
+        """Create a Redis vectorstore from raw documents.
+        This is a user-friendly interface that:
+            1. Embeds documents.
+            2. Creates a new index for the embeddings in Redis.
+            3. Adds the documents to the newly created Redis index.
+        This is intended to be a quick way to get started.
+        Example:
+            .. code-block:: python
+                from langchain.vectorstores import Redis
+                from langchain.embeddings import OpenAIEmbeddings
+                embeddings = OpenAIEmbeddings()
+                redisearch = RediSearch.from_texts(
+                    texts,
+                    embeddings,
+                    redis_url="redis://username:password@localhost:6379"
+                )
+        """
+        instance, _ = cls.from_texts_return_keys(cls=cls,
+                                    texts=texts,
+                                    embedding=embedding,
+                                    metadatas=metadatas,
+                                    index_name=index_name,
+                                    content_key=content_key,
+                                    metadata_key=metadata_key,
+                                    vector_key=vector_key,
+                                    kwargs=kwargs
+                                    )
+        return instance
 
     @staticmethod
     def drop_index(

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -365,7 +365,7 @@ class Redis(VectorStore):
         metadata_key: str = "metadata",
         vector_key: str = "content_vector",
         **kwargs: Any,
-    ) -> Redis:
+    ) -> Tuple[Redis, List[str]]:
         """Create a Redis vectorstore from raw documents.
         This is a user-friendly interface that:
             1. Embeds documents.
@@ -410,8 +410,8 @@ class Redis(VectorStore):
         instance._create_index(dim=len(embeddings[0]))
 
         # Add data to Redis
-        instance.add_texts(texts, metadatas, embeddings)
-        return instance
+        keys = instance.add_texts(texts, metadatas, embeddings)
+        return instance, keys
 
     @staticmethod
     def drop_index(


### PR DESCRIPTION
In order to be able to delete the entries in the Redis database again, you need the keys/ids of the individual entries. These are already returned in the `add_texts`, but ignored in the `from_texts`.