### PR TITLE
Allow to specify ID when adding to the FAISS vectorstore.

### DIFF
--- a/docs/modules/agents/agents/examples/structured_chat.ipynb
+++ b/docs/modules/agents/agents/examples/structured_chat.ipynb
@@ -27,18 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "cc0f8a07",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import langchain\n",
-    "langchain.debug = True"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "f65308ab",
    "metadata": {
     "tags": []
@@ -62,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "71027ff2-5d09-49cd-92a1-24b2c454a7ae",
    "metadata": {
     "tags": []
@@ -82,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "5fb14d6d",
    "metadata": {
     "tags": []
@@ -96,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "cafe9bc1",
    "metadata": {
     "tags": []
@@ -109,96 +98,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "4f4aa234-9746-47d8-bec7-d76081ac3ef6",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Failed to load default session, using empty session: Expecting value: line 2 column 1 (char 1)\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32;1m\u001b[1;3m[chain/start]\u001b[0m \u001b[1m[1:chain:AgentExecutor] Entering Chain run with input:\n",
-      "\u001b[0m{\n",
-      "  \"input\": \"Hi I'm Erica.\"\n",
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mAction:\n",
+      "```\n",
+      "{\n",
+      "  \"action\": \"Final Answer\",\n",
+      "  \"action_input\": \"Hello Erica, how can I assist you today?\"\n",
       "}\n",
-      "\u001b[32;1m\u001b[1;3m[chain/start]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain] Entering Chain run with input:\n",
-      "\u001b[0m{\n",
-      "  \"input\": \"Hi I'm Erica.\",\n",
-      "  \"agent_scratchpad\": \"\",\n",
-      "  \"stop\": [\n",
-      "    \"Observation:\"\n",
-      "  ]\n",
-      "}\n",
-      "\u001b[32;1m\u001b[1;3m[llm/start]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain > 3:llm:ChatOpenAI] Entering LLM run with input:\n",
-      "\u001b[0m{\n",
-      "  \"prompts\": [\n",
-      "    \"System: Respond to the human as helpfully and accurately as possible. You have access to the following tools:\\n\\nclick_element: Click on an element with the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': 'CSS selector for the element to click', 'type': 'string'}}}}\\nnavigate_browser: Navigate a browser to the specified URL, args: {{'url': {{'title': 'Url', 'description': 'url to navigate to', 'type': 'string'}}}}\\nprevious_webpage: Navigate back to the previous page in the browser history, args: {{}}\\nextract_text: Extract all the text on the current webpage, args: {{}}\\nextract_hyperlinks: Extract all hyperlinks on the current webpage, args: {{'absolute_urls': {{'title': 'Absolute Urls', 'description': 'Return absolute URLs instead of relative URLs', 'default': False, 'type': 'boolean'}}}}\\nget_elements: Retrieve elements in the current web page matching the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': \\\"CSS selector, such as '*', 'div', 'p', 'a', #id, .classname\\\", 'type': 'string'}}, 'attributes': {{'title': 'Attributes', 'description': 'Set of attributes to retrieve for each element', 'type': 'array', 'items': {{'type': 'string'}}}}}}\\ncurrent_webpage: Returns the URL of the current page, args: {{}}\\n\\nUse a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).\\n\\nValid \\\"action\\\" values: \\\"Final Answer\\\" or click_element, navigate_browser, previous_webpage, extract_text, extract_hyperlinks, get_elements, current_webpage\\n\\nProvide only ONE action per $JSON_BLOB, as shown:\\n\\n```\\n{\\n  \\\"action\\\": $TOOL_NAME,\\n  \\\"action_input\\\": $INPUT\\n}\\n```\\n\\nFollow this format:\\n\\nQuestion: input question to answer\\nThought: consider previous and subsequent steps\\nAction:\\n```\\n$JSON_BLOB\\n```\\nObservation: action result\\n... (repeat Thought/Action/Observation N times)\\nThought: I know what to respond\\nAction:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Final response to human\\\"\\n}\\n```\\n\\nBegin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:```$JSON_BLOB```then Observation:.\\nThought:\\nHuman: Hi I'm Erica.\"\n",
-      "  ]\n",
-      "}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Failed to persist run: \n",
-      "<html><head>\n",
-      "<meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n",
-      "<title>404 Page not found</title>\n",
-      "</head>\n",
-      "<body text=#000000 bgcolor=#ffffff>\n",
-      "<h1>Error: Page not found</h1>\n",
-      "<h2>The requested URL was not found on this server.</h2>\n",
-      "<h2></h2>\n",
-      "</body></html>\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36;1m\u001b[1;3m[llm/end]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain > 3:llm:ChatOpenAI] [3.40s] Exiting LLM run with output:\n",
-      "\u001b[0m{\n",
-      "  \"generations\": [\n",
-      "    [\n",
-      "      {\n",
-      "        \"text\": \"Action:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Hello Erica, how can I assist you today?\\\"\\n}\\n```\\n\",\n",
-      "        \"generation_info\": null,\n",
-      "        \"message\": {\n",
-      "          \"content\": \"Action:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Hello Erica, how can I assist you today?\\\"\\n}\\n```\\n\",\n",
-      "          \"additional_kwargs\": {},\n",
-      "          \"example\": false\n",
-      "        }\n",
-      "      }\n",
-      "    ]\n",
-      "  ],\n",
-      "  \"llm_output\": {\n",
-      "    \"token_usage\": {\n",
-      "      \"prompt_tokens\": 551,\n",
-      "      \"completion_tokens\": 32,\n",
-      "      \"total_tokens\": 583\n",
-      "    },\n",
-      "    \"model_name\": \"gpt-3.5-turbo\"\n",
-      "  }\n",
-      "}\n",
-      "\u001b[36;1m\u001b[1;3m[chain/end]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain] [8.38s] Exiting Chain run with output:\n",
-      "\u001b[0m{\n",
-      "  \"text\": \"Action:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Hello Erica, how can I assist you today?\\\"\\n}\\n```\\n\"\n",
-      "}\n",
-      "\u001b[36;1m\u001b[1;3m[chain/end]\u001b[0m \u001b[1m[1:chain:AgentExecutor] [13.29s] Exiting Chain run with output:\n",
-      "\u001b[0m{\n",
-      "  \"output\": \"Hello Erica, how can I assist you today?\"\n",
-      "}\n",
+      "```\n",
+      "\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n",
       "Hello Erica, how can I assist you today?\n"
      ]
     }
@@ -358,68 +280,6 @@
    "source": [
     "response = await agent_chain.arun(input=\"What's the latest xkcd comic about?\")\n",
     "print(response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "e8baf711",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "System: Respond to the human as helpfully and accurately as possible. You have access to the following tools:\n",
-      "\n",
-      "click_element: Click on an element with the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': 'CSS selector for the element to click', 'type': 'string'}}}}\n",
-      "navigate_browser: Navigate a browser to the specified URL, args: {{'url': {{'title': 'Url', 'description': 'url to navigate to', 'type': 'string'}}}}\n",
-      "previous_webpage: Navigate back to the previous page in the browser history, args: {{}}\n",
-      "extract_text: Extract all the text on the current webpage, args: {{}}\n",
-      "extract_hyperlinks: Extract all hyperlinks on the current webpage, args: {{'absolute_urls': {{'title': 'Absolute Urls', 'description': 'Return absolute URLs instead of relative URLs', 'default': False, 'type': 'boolean'}}}}\n",
-      "get_elements: Retrieve elements in the current web page matching the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': \"CSS selector, such as '*', 'div', 'p', 'a', #id, .classname\", 'type': 'string'}}, 'attributes': {{'title': 'Attributes', 'description': 'Set of attributes to retrieve for each element', 'type': 'array', 'items': {{'type': 'string'}}}}}}\n",
-      "current_webpage: Returns the URL of the current page, args: {{}}\n",
-      "\n",
-      "Use a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).\n",
-      "\n",
-      "Valid \"action\" values: \"Final Answer\" or click_element, navigate_browser, previous_webpage, extract_text, extract_hyperlinks, get_elements, current_webpage\n",
-      "\n",
-      "Provide only ONE action per $JSON_BLOB, as shown:\n",
-      "\n",
-      "```\n",
-      "{\n",
-      "  \"action\": $TOOL_NAME,\n",
-      "  \"action_input\": $INPUT\n",
-      "}\n",
-      "```\n",
-      "\n",
-      "Follow this format:\n",
-      "\n",
-      "Question: input question to answer\n",
-      "Thought: consider previous and subsequent steps\n",
-      "Action:\n",
-      "```\n",
-      "$JSON_BLOB\n",
-      "```\n",
-      "Observation: action result\n",
-      "... (repeat Thought/Action/Observation N times)\n",
-      "Thought: I know what to respond\n",
-      "Action:\n",
-      "```\n",
-      "{\n",
-      "  \"action\": \"Final Answer\",\n",
-      "  \"action_input\": \"Final response to human\"\n",
-      "}\n",
-      "```\n",
-      "\n",
-      "Begin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:```$JSON_BLOB```then Observation:.\n",
-      "Thought:\n",
-      "Human: Hi I'm Erica.\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"\"\"System: Respond to the human as helpfully and accurately as possible. You have access to the following tools:\\n\\nclick_element: Click on an element with the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': 'CSS selector for the element to click', 'type': 'string'}}}}\\nnavigate_browser: Navigate a browser to the specified URL, args: {{'url': {{'title': 'Url', 'description': 'url to navigate to', 'type': 'string'}}}}\\nprevious_webpage: Navigate back to the previous page in the browser history, args: {{}}\\nextract_text: Extract all the text on the current webpage, args: {{}}\\nextract_hyperlinks: Extract all hyperlinks on the current webpage, args: {{'absolute_urls': {{'title': 'Absolute Urls', 'description': 'Return absolute URLs instead of relative URLs', 'default': False, 'type': 'boolean'}}}}\\nget_elements: Retrieve elements in the current web page matching the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': \\\"CSS selector, such as '*', 'div', 'p', 'a', #id, .classname\\\", 'type': 'string'}}, 'attributes': {{'title': 'Attributes', 'description': 'Set of attributes to retrieve for each element', 'type': 'array', 'items': {{'type': 'string'}}}}}}\\ncurrent_webpage: Returns the URL of the current page, args: {{}}\\n\\nUse a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).\\n\\nValid \\\"action\\\" values: \\\"Final Answer\\\" or click_element, navigate_browser, previous_webpage, extract_text, extract_hyperlinks, get_elements, current_webpage\\n\\nProvide only ONE action per $JSON_BLOB, as shown:\\n\\n```\\n{\\n  \\\"action\\\": $TOOL_NAME,\\n  \\\"action_input\\\": $INPUT\\n}\\n```\\n\\nFollow this format:\\n\\nQuestion: input question to answer\\nThought: consider previous and subsequent steps\\nAction:\\n```\\n$JSON_BLOB\\n```\\nObservation: action result\\n... (repeat Thought/Action/Observation N times)\\nThought: I know what to respond\\nAction:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Final response to human\\\"\\n}\\n```\\n\\nBegin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:```$JSON_BLOB```then Observation:.\\nThought:\\nHuman: Hi I'm Erica.\"\"\")"
    ]
   },
   {

--- a/docs/modules/agents/agents/examples/structured_chat.ipynb
+++ b/docs/modules/agents/agents/examples/structured_chat.ipynb
@@ -27,7 +27,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "id": "cc0f8a07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import langchain\n",
+    "langchain.debug = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "f65308ab",
    "metadata": {
     "tags": []
@@ -51,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "71027ff2-5d09-49cd-92a1-24b2c454a7ae",
    "metadata": {
     "tags": []
@@ -71,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "5fb14d6d",
    "metadata": {
     "tags": []
@@ -85,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "cafe9bc1",
    "metadata": {
     "tags": []
@@ -98,29 +109,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "4f4aa234-9746-47d8-bec7-d76081ac3ef6",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Failed to load default session, using empty session: Expecting value: line 2 column 1 (char 1)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "\n",
-      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
-      "\u001b[32;1m\u001b[1;3mAction:\n",
-      "```\n",
-      "{\n",
-      "  \"action\": \"Final Answer\",\n",
-      "  \"action_input\": \"Hello Erica, how can I assist you today?\"\n",
+      "\u001b[32;1m\u001b[1;3m[chain/start]\u001b[0m \u001b[1m[1:chain:AgentExecutor] Entering Chain run with input:\n",
+      "\u001b[0m{\n",
+      "  \"input\": \"Hi I'm Erica.\"\n",
       "}\n",
-      "```\n",
-      "\u001b[0m\n",
-      "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m[chain/start]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain] Entering Chain run with input:\n",
+      "\u001b[0m{\n",
+      "  \"input\": \"Hi I'm Erica.\",\n",
+      "  \"agent_scratchpad\": \"\",\n",
+      "  \"stop\": [\n",
+      "    \"Observation:\"\n",
+      "  ]\n",
+      "}\n",
+      "\u001b[32;1m\u001b[1;3m[llm/start]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain > 3:llm:ChatOpenAI] Entering LLM run with input:\n",
+      "\u001b[0m{\n",
+      "  \"prompts\": [\n",
+      "    \"System: Respond to the human as helpfully and accurately as possible. You have access to the following tools:\\n\\nclick_element: Click on an element with the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': 'CSS selector for the element to click', 'type': 'string'}}}}\\nnavigate_browser: Navigate a browser to the specified URL, args: {{'url': {{'title': 'Url', 'description': 'url to navigate to', 'type': 'string'}}}}\\nprevious_webpage: Navigate back to the previous page in the browser history, args: {{}}\\nextract_text: Extract all the text on the current webpage, args: {{}}\\nextract_hyperlinks: Extract all hyperlinks on the current webpage, args: {{'absolute_urls': {{'title': 'Absolute Urls', 'description': 'Return absolute URLs instead of relative URLs', 'default': False, 'type': 'boolean'}}}}\\nget_elements: Retrieve elements in the current web page matching the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': \\\"CSS selector, such as '*', 'div', 'p', 'a', #id, .classname\\\", 'type': 'string'}}, 'attributes': {{'title': 'Attributes', 'description': 'Set of attributes to retrieve for each element', 'type': 'array', 'items': {{'type': 'string'}}}}}}\\ncurrent_webpage: Returns the URL of the current page, args: {{}}\\n\\nUse a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).\\n\\nValid \\\"action\\\" values: \\\"Final Answer\\\" or click_element, navigate_browser, previous_webpage, extract_text, extract_hyperlinks, get_elements, current_webpage\\n\\nProvide only ONE action per $JSON_BLOB, as shown:\\n\\n```\\n{\\n  \\\"action\\\": $TOOL_NAME,\\n  \\\"action_input\\\": $INPUT\\n}\\n```\\n\\nFollow this format:\\n\\nQuestion: input question to answer\\nThought: consider previous and subsequent steps\\nAction:\\n```\\n$JSON_BLOB\\n```\\nObservation: action result\\n... (repeat Thought/Action/Observation N times)\\nThought: I know what to respond\\nAction:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Final response to human\\\"\\n}\\n```\\n\\nBegin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:```$JSON_BLOB```then Observation:.\\nThought:\\nHuman: Hi I'm Erica.\"\n",
+      "  ]\n",
+      "}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Failed to persist run: \n",
+      "<html><head>\n",
+      "<meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n",
+      "<title>404 Page not found</title>\n",
+      "</head>\n",
+      "<body text=#000000 bgcolor=#ffffff>\n",
+      "<h1>Error: Page not found</h1>\n",
+      "<h2>The requested URL was not found on this server.</h2>\n",
+      "<h2></h2>\n",
+      "</body></html>\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36;1m\u001b[1;3m[llm/end]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain > 3:llm:ChatOpenAI] [3.40s] Exiting LLM run with output:\n",
+      "\u001b[0m{\n",
+      "  \"generations\": [\n",
+      "    [\n",
+      "      {\n",
+      "        \"text\": \"Action:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Hello Erica, how can I assist you today?\\\"\\n}\\n```\\n\",\n",
+      "        \"generation_info\": null,\n",
+      "        \"message\": {\n",
+      "          \"content\": \"Action:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Hello Erica, how can I assist you today?\\\"\\n}\\n```\\n\",\n",
+      "          \"additional_kwargs\": {},\n",
+      "          \"example\": false\n",
+      "        }\n",
+      "      }\n",
+      "    ]\n",
+      "  ],\n",
+      "  \"llm_output\": {\n",
+      "    \"token_usage\": {\n",
+      "      \"prompt_tokens\": 551,\n",
+      "      \"completion_tokens\": 32,\n",
+      "      \"total_tokens\": 583\n",
+      "    },\n",
+      "    \"model_name\": \"gpt-3.5-turbo\"\n",
+      "  }\n",
+      "}\n",
+      "\u001b[36;1m\u001b[1;3m[chain/end]\u001b[0m \u001b[1m[1:chain:AgentExecutor > 2:chain:LLMChain] [8.38s] Exiting Chain run with output:\n",
+      "\u001b[0m{\n",
+      "  \"text\": \"Action:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Hello Erica, how can I assist you today?\\\"\\n}\\n```\\n\"\n",
+      "}\n",
+      "\u001b[36;1m\u001b[1;3m[chain/end]\u001b[0m \u001b[1m[1:chain:AgentExecutor] [13.29s] Exiting Chain run with output:\n",
+      "\u001b[0m{\n",
+      "  \"output\": \"Hello Erica, how can I assist you today?\"\n",
+      "}\n",
       "Hello Erica, how can I assist you today?\n"
      ]
     }
@@ -280,6 +358,68 @@
    "source": [
     "response = await agent_chain.arun(input=\"What's the latest xkcd comic about?\")\n",
     "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e8baf711",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "System: Respond to the human as helpfully and accurately as possible. You have access to the following tools:\n",
+      "\n",
+      "click_element: Click on an element with the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': 'CSS selector for the element to click', 'type': 'string'}}}}\n",
+      "navigate_browser: Navigate a browser to the specified URL, args: {{'url': {{'title': 'Url', 'description': 'url to navigate to', 'type': 'string'}}}}\n",
+      "previous_webpage: Navigate back to the previous page in the browser history, args: {{}}\n",
+      "extract_text: Extract all the text on the current webpage, args: {{}}\n",
+      "extract_hyperlinks: Extract all hyperlinks on the current webpage, args: {{'absolute_urls': {{'title': 'Absolute Urls', 'description': 'Return absolute URLs instead of relative URLs', 'default': False, 'type': 'boolean'}}}}\n",
+      "get_elements: Retrieve elements in the current web page matching the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': \"CSS selector, such as '*', 'div', 'p', 'a', #id, .classname\", 'type': 'string'}}, 'attributes': {{'title': 'Attributes', 'description': 'Set of attributes to retrieve for each element', 'type': 'array', 'items': {{'type': 'string'}}}}}}\n",
+      "current_webpage: Returns the URL of the current page, args: {{}}\n",
+      "\n",
+      "Use a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).\n",
+      "\n",
+      "Valid \"action\" values: \"Final Answer\" or click_element, navigate_browser, previous_webpage, extract_text, extract_hyperlinks, get_elements, current_webpage\n",
+      "\n",
+      "Provide only ONE action per $JSON_BLOB, as shown:\n",
+      "\n",
+      "```\n",
+      "{\n",
+      "  \"action\": $TOOL_NAME,\n",
+      "  \"action_input\": $INPUT\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Follow this format:\n",
+      "\n",
+      "Question: input question to answer\n",
+      "Thought: consider previous and subsequent steps\n",
+      "Action:\n",
+      "```\n",
+      "$JSON_BLOB\n",
+      "```\n",
+      "Observation: action result\n",
+      "... (repeat Thought/Action/Observation N times)\n",
+      "Thought: I know what to respond\n",
+      "Action:\n",
+      "```\n",
+      "{\n",
+      "  \"action\": \"Final Answer\",\n",
+      "  \"action_input\": \"Final response to human\"\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Begin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:```$JSON_BLOB```then Observation:.\n",
+      "Thought:\n",
+      "Human: Hi I'm Erica.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\"\"System: Respond to the human as helpfully and accurately as possible. You have access to the following tools:\\n\\nclick_element: Click on an element with the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': 'CSS selector for the element to click', 'type': 'string'}}}}\\nnavigate_browser: Navigate a browser to the specified URL, args: {{'url': {{'title': 'Url', 'description': 'url to navigate to', 'type': 'string'}}}}\\nprevious_webpage: Navigate back to the previous page in the browser history, args: {{}}\\nextract_text: Extract all the text on the current webpage, args: {{}}\\nextract_hyperlinks: Extract all hyperlinks on the current webpage, args: {{'absolute_urls': {{'title': 'Absolute Urls', 'description': 'Return absolute URLs instead of relative URLs', 'default': False, 'type': 'boolean'}}}}\\nget_elements: Retrieve elements in the current web page matching the given CSS selector, args: {{'selector': {{'title': 'Selector', 'description': \\\"CSS selector, such as '*', 'div', 'p', 'a', #id, .classname\\\", 'type': 'string'}}, 'attributes': {{'title': 'Attributes', 'description': 'Set of attributes to retrieve for each element', 'type': 'array', 'items': {{'type': 'string'}}}}}}\\ncurrent_webpage: Returns the URL of the current page, args: {{}}\\n\\nUse a json blob to specify a tool by providing an action key (tool name) and an action_input key (tool input).\\n\\nValid \\\"action\\\" values: \\\"Final Answer\\\" or click_element, navigate_browser, previous_webpage, extract_text, extract_hyperlinks, get_elements, current_webpage\\n\\nProvide only ONE action per $JSON_BLOB, as shown:\\n\\n```\\n{\\n  \\\"action\\\": $TOOL_NAME,\\n  \\\"action_input\\\": $INPUT\\n}\\n```\\n\\nFollow this format:\\n\\nQuestion: input question to answer\\nThought: consider previous and subsequent steps\\nAction:\\n```\\n$JSON_BLOB\\n```\\nObservation: action result\\n... (repeat Thought/Action/Observation N times)\\nThought: I know what to respond\\nAction:\\n```\\n{\\n  \\\"action\\\": \\\"Final Answer\\\",\\n  \\\"action_input\\\": \\\"Final response to human\\\"\\n}\\n```\\n\\nBegin! Reminder to ALWAYS respond with a valid json blob of a single action. Use tools if necessary. Respond directly if appropriate. Format is Action:```$JSON_BLOB```then Observation:.\\nThought:\\nHuman: Hi I'm Erica.\"\"\")"
    ]
   },
   {

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -391,7 +391,7 @@ class FAISS(VectorStore):
             documents.append(Document(page_content=text, metadata=metadata))
         index_to_id = dict(enumerate(ids))
         docstore = InMemoryDocstore(
-            dict(zip(index_to_id, documents))
+            dict(zip(index_to_id.values(), documents))
         )
         return cls(
             embedding.embed_query,

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -118,10 +118,7 @@ class FAISS(VectorStore):
             faiss.normalize_L2(vector)
         self.index.add(vector)
         # Get list of index, id, and docs.
-        full_info = [
-            (starting_len + i, ids[i], doc)
-            for i, doc in enumerate(documents)
-        ]
+        full_info = [(starting_len + i, ids[i], doc) for i, doc in enumerate(documents)]
         # Add information to docstore and index.
         self.docstore.add({_id: doc for _, _id, doc in full_info})
         index_to_id = {index: _id for index, _id, _ in full_info}
@@ -152,7 +149,7 @@ class FAISS(VectorStore):
             )
         # Embed and create the documents.
         embeddings = [self.embedding_function(text) for text in texts]
-        return self.__add(texts, embeddings, metadatas, ids, **kwargs)
+        return self.__add(texts, embeddings, metadatas=metadatas, ids=ids, **kwargs)
 
     def add_embeddings(
         self,
@@ -181,7 +178,7 @@ class FAISS(VectorStore):
 
         texts = [te[0] for te in text_embeddings]
         embeddings = [te[1] for te in text_embeddings]
-        return self.__add(texts, embeddings, metadatas, ids, **kwargs)
+        return self.__add(texts, embeddings, metadatas=metadatas, ids=ids, **kwargs)
 
     def similarity_search_with_score_by_vector(
         self, embedding: List[float], k: int = 4
@@ -390,9 +387,7 @@ class FAISS(VectorStore):
             metadata = metadatas[i] if metadatas else {}
             documents.append(Document(page_content=text, metadata=metadata))
         index_to_id = dict(enumerate(ids))
-        docstore = InMemoryDocstore(
-            dict(zip(index_to_id.values(), documents))
-        )
+        docstore = InMemoryDocstore(dict(zip(index_to_id.values(), documents)))
         return cls(
             embedding.embed_query,
             index,
@@ -433,8 +428,8 @@ class FAISS(VectorStore):
             texts,
             embeddings,
             embedding,
-            metadatas,
-            ids,
+            metadatas=metadatas,
+            ids=ids,
             **kwargs,
         )
 
@@ -472,8 +467,8 @@ class FAISS(VectorStore):
             texts,
             embeddings,
             embedding,
-            metadatas,
-            ids,
+            metadatas=metadatas,
+            ids=ids,
             **kwargs,
         )
 

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -132,6 +132,7 @@ class FAISS(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> List[str]:
         """Run more texts through the embeddings and add to the vectorstore.
@@ -139,6 +140,7 @@ class FAISS(VectorStore):
         Args:
             texts: Iterable of strings to add to the vectorstore.
             metadatas: Optional list of metadatas associated with the texts.
+            ids: Optional list of unique IDs.
 
         Returns:
             List of ids from adding the texts into the vectorstore.
@@ -156,6 +158,7 @@ class FAISS(VectorStore):
         self,
         text_embeddings: Iterable[Tuple[str, List[float]]],
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> List[str]:
         """Run more texts through the embeddings and add to the vectorstore.
@@ -164,6 +167,7 @@ class FAISS(VectorStore):
             text_embeddings: Iterable pairs of string and embedding to
                 add to the vectorstore.
             metadatas: Optional list of metadatas associated with the texts.
+            ids: Optional list of unique IDs.
 
         Returns:
             List of ids from adding the texts into the vectorstore.
@@ -404,6 +408,7 @@ class FAISS(VectorStore):
         texts: List[str],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> FAISS:
         """Construct FAISS wrapper from raw documents.
@@ -438,6 +443,7 @@ class FAISS(VectorStore):
         text_embeddings: List[Tuple[str, List[float]]],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> FAISS:
         """Construct FAISS wrapper from raw documents.

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -152,7 +152,7 @@ class FAISS(VectorStore):
             )
         # Embed and create the documents.
         embeddings = [self.embedding_function(text) for text in texts]
-        return self.__add(texts, embeddings, metadatas, **kwargs)
+        return self.__add(texts, embeddings, metadatas, ids, **kwargs)
 
     def add_embeddings(
         self,
@@ -181,7 +181,7 @@ class FAISS(VectorStore):
 
         texts = [te[0] for te in text_embeddings]
         embeddings = [te[1] for te in text_embeddings]
-        return self.__add(texts, embeddings, metadatas, **kwargs)
+        return self.__add(texts, embeddings, metadatas, ids, **kwargs)
 
     def similarity_search_with_score_by_vector(
         self, embedding: List[float], k: int = 4
@@ -434,6 +434,7 @@ class FAISS(VectorStore):
             embeddings,
             embedding,
             metadatas,
+            ids,
             **kwargs,
         )
 
@@ -472,6 +473,7 @@ class FAISS(VectorStore):
             embeddings,
             embedding,
             metadatas,
+            ids,
             **kwargs,
         )
 


### PR DESCRIPTION
# Allow to specify ID when adding to the FAISS vectorstore

This change allows unique IDs to be specified when adding documents / embeddings to a faiss vectorstore.

- This reflects the current approach with the chroma vectorstore.
- It allows rejection of inserts on duplicate IDs
- will allow deletion / update by searching on deterministic ID (such as a hash).
- If not specified, a random UUID is generated (as per previous behaviour, so non-breaking).

This commit fixes #5065 and #3896 and should fix #2699 indirectly. I've tested adding and merging.

Kindly tagging @Xmaster6y @dev2049 for review.