### PR TITLE
read texts with UTF-8 encoding

### DIFF
--- a/langchain/document_loaders/notion.py
+++ b/langchain/document_loaders/notion.py
@@ -9,16 +9,17 @@ from langchain.document_loaders.base import BaseLoader
 class NotionDirectoryLoader(BaseLoader):
     """Loader that loads Notion directory dump."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, encoding: str ="UTF-8"):
         """Initialize with path."""
         self.file_path = path
+        self.encoding = encoding
 
     def load(self) -> List[Document]:
         """Load documents."""
         ps = list(Path(self.file_path).glob("**/*.md"))
         docs = []
         for p in ps:
-            with open(p) as f:
+            with open(p, encoding=self.encoding) as f:
                 text = f.read()
             metadata = {"source": str(p)}
             docs.append(Document(page_content=text, metadata=metadata))

--- a/langchain/document_loaders/obsidian.py
+++ b/langchain/document_loaders/obsidian.py
@@ -13,12 +13,12 @@ class ObsidianLoader(BaseLoader):
     FRONT_MATTER_REGEX = re.compile(r"^---\n(.*?)\n---\n", re.MULTILINE | re.DOTALL)
 
     def __init__(
-        self, path: str, encoding: str = "UTF-8", collect_metadata: bool = True
+        self, path: str, collect_metadata: bool = True, encoding: str ="UTF-8"
     ):
         """Initialize with path."""
         self.file_path = path
-        self.encoding = encoding
         self.collect_metadata = collect_metadata
+        self.encoding = encoding
 
     def _parse_front_matter(self, content: str) -> dict:
         """Parse front matter metadata from the content and return it as a dict."""

--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -12,8 +12,8 @@ class ReadTheDocsLoader(BaseLoader):
     def __init__(
         self,
         path: str,
-        encoding: Optional[str] = None,
         errors: Optional[str] = None,
+        encoding: str = "UTF-8",
         **kwargs: Optional[Any]
     ):
         """Initialize path."""
@@ -34,9 +34,9 @@ class ReadTheDocsLoader(BaseLoader):
             raise ValueError("Parsing kwargs do not appear valid") from e
 
         self.file_path = path
-        self.encoding = encoding
         self.errors = errors
         self.bs_kwargs = kwargs
+        self.encoding = encoding
 
     def load(self) -> List[Document]:
         """Load documents."""

--- a/langchain/document_loaders/roam.py
+++ b/langchain/document_loaders/roam.py
@@ -9,16 +9,17 @@ from langchain.document_loaders.base import BaseLoader
 class RoamLoader(BaseLoader):
     """Loader that loads Roam files from disk."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, encoding: str ="UTF-8"):
         """Initialize with path."""
         self.file_path = path
+        self.encoding = encoding
 
     def load(self) -> List[Document]:
         """Load documents."""
         ps = list(Path(self.file_path).glob("**/*.md"))
         docs = []
         for p in ps:
-            with open(p) as f:
+            with open(p, encoding=self.encoding) as f:
                 text = f.read()
             metadata = {"source": str(p)}
             docs.append(Document(page_content=text, metadata=metadata))

--- a/langchain/document_loaders/text.py
+++ b/langchain/document_loaders/text.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -7,7 +7,7 @@ from langchain.document_loaders.base import BaseLoader
 class TextLoader(BaseLoader):
     """Load text files."""
 
-    def __init__(self, file_path: str, encoding: Optional[str] = None):
+    def __init__(self, file_path: str, encoding: str = "UTF-8"):
         """Initialize with file path."""
         self.file_path = file_path
         self.encoding = encoding

--- a/langchain/document_loaders/whatsapp_chat.py
+++ b/langchain/document_loaders/whatsapp_chat.py
@@ -14,16 +14,17 @@ def concatenate_rows(date: str, sender: str, text: str) -> str:
 class WhatsAppChatLoader(BaseLoader):
     """Loader that loads WhatsApp messages text file."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, encoding: str = "UTF-8"):
         """Initialize with path."""
         self.file_path = path
+        self.encoding = encoding
 
     def load(self) -> List[Document]:
         """Load documents."""
         p = Path(self.file_path)
         text_content = ""
 
-        with open(p, encoding="utf8") as f:
+        with open(p, encoding=self.encoding) as f:
             lines = f.readlines()
 
         message_line_regex = r"""


### PR DESCRIPTION
For processing non-english texts, especially on windows, we often encoutered text encoding problem and error message like `UnicodeDecodeError: 'cp950' codec can't decode byte 0xe6 in position 2: illegal multibyte sequence`. This PR make the most text-based document loader (search by matching `f.read`) to read text with the universal utf-8 encoding.