### PR TITLE
Update playwright utils.py to make headless an optional argument

### DIFF
--- a/langchain/tools/playwright/utils.py
+++ b/langchain/tools/playwright/utils.py
@@ -33,18 +33,18 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def create_async_playwright_browser() -> AsyncBrowser:
+def create_async_playwright_browser(headless=True) -> AsyncBrowser:
     from playwright.async_api import async_playwright
 
     browser = run_async(async_playwright().start())
-    return run_async(browser.chromium.launch(headless=True))
+    return run_async(browser.chromium.launch(headless=headless))
 
 
-def create_sync_playwright_browser() -> SyncBrowser:
+def create_sync_playwright_browser(headless=True) -> SyncBrowser:
     from playwright.sync_api import sync_playwright
 
     browser = sync_playwright().start()
-    return browser.chromium.launch(headless=True)
+    return browser.chromium.launch(headless=headless)
 
 
 T = TypeVar("T")


### PR DESCRIPTION
Making the headless argument optional would allow for disabled individuals to use a browser with their voice for example, while still being able to actually see the content. Along with many other use cases I imagine
Relevant reviewer: @vowelparrot 

