### PR TITLE
Add llama.cpp get_num_tokens support

### DIFF
--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -279,3 +279,7 @@ class LlamaCpp(LLM):
                     token=token, verbose=self.verbose, log_probs=log_probs
                 )
             yield chunk
+    
+    def get_num_tokens(self, text: str) -> int:
+        tokenized_text = self.client.tokenize(text.encode("utf-8"))
+        return len(tokenized_text)


### PR DESCRIPTION
# Adds support for counting tokens using the llama.cpp python interface rather than the default huggingface transformers library

The current implementation of the `LlamaCpp` LLM defaults to the base `LLM` for token counting. This results in the need for the huggingface transformers library to be loaded.

The Llama.cpp python interface provides a method for tokenizing a given string. This PR overloads the `get_num_tokens` method of the base class to use that instead.

Using the native tokenizer should yield more accurate token counts dependent on the loaded model.

For llama.cpp workflows this PR reduces dependencies.

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.
-->

## Before submitting

Wasn't sure how to setup a test for this without spinning up a particular model. But I have tested it in a project.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@hwchase17
@agola11
<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049
        
 -->
