### PR TITLE
Obsidian front_matter fix

### DIFF
--- a/langchain/document_loaders/obsidian.py
+++ b/langchain/document_loaders/obsidian.py
@@ -28,7 +28,8 @@ class ObsidianLoader(BaseLoader):
         match = self.FRONT_MATTER_REGEX.search(content)
         front_matter = {}
         if match:
-            front_matter = yaml.safe_load(match)
+            front_matter_match = match.group(1)
+            front_matter = yaml.safe_load(front_matter_match)
         return front_matter
 
     def _remove_front_matter(self, content: str) -> str:


### PR DESCRIPTION
# ObsidianLoader front_matter fixed to proper YAML parsing

Obsidian Notes can have front_matter at the beginning of their markdown files.
This front_matter is formatted as YAML. The previous implementation simply went through line-by-line checking for a key-value pair.
This PR uses the python yaml package to parse the front_matter, allowing for all kind of YAML compatible front_matter in line with the Obsidian rules.

At the same time, variable names in the ObsidianLoader class were replaced from single letter or abbreviations to named variables.


Fixes #4991 


## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@eyurtsev  

