### PR TITLE
fix: remove expand parameter from ConfluenceLoader by label

### DIFF
--- a/langchain/document_loaders/confluence.py
+++ b/langchain/document_loaders/confluence.py
@@ -217,7 +217,6 @@ class ConfluenceLoader(BaseLoader):
                 label=label,
                 limit=limit,
                 max_pages=max_pages,
-                expand="body.storage.value",
             )
             ids_by_label = [page["id"] for page in pages]
             if page_ids:


### PR DESCRIPTION
expand is not an allowed parameter for the method confluence.get_all_pages_by_label, since it doesn't return the body of the text but just metadata of documents