### PR TITLE
fix: compatibility with old version FAISS vector store file

### DIFF
--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -114,8 +114,9 @@ class FAISS(VectorStore):
         starting_len = len(self.index_to_docstore_id)
         faiss = dependable_faiss_import()
         vector = np.array(embeddings, dtype=np.float32)
-        if self._normalize_L2:
+        if getattr(self, "_normalize_L2", False):
             faiss.normalize_L2(vector)
+
         self.index.add(vector)
         # Get list of index, id, and docs.
         full_info = [(starting_len + i, ids[i], doc) for i, doc in enumerate(documents)]

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -193,8 +193,9 @@ class FAISS(VectorStore):
         """
         faiss = dependable_faiss_import()
         vector = np.array([embedding], dtype=np.float32)
-        if self._normalize_L2:
+        if getattr(self, "_normalize_L2", None):
             faiss.normalize_L2(vector)
+
         scores, indices = self.index.search(vector, k)
         docs = []
         for j, i in enumerate(indices[0]):


### PR DESCRIPTION
# fix: compatibility with old version FAISS vector store file

This PR addresses the compatibility issues with langchain when processing vector files generated by older versions of langchain and FAISS. The older files lack the required internal member variables (`deployment, allowed_special, disallowed_special, request_timeout`) that are needed by the new version, leading to compatibility issues as reported in #3251.

In addition, this PR also adds a new environment variable `OPENAI_EMBEDDINGS_DEPLOYMENT` which enables langchain to dynamically set the deployment id for older versions of the data files.

This fix does not introduce any functional changes. Instead, it sets default values for these new variables so that they can handle older data files and prevent compatibility bugs from occurring.

Fixes #3251 

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

  @hwchase17 - project lead

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  VectorStores / Retrievers / Memory
  - @dev2049
        
