### PR TITLE
fix: add_texts method of Weaviate vector store creats wrong embeddings

### DIFF
--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -63,6 +63,12 @@ def _default_score_normalizer(val: float) -> float:
     return 1 - 1 / (1 + np.exp(val))
 
 
+def _json_serializable(value: Any) -> Any:
+    if isinstance(value, datetime.datetime):
+        return value.isoformat()
+    return value
+
+
 class Weaviate(VectorStore):
     """Wrapper around Weaviate vector database.
 
@@ -121,43 +127,28 @@ class Weaviate(VectorStore):
         """Upload texts with metadata (properties) to Weaviate."""
         from weaviate.util import get_valid_uuid
 
-        def json_serializable(value: Any) -> Any:
-            if isinstance(value, datetime.datetime):
-                return value.isoformat()
-            return value
-
-        embeddings = self._embedding.embed_documents(list(texts))
-
+        ids = []
         with self._client.batch as batch:
-            ids = []
-            for i, doc in enumerate(texts):
-                data_properties = {
-                    self._text_key: doc,
-                }
+            for i, text in enumerate(texts):
+                data_properties = {self._text_key: text}
                 if metadatas is not None:
-                    for key in metadatas[i].keys():
-                        data_properties[key] = json_serializable(metadatas[i][key])
+                    for key, val in metadatas[i].items():
+                        data_properties[key] = _json_serializable(val)
 
                 # If the UUID of one of the objects already exists
                 # then the existing object will be replaced by the new object.
-                if "uuids" in kwargs:
-                    _id = kwargs["uuids"][i]
-                else:
-                    _id = get_valid_uuid(uuid4())
+                _id = kwargs["uuid"][i] if "uuid" in kwargs else get_valid_uuid(uuid4())
 
                 if self._embedding is not None:
-                    batch.add_data_object(
-                        data_object=data_properties,
-                        class_name=self._index_name,
-                        uuid=_id,
-                        vector=embeddings[i],
-                    )
+                    vector = self._embedding.embed_documents([text])[0]
                 else:
-                    batch.add_data_object(
-                        data_object=data_properties,
-                        class_name=self._index_name,
-                        uuid=_id,
-                    )
+                    vector = None
+                batch.add_data_object(
+                    data_object=data_properties,
+                    class_name=self._index_name,
+                    uuid=_id,
+                    vector=vector,
+                )
                 ids.append(_id)
         return ids
 

--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -126,6 +126,8 @@ class Weaviate(VectorStore):
                 return value.isoformat()
             return value
 
+        embeddings = self._embedding.embed_documents(list(texts))
+
         with self._client.batch as batch:
             ids = []
             for i, doc in enumerate(texts):
@@ -137,19 +139,18 @@ class Weaviate(VectorStore):
                         data_properties[key] = json_serializable(metadatas[i][key])
 
                 # If the UUID of one of the objects already exists
-                # then the existing objectwill be replaced by the new object.
+                # then the existing object will be replaced by the new object.
                 if "uuids" in kwargs:
                     _id = kwargs["uuids"][i]
                 else:
                     _id = get_valid_uuid(uuid4())
 
                 if self._embedding is not None:
-                    embeddings = self._embedding.embed_documents(list(doc))
                     batch.add_data_object(
                         data_object=data_properties,
                         class_name=self._index_name,
                         uuid=_id,
-                        vector=embeddings[0],
+                        vector=embeddings[i],
                     )
                 else:
                     batch.add_data_object(

--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -137,7 +137,9 @@ class Weaviate(VectorStore):
 
                 # If the UUID of one of the objects already exists
                 # then the existing object will be replaced by the new object.
-                _id = kwargs["uuids"][i] if "uuids" in kwargs else get_valid_uuid(uuid4())
+                _id = (
+                    kwargs["uuids"][i] if "uuids" in kwargs else get_valid_uuid(uuid4())
+                )
 
                 if self._embedding is not None:
                     vector = self._embedding.embed_documents([text])[0]

--- a/langchain/vectorstores/weaviate.py
+++ b/langchain/vectorstores/weaviate.py
@@ -137,7 +137,7 @@ class Weaviate(VectorStore):
 
                 # If the UUID of one of the objects already exists
                 # then the existing object will be replaced by the new object.
-                _id = kwargs["uuid"][i] if "uuid" in kwargs else get_valid_uuid(uuid4())
+                _id = kwargs["uuids"][i] if "uuids" in kwargs else get_valid_uuid(uuid4())
 
                 if self._embedding is not None:
                     vector = self._embedding.embed_documents([text])[0]


### PR DESCRIPTION
# fix a bug in the add_texts method of Weaviate vector store that creats wrong embeddings

The following is the original code in the `add_texts` method of the Weaviate vector store, from line 131 to 153, which contains a bug. The code here includes some extra explanations in the form of comments and some omissions.

```python
            for i, doc in enumerate(texts):

                # some code omitted

                if self._embedding is not None:
                    # variable texts is a list of string and doc here is just a string. 
                    # list(doc) actually breaks up the string into characters.
                    # so, embeddings[0] is just the embedding of the first character
                    embeddings = self._embedding.embed_documents(list(doc))
                    batch.add_data_object(
                        data_object=data_properties,
                        class_name=self._index_name,
                        uuid=_id,
                        vector=embeddings[0],
                    )
```

To fix this bug, I pulled the embedding operation out of the for loop and embed all texts at once. 

According to the contributing.md doc, it seems I can have my twitter account mentioned? I'd love that very much. My twitter handler is `ShawnDeveloping`. HAHA.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@dev2049
