### PR TITLE
DeepSpeed Support And Device Map Fix For HuggingFacePipeline

### DIFF
--- a/docs/modules/models/llms/integrations/huggingface_pipelines.ipynb
+++ b/docs/modules/models/llms/integrations/huggingface_pipelines.ipynb
@@ -141,14 +141,6 @@
     "\n",
     "print(llm_chain.run(question))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "843a3837",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/modules/models/llms/integrations/huggingface_pipelines.ipynb
+++ b/docs/modules/models/llms/integrations/huggingface_pipelines.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "959300d4",
    "metadata": {},
@@ -15,6 +16,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4c1b8450-5eaf-4d34-8341-2d785448a1ff",
    "metadata": {
@@ -26,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d772b637-de00-4663-bd77-9bc96d798db2",
    "metadata": {
     "tags": []
@@ -37,6 +39,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "91ad075f-71d5-4bc8-ab91-cc0ad5ef16bb",
    "metadata": {},
@@ -46,20 +49,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "165ae236-962a-4763-8052-c4836d78a5d2",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Failed to default session, using empty session: HTTPConnectionPool(host='localhost', port=8000): Max retries exceeded with url: /sessions (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1117f9790>: Failed to establish a new connection: [Errno 61] Connection refused'))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain import HuggingFacePipeline\n",
     "\n",
@@ -67,6 +62,58 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "47e45c72",
+   "metadata": {},
+   "source": [
+    "### Accelerate Model Inference With DeepSpeed\n",
+    "\n",
+    "DeepSpeed allows an over 2X inference speedup for a wide variety of models.  To use DeepSpeed, you need to have Cuda installed and install a version of Pytorch that was compiled with the version of Cuda you have installed.  Using docker and nvidia-docker along with official Cuda docker images can help set up the environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdd1d670",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install deepspeed > /dev/null"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8da848c2",
+   "metadata": {},
+   "source": [
+    "#### DeepSpeed Arguments\n",
+    "You can control DeepSpeed with an optional argument called ```deepspeed_args```\n",
+    "\n",
+    "This variable takes a dictionary with two key values, ```dtype``` and ```max_tokens```\n",
+    "\n",
+    "Valid values for ```dtype``` include ```fp32```, ```fp16``` and ```int8```.  Defaults to ```fp16```\n",
+    "\n",
+    "Valid values for ```max_tokens``` is any integer less than the max context window for the model.  Smaller values take less memory.  Defaults to the max size given a model.\n",
+    "\n",
+    "Passing any value, including an empty dictionary, will activate DeepSpeed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddf51ef4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain import HuggingFacePipeline\n",
+    "import torch\n",
+    "llm = HuggingFacePipeline.from_model_id(model_id=\"EleutherAI/gpt-j-6b\", task=\"text-generation\", model_kwargs={\"torch_dytpe\":torch.float16},deepspeed_args={\"dtype\":\"fp16\"})"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "00104b27-0c15-4a97-b198-4512337ee211",
    "metadata": {},
@@ -76,27 +123,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "3acf0069",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/wfh/code/lc/lckg/.venv/lib/python3.11/site-packages/transformers/generation/utils.py:1288: UserWarning: Using `max_length`'s default (64) to control the generation length. This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we recommend using `max_new_tokens` to control the maximum length of the generation.\n",
-      "  warnings.warn(\n",
-      "WARNING:root:Failed to persist run: HTTPConnectionPool(host='localhost', port=8000): Max retries exceeded with url: /chain-runs (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x144d06910>: Failed to establish a new connection: [Errno 61] Connection refused'))\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " First, we need to understand what is an electroencephalogram. An electroencephalogram is a recording of brain activity. It is a recording of brain activity that is made by placing electrodes on the scalp. The electrodes are placed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain import PromptTemplate,  LLMChain\n",
     "\n",
@@ -137,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/langchain/llms/base.py
+++ b/langchain/llms/base.py
@@ -409,6 +409,7 @@ class LLM(BaseLLM):
         prompt: str,
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
+        generation_kwargs: Optional[dict] = None
     ) -> str:
         """Run the LLM on the given prompt and input."""
 

--- a/langchain/llms/base.py
+++ b/langchain/llms/base.py
@@ -409,7 +409,6 @@ class LLM(BaseLLM):
         prompt: str,
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
-        generation_kwargs: Optional[dict] = None
     ) -> str:
         """Run the LLM on the given prompt and input."""
 

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -143,7 +143,7 @@ class HuggingFacePipeline(LLM):
                 f"currently only {VALID_TASKS} are supported"
             )
         if deepspeed_args is not None:
-            import deepseed
+            import deepspeed
             world_size = 1
             dtype = torch.float16
             pipeline.model = deepspeed.init_inference(pipeline.model,

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -206,8 +206,9 @@ class HuggingFacePipeline(LLM):
         prompt: str,
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
+        generation_kwargs: Optional[dict] = None,
     ) -> str:
-        response = self.pipeline(prompt)
+        response = self.pipeline(prompt,generation_kwargs=generation_kwargs)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.
             text = response[0]["generated_text"][len(prompt) :]

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -204,12 +204,13 @@ class HuggingFacePipeline(LLM):
     def _call(
         self,
         prompt: str,
-        gen_args: Optional[dict] = None,
         stop: Optional[List[str]] = None,
-        run_manager: Optional[CallbackManagerForLLMRun] = None
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        generation_kwargs: Optional[dict] = None,
+
     ) -> str:
         print("here2")
-        response = self.pipeline(prompt,generation_kwargs=gen_args)
+        response = self.pipeline(prompt,generation_kwargs=generation_kwargs)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.
             text = response[0]["generated_text"][len(prompt) :]

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -144,7 +144,13 @@ class HuggingFacePipeline(LLM):
                 f"currently only {VALID_TASKS} are supported"
             )
         if deepspeed_args is not None:
-            import deepspeed
+            try:
+                import deepspeed
+            except ImportError as e:
+                raise ValueError(
+                    "Could not import deepspeed python package. "
+                    "Please install it with `pip install deepspeed`."
+                ) from e
             world_size = 1
             if "dtype" in deepspeed_args:
                 deepspeed_dtype = deepspeed_args["dtype"]

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -210,7 +210,6 @@ class HuggingFacePipeline(LLM):
         generation_kwargs: Optional[dict] = None,
 
     ) -> str:
-        print("here2")
         response = self.pipeline(prompt,generation_kwargs=generation_kwargs)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -208,7 +208,7 @@ class HuggingFacePipeline(LLM):
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None
     ) -> str:
-        print("here")
+        print("here2")
         response = self.pipeline(prompt,generation_kwargs=gen_args)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -206,9 +206,8 @@ class HuggingFacePipeline(LLM):
         prompt: str,
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
-        generation_kwargs: Optional[dict] = None,
     ) -> str:
-        response = self.pipeline(prompt,generation_kwargs=generation_kwargs)
+        response = self.pipeline(prompt)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.
             text = response[0]["generated_text"][len(prompt) :]

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -204,12 +204,12 @@ class HuggingFacePipeline(LLM):
     def _call(
         self,
         prompt: str,
+        gen_args: Optional[dict] = None,
         stop: Optional[List[str]] = None,
-        run_manager: Optional[CallbackManagerForLLMRun] = None,
-        generation_kwargs: Optional[dict] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None
     ) -> str:
         print("here")
-        response = self.pipeline(prompt,generation_kwargs=generation_kwargs)
+        response = self.pipeline(prompt,generation_kwargs=gen_args)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.
             text = response[0]["generated_text"][len(prompt) :]

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -208,6 +208,7 @@ class HuggingFacePipeline(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         generation_kwargs: Optional[dict] = None,
     ) -> str:
+        print("here")
         response = self.pipeline(prompt,generation_kwargs=generation_kwargs)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -110,20 +110,21 @@ class HuggingFacePipeline(LLM):
         if importlib.util.find_spec("torch") is not None:
             import torch
 
-            cuda_device_count = torch.cuda.device_count()
-            if device < -1 or (device >= cuda_device_count):
-                raise ValueError(
-                    f"Got device=={device}, "
-                    f"device is required to be within [-1, {cuda_device_count})"
-                )
-            if device < 0 and cuda_device_count > 0:
-                logger.warning(
-                    "Device has %d GPUs available. "
-                    "Provide device={deviceId} to `from_model_id` to use available"
-                    "GPUs for execution. deviceId is -1 (default) for CPU and "
-                    "can be a positive integer associated with CUDA device id.",
-                    cuda_device_count,
-                )
+            if device is not None:
+                cuda_device_count = torch.cuda.device_count()
+                if device < -1 or (device >= cuda_device_count):
+                    raise ValueError(
+                        f"Got device=={device}, "
+                        f"device is required to be within [-1, {cuda_device_count})"
+                    )
+                if device < 0 and cuda_device_count > 0:
+                    logger.warning(
+                        "Device has %d GPUs available. "
+                        "Provide device={deviceId} to `from_model_id` to use available"
+                        "GPUs for execution. deviceId is -1 (default) for CPU and "
+                        "can be a positive integer associated with CUDA device id.",
+                        cuda_device_count,
+                    )
         if "trust_remote_code" in _model_kwargs:
             _model_kwargs = {
                 k: v for k, v in _model_kwargs.items() if k != "trust_remote_code"

--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -73,7 +73,6 @@ class HuggingFacePipeline(LLM):
         deepspeed_args: Optional[dict] = None,
         **kwargs: Any,
     ) -> LLM:
-        print("kwargs", kwargs)
         """Construct the pipeline object from model_id and task."""
         try:
             from transformers import (

--- a/tests/integration_tests/llms/test_huggingface_pipeline.py
+++ b/tests/integration_tests/llms/test_huggingface_pipeline.py
@@ -61,6 +61,6 @@ def test_init_with_pipeline() -> None:
 
 def test_deepspeed_support():
     model_id = "gpt2"
-    llm = HuggingFacePipeline.from_model_id(model_id=model_id, task="text-generation", model_kwargs={"torch_dtype":torch.float16}, deepspeed_args={"dtype": "fp16"})
+    llm = HuggingFacePipeline.from_model_id(model_id=model_id,device=0, task="text-generation", model_kwargs={"torch_dtype":torch.float16}, deepspeed_args={"dtype": "fp16"})
     output = llm("Say foo:")
     assert isinstance(output, str)

--- a/tests/integration_tests/llms/test_huggingface_pipeline.py
+++ b/tests/integration_tests/llms/test_huggingface_pipeline.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+import torch
 
 from langchain.llms.huggingface_pipeline import HuggingFacePipeline
 from langchain.llms.loading import load_llm
@@ -55,5 +56,11 @@ def test_init_with_pipeline() -> None:
         "text-generation", model=model, tokenizer=tokenizer, max_new_tokens=10
     )
     llm = HuggingFacePipeline(pipeline=pipe)
+    output = llm("Say foo:")
+    assert isinstance(output, str)
+
+def test_deepspeed_support():
+    model_id = "gpt2"
+    llm = HuggingFacePipeline.from_model_id(model_id=model_id, task="text-generation", model_kwargs={"torch_dtype":torch.float16}, deepspeed_args={"dtype": "fp16"})
     output = llm("Say foo:")
     assert isinstance(output, str)

--- a/tests/integration_tests/llms/test_huggingface_pipeline.py
+++ b/tests/integration_tests/llms/test_huggingface_pipeline.py
@@ -13,7 +13,7 @@ from tests.integration_tests.llms.utils import assert_llm_equality
 def test_huggingface_pipeline_text_generation() -> None:
     """Test valid call to HuggingFace text generation model."""
     llm = HuggingFacePipeline.from_model_id(
-        model_id="gpt2", task="text-generation", model_kwargs={"max_new_tokens": 10}
+        model_id="gpt2", task="text-generation", pipeline_kwargs={"max_new_tokens": 10}
     )
     output = llm("Say foo:")
     assert isinstance(output, str)
@@ -40,7 +40,7 @@ def text_huggingface_pipeline_summarization() -> None:
 def test_saving_loading_llm(tmp_path: Path) -> None:
     """Test saving/loading an HuggingFaceHub LLM."""
     llm = HuggingFacePipeline.from_model_id(
-        model_id="gpt2", task="text-generation", model_kwargs={"max_new_tokens": 10}
+        model_id="gpt2", task="text-generation", pipeline_kwargs={"max_new_tokens": 10}
     )
     llm.save(file_path=tmp_path / "hf.yaml")
     loaded_llm = load_llm(tmp_path / "hf.yaml")


### PR DESCRIPTION
# DeepSpeed Support For HuggingFacePipeline

This PR adds support for DeepSpeed with the Huggingface pipelines for local models.  DeepSpeed allows over 2x faster model inference for a wide variety of models.

To use this, you need a modern GPU and have CUDA installed that is the same version as the one used to compile Pytorch  

You also need to install deepspeed with the following command:
```pip install deepspeed```

Fixes # (issue)

A test has been added for this new feature.  As a side note, some existing tests seem to not be working due to the fact that ```max_new_tokens``` is not a supported keyword.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

  @hwchase17 - project lead
  Models
  - @hwchase17
  - @agola11


