### PR TITLE
Replace list comprehension with generator.

### DIFF
--- a/langchain/output_parsers/combining.py
+++ b/langchain/output_parsers/combining.py
@@ -35,10 +35,8 @@ class CombiningOutputParser(BaseOutputParser):
 
         initial = f"For your first output: {self.parsers[0].get_format_instructions()}"
         subsequent = "\n".join(
-            [
-                f"Complete that output fully. Then produce another output, separated by two newline characters: {p.get_format_instructions()}"  # noqa: E501
-                for p in self.parsers[1:]
-            ]
+            f"Complete that output fully. Then produce another output, separated by two newline characters: {p.get_format_instructions()}"  # noqa: E501
+            for p in self.parsers[1:]
         )
         return f"{initial}\n{subsequent}"
 


### PR DESCRIPTION
# Replace list comprehension with generator.

Since these strings can be fairly long, it's best to not construct unnecessary temporary list just to pass it to `join`. Generators produce items one-by-one and even though they are slightly more expensive than lists in terms of CPU they are much more memory-friendly and slightly more readable.