### PR TITLE
Add removing any text before json to parse_json_markdown

### DIFF
--- a/langchain/output_parsers/json.py
+++ b/langchain/output_parsers/json.py
@@ -5,8 +5,16 @@ from typing import List
 
 from langchain.schema import OutputParserException
 
+def remove_text_before_json(input_string: str) -> str:
+    index = input_string.find("```")
+    if index !=-1 :
+            return input_string[index:] 
+    return input_string
 
 def parse_json_markdown(json_string: str) -> dict:
+    # Remove any string before the json response
+    json_string = remove_text_before_json(json_string)
+    
     # Remove the triple backticks if present
     json_string = json_string.replace("```json", "").replace("```", "")
 


### PR DESCRIPTION
# Add removing any text before the json string to parse_json_markdown (Issue #1358)

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

<!-- Remove if not applicable -->

Fixes #1358 (ValueError: Could not parse LLM output: )

Sometimes the agent adds a little sentence before the thought JSON it's supposed to give. I causes an error. This little function removes that part before the main JSON response before trying to parse it. Here is an example error I got before this fix:

`````
Traceback (most recent call last):
  File ".../langchain/agents/conversational_chat/output_parser.py", line 17, in parse
    response = parse_json_markdown(text)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../langchain/output_parsers/json.py", line 17, in parse_json_markdown
    parsed = json.loads(json_string)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
...
  File ".../langchain/chains/base.py", line 239, in run
    return self(kwargs, callbacks=callbacks)[self.output_keys[0]]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../langchain/chains/base.py", line 140, in __call__
    raise e
  File ".../langchain/chains/base.py", line 134, in __call__
    self._call(inputs, run_manager=run_manager)
  File ".../langchain/agents/agent.py", line 951, in _call
    next_step_output = self._take_next_step(
                       ^^^^^^^^^^^^^^^^^^^^^
  File ".../langchain/agents/agent.py", line 773, in _take_next_step
    raise e
  File ".../langchain/agents/agent.py", line 762, in _take_next_step
    output = self.agent.plan(
             ^^^^^^^^^^^^^^^^
  File ".../langchain/agents/agent.py", line 444, in plan
    return self.output_parser.parse(full_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../langchain/agents/conversational_chat/output_parser.py", line 24, in parse
    raise OutputParserException(f"Could not parse LLM output: {text}") from e
langchain.schema.OutputParserException: Could not parse LLM output: Sure, here's a sentence-long description of the first tool in the list:

```json
{
    "action": "Final Answer",
    "action_input": "The 'Search the internet' tool is useful for finding information about current events or the current state of the world. You can input a single search term to get started."
}
```
`````

In this PR, in the example above `parse_json_markdown` will remove "Sure, here's a sentence-long description of the first tool in the list:" before trying to parse the string as a json.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@vowelparrot

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049
        
 -->
