### PR TITLE
Use jsonref to expand StructuredTool.args

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3602,6 +3602,18 @@ files = [
 ]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9"},
+    {file = "jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552"},
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.17.3"
 description = "An implementation of JSON Schema validation for Python"
@@ -10866,4 +10878,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "196588e10bb33939f5bae294a194ad01e803f40ed1087fe6a7a4b87e8d80712b"
+content-hash = "3f624c47154f1ad7ec3492ef4e201c4cf00b5838d105b172472b3227d7e06edc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ openlm = {version = "^0.0.5", optional = true}
 azure-ai-formrecognizer = {version = "^3.2.1", optional = true}
 azure-ai-vision = {version = "^0.11.1b1", optional = true}
 azure-cognitiveservices-speech = {version = "^1.28.0", optional = true}
+jsonref = {version = "^1.1.0", optional = true}
 
 [tool.poetry.group.docs.dependencies]
 autodoc_pydantic = "^1.8.0"
@@ -127,6 +128,7 @@ pytest-asyncio = "^0.20.3"
 lark = "^1.1.5"
 pytest-mock  = "^3.10.0"
 pytest-socket = "^0.6.0"
+jsonref = "^1.1.0"
 
 [tool.poetry.group.test_integration]
 optional = true

--- a/tests/unit_tests/test_depedencies.py
+++ b/tests/unit_tests/test_depedencies.py
@@ -62,6 +62,7 @@ def test_test_group_dependencies(poetry_conf: Mapping[str, Any]) -> None:
     assert test_group_deps == [
         "duckdb-engine",  # Should be removed
         "freezegun",
+        "jsonref",
         "lark",  # Should be removed
         "pytest",
         "pytest-asyncio",

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from enum import Enum
 from functools import partial
-from typing import Any, Optional, Type, Union
+from typing import Any, List, Optional, Type, Union
 
 import pytest
 from pydantic import BaseModel
@@ -276,6 +276,27 @@ def test_structured_tool_types_parsed() -> None:
         "some_base_model": SomeBaseModel(foo="bar"),
     }
     assert result == expected
+
+
+def test_structured_tool_nested_types() -> None:
+    """Test that the full schema of a complicated schema is included"""
+
+    class ModelNested(BaseModel):
+        data: List[str]
+
+    class ModelParent(BaseModel):
+        child: ModelNested
+
+    @tool()
+    def structured_tool(query: ModelParent) -> str:
+        """My structured tool"""
+        return "foo"
+
+    assert isinstance(structured_tool, StructuredTool)
+
+    args = str(structured_tool.args)
+    assert "$ref" not in args
+    assert "ModelNested" in args
 
 
 def test_base_tool_inheritance_base_schema() -> None:


### PR DESCRIPTION
With a nested `args_schema`, `StructuredTool.args` will currently only return the properties of the top level object without either including or resolving JSON Schema references, e.g.:

```
> structured_tool.args
{
  "table_id": {
    "title": "Table Id",
    "type": "string"
  },
  "body": {
    "title": "Body",
    "description": "an API query in the required format",
    "allOf": [
      {
        "$ref": "#/definitions/ApiQuery"
      }
    ]
  }
}
```

This PR implements the second of three possible solutions I see:

### 1. Include the full schema with references (i.e. not just top level `properties`):

```
{
  "title": "TableQuery",
  "type": "object",
  "properties": {
    "table_id": {
      "title": "Table Id",
      "type": "string"
    },
    "body": {
      "title": "Body",
      "description": "an API query in the required format",
      "allOf": [
        {
          "$ref": "#/definitions/ApiQuery"
        }
      ]
    }
  },
  "required": [
    "table_id",
    "body"
  ],
  "definitions": {
    "ApiQuery": {
      "title": "ApiQuery",
      "type": "object",
      "properties": { ... }
     }, 
  }
}
```

* **Pros**: Full schema is included with less token increase
* **Cons**: LLM may have a hard time understanding the references

### 2. Resolve (expand) the references using the `jsonref` package:

```
{
  "table_id": {
    "title": "Table Id",
    "type": "string"
  },
  "body": {
    "title": "Body",
    "description": "an API query in the required format",
    "allOf": [
      {
        "title": "ApiQuery",
        "type": "object",
        "properties": {
            ...
        }
      }
    ]
  }
}
```

* **Pros**: Includes the full schema in a way that the LLM might understand
* **Cons**: Token count bloat + adds new package dependency

### 3. Warn or raise

A third option would be to raise an exception that the schema is too complicated and ask the user to override `StructuredTool.args`. This would have helped me a lot in debugging my agent. Also has the benefit of not breaking existing agents relying on the old behaviour.

## Who can review?

@hwchase17
@vowelparrot
        
