### PR TITLE
Persist Volume After Stop

### DIFF
--- a/langchain/cli/docker-compose.yaml
+++ b/langchain/cli/docker-compose.yaml
@@ -44,3 +44,5 @@ services:
       - POSTGRES_DB=postgres
     ports:
       - 5433:5432
+    volumes:
+       - ./db:/var/lib/postgresql/data

--- a/langchain/cli/docker-compose.yaml
+++ b/langchain/cli/docker-compose.yaml
@@ -42,7 +42,9 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
+    volumes:
+      - langchain-db-data:/var/lib/postgresql/data
     ports:
       - 5433:5432
-    volumes:
-       - ./db:/var/lib/postgresql/data
+volumes:
+  langchain-db-data:


### PR DESCRIPTION
Previously, the data would be removed after shutting down the server. This mounts a local `db/` volume that isn't erased between calls
