### PR TITLE
refactor: BaseStringMessagePromptTemplate from_template method 

### DIFF
--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -71,7 +71,7 @@ class BaseStringMessagePromptTemplate(BaseMessagePromptTemplate, ABC):
     def from_template(
         cls: Type[MessagePromptTemplateT], template: str, **kwargs: Any
     ) -> MessagePromptTemplateT:
-        prompt = PromptTemplate.from_template(template)
+        prompt = PromptTemplate.from_template(template, **kwargs)
         return cls(prompt=prompt, **kwargs)
 
     @classmethod

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -69,7 +69,10 @@ class BaseStringMessagePromptTemplate(BaseMessagePromptTemplate, ABC):
 
     @classmethod
     def from_template(
-        cls: Type[MessagePromptTemplateT], template: str, template_format="f-string", **kwargs: Any
+        cls: Type[MessagePromptTemplateT],
+        template: str,
+        template_format="f-string",
+        **kwargs: Any,
     ) -> MessagePromptTemplateT:
         prompt = PromptTemplate.from_template(template, template_format=template_format)
         return cls(prompt=prompt, **kwargs)

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -69,12 +69,9 @@ class BaseStringMessagePromptTemplate(BaseMessagePromptTemplate, ABC):
 
     @classmethod
     def from_template(
-        cls: Type[MessagePromptTemplateT], template: str, **kwargs: Any
+        cls: Type[MessagePromptTemplateT], template: str, template_format="f-string", **kwargs: Any
     ) -> MessagePromptTemplateT:
-        if "template_format" in kwargs:
-            prompt = PromptTemplate.from_template(template, template_format=kwargs["template_format"])
-        else:
-            prompt = PromptTemplate.from_template(template)
+        prompt = PromptTemplate.from_template(template, template_format=template_format)
         return cls(prompt=prompt, **kwargs)
 
     @classmethod

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -71,7 +71,10 @@ class BaseStringMessagePromptTemplate(BaseMessagePromptTemplate, ABC):
     def from_template(
         cls: Type[MessagePromptTemplateT], template: str, **kwargs: Any
     ) -> MessagePromptTemplateT:
-        prompt = PromptTemplate.from_template(template, **kwargs)
+        if "template_format" in kwargs:
+            prompt = PromptTemplate.from_template(template, template_format=kwargs["template_format"])
+        else:
+            prompt = PromptTemplate.from_template(template)
         return cls(prompt=prompt, **kwargs)
 
     @classmethod

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -71,7 +71,7 @@ class BaseStringMessagePromptTemplate(BaseMessagePromptTemplate, ABC):
     def from_template(
         cls: Type[MessagePromptTemplateT],
         template: str,
-        template_format="f-string",
+        template_format: str = "f-string",
         **kwargs: Any,
     ) -> MessagePromptTemplateT:
         prompt = PromptTemplate.from_template(template, template_format=template_format)


### PR DESCRIPTION

# refactor BaseStringMessagePromptTemplate from_template method 

Refactor the `from_template` method of the `BaseStringMessagePromptTemplate` class to allow passing keyword arguments to the `from_template` method of `PromptTemplate`.
Enable the usage of arguments like `template_format`.
In my scenario, I intend to utilize Jinja2 for formatting the human message prompt in the chat template.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Models
  - @hwchase17
  - @agola11
  - @jonasalexander 

 -->
