### PR TITLE
using nearText or nearVector to request weaviate

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -107,6 +107,12 @@ class VectorStore(ABC):
     ) -> List[Document]:
         """Return docs most similar to query."""
 
+    @abstractmethod
+    def similarity_search_by_text(
+            self, query: str, k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to query."""
+
     def similarity_search_with_relevance_scores(
         self,
         query: str,

--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -83,6 +83,7 @@ class Weaviate(VectorStore):
         client: Any,
         index_name: str,
         text_key: str,
+        by_text: bool = True,
         embedding: Optional[Embeddings] = None,
         attributes: Optional[List[str]] = None,
         relevance_score_fn: Optional[
@@ -105,6 +106,7 @@ class Weaviate(VectorStore):
         self._index_name = index_name
         self._embedding = embedding
         self._text_key = text_key
+        self._by_text = by_text
         self._query_attrs = [self._text_key]
         self._relevance_score_fn = relevance_score_fn
         if attributes is not None:
@@ -154,6 +156,15 @@ class Weaviate(VectorStore):
         return ids
 
     def similarity_search(
+            self, query: str, k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        if self._by_text:
+            return self.similarity_search_by_text(query, k, **kwargs)
+        else:
+            embd = self._embedding.embed_query(query)
+            return self.similarity_search_by_vector(embd, k, **kwargs)
+
+    def similarity_search_by_text(
         self, query: str, k: int = 4, **kwargs: Any
     ) -> List[Document]:
         """Return docs most similar to query.


### PR DESCRIPTION
I updated the class Weavaite in the module weaviate, by:
- Adding an attribute by_text, takes the value True by default, if this attribute is true, we can use the nearText to request data from weaviate, else we use nearVector.
- I changed the name of similarity_search to similarity_search_by_text, which using nearText
- I added a new method similarity_search, which checks the attribute by_text and based on its value we can using nearText or nearVector
