### PR TITLE
chore: make request timeout configurable in NotionDBLoader

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/notiondb.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/notiondb.ipynb
@@ -103,9 +103,16 @@
     "loader = NotionDBLoader(\n",
     "    integration_token=NOTION_TOKEN, \n",
     "    database_id=DATABASE_ID,\n",
-    "    request_timeout_sec=10 # optional, default is 10s. Cannot exceed 30s\n",
+    "    request_timeout_sec=30 # optional, defaults to 10\n",
     ")"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "55f7ce09",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",

--- a/docs/modules/indexes/document_loaders/examples/notiondb.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/notiondb.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1dc7df1d",
    "metadata": {},
@@ -99,7 +100,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = NotionDBLoader(integration_token=NOTION_TOKEN, database_id=DATABASE_ID)"
+    "loader = NotionDBLoader(\n",
+    "    integration_token=NOTION_TOKEN, \n",
+    "    database_id=DATABASE_ID,\n",
+    "    request_timeout_sec=10 # optional, default is 10s. Cannot exceed 30s\n",
+    ")"
    ]
   },
   {

--- a/docs/modules/indexes/document_loaders/examples/notiondb.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/notiondb.ipynb
@@ -108,13 +108,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "55f7ce09",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
    "execution_count": 15,
    "id": "b1c30ff7",

--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -28,8 +28,6 @@ class NotionDBLoader(BaseLoader):
             raise ValueError("integration_token must be provided")
         if not database_id:
             raise ValueError("database_id must be provided")
-        if request_timeout_sec > 30:
-            raise ValueError("request timeout cannot exceed 30s")
 
         self.token = integration_token
         self.database_id = database_id

--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -22,12 +22,15 @@ class NotionDBLoader(BaseLoader):
         request_timeout_sec (int): Timeout for Notion requests in seconds.
     """
 
-    def __init__(self, integration_token: str, database_id: str, request_timeout_sec: int) -> None:
+    def __init__(self, integration_token: str, database_id: str, request_timeout_sec: int = None) -> None:
         """Initialize with parameters."""
         if not integration_token:
             raise ValueError("integration_token must be provided")
         if not database_id:
             raise ValueError("database_id must be provided")
+        if request_timeout_sec > 30:
+            raise ValueError("request timeout cannot exceed 30s")
+
         if not request_timeout_sec:
             request_timeout_sec = 10
 

--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -19,14 +19,17 @@ class NotionDBLoader(BaseLoader):
     Args:
         integration_token (str): Notion integration token.
         database_id (str): Notion database id.
+        request_timeout_sec (int): Timeout for Notion requests in seconds.
     """
 
-    def __init__(self, integration_token: str, database_id: str) -> None:
+    def __init__(self, integration_token: str, database_id: str, request_timeout_sec: int) -> None:
         """Initialize with parameters."""
         if not integration_token:
             raise ValueError("integration_token must be provided")
         if not database_id:
             raise ValueError("database_id must be provided")
+        if not request_timeout_sec:
+            request_timeout_sec = 10
 
         self.token = integration_token
         self.database_id = database_id
@@ -35,6 +38,7 @@ class NotionDBLoader(BaseLoader):
             "Content-Type": "application/json",
             "Notion-Version": "2022-06-28",
         }
+        self.request_timeout_sec = request_timeout_sec
 
     def load(self) -> List[Document]:
         """Load documents from the Notion database.
@@ -148,7 +152,7 @@ class NotionDBLoader(BaseLoader):
             url,
             headers=self.headers,
             json=query_dict,
-            timeout=10,
+            timeout=self.request_timeout_sec,
         )
         res.raise_for_status()
         return res.json()

--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -1,6 +1,6 @@
 """Notion DB loader for langchain"""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -22,7 +22,7 @@ class NotionDBLoader(BaseLoader):
         request_timeout_sec (int): Timeout for Notion requests in seconds.
     """
 
-    def __init__(self, integration_token: str, database_id: str, request_timeout_sec: int = None) -> None:
+    def __init__(self, integration_token: str, database_id: str, request_timeout_sec: Optional[int] = 10) -> None:
         """Initialize with parameters."""
         if not integration_token:
             raise ValueError("integration_token must be provided")
@@ -30,9 +30,6 @@ class NotionDBLoader(BaseLoader):
             raise ValueError("database_id must be provided")
         if request_timeout_sec > 30:
             raise ValueError("request timeout cannot exceed 30s")
-
-        if not request_timeout_sec:
-            request_timeout_sec = 10
 
         self.token = integration_token
         self.database_id = database_id


### PR DESCRIPTION
I am also hitting some timeouts on the Notion DB fetching (~20 documents in the source notion db)

https://github.com/hwchase17/langchain/pull/2056#issuecomment-1530002441

^ this user makes a good point about making this underlying fetch logic extensible for retries/Idempotence, but this PR just makes the request timeout configurable