### PR TITLE
Fix gpt4all model usage

### DIFF
--- a/langchain/callbacks/streaming_stdout.py
+++ b/langchain/callbacks/streaming_stdout.py
@@ -16,7 +16,7 @@ class StreamingStdOutCallbackHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         """Run on new LLM token. Only available when streaming is enabled."""
-        sys.stdout.write(token)
+        sys.stdout.write(str(token, "UTF-8"))
         sys.stdout.flush()
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:

--- a/langchain/llms/gpt4all.py
+++ b/langchain/llms/gpt4all.py
@@ -97,7 +97,6 @@ class GPT4All(LLM):
     def _default_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
         return {
-            "seed": self.seed,
             "n_predict": self.n_predict,
             "n_threads": self.n_threads,
             "n_batch": self.n_batch,
@@ -183,13 +182,13 @@ class GPT4All(LLM):
         """
         if run_manager:
             text_callback = partial(run_manager.on_llm_new_token, verbose=self.verbose)
-            text = self.client.generate(
+            text = self.client.cpp_generate(
                 prompt,
                 new_text_callback=text_callback,
                 **self._default_params,
             )
         else:
-            text = self.client.generate(prompt, **self._default_params)
+            text = self.client.cpp_generate(prompt, **self._default_params)
         if stop is not None:
             text = enforce_stop_tokens(text, stop)
         return text


### PR DESCRIPTION
Change from using generate to cpp_generate, which allows for the new_text_handler. That outputs bytes, so update the streaming stdout handler to convert to string.