### PR TITLE
Fix Lark import error

### DIFF
--- a/langchain/chains/query_constructor/parser.py
+++ b/langchain/chains/query_constructor/parser.py
@@ -10,7 +10,12 @@ try:
         )
     from lark import Lark, Transformer, v_args
 except ImportError:
-    pass
+
+    def v_args(*args: Any, **kwargs: Any) -> Any:
+        return lambda _: None
+
+    Transformer = object
+    Lark = object
 
 from langchain.chains.query_constructor.ir import (
     Comparator,

--- a/langchain/chains/query_constructor/parser.py
+++ b/langchain/chains/query_constructor/parser.py
@@ -11,11 +11,11 @@ try:
     from lark import Lark, Transformer, v_args
 except ImportError:
 
-    def v_args(*args: Any, **kwargs: Any) -> Any:
+    def v_args(*args: Any, **kwargs: Any) -> Any:  # type: ignore
         return lambda _: None
 
-    Transformer = object
-    Lark = object
+    Transformer = object  # type: ignore
+    Lark = object  # type: ignore
 
 from langchain.chains.query_constructor.ir import (
     Comparator,


### PR DESCRIPTION
Any import that touches langchain.retrievers currently requires Lark. Here's one attempt to fix. Not very pretty, very open to other ideas. Alternatives I thought of are 1) make Lark requirement, 2) put everything in parser.py  in the try/except. Neither sounds much better

Related to #4316, #4275