### PR TITLE
Add Support for Hugging Face Question Answering Models

### DIFF
--- a/Veluchs-Question-Answering.ipynb
+++ b/Veluchs-Question-Answering.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain import HuggingFacePipeline\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'score': 0.9906327128410339, 'start': 19, 'end': 25, 'answer': 'Berlin'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pipe = HuggingFacePipeline.from_model_id(task=\"question-answering\", model_id=\"deepset/tinyroberta-squad2\")\n",
+    "generation = pipe._call(prompt=\"The city is called Berlin.\", question=\"what is the name of the city?\")\n",
+    "\n",
+    "print(generation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Working on Adding HuggingFace Question Answering Model support to Langchain  #5660 

First Commit is just a proof on concept, that simply adds the functionality to the HuggingFacePipeline Class and its _call method.
This implementation is however in conflict with its Base Classes, since Q&A Models require an additional input (at least before the input gets tokenized).
 
Since this is about adding new models it might be of interest to you:
  - @hwchase17
  - @agola11

I'm not sure if it's best to modify the base classes to add the support for an additional argument (the question / context), or to add a new class for question answering models.
I am happy to discuss the best way forward / your ideas.