### PR TITLE
Add `n_gpu_layers` to llama.cpp

### DIFF
--- a/langchain/embeddings/llamacpp.py
+++ b/langchain/embeddings/llamacpp.py
@@ -53,6 +53,9 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
     """Number of tokens to process in parallel.
     Should be a number between 1 and n_ctx."""
 
+    n_gpu_layers: Optional[int] = None
+    """Number of layers to store in VRAM."""
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -71,6 +74,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
         use_mlock = values["use_mlock"]
         n_threads = values["n_threads"]
         n_batch = values["n_batch"]
+        n_gpu_layers = values["n_gpu_layers"]
 
         try:
             from llama_cpp import Llama
@@ -86,6 +90,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
                 use_mlock=use_mlock,
                 n_threads=n_threads,
                 n_batch=n_batch,
+                n_gpu_layers=n_gpu_layers,
                 embedding=True,
             )
         except ImportError:

--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -100,6 +100,9 @@ class LlamaCpp(LLM):
     streaming: bool = True
     """Whether to stream the results, token by token."""
 
+    n_gpu_layers: Optional[int] = None
+    """Number of layers to store in VRAM."""
+
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that llama-cpp-python library is installed."""
@@ -117,6 +120,7 @@ class LlamaCpp(LLM):
         n_batch = values["n_batch"]
         use_mmap = values["use_mmap"]
         last_n_tokens_size = values["last_n_tokens_size"]
+        n_gpu_layers = values["n_gpu_layers"]
 
         try:
             from llama_cpp import Llama
@@ -136,6 +140,7 @@ class LlamaCpp(LLM):
                 n_batch=n_batch,
                 use_mmap=use_mmap,
                 last_n_tokens_size=last_n_tokens_size,
+                n_gpu_layers=n_gpu_layers,
             )
         except ImportError:
             raise ModuleNotFoundError(


### PR DESCRIPTION
# Add `n-gpu-layers` param to Llama.cpp model & embedding

Adds a parameter `n_gpu_layers` to Llama.cpp model and embedding implementation to make it possible to load & run w/ GPU. Refer to this Llama.cpp PR for more info: https://github.com/ggerganov/llama.cpp/pull/1412


## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@hwchase17 @agola11 
