### PR TITLE
Skips creating boto client for Bedrock if passed in constructor

### DIFF
--- a/langchain/embeddings/bedrock.py
+++ b/langchain/embeddings/bedrock.py
@@ -68,6 +68,10 @@ class BedrockEmbeddings(BaseModel, Embeddings):
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that AWS credentials to and python package exists in environment."""
+
+        if "client" in values:
+            return values
+
         try:
             import boto3
 

--- a/langchain/llms/bedrock.py
+++ b/langchain/llms/bedrock.py
@@ -99,6 +99,11 @@ class Bedrock(LLM):
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that AWS credentials to and python package exists in environment."""
+
+        # Skip creating new client if passed in constructor
+        if "client" in values:
+            return values
+
         try:
             import boto3
 


### PR DESCRIPTION
# Skips creating boto client if passed in constructor
Current LLM and Embeddings class always creates a new boto client, even if one is passed in a constructor. This blocks certain users from passing in externally created boto clients, for example in SSO authentication. 

## Who can review?
@hwchase17 
@jasondotparse 
@rsgrewal-aws

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
