### PR TITLE
Only run linkcheck against docs dir on PR

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
   pull_request:
+    paths:
+      - 'docs/**'
 
 env:
   POETRY_VERSION: "1.4.2"


### PR DESCRIPTION
# Only run linkchecker on direct changes to docs

This is a stop-gap that will speed up PRs.

Some broken links can slip through if they're embedded in doc-strings inside
the codebase.

But we'll still be running the linkchecker on master. 
