### PR TITLE
remove extra "\n" to ensure that the format of the description, examp…

### DIFF
--- a/langchain/chains/llm_math/prompt.py
+++ b/langchain/chains/llm_math/prompt.py
@@ -16,7 +16,6 @@ Answer: ${{Answer}}
 Begin.
 
 Question: What is 37593 * 67?
-
 ```text
 37593 * 67
 ```


### PR DESCRIPTION
remove extra "\n" to ensure that the format of the description, example, and prompt&generation are completely consistent.