### PR TITLE
nit: pgvector python example notebook, fix variable reference

### DIFF
--- a/docs/modules/indexes/vectorstores/examples/pgvector.ipynb
+++ b/docs/modules/indexes/vectorstores/examples/pgvector.ipynb
@@ -246,7 +246,7 @@
    "outputs": [],
    "source": [
     "db = PGVector.from_documents(\n",
-    "    documents=data,\n",
+    "    documents=docs,\n",
     "    embedding=embeddings,\n",
     "    collection_name=collection_name,\n",
     "    connection_string=connection_string,\n",


### PR DESCRIPTION
# Your PR Title (What it does)

Fixes the pgvector python example notebook : one of the variables was not referencing anything

## Before submitting

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

VectorStores / Retrievers / Memory
  - @dev2049
