### PR TITLE
update qdrant docs to reflect the proper way to initialize Qdrant() constructor

### DIFF
--- a/docs/modules/indexes/vectorstores/examples/qdrant.ipynb
+++ b/docs/modules/indexes/vectorstores/examples/qdrant.ipynb
@@ -274,7 +274,7 @@
     ")\n",
     "qdrant = Qdrant(\n",
     "    client=client, collection_name=\"my_documents\", \n",
-    "    embedding_function=embeddings.embed_query\n",
+    "    embeddings=embeddings\n",
     ")"
    ]
   },


### PR DESCRIPTION
# update qdrant docs to reflect the proper way to initialize Qdrant() constructor

The [Qdrant docs](https://python.langchain.com/en/latest/modules/indexes/vectorstores/examples/qdrant.html) still contain an old reference for passing an `embedding_function` into the constructor.  This is no longer supported.

This PR updates the docs to reflect the proper way to initialize `Qdrant()`

Old:
![Screenshot 2023-05-12 at 3 06 33 PM](https://github.com/hwchase17/langchain/assets/1552962/dd4063d2-2a07-4340-91bb-e305f7215ddd)

New:
![Screenshot 2023-05-12 at 3 21 09 PM](https://github.com/hwchase17/langchain/assets/1552962/aebc3f63-1a8b-4ca3-93c0-a2ce30dcd282)
