### PR TITLE
Build an abstract dialogue model using classes and methods to represent different dialogue elements

### DIFF
--- a/langchain/chains/dialogue_answering/__init__.py
+++ b/langchain/chains/dialogue_answering/__init__.py
@@ -1,0 +1,7 @@
+from .base import (
+    DialogueWithSharedMemoryChains
+)
+
+__all__ = [
+    "DialogueWithSharedMemoryChains"
+]

--- a/langchain/chains/dialogue_answering/__main__.py
+++ b/langchain/chains/dialogue_answering/__main__.py
@@ -1,0 +1,31 @@
+import sys
+import os
+import argparse
+import asyncio
+from argparse import Namespace
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../../../')
+from langchain.chains.dialogue_answering import *
+from langchain.llms import OpenAI
+
+
+async def dispatch(args: Namespace):
+    args_dict = vars(args)
+
+    if not os.path.isfile(args.dialogue_path):
+        raise FileNotFoundError(f'Invalid dialogue file path for demo mode: "{args.dialogue_path}"')
+    llm = OpenAI(temperature=0)
+    dialogue_instance = DialogueWithSharedMemoryChains(zero_shot_react_llm=llm, ask_llm=llm, params=args_dict)
+
+    dialogue_instance.agent_chain.run(input="What did David say before, summarize it")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog='langchina-Dialogue',
+                                     description='langchina-Dialogue')
+    parser.add_argument('--dialogue-path', default='', type=str, help='dialogue-path')
+    parser.add_argument('--embedding-model', default='', type=str, help='embedding-model')
+    args = parser.parse_args(['--dialogue-path', '/home/dmeck/Downloads/log.txt',
+                              '--embedding-mode', '/media/checkpoint/text2vec-large-chinese/'])
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(dispatch(args))

--- a/langchain/chains/dialogue_answering/base.py
+++ b/langchain/chains/dialogue_answering/base.py
@@ -1,0 +1,99 @@
+from langchain.base_language import BaseLanguageModel
+from langchain.agents import ZeroShotAgent, Tool, AgentExecutor
+from langchain.memory import ConversationBufferMemory, ReadOnlySharedMemory
+from langchain.chains import LLMChain, RetrievalQA
+from langchain.embeddings.huggingface import HuggingFaceEmbeddings
+from langchain.prompts import PromptTemplate
+from langchain.text_splitter import CharacterTextSplitter
+from langchain.vectorstores import Chroma
+
+from langchain.document_loaders import DialogueLoader
+from langchain.chains.dialogue_answering.prompts import (
+    DIALOGUE_PREFIX,
+    DIALOGUE_SUFFIX,
+    SUMMARY_PROMPT
+)
+
+
+class DialogueWithSharedMemoryChains:
+    zero_shot_react_llm: BaseLanguageModel = None
+    ask_llm: BaseLanguageModel = None
+    embeddings: HuggingFaceEmbeddings = None
+    embedding_model: str = None
+    vector_search_top_k: int = 6
+    dialogue_path: str = None
+    dialogue_loader: DialogueLoader = None
+    device: str = None
+
+    def __init__(self, zero_shot_react_llm: BaseLanguageModel = None, ask_llm: BaseLanguageModel = None,
+                 params: dict = None):
+        self.zero_shot_react_llm = zero_shot_react_llm
+        self.ask_llm = ask_llm
+        params = params or {}
+        self.embedding_model = params.get('embedding_model', 'GanymedeNil/text2vec-large-chinese')
+        self.vector_search_top_k = params.get('vector_search_top_k', 6)
+        self.dialogue_path = params.get('dialogue_path', '')
+        self.device = 'cuda' if params.get('use_cuda', False) else 'cpu'
+
+        self.dialogue_loader = DialogueLoader(self.dialogue_path)
+        self._init_cfg()
+        self._init_state_of_history()
+        self.memory_chain, self.memory = self._agents_answer()
+        self.agent_chain = self._create_agent_chain()
+
+    def _init_cfg(self):
+        model_kwargs = {
+            'device': self.device
+        }
+        self.embeddings = HuggingFaceEmbeddings(model_name=self.embedding_model, model_kwargs=model_kwargs)
+
+    def _init_state_of_history(self):
+        documents = self.dialogue_loader.load()
+        text_splitter = CharacterTextSplitter(chunk_size=3, chunk_overlap=1)
+        texts = text_splitter.split_documents(documents)
+        docsearch = Chroma.from_documents(texts, self.embeddings, collection_name="state-of-history")
+        self.state_of_history = RetrievalQA.from_chain_type(llm=self.ask_llm, chain_type="stuff",
+                                                            retriever=docsearch.as_retriever())
+
+    def _agents_answer(self):
+
+        memory = ConversationBufferMemory(memory_key="chat_history")
+        readonly_memory = ReadOnlySharedMemory(memory=memory)
+        memory_chain = LLMChain(
+            llm=self.ask_llm,
+            prompt=SUMMARY_PROMPT,
+            verbose=True,
+            memory=readonly_memory,  # use the read-only memory to prevent the tool from modifying the memory
+        )
+        return memory_chain, memory
+
+    def _create_agent_chain(self):
+        dialogue_participants = self.dialogue_loader.dialogue.participants_to_export()
+        tools = [
+            Tool(
+                name="State of Dialogue History System",
+                func=self.state_of_history.run,
+                description=f"Dialogue with {dialogue_participants} - The answers in this section are very useful "
+                            f"when searching for chat content between {dialogue_participants}. Input should be a "
+                            f"complete question. "
+            ),
+            Tool(
+                name="Summary",
+                func=self.memory_chain.run,
+                description="useful for when you summarize a conversation. The input to this tool should be a string, "
+                            "representing who will read this summary. "
+            )
+        ]
+
+        prompt = ZeroShotAgent.create_prompt(
+            tools,
+            prefix=DIALOGUE_PREFIX,
+            suffix=DIALOGUE_SUFFIX,
+            input_variables=["input", "chat_history", "agent_scratchpad"]
+        )
+
+        llm_chain = LLMChain(llm=self.zero_shot_react_llm, prompt=prompt)
+        agent = ZeroShotAgent(llm_chain=llm_chain, tools=tools, verbose=True)
+        agent_chain = AgentExecutor.from_agent_and_tools(agent=agent, tools=tools, verbose=True, memory=self.memory)
+
+        return agent_chain

--- a/langchain/chains/dialogue_answering/prompts.py
+++ b/langchain/chains/dialogue_answering/prompts.py
@@ -1,0 +1,22 @@
+from langchain.prompts.prompt import PromptTemplate
+
+
+SUMMARY_TEMPLATE = """This is a conversation between a human and a bot:
+
+{chat_history}
+
+Write a summary of the conversation for {input}:
+"""
+
+SUMMARY_PROMPT = PromptTemplate(
+    input_variables=["input", "chat_history"],
+    template=SUMMARY_TEMPLATE
+)
+
+DIALOGUE_PREFIX = """Have a conversation with a human,Analyze the content of the conversation.
+You have access to the following tools: """
+DIALOGUE_SUFFIX = """Begin!
+
+{chat_history}
+Question: {input}
+{agent_scratchpad}"""

--- a/langchain/document_loaders/__init__.py
+++ b/langchain/document_loaders/__init__.py
@@ -115,6 +115,12 @@ from langchain.document_loaders.youtube import (
     GoogleApiYoutubeLoader,
     YoutubeLoader,
 )
+from langchain.document_loaders.dialogue import (
+    Person,
+    Dialogue,
+    Turn,
+    DialogueLoader
+)
 
 # Legacy: only for backwards compat. Use PyPDFLoader instead
 PagedPDFSplitter = PyPDFLoader
@@ -225,4 +231,5 @@ __all__ = [
     "TelegramChatLoader",
     "ToMarkdownLoader",
     "PsychicLoader",
+    "DialogueLoader",
 ]

--- a/langchain/document_loaders/dialogue.py
+++ b/langchain/document_loaders/dialogue.py
@@ -1,0 +1,131 @@
+import json
+from abc import ABC
+from typing import List
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseLoader
+
+
+class Person:
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+
+
+class Dialogue:
+    """
+    Build an abstract dialogue model using classes and methods to represent different dialogue elements.
+    This class serves as a fundamental framework for constructing dialogue models.
+    """
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self.turns = []
+
+    def add_turn(self, turn):
+        """
+        Create an instance of a conversation participant
+        :param turn:
+        :return:
+        """
+        self.turns.append(turn)
+
+    def parse_dialogue(self):
+        """
+        The parse_dialogue function reads the specified dialogue file and parses each dialogue turn line by line.
+        For each turn, the function extracts the name of the speaker and the message content from the text,
+        creating a Turn instance. If the speaker is not already present in the participants dictionary,
+        a new Person instance is created. Finally, the parsed Turn instance is added to the Dialogue object.
+
+        Please note that this sample code assumes that each line in the file follows a specific format:
+        <speaker>:\r\n<message>\r\n\r\n. If your file has a different format or includes other metadata,
+         you may need to adjust the parsing logic accordingly.
+        """
+        participants = {}
+        speaker_name = None
+        message = None
+
+        with open(self.file_path, encoding='utf-8') as file:
+            lines = file.readlines()
+            for i, line in enumerate(lines):
+                line = line.strip()
+                if not line:
+                    continue
+
+                if speaker_name is None:
+                    speaker_name, _ = line.split(':', 1)
+                elif message is None:
+                    message = line
+                    if speaker_name not in participants:
+                        participants[speaker_name] = Person(speaker_name, None)
+
+                    speaker = participants[speaker_name]
+                    turn = Turn(speaker, message)
+                    self.add_turn(turn)
+
+                    # Reset speaker_name and message for the next turn
+                    speaker_name = None
+                    message = None
+
+    def display(self):
+        for turn in self.turns:
+            print(f"{turn.speaker.name}: {turn.message}")
+
+    def export_to_file(self, file_path):
+        with open(file_path, 'w', encoding='utf-8') as file:
+            for turn in self.turns:
+                file.write(f"{turn.speaker.name}: {turn.message}\n")
+
+    def to_dict(self):
+        dialogue_dict = {"turns": []}
+        for turn in self.turns:
+            turn_dict = {
+                "speaker": turn.speaker.name,
+                "message": turn.message
+            }
+            dialogue_dict["turns"].append(turn_dict)
+        return dialogue_dict
+
+    def to_json(self):
+        dialogue_dict = self.to_dict()
+        return json.dumps(dialogue_dict, ensure_ascii=False, indent=2)
+
+    def participants_to_export(self):
+        """
+        participants_to_export
+        :return:
+        """
+        participants = set()
+        for turn in self.turns:
+            participants.add(turn.speaker.name)
+        return ', '.join(participants)
+
+
+class Turn:
+    def __init__(self, speaker, message):
+        self.speaker = speaker
+        self.message = message
+
+
+class DialogueLoader(BaseLoader, ABC):
+    """Load dialogue."""
+
+    def __init__(self, file_path: str):
+        """Initialize with dialogue."""
+        self.file_path = file_path
+        dialogue = Dialogue(file_path=file_path)
+        dialogue.parse_dialogue()
+        self.dialogue = dialogue
+
+    def load(self) -> List[Document]:
+        """Load from dialogue."""
+        documents = []
+        participants = self.dialogue.participants_to_export()
+
+        for turn in self.dialogue.turns:
+            metadata = {"source": f"Dialogue File：{self.dialogue.file_path},"
+                                  f"speaker：{turn.speaker.name}，"
+                                  f"participant：{participants}"}
+            turn_document = Document(page_content=turn.message, metadata=metadata.copy())
+            documents.append(turn_document)
+
+        return documents


### PR DESCRIPTION
# Build an abstract dialogue model using classes and methods to represent different dialogue elements


Fixes # None

## Before submitting


If you want to review, please refer to the quick start example provided in langchain/chains/dialogue_answering/__main__.py. You may need to set the openaikey and the following startup parameters: --dialogue-path: the location of the dialogue file, --embedding-model: the HuggingFaceEmbeddings model to use (defaults to GanymedeNil/text2vec-large-chinese) if not specified.

Regarding the format of the dialogue file, please refer to the following information:
```text
sun:
Has the offline model been run?

glide-the:
Yes, it has been run, but the results are not very satisfactory.

glide-the:
It lacks chat intelligence and falls far behind in terms of logic and reasoning.

sun:
Are you available for voice chat?

glide-the:
I'm considering using this offline model: https://huggingface.co/chat

glide-the:
voice chat okay.

glide-the:
You can take a look at the dev_agent branch of the langchain-chatglm project.

glide-the:
There's a dialogue model question-answering example under the agent.

sun:
Alright.

glide-the:
The specified chat record file is exported from WeChat.
```
## Who can review?


Including lorader and agent applications


- @eyurtsev
- @vowelparrot
- @dev2049
 
