### PR TITLE
Add missing comma in conv chat agent prompt json

### DIFF
--- a/langchain/agents/conversational_chat/prompt.py
+++ b/langchain/agents/conversational_chat/prompt.py
@@ -18,7 +18,7 @@ Markdown code snippet formatted in the following schema:
 
 ```json
 {{{{
-    "action": string \\ The action to take. Must be one of {tool_names}
+    "action": string, \\ The action to take. Must be one of {tool_names}
     "action_input": string \\ The input to the action
 }}}}
 ```


### PR DESCRIPTION
# Add missing comma in conversational chat agent prompt json

Inspired by: https://github.com/hwchase17/langchainjs/pull/1498

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->


## Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:
  Agents / Tools / Toolkits
  - @vowelparrot

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
