### PR TITLE
Fix TypeError in Vectorstore Redis class methods

### DIFF
--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -446,7 +446,6 @@ class Redis(VectorStore):
                 )
         """
         instance, _ = cls.from_texts_return_keys(
-            cls=cls,
             texts=texts,
             embedding=embedding,
             metadatas=metadatas,


### PR DESCRIPTION
# Fix TypeError in Vectorstore Redis class methods

This change resolves a TypeError that was raised when invoking the `from_texts_return_keys` method from the `from_texts` method in the `Redis` class. The error was due to the `cls` argument being passed explicitly, which led to it being provided twice since it's also implicitly passed in class methods.  No relevant tests were added as the issue appeared to be better suited for linters to catch proactively.

Changes:
- Removed `cls=cls` from the call to `from_texts_return_keys` in the `from_texts` method.

Related to:
https://github.com/hwchase17/langchain/pull/4653

@dev2049
@hwchase17 