### PR TITLE
Normalize vectors in faiss before add() and search()

### DIFF
--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -92,7 +92,10 @@ class FAISS(VectorStore):
             documents.append(Document(page_content=text, metadata=metadata))
         # Add to the index, the index_to_id mapping, and the docstore.
         starting_len = len(self.index_to_docstore_id)
-        self.index.add(np.array(embeddings, dtype=np.float32))
+        faiss = dependable_faiss_import()
+        vector = np.array(embeddings, dtype=np.float32)
+        faiss.normalize_L2(vector)
+        self.index.add(vector)
         # Get list of index, id, and docs.
         full_info = [
             (starting_len + i, str(uuid.uuid4()), doc)
@@ -167,7 +170,10 @@ class FAISS(VectorStore):
         Returns:
             List of Documents most similar to the query and score for each
         """
-        scores, indices = self.index.search(np.array([embedding], dtype=np.float32), k)
+        faiss = dependable_faiss_import()
+        vector = np.array([embedding], dtype=np.float32)
+        faiss.normalize_L2(vector)
+        scores, indices = self.index.search(vector, k)
         docs = []
         for j, i in enumerate(indices[0]):
             if i == -1:
@@ -345,7 +351,9 @@ class FAISS(VectorStore):
     ) -> FAISS:
         faiss = dependable_faiss_import()
         index = faiss.IndexFlatL2(len(embeddings[0]))
-        index.add(np.array(embeddings, dtype=np.float32))
+        vector = np.array(embeddings, dtype=np.float32)
+        faiss.normalize_L2(vector)
+        index.add(vector)
         documents = []
         for i, text in enumerate(texts):
             metadata = metadatas[i] if metadatas else {}


### PR DESCRIPTION
Adding normalization is to make sure the score returned is between 0 and 1.

# Your PR Title (What it does)

The PR fixes some score out of <0, 1> range issue in FAISS. The issue is https://github.com/hwchase17/langchain/issues/4086 

<!-- Remove if not applicable -->

Fixes https://github.com/hwchase17/langchain/issues/4086

## Before submitting

Finish the manual testing

Before (with customized `score_normalizer`)
```
score : 68.8683853149414, result : 1.0
score : 74.28987121582031, result : 1.0
score : 77.00814056396484, result : 1.0
score : 79.08580017089844, result : 1.0
```

After

```
score : 0.22136175632476807, result : 0.8434736010073924
score : 0.2508389353752136, result : 0.8226300878105723
score : 0.25133150815963745, result : 0.8222817862544782
score : 0.25269198417663574, result : 0.8213197844372171
```



## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

Tools / Toolkits
- @vowelparrot