### PR TITLE
Removes leftover embedding_function name / doc references from chroma/atlas vectorstores

### DIFF
--- a/langchain/vectorstores/atlas.py
+++ b/langchain/vectorstores/atlas.py
@@ -74,8 +74,9 @@ class AtlasDB(VectorStore):
 
         if embeddings is None and "embedding_function" in kwargs:
             # Use kwarg embedding_function and print a deprecation warning
-            assert isinstance(kwargs["embedding_function"], Embeddings), \
-                "Class `AtlasDB` expects to instantiated with an `Embeddings` instance."
+            if not isinstance(kwargs["embedding_function"], Embeddings):
+                raise ValueError("Class `AtlasDB` expects kwarg `embedding_function`" +\
+                                 " to be of type `Embeddings`.")
             embeddings = kwargs["embedding_function"]
             warn("Using the named argument `embedding_function` is "+\
                  "deprecated. Please use the argument `embeddings` instead.",

--- a/langchain/vectorstores/atlas.py
+++ b/langchain/vectorstores/atlas.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import uuid
 from typing import Any, Iterable, List, Optional, Type
+from warnings import warn
 
 import numpy as np
 
@@ -39,6 +40,7 @@ class AtlasDB(VectorStore):
         description: str = "A description for your project",
         is_public: bool = True,
         reset_project_if_exists: bool = False,
+        **kwargs: Any
     ) -> None:
         """
         Initialize the Atlas Client
@@ -69,6 +71,16 @@ class AtlasDB(VectorStore):
         if api_key is None:
             raise ValueError("No API key provided. Sign up at atlas.nomic.ai!")
         nomic.login(api_key)
+
+        if embeddings is None and "embedding_function" in kwargs:
+            # Use kwarg embedding_function and print a deprecation warning
+            assert isinstance(kwargs["embedding_function"], Embeddings), \
+                "Class `AtlasDB` expects to instantiated with an `Embeddings` instance."
+            embeddings = kwargs["embedding_function"]
+            warn("Using the named argument `embedding_function` is "+\
+                 "deprecated. Please use the argument `embeddings` instead.",
+                 DeprecationWarning
+            )
 
         self._embeddings = embeddings
         modality = "text"

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -91,8 +91,9 @@ class Chroma(VectorStore):
 
         if embeddings is None and "embedding_function" in kwargs:
             # Use kwarg embedding_function and print a deprecation warning
-            assert isinstance(kwargs["embedding_function"], Embeddings), \
-                "Class `Chroma` expects to instantiated with an `Embeddings` instance."
+            if not isinstance(kwargs["embedding_function"], Embeddings):
+                raise ValueError("Class `Chroma` expects kwarg `embedding_function`" +\
+                                 " to be of type `Embeddings`.")
             embeddings = kwargs["embedding_function"]
             warn("The named argument `embedding_function` is deprecated. " + \
                  "Please use the argument `embeddings` instead.",

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type
+from warnings import warn
 
 import numpy as np
 
@@ -62,6 +63,7 @@ class Chroma(VectorStore):
         client_settings: Optional[chromadb.config.Settings] = None,
         collection_metadata: Optional[Dict] = None,
         client: Optional[chromadb.Client] = None,
+        **kwargs: Any
     ) -> None:
         """Initialize with Chroma client."""
         try:
@@ -86,6 +88,16 @@ class Chroma(VectorStore):
                         persist_directory=persist_directory,
                     )
             self._client = chromadb.Client(self._client_settings)
+
+        if embeddings is None and "embedding_function" in kwargs:
+            # Use kwarg embedding_function and print a deprecation warning
+            assert isinstance(kwargs["embedding_function"], Embeddings), \
+                "Class `Chroma` expects to instantiated with an `Embeddings` instance."
+            embeddings = kwargs["embedding_function"]
+            warn("The named argument `embedding_function` is deprecated. " + \
+                 "Please use the argument `embeddings` instead.",
+                DeprecationWarning
+            )
 
         self._embeddings = embeddings
         self._persist_directory = persist_directory

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -115,7 +115,7 @@ def test_chroma_with_persistence() -> None:
     # Get a new VectorStore from the persisted directory
     docsearch = Chroma(
         collection_name=collection_name,
-        embedding_function=FakeEmbeddings(),
+        embeddings=FakeEmbeddings(),
         persist_directory=chroma_persist_dir,
     )
     output = docsearch.similarity_search("foo", k=1)


### PR DESCRIPTION


# Removes leftover embedding_function name / doc references from chroma/atlas vectorstores

The Chroma and Atlas vector stores had been refactored to use a `Embeddings` instance rather than an `embedding_function`.

This PR cleans up a few variable names and comments which still used the old name `embedding_function` but used the new `Embeddings` object. This should make those sections of the code more readable.

## Who can review?

Anybody, but @dev2049 in particular
        