### PR TITLE
Change methodology for scraping

### DIFF
--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -74,27 +74,13 @@ class ReadTheDocsLoader(BaseLoader):
 
         soup = BeautifulSoup(data, **self.bs_kwargs)
 
-        # default tags
-        html_tags = [
-            ("div", {"role": "main"}),
-            ("main", {"id": "main-content"}),
-        ]
-
-        if self.custom_html_tag is not None:
-            html_tags.append(self.custom_html_tag)
-
-        text = None
-
-        # reversed order. check the custom one first
-        for tag, attrs in html_tags[::-1]:
-            text = soup.find(tag, attrs)
-            # if found, break
-            if text is not None:
-                break
-
+        # Check for the body tag
+        text = soup.find('body')
+        
         if text is not None:
             text = text.get_text()
         else:
             text = ""
-        # trim empty lines
+
+        # Trim empty lines
         return "\n".join([t for t in text.split("\n") if t])

--- a/langchain/document_loaders/readthedocs.py
+++ b/langchain/document_loaders/readthedocs.py
@@ -75,8 +75,8 @@ class ReadTheDocsLoader(BaseLoader):
         soup = BeautifulSoup(data, **self.bs_kwargs)
 
         # Check for the body tag
-        text = soup.find('body')
-        
+        text = soup.find("body")
+
         if text is not None:
             text = text.get_text()
         else:


### PR DESCRIPTION
It seems that the ReadTheDocsLoader is trying to parse and clean HTML contents from specific tags in the HTML file. If the HTML file doesn't contain the exact tag, the page_content will be empty.

The loader is looking for the "main" tag with the id "main-content" and if it doesn't find it, it's looking for a "div" tag with the role "main". If neither is found, it returns an empty string.

One way to fix this issue is to adjust the tags to those present in the HTML files to be scraped.

@eyurtsev