### PR TITLE
fix for azure open ai not returning content sometimes for the when stopping.

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -72,7 +72,7 @@ def _convert_dict_to_message(_dict: dict) -> BaseMessage:
     if role == "user":
         return HumanMessage(content=_dict["content"])
     elif role == "assistant":
-        return AIMessage(content=_dict["content"])
+        return AIMessage(content=(_dict["content"] if "content" in _dict else ""))
     elif role == "system":
         return SystemMessage(content=_dict["content"])
     else:


### PR DESCRIPTION
When making hundreds of async calls to azure openai, sometimes the response is missing content. `{"finish_reason":"stop", ...}`
This happens in  `_create_chat_result()`. From here `_convert_dict_to_message()` is called and `_dict["content"]` is accessed.
This leads to very long chain crashing. This error is not caught by any retry mechanism.