### PR TITLE
docs supabase update

### DIFF
--- a/docs/modules/indexes/vectorstores/examples/supabase.ipynb
+++ b/docs/modules/indexes/vectorstores/examples/supabase.ipynb
@@ -5,7 +5,7 @@
    "id": "683953b3",
    "metadata": {},
    "source": [
-    "# SupabaseVectorStore"
+    "# Supabase (Postgres)"
    ]
   },
   {
@@ -13,7 +13,9 @@
    "id": "cc80fa84-1f2f-48b4-bd39-3e6412f012f1",
    "metadata": {},
    "source": [
-    ">[Supabase](https://supabase.com/docs) is an open source Firebase alternative.\n",
+    ">[Supabase](https://supabase.com/docs) is an open source Firebase alternative. `Supabase` is built on top of `PostgreSQL`, which offers strong SQL querying capabilities and enables a simple interface with already-existing tools and frameworks.\n",
+    "\n",
+    ">[PostgreSQL](https://en.wikipedia.org/wiki/PostgreSQL) also known as `Postgres`, is a free and open-source relational database management system (RDBMS) emphasizing extensibility and SQL compliance.\n",
     "\n",
     "This notebook shows how to use `Supabase` and `pgvector` as your VectorStore.\n",
     "\n",
@@ -125,21 +127,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "90afc6df",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# If you're storing your Supabase and OpenAI API keys in a .env file, you can load them with dotenv\n",
     "from dotenv import load_dotenv\n",
@@ -164,18 +157,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "aac9563e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-04-19 20:12:28,593:INFO - NumExpr defaulting to 8 threads.\n"
-     ]
-    }
-   ],
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "from langchain.embeddings.openai import OpenAIEmbeddings\n",
     "from langchain.text_splitter import CharacterTextSplitter\n",


### PR DESCRIPTION
# docs: updated `Supabase` notebook

- the title of the notebook was inconsistent (included redundant "Vectorstore"). Removed this "Vectorstore"
- added `Postgress` to the title. It is important. The `Postgres` name is much more popular than `Supabase`.
- added description for the `Postrgress`
- added more info to the `Supabase` description

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@dev2049
  
