### PR TITLE
[pyproject.toml] add `tiktoken` when install `langchain[openai]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ setuptools = "^67.6.1"
 [tool.poetry.extras]
 llms = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "manifest-ml", "torch", "transformers"]
 qdrant = ["qdrant-client"]
-openai = ["openai"]
+openai = ["openai", "tiktoken"]
 cohere = ["cohere"]
 in_memory_store = ["docarray"]
 hnswlib = ["docarray", "protobuf", "hnswlib"]


### PR DESCRIPTION
# Add `tiktoken` as dependency when installed as `langchain[openai]`

Fixes #4513 (issue)

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@vowelparrot 

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
