### PR TITLE
Add a "paged" mode for unstructured to include page number in metadata

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/unstructured_file.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/unstructured_file.ipynb
@@ -118,7 +118,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = UnstructuredFileLoader(\"./example_data/state_of_the_union.txt\", mode=\"elements\")"
+    "loader = UnstructuredFileLoader(\n",
+    "    \"./example_data/state_of_the_union.txt\", mode=\"elements\"\n",
+    ")"
    ]
   },
   {
@@ -183,7 +185,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = UnstructuredFileLoader(\"layout-parser-paper-fast.pdf\", strategy=\"fast\", mode=\"elements\")"
+    "loader = UnstructuredFileLoader(\n",
+    "    \"layout-parser-paper-fast.pdf\", strategy=\"fast\", mode=\"elements\"\n",
+    ")"
    ]
   },
   {
@@ -222,13 +226,17 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8de9ef16",
    "metadata": {},
    "source": [
     "## PDF Example\n",
     "\n",
-    "Processing PDF documents works exactly the same way. Unstructured detects the file type and extracts the same types of `elements`. "
+    "Processing PDF documents works exactly the same way. Unstructured detects the file type and extracts the same types of elements. Modes of operation are \n",
+    "- `single` all the text from all elements are combined into one (default)\n",
+    "- `elements` maintain individual elements\n",
+    "- `paged` texts from each page are only combined"
    ]
   },
   {
@@ -248,7 +256,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = UnstructuredFileLoader(\"./example_data/layout-parser-paper.pdf\", mode=\"elements\")"
+    "loader = UnstructuredFileLoader(\n",
+    "    \"./example_data/layout-parser-paper.pdf\", mode=\"elements\"\n",
+    ")"
    ]
   },
   {

--- a/tests/integration_tests/document_loaders/test_pdf.py
+++ b/tests/integration_tests/document_loaders/test_pdf.py
@@ -11,7 +11,25 @@ from langchain.document_loaders import (
 )
 
 
-def test_unstructured_pdf_loader() -> None:
+def test_unstructured_pdf_loader_elements_mode() -> None:
+    """Test unstructured loader with various modes."""
+    file_path = Path(__file__).parent.parent / "examples/hello.pdf"
+    loader = UnstructuredPDFLoader(str(file_path), mode="elements")
+    docs = loader.load()
+
+    assert len(docs) == 2
+
+
+def test_unstructured_pdf_loader_paged_mode() -> None:
+    """Test unstructured loader with various modes."""
+    file_path = Path(__file__).parent.parent / "examples/layout-parser-paper.pdf"
+    loader = UnstructuredPDFLoader(str(file_path), mode="paged")
+    docs = loader.load()
+
+    assert len(docs) == 16
+
+
+def test_unstructured_pdf_loader_default_mode() -> None:
     """Test unstructured loader."""
     file_path = Path(__file__).parent.parent / "examples/hello.pdf"
     loader = UnstructuredPDFLoader(str(file_path))


### PR DESCRIPTION
# Support "paged" mode for unstructured loader
<!--
UnstructuredPDF Loader now supports the mode "paged". This ensures content returned that are from the same page within the PDF are combined into a single Document object with metadata referencing back the page this content came from.

Twitter @RayzerCA
-->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  DataLoaders
  - @eyurtsev

 -->
