### PR TITLE
Fixing blank thoughts in verbose for "_Exception" Action

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -785,6 +785,8 @@ class AgentExecutor(Chain):
             else:
                 raise ValueError("Got unexpected type of `handle_parsing_errors`")
             output = AgentAction("_Exception", observation, text)
+            if run_manager:
+                run_manager.on_agent_action(output, color="green")
             tool_run_kwargs = self.agent.tool_run_logging_kwargs()
             observation = ExceptionTool().run(
                 output.tool_input,


### PR DESCRIPTION
Fixed the issue of blank Thoughts being printed in verbose when `handle_parsing_errors=True`, as below:

Before Fix:
```
Observation: There are 38175 accounts available in the dataframe.
Thought:
Observation: Invalid or incomplete response
Thought:
Observation: Invalid or incomplete response
Thought:
```

After Fix:
```
Observation: There are 38175 accounts available in the dataframe.
Thought:AI: {
    "action": "Final Answer",
    "action_input": "There are 38175 accounts available in the dataframe."
}
Observation: Invalid Action or Action Input format
Thought:AI: {
    "action": "Final Answer",
    "action_input": "The number of available accounts is 38175."
}
Observation: Invalid Action or Action Input format
```

@vowelparrot currently I have set the colour of thought to green (same as the colour when `handle_parsing_errors=False`). If you want to change the colour of this "_Exception" case to red or something else (when `handle_parsing_errors=True`), feel free to change it in line 789.
