### PR TITLE
fix: missing parameter 

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -219,6 +219,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     engine=self.deployment,
                     request_timeout=self.request_timeout,
                     headers=self.headers,
+                    engine=self.deployment,
                 )
                 batched_embeddings += [r["embedding"] for r in response["data"]]
 


### PR DESCRIPTION
When using Elasticsearch Vectorstore, I encountered the following error due to a missing parameter. The issue has been resolved. 
InvalidRequestError: Must provide an 'engine' or 'deployment_id' parameter to create a <class 'openai.api_resources.embedding.Embedding'>


```
from langchain.document_loaders import PyPDFLoader
from langchain import ElasticVectorSearch
from langchain.embeddings import OpenAIEmbeddings
embeddings = OpenAIEmbeddings(
    deployment='',
    model='',
    openai_api_base='',
    openai_api_type="azure",
    openai_api_version='2023-03-15-preview',
    chunk_size=1,
    )
loader = PyPDFLoader("*.pdf")
pages = loader.load_and_split()
db = ElasticVectorSearch.from_documents(pages, embeddings, elasticsearch_url='http://localhost:9200')
```

@dev2049
