### PR TITLE
Adds check for `docker-compose` vs `docker compose`

### DIFF
--- a/langchain/server.py
+++ b/langchain/server.py
@@ -1,21 +1,36 @@
-"""Script to run langchain-server locally using docker-compose."""
-import shutil
+"""Script to run langchain-server locally using Docker."""
 import subprocess
 from pathlib import Path
+from subprocess import CalledProcessError
 
+
+def check_command(command: str) -> bool:
+    """Check if a command is available."""
+    try:
+        subprocess.run(
+            command.split(" "),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
+        return True
+    except (FileNotFoundError, CalledProcessError):
+        return False
 
 def main() -> None:
     """Run the langchain server locally."""
     p = Path(__file__).absolute().parent / "docker-compose.yaml"
 
-    if shutil.which("docker-compose") is None:
-        docker_compose_command = ["docker", "compose"]
+    if check_command('docker compose'):
+        subprocess.run(["docker", "compose", "-f", str(p), "pull"])
+        subprocess.run(["docker", "compose", "-f", str(p), "up"])
+    elif check_command('docker-compose'):
+        print("We recommend upgrading to Docker Compose V2." + \
+            "'docker-compose' is being used as fallback.")
+        subprocess.run(["docker-compose", "-f", str(p), "pull"])
+        subprocess.run(["docker-compose", "-f", str(p), "up"])
     else:
-        docker_compose_command = ["docker-compose"]
-
-    subprocess.run([*docker_compose_command, "-f", str(p), "pull"])
-    subprocess.run([*docker_compose_command, "-f", str(p), "up"])
-
+        raise ValueError("`docker compose` or `docker-compose` is required to run" + \
+                        " langchain-server.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Adds check for `docker-compose` vs `docker compose`

`server.py` now checks for `docker compose` and falls back to `docker-compose` (also prints explanatory message if both are missing_

Fixes #935 

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested: @agola11
