### PR TITLE
- Fix the parameter passing at as_retriever

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -340,7 +340,7 @@ class VectorStore(ABC):
         raise NotImplementedError
 
     def as_retriever(self, **kwargs: Any) -> VectorStoreRetriever:
-        return VectorStoreRetriever(vectorstore=self, **kwargs)
+        return VectorStoreRetriever(vectorstore=self, search_kwargs=kwargs)
 
 
 class VectorStoreRetriever(BaseRetriever, BaseModel):


### PR DESCRIPTION
```
qa = ConversationalRetrievalChain.from_llm(
    ChatOpenAI(
        openai_api_key=config.settings.BaseConfig.OPENAI_API_KEY,
        temperature=0.7,
        max_tokens=1024,
    ),
    documents_vector_store.as_retriever(
        filter={"user_id": user_id, "doc_id": doc_id}
    ),
    verbose=True,
    max_tokens_limit=1024,
)
```
- can't pass arguments (filter={"user_id": user_id, "doc_id": doc_id}) from documents_vector_store.as_retriever to the function self._collection.query
https://github.com/lyntcelec/langchain/blob/db45970a66f39a32f2cdd83e7bde26a404efad7b/langchain/vectorstores/chroma.py#LL121C21-L121C21
- It is not passed because the assignment is not reasonable
## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
