### PR TITLE
Improve the recursive text splitting algorithm to minimize the number of chunks

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -367,8 +367,8 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 if _good_splits:
                     merged_text = self._merge_splits(_good_splits, _separator)
                     final_chunks.extend(merged_text)
+                    _good_splits = []
                 final_chunks.append(s)
-                _good_splits = []
         if _good_splits:
             merged_text = self._merge_splits(_good_splits, _separator)
             final_chunks.extend(merged_text)

--- a/tests/unit_tests/test_text_splitter.py
+++ b/tests/unit_tests/test_text_splitter.py
@@ -142,8 +142,7 @@ Bye!\n\n-H."""
     splitter = RecursiveCharacterTextSplitter(chunk_size=10, chunk_overlap=1)
     output = splitter.split_text(text)
     expected_output = [
-        "Hi.",
-        "I'm",
+        "Hi.\nI'm",
         "Harrison.",
         "How? Are?",
         "You?",
@@ -155,14 +154,25 @@ Bye!\n\n-H."""
         "write,",
         "but gotta",
         "test the",
-        "splitting",
-        "gggg",
-        "some how.",
+        "splittingg",
+        "ggg some",
+        "how.",
         "Bye!",
         "-H.",
     ]
     assert output == expected_output
 
+def test_iterative_text_splitter_large_chunks() -> None:
+    """Test iterative text splitter."""
+    text = """Hi.\n\nI'm Harrison.\n\nHow? Are? You?\nOkay then f f f f.
+This is a weird text to write, but gotta test the splittingggg some how.
+
+Bye!\n\n-H."""
+    splitter = RecursiveCharacterTextSplitter(chunk_size=100, chunk_overlap=1)
+    output = splitter.split_text(text)
+    assert output == [
+        "Hi.\n\nI'm Harrison.\nHow? Are? You?\nOkay then f f f f.",
+        'This is a weird text to write, but gotta test the splittingggg some how.\n\nBye!\n\n-H.']
 
 def test_split_documents() -> None:
     """Test split_documents."""
@@ -246,10 +256,8 @@ func main() {
         'import "fmt"',
         "func",
         "helloWorld() {",
-        'fmt.Println("He',
-        "llo,",
-        'World!")',
-        "}",
+        'fmt.Println("Hel',
+        'lo, World!")\n}',
         "func main() {",
         "helloWorld()",
         "}",
@@ -280,8 +288,7 @@ Lists
     assert chunks == [
         "Sample Document",
         "===============",
-        "Section",
-        "-------",
+        "Section\n-------",
         "This is the",
         "content of the",
         "section.",
@@ -314,15 +321,11 @@ message Person {
         "package",
         "example;",
         "message Person",
-        "{",
-        "string name",
-        "= 1;",
-        "int32 age =",
-        "2;",
-        "repeated",
-        "string hobbies",
-        "= 3;",
-        "}",
+        "{ string name =",
+        "1;",
+        "int32 age = 2;",
+        "repeated string",
+        "hobbies = 3;\n}"
     ]
 
 
@@ -342,10 +345,8 @@ helloWorld();
     assert chunks == [
         "function",
         "helloWorld() {",
-        'console.log("He',
-        "llo,",
-        'World!");',
-        "}",
+        'console.log("Hel',
+        'lo, World!");\n}',
         "// Call the",
         "function",
         "helloWorld();",
@@ -367,14 +368,14 @@ public class HelloWorld {
     assert chunks == [
         "public class",
         "HelloWorld {",
-        "public",
-        "static void",
+        "public static",
+        "void",
         "main(String[]",
         "args) {",
-        "System.out.prin",
-        'tln("Hello,',
-        'World!");',
-        "}\n}",
+        "System.out.print",
+        'ln("Hello,',
+        'World!");\n    }',
+        '}',
     ]
 
 
@@ -395,10 +396,9 @@ int main() {
         "#include",
         "<iostream>",
         "int main() {",
-        "std::cout",
-        '<< "Hello,',
-        'World!" <<',
-        "std::endl;",
+        "std::cout <<",
+        '"Hello, World!"',
+        "<< std::endl;",
         "return 0;\n}",
     ]
 
@@ -418,13 +418,11 @@ object HelloWorld {
     assert chunks == [
         "object",
         "HelloWorld {",
-        "def",
-        "main(args:",
+        "def main(args:",
         "Array[String]):",
         "Unit = {",
         'println("Hello,',
-        'World!")',
-        "}\n}",
+        'World!")\n  }\n}',
     ]
 
 
@@ -443,8 +441,7 @@ hello_world
     assert chunks == [
         "def hello_world",
         'puts "Hello,',
-        'World!"',
-        "end",
+        'World!"\nend',
         "hello_world",
     ]
 
@@ -464,13 +461,10 @@ hello_world();
     """
     chunks = splitter.split_text(code)
     assert chunks == [
-        "<?php",
-        "function",
+        "<?php\nfunction",
         "hello_world() {",
-        "echo",
-        '"Hello,',
-        'World!";',
-        "}",
+        'echo "Hello,',
+        'World!";\n}',
         "hello_world();",
         "?>",
     ]
@@ -492,8 +486,7 @@ helloWorld()
         "func",
         "helloWorld() {",
         'print("Hello,',
-        'World!")',
-        "}",
+        'World!")\n}',
         "helloWorld()",
     ]
 
@@ -508,4 +501,7 @@ fn main() {
 }
     """
     chunks = splitter.split_text(code)
-    assert chunks == ["fn main() {", 'println!("Hello', ",", 'World!");', "}"]
+    assert chunks == [
+        'fn main() {',
+        'println!("Hello,',
+        'World!");\n}']

--- a/tests/unit_tests/test_text_splitter.py
+++ b/tests/unit_tests/test_text_splitter.py
@@ -162,6 +162,7 @@ Bye!\n\n-H."""
     ]
     assert output == expected_output
 
+
 def test_iterative_text_splitter_large_chunks() -> None:
     """Test iterative text splitter."""
     text = """Hi.\n\nI'm Harrison.\n\nHow? Are? You?\nOkay then f f f f.
@@ -172,7 +173,9 @@ Bye!\n\n-H."""
     output = splitter.split_text(text)
     assert output == [
         "Hi.\n\nI'm Harrison.\nHow? Are? You?\nOkay then f f f f.",
-        'This is a weird text to write, but gotta test the splittingggg some how.\n\nBye!\n\n-H.']
+        "This is a weird text to write, but gotta test the splittingggg some how.\n\nBye!\n\n-H.",
+    ]
+
 
 def test_split_documents() -> None:
     """Test split_documents."""
@@ -325,7 +328,7 @@ message Person {
         "1;",
         "int32 age = 2;",
         "repeated string",
-        "hobbies = 3;\n}"
+        "hobbies = 3;\n}",
     ]
 
 
@@ -375,7 +378,7 @@ public class HelloWorld {
         "System.out.print",
         'ln("Hello,',
         'World!");\n    }',
-        '}',
+        "}",
     ]
 
 
@@ -501,7 +504,4 @@ fn main() {
 }
     """
     chunks = splitter.split_text(code)
-    assert chunks == [
-        'fn main() {',
-        'println!("Hello,',
-        'World!");\n}']
+    assert chunks == ["fn main() {", 'println!("Hello,', 'World!");\n}']


### PR DESCRIPTION
I notice `RecursiveCharacterTextSplitter` often produce chunks that are much smaller than the specified chunk_size. 

The problem happens because we merge the `_good_splits` and add it to the `final_chunks` as soon as we encounter a large next chunk. We can improve chunk space utilization by putting `splits` in a stack, so that during iteration we can further split the next chunk and push the smaller chunks into the stack. 

@hwchase17  What do you think about this approach?