### PR TITLE
FIX: GPTCache cache_obj creation loop

### DIFF
--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -336,6 +336,7 @@ class GPTCache(BaseCache):
                 self.init_gptcache_func(_gptcache, llm_string)  # type: ignore[call-arg]
             else:
                 self.init_gptcache_func(_gptcache)  # type: ignore[call-arg]
+            self.gptcache_dict[llm_string] = _gptcache
         else:
             _gptcache.init(
                 pre_embedding_func=get_prompt,

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -341,7 +341,7 @@ class GPTCache(BaseCache):
                 pre_embedding_func=get_prompt,
                 data_manager=get_data_manager(data_path=llm_string),
             )
-            
+
         self.gptcache_dict[llm_string] = _gptcache
         return _gptcache
 

--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -336,12 +336,13 @@ class GPTCache(BaseCache):
                 self.init_gptcache_func(_gptcache, llm_string)  # type: ignore[call-arg]
             else:
                 self.init_gptcache_func(_gptcache)  # type: ignore[call-arg]
-            self.gptcache_dict[llm_string] = _gptcache
         else:
             _gptcache.init(
                 pre_embedding_func=get_prompt,
                 data_manager=get_data_manager(data_path=llm_string),
             )
+            
+        self.gptcache_dict[llm_string] = _gptcache
         return _gptcache
 
     def _get_gptcache(self, llm_string: str) -> Any:


### PR DESCRIPTION
_get_gptcache method keep creating new gptcache instance, here's the fix

# Fix GPTCache cache_obj creation loop

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes #4830 

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
