### PR TITLE
Fix wrong class instantiation in docs MMR example

### DIFF
--- a/docs/modules/prompts/example_selectors/examples/mmr.ipynb
+++ b/docs/modules/prompts/example_selectors/examples/mmr.ipynb
@@ -12,12 +12,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "ac95c968",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.prompts.example_selector import MaxMarginalRelevanceExampleSelector\n",
+    "from langchain.prompts.example_selector import MaxMarginalRelevanceExampleSelector, SemanticSimilarityExampleSelector\n",
     "from langchain.vectorstores import FAISS\n",
     "from langchain.embeddings import OpenAIEmbeddings\n",
     "from langchain.prompts import FewShotPromptTemplate, PromptTemplate\n",
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "db579bea",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "cd76e344",
    "metadata": {},
    "outputs": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "id": "cf82956b",
    "metadata": {},
    "outputs": [
@@ -107,8 +107,8 @@
       "Input: happy\n",
       "Output: sad\n",
       "\n",
-      "Input: windy\n",
-      "Output: calm\n",
+      "Input: sunny\n",
+      "Output: gloomy\n",
       "\n",
       "Input: worried\n",
       "Output:\n"
@@ -116,7 +116,18 @@
     }
    ],
    "source": [
-    "# Let's compare this to what we would just get if we went solely off of similarity\n",
+    "# Let's compare this to what we would just get if we went solely off of similarity,\n",
+    "# by using SemanticSimilarityExampleSelector instead of MaxMarginalRelevanceExampleSelector.\n",
+    "example_selector = SemanticSimilarityExampleSelector.from_examples(\n",
+    "    # This is the list of examples available to select from.\n",
+    "    examples, \n",
+    "    # This is the embedding class used to produce embeddings which are used to measure semantic similarity.\n",
+    "    OpenAIEmbeddings(), \n",
+    "    # This is the VectorStore class that is used to store the embeddings and do a similarity search over.\n",
+    "    FAISS, \n",
+    "    # This is the number of examples to produce.\n",
+    "    k=2\n",
+    ")\n",
     "similar_prompt = FewShotPromptTemplate(\n",
     "    # We provide an ExampleSelector instead of examples.\n",
     "    example_selector=example_selector,\n",
@@ -125,7 +136,6 @@
     "    suffix=\"Input: {adjective}\\nOutput:\", \n",
     "    input_variables=[\"adjective\"],\n",
     ")\n",
-    "similar_prompt.example_selector.k = 2\n",
     "print(similar_prompt.format(adjective=\"worried\"))"
    ]
   },
@@ -154,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Fix wrong class instantiation in docs MMR example

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

When looking at the Maximal Marginal Relevance ExampleSelector example at https://python.langchain.com/en/latest/modules/prompts/example_selectors/examples/mmr.html, I noticed that there seems to be an error. Initially, the `MaxMarginalRelevanceExampleSelector` class is used as an `example_selector` argument to the `FewShotPromptTemplate` class. Then, according to the text, a comparison is made to regular similarity search. However, the `FewShotPromptTemplate` still uses the `MaxMarginalRelevanceExampleSelector` class, so the output is the same. 

To fix it, I added an instantiation of the `SemanticSimilarityExampleSelector` class, because this seems to be what is intended.


## Who can review?

@hwchase17 
