### PR TITLE
CombinedMemory class should remove other sub-memory variables from inputs/outputs before save_context method on each memory.

### DIFF
--- a/langchain/memory/combined.py
+++ b/langchain/memory/combined.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Set
 
 from pydantic import validator
 
+from langchain.memory.utils import get_prompt_input_key
 from langchain.schema import BaseMemory
 
 
@@ -55,9 +56,21 @@ class CombinedMemory(BaseMemory):
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
         """Save context from this session for every memory."""
+        # Remove the variables supplied from sub-memories.
+        input_nonmemory_variables = set(inputs) - set(self.memory_variables)
+        output_nonmemory_variables = set(outputs) - set(self.memory_variables)
+
         # Save context for all sub-memories
         for memory in self.memories:
-            memory.save_context(inputs, outputs)
+            # Add back in the variables supplied from this memory.
+            memory_variables = input_nonmemory_variables | (
+                            set(inputs) & set(memory.memory_variables))
+            memory_inputs = {k : inputs[k] for k in memory_variables}
+            memory_variables = output_nonmemory_variables | (
+                            set(outputs) & set(memory.memory_variables))
+            memory_outputs = {k : outputs[k] for k in memory_variables}
+
+            memory.save_context(memory_inputs, memory_outputs)
 
     def clear(self) -> None:
         """Clear context from this session for every memory."""

--- a/tests/unit_tests/memory/test_combined_memory.py
+++ b/tests/unit_tests/memory/test_combined_memory.py
@@ -35,3 +35,22 @@ def test_repeated_memory_var(example_memory: List[ConversationBufferMemory]) -> 
     """Test raising error when repeated memory variables found"""
     with pytest.raises(ValueError):
         CombinedMemory(memories=[example_memory[1], example_memory[2]])
+
+
+def test_save_context_input_disambiguation(example_memory: List[ConversationBufferMemory]) -> None:
+    """Test basic functionality of methods exposed by class"""
+    combined_memory = CombinedMemory(memories=[example_memory[0], example_memory[1]])
+    assert combined_memory.memory_variables == ["foo", "bar"]
+    assert combined_memory.load_memory_variables({}) == {"foo": "", "bar": ""}
+    combined_memory.save_context(
+        {"input": "Hello there", "foo": ""},
+	{"output": "Hello, how can I help you?"}
+    )
+    assert combined_memory.load_memory_variables({}) == {
+        "foo": "Human: Hello there\nAI: Hello, how can I help you?",
+        "bar": "Human: Hello there\nAI: Hello, how can I help you?",
+    }
+    combined_memory.clear()
+    assert combined_memory.load_memory_variables({}) == {"foo": "", "bar": ""}
+
+


### PR DESCRIPTION
If you have a prompt template with a variable from each sub-memory, then the current CombinedMemory save_context method fails because it passes in too many input & output variables to each sub-memory.  The new implementation strips out variables from the other sub-memories before calling memory.save_context().

I added a test for this behavior too.

Tagging possible reviewers: @eyurtsev