### PR TITLE
Update MongoDBChatMessageHistory to create an index on SessionId

### DIFF
--- a/langchain/memory/chat_message_histories/mongodb.py
+++ b/langchain/memory/chat_message_histories/mongodb.py
@@ -47,6 +47,7 @@ class MongoDBChatMessageHistory(BaseChatMessageHistory):
 
         self.db = self.client[database_name]
         self.collection = self.db[collection_name]
+        self.collection.create_index("SessionId")
 
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore


### PR DESCRIPTION
All the queries to the database are done based on the SessionId property, this will optimize how Mongo retrieves all messages from a session

#### Who can review?

Tag maintainers/contributors who might be interested:
@dev2049
