### PR TITLE
Fix subclassing OpenAIEmbeddings

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Literal,
     Optional,
@@ -115,7 +116,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     openai_api_key: Optional[str] = None
     openai_organization: Optional[str] = None
     allowed_special: Union[Literal["all"], Set[str]] = set()
-    disallowed_special: Union[Literal["all"], Set[str], Tuple[()]] = "all"
+    disallowed_special: Union[Literal["all"], Iterable[str]] = "all"
     chunk_size: int = 1000
     """Maximum number of texts to embed in each batch"""
     max_retries: int = 6

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -6,10 +6,10 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
     List,
     Literal,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -116,7 +116,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     openai_api_key: Optional[str] = None
     openai_organization: Optional[str] = None
     allowed_special: Union[Literal["all"], Set[str]] = set()
-    disallowed_special: Union[Literal["all"], Iterable[str]] = "all"
+    disallowed_special: Union[Literal["all"], Set[str], Sequence[str]] = "all"
     chunk_size: int = 1000
     """Maximum number of texts to embed in each batch"""
     max_retries: int = 6


### PR DESCRIPTION
# Fix subclassing OpenAIEmbeddings
<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes #4498 

## Before submitting

- Problem: Due to annotated type `Tuple[()]`.
- Fix: Change the annotated type to "Iterable[str]". Even though tiktoken use [Collection[str]](https://github.com/openai/tiktoken/blob/095924e02c85617df6889698d94515f91666c7ea/tiktoken/core.py#L80) type annotation, but pydantic doesn't support Collection type, and [Iterable](https://docs.pydantic.dev/latest/usage/types/#typing-iterables) is the closest to Collection.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@shibanovp
@hwchase17


<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoader Abstractions
        - @eyurtsev

        LLM/Chat Wrappers
        - @hwchase17
        - @agola11

        Tools / Toolkits
        - @vowelparrot
 -->
