### PR TITLE
Jupyter Notebook Example for using Mongodb to store Chat Message History

### DIFF
--- a/docs/modules/memory/examples/mongodb_chat_message_history.ipynb
+++ b/docs/modules/memory/examples/mongodb_chat_message_history.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "91c6a7ef",
+   "metadata": {},
+   "source": [
+    "# Mongodb Chat Message History\n",
+    "\n",
+    "This notebook goes over how to use Mongodb to store chat message history.\n",
+    "\n",
+    "MongoDB is a source-available cross-platform document-oriented database program. Classified as a NoSQL database program, MongoDB uses JSON-like documents with optional schemas.\n",
+    "\n",
+    "MongoDB is developed by MongoDB Inc. and licensed under the Server Side Public License (SSPL). - [Wikipedia](https://en.wikipedia.org/wiki/MongoDB)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "47a601d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Provide the connection string to connect to the MongoDB database\n",
+    "connection_string = \"mongodb://mongo_user:password123@mongo:27017\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d15e3302",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.memory import MongoDBChatMessageHistory\n",
+    "\n",
+    "message_history = MongoDBChatMessageHistory(\n",
+    "        connection_string=connection_string, session_id=\"test-session\"\n",
+    "    )\n",
+    "\n",
+    "message_history.add_user_message(\"hi!\")\n",
+    "\n",
+    "message_history.add_ai_message(\"whats up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "64fc465e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[HumanMessage(content='hi!', additional_kwargs={}, example=False),\n",
+       " AIMessage(content='whats up?', additional_kwargs={}, example=False)]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "message_history.messages"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Jupyter Notebook Example for using Mongodb Chat Message History

@dev2049 