### PR TITLE
Typos

### DIFF
--- a/docs/modules/agents/agents/custom_agent.ipynb
+++ b/docs/modules/agents/agents/custom_agent.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ba5f8741",
    "metadata": {},
@@ -9,7 +10,7 @@
     "\n",
     "This notebook goes through how to create your own custom agent.\n",
     "\n",
-    "An agent consists of three parts:\n",
+    "An agent consists of two parts:\n",
     "    \n",
     "    - Tools: The tools the agent has available to use.\n",
     "    - The agent class itself: this decides which action to take.\n",

--- a/docs/modules/indexes/retrievers/examples/wikipedia.ipynb
+++ b/docs/modules/indexes/retrievers/examples/wikipedia.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9fc6205b",
    "metadata": {},
@@ -13,6 +14,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "51489529-5dcd-4b86-bda6-de0a39d8ffd1",
    "metadata": {},
@@ -21,6 +23,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1435c804-069d-4ade-9a7b-006b97b767c1",
    "metadata": {},
@@ -41,6 +44,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6c15470b-a16b-4e0d-bc6a-6998bafbb5a4",
    "metadata": {},
@@ -54,6 +58,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ae3c3d16",
    "metadata": {},
@@ -62,6 +67,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6fafb73b-d6ec-4822-b161-edf0aaf5224a",
    "metadata": {},
@@ -145,6 +151,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2670363b-3806-4c7e-b14d-90a4d5d2a200",
    "metadata": {},
@@ -161,7 +168,7 @@
    },
    "outputs": [
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       " ········\n"
@@ -202,7 +209,7 @@
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.chains import ConversationalRetrievalChain\n",
     "\n",
-    "model = ChatOpenAI(model='gpt-3.5-turbo') # switch to 'gpt-4'\n",
+    "model = ChatOpenAI(model_name='gpt-3.5-turbo') # switch to 'gpt-4'\n",
     "qa = ConversationalRetrievalChain.from_llm(model,retriever=retriever)"
    ]
   },

--- a/docs/use_cases/agents/wikibase_agent.ipynb
+++ b/docs/use_cases/agents/wikibase_agent.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5e3cb542-933d-4bf3-a82b-d9d6395a7832",
    "metadata": {
@@ -16,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "07d42966-7e99-4157-90dc-6704977dcf1b",
    "metadata": {
@@ -26,6 +28,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9132f093-c61e-4b8d-abef-91ebef3fc85f",
    "metadata": {
@@ -69,6 +72,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "332b6658-c978-41ca-a2be-4f8677fecaef",
    "metadata": {
@@ -95,6 +99,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "42a9311b-600d-42bc-b000-2692ef87a213",
    "metadata": {
@@ -117,6 +122,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "db08d308-050a-4fc8-93c9-8de4ae977ac3",
    "metadata": {},
@@ -137,6 +143,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3dbc5bfc-48ce-4f90-873c-7336b21300c6",
    "metadata": {},
@@ -150,6 +157,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1f801b4e-6576-4914-aa4f-6f4c4e3c7924",
    "metadata": {
@@ -279,6 +287,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "78d66d8b-0e34-4d3f-a18d-c7284840ac76",
    "metadata": {},
@@ -287,6 +296,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c6f60069-fbe0-4015-87fb-0e487cd914e7",
    "metadata": {},
@@ -343,6 +353,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f0302fd-ba35-4acc-ba32-1d7c9295c898",
    "metadata": {},
@@ -351,6 +362,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3122a961-9673-4a52-b1cd-7d62fbdf8d96",
    "metadata": {},
@@ -401,6 +413,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ab0f2778-a195-4a4a-a5b4-c1e809e1fb7b",
    "metadata": {},
@@ -500,6 +513,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "12c57d77-3c1e-4cde-9a83-7d2134392479",
    "metadata": {},
@@ -548,6 +562,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "48a758cb-93a7-4555-b69a-896d2d43c6f0",
    "metadata": {},
@@ -563,10 +578,11 @@
    "outputs": [],
    "source": [
     "from langchain.chat_models import ChatOpenAI\n",
-    "llm = ChatOpenAI(model=\"gpt-4\", temperature=0)"
+    "llm = ChatOpenAI(model_name=\"gpt-4\", temperature=0)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "95685d14-647a-4e24-ae2c-a8dd1e364921",
    "metadata": {},
@@ -612,6 +628,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "66e3d13b-77cf-41d3-b541-b54535c14459",
    "metadata": {},

--- a/docs/use_cases/code/code-analysis-deeplake.ipynb
+++ b/docs/use_cases/code/code-analysis-deeplake.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -16,6 +18,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -30,6 +33,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,6 +41,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -46,6 +51,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,6 +70,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -123,6 +130,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -130,6 +138,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -171,6 +180,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -362,6 +372,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -410,6 +421,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -496,6 +508,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -534,7 +547,7 @@
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.chains import ConversationalRetrievalChain\n",
     "\n",
-    "model = ChatOpenAI(model='gpt-3.5-turbo') # 'ada' 'gpt-3.5-turbo' 'gpt-4',\n",
+    "model = ChatOpenAI(model_name='gpt-3.5-turbo') # 'ada' 'gpt-3.5-turbo' 'gpt-4',\n",
     "qa = ConversationalRetrievalChain.from_llm(model,retriever=retriever)"
    ]
   },
@@ -562,6 +575,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -615,6 +629,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": []


### PR DESCRIPTION
# Fixed typos (issues #4818 & #4668 & more typos)
- At some places, it said `model = ChatOpenAI(model='gpt-3.5-turbo')` but should be `model = ChatOpenAI(model_name='gpt-3.5-turbo')`
- Fixes some other typos

Fixes #4818, #4668

## Who can review?
Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
        Models
        - @hwchase17
        - @agola11
        Agents / Tools / Toolkits
        - @vowelparrot
        