### PR TITLE
docs: improve flow of llm caching notebook

### DIFF
--- a/docs/modules/models/llms/examples/llm_caching.ipynb
+++ b/docs/modules/models/llms/examples/llm_caching.ipynb
@@ -16,10 +16,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.llms import OpenAI"
+    "import langchain\n",
+    "from langchain.llms import OpenAI\n",
+    "\n",
+    "# To make the caching really obvious, lets use a slower model.\n",
+    "llm = OpenAI(model_name=\"text-davinci-002\", n=2, best_of=2)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b50f0598",
    "metadata": {},
@@ -34,20 +39,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import langchain\n",
     "from langchain.cache import InMemoryCache\n",
     "langchain.llm_cache = InMemoryCache()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "f69f6283",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# To make the caching really obvious, lets use a slower model.\n",
-    "llm = OpenAI(model_name=\"text-davinci-002\", n=2, best_of=2)"
    ]
   },
   {


### PR DESCRIPTION
# docs: improve flow of llm caching notebook

The notebook `llm_caching` demos various caching providers. In the previous version, there was setup common to all examples but under the `In Memory Caching` heading.

If a user comes and only wants to try a particular example, they will run the common setup, then the cells for the specific provider they are interested in. Then they will get import and variable reference errors. This commit moves the common setup to the top to avoid this.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@dev2049 