### PR TITLE
Clarification of the reference to the "get_text_legth" function in ge…

### DIFF
--- a/docs/modules/prompts/prompt_templates/getting_started.md
+++ b/docs/modules/prompts/prompt_templates/getting_started.md
@@ -229,7 +229,11 @@ example_selector = LengthBasedExampleSelector(
     example_prompt=example_prompt, 
     # This is the maximum length that the formatted examples should be.
     # Length is measured by the get_text_length function below.
-    max_length=25,
+    max_length=25
+    # This is the function used to get the length of a string, which is used
+    # to determine which examples to include. It is commented out because
+    # it is provided as a default value if none is specified.
+    # get_text_length: Callable[[str], int] = lambda x: len(re.split("\n| ", x))
 )
 
 # We can now use the `example_selector` to create a `FewShotPromptTemplate`.


### PR DESCRIPTION
# Clarification of the reference to the "get_text_legth" function in getting_started.md

Reference to the function "get_text_legth" in the documentation did not make sense. Comment added for clarification.

@hwchase17 