### PR TITLE
Fix: Add run_manager on all AgentFinish returns in AgentExecutor

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -920,13 +920,15 @@ class AgentExecutor(Chain):
                 # See if tool should return directly
                 tool_return = self._get_tool_return(next_step_action)
                 if tool_return is not None:
-                    return self._return(tool_return, intermediate_steps)
+                    return self._return(
+                        tool_return, intermediate_steps, run_manager=run_manager
+                    )
             iterations += 1
             time_elapsed = time.time() - start_time
         output = self.agent.return_stopped_response(
             self.early_stopping_method, intermediate_steps, **inputs
         )
-        return self._return(output, intermediate_steps)
+        return self._return(output, intermediate_steps, run_manager=run_manager)
 
     async def _acall(
         self,
@@ -957,7 +959,11 @@ class AgentExecutor(Chain):
                         run_manager=run_manager,
                     )
                     if isinstance(next_step_output, AgentFinish):
-                        return await self._areturn(next_step_output, intermediate_steps)
+                        return await self._areturn(
+                            next_step_output,
+                            intermediate_steps,
+                            run_manager=run_manager,
+                        )
 
                     intermediate_steps.extend(next_step_output)
                     if len(next_step_output) == 1:
@@ -965,7 +971,9 @@ class AgentExecutor(Chain):
                         # See if tool should return directly
                         tool_return = self._get_tool_return(next_step_action)
                         if tool_return is not None:
-                            return await self._areturn(tool_return, intermediate_steps)
+                            return await self._areturn(
+                                tool_return, intermediate_steps, run_manager=run_manager
+                            )
 
                     iterations += 1
                     time_elapsed = time.time() - start_time
@@ -980,7 +988,9 @@ class AgentExecutor(Chain):
                 output = self.agent.return_stopped_response(
                     self.early_stopping_method, intermediate_steps, **inputs
                 )
-                return await self._areturn(output, intermediate_steps)
+                return await self._areturn(
+                    output, intermediate_steps, run_manager=run_manager
+                )
 
     def _get_tool_return(
         self, next_step_output: Tuple[AgentAction, str]


### PR DESCRIPTION
# Fix: Adds run_manager to all return calls on AgentExecutor

Currently, `run_manager` is only passed to _return / _areturn if we stop the execution due to timeout/max-iterations. We also would like to have the callback signal for `on_agent_finish` when the agent finished due to tool-return or simply decides to take that action.

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

Project lead
@hwchase17

Tracing / Callbacks / Async
@agola11
