### PR TITLE
[Fix][GenerativeAgent] Get the memory importance score from regex matched group

### DIFF
--- a/langchain/experimental/generative_agents/memory.py
+++ b/langchain/experimental/generative_agents/memory.py
@@ -118,7 +118,7 @@ class GenerativeAgentMemory(BaseMemory):
             logger.info(f"Importance score: {score}")
         match = re.search(r"^\D*(\d+)", score)
         if match:
-            return (float(score[0]) / 10) * self.importance_weight
+            return (float(match.group(1)) / 10) * self.importance_weight
         else:
             return 0.0
 


### PR DESCRIPTION
# Get the memory importance score from regex matched group

In `GenerativeAgentMemory`, the `_score_memory_importance()` will make a prompt to get a rating score. The prompt is:
```
        prompt = PromptTemplate.from_template(
            "On the scale of 1 to 10, where 1 is purely mundane"
            + " (e.g., brushing teeth, making bed) and 10 is"
            + " extremely poignant (e.g., a break up, college"
            + " acceptance), rate the likely poignancy of the"
            + " following piece of memory. Respond with a single integer."
            + "\nMemory: {memory_content}"
            + "\nRating: "
        )
```
For some LLM, it will respond with, for example, `Rating: 8`. Thus we might want to get the score from the matched regex group.
