### PR TITLE
query correction from when to what

### DIFF
--- a/docs/modules/agents/tools/examples/human_tools.ipynb
+++ b/docs/modules/agents/tools/examples/human_tools.ipynb
@@ -68,7 +68,7 @@
      ]
     },
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       " Zhu\n"
@@ -98,7 +98,7 @@
     }
    ],
    "source": [
-    "agent_chain.run(\"When's my friend Eric's surname?\")\n",
+    "agent_chain.run(\"What's my friend Eric's surname?\")\n",
     "# Answer with 'Zhu'"
    ]
   },
@@ -196,7 +196,7 @@
      ]
     },
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       " vini\n",
@@ -222,7 +222,7 @@
      ]
     },
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       " oh who said it \n",


### PR DESCRIPTION
# Minor Wording Documentation Change 

```python
agent_chain.run("When's my friend Eric's surname?")
# Answer with 'Zhu'
```

is change to 

```python
agent_chain.run("What's my friend Eric's surname?")
# Answer with 'Zhu'
```

I think when is a residual of the old query that was "When’s my friends Eric`s birthday?".