### PR TITLE
Create async copy of from_text() inside GraphIndexCreator.

### DIFF
--- a/langchain/indexes/graph.py
+++ b/langchain/indexes/graph.py
@@ -28,3 +28,15 @@ class GraphIndexCreator(BaseModel):
         for triple in knowledge:
             graph.add_triple(triple)
         return graph
+
+    async def afrom_text(self, text: str) -> NetworkxEntityGraph:
+        """Create graph index from text asynchronously."""
+        if self.llm is None:
+            raise ValueError("llm should not be None")
+        graph = self.graph_type()
+        chain = LLMChain(llm=self.llm, prompt=KNOWLEDGE_TRIPLE_EXTRACTION_PROMPT)
+        output = await chain.apredict(text=text)
+        knowledge = parse_triples(output)
+        for triple in knowledge:
+            graph.add_triple(triple)
+        return graph


### PR DESCRIPTION
Copies `GraphIndexCreator.from_text()` to make an async version called `GraphIndexCreator.afrom_text()`.

This is (should be) a trivial change: it just adds a copy of `GraphIndexCreator.from_text()` which is async and awaits a call to `chain.apredict()` instead of `chain.predict()`.  There is no unit test for GraphIndexCreator, and I did not create one, but this code works for me locally.

@agola11 @hwchase17
