### PR TITLE
add milvus _similarity_search_with_relevance_scores

### DIFF
--- a/langchain/vectorstores/milvus.py
+++ b/langchain/vectorstores/milvus.py
@@ -803,3 +803,22 @@ class Milvus(VectorStore):
         )
         vector_db.add_texts(texts=texts, metadatas=metadatas)
         return vector_db
+    
+    def relevance_score_fn(
+        self, 
+        score: float
+    ) -> float:
+        if self.search_params["metric_type"] == 'L2':
+            return 1 / (1 + score)
+        raise NotImplemented
+
+    def _similarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Return docs and their similarity scores on a scale from 0 to 1."""
+
+        docs_and_scores = self.similarity_search_with_score(query, k=k)
+        return [(doc, self.relevance_score_fn(score)) for doc, score in docs_and_scores]

--- a/langchain/vectorstores/milvus.py
+++ b/langchain/vectorstores/milvus.py
@@ -818,6 +818,11 @@ class Milvus(VectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs and their similarity scores on a scale from 0 to 1."""
+        if self.relevance_score_fn is None:
+            raise ValueError(
+                "normalize_score_fn must be provided to"
+                " milvus constructor to normalize scores"
+            )
 
         docs_and_scores = self.similarity_search_with_score(query, k=k)
         return [(doc, self.relevance_score_fn(score)) for doc, score in docs_and_scores]

--- a/langchain/vectorstores/milvus.py
+++ b/langchain/vectorstores/milvus.py
@@ -808,7 +808,7 @@ class Milvus(VectorStore):
         self, 
         score: float
     ) -> float:
-        if self.search_params["metric_type"] == 'L2':
+        if "metric_type" in self.search_params and self.search_params["metric_type"] == 'L2':
             return 1 / (1 + score)
         raise NotImplemented
 


### PR DESCRIPTION
When I used the generative agent code of the virtual town, I used milvus, but reported the following unimplemented error

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

```
Traceback (most recent call last):
  File "/Users/jxyxiangyu/project/smartMarketing/agent/demo_for_chat.py", line 103, in <module>
    print(tommie.get_summary())
          ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/experimental/generative_agents/generative_agent.py", line 215, in get_summary
    self.summary = self._compute_agent_summary()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/experimental/generative_agents/generative_agent.py", line 202, in _compute_agent_summary
    .run(name=self.name, queries=[f"{self.name}'s core characteristics"])
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/chains/base.py", line 239, in run
    return self(kwargs, callbacks=callbacks)[self.output_keys[0]]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/chains/base.py", line 123, in __call__
    inputs = self.prep_inputs(inputs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/chains/base.py", line 214, in prep_inputs
    external_context = self.memory.load_memory_variables(inputs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/experimental/generative_agents/memory.py", line 183, in load_memory_variables
    relevant_memories = [
                        ^
  File "/usr/local/lib/python3.11/site-packages/langchain/experimental/generative_agents/memory.py", line 184, in <listcomp>
    mem for query in queries for mem in self.fetch_memories(query)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/experimental/generative_agents/memory.py", line 147, in fetch_memories
    return self.memory_retriever.get_relevant_documents(observation)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/retrievers/time_weighted_retriever.py", line 91, in get_relevant_documents
    docs_and_scores.update(self.get_salient_docs(query))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/retrievers/time_weighted_retriever.py", line 72, in get_salient_docs
    docs_and_scores = self.vectorstore.similarity_search_with_relevance_scores(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/vectorstores/base.py", line 120, in similarity_search_with_relevance_scores
    docs_and_similarities = self._similarity_search_with_relevance_scores(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/langchain/vectorstores/base.py", line 143, in _similarity_search_with_relevance_scores
    raise NotImplementedError
NotImplementedError
```

So, I implement _similarity_search_with_relevance_scores function in milvus.py

Fixes when using milvus, it will raise _similarity_search_with_relevance_scores not implemented

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@hwchase17

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoader Abstractions
        - @eyurtsev

        LLM/Chat Wrappers
        - @hwchase17
        - @agola11

        Tools / Toolkits
        - @vowelparrot
 -->
