### PR TITLE
MRKL output parser no longer breaks well formed queries

### DIFF
--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -44,7 +44,13 @@ class MRKLOutputParser(AgentOutputParser):
                 raise OutputParserException(f"Could not parse LLM output: `{text}`")
         action = match.group(1).strip()
         action_input = match.group(2)
-        return AgentAction(action, action_input.strip(" ").strip('"'), text)
+
+        output = action_input.strip(" ")
+        # ensure if its a well formed SQL query we don't remove any trailing " chars
+        if action_input.startswith('SELECT ') is False:
+            output = output.strip('"')
+
+        return AgentAction(action, output, text)
 
     @property
     def _type(self) -> str:

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -45,12 +45,12 @@ class MRKLOutputParser(AgentOutputParser):
         action = match.group(1).strip()
         action_input = match.group(2)
 
-        output = action_input.strip(" ")
+        tool_input = action_input.strip(" ")
         # ensure if its a well formed SQL query we don't remove any trailing " chars
-        if action_input.startswith('SELECT ') is False:
-            output = output.strip('"')
+        if tool_input.startswith("SELECT ") is False:
+            tool_input = tool_input.strip('"')
 
-        return AgentAction(action, output, text)
+        return AgentAction(action, tool_input, text)
 
     @property
     def _type(self) -> str:

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -71,6 +71,20 @@ def test_get_action_and_input_newline_after_keyword() -> None:
     assert action_input == "ls -l ~/.bashrc.d/\n"
 
 
+def test_get_action_and_input_sql_query() -> None:
+    """Test getting the action and action input from the text
+    when the LLM output is a well formed SQL query
+    """
+    llm_output = """
+    I should query for the largest single shift payment for every unique user.
+    Action: query_sql_db
+    Action Input: SELECT "UserName", MAX(totalpayment) FROM user_shifts GROUP BY "UserName"
+    """
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "query_sql_db"
+    assert action_input == "SELECT \"UserName\", MAX(totalpayment) FROM user_shifts GROUP BY \"UserName\""
+
+
 def test_get_final_answer() -> None:
     """Test getting final answer."""
     llm_output = (

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -78,8 +78,8 @@ def test_get_action_and_input_sql_query() -> None:
     llm_output = """
     I should query for the largest single shift payment for every unique user.
     Action: query_sql_db
-    Action Input: SELECT "UserName", MAX(totalpayment) FROM user_shifts GROUP BY "UserName"
-    """
+    Action Input: \
+    SELECT "UserName", MAX(totalpayment) FROM user_shifts GROUP BY "UserName" """
     action, action_input = get_action_and_input(llm_output)
     assert action == "query_sql_db"
     assert (

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -82,7 +82,10 @@ def test_get_action_and_input_sql_query() -> None:
     """
     action, action_input = get_action_and_input(llm_output)
     assert action == "query_sql_db"
-    assert action_input == "SELECT \"UserName\", MAX(totalpayment) FROM user_shifts GROUP BY \"UserName\""
+    assert (
+        action_input
+        == 'SELECT "UserName", MAX(totalpayment) FROM user_shifts GROUP BY "UserName"'
+    )
 
 
 def test_get_final_answer() -> None:


### PR DESCRIPTION
# Handles the edge scenario in which the action input is a well formed SQL query which ends with a quoted column

There may be a cleaner option here (or indeed other edge scenarios) but this seems to robustly determine if the action input is likely to be a well formed SQL query in which we don't want to arbitrarily trim off `"` characters

Fixes #5423

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Agents / Tools / Toolkits
  - @vowelparrot
