### PR TITLE
Fix: Handle empty documents in ContextualCompressionRetriever (Issue #5304)

### DIFF
--- a/langchain/retrievers/document_compressors/cohere_rerank.py
+++ b/langchain/retrievers/document_compressors/cohere_rerank.py
@@ -50,6 +50,8 @@ class CohereRerank(BaseDocumentCompressor):
     def compress_documents(
         self, documents: Sequence[Document], query: str
     ) -> Sequence[Document]:
+        if len(documents)==0:   #to avoid empty api call
+            return []
         doc_list = list(documents)
         _docs = [d.page_content for d in doc_list]
         results = self.client.rerank(

--- a/langchain/retrievers/document_compressors/cohere_rerank.py
+++ b/langchain/retrievers/document_compressors/cohere_rerank.py
@@ -50,7 +50,7 @@ class CohereRerank(BaseDocumentCompressor):
     def compress_documents(
         self, documents: Sequence[Document], query: str
     ) -> Sequence[Document]:
-        if len(documents)==0:   #to avoid empty api call
+        if len(documents) == 0:  # to avoid empty api call
             return []
         doc_list = list(documents)
         _docs = [d.page_content for d in doc_list]


### PR DESCRIPTION
# Fix: Handle empty documents in ContextualCompressionRetriever (Issue #5304)

Fixes #5304 

Prevent cohere.error.CohereAPIError caused by an empty list of documents by adding a condition to check if the input documents list is empty in the compress_documents method. If the list is empty, return an empty list immediately, avoiding the error and unnecessary processing.

@dev2049 