### PR TITLE
More choices embedding search

### DIFF
--- a/langchain/callbacks/tracers/stdout.py
+++ b/langchain/callbacks/tracers/stdout.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 from langchain.callbacks.tracers.base import BaseTracer
 from langchain.callbacks.tracers.schemas import Run
-from langchain.input import get_colored_text
+from langchain.input import get_bolded_text, get_colored_text
 
 
 def try_json_stringify(obj: Any, fallback: str) -> str:
@@ -54,7 +54,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f"{get_colored_text('[chain/start]', color='green')} "
-            f"[{crumbs}] Entering Chain run with input:\n"
+            + get_bolded_text(f"[{crumbs}] Entering Chain run with input:\n") +
             f"{try_json_stringify(run.inputs, '[inputs]')}"
         )
 
@@ -62,7 +62,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f"{get_colored_text('[chain/end]', color='blue')} "
-            f"[{crumbs}] [{elapsed(run)}] Exiting Chain run with output:\n"
+            + get_bolded_text(f"[{crumbs}] [{elapsed(run)}] Exiting Chain run with output:\n") +
             f"{try_json_stringify(run.outputs, '[outputs]')}"
         )
 
@@ -70,7 +70,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f"{get_colored_text('[chain/error]', color='red')} "
-            f"[{crumbs}] [{elapsed(run)}] Chain run errored with error:\n"
+            + get_bolded_text(f"[{crumbs}] [{elapsed(run)}] Chain run errored with error:\n") +
             f"{try_json_stringify(run.error, '[error]')}"
         )
 
@@ -83,7 +83,7 @@ class ConsoleCallbackHandler(BaseTracer):
         )
         print(
             f"{get_colored_text('[llm/start]', color='green')} "
-            f"[{crumbs}] Entering LLM run with input:\n"
+            + get_bolded_text(f"[{crumbs}] Entering LLM run with input:\n") +
             f"{try_json_stringify(inputs, '[inputs]')}"
         )
 
@@ -91,7 +91,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f"{get_colored_text('[llm/end]', color='blue')} "
-            f"[{crumbs}] [{elapsed(run)}] Exiting LLM run with output:\n"
+            + get_bolded_text(f"[{crumbs}] [{elapsed(run)}] Exiting LLM run with output:\n") +
             f"{try_json_stringify(run.outputs, '[response]')}"
         )
 
@@ -99,7 +99,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f"{get_colored_text('[llm/error]', color='red')} "
-            f"[{crumbs}] [{elapsed(run)}] LLM run errored with error:\n"
+            + get_bolded_text(f"[{crumbs}] [{elapsed(run)}] LLM run errored with error:\n") +
             f"{try_json_stringify(run.error, '[error]')}"
         )
 
@@ -107,7 +107,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f'{get_colored_text("[tool/start]", color="green")} '
-            f"[{crumbs}] Entering Tool run with input:\n"
+            + get_bolded_text(f"[{crumbs}] Entering Tool run with input:\n") +
             f'"{run.inputs["input"].strip()}"'
         )
 
@@ -116,7 +116,7 @@ class ConsoleCallbackHandler(BaseTracer):
         if run.outputs:
             print(
                 f'{get_colored_text("[tool/end]", color="blue")} '
-                f"[{crumbs}] [{elapsed(run)}] Exiting Tool run with output:\n"
+                + get_bolded_text(f"[{crumbs}] [{elapsed(run)}] Exiting Tool run with output:\n") +
                 f'"{run.outputs["output"].strip()}"'
             )
 
@@ -124,7 +124,7 @@ class ConsoleCallbackHandler(BaseTracer):
         crumbs = self.get_breadcrumbs(run)
         print(
             f"{get_colored_text('[tool/error]', color='red')} "
-            f"[{crumbs}] [{elapsed(run)}] "
+            + get_bolded_text(f"[{crumbs}] [{elapsed(run)}] ") +
             f"Tool run errored with error:\n"
             f"{run.error}"
         )

--- a/langchain/input.py
+++ b/langchain/input.py
@@ -27,6 +27,11 @@ def get_colored_text(text: str, color: str) -> str:
     return f"\u001b[{color_str}m\033[1;3m{text}\u001b[0m"
 
 
+def get_bolded_text(text: str) -> str:
+    """Get bolded text."""
+    return f"\033[1m{text}\033[0m"
+
+
 def print_text(text: str, color: Optional[str] = None, end: str = "") -> None:
     """Print text with highlighting and no end characters."""
     if color is None:


### PR DESCRIPTION
Feature Description
An optional configuration is provided, which allows users to freely choose to use faiss local library(or annoy,hnswlib， jina) remote/distributed vector database as vector storage.

Problem Solved
When the amount of data in the knowledge base is large (txt file larger than 200m), the io speed of faiss-cpu is too slow to use gpu and cannot be expanded horizontally.

Implementation Suggestions
Implement an interface, which vector database can be configured by configuration file, such as annoy,hnswlib,faiss or jina.

 Alternative Solutions
There is no alternative plan at present

Additional Information
Add any other information related to the feature request.