### PR TITLE
Add link to Psychic from document loaders documentation page

### DIFF
--- a/docs/modules/indexes/document_loaders.rst
+++ b/docs/modules/indexes/document_loaders.rst
@@ -123,6 +123,7 @@ We need access tokens and sometime other parameters to get access to these datas
    ./document_loaders/examples/notiondb.ipynb
    ./document_loaders/examples/notion.ipynb
    ./document_loaders/examples/obsidian.ipynb
+   ./document_loaders/examples/psychic.ipynb
    ./document_loaders/examples/readthedocs_documentation.ipynb
    ./document_loaders/examples/reddit.ipynb
    ./document_loaders/examples/roam.ipynb


### PR DESCRIPTION
# Add link to Psychic from document loaders documentation page

In my previous PR I forgot to update `document_loaders.rst` to link to `psychic.ipynb` to make it discoverable from the main documentation.