### PR TITLE
[fix] GPT sometimes ignores the SQL format request.

### DIFF
--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -25,9 +25,7 @@ class MRKLOutputParser(AgentOutputParser):
         if not match:
             # Sometimes GPT ignored the requested format and returned result separated
             # by a comma. This is a mitigation to GPT noises.
-            regex = (
-                r"Action\s*\d*\s*:[\s]*(.*?)[\s]*, (.*)"
-            )
+            regex = r"Action\s*\d*\s*:[\s]*(.*?)[\s]*, (.*)"
             match = re.search(regex, text, re.DOTALL)
         if not match:
             raise OutputParserException(f"Could not parse LLM output: `{text}`")

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -23,6 +23,13 @@ class MRKLOutputParser(AgentOutputParser):
         )
         match = re.search(regex, text, re.DOTALL)
         if not match:
+            # Sometimes GPT ignored the requested format and returned result separated
+            # by a comma. This is a mitigation to GPT noises.
+            regex = (
+                r"Action\s*\d*\s*:[\s]*(.*?)[\s]*, (.*)"
+            )
+            match = re.search(regex, text, re.DOTALL)
+        if not match:
             raise OutputParserException(f"Could not parse LLM output: `{text}`")
         action = match.group(1).strip()
         action_input = match.group(2)


### PR DESCRIPTION
I found GPT3.5 sometimes consistently ignores the requested SQL format - “Action *** Action Input ***”, instead provided “Action ***, “”” when there is no Action Input. This will cause exception in the match check below. 

Adding a secondary match to mitigate the problem as I couldn’t find a good way to force GPT to use the format all the time…

In the example below, you can find in my prints starting with “MK, “, the Action Input placeholder is missed in the beginning when query table name. This mitigation makes it pass and continue the flow.

<img width="1023" alt="Screenshot 2023-05-10 at 10 28 20 PM" src="https://github.com/hwchase17/langchain/assets/62768671/01898c5e-20ac-4f19-8fa6-d560c1164e5d">
