### PR TITLE
Add session-based context storage to VectorStoreRetrieverMemory

### DIFF
--- a/langchain/memory/sessionvectorstore.py
+++ b/langchain/memory/sessionvectorstore.py
@@ -1,0 +1,74 @@
+"""Class for a Session-based VectorStore-backed memory object."""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import Field
+
+from langchain.memory.chat_memory import BaseMemory
+from langchain.memory.utils import get_prompt_input_key
+from langchain.schema import Document
+from langchain.vectorstores.base import VectorStoreRetriever
+
+
+class SessionVectorStoreRetrieverMemory(BaseMemory):
+    """Class for a VectorStore-backed memory object."""
+
+    retriever: VectorStoreRetriever = Field(exclude=True)
+    """VectorStoreRetriever object to connect to."""
+
+    memory_key: str = "history"  #: :meta private:
+    """Key name to locate the memories in the result of load_memory_variables."""
+
+    input_key: Optional[str] = None
+    """Key name to index the inputs to load_memory_variables."""
+
+    return_docs: bool = False
+    """Whether or not to return the result of querying the database directly."""
+
+    session_id: str = Field(exclude=True)
+
+    @property
+    def memory_variables(self) -> List[str]:
+        """The list of keys emitted from the load_memory_variables method."""
+        return [self.memory_key]
+
+    def _get_prompt_input_key(self, inputs: Dict[str, Any]) -> str:
+        """Get the input key for the prompt."""
+        if self.input_key is None:
+            return get_prompt_input_key(inputs, self.memory_variables)
+        return self.input_key
+
+    def load_memory_variables(
+        self, inputs: Dict[str, Any]
+    ) -> Dict[str, Union[List[Document], str]]:
+        """Return history buffer."""
+        input_key = self._get_prompt_input_key(inputs)
+        query = inputs[input_key]
+        docs = self.retriever.get_relevant_documents(query)
+        result: Union[List[Document], str]
+        if not self.return_docs:
+            result = "\n".join([doc.page_content for doc in docs])
+        else:
+            result = docs
+        return {self.memory_key: result}
+
+    def _form_documents(
+        self, inputs: Dict[str, Any], outputs: Dict[str, str]
+    ) -> List[Document]:
+        """Format context from this conversation to buffer."""
+        # Each document should only include the current turn, not the chat history
+        filtered_inputs = {k: v for k, v in inputs.items() if k != self.memory_key}
+        texts = [
+            f"{k}: {v}"
+            for k, v in list(filtered_inputs.items()) + list(outputs.items())
+        ]
+        page_content = "\n".join(texts)
+        return [Document(page_content=page_content, metadata=dict(session_id = self.session_id))]
+
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Save context from this conversation to buffer."""
+        documents = self._form_documents(inputs, outputs)
+        self.retriever.add_documents(documents)
+
+    def clear(self) -> None:
+        """Nothing to clear."""


### PR DESCRIPTION
### Title: Add Session-Based Context Storage to SessionVectorStoreRetrieverMemory

#### Description:

This PR introduces a new feature to the `SessionVectorStoreRetrieverMemory` class that allows developers to store and retrieve the history of a particular chat session. It proposes a new class, `SessionVectorStoreRetrieverMemory`, which extends `VectorStoreRetrieverMemory` and adds a `session_id` field. 

The key changes include:

- The addition of a `session_id` field, which will be used to uniquely identify a chat session. This will allow us to store and retrieve the history of a particular session.

- Modifying the `_form_documents` method to attach the `session_id` to each document created. This means that each document in our vector store will now include information about the session it belongs to.

This feature requires the `VectorStoreRetriever` to support metadata filtering. For instance, you can create a retriever that filters on the `session_id` field as follows:

```python
import uuid
from langchain.embeddings.openai import OpenAIEmbeddings
from langchain.llms import OpenAI
from langchain.memory import SessionVectorStoreRetrieverMemory

# generate a random session id
session_id = uuid.uuid4().hex

embedding_fn = OpenAIEmbeddings()

vec_store = Pinecone.from_existing_index(PINECONE_INDEX, embedding_fn, text_key="chat_memory")

# include session_id as param in retriever and memory object
retriever = vec_store.as_retriever(search_kwargs={'k': 1, 'filter': {'session_id': session_id}})
memory = SessionVectorStoreRetrieverMemory(retriever=retriever, session_id=session_id)  

memory.save_context({"input": "My favorite food is pizza"}, {"output": "thats good to know"})
memory.save_context({"input": "My favorite sport is soccer"}, {"output": "..."})
memory.save_context({"input": "I don't the Celtics"}, {"output": "ok"}) 

print(memory.load_memory_variables({"prompt": "what sport should i watch?"})["history"])


```
This will ensure that only documents with the specified session_id are returned when a query is made.

The rationale behind these changes is to enable a finer granularity of data retrieval. Currently, the SessionVectorStoreRetrieverMemory class retrieves relevant documents based on a query without considering the context of a chat session. By adding the session_id, we can retrieve documents that are not only relevant to the query but also belong to the same chat session. This makes it possible to have more context-aware conversations and could improve the quality of our chatbot's responses, while maintaining privacy between sessions of different users.

The change is backward-compatible and does not affect the existing functionality of the SessionVectorStoreRetrieverMemory class. Developers can choose to use the session-based version or the original version depending on their needs.

Contributor: Adi Sidapara (Github: @asidapara, Twitter: @AdiSidapara)

Could you review? @hwchase17 @dev2049 Thanks in advance!


