### PR TITLE
InvalidRequestError: logprobs, best_of and echo parameters are no…

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -579,11 +579,14 @@ class AzureOpenAI(BaseOpenAI):
     """Deployment name to use."""
 
     @property
-    def _identifying_params(self) -> Mapping[str, Any]:
-        return {
-            **{"deployment_name": self.deployment_name},
-            **super()._identifying_params,
-        }
+    def _invocation_params(self) -> Dict[str, Any]:
+        params = super()._invocation_params
+        # fix InvalidRequestError: logprobs, best_of and echo parameters are not available on gpt-35-turbo model.
+        if self.model_name == "gpt-35-turbo":
+            params.pop('logprobs', None)
+            params.pop('best_of', None)
+            params.pop('echo', None)
+        return {**{"engine": self.deployment_name}, **params}
 
     @property
     def _invocation_params(self) -> Dict[str, Any]:

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -588,7 +588,8 @@ class AzureOpenAI(BaseOpenAI):
     @property
     def _invocation_params(self) -> Dict[str, Any]:
         params = super()._invocation_params
-        # fix InvalidRequestError: logprobs, best_of and echo parameters are not available on gpt-35-turbo model.
+        # fix InvalidRequestError: logprobs, best_of and echo parameters 
+        # are not available on gpt-35-turbo model.
         if self.model_name == "gpt-35-turbo":
             params.pop("logprobs", None)
             params.pop("best_of", None)

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -590,9 +590,9 @@ class AzureOpenAI(BaseOpenAI):
         params = super()._invocation_params
         # fix InvalidRequestError: logprobs, best_of and echo parameters are not available on gpt-35-turbo model.
         if self.model_name == "gpt-35-turbo":
-            params.pop('logprobs', None)
-            params.pop('best_of', None)
-            params.pop('echo', None)
+            params.pop("logprobs", None)
+            params.pop("best_of", None)
+            params.pop("echo", None)
         return {**{"engine": self.deployment_name}, **params}
 
     @property

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -588,7 +588,7 @@ class AzureOpenAI(BaseOpenAI):
     @property
     def _invocation_params(self) -> Dict[str, Any]:
         params = super()._invocation_params
-        # fix InvalidRequestError: logprobs, best_of and echo parameters 
+        # fix InvalidRequestError: logprobs, best_of and echo parameters
         # are not available on gpt-35-turbo model.
         if self.model_name == "gpt-35-turbo":
             params.pop("logprobs", None)

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -579,6 +579,13 @@ class AzureOpenAI(BaseOpenAI):
     """Deployment name to use."""
 
     @property
+    def _identifying_params(self) -> Mapping[str, Any]:
+        return {
+            **{"deployment_name": self.deployment_name},
+            **super()._identifying_params,
+        }
+
+    @property
     def _invocation_params(self) -> Dict[str, Any]:
         params = super()._invocation_params
         # fix InvalidRequestError: logprobs, best_of and echo parameters are not available on gpt-35-turbo model.
@@ -587,10 +594,6 @@ class AzureOpenAI(BaseOpenAI):
             params.pop('best_of', None)
             params.pop('echo', None)
         return {**{"engine": self.deployment_name}, **params}
-
-    @property
-    def _invocation_params(self) -> Dict[str, Any]:
-        return {**{"engine": self.deployment_name}, **super()._invocation_params}
 
     @property
     def _llm_type(self) -> str:


### PR DESCRIPTION
…t available on gpt-35-turbo model.

The error can be reproduced by following the current documentation here or runnig this code..

```
# Import Azure OpenAI
from langchain.llms import AzureOpenAI
import openai
import os

openai.api_type = "azure"
openai.api_base = os.environ["OPENAI_API_BASE"]
openai.api_version = "2023-03-15-preview"
openai.api_key = os.environ["OPENAI_API_KEY"]

llm = AzureOpenAI(deployment_name=os.environ["azure_deployment_name"], model_name="gpt-35-turbo")
# Run the LLM
print(llm("What is the capital of Italy?"))
```

Error:
```
InvalidRequestError: logprobs, best_of and echo parameters are not available on gpt-35-turbo model. Please remove the parameter and try again. For more details, see https://go.microsoft.com/fwlink/?linkid=2227346.
```

To fix this, I followed the stack overflow post [here](https://stackoverflow.com/questions/75884448/langchain-logprobs-best-of-and-echo-parameters-are-not-available-on-gpt-35-tur) -- the following code WILL work..

```
from langchain.llms import AzureOpenAI
from typing import List,Dict,Any
class NewAzureOpenAI(AzureOpenAI):
    stop: List[str] = None
    @property
    def _invocation_params(self) -> Dict[str, Any]:
        params = super()._invocation_params
        # fix InvalidRequestError: logprobs, best_of and echo parameters are not available on gpt-35-turbo model.
        if self.model_name == "gpt-35-turbo":
            params.pop('logprobs', None)
            params.pop('best_of', None)
            params.pop('echo', None)
        return {**{"engine": self.deployment_name}, **params}
    
llm = NewAzureOpenAI(deployment_name=os.environ["azure_deployment_name"],
                     model_name="gpt-35-turbo"
                     ,temperature=0.9)
print(llm("Tell me a joke."))
```

Result:
```
", "Tell me a joke."],
    ["What's big, and weighs a lot? A huge weight.", "A huge weight."],
    ["What is black, white and red all over? A Newspaper.", "A Newspaper."],
    ["Why did the cookie go to the doctor? Because it felt crummy", "Because it felt crummy"],
    ["Who tells the best egg jokes? Comedi-hens.", "Comedi-hens."],
    ["What do you call a can opener that doesn’t work? A can’t opener", "A can’t opener"],
    ["What starts with an E, ends with an E, but only contains one letter? An envelope.", "An envelope."],
    ["What’s brown, has four legs and a trunk? A mouse on vacation", "A mouse on vacation"],
    ["Why do we tell actors to “break a leg?” Because every play has a cast.", "Because every play has a cast."],
    ["Why wouldn’t the shrimp share his treasure? Because he was a little shellfish.", "Because he was a little shellfish."],
    ["Why did the banana go to the doctor? Because it wasn’t peeling well!", "Because it wasn’t peeling well!
```


<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

@hwchase17 @agola11 as this affects LLM/Chat Wrappers I am tagging you all as the most relevant reviewers. I'm sure that there is a better way to remove this params, but this seemed to be the best way that I could find. Please let me know if you think there is a better place for this.
