### PR TITLE
Update utils.py to make headless an optional argument

### DIFF
--- a/langchain/tools/playwright/utils.py
+++ b/langchain/tools/playwright/utils.py
@@ -33,18 +33,18 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def create_async_playwright_browser() -> AsyncBrowser:
+def create_async_playwright_browser(headless:bool=True) -> AsyncBrowser:
     from playwright.async_api import async_playwright
 
     browser = run_async(async_playwright().start())
-    return run_async(browser.chromium.launch(headless=True))
+    return run_async(browser.chromium.launch(headless=headless))
 
 
-def create_sync_playwright_browser() -> SyncBrowser:
+def create_sync_playwright_browser(headless:bool=True) -> SyncBrowser:
     from playwright.sync_api import sync_playwright
 
     browser = sync_playwright().start()
-    return browser.chromium.launch(headless=True)
+    return browser.chromium.launch(headless=headless)
 
 
 T = TypeVar("T")

--- a/langchain/tools/playwright/utils.py
+++ b/langchain/tools/playwright/utils.py
@@ -33,14 +33,14 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def create_async_playwright_browser(headless:bool=True) -> AsyncBrowser:
+def create_async_playwright_browser(headless: bool = True) -> AsyncBrowser:
     from playwright.async_api import async_playwright
 
     browser = run_async(async_playwright().start())
     return run_async(browser.chromium.launch(headless=headless))
 
 
-def create_sync_playwright_browser(headless:bool=True) -> SyncBrowser:
+def create_sync_playwright_browser(headless: bool = True) -> SyncBrowser:
     from playwright.sync_api import sync_playwright
 
     browser = sync_playwright().start()


### PR DESCRIPTION
Making headless an optional argument for create_async_playwright_browser() and create_sync_playwright_browser()
By default no functionality is changed.

This allows for disabled people to use a web browser intelligently with their voice, for example, while still seeing the content on the screen. As well as many other use cases

Relevant reviewer: @vowelparrot 