### PR TITLE
Improved json parse sanitization

### DIFF
--- a/langchain/output_parsers/json.py
+++ b/langchain/output_parsers/json.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import List
 
 from langchain.schema import OutputParserException
 
 
 def parse_json_markdown(json_string: str) -> dict:
-    # Remove the triple backticks if present
-    json_string = json_string.replace("```json", "").replace("```", "")
+    # Remove all characters that are not { or [ from start of string
+    json_string = re.sub("^[^\[{]*", "", json_string)
 
-    # Strip whitespace and newlines from the start and end
-    json_string = json_string.strip()
+    # Remove all characters that are not } or ] from end of string
+    json_string = re.sub(r"[^}\]]*$", "", json_string)
 
     # Parse the JSON string into a Python dictionary
     parsed = json.loads(json_string)


### PR DESCRIPTION
@vowelparrot  Added regex expressions (superset to the previously present non regex expressions) to also solve the case where unnecessary characters are present after the triple backticks but before the {, and after the } but before the closing triple backticks.

Before fix (additional "AI: " is present after Thought:):
```
Observation: There are 38175 accounts available in the dataframe.
Thought:AI: {
    "action": "Final Answer",
    "action_input": "There are 38175 accounts available in the dataframe."
}
Observation: Invalid or incomplete response
```

After fix:
```
Observation: There are 38175 accounts available in the dataframe.
Thought:AI: {
    "action": "Final Answer",
    "action_input": "There are 38175 accounts available in the dataframe."
}

> Finished chain.
[AI Message]: There are 38175 accounts available in the dataframe.
```
