### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/getting_started/getting_started.md
+++ b/docs/getting_started/getting_started.md
@@ -37,6 +37,12 @@ import os
 os.environ["OPENAI_API_KEY"] = "..."
 ```
 
+If you want to set the API key dynamically, you can use the openai_api_key parameter when initiating OpenAI class—for instance, each user's API key.
+
+```python
+from langchain.llms import OpenAI
+llm = OpenAI(openai_api_key="OPENAI_API_KEY")
+```
 
 ## Building a Language Model Application: LLMs
 

--- a/docs/modules/chains/getting_started.ipynb
+++ b/docs/modules/chains/getting_started.ipynb
@@ -40,6 +40,8 @@
    "source": [
     "from langchain.prompts import PromptTemplate\n",
     "from langchain.llms import OpenAI\n",
+    "import os\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"Your-API-KEY\"\n",
     "\n",
     "llm = OpenAI(temperature=0.9)\n",
     "prompt = PromptTemplate(\n",
@@ -68,7 +70,7 @@
      "text": [
       "\n",
       "\n",
-      "SockSplash!\n"
+      "Colorful Toes Co.\n"
      ]
     }
    ],
@@ -81,6 +83,41 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If there are multiple variables, you can input them all at once using a dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Socktopia Colourful Creations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = PromptTemplate(\n",
+    "    input_variables=[\"company\", \"product\"],\n",
+    "    template=\"What is a good name for {company} that makes {product}?\",\n",
+    ")\n",
+    "chain = LLMChain(llm=llm, prompt=prompt)\n",
+    "print(chain.run({\n",
+    "    'company': \"ABC Startup\",\n",
+    "    'product': \"colorful socks\"\n",
+    "    }))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -89,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -98,7 +135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rainbow Sox Co.\n"
+      "Rainbow Socks Co.\n"
      ]
     }
    ],
@@ -131,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -141,7 +178,7 @@
        " 'text': 'Why did the tomato turn red? Because it saw the salad dressing!'}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -166,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -175,7 +212,7 @@
        "{'text': 'Why did the tomato turn red? Because it saw the salad dressing!'}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -193,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +239,7 @@
        "['text']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -214,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -223,7 +260,7 @@
        "'Why did the tomato turn red? Because it saw the salad dressing!'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -251,7 +288,7 @@
        " 'text': 'Why did the tomato turn red? Because it saw the salad dressing!'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -284,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -293,7 +330,7 @@
        "'The next four colors of a rainbow are green, blue, indigo, and violet.'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -358,7 +395,7 @@
        "'ChatGPT is an AI language model developed by OpenAI. It is based on the GPT-3 architecture and is capable of generating human-like responses to text prompts. ChatGPT has been trained on a massive amount of text data and can understand and respond to a wide range of topics. It is often used for chatbots, virtual assistants, and other conversational AI applications.'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -387,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -420,12 +457,12 @@
       "\u001b[36;1m\u001b[1;3mRainbow Socks Co.\u001b[0m\n",
       "\u001b[33;1m\u001b[1;3m\n",
       "\n",
-      "\"Step into Color with Rainbow Socks!\"\u001b[0m\n",
+      "\"Put a little rainbow in your step!\"\u001b[0m\n",
       "\n",
       "\u001b[1m> Finished chain.\u001b[0m\n",
       "\n",
       "\n",
-      "\"Step into Color with Rainbow Socks!\"\n"
+      "\"Put a little rainbow in your step!\"\n"
      ]
     }
    ],
@@ -456,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -506,9 +543,9 @@
       "Concatenated output:\n",
       "\n",
       "\n",
-      "Socktastic Colors.\n",
+      "Funky Footwear Company\n",
       "\n",
-      "\"Put Some Color in Your Step!\"\n"
+      "\"Brighten Up Your Day with Our Colorful Socks!\"\n"
      ]
     }
    ],
@@ -554,7 +591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/docs/modules/chains/getting_started.ipynb
+++ b/docs/modules/chains/getting_started.ipynb
@@ -40,8 +40,6 @@
    "source": [
     "from langchain.prompts import PromptTemplate\n",
     "from langchain.llms import OpenAI\n",
-    "import os\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"Your-API-KEY\"\n",
     "\n",
     "llm = OpenAI(temperature=0.9)\n",
     "prompt = PromptTemplate(\n",


### PR DESCRIPTION
# Added another helpful way for developers who want to set OpenAI API Key dynamically

Previous methods like exporting environment variables are good for project-wide settings.
But many use cases need to assign API keys dynamically, recently.

```python
from langchain.llms import OpenAI
llm = OpenAI(openai_api_key="OPENAI_API_KEY")
```

## Before submitting
```bash
export OPENAI_API_KEY="..."
```
Or,
```python
import os
os.environ["OPENAI_API_KEY"] = "..."
```

<hr>

Thank you.
Cheers,
Bongsang