### PR TITLE
This fixes issue #5651 - GPT4All wrapper loading issue

### DIFF
--- a/langchain/llms/gpt4all.py
+++ b/langchain/llms/gpt4all.py
@@ -153,7 +153,7 @@ class GPT4All(LLM):
         if values["n_threads"] is not None:
             # set n_threads
             values["client"].model.set_thread_count(values["n_threads"])
-        values["backend"] = values["client"].model.model_type
+        values["backend"] = values["client"].model_type
 
         return values
 


### PR DESCRIPTION
Fixes #5651 

Small typo in wrapper code. Note the `model_type` parameter is currently unused by GPT4All.

https://github.com/hwchase17/langchain/issues/5651

#### Who can review?