### PR TITLE
Move chat agent prompt formatting instructions into human message

### DIFF
--- a/langchain/agents/chat/base.py
+++ b/langchain/agents/chat/base.py
@@ -7,6 +7,8 @@ from langchain.agents.chat.output_parser import ChatOutputParser
 from langchain.agents.chat.prompt import (
     FORMAT_INSTRUCTIONS,
     HUMAN_MESSAGE,
+    HUMAN_MESSAGE_PREFIX,
+    HUMAN_MESSAGE_SUFFIX,
     SYSTEM_MESSAGE_PREFIX,
     SYSTEM_MESSAGE_SUFFIX,
 )
@@ -72,23 +74,30 @@ class ChatAgent(Agent):
         system_message_prefix: str = SYSTEM_MESSAGE_PREFIX,
         system_message_suffix: str = SYSTEM_MESSAGE_SUFFIX,
         human_message: str = HUMAN_MESSAGE,
+        human_message_prefix: str = HUMAN_MESSAGE_PREFIX,
+        human_message_suffix: str = HUMAN_MESSAGE_SUFFIX,
         format_instructions: str = FORMAT_INSTRUCTIONS,
         input_variables: Optional[List[str]] = None,
     ) -> BasePromptTemplate:
         tool_strings = "\n".join([f"{tool.name}: {tool.description}" for tool in tools])
         tool_names = ", ".join([tool.name for tool in tools])
         format_instructions = format_instructions.format(tool_names=tool_names)
-        template = "\n\n".join(
+        system_message_template = "\n\n".join(
+          system_message_prefix,
+          system_message_suffix
+        )
+        human_message_template = human_message or "\n\n".join(
             [
-                system_message_prefix,
+                human_message_prefix,
                 tool_strings,
                 format_instructions,
-                system_message_suffix,
+                human_message_suffix,
+                human_message,
             ]
         )
         messages = [
-            SystemMessagePromptTemplate.from_template(template),
-            HumanMessagePromptTemplate.from_template(human_message),
+            SystemMessagePromptTemplate.from_template(system_message_template),
+            HumanMessagePromptTemplate.from_template(human_message_template),
         ]
         if input_variables is None:
             input_variables = ["input", "agent_scratchpad"]

--- a/langchain/agents/chat/prompt.py
+++ b/langchain/agents/chat/prompt.py
@@ -1,5 +1,7 @@
 # flake8: noqa
-SYSTEM_MESSAGE_PREFIX = """Answer the following questions as best you can. You have access to the following tools:"""
+SYSTEM_MESSAGE_PREFIX = """Assistant is a large language model trained by OpenAI."""
+SYSTEM_MESSAGE_SUFFIX = ""
+HUMAN_MESSAGE_PREFIX = """Answer the following questions as best you can. You have access to the following tools:"""
 FORMAT_INSTRUCTIONS = """The way you use the tools is by specifying a json blob.
 Specifically, this json should have a `action` key (with the name of the tool to use) and a `action_input` key (with the input to the tool going here).
 
@@ -26,5 +28,5 @@ Observation: the result of the action
 ... (this Thought/Action/Observation can repeat N times)
 Thought: I now know the final answer
 Final Answer: the final answer to the original input question"""
-SYSTEM_MESSAGE_SUFFIX = """Begin! Reminder to always use the exact characters `Final Answer` when responding."""
+HUMAN_MESSAGE_SUFFIX = """Begin! Reminder to always use the exact characters `Final Answer` when responding."""
 HUMAN_MESSAGE = "{input}\n\n{agent_scratchpad}"


### PR DESCRIPTION
# Move chat agent prompt formatting instructions into human message

Partially addresses #5353 around chat agent reliability.

OpenAI's 3.5 turbo model is documented as "not pay[ing] strong attention to the system message, and therefore important instructions are often better placed in a user message.". Could use a bit of testing, opening for discussion at the moment.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@vowelparrot 
@agola11 
