### PR TITLE
added an option to extract more metadata from crawled websites

### DIFF
--- a/langchain/document_loaders/sitemap.py
+++ b/langchain/document_loaders/sitemap.py
@@ -10,8 +10,10 @@ from langchain.schema import Document
 def _default_parsing_function(content: Any) -> str:
     return str(content.get_text())
 
+
 def _default_meta_function(meta: dict, _content: Any) -> dict:
     return {"source": meta["loc"], **meta}
+
 
 def _batch_block(iterable: Iterable, size: int) -> Generator[List[dict], None, None]:
     it = iter(iterable)
@@ -41,8 +43,8 @@ class SitemapLoader(WebBaseLoader):
             blocksize: number of sitemap locations per block
             blocknum: the number of the block that should be loaded - zero indexed
             meta_function: Function to parse bs4.Soup output for metadata
-                remember when setting this method to also copy metadata["loc"] to metadata["source"]
-                if you are using this field
+                remember when setting this method to also copy metadata["loc"]
+                to metadata["source"] if you are using this field
         """
 
         if blocksize is not None and blocksize < 1:

--- a/langchain/document_loaders/sitemap.py
+++ b/langchain/document_loaders/sitemap.py
@@ -11,7 +11,7 @@ def _default_parsing_function(content: Any) -> str:
     return str(content.get_text())
 
 def _default_meta_function(meta: dict, _content: Any) -> dict:
-    return meta
+    return {"source": meta["loc"], **meta}
 
 def _batch_block(iterable: Iterable, size: int) -> Generator[List[dict], None, None]:
     it = iter(iterable)
@@ -41,6 +41,8 @@ class SitemapLoader(WebBaseLoader):
             blocksize: number of sitemap locations per block
             blocknum: the number of the block that should be loaded - zero indexed
             meta_function: Function to parse bs4.Soup output for metadata
+                remember when setting this method to also copy metadata["loc"] to metadata["source"]
+                if you are using this field
         """
 
         if blocksize is not None and blocksize < 1:
@@ -115,7 +117,7 @@ class SitemapLoader(WebBaseLoader):
         return [
             Document(
                 page_content=self.parsing_function(results[i]),
-                metadata={**{"source": els[i]["loc"]}, **self.meta_function(els[i], results[i])},
+                metadata=self.meta_function(els[i], results[i]),
             )
             for i in range(len(results))
         ]

--- a/langchain/document_loaders/sitemap.py
+++ b/langchain/document_loaders/sitemap.py
@@ -10,8 +10,8 @@ from langchain.schema import Document
 def _default_parsing_function(content: Any) -> str:
     return str(content.get_text())
 
-def _default_meta_function(list: dict, _content: Any) -> dict:
-    return list
+def _default_meta_function(meta: dict, _content: Any) -> dict:
+    return meta
 
 def _batch_block(iterable: Iterable, size: int) -> Generator[List[dict], None, None]:
     it = iter(iterable)

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from langchain.document_loaders import SitemapLoader
@@ -81,14 +83,13 @@ def test_filter_sitemap() -> None:
 
 
 def test_sitemap_metadata() -> None:
-
-    def sitemap_metadata_one(meta, _content) -> dict:
+    def sitemap_metadata_one(meta: dict, _content: None) -> dict:
         return {**meta, "mykey": "Super Important Metadata"}
 
     """Test sitemap loader."""
     loader = SitemapLoader(
         "https://langchain.readthedocs.io/sitemap.xml",
-        meta_function = sitemap_metadata_one
+        meta_function=sitemap_metadata_one,
     )
     documents = loader.load()
     assert len(documents) > 1
@@ -97,8 +98,7 @@ def test_sitemap_metadata() -> None:
 
 
 def test_sitemap_metadata_extraction() -> None:
-
-    def sitemap_metadata_two(meta, content) -> dict:
+    def sitemap_metadata_two(meta: dict, content: Any) -> dict:
         title = content.find("title")
         if title:
             return {**meta, "title": title.get_text()}
@@ -107,7 +107,7 @@ def test_sitemap_metadata_extraction() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
         "https://langchain.readthedocs.io/sitemap.xml",
-        meta_function = sitemap_metadata_two
+        meta_function=sitemap_metadata_two,
     )
     documents = loader.load()
     assert len(documents) > 1

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -113,3 +113,12 @@ def test_sitemap_metadata_extraction() -> None:
     assert len(documents) > 1
     assert "title" in documents[0].metadata
     assert "LangChain" in documents[0].metadata["title"]
+
+
+def test_sitemap_metadata_default() -> None:
+    """Test sitemap loader."""
+    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml")
+    documents = loader.load()
+    assert len(documents) > 1
+    assert "source" in documents[0].metadata
+    assert "loc" in documents[0].metadata

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -78,3 +78,19 @@ def test_filter_sitemap() -> None:
     documents = loader.load()
     assert len(documents) == 1
     assert "🦜🔗" in documents[0].page_content
+
+
+def test_sitemap_metadata() -> None:
+
+    def sitemap_metadata_one(meta, _content) -> dict:
+        return {**meta, "mykey": "Super Important Metadata"}
+
+    """Test sitemap loader."""
+    loader = SitemapLoader(
+        "https://langchain.readthedocs.io/sitemap.xml",
+        meta_function = sitemap_metadata_one
+    )
+    documents = loader.load()
+    assert len(documents) > 1
+    assert "mykey" in documents[0].metadata
+    assert "Super Important Metadata" in documents[0].metadata["mykey"]

--- a/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/tests/integration_tests/document_loaders/test_sitemap.py
@@ -94,3 +94,22 @@ def test_sitemap_metadata() -> None:
     assert len(documents) > 1
     assert "mykey" in documents[0].metadata
     assert "Super Important Metadata" in documents[0].metadata["mykey"]
+
+
+def test_sitemap_metadata_extraction() -> None:
+
+    def sitemap_metadata_two(meta, content) -> dict:
+        title = content.find("title")
+        if title:
+            return {**meta, "title": title.get_text()}
+        return meta
+
+    """Test sitemap loader."""
+    loader = SitemapLoader(
+        "https://langchain.readthedocs.io/sitemap.xml",
+        meta_function = sitemap_metadata_two
+    )
+    documents = loader.load()
+    assert len(documents) > 1
+    assert "title" in documents[0].metadata
+    assert "LangChain" in documents[0].metadata["title"]


### PR DESCRIPTION
# Sitemap Metadata extractor

this pr makes it possible to extract more metadata from websites for later use.

my usecase:
parsing ld+json or microdata from sites and store it as structured data in the metadata field