### PR TITLE
Replace loop appends with list comprehension.

### DIFF
--- a/langchain/retrievers/tfidf.py
+++ b/langchain/retrievers/tfidf.py
@@ -67,9 +67,7 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
         results = cosine_similarity(self.tfidf_array, query_vec).reshape(
             (-1,)
         )  # Op -- (n_docs,1) -- Cosine Sim with each doc
-        return_docs = [
-            self.docs[i] for i in results.argsort()[-self.k :][::-1]
-        ]
+        return_docs = [self.docs[i] for i in results.argsort()[-self.k :][::-1]]
         return return_docs
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:

--- a/langchain/retrievers/tfidf.py
+++ b/langchain/retrievers/tfidf.py
@@ -67,9 +67,9 @@ class TFIDFRetriever(BaseRetriever, BaseModel):
         results = cosine_similarity(self.tfidf_array, query_vec).reshape(
             (-1,)
         )  # Op -- (n_docs,1) -- Cosine Sim with each doc
-        return_docs = []
-        for i in results.argsort()[-self.k :][::-1]:
-            return_docs.append(self.docs[i])
+        return_docs = [
+            self.docs[i] for i in results.argsort()[-self.k :][::-1]
+        ]
         return return_docs
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:


### PR DESCRIPTION
# Replace loop appends with list comprehension.

It's significantly faster because it avoids repeated method lookup. It's also more idiomatic and readable.