### PR TITLE
feat: :sparkles: `from_documents` in TFiDF retireiver

### DIFF
--- a/docs/modules/indexes/retrievers/examples/tf_idf.ipynb
+++ b/docs/modules/indexes/retrievers/examples/tf_idf.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install scikit-learn"
+    "# !pip install scikit-learn\n"
    ]
   },
   {

--- a/docs/modules/indexes/retrievers/examples/tf_idf.ipynb
+++ b/docs/modules/indexes/retrievers/examples/tf_idf.ipynb
@@ -27,12 +27,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "393ac030",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Could not import azure.core python package.\n"
+     ]
+    }
+   ],
    "source": [
     "from langchain.retrievers import TFIDFRetriever"
    ]
@@ -71,13 +79,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "id": "53af4f00",
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain.schema import Document\n",
-    "retriever = TFIDFRetriever.from_documents([Document(page_content=\"foo\"), Document(page_content=\"bar\"), Document(page_content=\"world\"), Document(page_content=\"hello\"), Document(page_content=\"foo bar\")])"
+    "retriever = TFIDFRetriever.from_documents([Document(page_content=\"foo\", metadata={'source':'bar'}), Document(page_content=\"bar\"), Document(page_content=\"world\"), Document(page_content=\"hello\"), Document(page_content=\"foo bar\")])"
    ]
   },
   {
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "c0455218",
    "metadata": {
     "tags": []
@@ -105,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "id": "7dfa5c29",
    "metadata": {
     "tags": []
@@ -114,13 +122,13 @@
     {
      "data": {
       "text/plain": [
-       "[Document(page_content='foo', metadata={}),\n",
+       "[Document(page_content='foo', metadata={'source': 'bar'}),\n",
        " Document(page_content='foo bar', metadata={}),\n",
        " Document(page_content='hello', metadata={}),\n",
        " Document(page_content='world', metadata={})]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/modules/indexes/retrievers/examples/tf_idf.ipynb
+++ b/docs/modules/indexes/retrievers/examples/tf_idf.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ab66dd43",
    "metadata": {},
@@ -16,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "a801b57c",
    "metadata": {},
    "outputs": [],
@@ -26,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "393ac030",
    "metadata": {
     "tags": []
@@ -37,6 +38,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "aaf80e7f",
    "metadata": {},
@@ -46,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "98b1c017",
    "metadata": {
     "tags": []
@@ -57,6 +59,29 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c016b266",
+   "metadata": {},
+   "source": [
+    "# Create a New Retriever with Documents\n",
+    "\n",
+    "You can now create a new retriever with the documents you created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "53af4f00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.schema import Document\n",
+    "retriever = TFIDFRetriever.from_documents([Document(page_content=\"foo\"), Document(page_content=\"bar\"), Document(page_content=\"world\"), Document(page_content=\"hello\"), Document(page_content=\"foo bar\")])"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "08437fa2",
    "metadata": {},
@@ -68,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c0455218",
    "metadata": {
     "tags": []
@@ -80,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "7dfa5c29",
    "metadata": {
     "tags": []
@@ -95,7 +120,7 @@
        " Document(page_content='world', metadata={})]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -129,7 +154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/langchain/retrievers/tfidf.py
+++ b/langchain/retrievers/tfidf.py
@@ -34,11 +34,11 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
         tfidf_array = vectorizer.fit_transform(texts)
         docs = [Document(page_content=t) for t in texts]
         return cls(vectorizer=vectorizer, docs=docs, tfidf_array=tfidf_array, **kwargs)
-    
+
     @classmethod
     def from_documents(
         cls,
-        docs: List[Document],
+        documents: List[Document],
         tfidf_params: Optional[Dict[str, Any]] = None,
         **kwargs: Any
     ) -> "TFIDFRetriever":
@@ -46,8 +46,8 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
 
         tfidf_params = tfidf_params or {}
         vectorizer = TfidfVectorizer(**tfidf_params)
-        tfidf_array = vectorizer.fit_transform([d.page_content for d in docs])
-        return cls(vectorizer=vectorizer, docs=docs, tfidf_array=tfidf_array, **kwargs)
+        tfidf_array = vectorizer.fit_transform([d.page_content for d in documents])
+        return cls(vectorizer=vectorizer, docs=documents, tfidf_array=tfidf_array, **kwargs)
 
     def get_relevant_documents(self, query: str) -> List[Document]:
         from sklearn.metrics.pairwise import cosine_similarity

--- a/langchain/retrievers/tfidf.py
+++ b/langchain/retrievers/tfidf.py
@@ -25,6 +25,7 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
         cls,
         texts: List[str],
         tfidf_params: Optional[Dict[str, Any]] = None,
+        metadatas: Optional[List[Dict]] = None,
         **kwargs: Any
     ) -> "TFIDFRetriever":
         from sklearn.feature_extraction.text import TfidfVectorizer
@@ -32,22 +33,18 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
         tfidf_params = tfidf_params or {}
         vectorizer = TfidfVectorizer(**tfidf_params)
         tfidf_array = vectorizer.fit_transform(texts)
-        docs = [Document(page_content=t) for t in texts]
+        if metadatas is None:
+            metadatas = [dict()] * len(texts)
+        assert len(metadatas) == len(texts)
+        docs = [Document(page_content=t, metadata=m) for t, m in zip(texts, metadatas)]
         return cls(vectorizer=vectorizer, docs=docs, tfidf_array=tfidf_array, **kwargs)
 
     @classmethod
     def from_documents(
-        cls,
-        documents: List[Document],
-        tfidf_params: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        cls, documents: List[Document], **kwargs: Any
     ) -> "TFIDFRetriever":
-        from sklearn.feature_extraction.text import TfidfVectorizer
-
-        tfidf_params = tfidf_params or {}
-        vectorizer = TfidfVectorizer(**tfidf_params)
-        tfidf_array = vectorizer.fit_transform([d.page_content for d in documents])
-        return cls(vectorizer=vectorizer, docs=documents, tfidf_array=tfidf_array, **kwargs)
+        metadatas, texts = zip(*[(d.metadata, d.page_content) for d in documents])
+        return cls.from_texts(texts, metadatas=metadatas)
 
     def get_relevant_documents(self, query: str) -> List[Document]:
         from sklearn.metrics.pairwise import cosine_similarity

--- a/langchain/retrievers/tfidf.py
+++ b/langchain/retrievers/tfidf.py
@@ -34,6 +34,20 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
         tfidf_array = vectorizer.fit_transform(texts)
         docs = [Document(page_content=t) for t in texts]
         return cls(vectorizer=vectorizer, docs=docs, tfidf_array=tfidf_array, **kwargs)
+    
+    @classmethod
+    def from_documents(
+        cls,
+        docs: List[Document],
+        tfidf_params: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> "TFIDFRetriever":
+        from sklearn.feature_extraction.text import TfidfVectorizer
+
+        tfidf_params = tfidf_params or {}
+        vectorizer = TfidfVectorizer(**tfidf_params)
+        tfidf_array = vectorizer.fit_transform([d.page_content for d in docs])
+        return cls(vectorizer=vectorizer, docs=docs, tfidf_array=tfidf_array, **kwargs)
 
     def get_relevant_documents(self, query: str) -> List[Document]:
         from sklearn.metrics.pairwise import cosine_similarity

--- a/tests/integration_tests/retrievers/test_tfidf.py
+++ b/tests/integration_tests/retrievers/test_tfidf.py
@@ -1,4 +1,5 @@
 from langchain.retrievers.tfidf import TFIDFRetriever
+from langchain.schema import Document
 
 
 def test_from_texts() -> None:
@@ -15,3 +16,13 @@ def test_from_texts_with_tfidf_params() -> None:
     )
     # should count only multiple words (have, pan)
     assert tfidf_retriever.tfidf_array.toarray().shape == (3, 2)
+
+def test_from_documents() -> None:
+    input_docs = [
+        Document(page_content="I have a pen."),
+        Document(page_content="Do you have a pen?"),
+        Document(page_content="I have a bag."),
+    ]
+    tfidf_retriever = TFIDFRetriever.from_documents(docs=input_docs)
+    assert len(tfidf_retriever.docs) == 3
+    assert tfidf_retriever.tfidf_array.toarray().shape == (3, 5)

--- a/tests/integration_tests/retrievers/test_tfidf.py
+++ b/tests/integration_tests/retrievers/test_tfidf.py
@@ -17,12 +17,13 @@ def test_from_texts_with_tfidf_params() -> None:
     # should count only multiple words (have, pan)
     assert tfidf_retriever.tfidf_array.toarray().shape == (3, 2)
 
+
 def test_from_documents() -> None:
     input_docs = [
         Document(page_content="I have a pen."),
         Document(page_content="Do you have a pen?"),
         Document(page_content="I have a bag."),
     ]
-    tfidf_retriever = TFIDFRetriever.from_documents(docs=input_docs)
+    tfidf_retriever = TFIDFRetriever.from_documents(documents=input_docs)
     assert len(tfidf_retriever.docs) == 3
     assert tfidf_retriever.tfidf_array.toarray().shape == (3, 5)


### PR DESCRIPTION
# `from_documents` in TFiDF retriever

Hello Langchainers, just added this method in the TFiDF retriever as it was useful and it does not break any code, it can be useful in complex chains to have a simple text-based retriever as one of the tools in your toolkits for text matching docs.

## Before submitting

added `test_from_documents` in `tests/integration_tests/retrievers/test_tfidf.py`

## Who can review?
@dev2049
