### PR TITLE
Sitemap localpath

### DIFF
--- a/langchain/document_loaders/sitemap.py
+++ b/langchain/document_loaders/sitemap.py
@@ -90,7 +90,7 @@ class SitemapLoader(WebBaseLoader):
             els.extend(self.parse_sitemap(soup_child))
         return els
 
-    def is_url(url):
+    def is_url(self, url):
         try:
             result = urlparse(url)
             return all([result.scheme, result.netloc])

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 
 from langchain.document_loaders import SitemapLoader
@@ -77,4 +78,13 @@ def test_filter_sitemap() -> None:
     )
     documents = loader.load()
     assert len(documents) == 1
+    assert "🦜🔗" in documents[0].page_content
+
+
+def test_local_sitemap() -> None:
+    """Test sitemap loader."""
+    file_path = Path(__file__).parent.parent / "examples/sitemap.xml"
+    loader = SitemapLoader(str(file_path))
+    documents = loader.load()
+    assert len(documents) > 1
     assert "🦜🔗" in documents[0].page_content

--- a/tests/integration_tests/examples/sitemap.xml
+++ b/tests/integration_tests/examples/sitemap.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  
+  <url>
+    <loc>https://python.langchain.com/en/stable/</loc>
+    
+    
+    <lastmod>2023-05-04T16:15:31.377584+00:00</lastmod>
+    
+    <changefreq>weekly</changefreq>
+    <priority>1</priority>
+  </url>
+  
+  <url>
+    <loc>https://python.langchain.com/en/latest/</loc>
+    
+    
+    <lastmod>2023-05-05T07:52:19.633878+00:00</lastmod>
+    
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  
+  <url>
+    <loc>https://python.langchain.com/en/harrison-docs-refactor-3-24/</loc>
+    
+    
+    <lastmod>2023-03-27T02:32:55.132916+00:00</lastmod>
+    
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  
+</urlset>


### PR DESCRIPTION
- Makes it possible to pass the path of a local file to the SitemapLoader
- Is useful when the sitemap is only available locally or for testing purposes