### PR TITLE
Fix #5027: Make ChatOpenAI models work with prompts created via ChatPromptTemplate.from_role_strings

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -81,7 +81,9 @@ def _convert_dict_to_message(_dict: dict) -> BaseMessage:
 
 def _convert_message_to_dict(message: BaseMessage) -> dict:
     if isinstance(message, ChatMessage):
-        message_dict = {"role": message.role, "content": message.content}
+        # map role strings used by LangChain to those used by OpenAI
+        role_mapping = {"human": "user", "ai": "assistant", "system": "system"}
+        message_dict = {"role": role_mapping[message.role], "content": message.content}
     elif isinstance(message, HumanMessage):
         message_dict = {"role": "user", "content": message.content}
     elif isinstance(message, AIMessage):


### PR DESCRIPTION
# Make `ChatOpenAI` models work with prompts created via `ChatPromptTemplate.from_role_strings`

As described in #5027, currently, `ChatOpenAI` models don't work with prompts created via `ChatPromptTemplate.from_role_strings`. The reason is that `ChatPromptTemplate.from_role_strings` creates generic `ChatMessage`s which `ChatOpenAI._convert_message_to_dict` can't correctly parse. E.g. a `ChatMessage` with `type="human"` should be mapped to a dict with `role="user"` but is mapped to `role="human"`.

This PR fixes that.

Fixes #5027

## Who can review?
Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
Models
- @hwchase17
- @agola11

Twitter: [@UmerHAdil](https://twitter.com/@UmerHAdil) | Discord: RicChilligerDude#7589