### PR TITLE
Empty check before pop

### DIFF
--- a/langchain/callbacks/streaming_aiter.py
+++ b/langchain/callbacks/streaming_aiter.py
@@ -58,7 +58,8 @@ class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
             )
 
             # Cancel the other task
-            other.pop().cancel()
+            if other:
+                other.pop().cancel()
 
             # Extract the value of the first completed task
             token_or_done = cast(Union[str, Literal[True]], done.pop().result())


### PR DESCRIPTION
# Check whether 'other' is empty before popping

This PR could fix a potential 'popping empty set' error.

