### PR TITLE
Fixed docstring in faiss.py for load_local

### DIFF
--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -496,7 +496,7 @@ class FAISS(VectorStore):
     def load_local(
         cls, folder_path: str, embeddings: Embeddings, index_name: str = "index"
     ) -> FAISS:
-        """Load FAISS index, docstore, and index_to_docstore_id to disk.
+        """Load FAISS index, docstore, and index_to_docstore_id from disk.
 
         Args:
             folder_path: folder path to load index, docstore,


### PR DESCRIPTION
# Fix for docstring in faiss.py vectorstore (load_local)

The doctring should reflect that load_local loads something FROM the disk.

 @dev2049
