### PR TITLE
[GoogleSerperAPIWrapper] fix bug in result parsing(_parse_results)

### DIFF
--- a/langchain/utilities/google_serper.py
+++ b/langchain/utilities/google_serper.py
@@ -1,5 +1,6 @@
 """Util that calls Google Search using the Serper.dev API."""
 from typing import Any, Dict, Optional
+from typing_extensions import Literal
 
 import aiohttp
 import requests
@@ -28,7 +29,16 @@ class GoogleSerperAPIWrapper(BaseModel):
     k: int = 10
     gl: str = "us"
     hl: str = "en"
-    type: str = "search"  # search, images, places, news
+    # "places" and "images" is available from Serper but not implemented in the
+    # parser of run(). They can be used in results()
+    type: Literal["news", "search", "places", "images"] = "search"
+    result_key_for_type = {
+        "news": "news",
+        "places": "places",
+        "images": "images",
+        "search": "organic"
+    }
+
     tbs: Optional[str] = None
     serper_api_key: Optional[str] = None
     aiosession: Optional[aiohttp.ClientSession] = None
@@ -50,7 +60,7 @@ class GoogleSerperAPIWrapper(BaseModel):
 
     def results(self, query: str, **kwargs: Any) -> Dict:
         """Run query through GoogleSearch."""
-        return self._google_serper_search_results(
+        return self._google_serper_api_results(
             query,
             gl=self.gl,
             hl=self.hl,
@@ -62,7 +72,7 @@ class GoogleSerperAPIWrapper(BaseModel):
 
     def run(self, query: str, **kwargs: Any) -> str:
         """Run query through GoogleSearch and parse result."""
-        results = self._google_serper_search_results(
+        results = self._google_serper_api_results(
             query,
             gl=self.gl,
             hl=self.hl,
@@ -125,7 +135,7 @@ class GoogleSerperAPIWrapper(BaseModel):
             for attribute, value in kg.get("attributes", {}).items():
                 snippets.append(f"{title} {attribute}: {value}.")
 
-        for result in results["organic"][: self.k]:
+        for result in results[self.result_key_for_type[self.type]][: self.k]:
             if "snippet" in result:
                 snippets.append(result["snippet"])
             for attribute, value in result.get("attributes", {}).items():
@@ -136,7 +146,7 @@ class GoogleSerperAPIWrapper(BaseModel):
 
         return " ".join(snippets)
 
-    def _google_serper_search_results(
+    def _google_serper_api_results(
         self, search_term: str, search_type: str = "search", **kwargs: Any
     ) -> dict:
         headers = {

--- a/tests/integration_tests/utilities/test_googleserper_api.py
+++ b/tests/integration_tests/utilities/test_googleserper_api.py
@@ -4,11 +4,18 @@ import pytest
 from langchain.utilities.google_serper import GoogleSerperAPIWrapper
 
 
-def test_call() -> None:
-    """Test that call gives the correct answer."""
+def test_search_call() -> None:
+    """Test that call gives the correct answer from search."""
     search = GoogleSerperAPIWrapper()
     output = search.run("What was Obama's first name?")
     assert "Barack Hussein Obama II" in output
+
+
+def test_news_call() -> None:
+    """Test that call gives the correct answer from news search."""
+    search = GoogleSerperAPIWrapper(type="news")
+    output = search.run("What's new with stock market?").lower()
+    assert ("stock" in output or "market" in output)
 
 
 async def test_results() -> None:


### PR DESCRIPTION
# Parse news search result in GoogleSerperAPIWrapper.run


GoogleSerperAPIWrapper's parser method, _parse_results, assumes the result list is under the key "organic". For other search types (news, places, images), the key is not "organic". Before this PR, calling the run() from GoogleSerperAPIWrapper with other types than "search" will throw exception because "organic" doesn't exist in the API response.



## Who can review?

@rogerserper 

