### PR TITLE
Add no_avx2 to FAISS vector store

### DIFF
--- a/docs/modules/indexes/vectorstores/examples/faiss.ipynb
+++ b/docs/modules/indexes/vectorstores/examples/faiss.ipynb
@@ -56,7 +56,10 @@
     "import os\n",
     "import getpass\n",
     "\n",
-    "os.environ['OPENAI_API_KEY'] = getpass.getpass('OpenAI API Key:')"
+    "os.environ['OPENAI_API_KEY'] = getpass.getpass('OpenAI API Key:')\n",
+    "\n",
+    "# Uncomment the following line if you need to initialize FAISS with no AVX2 optimization\n",
+    "# os.environ['FAISS_NO_AVX2'] = '1'"
    ]
   },
   {

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -1,6 +1,7 @@
 """Wrapper around FAISS vector database."""
 from __future__ import annotations
 
+import os
 import math
 import pickle
 import uuid
@@ -17,10 +18,24 @@ from langchain.vectorstores.base import VectorStore
 from langchain.vectorstores.utils import maximal_marginal_relevance
 
 
-def dependable_faiss_import() -> Any:
-    """Import faiss if available, otherwise raise error."""
+def dependable_faiss_import(no_avx2: Optional[bool] = None) -> Any:
+    """
+    Import faiss if available, otherwise raise error.
+    If FAISS_NO_AVX2 environment variable is set, it will be considered
+    to load FAISS with no AVX2 optimization.
+
+    Args:
+        no_avx2: Load FAISS strictly with no AVX2 optimization
+            so that the vectorstore is portable and compatible with other devices.
+    """
+    if no_avx2 is None and 'FAISS_NO_AVX2' in os.environ:
+        no_avx2 = bool(os.getenv('FAISS_NO_AVX2'))
+
     try:
-        import faiss
+        if no_avx2:
+            from faiss import swigfaiss as faiss
+        else:
+            import faiss
     except ImportError:
         raise ValueError(
             "Could not import faiss python package. "

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -161,7 +161,7 @@ class FAISS(VectorStore):
         """Return docs most similar to query.
 
         Args:
-            query: Text to look up documents similar to.
+            embedding: Embedding vector to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
 
         Returns:


### PR DESCRIPTION
# Add no_avx2 to FAISS vector store

This PR adds the `no_avx2` argument and `FAISS_NO_AVX2` environment variable to `dependable_faiss_import` function to not load FAISS vector store with AVX2 optimization.

This option comes in handy when the developer wants to save the vector store to a file and load it on somewhere else. Most modern CPUs have AVX2 optimization but there are situations where the hardware is old, the `faiss-cpu` pypi package is not compiled with AVX2 flag or this feature is disabled for some reason.

I encountered this issue on a PaaS where FAISS pickle and database files created by `save_index` in Colab could not be loaded inside the Docker containers due to the platform not supporting AVX2.

@dev2049
