### PR TITLE
docs: fix minor typo + add wikipedia package installation part in human_input_llm.ipynb

### DIFF
--- a/docs/modules/models/llms/examples/human_input_llm.ipynb
+++ b/docs/modules/models/llms/examples/human_input_llm.ipynb
@@ -35,6 +35,23 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we use `WikipediaQueryRun` tool here, you might need to install `wikipedia` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install wikipedia"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -217,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.9"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/modules/models/llms/examples/human_input_llm.ipynb
+++ b/docs/modules/models/llms/examples/human_input_llm.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# How (and why) to use the the human input LLM\n",
+    "# How (and why) to use the human input LLM\n",
     "\n",
     "Similar to the fake LLM, LangChain provides a pseudo LLM class that can be used for testing, debugging, or educational purposes. This allows you to mock out calls to the LLM and simulate how a human would respond if they received the prompts.\n",
     "\n",

--- a/docs/modules/models/llms/examples/human_input_llm.ipynb
+++ b/docs/modules/models/llms/examples/human_input_llm.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we use `WikipediaQueryRun` tool here, you might need to install `wikipedia` package."
+    "Since we will use the `WikipediaQueryRun` tool in this notebook, you might need to install the `wikipedia` package if you haven't done so already."
    ]
   },
   {


### PR DESCRIPTION
# Fix typo + add wikipedia package installation part in human_input_llm.ipynb
This PR
1. Fixes typo ("the the human input LLM"), 
2. Addes wikipedia package installation part (in accordance with `WikipediaQueryRun` [documentation](https://python.langchain.com/en/latest/modules/agents/tools/examples/wikipedia.html))

in `human_input_llm.ipynb` (`docs/modules/models/llms/examples/human_input_llm.ipynb`)

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@hwchase17
@agola11
