### PR TITLE
Output parsing variation allowance

### DIFF
--- a/langchain/agents/self_ask_with_search/output_parser.py
+++ b/langchain/agents/self_ask_with_search/output_parser.py
@@ -1,4 +1,4 @@
-from typing import Union, Sequence
+from typing import Sequence, Union
 
 from langchain.agents.agent import AgentOutputParser
 from langchain.schema import AgentAction, AgentFinish, OutputParserException
@@ -13,7 +13,7 @@ class SelfAskOutputParser(AgentOutputParser):
         if not any([follow in last_line for follow in self.followups]):
             if self.finish_string not in last_line:
                 raise OutputParserException(f"Could not parse output: {text}")
-            return AgentFinish({"output": last_line[len(self.finish_string):]}, text)
+            return AgentFinish({"output": last_line[len(self.finish_string) :]}, text)
 
         after_colon = text.split(":")[-1].strip()
         return AgentAction("Intermediate Answer", after_colon, text)

--- a/langchain/agents/self_ask_with_search/output_parser.py
+++ b/langchain/agents/self_ask_with_search/output_parser.py
@@ -1,29 +1,21 @@
-from typing import Union
+from typing import Union, Sequence
 
 from langchain.agents.agent import AgentOutputParser
 from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 
 class SelfAskOutputParser(AgentOutputParser):
+    followups: Sequence[str] = ("Follow up:", "Followup:")
+    finish_string: str = "So the final answer is: "
+
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        followup = ["Follow up:", "Followup:"]
         last_line = text.split("\n")[-1]
-
-        followup_present = False
-        for phrase in followup:
-            if phrase in last_line:
-                followup_present = True
-
-        if not followup_present:
-            finish_string = "So the final answer is: "
-            if finish_string not in last_line:
+        if not any([follow in last_line for follow in self.followups]):
+            if self.finish_string not in last_line:
                 raise OutputParserException(f"Could not parse output: {text}")
-            return AgentFinish({"output": last_line[len(finish_string) :]}, text)
+            return AgentFinish({"output": last_line[len(self.finish_string):]}, text)
 
-        after_colon = text.split(":")[-1]
-
-        if " " == after_colon[0]:
-            after_colon = after_colon[1:]
+        after_colon = text.split(":")[-1].strip()
         return AgentAction("Intermediate Answer", after_colon, text)
 
     @property

--- a/langchain/agents/self_ask_with_search/output_parser.py
+++ b/langchain/agents/self_ask_with_search/output_parser.py
@@ -6,10 +6,15 @@ from langchain.schema import AgentAction, AgentFinish, OutputParserException
 
 class SelfAskOutputParser(AgentOutputParser):
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        followup = "Follow up:"
+        followup = ["Follow up:", "Followup:"]
         last_line = text.split("\n")[-1]
 
-        if followup not in last_line:
+        followup_present = False
+        for phrase in followup:
+            if phrase in last_line:
+                followup_present = True
+
+        if not followup_present:
             finish_string = "So the final answer is: "
             if finish_string not in last_line:
                 raise OutputParserException(f"Could not parse output: {text}")


### PR DESCRIPTION
# Output parsing variation allowance for self-ask with search

This change makes self-ask with search easier for Llama models to follow, as they tend toward returning 'Followup:' instead of 'Follow up:' despite an otherwise valid remaining output.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@vowelparrot 

Thank you for considering this small change!
