### PR TITLE
Refactor SQL dialect prompts to eliminate code duplication.

### DIFF
--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -1,7 +1,9 @@
 # flake8: noqa
+
+from enum import Enum
+
 from langchain.output_parsers.list import CommaSeparatedListOutputParser
 from langchain.prompts.prompt import PromptTemplate
-
 
 PROMPT_SUFFIX = """Only use the following tables:
 {table_info}
@@ -28,7 +30,6 @@ PROMPT = PromptTemplate(
     template=_DEFAULT_TEMPLATE + PROMPT_SUFFIX,
 )
 
-
 _DECIDER_TEMPLATE = """Given the below input question and list of potential tables, output a comma separated list of the table names that may be necessary to answer this question.
 
 Question: {query}
@@ -42,212 +43,157 @@ DECIDER_PROMPT = PromptTemplate(
     output_parser=CommaSeparatedListOutputParser(),
 )
 
-_duckdb_prompt = """You are a DuckDB expert. Given an input question, first create a syntactically correct DuckDB query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per DuckDB. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use today() function to get the current date, if the question involves "today".
 
-Use the following format:
+class SqlQueryDict(dict):
+    def __missing__(self, key):
+        return key.join("{}")
 
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
 
-"""
+class SqlQueryDialect(Enum):
+    """
+    Encapsulates variations in syntax for SQL query prompts. For the purposes of SQL query
+    prompts, all variations (currently) are described by -  quote character, row limiting clause,
+    and current date function. To add a new SQL dialect simply add a new enumerated value - e.g. FOODB = (...).
+    """
+
+    DUCKDB = ("DuckDB", "LIMIT", "double quotes", '"', "today()")
+    GOOGLESQL = ("GoogleSQL", "LIMIT", "backticks", "`", "CURRENT_DATE()")
+    MSSQL = ("MS SQL", "TOP", "square brackets", "[]", "CAST(GETDATE() as date)")
+    MYSQL = ("MySQL", "LIMIT", "backticks", "`", "CURDATE()")
+    MARIADB = ("MariaDB", "LIMIT", "backticks", "`", "CURDATE()")
+    ORACLE = (
+        "Oracle SQL",
+        "FETCH FIRST n ROWS ONLY",
+        "double quotes",
+        '"',
+        "TRUNC(SYSDATE)",
+    )
+
+    POSTGRES = ("PostgreSQL", "LIMIT", "double quotes", '"', "CURRENT_DATE")
+    SQLITE = ("SQLite", "LIMIT", "double quotes", '"', "date('now')")
+    CLICKHOUSE = ("Clickhouse", "LIMIT", "double quotes", '"', "today()")
+    PRESTODB = ("PrestoDB", "LIMIT", "double quotes", '"', "current_date")
+
+    def __init__(
+        self,
+        dialect_name: str,
+        limit_clause: str,
+        quote_char_name: str,
+        quote_char: str,
+        curr_date_func: str,
+    ):
+        self.dialect_name = dialect_name
+        self.limit_clause = limit_clause
+        self.quote_char_name = quote_char_name
+        self.quote_char = quote_char
+        self.curr_date_func = curr_date_func
+
+    def __repr__(self):
+        cls_name = self.__class__.__name__
+        return f"{cls_name}.{self.name}: {self.dialect_name}, {self.limit_clause}, {self.quote_char_name}, {self.quote_char}, {self.curr_date_func}"
+
+    def create_prompt(self) -> str:
+        base_prompt = """You are a {dialect_name} expert. Given an input question, first create a syntactically 
+        correct {dialect_name} query to run, then look at the results of the query and return the answer to the input 
+        question. Unless the user specifies in the question a specific number of examples to obtain, query for at 
+        most {top_k} results using the {limit_clause} clause as per {dialect_name}. You can order the results to 
+        return the most informative data in the database. Never query for all columns from a table. You must query 
+        only the columns that are needed to answer the question. Wrap each column name in {quote_char_name} ({quote_char}) 
+        to denote them as delimited identifiers. Pay attention to use only the column names you can see 
+        in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which 
+        column is in which table. Pay attention to use {curr_date_func} function to get the current date, 
+        if the question involves "today". 
+
+        Use the following format:
+
+        Question: Question here
+        SQLQuery: SQL Query to run
+        SQLResult: Result of the SQLQuery
+        Answer: Final answer here
+        """
+
+        # make sure to preserve unused placeholders - e.g. {top_k}
+        d = SqlQueryDict(
+            {
+                "dialect_name": self.dialect_name,
+                "limit_clause": self.limit_clause,
+                "quote_char_name": self.quote_char_name,
+                "quote_char": self.quote_char,
+                "curr_date_func": self.curr_date_func,
+            }
+        )
+        return base_prompt.format_map(d)
+
+
+_duckdb_prompt = SqlQueryDialect.DUCKDB.create_prompt()
 
 DUCKDB_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_duckdb_prompt + PROMPT_SUFFIX,
 )
 
-_googlesql_prompt = """You are a GoogleSQL expert. Given an input question, first create a syntactically correct GoogleSQL query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per GoogleSQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use CURRENT_DATE() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_googlesql_prompt = SqlQueryDialect.GOOGLESQL.create_prompt()
 
 GOOGLESQL_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_googlesql_prompt + PROMPT_SUFFIX,
 )
 
-
-_mssql_prompt = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in square brackets ([]) to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use CAST(GETDATE() as date) function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_mssql_prompt = SqlQueryDialect.MSSQL.create_prompt()
 
 MSSQL_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_mssql_prompt + PROMPT_SUFFIX,
 )
 
-
-_mysql_prompt = """You are a MySQL expert. Given an input question, first create a syntactically correct MySQL query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MySQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use CURDATE() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_mysql_prompt = SqlQueryDialect.MYSQL.create_prompt()
 
 MYSQL_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_mysql_prompt + PROMPT_SUFFIX,
 )
 
-
-_mariadb_prompt = """You are a MariaDB expert. Given an input question, first create a syntactically correct MariaDB query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MariaDB. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use CURDATE() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_mariadb_prompt = SqlQueryDialect.MARIADB.create_prompt()
 
 MARIADB_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_mariadb_prompt + PROMPT_SUFFIX,
 )
 
-
-_oracle_prompt = """You are an Oracle SQL expert. Given an input question, first create a syntactically correct Oracle SQL query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the FETCH FIRST n ROWS ONLY clause as per Oracle SQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use TRUNC(SYSDATE) function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_oracle_prompt = SqlQueryDialect.ORACLE.create_prompt()
 
 ORACLE_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_oracle_prompt + PROMPT_SUFFIX,
 )
 
-
-_postgres_prompt = """You are a PostgreSQL expert. Given an input question, first create a syntactically correct PostgreSQL query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PostgreSQL. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use CURRENT_DATE function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_postgres_prompt = SqlQueryDialect.POSTGRES.create_prompt()
 
 POSTGRES_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_postgres_prompt + PROMPT_SUFFIX,
 )
 
-
-_sqlite_prompt = """You are a SQLite expert. Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per SQLite. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use date('now') function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
-"""
+_sqlite_prompt = SqlQueryDialect.SQLITE.create_prompt()
 
 SQLITE_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_sqlite_prompt + PROMPT_SUFFIX,
 )
 
-_clickhouse_prompt = """You are a ClickHouse expert. Given an input question, first create a syntactically correct Clic query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per ClickHouse. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use today() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
-
-"""
+_clickhouse_prompt = SqlQueryDialect.CLICKHOUSE.create_prompt()
 
 CLICKHOUSE_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_clickhouse_prompt + PROMPT_SUFFIX,
 )
 
-_prestodb_prompt = """You are a PrestoDB expert. Given an input question, first create a syntactically correct PrestoDB query to run, then look at the results of the query and return the answer to the input question.
-Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PrestoDB. You can order the results to return the most informative data in the database.
-Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
-Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-Pay attention to use current_date function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
-
-"""
+_prestodb_prompt = SqlQueryDialect.PRESTODB.create_prompt()
 
 PRESTODB_PROMPT = PromptTemplate(
     input_variables=["input", "table_info", "top_k"],
     template=_prestodb_prompt + PROMPT_SUFFIX,
 )
-
 
 SQL_PROMPTS = {
     "duckdb": DUCKDB_PROMPT,

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -5,6 +5,9 @@ from enum import Enum
 from langchain.output_parsers.list import CommaSeparatedListOutputParser
 from langchain.prompts.prompt import PromptTemplate
 
+from collections import namedtuple
+from typing import Any
+
 PROMPT_SUFFIX = """Only use the following tables:
 {table_info}
 
@@ -44,166 +47,62 @@ DECIDER_PROMPT = PromptTemplate(
 )
 
 
+# Add new SQL dialects here
+SqlQueryDialect = namedtuple('SqlQueryDialect', ['key', 'name', 'limit_clause', 'quote_char_name', 'quote_char', 'curr_date_func'])
+query_dialects = [
+    SqlQueryDialect('duckdb', "DuckDB", "LIMIT", "double quotes", '"', "today()"),
+    SqlQueryDialect('googlesql', "GoogleSQL", "LIMIT", "backticks", "`", "CURRENT_DATE()"),
+    SqlQueryDialect('mssql', "MS SQL", "TOP", "square brackets", "[]", "CAST(GETDATE() as date)"),
+    SqlQueryDialect('mysql', "MySQL", "LIMIT", "backticks", "`", "CURDATE()"),
+    SqlQueryDialect('mariadb', "MariaDB", "LIMIT", "backticks", "`", "CURDATE()"),
+    SqlQueryDialect('oracle', "Oracle SQL", "FETCH FIRST n ROWS ONLY", "double quotes", '"', "TRUNC(SYSDATE)"),
+    SqlQueryDialect('postgresql', "PostgreSQL", "LIMIT", "double quotes", '"', "CURRENT_DATE"),
+    SqlQueryDialect('sqlite', "SQLite", "LIMIT", "double quotes", '"', "date('now')"),
+    SqlQueryDialect('clickhouse', "Clickhouse", "LIMIT", "double quotes", '"', "today()"),
+    SqlQueryDialect('prestodb', "PrestoDB", "LIMIT", "double quotes", '"', "current_date")
+    ]
+
 class SqlQueryDict(dict):
-    def __missing__(self, key):
+    def __missing__(self, key) -> str:
         return key.join("{}")
 
+def create_prompt(dialect : SqlQueryDialect) -> str:
+    base_prompt = """You are a {dialect_name} expert. Given an input question, first create a syntactically 
+    correct {dialect_name} query to run, then look at the results of the query and return the answer to the input 
+    question. Unless the user specifies in the question a specific number of examples to obtain, query for at 
+    most {top_k} results using the {limit_clause} clause as per {dialect_name}. You can order the results to 
+    return the most informative data in the database. Never query for all columns from a table. You must query 
+    only the columns that are needed to answer the question. Wrap each column name in {quote_char_name} ({quote_char}) 
+    to denote them as delimited identifiers. Pay attention to use only the column names you can see 
+    in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which 
+    column is in which table. Pay attention to use {curr_date_func} function to get the current date, 
+    if the question involves "today". 
 
-class SqlQueryDialect(Enum):
-    """
-    Encapsulates variations in syntax for SQL query prompts. For the purposes of SQL query
-    prompts, all variations (currently) are described by -  quote character, row limiting clause,
-    and current date function. To add a new SQL dialect simply add a new enumerated value - e.g. FOODB = (...).
+    Use the following format:
+
+    Question: Question here
+    SQLQuery: SQL Query to run
+    SQLResult: Result of the SQLQuery
+    Answer: Final answer here
     """
 
-    DUCKDB = ("DuckDB", "LIMIT", "double quotes", '"', "today()")
-    GOOGLESQL = ("GoogleSQL", "LIMIT", "backticks", "`", "CURRENT_DATE()")
-    MSSQL = ("MS SQL", "TOP", "square brackets", "[]", "CAST(GETDATE() as date)")
-    MYSQL = ("MySQL", "LIMIT", "backticks", "`", "CURDATE()")
-    MARIADB = ("MariaDB", "LIMIT", "backticks", "`", "CURDATE()")
-    ORACLE = (
-        "Oracle SQL",
-        "FETCH FIRST n ROWS ONLY",
-        "double quotes",
-        '"',
-        "TRUNC(SYSDATE)",
+    # Using special dict in order to preserve unused placeholders - e.g. {top_k}
+    d = SqlQueryDict(
+        {
+            "dialect_name": dialect.name,
+            "limit_clause": dialect.limit_clause,
+            "quote_char_name": dialect.quote_char_name,
+            "quote_char": dialect.quote_char,
+            "curr_date_func": dialect.curr_date_func
+        }
     )
-
-    POSTGRES = ("PostgreSQL", "LIMIT", "double quotes", '"', "CURRENT_DATE")
-    SQLITE = ("SQLite", "LIMIT", "double quotes", '"', "date('now')")
-    CLICKHOUSE = ("Clickhouse", "LIMIT", "double quotes", '"', "today()")
-    PRESTODB = ("PrestoDB", "LIMIT", "double quotes", '"', "current_date")
-
-    def __init__(
-        self,
-        dialect_name: str,
-        limit_clause: str,
-        quote_char_name: str,
-        quote_char: str,
-        curr_date_func: str,
-    ):
-        self.dialect_name = dialect_name
-        self.limit_clause = limit_clause
-        self.quote_char_name = quote_char_name
-        self.quote_char = quote_char
-        self.curr_date_func = curr_date_func
-
-    def __repr__(self):
-        cls_name = self.__class__.__name__
-        return f"{cls_name}.{self.name}: {self.dialect_name}, {self.limit_clause}, {self.quote_char_name}, {self.quote_char}, {self.curr_date_func}"
-
-    def create_prompt(self) -> str:
-        base_prompt = """You are a {dialect_name} expert. Given an input question, first create a syntactically 
-        correct {dialect_name} query to run, then look at the results of the query and return the answer to the input 
-        question. Unless the user specifies in the question a specific number of examples to obtain, query for at 
-        most {top_k} results using the {limit_clause} clause as per {dialect_name}. You can order the results to 
-        return the most informative data in the database. Never query for all columns from a table. You must query 
-        only the columns that are needed to answer the question. Wrap each column name in {quote_char_name} ({quote_char}) 
-        to denote them as delimited identifiers. Pay attention to use only the column names you can see 
-        in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which 
-        column is in which table. Pay attention to use {curr_date_func} function to get the current date, 
-        if the question involves "today". 
-
-        Use the following format:
-
-        Question: Question here
-        SQLQuery: SQL Query to run
-        SQLResult: Result of the SQLQuery
-        Answer: Final answer here
-        """
-
-        # make sure to preserve unused placeholders - e.g. {top_k}
-        d = SqlQueryDict(
-            {
-                "dialect_name": self.dialect_name,
-                "limit_clause": self.limit_clause,
-                "quote_char_name": self.quote_char_name,
-                "quote_char": self.quote_char,
-                "curr_date_func": self.curr_date_func,
-            }
-        )
-        return base_prompt.format_map(d)
+    return base_prompt.format_map(d)
 
 
-_duckdb_prompt = SqlQueryDialect.DUCKDB.create_prompt()
+SQL_PROMPTS = {}
+for dialect in query_dialects:
+    pt = PromptTemplate(
+        input_variables=["input", "table_info", "top_k"],
+        template=create_prompt(dialect) + PROMPT_SUFFIX)
+    SQL_PROMPTS[dialect.key] = pt
 
-DUCKDB_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_duckdb_prompt + PROMPT_SUFFIX,
-)
-
-_googlesql_prompt = SqlQueryDialect.GOOGLESQL.create_prompt()
-
-GOOGLESQL_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_googlesql_prompt + PROMPT_SUFFIX,
-)
-
-_mssql_prompt = SqlQueryDialect.MSSQL.create_prompt()
-
-MSSQL_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_mssql_prompt + PROMPT_SUFFIX,
-)
-
-_mysql_prompt = SqlQueryDialect.MYSQL.create_prompt()
-
-MYSQL_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_mysql_prompt + PROMPT_SUFFIX,
-)
-
-_mariadb_prompt = SqlQueryDialect.MARIADB.create_prompt()
-
-MARIADB_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_mariadb_prompt + PROMPT_SUFFIX,
-)
-
-_oracle_prompt = SqlQueryDialect.ORACLE.create_prompt()
-
-ORACLE_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_oracle_prompt + PROMPT_SUFFIX,
-)
-
-_postgres_prompt = SqlQueryDialect.POSTGRES.create_prompt()
-
-POSTGRES_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_postgres_prompt + PROMPT_SUFFIX,
-)
-
-_sqlite_prompt = SqlQueryDialect.SQLITE.create_prompt()
-
-SQLITE_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_sqlite_prompt + PROMPT_SUFFIX,
-)
-
-_clickhouse_prompt = SqlQueryDialect.CLICKHOUSE.create_prompt()
-
-CLICKHOUSE_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_clickhouse_prompt + PROMPT_SUFFIX,
-)
-
-_prestodb_prompt = SqlQueryDialect.PRESTODB.create_prompt()
-
-PRESTODB_PROMPT = PromptTemplate(
-    input_variables=["input", "table_info", "top_k"],
-    template=_prestodb_prompt + PROMPT_SUFFIX,
-)
-
-SQL_PROMPTS = {
-    "duckdb": DUCKDB_PROMPT,
-    "googlesql": GOOGLESQL_PROMPT,
-    "mssql": MSSQL_PROMPT,
-    "mysql": MYSQL_PROMPT,
-    "mariadb": MARIADB_PROMPT,
-    "oracle": ORACLE_PROMPT,
-    "postgresql": POSTGRES_PROMPT,
-    "sqlite": SQLITE_PROMPT,
-    "clickhouse": CLICKHOUSE_PROMPT,
-    "prestodb": PRESTODB_PROMPT,
-}

--- a/langchain/chains/sql_database/prompt.py
+++ b/langchain/chains/sql_database/prompt.py
@@ -50,6 +50,7 @@ DECIDER_PROMPT = PromptTemplate(
 # Add new SQL dialects here
 SqlQueryDialect = namedtuple('SqlQueryDialect', ['key', 'name', 'limit_clause', 'quote_char_name', 'quote_char', 'curr_date_func'])
 query_dialects = [
+    SqlQueryDialect('create', "CrateDB", "LIMIT", "double quotes", '"', "CURRENT_DATE"),
     SqlQueryDialect('duckdb', "DuckDB", "LIMIT", "double quotes", '"', "today()"),
     SqlQueryDialect('googlesql', "GoogleSQL", "LIMIT", "backticks", "`", "CURRENT_DATE()"),
     SqlQueryDialect('mssql', "MS SQL", "TOP", "square brackets", "[]", "CAST(GETDATE() as date)"),


### PR DESCRIPTION
Refactored code to eliminate multiple copies of the query prompt (prompt per dialect). Now, there is a single copy of the prompt and all placeholders are encapsulated in **SqlQueryDialect** enumeration class. This should make it much easier and less error to add new SQL dialects and/or extend prompt template (e.g. adding new hints for the LLM). Code changes have been formatted, linted, and tested.

#### Who can review?
@hwchase17 