### PR TITLE
Add top K as Self Query Retriever Get Documents Input

### DIFF
--- a/langchain/chains/query_constructor/ir.py
+++ b/langchain/chains/query_constructor/ir.py
@@ -81,3 +81,4 @@ class Operation(FilterDirective):
 class StructuredQuery(Expr):
     query: str
     filter: Optional[FilterDirective]
+    k: Optional[int]

--- a/langchain/chains/query_constructor/parser.py
+++ b/langchain/chains/query_constructor/parser.py
@@ -47,11 +47,13 @@ class QueryTransformer(Transformer):
         *args: Any,
         allowed_comparators: Optional[Sequence[Comparator]] = None,
         allowed_operators: Optional[Sequence[Operator]] = None,
+        k: int = 4,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self.allowed_comparators = allowed_comparators
         self.allowed_operators = allowed_operators
+        self.k = k
 
     def program(self, *items: Any) -> tuple:
         return items
@@ -113,8 +115,9 @@ class QueryTransformer(Transformer):
 def get_parser(
     allowed_comparators: Optional[Sequence[Comparator]] = None,
     allowed_operators: Optional[Sequence[Operator]] = None,
+    k: int = 4
 ) -> Lark:
     transformer = QueryTransformer(
-        allowed_comparators=allowed_comparators, allowed_operators=allowed_operators
+        allowed_comparators=allowed_comparators, allowed_operators=allowed_operators, k=k
     )
     return Lark(GRAMMAR, parser="lalr", transformer=transformer, start="program")

--- a/langchain/chains/query_constructor/prompt.py
+++ b/langchain/chains/query_constructor/prompt.py
@@ -86,6 +86,7 @@ following schema:
 {{{{
     "query": string \\ text string to compare to document contents
     "filter": string \\ logical condition statement for filtering documents
+    "k": int \\ the number of documents to retrieve
 }}}}
 ```
 
@@ -112,6 +113,7 @@ Make sure that filters take into account the descriptions of attributes and only
 comparisons that are feasible given the type of data being stored.
 Make sure that filters are only used as needed. If there are no filters that should be \
 applied return "NO_FILTER" for the filter value.\
+Make sure the k is always an int value. It is an optional parameter so leave it blank if it is not in the input.
 """
 
 DEFAULT_PREFIX = """\
@@ -132,6 +134,9 @@ Data Source:
 
 User Query:
 {{query}}
+
+k:
+{{k}}
 
 Structured Request:
 """

--- a/langchain/retrievers/self_query/base.py
+++ b/langchain/retrievers/self_query/base.py
@@ -57,7 +57,7 @@ class SelfQueryRetriever(BaseRetriever, BaseModel):
             )
         return values
 
-    def get_relevant_documents(self, query: str) -> List[Document]:
+    def get_relevant_documents(self, query: str, k: int = 4) -> List[Document]:
         """Get documents relevant for a query.
 
         Args:
@@ -66,15 +66,17 @@ class SelfQueryRetriever(BaseRetriever, BaseModel):
         Returns:
             List of relevant documents
         """
-        inputs = self.llm_chain.prep_inputs(query)
+        inputs = self.llm_chain.prep_inputs({'query' : query, 'k' : k})
         structured_query = cast(
             StructuredQuery, self.llm_chain.predict_and_parse(callbacks=None, **inputs)
         )
+        structured_query.k = k
         if self.verbose:
             print(structured_query)
         new_query, new_kwargs = self.structured_query_translator.visit_structured_query(
             structured_query
         )
+        
         search_kwargs = {**self.search_kwargs, **new_kwargs}
         docs = self.vectorstore.search(query, self.search_type, **search_kwargs)
         return docs
@@ -96,6 +98,7 @@ class SelfQueryRetriever(BaseRetriever, BaseModel):
         if structured_query_translator is None:
             structured_query_translator = _get_builtin_translator(vectorstore.__class__)
         chain_kwargs = chain_kwargs or {}
+        
         if "allowed_comparators" not in chain_kwargs:
             chain_kwargs[
                 "allowed_comparators"

--- a/langchain/retrievers/self_query/pinecone.py
+++ b/langchain/retrievers/self_query/pinecone.py
@@ -47,7 +47,7 @@ class PineconeTranslator(Visitor):
         self, structured_query: StructuredQuery
     ) -> Tuple[str, dict]:
         if structured_query.filter is None:
-            kwargs = {}
+            kwargs = {"k": structured_query.k}
         else:
-            kwargs = {"filter": structured_query.filter.accept(self)}
+            kwargs = {"filter": structured_query.filter.accept(self), "k": structured_query.k}
         return structured_query.query, kwargs


### PR DESCRIPTION
Add Top K as Optional Parameter for Self Query Retriever

Adding k as a parameter to Self-Retriever's Get Relevant Documents method. This allows users to specify how many documents they want it to retrieve during a search. This is a fixed PR from previous PR: https://github.com/hwchase17/langchain/pull/4297


## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoader Abstractions
        - @eyurtsev

        LLM/Chat Wrappers
        - @hwchase17
        - @agola11

        Tools / Toolkits
        - @vowelparrot
 -->
