### PR TITLE
Ability to specify credentials wihen using Google BigQuery as a data loader

### DIFF
--- a/langchain/document_loaders/bigquery.py
+++ b/langchain/document_loaders/bigquery.py
@@ -11,19 +11,33 @@ class BigQueryLoader(BaseLoader):
     are written into the `page_content` of the document. The `metadata_columns`
     are written into the `metadata` of the document. By default, all columns
     are written into the `page_content` and none into the `metadata`.
+
     """
 
     def __init__(
-        self,
-        query: str,
-        project: Optional[str] = None,
-        page_content_columns: Optional[List[str]] = None,
-        metadata_columns: Optional[List[str]] = None,
+            self,
+            query: str,
+            project: Optional[str] = None,
+            page_content_columns: Optional[List[str]] = None,
+            metadata_columns: Optional[List[str]] = None,
+            credentials=None,
     ):
+        """
+        :param query: The query to run in BigQuery.
+        :param project: Optional. The project to run the query in.
+        :param page_content_columns: Optional. The columns to write into the `page_content` of the document.
+        :param metadata_columns: Optional. The columns to write into the `metadata` of the document.
+        :param credentials : google.auth.credentials.Credentials, optional
+            Credentials for accessing Google APIs. Use this parameter to override
+            default credentials, such as to use Compute Engine
+            :class:`google.auth.compute_engine.Credentials` or Service Account
+            :class:`google.oauth2.service_account.Credentials` directly.
+        """
         self.query = query
         self.project = project
         self.page_content_columns = page_content_columns
         self.metadata_columns = metadata_columns
+        self.credentials = credentials
 
     def load(self) -> List[Document]:
         try:
@@ -34,7 +48,7 @@ class BigQueryLoader(BaseLoader):
                 "Please install it with `pip install google-cloud-bigquery`."
             ) from ex
 
-        bq_client = bigquery.Client(self.project)
+        bq_client = bigquery.Client(credentials=self.credentials, project=self.project)
         query_result = bq_client.query(self.query).result()
         docs: List[Document] = []
 

--- a/langchain/document_loaders/bigquery.py
+++ b/langchain/document_loaders/bigquery.py
@@ -1,9 +1,12 @@
-from typing import List, Optional
+from __future__ import annotations
 
-import google.auth
+from typing import TYPE_CHECKING, List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
 
 
 class BigQueryLoader(BaseLoader):
@@ -22,18 +25,22 @@ class BigQueryLoader(BaseLoader):
         project: Optional[str] = None,
         page_content_columns: Optional[List[str]] = None,
         metadata_columns: Optional[List[str]] = None,
-        credentials: Optional[google.auth.credentials.Credentials] = None,
+        credentials: Optional[Credentials] = None,
     ):
-        """
-        :param query: The query to run in BigQuery.
-        :param project: Optional. The project to run the query in.
-        :param page_content_columns: Optional. The columns to write into the `page_content` of the document.
-        :param metadata_columns: Optional. The columns to write into the `metadata` of the document.
-        :param credentials : google.auth.credentials.Credentials, optional
+        """Initialize BigQuery document loader.
+
+        Args:
+            query: The query to run in BigQuery.
+            project: Optional. The project to run the query in.
+            page_content_columns: Optional. The columns to write into the `page_content`
+                of the document.
+            metadata_columns: Optional. The columns to write into the `metadata` of the
+                document.
+            credentials : google.auth.credentials.Credentials, optional
             Credentials for accessing Google APIs. Use this parameter to override
-            default credentials, such as to use Compute Engine
-            :class:`google.auth.compute_engine.Credentials` or Service Account
-            :class:`google.oauth2.service_account.Credentials` directly.
+                default credentials, such as to use Compute Engine
+                (`google.auth.compute_engine.Credentials`) or Service Account
+                (`google.oauth2.service_account.Credentials`) credentials directly.
         """
         self.query = query
         self.project = project

--- a/langchain/document_loaders/bigquery.py
+++ b/langchain/document_loaders/bigquery.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
-
+import google.auth
 
 class BigQueryLoader(BaseLoader):
     """Loads a query result from BigQuery into a list of documents.
@@ -15,12 +15,12 @@ class BigQueryLoader(BaseLoader):
     """
 
     def __init__(
-            self,
-            query: str,
-            project: Optional[str] = None,
-            page_content_columns: Optional[List[str]] = None,
-            metadata_columns: Optional[List[str]] = None,
-            credentials=None,
+        self,
+        query: str,
+        project: Optional[str] = None,
+        page_content_columns: Optional[List[str]] = None,
+        metadata_columns: Optional[List[str]] = None,
+        credentials: Optional[google.auth.credentials.Credentials] = None,
     ):
         """
         :param query: The query to run in BigQuery.

--- a/langchain/document_loaders/bigquery.py
+++ b/langchain/document_loaders/bigquery.py
@@ -1,8 +1,10 @@
 from typing import List, Optional
 
+import google.auth
+
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
-import google.auth
+
 
 class BigQueryLoader(BaseLoader):
     """Loads a query result from BigQuery into a list of documents.

--- a/poetry.lock
+++ b/poetry.lock
@@ -10948,7 +10948,7 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 cffi = ["cffi (>=1.11)"]
 
 [extras]
-all = ["O365", "aleph-alpha-client", "anthropic", "arxiv", "atlassian-python-api", "azure-ai-formrecognizer", "azure-ai-vision", "azure-cognitiveservices-speech", "azure-cosmos", "azure-identity", "beautifulsoup4", "clickhouse-connect", "cohere", "deeplake", "docarray", "duckduckgo-search", "elasticsearch", "faiss-cpu", "google-api-python-client", "google-search-results", "gptcache", "html2text", "huggingface_hub", "jina", "jinja2", "jq", "lancedb", "langkit", "lark", "lxml", "manifest-ml", "momento", "neo4j", "networkx", "nlpcloud", "nltk", "nomic", "openai", "openlm", "opensearch-py", "pdfminer-six", "pexpect", "pgvector", "pinecone-client", "pinecone-text", "psycopg2-binary", "pymongo", "pyowm", "pypdf", "pytesseract", "pyvespa", "qdrant-client", "redis", "requests-toolbelt", "sentence-transformers", "spacy", "steamship", "tensorflow-text", "tiktoken", "torch", "transformers", "weaviate-client", "wikipedia", "wolframalpha"]
+all = ["O365", "aleph-alpha-client", "anthropic", "arxiv", "atlassian-python-api", "azure-ai-formrecognizer", "azure-ai-vision", "azure-cognitiveservices-speech", "azure-cosmos", "azure-identity", "beautifulsoup4", "clickhouse-connect", "cohere", "deeplake", "docarray", "duckduckgo-search", "elasticsearch", "faiss-cpu", "google-api-python-client", "google-auth", "google-search-results", "gptcache", "html2text", "huggingface_hub", "jina", "jinja2", "jq", "lancedb", "langkit", "lark", "lxml", "manifest-ml", "momento", "neo4j", "networkx", "nlpcloud", "nltk", "nomic", "openai", "openlm", "opensearch-py", "pdfminer-six", "pexpect", "pgvector", "pinecone-client", "pinecone-text", "psycopg2-binary", "pymongo", "pyowm", "pypdf", "pytesseract", "pyvespa", "qdrant-client", "redis", "requests-toolbelt", "sentence-transformers", "spacy", "steamship", "tensorflow-text", "tiktoken", "torch", "transformers", "weaviate-client", "wikipedia", "wolframalpha"]
 azure = ["azure-ai-formrecognizer", "azure-ai-vision", "azure-cognitiveservices-speech", "azure-core", "azure-cosmos", "azure-identity", "openai"]
 cohere = ["cohere"]
 docarray = ["docarray"]
@@ -10962,4 +10962,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "937d2f0165f6aa381ea1e26002272a92b189ab18607bd05895e36d23f56978f4"
+content-hash = "b63bc93172f2ef12333fc899f763a474aa108d2a4a2b8aee89d9aca7cd1df4cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ pymongo = {version = "^4.3.3", optional = true}
 clickhouse-connect = {version="^0.5.14", optional=true}
 weaviate-client = {version = "^3", optional = true}
 google-api-python-client = {version = "2.70.0", optional = true}
+google-auth = {version = "^2.18.1", optional = true}
 wolframalpha = {version = "5.0.0", optional = true}
 anthropic = {version = "^0.2.6", optional = true}
 qdrant-client = {version = "^1.1.2", optional = true, python = ">=3.8.1,<3.12"}
@@ -239,6 +240,7 @@ all = [
     "weaviate-client",
     "redis",
     "google-api-python-client",
+    "google-auth",
     "wolframalpha",
     "qdrant-client",
     "tensorflow-text",


### PR DESCRIPTION
# Adds ability to specify credentials when using Google BigQuery as a data loader

Fixes #5465 . Adds ability to set credentials which must be of the `google.auth.credentials.Credentials` type. This argument is optional and will default to `None.

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
@eyurtsev
