### PR TITLE
convert the parameter 'text' to uppercase in the function 'parse' of the class BooleanOutputParser

### DIFF
--- a/langchain/output_parsers/boolean.py
+++ b/langchain/output_parsers/boolean.py
@@ -15,13 +15,13 @@ class BooleanOutputParser(BaseOutputParser[bool]):
             boolean
 
         """
-        cleaned_text = text.upper().strip()
-        if cleaned_text not in (self.true_val, self.false_val):
+        cleaned_text = text.strip()
+        if cleaned_text.upper() not in (self.true_val.upper(), self.false_val.upper()):
             raise ValueError(
                 f"BooleanOutputParser expected output value to either be "
                 f"{self.true_val} or {self.false_val}. Received {cleaned_text}."
             )
-        return cleaned_text == self.true_val
+        return cleaned_text.upper() == self.true_val.upper()
 
     @property
     def _type(self) -> str:

--- a/langchain/output_parsers/boolean.py
+++ b/langchain/output_parsers/boolean.py
@@ -15,7 +15,7 @@ class BooleanOutputParser(BaseOutputParser[bool]):
             boolean
 
         """
-        cleaned_text = text.strip()
+        cleaned_text = text.upper().strip()
         if cleaned_text not in (self.true_val, self.false_val):
             raise ValueError(
                 f"BooleanOutputParser expected output value to either be "

--- a/tests/unit_tests/output_parsers/test_boolean_parser.py
+++ b/tests/unit_tests/output_parsers/test_boolean_parser.py
@@ -11,7 +11,7 @@ def test_boolean_output_parser_parse() -> None:
     # Test valid input
     result = parser.parse("NO")
     assert result is False
-    
+
     # Test valid input
     result = parser.parse("yes")
     assert result is True

--- a/tests/unit_tests/output_parsers/test_boolean_parser.py
+++ b/tests/unit_tests/output_parsers/test_boolean_parser.py
@@ -11,6 +11,14 @@ def test_boolean_output_parser_parse() -> None:
     # Test valid input
     result = parser.parse("NO")
     assert result is False
+    
+    # Test valid input
+    result = parser.parse("yes")
+    assert result is True
+
+    # Test valid input
+    result = parser.parse("no")
+    assert result is False
 
     # Test invalid input
     try:


### PR DESCRIPTION
when the LLMs output 'yes|no'，BooleanOutputParser can parse it to 'True|False', fix the ValueError in parse().
<!--
when use the BooleanOutputParser in the chain_filter.py, the LLMs output 'yes|no'，the function 'parse' will throw ValueError。
-->

Fixes # (issue)
  #5396
  https://github.com/hwchase17/langchain/issues/5396


@hwchase17 