### PR TITLE
Fixes scope of query Session in PGVector

### DIFF
--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -298,15 +298,17 @@ class PGVector(VectorStore):
                 for key, value in filter.items():
                     IN = "in"
                     if isinstance(value, dict) and IN in map(str.lower, value):
-                        value_case_insensitive = {k.lower(): v for k, v in value.items()}
+                        value_case_insensitive = {
+                            k.lower(): v for k, v in value.items()
+                        }
                         filter_by_metadata = EmbeddingStore.cmetadata[key].astext.in_(
                             value_case_insensitive[IN]
                         )
                         filter_clauses.append(filter_by_metadata)
                     else:
-                        filter_by_metadata = EmbeddingStore.cmetadata[key].astext == str(
-                            value
-                        )
+                        filter_by_metadata = EmbeddingStore.cmetadata[
+                            key
+                        ].astext == str(value)
                         filter_clauses.append(filter_by_metadata)
 
                 filter_by = sqlalchemy.and_(filter_by, *filter_clauses)

--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -291,40 +291,41 @@ class PGVector(VectorStore):
             if not collection:
                 raise ValueError("Collection not found")
 
-        filter_by = EmbeddingStore.collection_id == collection.uuid
+            filter_by = EmbeddingStore.collection_id == collection.uuid
 
-        if filter is not None:
-            filter_clauses = []
-            for key, value in filter.items():
-                IN = "in"
-                if isinstance(value, dict) and IN in map(str.lower, value):
-                    value_case_insensitive = {k.lower(): v for k, v in value.items()}
-                    filter_by_metadata = EmbeddingStore.cmetadata[key].astext.in_(
-                        value_case_insensitive[IN]
-                    )
-                    filter_clauses.append(filter_by_metadata)
-                else:
-                    filter_by_metadata = EmbeddingStore.cmetadata[key].astext == str(
-                        value
-                    )
-                    filter_clauses.append(filter_by_metadata)
+            if filter is not None:
+                filter_clauses = []
+                for key, value in filter.items():
+                    IN = "in"
+                    if isinstance(value, dict) and IN in map(str.lower, value):
+                        value_case_insensitive = {k.lower(): v for k, v in value.items()}
+                        filter_by_metadata = EmbeddingStore.cmetadata[key].astext.in_(
+                            value_case_insensitive[IN]
+                        )
+                        filter_clauses.append(filter_by_metadata)
+                    else:
+                        filter_by_metadata = EmbeddingStore.cmetadata[key].astext == str(
+                            value
+                        )
+                        filter_clauses.append(filter_by_metadata)
 
-            filter_by = sqlalchemy.and_(filter_by, *filter_clauses)
+                filter_by = sqlalchemy.and_(filter_by, *filter_clauses)
 
-        results: List[QueryResult] = (
-            session.query(
-                EmbeddingStore,
-                self.distance_strategy(embedding).label("distance"),  # type: ignore
+            results: List[QueryResult] = (
+                session.query(
+                    EmbeddingStore,
+                    self.distance_strategy(embedding).label("distance"),  # type: ignore
+                )
+                .filter(filter_by)
+                .order_by(sqlalchemy.asc("distance"))
+                .join(
+                    CollectionStore,
+                    EmbeddingStore.collection_id == CollectionStore.uuid,
+                )
+                .limit(k)
+                .all()
             )
-            .filter(filter_by)
-            .order_by(sqlalchemy.asc("distance"))
-            .join(
-                CollectionStore,
-                EmbeddingStore.collection_id == CollectionStore.uuid,
-            )
-            .limit(k)
-            .all()
-        )
+
         docs = [
             (
                 Document(


### PR DESCRIPTION
`vectorstore.PGVector`: The transactional boundary should be increased to cover the query itself

Currently, within the `similarity_search_with_score_by_vector` the transactional boundary (created via the `Session` call) does not include the select query being made.

This can result in un-intended consequences when interacting with the PGVector instance methods directly

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

For a quicker response, figure out the right person to tag with @
        
VectorStores / Retrievers / Memory
- @dev2049
        
