### PR TITLE
Fix transposed properties

### DIFF
--- a/langchain/chat_models/vertexai.py
+++ b/langchain/chat_models/vertexai.py
@@ -122,7 +122,13 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         chat = self.client.start_chat(context=context, **self._default_params)
         for pair in history.history:
             chat._history.append((pair.question.content, pair.answer.content))
-        response = chat.send_message(question.content)
+        response = chat.send_message(
+            question.content,
+            max_output_tokens=chat._max_output_tokens,
+            temperature=chat._temperature,
+            top_k=chat._top_k,
+            top_p=chat._top_p,
+        )
         text = self._enforce_stop_words(response.text, stop)
         return ChatResult(generations=[ChatGeneration(message=AIMessage(content=text))])
 

--- a/langchain/llms/vertexai.py
+++ b/langchain/llms/vertexai.py
@@ -43,8 +43,8 @@ class _VertexAICommon(BaseModel):
         base_params = {
             "temperature": self.temperature,
             "max_output_tokens": self.max_output_tokens,
-            "top_k": self.top_p,
-            "top_p": self.top_k,
+            "top_k": self.top_k,
+            "top_p": self.top_p,
         }
         return {**base_params}
 

--- a/tests/unit_tests/chat_models/test_vertexai.py
+++ b/tests/unit_tests/chat_models/test_vertexai.py
@@ -1,0 +1,43 @@
+"""Test Vertex AI API wrapper."""
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
+
+from langchain.chat_models.vertexai import ChatVertexAI
+from langchain.schema import (
+    HumanMessage,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_vertexai_args_passed(monkeypatch: "pytest.MonkeyPatch") -> None:
+    # Mock/suppress credential validation in langchain
+    monkeypatch.setattr(ChatVertexAI, "validate_environment", Mock())
+
+    response_text = "Goodbye"
+    user_prompt = "Hello"
+    prompt_params = {
+        "max_output_tokens": 1,
+        "temperature": 10000.0,
+        "top_k": 10,
+        "top_p": 0.5,
+    }
+
+    # Mock the library to ensure the args are passed correctly
+    with patch(
+        "vertexai.language_models._language_models.ChatSession.send_message"
+    ) as send_message:
+        response = Mock(text=response_text)
+        send_message.return_value = response
+
+        model = ChatVertexAI(**prompt_params)
+        message = HumanMessage(content=user_prompt)
+        response = model([message])
+
+        assert response.content == response_text
+        send_message.assert_called_once_with(
+            user_prompt,
+            **prompt_params,
+        )


### PR DESCRIPTION
~Args given to ChatVertexAI were not being transmitted to the google library.~
In the course of writing the unit test, I found that top_k and top_p were transposed.
~The unit tests uses pytest's monkeypatch because I could not get mock.patch to work (I'm not used to using it, the Python doc, and gpt4 were all unhelpful, sorry).~
~If you would like to rewrite the monkeypatch using patch: by all means. I would love to see how it's done!~
~If you would like me to rewrite the patch with monkeypatch (for consistency) I would be happy to do that.~

~Fixes #5667~

#### Who can review?

Tag maintainers/contributors who might be interested:
@hwchase17
@agola11

Thanks for the amazing work you've all done on this project. I've been using it every day for months and I'm incredibly impressed!