### PR TITLE
Fixed regression in JoplinLoader's get note url

### DIFF
--- a/langchain/document_loaders/joplin.py
+++ b/langchain/document_loaders/joplin.py
@@ -36,7 +36,7 @@ class JoplinLoader(BaseLoader):
         base_url = f"http://{host}:{port}"
         self._get_note_url = (
             f"{base_url}/notes?token={access_token}"
-            "&fields=id,parent_id,title,body,created_time,updated_time&page={{page}}"
+            f"&fields=id,parent_id,title,body,created_time,updated_time&page={{page}}"
         )
         self._get_folder_url = (
             f"{base_url}/folders/{{id}}?token={access_token}&fields=title"


### PR DESCRIPTION
Fixes a regression in JoplinLoader that was introduced during the code review (bad `page` wildcard in _get_note_url).

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@dev2049
@leo-gan
