### PR TITLE
Update the GPTCache example

### DIFF
--- a/docs/modules/models/llms/examples/llm_caching.ipynb
+++ b/docs/modules/models/llms/examples/llm_caching.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "f69f6283",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "64005d1f",
    "metadata": {},
    "outputs": [
@@ -60,17 +60,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 26.1 ms, sys: 21.5 ms, total: 47.6 ms\n",
-      "Wall time: 1.68 s\n"
+      "CPU times: user 35.9 ms, sys: 28.6 ms, total: 64.6 ms\n",
+      "Wall time: 4.83 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side.'"
+       "\"\\n\\nWhy couldn't the bicycle stand up by itself? It was...two tired!\""
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "14a82124",
    "metadata": {},
    "outputs": [],
@@ -412,13 +412,16 @@
     "from gptcache.manager.factory import manager_factory\n",
     "from gptcache.processor.pre import get_prompt\n",
     "from langchain.cache import GPTCache\n",
+    "import hashlib\n",
     "\n",
-    "# Avoid multiple caches using the same file, causing different llm model caches to affect each other\n",
+    "def get_hashed_name(name):\n",
+    "    return hashlib.sha256(name.encode()).hexdigest()\n",
     "\n",
     "def init_gptcache(cache_obj: Cache, llm: str):\n",
+    "    hashed_llm = get_hashed_name(llm)\n",
     "    cache_obj.init(\n",
     "        pre_embedding_func=get_prompt,\n",
-    "        data_manager=manager_factory(manager=\"map\", data_dir=f\"map_cache_{llm}\"),\n",
+    "        data_manager=manager_factory(manager=\"map\", data_dir=f\"map_cache_{hashed_llm}\"),\n",
     "    )\n",
     "\n",
     "langchain.llm_cache = GPTCache(init_gptcache)"
@@ -426,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "9e4ecfd1",
    "metadata": {},
    "outputs": [
@@ -434,17 +437,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.6 ms, sys: 3.82 ms, total: 12.4 ms\n",
-      "Wall time: 881 ms\n"
+      "CPU times: user 21.5 ms, sys: 21.3 ms, total: 42.8 ms\n",
+      "Wall time: 6.2 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side.'"
+       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side!'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -457,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "c98bbe3b",
    "metadata": {},
    "outputs": [
@@ -465,17 +468,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 286 µs, sys: 21 µs, total: 307 µs\n",
-      "Wall time: 316 µs\n"
+      "CPU times: user 571 µs, sys: 43 µs, total: 614 µs\n",
+      "Wall time: 635 µs\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side.'"
+       "'\\n\\nWhy did the chicken cross the road?\\n\\nTo get to the other side!'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,11 +507,14 @@
     "from gptcache import Cache\n",
     "from gptcache.adapter.api import init_similar_cache\n",
     "from langchain.cache import GPTCache\n",
+    "import hashlib\n",
     "\n",
-    "# Avoid multiple caches using the same file, causing different llm model caches to affect each other\n",
+    "def get_hashed_name(name):\n",
+    "    return hashlib.sha256(name.encode()).hexdigest()\n",
     "\n",
-    "def init_gptcache(cache_obj: Cache, llm str):\n",
-    "    init_similar_cache(cache_obj=cache_obj, data_dir=f\"similar_cache_{llm}\")\n",
+    "def init_gptcache(cache_obj: Cache, llm: str):\n",
+    "    hashed_llm = get_hashed_name(llm)\n",
+    "    init_similar_cache(cache_obj=cache_obj, data_dir=f\"similar_cache_{hashed_llm}\")\n",
     "\n",
     "langchain.llm_cache = GPTCache(init_gptcache)"
    ]
@@ -523,8 +529,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.01 s, sys: 153 ms, total: 1.16 s\n",
-      "Wall time: 2.49 s\n"
+      "CPU times: user 1.42 s, sys: 279 ms, total: 1.7 s\n",
+      "Wall time: 8.44 s\n"
      ]
     },
     {
@@ -554,8 +560,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 745 ms, sys: 13.2 ms, total: 758 ms\n",
-      "Wall time: 136 ms\n"
+      "CPU times: user 866 ms, sys: 20 ms, total: 886 ms\n",
+      "Wall time: 226 ms\n"
      ]
     },
     {
@@ -585,8 +591,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 737 ms, sys: 7.79 ms, total: 745 ms\n",
-      "Wall time: 135 ms\n"
+      "CPU times: user 853 ms, sys: 14.8 ms, total: 868 ms\n",
+      "Wall time: 224 ms\n"
      ]
     },
     {


### PR DESCRIPTION
# Update the GPTCache example

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes #4757

## Before submitting

<!-- If you're adding a new integration, include an integration test and an example notebook showing its use! -->

The llm parameter does not seem to represent the llm model name, but rather the request parameter list. Too many parameters lead to a GPTCache file name that is too long. I updated the demo and used a hash method for the llm parameter. Perhaps the llm value can be optimized.

## Who can review?

Please help me checkout it
@hwchase17
@dev2049

<!-- For a quicker response, figure out the right person to tag with @

        @hwchase17 - project lead

        Tracing / Callbacks
        - @agola11

        Async
        - @agola11

        DataLoaders
        - @eyurtsev

        Models
        - @hwchase17
        - @agola11

        Agents / Tools / Toolkits
        - @vowelparrot
        
        VectorStores / Retrievers / Memory
        - @dev2049
        
 -->
