### PR TITLE
Update the parameters of the<openai. embedding. create>interface

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -187,7 +187,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     # please refer to
     # https://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb
     def _get_len_safe_embeddings(
-        self, texts: List[str], *, model: str, chunk_size: Optional[int] = None
+        self, texts: List[str], *, engine: str, chunk_size: Optional[int] = None
     ) -> List[List[float]]:
         embeddings: List[List[float]] = [[] for _ in range(len(texts))]
         try:
@@ -223,9 +223,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 self,
                 input=tokens[i : i + _chunk_size],
                 model=self.model,
-                # engine=self.deployment,
-                # request_timeout=self.request_timeout,
-                # headers=self.headers,
+                engine=self.deployment,
+                request_timeout=self.request_timeout,
+                headers=self.headers,
             )
             batched_embeddings += [r["embedding"] for r in response["data"]]
 
@@ -242,9 +242,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     self,
                     input="",
                     model=self.model,
-                    # engine=self.deployment,
-                    # request_timeout=self.request_timeout,
-                    # headers=self.headers,
+                    engine=self.deployment,
+                    request_timeout=self.request_timeout,
+                    headers=self.headers,
                 )["data"][0]["embedding"]
             else:
                 average = np.average(_result, axis=0, weights=num_tokens_in_batch[i])
@@ -252,11 +252,11 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
 
         return embeddings
 
-    def _embedding_func(self, text: str, *, model: str) -> List[float]:
+    def _embedding_func(self, text: str, *, engine: str) -> List[float]:
         """Call out to OpenAI's embedding endpoint."""
         # handle large input text
         if len(text) > self.embedding_ctx_length:
-            return self._get_len_safe_embeddings([text], model=model)[0]
+            return self._get_len_safe_embeddings([text], engine=engine)[0]
         else:
             if self.model.endswith("001"):
                 # See: https://github.com/openai/openai-python/issues/418#issuecomment-1525939500
@@ -265,10 +265,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             return embed_with_retry(
                 self,
                 input=[text],
-                model=model,
-                # engine=engine,
-                # request_timeout=self.request_timeout,
-                # headers=self.headers,
+                model=self.model,
+                engine=engine,
+                request_timeout=self.request_timeout,
+                headers=self.headers,
             )["data"][0]["embedding"]
 
     def embed_documents(
@@ -286,7 +286,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         """
         # NOTE: to keep things simple, we assume the list may contain texts longer
         #       than the maximum context and use length-safe embedding function.
-        return self._get_len_safe_embeddings(texts, model=self.model)
+        return self._get_len_safe_embeddings(texts, engine=self.deployment)
 
     def embed_query(self, text: str) -> List[float]:
         """Call out to OpenAI's embedding endpoint for embedding query text.
@@ -297,5 +297,5 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         Returns:
             Embedding for the text.
         """
-        embedding = self._embedding_func(text, model=self.model)
+        embedding = self._embedding_func(text, engine=self.deployment)
         return embedding

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -222,9 +222,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             response = embed_with_retry(
                 self,
                 input=tokens[i : i + _chunk_size],
-                engine=self.deployment,
-                request_timeout=self.request_timeout,
-                headers=self.headers,
+                model=self.model,
+                # request_timeout=self.request_timeout,
+                # headers=self.headers,
             )
             batched_embeddings += [r["embedding"] for r in response["data"]]
 
@@ -240,9 +240,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 average = embed_with_retry(
                     self,
                     input="",
-                    engine=self.deployment,
-                    request_timeout=self.request_timeout,
-                    headers=self.headers,
+                    model=self.model,
+                    # request_timeout=self.request_timeout,
+                    # headers=self.headers,
                 )["data"][0]["embedding"]
             else:
                 average = np.average(_result, axis=0, weights=num_tokens_in_batch[i])
@@ -263,9 +263,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             return embed_with_retry(
                 self,
                 input=[text],
-                engine=engine,
-                request_timeout=self.request_timeout,
-                headers=self.headers,
+                model=self.model,
+                # request_timeout=self.request_timeout,
+                # headers=self.headers,
             )["data"][0]["embedding"]
 
     def embed_documents(


### PR DESCRIPTION
# Update the parameters of the<openai. embedding. create>interface,restored interface validity

<!--

In the latest version, the parameters for calling the embedding.create interface are engine, input, and so on. Due to the existence of engine, the program will report an error. The specific error is that the interface is not supported. After checking the official website of openai, it is found that the parameters required for this interface are module (which is exactly what I have corrected), input, and user (not required). I found that all engine related interfaces are currently deprecated, and according to the previous code comments, The services for Azure have not appeared on the official website either

-->
I changed all the engine parameters in the program to modles, and marked out other unnecessary parameters. It should be noted that I did not add user to the parameter list because I was afraid of unexpected errors, as this parameter is not a required item. I used "/embedding/test_ openai.py" and it has been tested. the test results are normal

It should be noted that I use "make integration_tests" When testing, the program did not test"/embedding/test_ Openai.py", which resulted in the error report not mentioning this error. I think this may also be a bug. To verify the effectiveness of the modification, I debugged this separate test file and found that the existing version reported an error. After the modification, the test passed


I did not add a new integration, I only restored the effectiveness of the interface mentioned above. I tested the test units involved in the modified files separately and found that the modified files can pass the test normally!



-@hwchase17

-@agola11