### PR TITLE
Change _parse_input implementation in BaseTool

### DIFF
--- a/langchain/tools/base.py
+++ b/langchain/tools/base.py
@@ -188,7 +188,7 @@ class BaseTool(ABC, BaseModel, metaclass=ToolMetaclass):
         else:
             if input_args is not None:
                 result = input_args.parse_obj(tool_input)
-                return {k: v for k, v in result.dict().items() if k in tool_input}
+                return result.dict()
         return tool_input
 
     @root_validator()


### PR DESCRIPTION
- Change to respect the BaseModel more than the results of the agent.

# Change _parse_input implementation in BaseTool

It's hard for me to figure out the intent of the original author of the old code. The original code tends to prioritize the agent's output over the results of pydantic's BaseModel parse_obj. For example, the old code does not honor pydantic's default value or alias. (If they are not included in the key of the agent's output, they are removed.) I was a bit curious about why this implementation was needed, so I created a pull request.

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@vowelparrot
