### PR TITLE
Pass Callbacks through load_tools

### DIFF
--- a/tests/unit_tests/agents/test_tools.py
+++ b/tests/unit_tests/agents/test_tools.py
@@ -1,9 +1,11 @@
 """Test tool utils."""
+import unittest
 from typing import Any, Type
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
+from langchain.agents import load_tools
 from langchain.agents.agent import Agent
 from langchain.agents.chat.base import ChatAgent
 from langchain.agents.conversational.base import ConversationalAgent
@@ -12,6 +14,7 @@ from langchain.agents.mrkl.base import ZeroShotAgent
 from langchain.agents.react.base import ReActDocstoreAgent, ReActTextWorldAgent
 from langchain.agents.self_ask_with_search.base import SelfAskWithSearchAgent
 from langchain.agents.tools import Tool, tool
+from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 
 @pytest.mark.parametrize(
@@ -62,3 +65,28 @@ def test_tool_no_args_specified_assumes_str() -> None:
     assert some_tool.run({"tool_input": "foobar"}) == "foobar"
     with pytest.raises(ValueError, match="Too many arguments to single-input tool"):
         some_tool.run({"tool_input": "foobar", "other_input": "bar"})
+
+
+def test_load_tools_with_callback_manager_raises_deprecation_warning() -> None:
+    """Test load_tools raises a deprecation for old callback manager kwarg."""
+    callback_manager = MagicMock()
+    with pytest.warns(DeprecationWarning, match="callback_manager is deprecated"):
+        tools = load_tools(["requests_get"], callback_manager=callback_manager)
+    assert len(tools) == 1
+    assert tools[0].callbacks == callback_manager
+
+
+def test_load_tools_with_callbacks_is_called() -> None:
+    """Test callbacks are called when provided to load_tools fn."""
+    callbacks = [FakeCallbackHandler()]
+    tools = load_tools(["requests_get"], callbacks=callbacks)  # type: ignore
+    assert len(tools) == 1
+    # Patch the requests.get() method to return a mock response
+    with unittest.mock.patch(
+        "langchain.requests.TextRequestsWrapper.get",
+        return_value=Mock(text="Hello world!"),
+    ):
+        result = tools[0].run("https://www.google.com")
+        assert result.text == "Hello world!"
+    assert callbacks[0].tool_starts == 1
+    assert callbacks[0].tool_ends == 1


### PR DESCRIPTION
- Update the load_tools method to properly accept `callbacks` arguments.
- Add a deprecation warning when `callback_manager` is passed
- Add two unit tests to check the deprecation warning is raised and to confirm the callback is passed through.

Closes issue #4096