### PR TITLE
Allow setting explicit _id when indexing in elasticsearch

### DIFF
--- a/langchain/vectorstores/elastic_vector_search.py
+++ b/langchain/vectorstores/elastic_vector_search.py
@@ -181,7 +181,7 @@ class ElasticVectorSearch(VectorStore, ABC):
 
         for i, text in enumerate(texts):
             metadata = metadatas[i] if metadatas else {}
-            _id = str(uuid.uuid4())
+            _id = str(metadata.pop("_id", uuid.uuid4())
             request = {
                 "_op_type": "index",
                 "_index": self.index_name,


### PR DESCRIPTION
This PR improves the method `add_texts` of `ElasticVectorSearch`.
If a key `_id` is available in metadata it will be used as unique identifier when indexing in elasticsearch.
I makes the method idempotent and prevents duplicates.

Fixes #5437 
cc: @jeffvestal @derickson @hwchase17 

