### PR TITLE
Add Chainlit to deployment options

### DIFF
--- a/docs/ecosystem/deployments.md
+++ b/docs/ecosystem/deployments.md
@@ -19,6 +19,12 @@ It implements a chatbot interface, with a "Bring-Your-Own-Token" approach (nice 
 It also contains instructions for how to deploy this app on the Hugging Face platform.
 This is heavily influenced by James Weaver's [excellent examples](https://huggingface.co/JavaFXpert).
 
+## [Chainlit](https://github.com/Chainlit/cookbook)
+
+This repo is a cookbook explaining how to visualize and deploy LangChain agents with Chainlit.
+You create ChatGPT-like UIs with Chainlit. Some of the key features include intermediary steps visualisation, element management & display (images, text, carousel, etc.) as well as cloud deployment.
+Chainlit [doc](https://docs.chainlit.io/langchain) on the integration with LangChain
+
 ## [Beam](https://github.com/slai-labs/get-beam/tree/main/examples/langchain-question-answering)
 
 This repo serves as a template for how deploy a LangChain with [Beam](https://beam.cloud).


### PR DESCRIPTION
# Add Chainlit to deployment options

Add [Chainlit](https://github.com/Chainlit/chainlit) as deployment options
Used links to Github examples and Chainlit doc on the LangChain integration