### PR TITLE
Fix grammar in Text Splitters docs

### DIFF
--- a/docs/modules/indexes/text_splitters.rst
+++ b/docs/modules/indexes/text_splitters.rst
@@ -15,7 +15,7 @@ At a high level, text splitters work as following:
 2. Start combining these small chunks into a larger chunk until you reach a certain size (as measured by some function).
 3. Once you reach that size, make that chunk its own piece of text and then start creating a new chunk of text with some overlap (to keep context between chunks).
 
-That means there two different axes along which you can customize your text splitter:
+That means there are two different axes along which you can customize your text splitter:
 
 1. How the text is split
 2. How the chunk size is measured


### PR DESCRIPTION
# Fix grammar in Text Splitters docs

Just a small fix of grammar in the documentation:

"That means there two different axes" -> "That means there are two different axes"
<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->


<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoader Abstractions
        - @eyurtsev

        LLM/Chat Wrappers
        - @hwchase17
        - @agola11

        Tools / Toolkits
        - @vowelparrot
 -->
