### PR TITLE
Add parameters to send_message() call for vertexai chat models (PaLM2)

### DIFF
--- a/langchain/chat_models/vertexai.py
+++ b/langchain/chat_models/vertexai.py
@@ -122,7 +122,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         chat = self.client.start_chat(context=context, **self._default_params)
         for pair in history.history:
             chat._history.append((pair.question.content, pair.answer.content))
-        response = chat.send_message(question.content)
+        response = chat.send_message(question.content, **self._default_params)
         text = self._enforce_stop_words(response.text, stop)
         return ChatResult(generations=[ChatGeneration(message=AIMessage(content=text))])
 


### PR DESCRIPTION
# Ensure parameters are used by vertexai chat models (PaLM2)

The current version of the google aiplatform contains a bug where parameters for a chat model are not used as intended.

See https://github.com/googleapis/python-aiplatform/issues/2263

Params can be passed both to start_chat() and send_message(); however, the parameters passed to start_chat() will not be used if send_message() is called without the overrides.  This is due to the defaults in send_message() being global values rather than None (there is code in send_message() which would use the params from start_chat() if the param passed to send_message() evaluates to False, but that won't happen as the defaults are global values).

Fixes # 5531

@hwchase17
@agola11
