### PR TITLE
Do not overwrite openai.api_version.

### DIFF
--- a/docs/modules/models/text_embedding/examples/azureopenai.ipynb
+++ b/docs/modules/models/text_embedding/examples/azureopenai.ipynb
@@ -22,7 +22,8 @@
     "\n",
     "os.environ[\"OPENAI_API_TYPE\"] = \"azure\"\n",
     "os.environ[\"OPENAI_API_BASE\"] = \"https://<your-endpoint.openai.azure.com/\"\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"your AzureOpenAI key\""
+    "os.environ[\"OPENAI_API_KEY\"] = \"your AzureOpenAI key\"\n",
+    "os.environ[\"OPENAI_API_VERSION\"] = \"2023-03-15-preview\""
    ]
   },
   {

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -144,11 +144,14 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             "OPENAI_API_TYPE",
             default="",
         )
-        openai_api_version = get_from_dict_or_env(
-            values,
-            "openai_api_version",
-            "OPENAI_API_VERSION",
-        )
+        if openai_api_type in ("azure", "azure_ad", "azuread"):
+            openai_api_version = get_from_dict_or_env(
+                values,
+                "openai_api_version",
+                "OPENAI_API_VERSION",
+            )
+        else:
+            openai_api_version = None
         openai_organization = get_from_dict_or_env(
             values,
             "openai_organization",
@@ -163,6 +166,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 openai.organization = openai_organization
             if openai_api_base:
                 openai.api_base = openai_api_base
+            if openai_api_version:
                 openai.api_version = openai_api_version
             if openai_api_type:
                 openai.api_type = openai_api_type

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -106,7 +106,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     client: Any  #: :meta private:
     model: str = "text-embedding-ada-002"
     deployment: str = model  # to support Azure OpenAI Service custom deployment names
-    openai_api_version: str = "2022-12-01"
+    openai_api_version: str = ""
     # to support Azure OpenAI Service custom endpoints
     openai_api_base: Optional[str] = None
     # to support Azure OpenAI Service custom endpoints

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -77,8 +77,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             openai = OpenAIEmbeddings(openai_api_key="my-api-key")
 
     In order to use the library with Microsoft Azure endpoints, you need to set
-    the OPENAI_API_TYPE, OPENAI_API_BASE, OPENAI_API_KEY and optionally and
-    API_VERSION.
+    the OPENAI_API_TYPE, OPENAI_API_BASE, OPENAI_API_KEY and OPENAI_API_VERSION.
     The OPENAI_API_TYPE must be set to 'azure' and the others correspond to
     the properties of your endpoint.
     In addition, the deployment name must be passed as the model parameter.
@@ -90,6 +89,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             os.environ["OPENAI_API_TYPE"] = "azure"
             os.environ["OPENAI_API_BASE"] = "https://<your-endpoint.openai.azure.com/"
             os.environ["OPENAI_API_KEY"] = "your AzureOpenAI key"
+            os.environ["OPENAI_API_VERSION"] = "2023-03-15-preview"
 
             from langchain.embeddings.openai import OpenAIEmbeddings
             embeddings = OpenAIEmbeddings(


### PR DESCRIPTION
I found an issue that the value of `openai.api_version` was modified after creating the embedding model:

```
In [1]: import os
   ...: import openai
   ...: from langchain.chat_models import AzureChatOpenAI
   ...: from langchain.schema import HumanMessage
   ...: from langchain.embeddings import OpenAIEmbeddings
   ...:
   ...: os.environ["OPENAI_API_TYPE"] = "azure"
   ...: os.environ["OPENAI_API_VERSION"] = "2023-03-15-preview"
   ...: os.environ["OPENAI_API_BASE"] = "https://dummy.openai.azure.com/"
   ...: os.environ["OPENAI_API_KEY"] = "dummy_key"
   ...:
   ...: openai.api_type = os.getenv("OPENAI_API_TYPE")
   ...: openai.api_version = os.getenv("OPENAI_API_VERSION")
   ...: openai.api_base = os.getenv("OPENAI_API_BASE")
   ...: openai.api_key = os.getenv("OPENAI_API_KEY")

In [2]: print(openai.api_version)
2023-03-15-preview

In [3]: emb_model = OpenAIEmbeddings()

In [4]: print(openai.api_version)
2022-12-01
```

This will lead to many weird problems, such as environment variables and named parameter will NOT work in subsequent use of other Azure OpenAI models and lead to "Resource not found" errors (gpt-3.5 and gpt-4).

The fix is simple. But it may cause some regression error if user didn't set `OPENAI_API_VERSION` in environment variables nor pass it as a named parameter.