### PR TITLE
Make `lark` a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ html2text = {version="^2020.1.16", optional=true}
 numexpr = "^2.8.4"
 duckduckgo-search = {version="^2.8.6", optional=true}
 azure-cosmos = {version="^4.4.0b1", optional=true}
-lark = {version="^1.1.5", optional=true}
+lark = "^1.1.5"
 lancedb = {version = "^0.1", optional = true}
 pexpect = {version = "^4.8.0", optional = true}
 pyvespa = {version = "^0.33.0", optional = true}


### PR DESCRIPTION
# Make `lark` a required dependency

Make `lark` a required dependency since it is required by `langchain.chains.query_constructor.parser`.

Fixes #4275 and fixes #4316

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

- @hwchase17
