### PR TITLE
feat: filter on list of values

### DIFF
--- a/langchain/vectorstores/elastic_vector_search.py
+++ b/langchain/vectorstores/elastic_vector_search.py
@@ -23,7 +23,7 @@ def _default_text_mapping(dim: int) -> Dict:
 def _default_script_query(query_vector: List[float], filter: Optional[dict]) -> Dict:
     if filter:
         ((key, value),) = filter.items()
-        filter = {"match": {f"metadata.{key}.keyword": f"{value}"}}
+        filter = {"terms": {f"metadata.{key}.keyword": value}}
     else:
         filter = {"match_all": {}}
     return {


### PR DESCRIPTION
### Issue
The old filter could only filter on a single value, as it used the ElasticSearch match query.

### Description
This change would allow the user to filter on a list of values using the ElasticSearch terms query.
Fixes: https://github.com/hwchase17/langchain/issues/2095#issuecomment-1536225159
