### PR TITLE
Corrects inconsistently misspelled variable name.

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -742,8 +742,8 @@ class PythonCodeTextSplitter(RecursiveCharacterTextSplitter):
 
     def __init__(self, **kwargs: Any):
         """Initialize a PythonCodeTextSplitter."""
-        seperators = self.get_separators_for_language(Language.PYTHON)
-        super().__init__(separators=seperators, **kwargs)
+        separators = self.get_separators_for_language(Language.PYTHON)
+        super().__init__(separators=separators, **kwargs)
 
 
 class MarkdownTextSplitter(RecursiveCharacterTextSplitter):
@@ -751,8 +751,8 @@ class MarkdownTextSplitter(RecursiveCharacterTextSplitter):
 
     def __init__(self, **kwargs: Any):
         """Initialize a MarkdownTextSplitter."""
-        seperators = self.get_separators_for_language(Language.MARKDOWN)
-        super().__init__(separators=seperators, **kwargs)
+        separators = self.get_separators_for_language(Language.MARKDOWN)
+        super().__init__(separators=separators, **kwargs)
 
 
 class LatexTextSplitter(RecursiveCharacterTextSplitter):
@@ -760,5 +760,5 @@ class LatexTextSplitter(RecursiveCharacterTextSplitter):
 
     def __init__(self, **kwargs: Any):
         """Initialize a LatexTextSplitter."""
-        seperators = self.get_separators_for_language(Language.LATEX)
-        super().__init__(separators=seperators, **kwargs)
+        separators = self.get_separators_for_language(Language.LATEX)
+        super().__init__(separators=separators, **kwargs)


### PR DESCRIPTION
Corrects a spelling error (of the word separator) in several variable names.  Three cut/paste instances of this were corrected, amidst instances of it also being named properly, which would likely would lead to issues for someone in the future.

Here is one such example:

```
        seperators = self.get_separators_for_language(Language.PYTHON)
        super().__init__(separators=seperators, **kwargs)
```
becomes
```
        separators = self.get_separators_for_language(Language.PYTHON)
        super().__init__(separators=separators, **kwargs)
```

Make test results below:

```
============================== 708 passed, 52 skipped, 27 warnings in 11.70s ==============================
```

