### PR TITLE
preserve language in conversation retrieval

### DIFF
--- a/langchain/chains/conversational_retrieval/prompts.py
+++ b/langchain/chains/conversational_retrieval/prompts.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from langchain.prompts.prompt import PromptTemplate
 
-_template = """Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question.
+_template = """Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
 
 Chat History:
 {chat_history}


### PR DESCRIPTION
Without the addition of 'in its original language', the condensing response, more often than not, outputs the rephrased question in English, even when the conversation is in another language. This question in English then transfers to the question in the retrieval prompt and the chatbot is stuck in English.

I'm sometimes surprised that this does not happen more often, but apparently the GPT models are smart enough to understand that when the template contains

Question: ....
Answer:

then the answer should be in in the language of the question.
