### PR TITLE
Query_constructor.base.py function _get_prompt() not including passed examples.

### DIFF
--- a/langchain/chains/query_constructor/base.py
+++ b/langchain/chains/query_constructor/base.py
@@ -87,7 +87,7 @@ def _get_prompt(
         allowed_comparators=allowed_comparators, allowed_operators=allowed_operators
     )
     return FewShotPromptTemplate(
-        examples=DEFAULT_EXAMPLES,
+        examples=examples,
         example_prompt=EXAMPLE_PROMPT,
         input_variables=["query"],
         suffix=suffix,


### PR DESCRIPTION
The function _get_prompt() was returning the DEFAULT_EXAMPLES even if some custom examples were given. The return FewShotPromptTemplate was returnong DEFAUL_EXAMPLES and not examples

# Fixing the function _get_prompt(). Taking the examples given to the return

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
