### PR TITLE
Fix annoying typo in docs

### DIFF
--- a/docs/modules/agents/tools/examples/python.ipynb
+++ b/docs/modules/agents/tools/examples/python.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984a8fca",
    "metadata": {},
@@ -9,7 +10,7 @@
     "\n",
     "Sometimes, for complex calculations, rather than have an LLM generate the answer directly, it can be better to have the LLM generate code to calculate the answer, and then run that code to get the answer. In order to easily do that, we provide a simple Python REPL to execute commands in.\n",
     "\n",
-    "This interface will only return things that are printed - therefor, if you want to use it to calculate an answer, make sure to have it print out the answer."
+    "This interface will only return things that are printed - therefore, if you want to use it to calculate an answer, make sure to have it print out the answer."
    ]
   },
   {


### PR DESCRIPTION
# Fixes an annoying typo in docs

<!--
Thank you for contributing to LangChain! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes Annoying typo in docs - "Therefor" -> "Therefore". It's so annoying to read that I just had to make this PR.
