### PR TITLE
Remove unused variables in Milvus vectorstore

### DIFF
--- a/langchain/vectorstores/milvus.py
+++ b/langchain/vectorstores/milvus.py
@@ -545,10 +545,6 @@ class Milvus(VectorStore):
         # Embed the query text.
         embedding = self.embedding_func.embed_query(query)
 
-        # Determine result metadata fields.
-        output_fields = self.fields[:]
-        output_fields.remove(self._vector_field)
-
         res = self.similarity_search_with_score_by_vector(
             embedding=embedding, k=k, param=param, expr=expr, timeout=timeout, **kwargs
         )


### PR DESCRIPTION
# Remove unused variables in Milvus vectorstore
This PR simply removes a variable unused in Milvus. The variable looks like a copy-paste from other functions in Milvus but it is really unnecessary.
<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

## Who can review?
@dev2049

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
