### PR TITLE
Remove autoreload in examples

### DIFF
--- a/docs/modules/agents/tools/examples/zapier.ipynb
+++ b/docs/modules/agents/tools/examples/zapier.ipynb
@@ -29,19 +29,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "a363309c",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "id": "5cf33377",
    "metadata": {},

--- a/docs/modules/chains/examples/sqlite.ipynb
+++ b/docs/modules/chains/examples/sqlite.ipynb
@@ -1,17 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "ca883d49",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "0ed6aab1",
    "metadata": {


### PR DESCRIPTION
# Remove autoreload in examples
Remove the `autoreload` in examples since it is not necessary for most users:
```
%load_ext autoreload,
%autoreload 2
```




## Before submitting
In https://python.langchain.com/en/latest/modules/chains/examples/sqlite.html:
<img width="872" alt="image" src="https://github.com/hwchase17/langchain/assets/1097932/9d123ed0-1af4-4247-8709-e059bda3714e">

In https://python.langchain.com/en/latest/modules/agents/tools/examples/zapier.html:
<img width="827" alt="image" src="https://github.com/hwchase17/langchain/assets/1097932/2e80422a-964f-4976-a916-498a2258af07">

## Who can review?
@vowelparrot @hwchase17
