### PR TITLE
Add from_string to PromptTemplate

### DIFF
--- a/langchain/prompts/prompt.py
+++ b/langchain/prompts/prompt.py
@@ -23,6 +23,30 @@ class PromptTemplate(StringPromptTemplate):
 
             from langchain import PromptTemplate
             prompt = PromptTemplate(input_variables=["foo"], template="Say {foo}")
+
+            # Instantiate from a string template
+            prompt = PromptTemplate.from_string(
+                "Say {foo}"
+            )
+
+            # With partial variables
+            prompt = PromptTemplate.from_string(
+                "Say {foo} {bar}",
+                partial_variables={"foo": "hello world"}
+            )
+            prompt.format(bar="!!")
+
+            # Alternatively, from_template class method
+            prompt = PromptTemplate.from_template(
+                "This is a {foo}, {bar} test."
+                partial_variables={"bar": "!!"}
+            )
+
+            # Which also supports jinja2 templates
+            prompt = PromptTemplate.from_template(
+                jinja2_template, template_format="jinja2"
+            )
+
     """
 
     input_variables: List[str]
@@ -116,6 +140,7 @@ class PromptTemplate(StringPromptTemplate):
             template_file: The path to the file containing the prompt template.
             input_variables: A list of variable names the final prompt template
                 will expect.
+
         Returns:
             The prompt loaded from the file.
         """
@@ -144,6 +169,22 @@ class PromptTemplate(StringPromptTemplate):
         return cls(
             input_variables=list(sorted(input_variables)), template=template, **kwargs
         )
+
+    @classmethod
+    def from_string(cls, string: str, **partial_variables: Any) -> PromptTemplate:
+        """Load a prompt template from a python string.
+
+        A helper method around from_template that is streamlined specifically
+        for python string templates (e.g., "say {foo}").
+
+        Args:
+            string: a python string to use as the template (e.g., "say {foo}")
+            partial_variables: named arguments to use as partials (e.g., {"foo": "bar"})
+
+        Returns:
+            PromptTemplate instance
+        """
+        return cls.from_template(string, partial_variables=partial_variables)
 
 
 # For backwards compatibility.

--- a/tests/unit_tests/prompts/test_prompt.py
+++ b/tests/unit_tests/prompts/test_prompt.py
@@ -1,5 +1,6 @@
 """Test functionality related to prompts."""
 import pytest
+from pydantic import ValidationError
 
 from langchain.prompts.prompt import PromptTemplate
 
@@ -32,6 +33,30 @@ def test_prompt_from_template() -> None:
     prompt = PromptTemplate.from_template(template)
     expected_prompt = PromptTemplate(template=template, input_variables=["bar", "foo"])
     assert prompt == expected_prompt
+
+
+def test_prompt_from_string() -> None:
+    """Test prompt can be constructed from a string template."""
+    template = "This {bar} is a {foo} test {foo}."
+    prompt = PromptTemplate.from_string(template)
+    expected_prompt = PromptTemplate(template=template, input_variables=["bar", "foo"])
+    assert prompt == expected_prompt
+
+    # Multiple input variables with repeats.
+    template = "This {bar} is a {foo} test {foo}."
+    prompt = PromptTemplate.from_string(template)
+    expected_prompt = PromptTemplate(template=template, input_variables=["bar", "foo"])
+    assert prompt == expected_prompt
+
+    template = "This {bar} is a {foo} test {foo}."
+    prompt = PromptTemplate.from_string(template, foo="hello")
+    assert prompt.format(bar="world") == "This world is a hello test hello."
+
+    # Test with invalid partial variables.
+    template = "This {bar} is a {foo} test {foo}."
+
+    with pytest.raises(ValidationError):
+        PromptTemplate.from_string(template, meow="hello")
 
 
 def test_prompt_missing_input_variables() -> None:


### PR DESCRIPTION
# Add from_string to PromptTemplate

This PR adds documentation to PromptTemplate with some examples of how to instantiate the PromptTemplate.

This PR proposes adding a from_string method to make the method easier to discover and use with partial variables.

I understand that we may be opposed to `from_string` to keep number of on-ramps low. One argument for is that
there won't be many templating languages, so it may make more sense to make the
common use case as easy as possible to discover and use.

## Before submitting

## Who can review?
