### PR TITLE
PGVector logger message level

### DIFF
--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -184,7 +184,7 @@ class PGVector(VectorStore):
         with Session(self._conn) as session:
             collection = self.get_collection(session)
             if not collection:
-                self.logger.error("Collection not found")
+                self.logger.warning("Collection not found")
                 return
             session.delete(collection)
             session.commit()


### PR DESCRIPTION
# Change the logger message level

The library is logging at `error` level a situation that is not an error.
We noticed this error in our logs, but from our point of view it's an expected behavior and the log level should be `warning`.

