### PR TITLE
Fixed query checker for SQLDatabaseChain

### DIFF
--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -130,7 +130,7 @@ class SQLDatabaseChain(Chain):
                     template=QUERY_CHECKER, input_variables=["query", "dialect"]
                 )
                 query_checker_chain = LLMChain(
-                    llm=self.llm, prompt=query_checker_prompt
+                    llm=self.llm_chain.llm, prompt=query_checker_prompt
                 )
                 query_checker_inputs = {
                     "query": sql_cmd,


### PR DESCRIPTION
# Fixed query checker for SQLDatabaseChain

When `SQLDatabaseChain`'s llm attribute was deprecated, the query checker stopped working if `SQLDatabaseChain` is initialised via `from_llm` method. With this fix, `SQLDatabaseChain`'s query checker would use the same `llm` as used in the `llm_chain`


## Who can review?
@hwchase17 - project lead

