### PR TITLE
Add OpenLM LLM multi-provider

### DIFF
--- a/docs/modules/models/llms/integrations/openlm.ipynb
+++ b/docs/modules/models/llms/integrations/openlm.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,17 +76,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Choices [{'id': '13807ea7-c2f7-4f6a-a5bb-a21490d8622c', 'model_name': 'openai.com/text-davinci-003', 'created': 1684788067, 'text': ' First, what country are we looking for the capital of? France. The capital of France is Paris.', 'usage': {'prompt_tokens': 20, 'completion_tokens': 21, 'total_tokens': 41}, 'extra': {'id': 'cmpl-7J6cySQCqXIvWNhkeiaGEaezMfme3'}}]\n",
       "Model: text-davinci-003\n",
-      "Result:  First, what country are we looking for the capital of? France. The capital of France is Paris.\n",
-      "Choices [{'id': '5a824a67-4020-4a9b-b09b-b1f8ee61e907', 'model_name': 'huggingface.co/gpt2', 'created': 1684788067, 'text': \"Question: What is the capital of France?\\n\\nAnswer: Let's think step by step. I am not going to lie, this is a complicated issue, and I don't see any solutions to all this, but it is still far more\"}]\n",
+      "Result:  France is a country in Europe. The capital of France is Paris.\n",
       "Model: huggingface.co/gpt2\n",
       "Result: Question: What is the capital of France?\n",
       "\n",

--- a/docs/modules/models/llms/integrations/openlm.ipynb
+++ b/docs/modules/models/llms/integrations/openlm.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenLM\n",
+    "[OpenLM](https://github.com/r2d4/openlm) is a zero-dependency OpenAI-compatible LLM provider that can call different inference endpoints directly via HTTP. \n",
+    "\n",
+    "\n",
+    "It implements the OpenAI Completion class so that it can be used as a drop-in replacement for the OpenAI API. This changeset utilizes BaseOpenAI for minimal added code.\n",
+    "\n",
+    "This examples goes over how to use LangChain to interact with both OpenAI and HuggingFace. You'll need API keys from both."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "environ({'ASSETS_PATH': '/Users/matt/.config/raycast/extensions/open-code/assets', 'COMMAND_MODE': 'unix2003', 'COMMAND_NAME': 'index', 'DISPLAY': '/private/tmp/com.apple.launchd.S41rcVrtNR/org.xquartz:0', 'ELECTRON_NO_ATTACH_CONSOLE': '1', 'EXTENSION_NAME': 'open-code', 'HOME': '/Users/matt', 'LC_ALL': 'en_US-u-hc-h12-u-ca-gregory-u-nu-latn', 'LOGNAME': 'matt', 'MallocNanoZone': '0', 'NODE_ENV': 'development', 'NODE_PATH': '/Applications/Raycast.app/Contents/Resources/RaycastCommands_RaycastCommands.bundle/Contents/Resources/api/node_modules', 'ORIGINAL_XDG_CURRENT_DESKTOP': 'undefined', 'PATH': '/Users/matt/code/langchain/.venv/bin:/usr/bin:/bin:/usr/sbin:/sbin', 'PWD': '/', 'RAYCAST_BUNDLE_ID': 'com.raycast.macos', 'RAYCAST_VERSION': '1.51.3', 'SHELL': '/bin/zsh', 'SHLVL': '3', 'SSH_AUTH_SOCK': '/private/tmp/com.apple.launchd.HS0rnuvEbV/Listeners', 'SUPPORT_PATH': '/Users/matt/Library/Application Support/com.raycast.macos/extensions/open-code', 'TMPDIR': '/var/folders/18/8z30tbys2w18jwwvm_wbbrhc0000gn/T', 'USER': 'matt', 'VSCODE_AMD_ENTRYPOINT': 'vs/workbench/api/node/extensionHostProcess', 'VSCODE_CLI': '1', 'VSCODE_CODE_CACHE_PATH': '/Users/matt/Library/Application Support/Code/CachedData/b3e4e68a0bc097f0ae7907b217c1119af9e03435', 'VSCODE_CRASH_REPORTER_PROCESS_TYPE': 'extensionHost', 'VSCODE_CRASH_REPORTER_SANDBOXED_HINT': '1', 'VSCODE_CWD': '/', 'VSCODE_HANDLES_UNCAUGHT_ERRORS': 'true', 'VSCODE_IPC_HOOK': '/Users/matt/Library/Application Support/Code/1.78-main.sock', 'VSCODE_NLS_CONFIG': '{\"locale\":\"en-us\",\"osLocale\":\"en-us\",\"availableLanguages\":{},\"_languagePackSupport\":true}', 'VSCODE_PID': '22699', 'XPC_FLAGS': '0x0', 'XPC_SERVICE_NAME': '0', '__CFBundleIdentifier': 'com.microsoft.VSCode', '__CF_USER_TEXT_ENCODING': '0x1F5:0x0:0x0', 'ELECTRON_RUN_AS_NODE': '1', 'APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL': '1', 'VSCODE_L10N_BUNDLE_LOCATION': '', 'PYTHONUNBUFFERED': '1', 'PYTHONIOENCODING': 'utf-8', 'VIRTUAL_ENV': '/Users/matt/code/langchain/.venv', 'PS1': '(langchain-py3.11) ', '_': '/Users/matt/code/langchain/.venv/bin/python', 'PYDEVD_IPYTHON_COMPATIBLE_DEBUGGING': '1', 'PYDEVD_USE_FRAME_EVAL': 'NO', 'TERM': 'xterm-color', 'CLICOLOR': '1', 'FORCE_COLOR': '1', 'CLICOLOR_FORCE': '1', 'PAGER': 'cat', 'GIT_PAGER': 'cat', 'MPLBACKEND': 'module://matplotlib_inline.backend_inline', 'OPENAI_API_KEY': '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', 'HF_API_TOKEN': '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'})\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "from getpass import getpass\n",
+    "\n",
+    "print(os.environ)\n",
+    "\n",
+    "# Check if OPENAI_API_KEY environment variable is set\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    print(\"Enter your OpenAI API key:\")\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass()\n",
+    "\n",
+    "# Check if HF_API_TOKEN environment variable is set\n",
+    "if \"HF_API_TOKEN\" not in os.environ:\n",
+    "    print(\"Enter your HuggingFace Hub API key:\")\n",
+    "    os.environ[\"HF_API_TOKEN\"] = getpass()\n",
+    "\n",
+    "try:\n",
+    "    import openlm\n",
+    "    import openai\n",
+    "except ImportError:\n",
+    "    print(\"openlm package not found. Installing openlm...\")\n",
+    "    subprocess.run([\"pip\", \"install\", \"openlm\", \"openai\"])\n",
+    "\n",
+    "from langchain.llms import OpenLM\n",
+    "from langchain import PromptTemplate, LLMChain"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using LangChain with OpenLM\n",
+    "\n",
+    "Here we're going to call two models in an LLMChain, `text-davinci-003` from OpenAI and `gpt2` on HuggingFace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Choices [{'id': '13807ea7-c2f7-4f6a-a5bb-a21490d8622c', 'model_name': 'openai.com/text-davinci-003', 'created': 1684788067, 'text': ' First, what country are we looking for the capital of? France. The capital of France is Paris.', 'usage': {'prompt_tokens': 20, 'completion_tokens': 21, 'total_tokens': 41}, 'extra': {'id': 'cmpl-7J6cySQCqXIvWNhkeiaGEaezMfme3'}}]\n",
+      "Model: text-davinci-003\n",
+      "Result:  First, what country are we looking for the capital of? France. The capital of France is Paris.\n",
+      "Choices [{'id': '5a824a67-4020-4a9b-b09b-b1f8ee61e907', 'model_name': 'huggingface.co/gpt2', 'created': 1684788067, 'text': \"Question: What is the capital of France?\\n\\nAnswer: Let's think step by step. I am not going to lie, this is a complicated issue, and I don't see any solutions to all this, but it is still far more\"}]\n",
+      "Model: huggingface.co/gpt2\n",
+      "Result: Question: What is the capital of France?\n",
+      "\n",
+      "Answer: Let's think step by step. I am not going to lie, this is a complicated issue, and I don't see any solutions to all this, but it is still far more\n"
+     ]
+    }
+   ],
+   "source": [
+    "question = \"What is the capital of France?\"\n",
+    "template = \"\"\"Question: {question}\n",
+    "\n",
+    "Answer: Let's think step by step.\"\"\"\n",
+    "\n",
+    "prompt = PromptTemplate(template=template, input_variables=[\"question\"])\n",
+    "\n",
+    "for model in [\"text-davinci-003\", \"huggingface.co/gpt2\"]:\n",
+    "    llm = OpenLM(model=model)\n",
+    "    llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
+    "    result = llm_chain.run(question)\n",
+    "    print(\"\"\"Model: {}\n",
+    "Result: {}\"\"\".format(model, result))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/modules/models/llms/integrations/openlm.ipynb
+++ b/docs/modules/models/llms/integrations/openlm.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -15,32 +14,35 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Setup"
+    "### Setup\n",
+    "Install dependencies and set API keys."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "environ({'ASSETS_PATH': '/Users/matt/.config/raycast/extensions/open-code/assets', 'COMMAND_MODE': 'unix2003', 'COMMAND_NAME': 'index', 'DISPLAY': '/private/tmp/com.apple.launchd.S41rcVrtNR/org.xquartz:0', 'ELECTRON_NO_ATTACH_CONSOLE': '1', 'EXTENSION_NAME': 'open-code', 'HOME': '/Users/matt', 'LC_ALL': 'en_US-u-hc-h12-u-ca-gregory-u-nu-latn', 'LOGNAME': 'matt', 'MallocNanoZone': '0', 'NODE_ENV': 'development', 'NODE_PATH': '/Applications/Raycast.app/Contents/Resources/RaycastCommands_RaycastCommands.bundle/Contents/Resources/api/node_modules', 'ORIGINAL_XDG_CURRENT_DESKTOP': 'undefined', 'PATH': '/Users/matt/code/langchain/.venv/bin:/usr/bin:/bin:/usr/sbin:/sbin', 'PWD': '/', 'RAYCAST_BUNDLE_ID': 'com.raycast.macos', 'RAYCAST_VERSION': '1.51.3', 'SHELL': '/bin/zsh', 'SHLVL': '3', 'SSH_AUTH_SOCK': '/private/tmp/com.apple.launchd.HS0rnuvEbV/Listeners', 'SUPPORT_PATH': '/Users/matt/Library/Application Support/com.raycast.macos/extensions/open-code', 'TMPDIR': '/var/folders/18/8z30tbys2w18jwwvm_wbbrhc0000gn/T', 'USER': 'matt', 'VSCODE_AMD_ENTRYPOINT': 'vs/workbench/api/node/extensionHostProcess', 'VSCODE_CLI': '1', 'VSCODE_CODE_CACHE_PATH': '/Users/matt/Library/Application Support/Code/CachedData/b3e4e68a0bc097f0ae7907b217c1119af9e03435', 'VSCODE_CRASH_REPORTER_PROCESS_TYPE': 'extensionHost', 'VSCODE_CRASH_REPORTER_SANDBOXED_HINT': '1', 'VSCODE_CWD': '/', 'VSCODE_HANDLES_UNCAUGHT_ERRORS': 'true', 'VSCODE_IPC_HOOK': '/Users/matt/Library/Application Support/Code/1.78-main.sock', 'VSCODE_NLS_CONFIG': '{\"locale\":\"en-us\",\"osLocale\":\"en-us\",\"availableLanguages\":{},\"_languagePackSupport\":true}', 'VSCODE_PID': '22699', 'XPC_FLAGS': '0x0', 'XPC_SERVICE_NAME': '0', '__CFBundleIdentifier': 'com.microsoft.VSCode', '__CF_USER_TEXT_ENCODING': '0x1F5:0x0:0x0', 'ELECTRON_RUN_AS_NODE': '1', 'APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL': '1', 'VSCODE_L10N_BUNDLE_LOCATION': '', 'PYTHONUNBUFFERED': '1', 'PYTHONIOENCODING': 'utf-8', 'VIRTUAL_ENV': '/Users/matt/code/langchain/.venv', 'PS1': '(langchain-py3.11) ', '_': '/Users/matt/code/langchain/.venv/bin/python', 'PYDEVD_IPYTHON_COMPATIBLE_DEBUGGING': '1', 'PYDEVD_USE_FRAME_EVAL': 'NO', 'TERM': 'xterm-color', 'CLICOLOR': '1', 'FORCE_COLOR': '1', 'CLICOLOR_FORCE': '1', 'PAGER': 'cat', 'GIT_PAGER': 'cat', 'MPLBACKEND': 'module://matplotlib_inline.backend_inline', 'OPENAI_API_KEY': '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', 'HF_API_TOKEN': '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'})\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# Uncomment to install openlm and openai if you haven't already\n",
+    "\n",
+    "# !pip install openlm\n",
+    "# !pip install openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from getpass import getpass\n",
     "import os\n",
     "import subprocess\n",
-    "from getpass import getpass\n",
     "\n",
-    "print(os.environ)\n",
     "\n",
     "# Check if OPENAI_API_KEY environment variable is set\n",
     "if \"OPENAI_API_KEY\" not in os.environ:\n",
@@ -50,27 +52,26 @@
     "# Check if HF_API_TOKEN environment variable is set\n",
     "if \"HF_API_TOKEN\" not in os.environ:\n",
     "    print(\"Enter your HuggingFace Hub API key:\")\n",
-    "    os.environ[\"HF_API_TOKEN\"] = getpass()\n",
-    "\n",
-    "try:\n",
-    "    import openlm\n",
-    "    import openai\n",
-    "except ImportError:\n",
-    "    print(\"openlm package not found. Installing openlm...\")\n",
-    "    subprocess.run([\"pip\", \"install\", \"openlm\", \"openai\"])\n",
-    "\n",
-    "from langchain.llms import OpenLM\n",
-    "from langchain import PromptTemplate, LLMChain"
+    "    os.environ[\"HF_API_TOKEN\"] = getpass()\n"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Using LangChain with OpenLM\n",
     "\n",
     "Here we're going to call two models in an LLMChain, `text-davinci-003` from OpenAI and `gpt2` on HuggingFace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.llms import OpenLM\n",
+    "from langchain import PromptTemplate, LLMChain"
    ]
   },
   {
@@ -112,7 +113,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -127,8 +128,7 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.3"
-  },
-  "orig_nbformat": 4
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/langchain/llms/__init__.py
+++ b/langchain/llms/__init__.py
@@ -24,6 +24,7 @@ from langchain.llms.llamacpp import LlamaCpp
 from langchain.llms.modal import Modal
 from langchain.llms.nlpcloud import NLPCloud
 from langchain.llms.openai import AzureOpenAI, OpenAI, OpenAIChat
+from langchain.llms.openlm import OpenLM
 from langchain.llms.petals import Petals
 from langchain.llms.pipelineai import PipelineAI
 from langchain.llms.predictionguard import PredictionGuard
@@ -53,6 +54,7 @@ __all__ = [
     "NLPCloud",
     "OpenAI",
     "OpenAIChat",
+    "OpenLM",
     "Petals",
     "PipelineAI",
     "HuggingFaceEndpoint",
@@ -96,6 +98,7 @@ type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
     "nlpcloud": NLPCloud,
     "human-input": HumanInputLLM,
     "openai": OpenAI,
+    "openlm": OpenLM,
     "petals": Petals,
     "pipelineai": PipelineAI,
     "huggingface_pipeline": HuggingFacePipeline,

--- a/langchain/llms/openlm.py
+++ b/langchain/llms/openlm.py
@@ -1,17 +1,19 @@
-from typing import Dict,Any
+from typing import Dict, Any
 from pydantic import root_validator
 
 from langchain.llms.openai import BaseOpenAI
+
 
 class OpenLM(BaseOpenAI):
     @property
     def _invocation_params(self) -> Dict[str, Any]:
         return {**{"model": self.model_name}, **super()._invocation_params}
-    
+
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         try:
             import openlm
+
             values["client"] = openlm.Completion
         except ImportError:
             raise ValueError(

--- a/langchain/llms/openlm.py
+++ b/langchain/llms/openlm.py
@@ -1,0 +1,23 @@
+from typing import Dict,Any
+from pydantic import root_validator
+
+from langchain.llms.openai import BaseOpenAI
+
+class OpenLM(BaseOpenAI):
+    @property
+    def _invocation_params(self) -> Dict[str, Any]:
+        return {**{"model": self.model_name}, **super()._invocation_params}
+    
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        try:
+            import openlm
+            values["client"] = openlm.Completion
+        except ImportError:
+            raise ValueError(
+                "Could not import openlm python package. "
+                "Please install it with `pip install openlm`."
+            )
+        if values["streaming"]:
+            raise ValueError("Streaming not supported with openlm")
+        return values

--- a/langchain/llms/openlm.py
+++ b/langchain/llms/openlm.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any
+from typing import Any, Dict
+
 from pydantic import root_validator
 
 from langchain.llms.openai import BaseOpenAI

--- a/poetry.lock
+++ b/poetry.lock
@@ -5237,6 +5237,21 @@ files = [
 pydantic = ">=1.8.2"
 
 [[package]]
+name = "openlm"
+version = "0.0.5"
+description = "Drop-in OpenAI-compatible that can call LLMs from other providers"
+category = "main"
+optional = true
+python-versions = ">=3.8.1,<4.0"
+files = [
+    {file = "openlm-0.0.5-py3-none-any.whl", hash = "sha256:9fcbbc575d2869e2a6c0b00827f9be2189c067c2de4bf03ef3cbdf488367ae93"},
+    {file = "openlm-0.0.5.tar.gz", hash = "sha256:0eb3fd7a9e4f7b4248931ff2f0dc91c525d990b99956886861a1b3f9868bc451"},
+]
+
+[package.dependencies]
+requests = ">=2,<3"
+
+[[package]]
 name = "opensearch-py"
 version = "2.2.0"
 description = "Python client for OpenSearch"
@@ -10393,4 +10408,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "7c14d63435a60c32edbb4d7adcc647430cf64a80aa26c1515fba28d5433efc6b"
+content-hash = "e32ad3cc19b12da08a6625030367028dc7545a8c80f50dc0e159ad5674931b13"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6670,6 +6670,7 @@ files = [
     {file = "pylance-0.4.12-cp38-abi3-macosx_10_15_x86_64.whl", hash = "sha256:2b86fb8dccc03094c0db37bef0d91bda60e8eb0d1eddf245c6971450c8d8a53f"},
     {file = "pylance-0.4.12-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bc82914b13204187d673b5f3d45f93219c38a0e9d0542ba251074f639669789"},
     {file = "pylance-0.4.12-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a4bcce77f99ecd4cbebbadb01e58d5d8138d40eb56bdcdbc3b20b0475e7a472"},
+    {file = "pylance-0.4.12-cp38-abi3-win_amd64.whl", hash = "sha256:9616931c5300030adb9626d22515710a127d1e46a46737a7a0f980b52f13627c"},
 ]
 
 [package.dependencies]
@@ -10394,13 +10395,13 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 cffi = ["cffi (>=1.11)"]
 
 [extras]
-all = ["O365", "aleph-alpha-client", "anthropic", "arxiv", "atlassian-python-api", "azure-cosmos", "azure-identity", "beautifulsoup4", "clickhouse-connect", "cohere", "deeplake", "docarray", "duckduckgo-search", "elasticsearch", "faiss-cpu", "google-api-python-client", "google-search-results", "gptcache", "html2text", "huggingface_hub", "jina", "jinja2", "jq", "lancedb", "lark", "lxml", "manifest-ml", "neo4j", "networkx", "nlpcloud", "nltk", "nomic", "openai", "opensearch-py", "pdfminer-six", "pexpect", "pgvector", "pinecone-client", "pinecone-text", "psycopg2-binary", "pyowm", "pypdf", "pytesseract", "pyvespa", "qdrant-client", "redis", "requests-toolbelt", "sentence-transformers", "spacy", "steamship", "tensorflow-text", "tiktoken", "torch", "transformers", "weaviate-client", "wikipedia", "wolframalpha"]
+all = ["O365", "aleph-alpha-client", "anthropic", "arxiv", "atlassian-python-api", "azure-cosmos", "azure-identity", "beautifulsoup4", "clickhouse-connect", "cohere", "deeplake", "docarray", "duckduckgo-search", "elasticsearch", "faiss-cpu", "google-api-python-client", "google-search-results", "gptcache", "html2text", "huggingface_hub", "jina", "jinja2", "jq", "lancedb", "lark", "lxml", "manifest-ml", "neo4j", "networkx", "nlpcloud", "nltk", "nomic", "openai", "openlm", "opensearch-py", "pdfminer-six", "pexpect", "pgvector", "pinecone-client", "pinecone-text", "psycopg2-binary", "pyowm", "pypdf", "pytesseract", "pyvespa", "qdrant-client", "redis", "requests-toolbelt", "sentence-transformers", "spacy", "steamship", "tensorflow-text", "tiktoken", "torch", "transformers", "weaviate-client", "wikipedia", "wolframalpha"]
 azure = ["azure-core", "azure-cosmos", "azure-identity", "openai"]
 cohere = ["cohere"]
 docarray = ["docarray"]
 embeddings = ["sentence-transformers"]
 extended-testing = ["atlassian-python-api", "beautifulsoup4", "beautifulsoup4", "chardet", "gql", "html2text", "jq", "lxml", "pandas", "pdfminer-six", "psychicapi", "pymupdf", "pypdf", "pypdfium2", "requests-toolbelt", "telethon", "tqdm", "zep-python"]
-llms = ["anthropic", "cohere", "huggingface_hub", "manifest-ml", "nlpcloud", "openai", "torch", "transformers"]
+llms = ["anthropic", "cohere", "huggingface_hub", "manifest-ml", "nlpcloud", "openai", "openlm", "torch", "transformers"]
 openai = ["openai", "tiktoken"]
 qdrant = ["qdrant-client"]
 text-helpers = ["chardet"]
@@ -10408,4 +10409,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "e32ad3cc19b12da08a6625030367028dc7545a8c80f50dc0e159ad5674931b13"
+content-hash = "6cb245c220bccf9d3617e04c6677e825f3bfe885bae054125d4a685d0007d024"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ psychicapi = {version = "^0.2", optional = true}
 zep-python = {version="^0.25", optional=true}
 chardet = {version="^5.1.0", optional=true}
 requests-toolbelt = {version = "^1.0.0", optional = true}
+openlm = {version = "^0.0.5", optional = true}
 
 [tool.poetry.group.docs.dependencies]
 autodoc_pydantic = "^1.8.0"
@@ -174,7 +175,7 @@ playwright = "^1.28.0"
 setuptools = "^67.6.1"
 
 [tool.poetry.extras]
-llms = ["anthropic", "cohere", "openai", "nlpcloud", "huggingface_hub", "manifest-ml", "torch", "transformers"]
+llms = ["anthropic", "cohere", "openai", "openlm", "nlpcloud", "huggingface_hub", "manifest-ml", "torch", "transformers"]
 qdrant = ["qdrant-client"]
 openai = ["openai", "tiktoken"]
 text_helpers = ["chardet"]
@@ -240,6 +241,7 @@ all = [
     "lxml",
     "requests-toolbelt",
     "neo4j",
+    "openlm"
 ]
 
 # An extra used to be able to add extended testing.

--- a/tests/integration_tests/llms/test_openlm.py
+++ b/tests/integration_tests/llms/test_openlm.py
@@ -1,0 +1,8 @@
+from langchain.llms.openlm import OpenLM
+
+
+def test_openlm_call() -> None:
+    """Test valid call to openlm."""
+    llm = OpenLM(model_name="dolly-v2-7b", max_tokens=10)
+    output = llm(prompt="Say foo:")
+    assert isinstance(output, str)


### PR DESCRIPTION
OpenLM is a zero-dependency OpenAI-compatible LLM provider that can call different inference endpoints directly via HTTP. It implements the OpenAI Completion class so that it can be used as a drop-in replacement for the OpenAI API. This changeset utilizes BaseOpenAI for minimal added code.
