### PR TITLE
Fixed assumptions misspelling

### DIFF
--- a/docs/modules/chains/examples/llm_summarization_checker.ipynb
+++ b/docs/modules/chains/examples/llm_summarization_checker.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# LLMSummarizationCheckerChain\n",
-    "This notebook shows some examples of LLMSummarizationCheckerChain in use with different types of texts.  It has a few distinct differences from the `LLMCheckerChain`, in that it doesn't have any assumtions to the format of the input text (or summary).\n",
+    "This notebook shows some examples of LLMSummarizationCheckerChain in use with different types of texts.  It has a few distinct differences from the `LLMCheckerChain`, in that it doesn't have any assumptions to the format of the input text (or summary).\n",
     "Additionally, as the LLMs like to hallucinate when fact checking or get confused by context, it is sometimes beneficial to run the checker multiple times.  It does this by feeding the rewritten \"True\" result back on itself, and checking the \"facts\" for truth.  As you can see from the examples below, this can be very effective in arriving at a generally true body of text.\n",
     "\n",
     "You can control the number of times the checker runs by setting the `max_checks` parameter.  The default is 2, but you can set it to 1 if you don't want any double-checking."


### PR DESCRIPTION
Fixed assumptions misspelling in the link mentioned below:-

https://python.langchain.com/en/latest/modules/chains/examples/llm_summarization_checker.html

![image](https://github.com/hwchase17/langchain/assets/16189966/94cf2be0-b3d0-495b-98ad-e1f44331727e)

Fix for Issue:- #4959 

@hwchase17 