### PR TITLE
Removes duplicated call from langchain/client/langchain.py

### DIFF
--- a/langchain/client/langchain.py
+++ b/langchain/client/langchain.py
@@ -249,11 +249,6 @@ class LangChainPlusClient(BaseSettings):
             params=params,
         )
         raise_for_status_with_text(response)
-        response = self._get(
-            path,
-            params=params,
-        )
-        raise_for_status_with_text(response)
         result = response.json()
         if isinstance(result, list):
             if len(result) == 0:


### PR DESCRIPTION
This removes duplicate code presumably introduced by a cut-and-paste error, spotted while reviewing the code in ```langchain/client/langchain.py```. The original code had back to back occurrences of the following code block:

```
        response = self._get(
            path,
            params=params,
        )
        raise_for_status_with_text(response)
```

Here are the ```make test``` results:

```
================= 693 passed, 52 skipped, 27 warnings in 8.38s =================
```