### PR TITLE
fix: correct momento chat history notebook typo and title

### DIFF
--- a/docs/modules/memory/examples/momento_chat_message_history.ipynb
+++ b/docs/modules/memory/examples/momento_chat_message_history.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "session_id = \"foo\"\n",
     "cache_name = \"langchain\"\n",
-    "ttl = timedelta(days=1),\n",
+    "ttl = timedelta(days=1)\n",
     "history = MomentoChatMessageHistory.from_client_params(\n",
     "    session_id, \n",
     "    cache_name,\n",

--- a/docs/modules/memory/examples/momento_chat_message_history.ipynb
+++ b/docs/modules/memory/examples/momento_chat_message_history.ipynb
@@ -5,7 +5,7 @@
    "id": "91c6a7ef",
    "metadata": {},
    "source": [
-    "# Momento\n",
+    "# Momento Chat Message History\n",
     "\n",
     "This notebook goes over how to use [Momento Cache](https://gomomento.com) to store chat message history using the `MomentoChatMessageHistory` class. See the Momento [docs](https://docs.momentohq.com/getting-started) for more detail on how to get set up with Momento.\n",
     "\n",


### PR DESCRIPTION
This PR corrects a minor typo in the Momento chat message history notebook and also expands the title from "Momento" to "Momento Chat History", inline with other chat history storage providers.


#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

cc @dev2049 who reviewed the original integration
