### PR TITLE
Improve PlanningOutputParser whitespace handling

### DIFF
--- a/langchain/experimental/plan_and_execute/planners/chat_planner.py
+++ b/langchain/experimental/plan_and_execute/planners/chat_planner.py
@@ -25,7 +25,7 @@ SYSTEM_PROMPT = (
 
 class PlanningOutputParser(PlanOutputParser):
     def parse(self, text: str) -> Plan:
-        steps = [Step(value=v) for v in re.split("\n\d+\. ", text)[1:]]
+        steps = [Step(value=v) for v in re.split("\n\s*\d+\. ", text)[1:]]
         return Plan(steps=steps)
 
 


### PR DESCRIPTION
Some LLM's will produce numbered lists with leading whitespace, i.e. in response to "What is the sum of 2 and 3?":
```
Plan:
  1. Add 2 and 3.
  2. Given the above steps taken, please respond to the users original question.
```
This commit updates the PlanningOutputParser regex to ignore leading whitespace before the step number, enabling it to correctly parse this format.