### PR TITLE
changed cohere.py to update the default model of embedding

### DIFF
--- a/langchain/embeddings/cohere.py
+++ b/langchain/embeddings/cohere.py
@@ -22,7 +22,13 @@ class CohereEmbeddings(BaseModel, Embeddings):
     """
 
     client: Any  #: :meta private:
-    model: str = "large"
+    # model: str = "large"
+    # Small, Large has been deprecated by cohere
+    # The new models are
+    # embed-english-light-v2.0
+    # embed-english-v2.0
+    # embed-multilingual-v2.0
+    model: str = "embed-english-v2.0"
     """Model name to use."""
 
     truncate: Optional[str] = None

--- a/langchain/embeddings/cohere.py
+++ b/langchain/embeddings/cohere.py
@@ -18,16 +18,12 @@ class CohereEmbeddings(BaseModel, Embeddings):
         .. code-block:: python
 
             from langchain.embeddings import CohereEmbeddings
-            cohere = CohereEmbeddings(model="medium", cohere_api_key="my-api-key")
+            cohere = CohereEmbeddings(
+                model="embed-english-light-v2.0", cohere_api_key="my-api-key"
+            )
     """
 
     client: Any  #: :meta private:
-    # model: str = "large"
-    # Small, Large has been deprecated by cohere
-    # The new models are
-    # embed-english-light-v2.0
-    # embed-english-v2.0
-    # embed-multilingual-v2.0
     model: str = "embed-english-v2.0"
     """Model name to use."""
 


### PR DESCRIPTION
# The cohere embedding model do not use large, small. It is deprecated. Changed the modules default model

<!--
I have added the solution to issue#4694
-->

<!-- Remove if not applicable -->

Fixes # 4694

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
