### PR TITLE
fix: #4128 missing run_manager parameter

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -957,7 +957,11 @@ class AgentExecutor(Chain):
                         run_manager=run_manager,
                     )
                     if isinstance(next_step_output, AgentFinish):
-                        return await self._areturn(next_step_output, intermediate_steps)
+                        return await self._areturn(
+                            next_step_output,
+                            intermediate_steps,
+                            run_manager=run_manager,
+                        )
 
                     intermediate_steps.extend(next_step_output)
                     if len(next_step_output) == 1:
@@ -965,7 +969,9 @@ class AgentExecutor(Chain):
                         # See if tool should return directly
                         tool_return = self._get_tool_return(next_step_action)
                         if tool_return is not None:
-                            return await self._areturn(tool_return, intermediate_steps)
+                            return await self._areturn(
+                                tool_return, intermediate_steps, run_manager=run_manager
+                            )
 
                     iterations += 1
                     time_elapsed = time.time() - start_time
@@ -980,7 +986,9 @@ class AgentExecutor(Chain):
                 output = self.agent.return_stopped_response(
                     self.early_stopping_method, intermediate_steps, **inputs
                 )
-                return await self._areturn(output, intermediate_steps)
+                return await self._areturn(
+                    output, intermediate_steps, run_manager=run_manager
+                )
 
     def _get_tool_return(
         self, next_step_output: Tuple[AgentAction, str]


### PR DESCRIPTION
`run_manager` was not being passed downstream. Not sure if this was a deliberate choice but it seems like it broke many agent callbacks like `agent_action` and `agent_finish`. This fix needs a proper review.

EDIT: this is only happening to async handlers.