### PR TITLE
Correct AutoGPT import in autogpt.ipynb

### DIFF
--- a/docs/use_cases/autonomous_agents/autogpt.ipynb
+++ b/docs/use_cases/autonomous_agents/autogpt.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.experimental import AutoGPT\n",
+    "from langchain.experimental.autonomous_agents.autogpt.agent import AutoGPT\n",
     "from langchain.chat_models import ChatOpenAI"
    ]
   },


### PR DESCRIPTION
Take into account modification of the structure of the experimental folder to load the AutoGPT class

# Correct AutoGPT import in autogpt.ipynb considering new experimental folder structure

The former block in  https://python.langchain.com/en/latest/use_cases/autonomous_agents/autogpt.html :

```
from langchain.experimental import AutoGPT
from langchain.chat_models import ChatOpenAI
```
Was not loading AutoGPT as the structure of the experimental folder changed. 
This PR fixes module import for AutoGPT

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested: @vowelparrot ?

