### PR TITLE
Resolve error in StructuredOutputParser docs

### DIFF
--- a/docs/modules/prompts/output_parsers/examples/structured.ipynb
+++ b/docs/modules/prompts/output_parsers/examples/structured.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "91871002",
    "metadata": {},
@@ -12,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 23,
    "id": "b492997a",
    "metadata": {},
    "outputs": [],
@@ -24,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "09473dce",
    "metadata": {},
@@ -33,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 24,
    "id": "432ac44a",
    "metadata": {},
    "outputs": [],
@@ -46,6 +48,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7b92ce96",
    "metadata": {},
@@ -55,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 25,
    "id": "593cfc25",
    "metadata": {},
    "outputs": [],
@@ -69,6 +72,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0943e783",
    "metadata": {},
@@ -78,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 26,
    "id": "106f1ba6",
    "metadata": {},
    "outputs": [],
@@ -88,28 +92,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 27,
    "id": "86d9d24f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "_input = prompt.format_prompt(question=\"what's the capital of france\")\n",
+    "_input = prompt.format_prompt(question=\"what's the capital of france?\")\n",
     "output = model(_input.to_string())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 28,
    "id": "956bdc99",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'answer': 'Paris', 'source': 'https://en.wikipedia.org/wiki/Paris'}"
+       "{'answer': 'Paris',\n",
+       " 'source': 'https://www.worldatlas.com/articles/what-is-the-capital-of-france.html'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -119,6 +124,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "da639285",
    "metadata": {},
@@ -128,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 29,
    "id": "8f483d7d",
    "metadata": {},
    "outputs": [],
@@ -138,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 30,
    "id": "f761cbf1",
    "metadata": {},
    "outputs": [],
@@ -154,18 +160,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 31,
    "id": "edd73ae3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "_input = prompt.format_prompt(question=\"what's the capital of france\")\n",
+    "_input = prompt.format_prompt(question=\"what's the capital of france?\")\n",
     "output = chat_model(_input.to_messages())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 32,
    "id": "a3c8b91e",
    "metadata": {},
    "outputs": [
@@ -175,7 +181,7 @@
        "{'answer': 'Paris', 'source': 'https://en.wikipedia.org/wiki/Paris'}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,7 +207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Resolve error in StructuredOutputParser docs

Documentation for `StructuredOutputParser` currently not reproducible, that is, `output_parser.parse(output)` raises an error because the LLM returns a response with an invalid format

```python
_input = prompt.format_prompt(question="what's the capital of france")
output = model(_input.to_string())

output

# ?
#
# ```json
# {
# 	"answer": "Paris",
# 	"source": "https://www.worldatlas.com/articles/what-is-the-capital-of-france.html"
# }
# ```
```

Was fixed by adding a question mark to the prompt