### PR TITLE
Block sockets for unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ lint lint_diff:
 TEST_FILE ?= tests/unit_tests/
 
 test:
-	poetry run pytest $(TEST_FILE)
+	poetry run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
-tests:
-	poetry run pytest $(TEST_FILE)
+tests: 
+	poetry run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 extended_tests:
-	poetry run pytest --only-extended tests/unit_tests
+	poetry run pytest --disable-socket --allow-unix-socket --only-extended tests/unit_tests
 
 test_watch:
 	poetry run ptw --now . -- tests/unit_tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -6983,6 +6983,21 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-socket"
+version = "0.6.0"
+description = "Pytest Plugin to disable socket calls during tests"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pytest_socket-0.6.0-py3-none-any.whl", hash = "sha256:cca72f134ff01e0023c402e78d31b32e68da3efdf3493bf7788f8eba86a6824c"},
+    {file = "pytest_socket-0.6.0.tar.gz", hash = "sha256:363c1d67228315d4fc7912f1aabfd570de29d0e3db6217d61db5728adacd7138"},
+]
+
+[package.dependencies]
+pytest = ">=3.6.3"
+
+[[package]]
 name = "pytest-vcr"
 version = "1.0.2"
 description = "Plugin for managing VCR.py cassettes"
@@ -10257,4 +10272,4 @@ qdrant = ["qdrant-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "811c25dc41049bffd84ddd350dbbbca8736737182dc8582dfbe05ce517122739"
+content-hash = "a41fec88e32b74b859208dd79de58c096466aeda631c17048e6b903100f7ac70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ responses = "^0.22.0"
 pytest-asyncio = "^0.20.3"
 lark = "^1.1.5"
 pytest-mock  = "^3.10.0"
+pytest-socket = "^0.6.0"
 
 [tool.poetry.group.test_integration]
 optional = true

--- a/tests/unit_tests/test_pytest_config.py
+++ b/tests/unit_tests/test_pytest_config.py
@@ -3,7 +3,7 @@ import pytest_socket
 import requests
 
 
-def test_socket_disabled():
+def test_socket_disabled() -> None:
     """This test should fail."""
     with pytest.raises(pytest_socket.SocketBlockedError):
         requests.get("https://www.example.com")

--- a/tests/unit_tests/test_pytest_config.py
+++ b/tests/unit_tests/test_pytest_config.py
@@ -1,0 +1,9 @@
+import pytest
+import pytest_socket
+import requests
+
+
+def test_socket_disabled():
+    """This test should fail."""
+    with pytest.raises(pytest_socket.SocketBlockedError):
+        requests.get("https://www.example.com")


### PR DESCRIPTION
# Block usage of sockets during unit tests

Catch any tests that attempt to use the network.
