### PR TITLE
Fix outputparser answer and action

### DIFF
--- a/langchain/agents/chat/output_parser.py
+++ b/langchain/agents/chat/output_parser.py
@@ -17,7 +17,8 @@ class ChatOutputParser(AgentOutputParser):
         try:
             action = text.split("```")[1]
             response = json.loads(action.strip())
-            if includes_answer:
+            includes_action = "action" in response and "action_input" in response
+            if includes_answer and includes_action:
                 raise OutputParserException(
                     f"Parsing LLM output produced a final answer and a parse-able action: {text}"
                 )

--- a/langchain/agents/chat/output_parser.py
+++ b/langchain/agents/chat/output_parser.py
@@ -13,17 +13,22 @@ class ChatOutputParser(AgentOutputParser):
         return FORMAT_INSTRUCTIONS
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        if FINAL_ANSWER_ACTION in text:
-            return AgentFinish(
-                {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
-            )
+        includes_answer = FINAL_ANSWER_ACTION in text
         try:
             action = text.split("```")[1]
             response = json.loads(action.strip())
+            if includes_answer:
+                raise OutputParserException(
+                    f"Parsing LLM output produced a final answer and a parse-able action: {text}"
+                )
             return AgentAction(response["action"], response["action_input"], text)
 
         except Exception:
-            raise OutputParserException(f"Could not parse LLM output: {text}")
+            if not includes_answer:
+                raise OutputParserException(f"Could not parse LLM output: {text}")
+            return AgentFinish(
+                {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
+            )
 
     @property
     def _type(self) -> str:

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -13,44 +13,49 @@ class MRKLOutputParser(AgentOutputParser):
         return FORMAT_INSTRUCTIONS
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        if FINAL_ANSWER_ACTION in text:
-            return AgentFinish(
-                {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
-            )
-        # \s matches against tab/newline/whitespace
+        includes_answer = FINAL_ANSWER_ACTION in text
         regex = (
             r"Action\s*\d*\s*:[\s]*(.*?)[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
         )
-        match = re.search(regex, text, re.DOTALL)
-        if not match:
-            if not re.search(r"Action\s*\d*\s*:[\s]*(.*?)", text, re.DOTALL):
+        action_match = re.search(regex, text, re.DOTALL)
+        if action_match:
+            if includes_answer:
                 raise OutputParserException(
-                    f"Could not parse LLM output: `{text}`",
-                    observation="Invalid Format: Missing 'Action:' after 'Thought:'",
-                    llm_output=text,
-                    send_to_llm=True,
+                    f"Parsing LLM output produced a final answer and a parse-able action: {text}"
                 )
-            elif not re.search(
-                r"[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL
-            ):
-                raise OutputParserException(
-                    f"Could not parse LLM output: `{text}`",
-                    observation="Invalid Format:"
-                    " Missing 'Action Input:' after 'Action:'",
-                    llm_output=text,
-                    send_to_llm=True,
-                )
-            else:
-                raise OutputParserException(f"Could not parse LLM output: `{text}`")
-        action = match.group(1).strip()
-        action_input = match.group(2)
+            action = action_match.group(1).strip()
+            action_input = action_match.group(2)
+            tool_input = action_input.strip(" ")
+            # ensure if its a well formed SQL query we don't remove any trailing " chars
+            if tool_input.startswith("SELECT ") is False:
+                tool_input = tool_input.strip('"')
 
-        tool_input = action_input.strip(" ")
-        # ensure if its a well formed SQL query we don't remove any trailing " chars
-        if tool_input.startswith("SELECT ") is False:
-            tool_input = tool_input.strip('"')
+            return AgentAction(action, tool_input, text)
 
-        return AgentAction(action, tool_input, text)
+        elif includes_answer:
+            return AgentFinish(
+                {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
+            )
+
+        if not re.search(r"Action\s*\d*\s*:[\s]*(.*?)", text, re.DOTALL):
+            raise OutputParserException(
+                f"Could not parse LLM output: `{text}`",
+                observation="Invalid Format: Missing 'Action:' after 'Thought:'",
+                llm_output=text,
+                send_to_llm=True,
+            )
+        elif not re.search(
+            r"[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL
+        ):
+            raise OutputParserException(
+                f"Could not parse LLM output: `{text}`",
+                observation="Invalid Format:"
+                " Missing 'Action Input:' after 'Action:'",
+                llm_output=text,
+                send_to_llm=True,
+            )
+        else:
+            raise OutputParserException(f"Could not parse LLM output: `{text}`")
 
     @property
     def _type(self) -> str:

--- a/langchain/agents/mrkl/output_parser.py
+++ b/langchain/agents/mrkl/output_parser.py
@@ -13,38 +13,44 @@ class MRKLOutputParser(AgentOutputParser):
         return FORMAT_INSTRUCTIONS
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        if FINAL_ANSWER_ACTION in text:
-            return AgentFinish(
-                {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
-            )
-        # \s matches against tab/newline/whitespace
+        includes_answer = FINAL_ANSWER_ACTION in text
         regex = (
             r"Action\s*\d*\s*:[\s]*(.*?)[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
         )
-        match = re.search(regex, text, re.DOTALL)
-        if not match:
-            if not re.search(r"Action\s*\d*\s*:[\s]*(.*?)", text, re.DOTALL):
+        action_match = re.search(regex, text, re.DOTALL)
+        if action_match:
+            if includes_answer:
                 raise OutputParserException(
-                    f"Could not parse LLM output: `{text}`",
-                    observation="Invalid Format: Missing 'Action:' after 'Thought:'",
-                    llm_output=text,
-                    send_to_llm=True,
+                    f"Parsing LLM output produced a final answer and a parse-able action: {text}"
                 )
-            elif not re.search(
-                r"[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL
-            ):
-                raise OutputParserException(
-                    f"Could not parse LLM output: `{text}`",
-                    observation="Invalid Format:"
-                    " Missing 'Action Input:' after 'Action:'",
-                    llm_output=text,
-                    send_to_llm=True,
-                )
-            else:
-                raise OutputParserException(f"Could not parse LLM output: `{text}`")
-        action = match.group(1).strip()
-        action_input = match.group(2)
-        return AgentAction(action, action_input.strip(" ").strip('"'), text)
+            action = action_match.group(1).strip()
+            action_input = action_match.group(2)
+            return AgentAction(action, action_input.strip(" ").strip('"'), text)
+
+        elif includes_answer:
+            return AgentFinish(
+                {"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text
+            )
+
+        if not re.search(r"Action\s*\d*\s*:[\s]*(.*?)", text, re.DOTALL):
+            raise OutputParserException(
+                f"Could not parse LLM output: `{text}`",
+                observation="Invalid Format: Missing 'Action:' after 'Thought:'",
+                llm_output=text,
+                send_to_llm=True,
+            )
+        elif not re.search(
+            r"[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL
+        ):
+            raise OutputParserException(
+                f"Could not parse LLM output: `{text}`",
+                observation="Invalid Format:"
+                " Missing 'Action Input:' after 'Action:'",
+                llm_output=text,
+                send_to_llm=True,
+            )
+        else:
+            raise OutputParserException(f"Could not parse LLM output: `{text}`")
 
     @property
     def _type(self) -> str:

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -90,14 +90,7 @@ def test_get_action_and_input_sql_query() -> None:
 
 def test_get_final_answer() -> None:
     """Test getting final answer."""
-    llm_output = (
-        "Thought: I need to search for NBA\n"
-        "Action: Search\n"
-        "Action Input: NBA\n"
-        "Observation: founded in 1994\n"
-        "Thought: I can now answer the question\n"
-        "Final Answer: 1994"
-    )
+    llm_output = "Thought: I can now answer the question\n" "Final Answer: 1994"
     action, action_input = get_action_and_input(llm_output)
     assert action == "Final Answer"
     assert action_input == "1994"
@@ -105,14 +98,7 @@ def test_get_final_answer() -> None:
 
 def test_get_final_answer_new_line() -> None:
     """Test getting final answer."""
-    llm_output = (
-        "Thought: I need to search for NBA\n"
-        "Action: Search\n"
-        "Action Input: NBA\n"
-        "Observation: founded in 1994\n"
-        "Thought: I can now answer the question\n"
-        "Final Answer:\n1994"
-    )
+    llm_output = "Thought: I can now answer the question\n" "Final Answer:\n1994"
     action, action_input = get_action_and_input(llm_output)
     assert action == "Final Answer"
     assert action_input == "1994"
@@ -120,14 +106,7 @@ def test_get_final_answer_new_line() -> None:
 
 def test_get_final_answer_multiline() -> None:
     """Test getting final answer that is multiline."""
-    llm_output = (
-        "Thought: I need to search for NBA\n"
-        "Action: Search\n"
-        "Action Input: NBA\n"
-        "Observation: founded in 1994 and 1993\n"
-        "Thought: I can now answer the question\n"
-        "Final Answer: 1994\n1993"
-    )
+    llm_output = "Thought: I can now answer the question\n" "Final Answer: 1994\n1993"
     action, action_input = get_action_and_input(llm_output)
     assert action == "Final Answer"
     assert action_input == "1994\n1993"
@@ -149,6 +128,20 @@ def test_bad_action_line() -> None:
     with pytest.raises(OutputParserException) as e_info:
         get_action_and_input(llm_output)
     assert e_info.value.observation is not None
+
+
+def test_valid_action_and_answer() -> None:
+    """Test handling when both an action and answer are found."""
+    llm_output = (
+        "Thought: I need to search for NBA\n"
+        "Action: Search\n"
+        "Action Input: NBA\n"
+        "Observation: founded in 1994\n"
+        "Thought: I can now answer the question\n"
+        "Final Answer: 1994"
+    )
+    with pytest.raises(OutputParserException) as e_info:
+        get_action_and_input(llm_output)
 
 
 def test_from_chains() -> None:

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -73,14 +73,7 @@ def test_get_action_and_input_newline_after_keyword() -> None:
 
 def test_get_final_answer() -> None:
     """Test getting final answer."""
-    llm_output = (
-        "Thought: I need to search for NBA\n"
-        "Action: Search\n"
-        "Action Input: NBA\n"
-        "Observation: founded in 1994\n"
-        "Thought: I can now answer the question\n"
-        "Final Answer: 1994"
-    )
+    llm_output = "Thought: I can now answer the question\n" "Final Answer: 1994"
     action, action_input = get_action_and_input(llm_output)
     assert action == "Final Answer"
     assert action_input == "1994"
@@ -88,14 +81,7 @@ def test_get_final_answer() -> None:
 
 def test_get_final_answer_new_line() -> None:
     """Test getting final answer."""
-    llm_output = (
-        "Thought: I need to search for NBA\n"
-        "Action: Search\n"
-        "Action Input: NBA\n"
-        "Observation: founded in 1994\n"
-        "Thought: I can now answer the question\n"
-        "Final Answer:\n1994"
-    )
+    llm_output = "Thought: I can now answer the question\n" "Final Answer:\n1994"
     action, action_input = get_action_and_input(llm_output)
     assert action == "Final Answer"
     assert action_input == "1994"
@@ -103,14 +89,7 @@ def test_get_final_answer_new_line() -> None:
 
 def test_get_final_answer_multiline() -> None:
     """Test getting final answer that is multiline."""
-    llm_output = (
-        "Thought: I need to search for NBA\n"
-        "Action: Search\n"
-        "Action Input: NBA\n"
-        "Observation: founded in 1994 and 1993\n"
-        "Thought: I can now answer the question\n"
-        "Final Answer: 1994\n1993"
-    )
+    llm_output = "Thought: I can now answer the question\n" "Final Answer: 1994\n1993"
     action, action_input = get_action_and_input(llm_output)
     assert action == "Final Answer"
     assert action_input == "1994\n1993"
@@ -132,6 +111,20 @@ def test_bad_action_line() -> None:
     with pytest.raises(OutputParserException) as e_info:
         get_action_and_input(llm_output)
     assert e_info.value.observation is not None
+
+
+def test_valid_action_and_answer() -> None:
+    """Test handling when both an action and answer are found."""
+    llm_output = (
+        "Thought: I need to search for NBA\n"
+        "Action: Search\n"
+        "Action Input: NBA\n"
+        "Observation: founded in 1994\n"
+        "Thought: I can now answer the question\n"
+        "Final Answer: 1994"
+    )
+    with pytest.raises(OutputParserException) as e_info:
+        get_action_and_input(llm_output)
 
 
 def test_from_chains() -> None:

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -130,7 +130,7 @@ def test_bad_action_line() -> None:
     assert e_info.value.observation is not None
 
 
-def test_valid_action_and_answer() -> None:
+def test_valid_action_and_answer_raises_exception() -> None:
     """Test handling when both an action and answer are found."""
     llm_output = (
         "Thought: I need to search for NBA\n"


### PR DESCRIPTION
Raises exception if OutputParsers receive a response with both a valid action and a final answer

Currently, if an OutputParser receives a response which includes both an action and a final answer, they return a FinalAnswer object. This allows the parser to accept responses which propose an action and hallucinate an answer without the action being parsed or taken by the agent.

This PR changes the logic to:
1. store a variable checking whether a response contains the `FINAL_ANSWER_ACTION` (this is the easier condition to check). 
2. store a variable checking whether the response contains a valid action
3. if both are present, raise a new exception stating that both are present
4. if an action is present, return an AgentAction
5. if an answer is present, return an AgentAnswer
6. if neither is present, raise the relevant exception based around the action format (these have been kept consistent with the prior exception messages)

Disclaimer:
* Existing mock data included strings which did include an action and an answer. This might mean that I am patching out desired behaviour? @hwchase17 up to you whether you are comfortable with this change conceptually, or whether there cases where this is not hallucinating, and we do want the LLM to output an action which isn't taken.
* I have not passed `send_to_llm` through this exception. The reason I haven't is that I can't think of a valid observation - for example, it is not accurate from a text completion standpoint to say "Final answer should not follow action" (or something to this effect). The problem is that the model hallucinates the correct format and returns that in the response. (I can easily make this change to the exception if we wish)

Fixes #5601 

## Who can review?

Community members can review the PR once tests pass. Tag maintainers/contributors who might be interested:

@hwchase17 - project lead
@vowelparrot