### PR TITLE
sqlalchemy MovedIn20Warning declarative_base DEPRICATION fix 

### DIFF
--- a/langchain/memory/chat_message_histories/sql.py
+++ b/langchain/memory/chat_message_histories/sql.py
@@ -3,7 +3,10 @@ import logging
 from typing import List
 
 from sqlalchemy import Column, Integer, Text, create_engine
-from sqlalchemy.ext.declarative import declarative_base
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from langchain.schema import (

--- a/langchain/memory/chat_message_histories/sql.py
+++ b/langchain/memory/chat_message_histories/sql.py
@@ -3,6 +3,7 @@ import logging
 from typing import List
 
 from sqlalchemy import Column, Integer, Text, create_engine
+
 try:
     from sqlalchemy.orm import declarative_base
 except ImportError:

--- a/langchain/vectorstores/analyticdb.py
+++ b/langchain/vectorstores/analyticdb.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import sqlalchemy
 from sqlalchemy import REAL, Index
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
-from sqlalchemy.ext.declarative import declarative_base
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, relationship
 from sqlalchemy.sql.expression import func
 

--- a/langchain/vectorstores/analyticdb.py
+++ b/langchain/vectorstores/analyticdb.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import sqlalchemy
 from sqlalchemy import REAL, Index
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
+
 try:
     from sqlalchemy.orm import declarative_base
 except ImportError:


### PR DESCRIPTION
fix for the sqlalchemy deprecated declarative_base import :

```
MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
  Base = declarative_base()  # type: Any
```

Import is wrapped in an try catch Block to fallback to the old import if needed.