### PR TITLE
Reference OpenAIEmbeddings client attr as private

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -128,7 +128,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Timeout in seconds for the OpenAPI request."""
     headers: Any = None
 
-    def __init__(self, **data: Any]):
+    def __init__(self, **data: Any):
         self.validate_environment(data)
         super().__init__(**data)
 

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 import numpy as np
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, PrivateAttr, root_validator
 from tenacity import (
     before_sleep_log,
     retry,
@@ -105,7 +105,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
 
     """
 
-    client: Any  #: :meta private:
+    _client: Any = PrivateAttr()  #: :meta private:
     model: str = "text-embedding-ada-002"
     deployment: str = model  # to support Azure OpenAI Service custom deployment names
     openai_api_version: Optional[str] = None
@@ -307,3 +307,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         """
         embedding = self._embedding_func(text, engine=self.deployment)
         return embedding
+
+    @property
+    def client(self) -> Any:
+        return self._client

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -128,7 +128,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Timeout in seconds for the OpenAPI request."""
     headers: Any = None
 
-    def __init__(self, **data: Dict[str, Any]):
+    def __init__(self, **data: Any]):
         self.validate_environment(data)
         super().__init__(**data)
 


### PR DESCRIPTION
Reference OpenAIEmbeddings client attr as private

When utilising Pylance it is currently unable to manage interpretation of the `client` attribute within `OpenAIEmbeddings` as private. This results in the following errors being displayed:

![Screenshot 2023-05-31 at 17 19 34](https://github.com/hwchase17/langchain/assets/38786/bb19e39a-2abd-471b-afd0-b3568913bd44)

Additionally newer versions of `mypy` also identify this issue:

`tests/integration_tests/embeddings/test_openai.py:11: error: Missing named argument "client" for "OpenAIEmbeddings"  [call-arg]`

One minor note is that I've include a property setter to preserve any access patterns for `OpenAIEmbeddings.client`

/cc @hwchase17 - project lead
/cc @agola11 - Models 
