### PR TITLE
fix: remove empty lines that cause InvalidRequestError

### DIFF
--- a/langchain/experimental/generative_agents/memory.py
+++ b/langchain/experimental/generative_agents/memory.py
@@ -34,7 +34,7 @@ class GenerativeAgentMemory(BaseMemory):
 
     aggregate_importance: float = 0.0  # : :meta private:
     """Track the sum of the 'importance' of recent memories.
-    
+
     Triggers reflection when it reaches reflection_threshold."""
 
     max_tokens_limit: int = 1200  # : :meta private:
@@ -56,6 +56,7 @@ class GenerativeAgentMemory(BaseMemory):
     def _parse_list(text: str) -> List[str]:
         """Parse a newline-separated string into a list of strings."""
         lines = re.split(r"\n", text.strip())
+        lines = [line for line in lines if line.strip()]  # remove empty lines
         return [re.sub(r"^\s*\d+\.\s*", "", line).strip() for line in lines]
 
     def _get_topics_of_reflection(self, last_k: int = 50) -> List[str]:


### PR DESCRIPTION

# remove empty lines in GenerativeAgentMemory that cause InvalidRequestError in OpenAIEmbeddings

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Let's say the text given to `GenerativeAgent._parse_list` is
```
text = """
Insight 1: <insight 1>

Insight 2: <insight 2>
"""
```
This creates an `openai.error.InvalidRequestError: [''] is not valid under any of the given schemas - 'input'` because `GenerativeAgent.add_memory()` tries to add an empty string to the vectorstore.

This PR fixes the issue by removing the empty line between `Insight 1` and `Insight 2`

## Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049
        
 -->
@hwchase17
@vowelparrot
@dev2049
