### PR TITLE
Add metadata filter capability to similarity search functions for Supabase

### DIFF
--- a/langchain/vectorstores/supabase.py
+++ b/langchain/vectorstores/supabase.py
@@ -113,32 +113,29 @@ class SupabaseVectorStore(VectorStore):
         return self._add_vectors(self._client, self.table_name, vectors, documents)
 
     def similarity_search(
-        self, query: str, k: int = 4, **kwargs: Any
+        self, query: str, k: int = 4, filter: Optional[Dict[str, str]] = None, **kwargs: Any
     ) -> List[Document]:
         vectors = self._embedding.embed_documents([query])
-        return self.similarity_search_by_vector(vectors[0], k)
+        return self.similarity_search_by_vector(vectors[0], k, filter=filter)
 
     def similarity_search_by_vector(
-        self, embedding: List[float], k: int = 4, **kwargs: Any
+        self, embedding: List[float], k: int = 4, filter: Optional[Dict[str, str]] = None, **kwargs: Any
     ) -> List[Document]:
-        result = self.similarity_search_by_vector_with_relevance_scores(embedding, k)
-
+        result = self.similarity_search_by_vector_with_relevance_scores(embedding, k, filter=filter)
         documents = [doc for doc, _ in result]
-
         return documents
 
     def similarity_search_with_relevance_scores(
-        self, query: str, k: int = 4, **kwargs: Any
+        self, query: str, k: int = 4, filter: Optional[Dict[str, str]] = None, **kwargs: Any
     ) -> List[Tuple[Document, float]]:
         vectors = self._embedding.embed_documents([query])
-        return self.similarity_search_by_vector_with_relevance_scores(vectors[0], k)
+        return self.similarity_search_by_vector_with_relevance_scores(vectors[0], k, filter=filter)
 
     def similarity_search_by_vector_with_relevance_scores(
-        self, query: List[float], k: int
+        self, query: List[float], k: int, filter: Optional[Dict[str, str]] = None
     ) -> List[Tuple[Document, float]]:
         match_documents_params = dict(query_embedding=query, match_count=k)
         res = self._client.rpc(self.query_name, match_documents_params).execute()
-
         match_result = [
             (
                 Document(
@@ -148,17 +145,15 @@ class SupabaseVectorStore(VectorStore):
                 search.get("similarity", 0.0),
             )
             for search in res.data
-            if search.get("content")
+            if search.get("content") and (filter is None or search.get("metadata", {}) == filter)
         ]
-
         return match_result
 
     def similarity_search_by_vector_returning_embeddings(
-        self, query: List[float], k: int
+        self, query: List[float], k: int, filter: Optional[Dict[str, str]] = None
     ) -> List[Tuple[Document, float, np.ndarray[np.float32, Any]]]:
         match_documents_params = dict(query_embedding=query, match_count=k)
         res = self._client.rpc(self.query_name, match_documents_params).execute()
-
         match_result = [
             (
                 Document(
@@ -166,16 +161,15 @@ class SupabaseVectorStore(VectorStore):
                     page_content=search.get("content", ""),
                 ),
                 search.get("similarity", 0.0),
-                # Supabase returns a vector type as its string represation (!).
+                # Supabase returns a vector type as its string representation (!).
                 # This is a hack to convert the string to numpy array.
                 np.fromstring(
                     search.get("embedding", "").strip("[]"), np.float32, sep=","
                 ),
             )
             for search in res.data
-            if search.get("content")
+            if search.get("content") and (filter is None or search.get("metadata", {}) == filter)
         ]
-
         return match_result
 
     @staticmethod

--- a/langchain/vectorstores/supabase.py
+++ b/langchain/vectorstores/supabase.py
@@ -10,6 +10,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    Dict
 )
 
 import numpy as np


### PR DESCRIPTION

Title:
Add metadata filtering capabilities to similarity search functions

Description:

This PR enhances the functionality of the similarity search methods in our codebase. Specifically, we now support optional metadata-based filtering in our search functions.

Details:

The affected functions include:

similarity_search
similarity_search_by_vector
similarity_search_with_relevance_scores
similarity_search_by_vector_with_relevance_scores
similarity_search_by_vector_returning_embeddings
For each of these functions, a new filter argument has been added. This argument accepts a dictionary that specifies metadata fields and their desired values.

When the filter dictionary is provided, the search functions will return documents that not only match the query based on similarity but also satisfy the metadata criteria defined by the filter.

Impact:

This change provides greater flexibility for users when conducting similarity searches. They can now refine their search results based on specific metadata properties, leading to more accurate and targeted results.

Tests:

Testing will involve invoking the modified functions with various filter criteria and verifying the returned documents meet both the similarity and metadata filter criteria.

  VectorStores / Retrievers / Memory
  - @dev2049 may be interested