### PR TITLE
Fix bilibili

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/bilibili.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/bilibili.ipynb
@@ -23,7 +23,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install bilibili-api"
+    "#!pip install bilibili-api-python"
    ]
   },
   {

--- a/langchain/document_loaders/bilibili.py
+++ b/langchain/document_loaders/bilibili.py
@@ -32,7 +32,7 @@ class BiliBiliLoader(BaseLoader):
         except ImportError:
             raise ValueError(
                 "requests package not found, please install it with "
-                "`pip install bilibili-api`"
+                "`pip install bilibili-api-python`"
             )
 
         bvid = re.search(r"BV\w+", url)


### PR DESCRIPTION
# Fix bilibili api import error

bilibili-api package is depracated and there is no sync module.

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes #2673 #2724 

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@vowelparrot  @liaokongVFX 

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
