### PR TITLE
Feature: Allows for structured output parser to parse lists of json objects 

### DIFF
--- a/langchain/output_parsers/json.py
+++ b/langchain/output_parsers/json.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 import re
-from typing import List
+from typing import List, Union
 
 from langchain.schema import OutputParserException
 
 
-def parse_json_markdown(json_string: str) -> dict:
+def parse_json_markdown(json_string: str) -> Union[dict, List[dict]]:
     # Try to find JSON string within triple backticks
     match = re.search(r"```(json)?(.*?)```", json_string, re.DOTALL)
 
@@ -27,15 +27,32 @@ def parse_json_markdown(json_string: str) -> dict:
     return parsed
 
 
-def parse_and_check_json_markdown(text: str, expected_keys: List[str]) -> dict:
+def parse_and_check_json_markdown(
+    text: str,
+    expected_keys: List[str]
+) -> Union[dict, List[dict]]:
     try:
         json_obj = parse_json_markdown(text)
     except json.JSONDecodeError as e:
         raise OutputParserException(f"Got invalid JSON object. Error: {e}")
-    for key in expected_keys:
-        if key not in json_obj:
-            raise OutputParserException(
-                f"Got invalid return object. Expected key `{key}` "
-                f"to be present, but got {json_obj}"
-            )
+    if isinstance(json_obj, list):
+      expected_keys_set = set(expected_keys)
+      missing_keys = []
+
+      for record in json_obj:
+            missing = expected_keys_set - set(record.keys())
+            missing_keys.extend(missing)
+      
+      if missing_keys:
+        raise OutputParserException(
+            f"Got invalid return object. Expected key(s) `{missing_keys}` "
+            f"to be present, but got {record}"
+        )
+    else:
+        for key in expected_keys:
+            if key not in json_obj:
+                raise OutputParserException(
+                    f"Got invalid return object. Expected key `{key}` "
+                    f"to be present, but got {json_obj}"
+                )
     return json_obj


### PR DESCRIPTION
# Description
Enables structured output parser to parse lists of json objects

Prior it would throw an error when parsing a list of json objects about missing keys. Now it evaluates if the parsed json object is a list then uses a difference in the set of keys from each record in the json list and the set of original expected keys.

This allows for the `StructuredOutputParser` to parse multiple objects of the same schema at once

#### Who can review?

Tag maintainers/contributors who might be interested:

@hwchase17
@eyurtsev
@vowelparrot