### PR TITLE
Change return type of as_retriever func

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -305,7 +305,7 @@ class VectorStore(ABC):
         """Return VectorStore initialized from texts and embeddings."""
         raise NotImplementedError
 
-    def as_retriever(self, **kwargs: Any) -> BaseRetriever:
+    def as_retriever(self, **kwargs: Any) -> VectorStoreRetriever:
         return VectorStoreRetriever(vectorstore=self, **kwargs)
 
 


### PR DESCRIPTION
This PR improves the as_retriever method by updating its return type to be more specific, ensuring that it returns an instance of the VectorStoreRetriever class. The changes are as follows:

Updated the return type of the as_retriever method from BaseRetriever to VectorStoreRetriever.
This change provides better type information for the as_retriever method, making it more clear that the method returns a VectorStoreRetriever instance. 