### PR TITLE
Enhance the sql prompt so that the sql query do not be arounded by the double quotes

### DIFF
--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -9,6 +9,8 @@ Never query for all the columns from a specific table, only ask for a the few re
 
 Pay attention to use only the column names that you can see in the schema description. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 
+Do not add double quotes (") around the SQL query.
+
 Use the following format:
 
 Question: "Question here"
@@ -44,6 +46,7 @@ _duckdb_prompt = """You are a DuckDB expert. Given an input question, first crea
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per DuckDB. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -66,6 +69,7 @@ _googlesql_prompt = """You are a GoogleSQL expert. Given an input question, firs
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per GoogleSQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -89,6 +93,7 @@ _mssql_prompt = """You are an MS SQL expert. Given an input question, first crea
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in square brackets ([]) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -111,6 +116,7 @@ _mysql_prompt = """You are a MySQL expert. Given an input question, first create
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MySQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -134,6 +140,7 @@ _mariadb_prompt = """You are a MariaDB expert. Given an input question, first cr
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MariaDB. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -157,6 +164,7 @@ _oracle_prompt = """You are an Oracle SQL expert. Given an input question, first
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the FETCH FIRST n ROWS ONLY clause as per Oracle SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -180,6 +188,7 @@ _postgres_prompt = """You are a PostgreSQL expert. Given an input question, firs
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PostgreSQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -202,6 +211,7 @@ _sqlite_prompt = """You are a SQLite expert. Given an input question, first crea
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per SQLite. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 
@@ -224,6 +234,7 @@ _clickhouse_prompt = """You are a ClickHouse expert. Given an input question, fi
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per ClickHouse. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
+Do not add double quotes (") around the SQL query.
 
 Use the following format:
 


### PR DESCRIPTION
…

# Enhance the sql prompt so that the sql query do not be arounded by the double quotes

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

In sqlite and clickhouse case, we found that the SQL returned by LLM is often surrounded by `""`, which can cause syntax errors when executed by SQL engine. We can avoid this problem by adding this prompt to the prompt template.
## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@eyurtsev

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoader Abstractions
        - @eyurtsev

        LLM/Chat Wrappers
        - @hwchase17
        - @agola11

        Tools / Toolkits
        - @vowelparrot
 -->
