### PR TITLE
"parse_json_markdown" function improved / fixed.

### DIFF
--- a/langchain/output_parsers/json.py
+++ b/langchain/output_parsers/json.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import json
 from typing import List
 
@@ -8,10 +9,16 @@ from langchain.schema import OutputParserException
 
 def parse_json_markdown(json_string: str) -> dict:
     # Remove the triple backticks if present
-    json_string = json_string.replace("```json", "").replace("```", "")
+    json_string = json_string.replace("```json", "").replace("```", "").replace("\n", "")
 
     # Strip whitespace and newlines from the start and end
     json_string = json_string.strip()
+
+    # ensure to extract json from llm output.
+    search = re.search(r".*{(.*)}.*", json_string)
+
+    if search:
+        json_string = "{ %s }" % search.group(1)
 
     # Parse the JSON string into a Python dictionary
     parsed = json.loads(json_string)


### PR DESCRIPTION
# "parse_json_markdown" function improved / fixed.

I've run into an LLm output parsing issue with an agent (type: conversational-react-description), it always raises llm output error/exception with this type of agent.
I couldn't wait for a fix to be released, so I fixed/improved the "parse_json_markdown" function to ensure parsing the json from LLM output, now it's working great for me, and I would like to contribute the fix :D

Note: I'm a Python expert, and I would like to contribute more, is there anyone that can help/guide me to do the testing for more complex contributions (any articles/blogs may help)?

## Before submitting
Thanks in advance :D

## Who can review?
@hwchase17
@vowelparrot

