### PR TITLE
Improve Error Messaging for APOC Procedure Failure in Neo4jGraph

### DIFF
--- a/langchain/graphs/neo4j_graph.py
+++ b/langchain/graphs/neo4j_graph.py
@@ -6,6 +6,7 @@ YIELD label, other, elementType, type, property
 WHERE NOT type = "RELATIONSHIP" AND elementType = "node"
 WITH label AS nodeLabels, collect({property:property, type:type}) AS properties
 RETURN {labels: nodeLabels, properties: properties} AS output
+
 """
 
 rel_properties_query = """
@@ -62,7 +63,7 @@ class Neo4jGraph:
             raise ValueError(
                 "Could not use APOC procedures. "
                 "Please ensure the APOC plugin is installed in Neo4j and that "
-                "the procedure 'apoc.meta.data()' is allowed in Neo4j configuration "
+                "'apoc.meta.data()' is allowed in Neo4j configuration "
             )
 
     @property

--- a/langchain/graphs/neo4j_graph.py
+++ b/langchain/graphs/neo4j_graph.py
@@ -6,7 +6,6 @@ YIELD label, other, elementType, type, property
 WHERE NOT type = "RELATIONSHIP" AND elementType = "node"
 WITH label AS nodeLabels, collect({property:property, type:type}) AS properties
 RETURN {labels: nodeLabels, properties: properties} AS output
-
 """
 
 rel_properties_query = """
@@ -62,7 +61,8 @@ class Neo4jGraph:
         except neo4j.exceptions.ClientError:
             raise ValueError(
                 "Could not use APOC procedures. "
-                "Please install the APOC plugin in Neo4j."
+                "Please ensure the APOC plugin is installed in Neo4j "
+                "and that the procedure 'apoc.meta.data()' is allowed in your configuration. "
             )
 
     @property

--- a/langchain/graphs/neo4j_graph.py
+++ b/langchain/graphs/neo4j_graph.py
@@ -61,8 +61,8 @@ class Neo4jGraph:
         except neo4j.exceptions.ClientError:
             raise ValueError(
                 "Could not use APOC procedures. "
-                "Please ensure the APOC plugin is installed in Neo4j "
-                "and that the procedure 'apoc.meta.data()' is allowed in your configuration. "
+                "Please ensure the APOC plugin is installed in Neo4j and that "
+                "the procedure 'apoc.meta.data()' is allowed in Neo4j configuration "
             )
 
     @property


### PR DESCRIPTION
## Improve Error Messaging for APOC Procedure Failure in Neo4jGraph

This commit revises the error message provided when the 'apoc.meta.data()' procedure fails. Previously, the message simply instructed the user to install the APOC plugin in Neo4j. The new error message is more specific.

Also removed an unnecessary newline in the Cypher statement variable: `node_properties_query`.

Fixes #5545 

## Who can review?
  - @vowelparrot
  - @dev2049