### PR TITLE
Add support for Qdrant nested filter

### DIFF
--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -472,13 +472,13 @@ class Qdrant(VectorStore):
                 for _key, value in value.items():
                     return _build_condition(f"{key}.{_key}", value)
             else:
-                return rest.FieldCondition(
+                out = rest.FieldCondition(
                     key=f"{self.metadata_payload_key}.{key}",
                     match=rest.MatchValue(value=value),
                 )
 
+            return out
+
         return rest.Filter(
-            must=[
-                _build_condition(key, value) for key, value in filter.items()
-            ]
+            must=[_build_condition(key, value) for key, value in filter.items()]
         )

--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -500,11 +500,13 @@ class Qdrant(VectorStore):
 
         return out
 
-    def _qdrant_filter_from_dict(self, filter: Optional[MetadataFilter]) -> rest.Filter:
+    def _qdrant_filter_from_dict(
+        self, filter: Optional[MetadataFilter]
+    ) -> Optional[rest.Filter]:
+        from qdrant_client.http import models as rest
+
         if not filter:
             return None
-
-        from qdrant_client.http import models as rest
 
         return rest.Filter(
             must=[

--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -14,7 +14,7 @@ from langchain.embeddings.base import Embeddings
 from langchain.vectorstores import VectorStore
 from langchain.vectorstores.utils import maximal_marginal_relevance
 
-MetadataFilter = Dict[str, Union[str, int, bool]]
+MetadataFilter = Dict[str, Union[str, int, bool, dict, list]]
 
 
 class Qdrant(VectorStore):

--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -467,12 +467,18 @@ class Qdrant(VectorStore):
 
         from qdrant_client.http import models as rest
 
-        return rest.Filter(
-            must=[
-                rest.FieldCondition(
+        def _build_condition(key: str, value: Any) -> rest.FieldCondition:
+            if isinstance(value, dict):
+                for _key, value in value.items():
+                    return _build_condition(f"{key}.{_key}", value)
+            else:
+                return rest.FieldCondition(
                     key=f"{self.metadata_payload_key}.{key}",
                     match=rest.MatchValue(value=value),
                 )
-                for key, value in filter.items()
+
+        return rest.Filter(
+            must=[
+                _build_condition(key, value) for key, value in filter.items()
             ]
         )

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -78,7 +78,10 @@ def test_qdrant_with_metadatas(
 def test_qdrant_similarity_search_filters() -> None:
     """Test end to end construction and search."""
     texts = ["foo", "bar", "baz"]
-    metadatas = [{"page": i, "metadata": {"page": i + 1}} for i in range(len(texts))]
+    metadatas = [
+        {"page": i, "metadata": {"page": i + 1, "pages": [i + 2, -1]}}
+        for i in range(len(texts))
+    ]
     docsearch = Qdrant.from_texts(
         texts,
         FakeEmbeddings(),
@@ -87,10 +90,13 @@ def test_qdrant_similarity_search_filters() -> None:
     )
 
     output = docsearch.similarity_search(
-        "foo", k=1, filter={"page": 1, "metadata": {"page": 2}}
+        "foo", k=1, filter={"page": 1, "metadata": {"page": 2, "pages": [3]}}
     )
     assert output == [
-        Document(page_content="bar", metadata={"page": 1, "metadata": {"page": 2}})
+        Document(
+            page_content="bar",
+            metadata={"page": 1, "metadata": {"page": 2, "pages": [3, -1]}},
+        )
     ]
 
 

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -86,8 +86,12 @@ def test_qdrant_similarity_search_filters() -> None:
         location=":memory:",
     )
 
-    output = docsearch.similarity_search("foo", k=1, filter={"page": 1, "metadata": {"page": 2}})
-    assert output == [Document(page_content="bar", metadata={"page": 1, "metadata": {"page": 2}})]
+    output = docsearch.similarity_search(
+        "foo", k=1, filter={"page": 1, "metadata": {"page": 2}}
+    )
+    assert output == [
+        Document(page_content="bar", metadata={"page": 1, "metadata": {"page": 2}})
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -78,15 +78,16 @@ def test_qdrant_with_metadatas(
 def test_qdrant_similarity_search_filters() -> None:
     """Test end to end construction and search."""
     texts = ["foo", "bar", "baz"]
-    metadatas = [{"page": i} for i in range(len(texts))]
+    metadatas = [{"page": i, "metadata": {"page": i + 1}} for i in range(len(texts))]
     docsearch = Qdrant.from_texts(
         texts,
         FakeEmbeddings(),
         metadatas=metadatas,
         location=":memory:",
     )
-    output = docsearch.similarity_search("foo", k=1, filter={"page": 1})
-    assert output == [Document(page_content="bar", metadata={"page": 1})]
+
+    output = docsearch.similarity_search("foo", k=1, filter={"page": 1, "metadata": {"page": 2}})
+    assert output == [Document(page_content="bar", metadata={"page": 1, "metadata": {"page": 2}})]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Add support for Qdrant nested filter

This extends the filter functionality for the Qdrant vectorstore. The current filter implementation is limited to a single-level metadata structure; however, Qdrant supports nested metadata filtering. This extends the functionality for users to maximize the filter functionality when using Qdrant as the vectorstore.

Reference: https://qdrant.tech/documentation/filtering/#nested-key
