### PR TITLE
Update WhatsAppChatLoader to include the character ~ in the sender name

### DIFF
--- a/langchain/document_loaders/whatsapp_chat.py
+++ b/langchain/document_loaders/whatsapp_chat.py
@@ -44,7 +44,7 @@ class WhatsAppChatLoader(BaseLoader):
             )
             \]?
             [\s-]*
-            ([\w\s]+)
+            ([~\w\s]+)
             [:]+
             \s
             (.+)

--- a/tests/integration_tests/document_loaders/test_whatsapp_chat.py
+++ b/tests/integration_tests/document_loaders/test_whatsapp_chat.py
@@ -16,4 +16,5 @@ def test_whatsapp_chat_loader() -> None:
         "User name on 11/8/21, 9:41:32 AM: Message 123\n\n"
         "User 2 on 1/23/23, 3:19 AM: Bye!\n\n"
         "User 1 on 1/23/23, 3:22_AM: And let me know if anything changes\n\n"
+        "~ User name 2 on 1/24/21, 12:41:03 PM: Of course!\n\n"
     )

--- a/tests/integration_tests/examples/whatsapp_chat.txt
+++ b/tests/integration_tests/examples/whatsapp_chat.txt
@@ -2,3 +2,4 @@
 [11/8/21, 9:41:32 AM] User name: Message 123
 1/23/23, 3:19 AM - User 2: Bye!
 1/23/23, 3:22_AM - User 1: And let me know if anything changes
+[1/24/21, 12:41:03 PM] ~ User name 2: Of course!


### PR DESCRIPTION
# Update WhatsAppChatLoader to include the character ~ in the sender name

Fixes #4153

If the sender of a message in a group chat isn't in your contact list, they will appear with a ~ prefix in the exported chat. This PR adds support for parsing such lines.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested: @eyurtsev @hp0404 @dev2049 
