### PR TITLE
fix chroma update_document to embed entire documents, fixes a characer-wise embedding bug

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -356,7 +356,7 @@ class Chroma(VectorStore):
             raise ValueError(
                 "For update, you must specify an embedding function on creation."
             )
-        embeddings = self._embedding_function.embed_documents(list(text))
+        embeddings = self._embedding_function.embed_documents([text])
 
         self._collection.update(
             ids=[document_id],

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -360,7 +360,7 @@ class Chroma(VectorStore):
 
         self._collection.update(
             ids=[document_id],
-            embeddings=[embeddings[0]],
+            embeddings=embeddings,
             documents=[text],
             metadatas=[metadata],
         )

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -4,8 +4,8 @@ import pytest
 from langchain.docstore.document import Document
 from langchain.vectorstores import Chroma
 from tests.integration_tests.vectorstores.fake_embeddings import (
-    FakeEmbeddings,
     ConsistentFakeEmbeddings,
+    FakeEmbeddings,
 )
 
 

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -3,7 +3,7 @@ import pytest
 
 from langchain.docstore.document import Document
 from langchain.vectorstores import Chroma
-from tests.integration_tests.vectorstores.fake_embeddings import FakeEmbeddings
+from tests.integration_tests.vectorstores.fake_embeddings import FakeEmbeddings, ConsistentFakeEmbeddings
 
 
 def test_chroma() -> None:
@@ -164,6 +164,8 @@ def test_chroma_with_include_parameter() -> None:
 
 def test_chroma_update_document() -> None:
     """Test the update_document function in the Chroma class."""
+    # Make a consistent embedding
+    embedding = ConsistentFakeEmbeddings()
 
     # Initial document content and id
     initial_content = "foo"
@@ -176,7 +178,7 @@ def test_chroma_update_document() -> None:
     docsearch = Chroma.from_documents(
         collection_name="test_collection",
         documents=[original_doc],
-        embedding=FakeEmbeddings(),
+        embedding=embedding,
         ids=[document_id],
     )
     old_embedding = docsearch._collection.peek()['embeddings'][docsearch._collection.peek()['ids'].index(document_id)]
@@ -198,5 +200,5 @@ def test_chroma_update_document() -> None:
 
     # Assert that the new embedding is correct
     new_embedding = docsearch._collection.peek()['embeddings'][docsearch._collection.peek()['ids'].index(document_id)]
-    assert new_embedding == docsearch._embedding_function.embed_documents([updated_content])[0]
+    assert new_embedding == embedding.embed_documents([updated_content])[0]
     assert new_embedding != old_embedding

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -179,7 +179,7 @@ def test_chroma_update_document() -> None:
         embedding=FakeEmbeddings(),
         ids=[document_id],
     )
-    old_embedding = docsearch._collection.peek['embeddings'][docsearch._collection.peek['ids'].index(document_id)]
+    old_embedding = docsearch._collection.peek()['embeddings'][docsearch._collection.peek()['ids'].index(document_id)]
 
     # Define updated content for the document
     updated_content = "updated foo"
@@ -197,6 +197,6 @@ def test_chroma_update_document() -> None:
     assert output == [Document(page_content=updated_content, metadata={"page": "0"})]
 
     # Assert that the new embedding is correct
-    new_embedding = docsearch._collection.peek['embeddings'][docsearch._collection.peek['ids'].index(document_id)]
+    new_embedding = docsearch._collection.peek()['embeddings'][docsearch._collection.peek()['ids'].index(document_id)]
     assert new_embedding == docsearch._embedding_function.embed_documents([updated_content])[0]
     assert new_embedding != old_embedding

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -179,7 +179,7 @@ def test_chroma_update_document() -> None:
         embedding=FakeEmbeddings(),
         ids=[document_id],
     )
-    old_embedding = docsearch_peek['embeddings'][docsearch_peek['ids'].index(document_id)]
+    old_embedding = docsearch._collection.peek['embeddings'][docsearch._collection.peek['ids'].index(document_id)]
 
     # Define updated content for the document
     updated_content = "updated foo"
@@ -197,6 +197,6 @@ def test_chroma_update_document() -> None:
     assert output == [Document(page_content=updated_content, metadata={"page": "0"})]
 
     # Assert that the new embedding is correct
-    new_embedding = docsearch_peek['embeddings'][docsearch_peek['ids'].index(document_id)]
+    new_embedding = docsearch._collection.peek['embeddings'][docsearch._collection.peek['ids'].index(document_id)]
     assert new_embedding == docsearch._embedding_function.embed_documents([updated_content])[0]
     assert new_embedding != old_embedding

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -3,7 +3,10 @@ import pytest
 
 from langchain.docstore.document import Document
 from langchain.vectorstores import Chroma
-from tests.integration_tests.vectorstores.fake_embeddings import FakeEmbeddings, ConsistentFakeEmbeddings
+from tests.integration_tests.vectorstores.fake_embeddings import (
+    FakeEmbeddings,
+    ConsistentFakeEmbeddings,
+)
 
 
 def test_chroma() -> None:
@@ -181,7 +184,9 @@ def test_chroma_update_document() -> None:
         embedding=embedding,
         ids=[document_id],
     )
-    old_embedding = docsearch._collection.peek()['embeddings'][docsearch._collection.peek()['ids'].index(document_id)]
+    old_embedding = docsearch._collection.peek()["embeddings"][
+        docsearch._collection.peek()["ids"].index(document_id)
+    ]
 
     # Define updated content for the document
     updated_content = "updated foo"
@@ -199,6 +204,8 @@ def test_chroma_update_document() -> None:
     assert output == [Document(page_content=updated_content, metadata={"page": "0"})]
 
     # Assert that the new embedding is correct
-    new_embedding = docsearch._collection.peek()['embeddings'][docsearch._collection.peek()['ids'].index(document_id)]
+    new_embedding = docsearch._collection.peek()["embeddings"][
+        docsearch._collection.peek()["ids"].index(document_id)
+    ]
     assert new_embedding == embedding.embed_documents([updated_content])[0]
     assert new_embedding != old_embedding

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -179,6 +179,7 @@ def test_chroma_update_document() -> None:
         embedding=FakeEmbeddings(),
         ids=[document_id],
     )
+    old_embedding = docsearch_peek['embeddings'][docsearch_peek['ids'].index(document_id)]
 
     # Define updated content for the document
     updated_content = "updated foo"
@@ -194,3 +195,8 @@ def test_chroma_update_document() -> None:
 
     # Assert that the updated document is returned by the search
     assert output == [Document(page_content=updated_content, metadata={"page": "0"})]
+
+    # Assert that the new embedding is correct
+    new_embedding = docsearch_peek['embeddings'][docsearch_peek['ids'].index(document_id)]
+    assert new_embedding == docsearch._embedding_function.embed_documents([updated_content])[0]
+    assert new_embedding != old_embedding


### PR DESCRIPTION
# Chroma update_document full document embeddings bugfix

Chroma update_document takes a single document, but treats the page_content sting of that document as a list when getting the new document embedding.

This is a two-fold problem, where the resulting embedding for the updated document is incorrect (it's only an embedding of the first character in the new page_content) and it calls the embedding function for every character in the new page_content string, using many tokens in the process.

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes #5582

## Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->

Tagging @dev2049 for vectorstore bugfix