### PR TITLE
Fix: spell `executor` consistently

### DIFF
--- a/docs/modules/agents/plan_and_execute.ipynb
+++ b/docs/modules/agents/plan_and_execute.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "406483c4",
    "metadata": {},
@@ -15,6 +16,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "91192118",
    "metadata": {},
@@ -38,6 +40,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0b10d200",
    "metadata": {},
@@ -70,6 +73,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ce38ae84",
    "metadata": {},
@@ -114,10 +118,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = PlanAndExecute(planner=planner, executer=executor, verbose=True)"
+    "agent = PlanAndExecute(planner=planner, executor=executor, verbose=True)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8be9f1bd",
    "metadata": {},

--- a/langchain/experimental/plan_and_execute/agent_executor.py
+++ b/langchain/experimental/plan_and_execute/agent_executor.py
@@ -14,7 +14,7 @@ from langchain.experimental.plan_and_execute.schema import (
 
 class PlanAndExecute(Chain):
     planner: BasePlanner
-    executer: BaseExecutor
+    executor: BaseExecutor
     step_container: BaseStepContainer = Field(default_factory=ListStepContainer)
     input_key: str = "input"
     output_key: str = "output"


### PR DESCRIPTION
# Fix: spell `executor` consistently

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

`executor` is spelt `executer` in the new experimental PlanAndExecute class, in one place only -- but also in docs.

Looks like a typo. Fixed both. No other occurrences after searching the whole repo.

Reported by Zewf on Discord.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@hwchase17 

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
