### PR TITLE
Incorrect docstring for PythonCodeTextSplitter

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -412,7 +412,7 @@ class PythonCodeTextSplitter(RecursiveCharacterTextSplitter):
     """Attempts to split the text along Python syntax."""
 
     def __init__(self, **kwargs: Any):
-        """Initialize a MarkdownTextSplitter."""
+        """Initialize a PythonCodeTextSplitter."""
         separators = [
             # First, try to split along class definitions
             "\nclass ",


### PR DESCRIPTION
Fixes a copy-paste error in the doctring