### PR TITLE
Add source field to metadata

### DIFF
--- a/langchain/document_loaders/git.py
+++ b/langchain/document_loaders/git.py
@@ -75,6 +75,7 @@ class GitLoader(BaseLoader):
                         continue
 
                     metadata = {
+                        "source": rel_file_path,
                         "file_path": rel_file_path,
                         "file_name": item.name,
                         "file_type": file_type,


### PR DESCRIPTION
This is needed if one want to use index.query_with_sources on git files. Without a source field, index.query_with_sources fails with an exception.