### PR TITLE
Fix for syntax when setting search_path for Snowflake database

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -224,7 +224,12 @@ class SQLDatabase:
         """
         with self._engine.begin() as connection:
             if self._schema is not None:
-                connection.exec_driver_sql(f"SET search_path TO {self._schema}")
+                if self.dialect == "snowflake":
+                    connection.exec_driver_sql(
+                        f"ALTER SESSION SET search_path='{self._schema}'"
+                    )
+                else:
+                    connection.exec_driver_sql(f"SET search_path TO {self._schema}")
             cursor = connection.execute(text(command))
             if cursor.returns_rows:
                 if fetch == "all":


### PR DESCRIPTION
# Fixes syntax for setting Snowflake database search_path

An error occurs when using a Snowflake database and providing a schema argument. 
I have updated the syntax to run a Snowflake specific query when the database dialect is 'snowflake'.