### PR TITLE
FIX[JSONLoader]: Solving ValidationError when load()

### DIFF
--- a/langchain/document_loaders/json_loader.py
+++ b/langchain/document_loaders/json_loader.py
@@ -87,17 +87,17 @@ class JSONLoader(BaseLoader):
             )
 
             if self._content_key is not None:
-                text = sample.get(self._content_key)
+                content = sample.get(self._content_key)
                 if self._metadata_func is not None:
                     # We pass in the metadata dict to the metadata_func
                     # so that the user can customize the default metadata
                     # based on the content of the JSON object.
                     metadata = self._metadata_func(sample, metadata)
             else:
-                text = sample
+                content = sample
 
             # In case the text is None, set it to an empty string
-            text: str = "" if not text else json.dumps(text)
+            text = str(content) if content else ""
 
             docs.append(Document(page_content=text, metadata=metadata))
 

--- a/langchain/document_loaders/json_loader.py
+++ b/langchain/document_loaders/json_loader.py
@@ -97,7 +97,7 @@ class JSONLoader(BaseLoader):
                 text = sample
 
             # In case the text is None, set it to an empty string
-            text = text or ""
+            text: str = "" if not text else json.dumps(text)
 
             docs.append(Document(page_content=text, metadata=metadata))
 

--- a/langchain/document_loaders/json_loader.py
+++ b/langchain/document_loaders/json_loader.py
@@ -97,7 +97,7 @@ class JSONLoader(BaseLoader):
                 content = sample
 
             # In case the text is None, set it to an empty string
-            text = str(content) if content else ""
+            text = json.dumps(content) if content else ""
 
             docs.append(Document(page_content=text, metadata=metadata))
 

--- a/langchain/document_loaders/json_loader.py
+++ b/langchain/document_loaders/json_loader.py
@@ -1,7 +1,7 @@
 """Loader that loads data from JSON."""
 import json
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -23,6 +23,7 @@ class JSONLoader(BaseLoader):
         jq_schema: str,
         content_key: Optional[str] = None,
         metadata_func: Optional[Callable[[Dict, Dict], Dict]] = None,
+        text_content: bool = True,
     ):
         """Initialize the JSONLoader.
 
@@ -35,6 +36,8 @@ class JSONLoader(BaseLoader):
             metadata_func (Callable[Dict, Dict]): A function that takes in the JSON
                 object extracted by the jq_schema and the default metadata and returns
                 a dict of the updated metadata.
+            text_content (bool): Boolean flag to indicates whether the content is in
+                string format, default to True
         """
         try:
             import jq  # noqa:F401
@@ -47,58 +50,75 @@ class JSONLoader(BaseLoader):
         self._jq_schema = jq.compile(jq_schema)
         self._content_key = content_key
         self._metadata_func = metadata_func
+        self._text_content = text_content
 
     def load(self) -> List[Document]:
         """Load and return documents from the JSON file."""
-
         data = self._jq_schema.input(json.loads(self.file_path.read_text()))
 
         # Perform some validation
         # This is not a perfect validation, but it should catch most cases
         # and prevent the user from getting a cryptic error later on.
         if self._content_key is not None:
-            sample = data.first()
-            if not isinstance(sample, dict):
-                raise ValueError(
-                    f"Expected the jq schema to result in a list of objects (dict), \
-                        so sample must be a dict but got `{type(sample)}`"
-                )
-
-            if sample.get(self._content_key) is None:
-                raise ValueError(
-                    f"Expected the jq schema to result in a list of objects (dict) \
-                        with the key `{self._content_key}`"
-                )
-
-            if self._metadata_func is not None:
-                sample_metadata = self._metadata_func(sample, {})
-                if not isinstance(sample_metadata, dict):
-                    raise ValueError(
-                        f"Expected the metadata_func to return a dict but got \
-                            `{type(sample_metadata)}`"
-                    )
+            self._validate_content_key(data)
 
         docs = []
-
         for i, sample in enumerate(data, 1):
             metadata = dict(
                 source=str(self.file_path),
                 seq_num=i,
             )
-
-            if self._content_key is not None:
-                content = sample.get(self._content_key)
-                if self._metadata_func is not None:
-                    # We pass in the metadata dict to the metadata_func
-                    # so that the user can customize the default metadata
-                    # based on the content of the JSON object.
-                    metadata = self._metadata_func(sample, metadata)
-            else:
-                content = sample
-
-            # In case the text is None, set it to an empty string
-            text = json.dumps(content) if content else ""
-
+            text = self._get_text(sample=sample, metadata=metadata)
             docs.append(Document(page_content=text, metadata=metadata))
 
         return docs
+
+    def _get_text(self, sample: Any, metadata: dict) -> str:
+        """Convert sample to string format"""
+        if self._content_key is not None:
+            content = sample.get(self._content_key)
+            if self._metadata_func is not None:
+                # We pass in the metadata dict to the metadata_func
+                # so that the user can customize the default metadata
+                # based on the content of the JSON object.
+                metadata = self._metadata_func(sample, metadata)
+        else:
+            content = sample
+
+        if self._text_content and not isinstance(content, str):
+            raise ValueError(
+                f"Expected page_content is string, got {type(content)} instead. \
+                    Set `text_content=False` if the desired input for \
+                    `page_content` is not a string"
+            )
+
+        # In case the text is None, set it to an empty string
+        elif isinstance(content, str):
+            return content
+        elif isinstance(content, dict):
+            return json.dumps(content) if content else ""
+        else:
+            return str(content) if content is not None else ""
+
+    def _validate_content_key(self, data: Any) -> None:
+        """Check if content key is valid"""
+        sample = data.first()
+        if not isinstance(sample, dict):
+            raise ValueError(
+                f"Expected the jq schema to result in a list of objects (dict), \
+                    so sample must be a dict but got `{type(sample)}`"
+            )
+
+        if sample.get(self._content_key) is None:
+            raise ValueError(
+                f"Expected the jq schema to result in a list of objects (dict) \
+                    with the key `{self._content_key}`"
+            )
+
+        if self._metadata_func is not None:
+            sample_metadata = self._metadata_func(sample, {})
+            if not isinstance(sample_metadata, dict):
+                raise ValueError(
+                    f"Expected the metadata_func to return a dict but got \
+                        `{type(sample_metadata)}`"
+                )

--- a/tests/unit_tests/document_loader/test_json_loader.py
+++ b/tests/unit_tests/document_loader/test_json_loader.py
@@ -1,0 +1,130 @@
+from pytest import raises
+from pytest_mock import MockerFixture
+
+from langchain.docstore.document import Document
+from langchain.document_loaders.json_loader import JSONLoader
+
+
+class TestJSONLoader:
+    def test_load_valid_string_content(self, mocker: MockerFixture) -> None:
+        file_path = "/workspaces/langchain/test.json"
+        expected_docs = [
+            Document(
+                page_content="value1",
+                metadata={"source": file_path, "seq_num": 1},
+            ),
+            Document(
+                page_content="value2",
+                metadata={"source": file_path, "seq_num": 2},
+            ),
+        ]
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_csv_reader = mocker.patch("pathlib.Path.read_text")
+        mock_csv_reader.return_value = '[{"text": "value1"}, {"text": "value2"}]'
+
+        loader = JSONLoader(
+            file_path=file_path, jq_schema=".[].text", text_content=True
+        )
+        result = loader.load()
+
+        assert result == expected_docs
+
+    def test_load_valid_dict_content(self, mocker: MockerFixture) -> None:
+        file_path = "/workspaces/langchain/test.json"
+        expected_docs = [
+            Document(
+                page_content='{"text": "value1"}',
+                metadata={"source": file_path, "seq_num": 1},
+            ),
+            Document(
+                page_content='{"text": "value2"}',
+                metadata={"source": file_path, "seq_num": 2},
+            ),
+        ]
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_csv_reader = mocker.patch("pathlib.Path.read_text")
+        mock_csv_reader.return_value = """
+            [{"text": "value1"}, {"text": "value2"}]
+        """
+
+        loader = JSONLoader(file_path=file_path, jq_schema=".[]", text_content=False)
+        result = loader.load()
+
+        assert result == expected_docs
+
+    def test_load_valid_bool_content(self, mocker: MockerFixture) -> None:
+        file_path = "/workspaces/langchain/test.json"
+        expected_docs = [
+            Document(
+                page_content="False",
+                metadata={"source": file_path, "seq_num": 1},
+            ),
+            Document(
+                page_content="True",
+                metadata={"source": file_path, "seq_num": 2},
+            ),
+        ]
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_csv_reader = mocker.patch("pathlib.Path.read_text")
+        mock_csv_reader.return_value = """
+            [
+                {"flag": false}, {"flag": true}
+            ]
+        """
+
+        loader = JSONLoader(
+            file_path=file_path, jq_schema=".[].flag", text_content=False
+        )
+        result = loader.load()
+
+        assert result == expected_docs
+
+    def test_load_valid_numeric_content(self, mocker: MockerFixture) -> None:
+        file_path = "/workspaces/langchain/test.json"
+        expected_docs = [
+            Document(
+                page_content="99",
+                metadata={"source": file_path, "seq_num": 1},
+            ),
+            Document(
+                page_content="99.5",
+                metadata={"source": file_path, "seq_num": 2},
+            ),
+        ]
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_csv_reader = mocker.patch("pathlib.Path.read_text")
+        mock_csv_reader.return_value = """
+            [
+                {"num": 99}, {"num": 99.5}
+            ]
+        """
+
+        loader = JSONLoader(
+            file_path=file_path, jq_schema=".[].num", text_content=False
+        )
+        result = loader.load()
+
+        assert result == expected_docs
+
+    def test_load_invalid_test_content(self, mocker: MockerFixture) -> None:
+        file_path = "/workspaces/langchain/test.json"
+        expected_docs = [
+            Document(
+                page_content='{"text": "value1"}',
+                metadata={"source": file_path, "seq_num": 1},
+            ),
+            Document(
+                page_content='{"text": "value2"}',
+                metadata={"source": file_path, "seq_num": 2},
+            ),
+        ]
+        mocker.patch("builtins.open", mocker.mock_open())
+        mock_csv_reader = mocker.patch("pathlib.Path.read_text")
+        mock_csv_reader.return_value = """
+            [{"text": "value1"}, {"text": "value2"}]
+        """
+
+        loader = JSONLoader(file_path=file_path, jq_schema=".[]", text_content=True)
+
+        with raises(ValueError):
+            loader.load()


### PR DESCRIPTION
In `json_loader.py`,
When `text` is a `dict` type,
```python
text = text or  ""
``` 
 The above snippet at line 100 make the program raise `ValidationError` from pydantic when calling `Document(page_contnt=text, metadata=metadata)` right after


Addressed this by converting `text` to `dict` whenever `text` is None
```python
 text = json.dumps(content) if content else ""
```