### PR TITLE
fix model name not being passed to __init__ when using from_tiktoken_encoder

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -158,6 +158,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
 
         if model_name is not None:
             enc = tiktoken.encoding_for_model(model_name)
+            kwargs["model_name"] = model_name
         else:
             enc = tiktoken.get_encoding(encoding_name)
 


### PR DESCRIPTION
# Fix model name not being passed to __init__ when using from_tiktoken_encoder

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/hwchase17/langchain/issues/4357


## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoader Abstractions
        - @eyurtsev

        LLM/Chat Wrappers
        - @hwchase17
        - @agola11

        Tools / Toolkits
        - @vowelparrot
 -->
@hwchase17 