### PR TITLE
docs: `Concepts`

### DIFF
--- a/docs/getting_started/concepts.md
+++ b/docs/getting_started/concepts.md
@@ -1,54 +1,44 @@
-# Glossary
+# Concepts
 
-This is a collection of terminology commonly used when developing LLM applications.
+These are concepts and terminology commonly used when developing LLM applications.
 It contains reference to external papers or sources where the concept was first introduced,
 as well as to places in LangChain where the concept is used.
 
-## Chain of Thought Prompting
+## Chain of Thought
 
-A prompting technique used to encourage the model to generate a series of intermediate reasoning steps.
+`Chain of Thought (CoT)` is a prompting technique used to encourage the model to generate a series of intermediate reasoning steps.
 A less formal way to induce this behavior is to include “Let’s think step-by-step” in the prompt.
-
-Resources:
 
 - [Chain-of-Thought Paper](https://arxiv.org/pdf/2201.11903.pdf)
 - [Step-by-Step Paper](https://arxiv.org/abs/2112.00114)
 
 ## Action Plan Generation
 
-A prompt usage that uses a language model to generate actions to take.
+`Action Plan Generation` is a prompting technique that uses a language model to generate actions to take.
 The results of these actions can then be fed back into the language model to generate a subsequent action.
-
-Resources:
 
 - [WebGPT Paper](https://arxiv.org/pdf/2112.09332.pdf)
 - [SayCan Paper](https://say-can.github.io/assets/palm_saycan.pdf)
 
-## ReAct Prompting
+## ReAct
 
-A prompting technique that combines Chain-of-Thought prompting with action plan generation.
+`ReAct` is a prompting technique that combines Chain-of-Thought prompting with action plan generation.
 This induces the to model to think about what action to take, then take it.
 
-Resources:
-
 - [Paper](https://arxiv.org/pdf/2210.03629.pdf)
-- [LangChain Example](modules/agents/agents/examples/react.ipynb)
+- [LangChain Example](../modules/agents/agents/examples/react.ipynb)
 
 ## Self-ask
 
-A prompting method that builds on top of chain-of-thought prompting.
+`Self-ask` is a prompting method that builds on top of chain-of-thought prompting.
 In this method, the model explicitly asks itself follow-up questions, which are then answered by an external search engine.
 
-Resources:
-
 - [Paper](https://ofir.io/self-ask.pdf)
-- [LangChain Example](modules/agents/agents/examples/self_ask_with_search.ipynb)
+- [LangChain Example](../modules/agents/agents/examples/self_ask_with_search.ipynb)
 
 ## Prompt Chaining
 
-Combining multiple LLM calls together, with the output of one-step being the input to the next.
-
-Resources:
+`Prompt Chaining` is combining multiple LLM calls, with the output of one-step being the input to the next.
 
 - [PromptChainer Paper](https://arxiv.org/pdf/2203.06566.pdf)
 - [Language Model Cascades](https://arxiv.org/abs/2207.10342)
@@ -57,34 +47,29 @@ Resources:
 
 ## Memetic Proxy
 
-Encouraging the LLM to respond in a certain way framing the discussion in a context that the model knows of and that will result in that type of response. For example, as a conversation between a student and a teacher.
-
-Resources:
+`Memetic Proxy` is encouraging the LLM
+to respond in a certain way framing the discussion in a context that the model knows of and that 
+will result in that type of response.
+For example, as a conversation between a student and a teacher.
 
 - [Paper](https://arxiv.org/pdf/2102.07350.pdf)
 
 ## Self Consistency
 
-A decoding strategy that samples a diverse set of reasoning paths and then selects the most consistent answer.
+`Self Consistency` is a decoding strategy that samples a diverse set of reasoning paths and then selects the most consistent answer.
 Is most effective when combined with Chain-of-thought prompting.
-
-Resources:
 
 - [Paper](https://arxiv.org/pdf/2203.11171.pdf)
 
 ## Inception
 
-Also called “First Person Instruction”.
-Encouraging the model to think a certain way by including the start of the model’s response in the prompt.
-
-Resources:
+`Inception` is also called `First Person Instruction`.
+It is encouraging the model to think a certain way by including the start of the model’s response in the prompt.
 
 - [Example](https://twitter.com/goodside/status/1583262455207460865?s=20&t=8Hz7XBnK1OF8siQrxxCIGQ)
 
 ## MemPrompt
 
-MemPrompt maintains a memory of errors and user feedback, and uses them to prevent repetition of mistakes.
-
-Resources:
+`MemPrompt` maintains a memory of errors and user feedback, and uses them to prevent repetition of mistakes.
 
 - [Paper](https://memprompt.com/)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,17 +17,22 @@ How to get started using LangChain to create an Language Model application.
 
 - `Getting Started tutorial <./getting_started/getting_started.html>`_
 
+Concepts and terminology.
+
+- `Concepts and terminology <./getting_started/concepts.html>`_
+
 Tutorials created by community experts and presented on YouTube.
 
 - `Tutorials <./getting_started/tutorials.html>`_
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Getting Started
    :name: getting_started
    :hidden:
 
    getting_started/getting_started.md
+   getting_started/concepts.md
    getting_started/tutorials.md
 
 
@@ -155,8 +160,6 @@ Additional Resources
 Additional collection of resources we think may be useful as you develop your application!
 
 - `LangChainHub <https://github.com/hwchase17/langchain-hub>`_: The LangChainHub is a place to share and explore other prompts, chains, and agents.
-
-- `Glossary <./glossary.html>`_: A glossary of all related terms, papers, methods, etc. Whether implemented in LangChain or not!
 
 - `Gallery <./gallery.html>`_: A collection of our favorite projects that use LangChain. Useful for finding inspiration or seeing how things were done in other applications.
 


### PR DESCRIPTION
# glossary.md renamed as concepts.md and moved under the Getting Started 

small PR.
`Concepts` looks right to the point. It is moved under Getting Started (typical place). Previously it was lost in the Additional Resources section.

## Who can review?

 @hwchase17 

