### PR TITLE
Add option to ignore column names in SQLDatabase.run()

### DIFF
--- a/langchain/sql_database.py
+++ b/langchain/sql_database.py
@@ -334,6 +334,7 @@ class SQLDatabase:
                 else:
                     connection.exec_driver_sql(f"SET search_path TO {self._schema}")
             cursor = connection.execute(text(command))
+            column_names = tuple(cursor.keys())
             if cursor.returns_rows:
                 if fetch == "all":
                     result = cursor.fetchall()
@@ -341,6 +342,7 @@ class SQLDatabase:
                     result = cursor.fetchone()[0]  # type: ignore
                 else:
                     raise ValueError("Fetch parameter must be either 'one' or 'all'")
+                result.insert(0, column_names)
                 return str(result)
         return ""
 


### PR DESCRIPTION
# Add column names to SQLDatabase.run() result

Description:
Current state: SQLDatabase.run() method returns a result from the database after executing a SQL query but there is no option of adding the column names as well to the returned result.

PR offer the following solution:

Adding a argument "ignore_column_names_on_query" to the SQLDatabase constructor.
By default, the argument is set to True, but when set to False, SQLDatabase.run() method will add the column names to the result (if the result is not empty).


Would love to hear some feedback!

  -  @hwchase17
  - @vowelparrot

