### PR TITLE
Update workflows to only cache from master

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -48,8 +48,9 @@ runs:
     - run: pipx install poetry==${{ inputs.poetry-version }} --python python${{ inputs.python-version }}
       shell: bash
 
-    - uses: actions/cache@v3
-      id: cache-poetry
+    - name: Restore Python Environment
+      id: cache-env-restore
+      uses: actions/cache/restore@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
       with:
@@ -59,6 +60,19 @@ runs:
           ~/.cache/pypoetry/artifacts
         key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}-${{ inputs.cache-key }}-${{ hashFiles('poetry.lock') }}
 
-    - run: ${{ inputs.install-command }}
+    - name: Install dependencies
+      run: ${{ inputs.install-command }}
+      if: steps.cache-poetry.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.working-directory }}
       shell: bash
+
+    - name: Restore Python Environment (Master Only)
+      if: ${{ github.ref == 'refs/heads/master' && steps.cache-env-restore.outputs.cache-hit != 'true' }}
+      id: cache-env-save
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cache/pypoetry/virtualenvs
+          ~/.cache/pypoetry/cache
+          ~/.cache/pypoetry/artifacts
+        key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}-${{ inputs.cache-key }}-${{ hashFiles('poetry.lock') }}


### PR DESCRIPTION
# Update workflows to only cache python env from master

For now, we'll only cache the python environment from master.

This will help prevent filling up our caches quickly.

There might be more sophicated solutions that would allow
some form of caching on branches that have a poetry lock file
that's out of sync with master, but this should be OK for most
use cases.

We'll likely need logic to clean up old caches regardless.

## Before submitting

## Who can review?
