### PR TITLE
Fixing DeepLake Overwrite Flag

### DIFF
--- a/langchain/vectorstores/deeplake.py
+++ b/langchain/vectorstores/deeplake.py
@@ -122,7 +122,7 @@ class DeepLake(VectorStore):
 
         if (
             deeplake.exists(dataset_path, token=token, **creds_args)
-            and ( ("overwrite" not in kwargs) or ("overwrite" in kwargs and not kwargs["overwrite"]) )
+            and not kwargs.get("overwrite", False)
         ):
             if "overwrite" in kwargs:
                 del kwargs["overwrite"]

--- a/langchain/vectorstores/deeplake.py
+++ b/langchain/vectorstores/deeplake.py
@@ -122,8 +122,11 @@ class DeepLake(VectorStore):
 
         if (
             deeplake.exists(dataset_path, token=token, **creds_args)
-            and "overwrite" not in kwargs
+            and ( ("overwrite" not in kwargs) or ("overwrite" in kwargs and not kwargs["overwrite"]) )
         ):
+            if "overwrite" in kwargs:
+                del kwargs["overwrite"]
+                
             self.ds = deeplake.load(
                 dataset_path,
                 token=token,

--- a/langchain/vectorstores/deeplake.py
+++ b/langchain/vectorstores/deeplake.py
@@ -120,13 +120,12 @@ class DeepLake(VectorStore):
         self.dataset_path = dataset_path
         creds_args = {"creds": kwargs["creds"]} if "creds" in kwargs else {}
 
-        if (
-            deeplake.exists(dataset_path, token=token, **creds_args)
-            and not kwargs.get("overwrite", False)
+        if deeplake.exists(dataset_path, token=token, **creds_args) and not kwargs.get(
+            "overwrite", False
         ):
             if "overwrite" in kwargs:
                 del kwargs["overwrite"]
-                
+
             self.ds = deeplake.load(
                 dataset_path,
                 token=token,

--- a/tests/integration_tests/vectorstores/test_deeplake.py
+++ b/tests/integration_tests/vectorstores/test_deeplake.py
@@ -83,6 +83,45 @@ def test_deeplakewith_persistence() -> None:
     # Or on program exit
 
 
+def test_deeplake_overwrite_flag() -> None:
+    """Test overwrite behavior"""
+    dataset_path = "./tests/persist_dir"
+    if deeplake.exists(dataset_path):
+        deeplake.delete(dataset_path)
+
+    texts = ["foo", "bar", "baz"]
+    docsearch = DeepLake.from_texts(
+        dataset_path=dataset_path,
+        texts=texts,
+        embedding=FakeEmbeddings(),
+    )
+    output = docsearch.similarity_search("foo", k=1)
+    assert output == [Document(page_content="foo")]
+
+    docsearch.persist()
+
+    # Get a new VectorStore from the persisted directory, with no overwrite
+    docsearch = DeepLake(
+        dataset_path=dataset_path,
+        embedding_function=FakeEmbeddings(),
+        overwrite=False,
+    )
+    output = docsearch.similarity_search("foo", k=1)
+    # assert page still present
+    assert output == [Document(page_content="foo")]
+
+
+    # Get a new VectorStore from the persisted directory, with overwrite
+    docsearch = DeepLake(
+        dataset_path=dataset_path,
+        embedding_function=FakeEmbeddings(),
+        overwrite=True,
+    )
+    output = docsearch.similarity_search("foo", k=1)
+    # assert page no longer present
+    assert output == []
+
+
 def test_similarity_search(deeplake_datastore: DeepLake, distance_metric: str) -> None:
     """Test similarity search."""
     output = deeplake_datastore.similarity_search(

--- a/tests/integration_tests/vectorstores/test_deeplake.py
+++ b/tests/integration_tests/vectorstores/test_deeplake.py
@@ -100,7 +100,6 @@ def test_deeplake_overwrite_flag() -> None:
 
     docsearch.persist()
 
-
     # Get a new VectorStore from the persisted directory, with no overwrite (implicit)
     docsearch = DeepLake(
         dataset_path=dataset_path,
@@ -109,7 +108,6 @@ def test_deeplake_overwrite_flag() -> None:
     output = docsearch.similarity_search("foo", k=1)
     # assert page still present
     assert output == [Document(page_content="foo")]
-
 
     # Get a new VectorStore from the persisted directory, with no overwrite (explicit)
     docsearch = DeepLake(
@@ -120,7 +118,6 @@ def test_deeplake_overwrite_flag() -> None:
     output = docsearch.similarity_search("foo", k=1)
     # assert page still present
     assert output == [Document(page_content="foo")]
-
 
     # Get a new VectorStore from the persisted directory, with overwrite
     docsearch = DeepLake(

--- a/tests/integration_tests/vectorstores/test_deeplake.py
+++ b/tests/integration_tests/vectorstores/test_deeplake.py
@@ -100,7 +100,18 @@ def test_deeplake_overwrite_flag() -> None:
 
     docsearch.persist()
 
-    # Get a new VectorStore from the persisted directory, with no overwrite
+
+    # Get a new VectorStore from the persisted directory, with no overwrite (implicit)
+    docsearch = DeepLake(
+        dataset_path=dataset_path,
+        embedding_function=FakeEmbeddings(),
+    )
+    output = docsearch.similarity_search("foo", k=1)
+    # assert page still present
+    assert output == [Document(page_content="foo")]
+
+
+    # Get a new VectorStore from the persisted directory, with no overwrite (explicit)
     docsearch = DeepLake(
         dataset_path=dataset_path,
         embedding_function=FakeEmbeddings(),


### PR DESCRIPTION
# Fix DeepLake Overwrite Flag Issue

Fixes Issue #4682: essentially, setting overwrite to False in the DeepLake constructor still triggers an overwrite, because the logic is just checking for the presence of "overwrite" in kwargs. The fix is simple--just add some checks to inspect if "overwrite" in kwargs AND kwargs["overwrite"]==True. 

Added a new test in tests/integration_tests/vectorstores/test_deeplake.py to reflect the desired behavior.

Tagging @dev2049 