### PR TITLE
fix: solve the infinite loop caused by 'add_memory' function when run…

### DIFF
--- a/langchain/experimental/generative_agents/memory.py
+++ b/langchain/experimental/generative_agents/memory.py
@@ -44,6 +44,7 @@ class GenerativeAgentMemory(BaseMemory):
     relevant_memories_key: str = "relevant_memories"
     relevant_memories_simple_key: str = "relevant_memories_simple"
     most_recent_memories_key: str = "most_recent_memories"
+    reflecting: bool = False
 
     def chain(self, prompt: PromptTemplate) -> LLMChain:
         return LLMChain(llm=self.llm, prompt=prompt, verbose=self.verbose)
@@ -136,10 +137,13 @@ class GenerativeAgentMemory(BaseMemory):
         if (
             self.reflection_threshold is not None
             and self.aggregate_importance > self.reflection_threshold
+            and not self.reflecting
         ):
+            self.reflecting = True
             self.pause_to_reflect()
             # Hack to clear the importance from reflection
             self.aggregate_importance = 0.0
+            self.reflecting = False
         return result
 
     def fetch_memories(self, observation: str) -> List[Document]:


### PR DESCRIPTION
fix: solve the infinite loop caused by 'add_memory' function when run 'pause_to_reflect' function

run steps:
'add_memory' -> 'pause_to_reflect' -> 'add_memory':  infinite loop