### PR TITLE
adjust sqlalchemy CursorResult import

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -6,7 +6,6 @@ from typing import Any, Iterable, List, Optional
 
 import sqlalchemy
 from sqlalchemy import (
-    CursorResult,
     MetaData,
     Table,
     create_engine,
@@ -14,7 +13,7 @@ from sqlalchemy import (
     select,
     text,
 )
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, CursorResult
 from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
 from sqlalchemy.schema import CreateTable
 


### PR DESCRIPTION
The line `from sqlalchemy import CursorResult` breaks in systems that are still using `sqlalchemy` v1.4 instead of v2. Packages such as `snowflake-sqlalchemy` still depend on `sqlalchemy` v1.4

Changing it to `from sqlalchemy.engine import CursorResult` makes it compatible with both `sqlalchemy` versions.