### PR TITLE
Add an example to make the prompt more robust

### DIFF
--- a/langchain/chains/llm_math/prompt.py
+++ b/langchain/chains/llm_math/prompt.py
@@ -25,6 +25,16 @@ Question: What is 37593 * 67?
 ```
 Answer: 2518731
 
+Question: 37593^(1/5)
+```text
+37593**(1/5)
+```
+...numexpr.evaluate("37593**(1/5)")...
+```output
+8.222831614237718
+```
+Answer: 8.222831614237718
+
 Question: {question}
 """
 


### PR DESCRIPTION
I am trying the opensource model for llm_math.  and I possibly found a typical problem.  chatgpt knows ** and always change a^b into  a**b(chatgpt doesn't think ^ is xor),  and opensource model prefer a^b.  so if my quesion is   29^(1/5) or the fifth root of 29,  I will get the error "_TypeError: unsupported operand type(s) for ^: 'int' and 'float'_'" from _"numexpr.evaluate("29^(1/5)")"_.  Then  I add this example, the model is able to solve questions like "a^b", "the square of a", "the fifth root of a" by using **