### PR TITLE
Use Default Factory

### DIFF
--- a/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/langchain/agents/agent_toolkits/openapi/planner.py
@@ -115,9 +115,8 @@ class RequestsPatchToolWithParsing(BaseRequestsTool, BaseTool):
     description = REQUESTS_PATCH_TOOL_DESCRIPTION
 
     response_length: Optional[int] = MAX_RESPONSE_LENGTH
-    llm_chain = LLMChain(
-        llm=OpenAI(),
-        prompt=PARSING_PATCH_PROMPT,
+    llm_chain: LLMChain = Field(
+        default_factory=_get_default_llm_chain_factory(PARSING_PATCH_PROMPT)
     )
 
     def _run(self, text: str) -> str:
@@ -140,9 +139,8 @@ class RequestsDeleteToolWithParsing(BaseRequestsTool, BaseTool):
     description = REQUESTS_DELETE_TOOL_DESCRIPTION
 
     response_length: Optional[int] = MAX_RESPONSE_LENGTH
-    llm_chain = LLMChain(
-        llm=OpenAI(),
-        prompt=PARSING_DELETE_PROMPT,
+    llm_chain: LLMChain = Field(
+        default_factory=_get_default_llm_chain_factory(PARSING_DELETE_PROMPT)
     )
 
     def _run(self, text: str) -> str:


### PR DESCRIPTION
We shouldn't be calling a constructor for a default value - should use default_factory instead. This is especially ad in this case since it requires an optional dependency and an API key to be set. 
 
Resolves #5361