### PR TITLE
Fixes iter error in FAISS add_embeddings call

### DIFF
--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -175,9 +175,8 @@ class FAISS(VectorStore):
                 f"adding items, which {self.docstore} does not"
             )
         # Embed and create the documents.
+        texts, embeddings = zip(*text_embeddings)
 
-        texts = [te[0] for te in text_embeddings]
-        embeddings = [te[1] for te in text_embeddings]
         return self.__add(texts, embeddings, metadatas=metadatas, ids=ids, **kwargs)
 
     def similarity_search_with_score_by_vector(


### PR DESCRIPTION
# Remove re-use of iter within add_embeddings causing error

As reported in https://github.com/hwchase17/langchain/issues/5336 there is an issue currently involving the atempted re-use of an iterator within the FAISS vectorstore adapter

Fixes # https://github.com/hwchase17/langchain/issues/5336

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

  VectorStores / Retrievers / Memory
  - @dev2049