### PR TITLE
SQL agent : Improved prompt engineering prevents agent guessing database column names.

### DIFF
--- a/langchain/agents/agent_toolkits/sql/prompt.py
+++ b/langchain/agents/agent_toolkits/sql/prompt.py
@@ -17,5 +17,5 @@ If the question does not seem related to the database, just return "I don't know
 SQL_SUFFIX = """Begin!
 
 Question: {input}
-Thought: I should look at the tables in the database to see what I can query.
+Thought: I should look at the tables in the database to see what I can query.  Then I should query the schema of the most relevant tables.
 {agent_scratchpad}"""


### PR DESCRIPTION
@vowelparrot:

Minor change to the SQL agent:

Tells agent to introspect the schema of the most relevant tables, I found this to dramatically decrease the chance that the agent wastes times guessing column names.
