### PR TITLE
Better error when running chain without any args

### DIFF
--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -238,6 +238,12 @@ class Chain(BaseModel, ABC):
         if kwargs and not args:
             return self(kwargs, callbacks=callbacks)[self.output_keys[0]]
 
+        if not kwargs and not args:
+            raise ValueError(
+                "`run` supported with either positional arguments or keyword arguments,"
+                " but none were provided."
+            )
+
         raise ValueError(
             f"`run` supported with either positional arguments or keyword arguments"
             f" but not both. Got args: {args} and kwargs: {kwargs}."


### PR DESCRIPTION
Today, when running a chain without any arguments, the raised ValueError incorrectly specifies that user provided "both positional arguments and keyword arguments".

This PR adds a more accurate error in that case.