### PR TITLE
Revert "Make serpapi base url configurable via env (#4402)"

### DIFF
--- a/docs/ecosystem/serpapi.md
+++ b/docs/ecosystem/serpapi.md
@@ -6,7 +6,6 @@ It is broken into two parts: installation and setup, and then references to the 
 ## Installation and Setup
 - Install requirements with `pip install google-search-results`
 - Get a SerpAPI api key and either set it as an environment variable (`SERPAPI_API_KEY`)
-- Optional, if you are using a proxy, set environment variable (`SERPAPI_BASE_URL`) or pass it to the LLM constructor to your proxy url.
 
 ## Wrappers
 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -30,7 +30,6 @@ The following use cases require specific installs and api keys:
 - _SerpAPI_:
   - Install requirements with `pip install google-search-results`
   - Get a SerpAPI api key and either set it as an environment variable (`SERPAPI_API_KEY`) or pass it to the LLM constructor as `serpapi_api_key`.
-  - Optional, if you are using a proxy, set environment variable (`SERPAPI_BASE_URL`) or pass it to the LLM constructor to your proxy url.
 - _GoogleSearchAPI_:
   - Install requirements with `pip install google-api-python-client`
   - Get a Google api key and either set it as an environment variable (`GOOGLE_API_KEY`) or pass it to the LLM constructor as `google_api_key`. You will also need to set the `GOOGLE_CSE_ID` environment variable to your custom search engine id. You can pass it to the LLM constructor as `google_cse_id` as well.

--- a/langchain/agents/load_tools.py
+++ b/langchain/agents/load_tools.py
@@ -285,10 +285,7 @@ _EXTRA_OPTIONAL_TOOLS: Dict[str, Tuple[Callable[[KwArg(Any)], BaseTool], List[st
         _get_google_serper_results_json,
         ["serper_api_key", "aiosession"],
     ),
-    "serpapi": (
-        _get_serpapi,
-        ["serpapi_api_key", "serpapi_base_url", "aiosession"],
-    ),
+    "serpapi": (_get_serpapi, ["serpapi_api_key", "aiosession"]),
     "searx-search": (_get_searx_search, ["searx_host", "engines", "aiosession"]),
     "wikipedia": (_get_wikipedia, ["top_k_results", "lang"]),
     "arxiv": (

--- a/langchain/utilities/serpapi.py
+++ b/langchain/utilities/serpapi.py
@@ -30,9 +30,8 @@ class SerpAPIWrapper(BaseModel):
     """Wrapper around SerpAPI.
 
     To use, you should have the ``google-search-results`` python package installed,
-    and the environment variable ``SERPAPI_API_KEY``, ``SERPAPI_BASE_URL``
-    set with your API key, or pass `serpapi_api_key`, `serpapi_base_url`
-    as a named parameter to the constructor.
+    and the environment variable ``SERPAPI_API_KEY`` set with your API key, or pass
+    `serpapi_api_key` as a named parameter to the constructor.
 
     Example:
         .. code-block:: python
@@ -51,7 +50,6 @@ class SerpAPIWrapper(BaseModel):
         }
     )
     serpapi_api_key: Optional[str] = None
-    serpapi_base_url: Optional[str] = None
     aiosession: Optional[aiohttp.ClientSession] = None
 
     class Config:
@@ -62,20 +60,11 @@ class SerpAPIWrapper(BaseModel):
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
-        """Validate that api key, base url, and python package exists in environment."""
+        """Validate that api key and python package exists in environment."""
         serpapi_api_key = get_from_dict_or_env(
             values, "serpapi_api_key", "SERPAPI_API_KEY"
         )
         values["serpapi_api_key"] = serpapi_api_key
-
-        serpapi_base_url = get_from_dict_or_env(
-            values,
-            "serpapi_base_url",
-            "SERPAPI_BASE_URL",
-            default="https://serpapi.com/search",
-        )
-        values["serpapi_base_url"] = serpapi_base_url
-
         try:
             from serpapi import GoogleSearch
 
@@ -111,9 +100,8 @@ class SerpAPIWrapper(BaseModel):
             params["source"] = "python"
             if self.serpapi_api_key:
                 params["serp_api_key"] = self.serpapi_api_key
-            if self.serpapi_base_url:
-                params["serp_api_base_url"] = self.serpapi_base_url
             params["output"] = "json"
+            url = "https://serpapi.com/search"
             return url, params
 
         url, params = construct_url_and_params()
@@ -131,7 +119,6 @@ class SerpAPIWrapper(BaseModel):
         """Get parameters for SerpAPI."""
         _params = {
             "api_key": self.serpapi_api_key,
-            "api_base_url": self.serpapi_base_url,
             "q": query,
         }
         params = {**self.params, **_params}


### PR DESCRIPTION
This reverts commit 5111bec54071e42a7865766dc8bb8dc72c1d13b4.

This PR introduced a bug in the async API (the `url` param isn't bound); it also didn't update the synchronous API correctly, which makes it error-prone (the behavior of the async and sync endpoints would be different)