### PR TITLE
feat: batch multiple files in a single Unstructured API request

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/unstructured_file.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/unstructured_file.ipynb
@@ -368,7 +368,7 @@
    "outputs": [],
    "source": [
     "loader = UnstructuredAPIFileLoader(\n",
-    "    file_paths=filenames,\n",
+    "    file_path=filenames,\n",
     "    api_key=\"FAKE_API_KEY\",\n",
     ")"
    ]
@@ -382,7 +382,7 @@
     {
      "data": {
       "text/plain": [
-       "Document(page_content='Lorem ipsum dolor sit amet.\\n\\nThis is a test email to use for unit tests.\\n\\nImportant points:\\n\\nRoses are red\\n\\nViolets are blue', metadata={'source': ''})"
+       "Document(page_content='Lorem ipsum dolor sit amet.\\n\\nThis is a test email to use for unit tests.\\n\\nImportant points:\\n\\nRoses are red\\n\\nViolets are blue', metadata={'source': ['example_data/fake.docx', 'example_data/fake-email.eml']})"
       ]
      },
      "execution_count": 6,

--- a/docs/modules/indexes/document_loaders/examples/unstructured_file.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/unstructured_file.ipynb
@@ -288,9 +288,117 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b066cb5a",
+   "metadata": {},
+   "source": [
+    "## Unstructured API\n",
+    "\n",
+    "If you want to get up and running with less set up, you can simply run `pip install unstructured` and use `UnstructuredAPIFileLoader` or `UnstructuredAPIFileIOLoader`. That will process your document using the hosted Unstructured API. Note that currently (as of 11 May 2023) the Unstructured API is open, but it will soon require an API. The [Unstructured documentation](https://unstructured-io.github.io/) page will have instructions on how to generate an API key once they’re available. Check out the instructions [here](https://github.com/Unstructured-IO/unstructured-api#dizzy-instructions-for-using-the-docker-image) if you’d like to self-host the Unstructured API or run it locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b50c70bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders import UnstructuredAPIFileLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "12b6d2cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filenames = [\"example_data/fake.docx\", \"example_data/fake-email.eml\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "39a9894d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = UnstructuredAPIFileLoader(\n",
+    "    file_path=filenames[0],\n",
+    "    api_key=\"FAKE_API_KEY\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "386eb63c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Document(page_content='Lorem ipsum dolor sit amet.', metadata={'source': 'example_data/fake.docx'})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs = loader.load()\n",
+    "docs[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94158999",
+   "metadata": {},
+   "source": [
+    "You can also batch multiple files through the Unstructured API in a single API using `UnstructuredAPIFileLoader`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "79a18e7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = UnstructuredAPIFileLoader(\n",
+    "    file_paths=filenames,\n",
+    "    api_key=\"FAKE_API_KEY\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a3d7c846",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Document(page_content='Lorem ipsum dolor sit amet.\\n\\nThis is a test email to use for unit tests.\\n\\nImportant points:\\n\\nRoses are red\\n\\nViolets are blue', metadata={'source': ''})"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs = loader.load()\n",
+    "docs[0]"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f52b04cb",
+   "id": "0e510495",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -312,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/langchain/document_loaders/powerpoint.py
+++ b/langchain/document_loaders/powerpoint.py
@@ -23,7 +23,7 @@ class UnstructuredPowerPointLoader(UnstructuredFileLoader):
 
             is_ppt = detect_filetype(self.file_path) == FileType.PPT
         except ImportError:
-            _, extension = os.path.splitext(self.file_path)
+            _, extension = os.path.splitext(str(self.file_path))
             is_ppt = extension == ".ppt"
 
         if is_ppt and unstructured_version < (0, 4, 11):

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -104,7 +104,10 @@ class UnstructuredFileLoader(UnstructuredBaseLoader):
         return partition(filename=self.file_path, **self.unstructured_kwargs)
 
     def _get_metadata(self) -> dict:
-        return {"source": self.file_path}
+        if self.file_path:
+            return {"source": self.file_path}
+        else:
+            return {"sources": self.file_paths}
 
 
 def get_elements_from_api(

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -1,6 +1,6 @@
 """Loader that uses unstructured to load files."""
 from abc import ABC, abstractmethod
-from typing import IO, Any, List, Optional
+from typing import IO, Any, List, Optional, Sequence
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
@@ -111,7 +111,7 @@ def get_elements_from_api(
     file_path: Optional[str] = None,
     file_paths: Optional[List[str]] = None,
     file: Optional[IO] = None,
-    files: Optional[List[IO]] = None,
+    files: Optional[Sequence[IO]] = None,
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
     **unstructured_kwargs: Any,
@@ -222,7 +222,7 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         mode: str = "single",
         url: str = "https://api.unstructured.io/general/v0/general",
         api_key: str = "",
-        files: Optional[List[IO]] = None,
+        files: Optional[Sequence[IO]] = None,
         **unstructured_kwargs: Any,
     ):
         """Initialize with file path."""

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -113,10 +113,10 @@ class UnstructuredAPIFileLoader(UnstructuredFileLoader):
     def __init__(
         self,
         file_path: str = "",
-        file_paths: Optional[List[str]] = None,
         mode: str = "single",
         url: str = "https://api.unstructured.io/general/v0/general",
         api_key: str = "",
+        file_paths: Optional[List[str]] = None,
         **unstructured_kwargs: Any,
     ):
         """Initialize with file path."""

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -104,10 +104,7 @@ class UnstructuredFileLoader(UnstructuredBaseLoader):
         return partition(filename=self.file_path, **self.unstructured_kwargs)
 
     def _get_metadata(self) -> dict:
-        if self.file_path:
-            return {"source": self.file_path}
-        else:
-            return {"sources": self.file_paths}
+        return {"source": self.file_path}
 
 
 def get_elements_from_api(
@@ -184,6 +181,12 @@ class UnstructuredAPIFileLoader(UnstructuredFileLoader):
         self.file_paths = file_paths
 
         super().__init__(file_path=file_path, mode=mode, **unstructured_kwargs)
+
+    def _get_metadata(self) -> dict:
+        if self.file_path:
+            return {"source": self.file_path}
+        else:
+            return {"sources": self.file_paths}
 
     def _get_elements(self) -> List:
         return get_elements_from_api(

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -112,6 +112,8 @@ def get_elements_from_api(
     file_paths: Optional[List[str]] = None,
     file: Optional[IO] = None,
     files: Optional[List[IO]] = None,
+    file_filename: Optional[str] = "",
+    file_filenames: Optional[List[str]] = None,
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
     **unstructured_kwargs: Any,
@@ -123,6 +125,7 @@ def get_elements_from_api(
         return partition_via_api(
             filename=file_path,
             file=file,
+            file_filename=file_filename,
             api_key=api_key,
             api_url=api_url,
             **unstructured_kwargs,
@@ -133,6 +136,7 @@ def get_elements_from_api(
         _doc_elements = partition_multiple_via_api(
             filenames=file_paths,
             files=files,
+            file_filenames=file_filenames,
             api_key=api_key,
             api_url=api_url,
             **unstructured_kwargs,
@@ -217,6 +221,8 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         url: str = "https://api.unstructured.io/general/v0/general",
         api_key: str = "",
         files: Optional[List[IO]] = None,
+        file_filename: Optional[str] = "",
+        file_filenames: Optional[List[str]] = None,
         **unstructured_kwargs: Any,
     ):
         """Initialize with file path."""
@@ -235,6 +241,8 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         self.url = url
         self.api_key = api_key
         self.files = files
+        self.file_filename = file_filename
+        self.file_filenames = file_filenames
 
         super().__init__(file=file, mode=mode, **unstructured_kwargs)
 
@@ -242,6 +250,8 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         return get_elements_from_api(
             file=self.file,
             files=self.files,
+            file_filename=self.file_filename,
+            file_filenames=self.file_filenames,
             api_key=self.api_key,
             api_url=self.url,
             **self.unstructured_kwargs,

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -1,7 +1,7 @@
 """Loader that uses unstructured to load files."""
 import collections
 from abc import ABC, abstractmethod
-from typing import IO, Any, List, Optional, Sequence, Union
+from typing import IO, Any, List, Sequence, Union
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -153,12 +153,18 @@ class UnstructuredAPIFileLoader(UnstructuredFileLoader):
         else:
             from unstructured.partition.api import partition_multiple_via_api
 
-            return partition_multiple_via_api(
+            _doc_elements = partition_multiple_via_api(
                 filenames=self.file_paths,
                 api_key=self.api_key,
                 api_url=self.url,
                 **self.unstructured_kwargs,
             )
+
+            elements = []
+            for _elements in _doc_elements:
+                elements.extend(_elements)
+
+            return elements
 
 
 class UnstructuredFileIOLoader(UnstructuredBaseLoader):

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -112,8 +112,6 @@ def get_elements_from_api(
     file_paths: Optional[List[str]] = None,
     file: Optional[IO] = None,
     files: Optional[List[IO]] = None,
-    file_filename: Optional[str] = "",
-    file_filenames: Optional[List[str]] = None,
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
     **unstructured_kwargs: Any,
@@ -125,7 +123,6 @@ def get_elements_from_api(
         return partition_via_api(
             filename=file_path,
             file=file,
-            file_filename=file_filename,
             api_key=api_key,
             api_url=api_url,
             **unstructured_kwargs,
@@ -136,7 +133,6 @@ def get_elements_from_api(
         _doc_elements = partition_multiple_via_api(
             filenames=file_paths,
             files=files,
-            file_filenames=file_filenames,
             api_key=api_key,
             api_url=api_url,
             **unstructured_kwargs,
@@ -227,8 +223,6 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         url: str = "https://api.unstructured.io/general/v0/general",
         api_key: str = "",
         files: Optional[List[IO]] = None,
-        file_filename: Optional[str] = "",
-        file_filenames: Optional[List[str]] = None,
         **unstructured_kwargs: Any,
     ):
         """Initialize with file path."""
@@ -247,8 +241,6 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         self.url = url
         self.api_key = api_key
         self.files = files
-        self.file_filename = file_filename
-        self.file_filenames = file_filenames
 
         super().__init__(file=file, mode=mode, **unstructured_kwargs)
 
@@ -256,8 +248,6 @@ class UnstructuredAPIFileIOLoader(UnstructuredFileIOLoader):
         return get_elements_from_api(
             file=self.file,
             files=self.files,
-            file_filename=self.file_filename,
-            file_filenames=self.file_filenames,
             api_key=self.api_key,
             api_url=self.url,
             **self.unstructured_kwargs,

--- a/langchain/document_loaders/unstructured.py
+++ b/langchain/document_loaders/unstructured.py
@@ -156,7 +156,6 @@ class UnstructuredAPIFileLoader(UnstructuredFileLoader):
         mode: str = "single",
         url: str = "https://api.unstructured.io/general/v0/general",
         api_key: str = "",
-        file_paths: Optional[List[str]] = None,
         **unstructured_kwargs: Any,
     ):
         """Initialize with file path."""

--- a/langchain/document_loaders/word_document.py
+++ b/langchain/document_loaders/word_document.py
@@ -82,7 +82,7 @@ class UnstructuredWordDocumentLoader(UnstructuredFileLoader):
 
             is_doc = detect_filetype(self.file_path) == FileType.DOC
         except ImportError:
-            _, extension = os.path.splitext(self.file_path)
+            _, extension = os.path.splitext(str(self.file_path))
             is_doc = extension == ".doc"
 
         if is_doc and unstructured_version < (0, 4, 11):

--- a/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/tests/integration_tests/document_loaders/test_unstructured.py
@@ -1,0 +1,79 @@
+from contextlib import ExitStack
+from pathlib import Path
+
+from langchain.document_loaders import (
+    UnstructuredAPIFileIOLoader,
+    UnstructuredAPIFileLoader,
+)
+
+
+def test_unstructured_api_file_loader() -> None:
+    """Test unstructured loader."""
+    file_path = str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf")
+    loader = UnstructuredAPIFileLoader(
+        file_path=file_path,
+        api_key="FAKE_API_KEY",
+        strategy="fast",
+        mode="elements",
+    )
+    docs = loader.load()
+
+    assert len(docs) > 1
+
+
+def test_unstructured_api_file_loader_multiple_files() -> None:
+    """Test unstructured loader."""
+    file_paths = [
+        str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf"),
+        str(Path(__file__).parent.parent / "examples/whatsapp_chat.txt"),
+    ]
+
+    loader = UnstructuredAPIFileLoader(
+        file_paths=file_paths,
+        api_key="FAKE_API_KEY",
+        strategy="fast",
+        mode="elements",
+    )
+    docs = loader.load()
+
+    assert len(docs) > 1
+
+
+def test_unstructured_api_file_io_loader() -> None:
+    """Test unstructured loader."""
+    file_path = str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf")
+
+    with open(file_path, "rb") as f:
+        loader = UnstructuredAPIFileIOLoader(
+            file=f,
+            file_filename=file_path,
+            api_key="FAKE_API_KEY",
+            strategy="fast",
+            mode="elements",
+        )
+        docs = loader.load()
+
+    assert len(docs) > 1
+
+
+def test_unstructured_api_file_loader_io_multiple_files() -> None:
+    """Test unstructured loader."""
+    file_paths = [
+        str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf"),
+        str(Path(__file__).parent.parent / "examples/whatsapp_chat.txt"),
+    ]
+
+    with ExitStack() as stack:
+        files = [stack.enter_context(open(file_path, "rb")) for file_path in file_paths]
+
+        loader = UnstructuredAPIFileIOLoader(
+            files=files,  # type: ignore
+            file_filenames=file_paths,
+            api_key="FAKE_API_KEY",
+            strategy="fast",
+            mode="elements",
+        )
+
+        docs = loader.load()
+
+    assert len(docs) > 1

--- a/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/tests/integration_tests/document_loaders/test_unstructured.py
@@ -46,10 +46,10 @@ def test_unstructured_api_file_io_loader() -> None:
     with open(file_path, "rb") as f:
         loader = UnstructuredAPIFileIOLoader(
             file=f,
-            file_filename=file_path,
             api_key="FAKE_API_KEY",
             strategy="fast",
             mode="elements",
+            file_filename=file_path,
         )
         docs = loader.load()
 
@@ -68,10 +68,10 @@ def test_unstructured_api_file_loader_io_multiple_files() -> None:
 
         loader = UnstructuredAPIFileIOLoader(
             files=files,  # type: ignore
-            file_filenames=file_paths,
             api_key="FAKE_API_KEY",
             strategy="fast",
             mode="elements",
+            file_filenames=file_paths,
         )
 
         docs = loader.load()

--- a/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/tests/integration_tests/document_loaders/test_unstructured.py
@@ -32,7 +32,7 @@ def test_unstructured_api_file_loader_multiple_files() -> None:
     ]
 
     loader = UnstructuredAPIFileLoader(
-        file_paths=file_paths,
+        file_path=file_paths,
         api_key="FAKE_API_KEY",
         strategy="fast",
         mode="elements",
@@ -70,7 +70,7 @@ def test_unstructured_api_file_loader_io_multiple_files() -> None:
         files = [stack.enter_context(open(file_path, "rb")) for file_path in file_paths]
 
         loader = UnstructuredAPIFileIOLoader(
-            files=files,  # type: ignore
+            file=files,  # type: ignore
             api_key="FAKE_API_KEY",
             strategy="fast",
             mode="elements",

--- a/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/tests/integration_tests/document_loaders/test_unstructured.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -6,10 +7,12 @@ from langchain.document_loaders import (
     UnstructuredAPIFileLoader,
 )
 
+EXAMPLE_DOCS_DIRECTORY = str(Path(__file__).parent.parent / "examples/")
+
 
 def test_unstructured_api_file_loader() -> None:
     """Test unstructured loader."""
-    file_path = str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf")
+    file_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf")
     loader = UnstructuredAPIFileLoader(
         file_path=file_path,
         api_key="FAKE_API_KEY",
@@ -24,8 +27,8 @@ def test_unstructured_api_file_loader() -> None:
 def test_unstructured_api_file_loader_multiple_files() -> None:
     """Test unstructured loader."""
     file_paths = [
-        str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf"),
-        str(Path(__file__).parent.parent / "examples/whatsapp_chat.txt"),
+        os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf"),
+        os.path.join(EXAMPLE_DOCS_DIRECTORY, "whatsapp_chat.txt"),
     ]
 
     loader = UnstructuredAPIFileLoader(
@@ -41,7 +44,7 @@ def test_unstructured_api_file_loader_multiple_files() -> None:
 
 def test_unstructured_api_file_io_loader() -> None:
     """Test unstructured loader."""
-    file_path = str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf")
+    file_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf")
 
     with open(file_path, "rb") as f:
         loader = UnstructuredAPIFileIOLoader(
@@ -59,8 +62,8 @@ def test_unstructured_api_file_io_loader() -> None:
 def test_unstructured_api_file_loader_io_multiple_files() -> None:
     """Test unstructured loader."""
     file_paths = [
-        str(Path(__file__).parent.parent / "examples/layout-parser-paper.pdf"),
-        str(Path(__file__).parent.parent / "examples/whatsapp_chat.txt"),
+        os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf"),
+        os.path.join(EXAMPLE_DOCS_DIRECTORY, "whatsapp_chat.txt"),
     ]
 
     with ExitStack() as stack:


### PR DESCRIPTION
### Submit Multiple Files to the Unstructured API

Enables batching multiple files into a single Unstructured API requests. Support for requests with multiple files was added to both `UnstructuredAPIFileLoader` and `UnstructuredAPIFileIOLoader`. Note that if you submit multiple files in "single" mode, the result will be concatenated into a single document. We recommend using this feature in "elements" mode.

### Testing

The following should load both documents, using two of the example docs from the integration tests folder.

```python
    from langchain.document_loaders import UnstructuredAPIFileLoader

    file_paths = ["examples/layout-parser-paper.pdf",  "examples/whatsapp_chat.txt"]

    loader = UnstructuredAPIFileLoader(
        file_paths=file_paths,
        api_key="FAKE_API_KEY",
        strategy="fast",
        mode="elements",
    )
    docs = loader.load()
```