### PR TITLE
Get tokens method for BaseLanguageModel, OpenAI, & ChatOpenAI

### DIFF
--- a/langchain/base_language.py
+++ b/langchain/base_language.py
@@ -26,7 +26,7 @@ def _get_tokens_default_method(text: str) -> list[int]:
     tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
     # tokenize the text using the GPT-2 tokenizer
-    return tokenizer.tokenize(text)
+    return tokenizer.encode(text)
 
 
 class BaseLanguageModel(BaseModel, ABC):

--- a/langchain/base_language.py
+++ b/langchain/base_language.py
@@ -10,7 +10,7 @@ from langchain.callbacks.manager import Callbacks
 from langchain.schema import BaseMessage, LLMResult, PromptValue, get_buffer_string
 
 
-def _get_num_tokens_default_method(text: str) -> int:
+def _get_tokens_default_method(text: str) -> list[int]:
     """Get the number of tokens present in the text."""
     # TODO: this method may not be exact.
     # TODO: this method may differ based on model (eg codex).
@@ -26,10 +26,7 @@ def _get_num_tokens_default_method(text: str) -> int:
     tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
     # tokenize the text using the GPT-2 tokenizer
-    tokenized_text = tokenizer.tokenize(text)
-
-    # calculate the number of tokens in the tokenized text
-    return len(tokenized_text)
+    return tokenizer.tokenize(text)
 
 
 class BaseLanguageModel(BaseModel, ABC):
@@ -61,9 +58,13 @@ class BaseLanguageModel(BaseModel, ABC):
     ) -> BaseMessage:
         """Predict message from messages."""
 
+    def get_tokens(self, text: str) -> list[int]:
+        """Get the tokens present in the text."""
+        return _get_tokens_default_method(text)
+
     def get_num_tokens(self, text: str) -> int:
         """Get the number of tokens present in the text."""
-        return _get_num_tokens_default_method(text)
+        return len(self.get_tokens(text))
 
     def get_num_tokens_from_messages(self, messages: List[BaseMessage]) -> int:
         """Get the number of tokens in the message."""

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -355,8 +355,8 @@ class ChatOpenAI(BaseChatModel):
         """Return type of chat model."""
         return "openai-chat"
 
-    def get_num_tokens(self, text: str) -> int:
-        """Calculate num tokens with tiktoken package."""
+    def get_tokens(self, text: str) -> list[int]:
+        """Get the tokens present in the text with tiktoken package."""
         # tiktoken NOT supported for Python 3.7 or below
         if sys.version_info[1] <= 7:
             return super().get_num_tokens(text)
@@ -372,10 +372,11 @@ class ChatOpenAI(BaseChatModel):
         enc = tiktoken.encoding_for_model(self.model_name)
 
         # encode the text using the GPT-3.5-Turbo encoder
-        tokenized_text = enc.encode(text)
+        return enc.encode(text)
 
-        # calculate the number of tokens in the encoded text
-        return len(tokenized_text)
+    def get_num_tokens(self, text: str) -> int:
+        """Calculate num tokens with tiktoken package."""
+        return len(self.get_tokens(text))
 
     def get_num_tokens_from_messages(self, messages: List[BaseMessage]) -> int:
         """Calculate num tokens for gpt-3.5-turbo and gpt-4 with tiktoken package.

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -455,8 +455,8 @@ class BaseOpenAI(BaseLLM):
         """Return type of llm."""
         return "openai"
 
-    def get_num_tokens(self, text: str) -> int:
-        """Calculate num tokens with tiktoken package."""
+    def get_tokens(self, text: str) -> list[int]:
+        """Get the tokens present in the text with tiktoken package."""
         # tiktoken NOT supported for Python < 3.8
         if sys.version_info[1] < 8:
             return super().get_num_tokens(text)
@@ -471,14 +471,15 @@ class BaseOpenAI(BaseLLM):
 
         enc = tiktoken.encoding_for_model(self.model_name)
 
-        tokenized_text = enc.encode(
+        return enc.encode(
             text,
             allowed_special=self.allowed_special,
             disallowed_special=self.disallowed_special,
         )
 
-        # calculate the number of tokens in the encoded text
-        return len(tokenized_text)
+    def get_num_tokens(self, text: str) -> int:
+        """Calculate num tokens with tiktoken package."""
+        return len(self.get_tokens(text))
 
     def modelname_to_contextsize(self, modelname: str) -> int:
         """Calculate the maximum number of tokens possible to generate for a model.

--- a/tests/integration_tests/test_schema.py
+++ b/tests/integration_tests/test_schema.py
@@ -1,15 +1,15 @@
 """Test formatting functionality."""
 
-from langchain.base_language import _get_num_tokens_default_method
+from langchain.base_language import _get_tokens_default_method
 
 
 class TestTokenCountingWithGPT2Tokenizer:
     def test_empty_token(self) -> None:
-        assert _get_num_tokens_default_method("") == 0
+        assert len(_get_tokens_default_method("")) == 0
 
     def test_multiple_tokens(self) -> None:
-        assert _get_num_tokens_default_method("a b c") == 3
+        assert len(_get_tokens_default_method("a b c")) == 3
 
     def test_special_tokens(self) -> None:
         # test for consistency when the default tokenizer is changed
-        assert _get_num_tokens_default_method("a:b_c d") == 6
+        assert len(_get_tokens_default_method("a:b_c d")) == 6

--- a/tests/integration_tests/test_schema.py
+++ b/tests/integration_tests/test_schema.py
@@ -4,6 +4,10 @@ from langchain.base_language import _get_tokens_default_method
 
 
 class TestTokenCountingWithGPT2Tokenizer:
+    def test_tokenization(self) -> None:
+        # Check that the tokenization is consistent with the GPT-2 tokenizer
+        assert _get_tokens_default_method("This is a test") == [1212, 318, 257, 1332]
+
     def test_empty_token(self) -> None:
         assert len(_get_tokens_default_method("")) == 0
 


### PR DESCRIPTION
# Get tokens method for BaseLanguageModel, OpenAI, & ChatOpenAI
Sometimes it's helpful to inspect the tokenization of your model to better understand how certain words are being tokenized. Therefore, I have split the preexisting `get_num_tokens` of `BaseLanguageModel` into a `get_tokens` method - which returns a list of integer tokens - and the same `get_num_tokens` method, now calling `get_tokens` under the hood. I have further implemented these methods for the `OpenAI` and `ChatOpenAI` language models.

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

## Before submitting

I updated the integration test here `tests/integration_tests/test_schema.py` to also check the tokenization of the default `GPT2TokenizerFast` tokenizer.

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@hwchase17, @agola11 

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
