### PR TITLE
Fix error in sample prompt in docs getting_started.md

### DIFF
--- a/docs/getting_started/getting_started.md
+++ b/docs/getting_started/getting_started.md
@@ -420,7 +420,7 @@ tools = load_tools(["serpapi", "llm-math"], llm=llm)
 agent = initialize_agent(tools, chat, agent=AgentType.CHAT_ZERO_SHOT_REACT_DESCRIPTION, verbose=True)
 
 # Now let's test it out!
-agent.run("Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?")
+agent.run("Who is Olivia Wilde's boyfriend? What is his current age? Raise it to the 0.23 power.")
 ```
 
 ```pycon


### PR DESCRIPTION
Fix an error 'VariableNode' object is not callable.

The error log as below.

Observation: Olivia Wilde started dating Harry Styles after ending her years-long engagement to Jason Sudeikis — see their relationship timeline.
Thought:Now I need to use a calculator to raise Harry Styles' age to the 0.23 power.
Action:
```
{
  "action": "Calculator",
  "action_input": "pow(27, 0.23)"
}
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[/usr/local/lib/python3.10/dist-packages/langchain/chains/llm_math/base.py](https://localhost:8080/#) in _evaluate_expression(self, expression)
     79             output = str(
---> 80                 numexpr.evaluate(
     81                     expression.strip(),
.
.
.

<expr> in <module>

TypeError: 'VariableNode' object is not callable

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
[/usr/local/lib/python3.10/dist-packages/langchain/chains/llm_math/base.py](https://localhost:8080/#) in _evaluate_expression(self, expression)
     85             )
     86         except Exception as e:
---> 87             raise ValueError(f"{e}. Please try again with a valid numerical expression")
     88 
     89         # Remove any leading and trailing brackets from the output

ValueError: 'VariableNode' object is not callable. Please try again with a valid numerical expression