### PR TITLE
[Draft] Add initial draft of document manager

### DIFF
--- a/langchain/document_manager/__init__.py
+++ b/langchain/document_manager/__init__.py
@@ -1,0 +1,4 @@
+"""Wrappers on top of docstores."""
+from langchain.document_manager.in_memory import InMemoryDocumentManager
+
+__all__ = ["InMemoryDocumentManager"]

--- a/langchain/document_manager/base.py
+++ b/langchain/document_manager/base.py
@@ -1,0 +1,44 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from langchain.docstore.document import Document
+from langchain.vectorstores import VectorStore
+import hashlib
+import json
+
+class DocumentManager(ABC):
+    """Interface for document manager.
+
+    The document manager is an abstraction that helps manage
+    updates to a collection of documents.
+    """
+
+    def get_document_hash(self, document: Document) -> str:
+        """Returns the hash of the document."""
+        hashable_content = document.page_content + json.dumps(document.metadata)
+        return hashlib.sha256(hashable_content.encode('utf-8')).hexdigest()
+
+    @abstractmethod
+    def add(self, documents: List[Document], ids: List[str]) -> List[DocumentWithOperation]:
+        """Adds documents to the document manager."""
+
+    @abstractmethod
+    def update(self, documents: List[Document], ids: List[str]) -> List[DocumentWithOperation]:
+        """Updates documents in the document manager."""
+
+    @abstractmethod
+    def update_truncate(self, documents: List[Document], ids: List[str])-> List[DocumentWithOperation]:
+        """Updates the documents in the document manager.
+        Additionally, removes any documents that are not in
+        `documents`.
+        """
+
+class ChunkOperation(str, Enum):
+    """Enum for chunk operations."""
+    ADD = 'ADD'
+    UPDATE = 'UPDATE'
+    REMOVE = 'REMOVE'
+
+class DocumentWithOperation(Document):
+    operation: ChunkOperation
+    id: str

--- a/langchain/document_manager/base.py
+++ b/langchain/document_manager/base.py
@@ -1,10 +1,21 @@
 from abc import ABC, abstractmethod
 from typing import List
+from enum import Enum
 
 from langchain.docstore.document import Document
 from langchain.vectorstores import VectorStore
 import hashlib
 import json
+
+class ChunkOperation(str, Enum):
+    """Enum for chunk operations."""
+    ADD = 'ADD'
+    UPDATE = 'UPDATE'
+    REMOVE = 'REMOVE'
+
+class DocumentWithOperation(Document):
+    operation: ChunkOperation
+    id: str
 
 class DocumentManager(ABC):
     """Interface for document manager.
@@ -32,13 +43,3 @@ class DocumentManager(ABC):
         Additionally, removes any documents that are not in
         `documents`.
         """
-
-class ChunkOperation(str, Enum):
-    """Enum for chunk operations."""
-    ADD = 'ADD'
-    UPDATE = 'UPDATE'
-    REMOVE = 'REMOVE'
-
-class DocumentWithOperation(Document):
-    operation: ChunkOperation
-    id: str

--- a/langchain/document_manager/example_interface.py
+++ b/langchain/document_manager/example_interface.py
@@ -1,0 +1,42 @@
+from in_memory import InMemoryDocumentManager
+from langchain.text_splitter import CharacterTextSplitter
+from langchain.docstore.document import Document
+
+_TEST_DOCUMENTS = [Document(page_content='This is a test document.'),
+                   Document(page_content='This is another test document.'),
+                   Document(page_content='This is a third test document.')]
+
+
+def main():
+    # Create a document manager
+    document_manager = InMemoryDocumentManager(CharacterTextSplitter(separator=" "))
+
+    # Add some documents.
+    ops = document_manager.add(_TEST_DOCUMENTS, ['1', '2', '3'])
+    print(ops)
+    print('-'*100)
+    # Apply change to vector store.
+    # VectorStore.apply_operations(ops)
+
+    # Update documents.
+    ops = document_manager.update([Document(page_content='This is a modified test document.')], ['1'])
+    print(ops)
+    print('-'*100)
+    # Apply change to vector store.
+    # VectorStore.apply_operations(ops)
+
+    # Replacing existing documents.
+    ops = document_manager.update_truncate([Document(page_content='This is the final test document.'),
+                                            Document(page_content='This is another final test document')], 
+                                           ['1', '2'])
+    print(ops)
+    # Apply change to vector store.
+    # VectorStore.apply_operations(ops)
+
+
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/langchain/document_manager/in_memory.py
+++ b/langchain/document_manager/in_memory.py
@@ -1,0 +1,127 @@
+from typing import Dict
+
+from dataclasses import dataclass
+
+from langchain.document_manager.base import DocumentManager, ChunkOperation, DocumentWithOperation
+
+from langchain.docstore.document import Document
+from langchain.text_splitter import TextSplitter
+
+
+def _get_hash(document: Document) -> str:
+    """Returns the hash of the document."""
+    hashable_content = document.page_content + json.dumps(document.metadata)
+    return hashlib.sha256(hashable_content.encode('utf-8')).hexdigest()
+
+def _get_chunk_id(doc_id: str, chunk_index: int) -> str:
+    """Returns the chunk id."""
+    return f'{doc_id}-{chunk_index}'
+
+@dataclass
+class _DocumentWithState:
+    """A document with its state."""
+    document_id: str
+    hash: str
+    chunk_hashes: List[str]
+
+
+class InMemoryDocumentManager(DocumentManager):
+    """In memory implementation of the document manager."""
+
+    def __init__(self, text_splitter: TextSplitter):
+        self._documents_with_state = {}
+        self.text_splitter = text_splitter
+
+
+    def add(self, documents: List[Document], ids: List[str]) -> List[DocumentWithOperation]:
+        """Adds documents to the document manager.
+
+        Returns a Dict of chunks that should be added to the vector store.
+        """
+        if len(documents) != len(ids):
+            raise ValueError("Unequal count of documents and ids."
+
+        seen = set()
+        for id in ids:
+            if id in seen:
+                raise ValueError("Duplicate ids.")
+            if id in self._documents:
+                raise ValueError("Document with id {} already exists.".format(id))
+            seen.add(id)
+
+        chunks_to_add = []
+        for document, id in zip(documents, ids):
+            chunks = self.text_splitter.create_documents([document.page_content])
+            chunk_hashes = [_get_hash(chunk) for chunk in chunks]
+            doc_with_state = _DocumentWithState(id, self.get_document_hash(document), chunk_hashes)
+            self._documents_with_state[id] = doc_with_state
+            for i, chunk in enumerate(chunks):
+                chunks_to_add.append(DocumentWithOperation(
+                page_content=chunk.page_content, operation=ChunkOperation.ADD, id=_get_chunk_id(id, i)))
+        return chunks_to_add
+
+
+
+    def update(self, documents: List[Document], ids: List[str]) -> List[DocumentWithOperation]:
+        """Updates documents in the document manager."""
+        chunk_operations = {}
+        for new_document, id in zip(documents, ids):
+            if id not in self._documents_with_state:
+                raise ValueError(f"Document with id {id} does not exist.")
+            doc_with_state = self._documents_with_state[id]
+            new_document_hash = self.get_document_hash(new_document)
+            if doc_with_state.hash != new_document_hash:
+                new_chunks = self.text_splitter.create_documents(new_document.page_content)
+                new_hashes = [_get_hash(chunk) for chunk in new_chunks]
+                for i, new_chunk in enumerate(new_chunks):
+                    if i < len(doc_with_state.chunk_hashes):
+                        old_hash = doc_with_state.chunk_hashes[i]
+                        if new_hashes[i] != old_hash:
+                            chunk_operations.append(DocumentWithOperation(
+                            page_content=new_chunk.page_content,
+                            operation=ChunkOperation.UPDATE, id=_get_chunk_id(id, i)))
+                    else:
+                        # Add new chunks.
+                        chunk_operations.append(DocumentWithOperation(
+                            page_content=new_chunk.page_content,
+                            operation=ChunkOperation.ADD, id=_get_chunk_id(id, i)))
+
+                # If there are fewer new chunks than old chunks, remove the old chunks.
+                if len(new_chunks) < len(doc_with_state.chunk_hashes):
+                    # Remove old chunks.
+                    for i in range(len(new_chunks), len(doc_with_state.chunk_hashes)):
+                        chunk_operations.append(
+                        DocumentWithOperation(id=_get_chunk_id(id, i), operation=ChunkOperation.REMOVE))
+                doc_with_state.hash = new_document_hash
+                doc_with_state.chunk_hashes = new_hashes
+        return chunk_operations
+
+
+    def update_truncate(self, documents: List[Document], ids: List[str]):
+        """Updates the documents in the document manager.
+        Additionally, removes any documents that are not in
+        `documents`.
+        """
+        if len(documents) != len(ids):
+            raise ValueError("Unequal count of documents and ids."
+        id_set = set(ids)
+        if len(ids) != len(id_set):
+            raise ValueError("Duplicate ids.")
+
+        # Compute chunks to be added and updated.
+        for document, id in zip(documents, ids):
+            if id not in self._documents_with_state:
+                chunk_operations.extend(self.add([document], [id]))
+            else:
+                chunk_operations.extend(self.update([document], [id]))
+
+        # Compute chunks to be deleted.
+        chunk_operations = []
+        for doc_id in self._documents_with_state:
+            if doc_id not in id_set:
+                doc_with_state = self._documents_with_state[doc_id]
+                for i in range(len(doc_with_state.chunk_hashes)):
+                    chunk_operations.append(
+                        DocumentWithOperation(id=_get_chunk_id(doc_id, i), operation=ChunkOperation.REMOVE))
+
+        return chunk_operations

--- a/langchain/document_manager/test_vectordb_integration.ipynb
+++ b/langchain/document_manager/test_vectordb_integration.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3216eb4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pinecone\n",
+    "from langchain.vectorstores import Pinecone\n",
+    "from langchain.embeddings.openai import OpenAIEmbeddings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37fe8a52",
+   "metadata": {},
+   "source": [
+    "`Init Pinecone`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9d845772",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Init\n",
+    "pinecone.init(\n",
+    "    api_key=os.environ.get('PINECONE_API_KEY'),  \n",
+    "    environment=\"us-east1-gcp\"  \n",
+    ")\n",
+    "\n",
+    "# Connect to index\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "index_name = \"langchain-test\"\n",
+    "vectorstore = Pinecone.from_existing_index(index_name=index_name,embedding=embeddings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15365f2b",
+   "metadata": {},
+   "source": [
+    "`Test pipeline`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c347016e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.docstore.document import Document\n",
+    "from langchain.document_manager.example_interface import _TEST_DOCUMENTS\n",
+    "from langchain.document_manager.in_memory import InMemoryDocumentManager\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "\n",
+    "def create_document_manager():\n",
+    "    document_manager = InMemoryDocumentManager(CharacterTextSplitter(separator=\" \"))\n",
+    "    return document_manager\n",
+    "\n",
+    "def add_documents(document_manager):\n",
+    "    ops = document_manager.add(_TEST_DOCUMENTS, ['1', '2', '3'])\n",
+    "    return document_manager\n",
+    "\n",
+    "def update_documents(document_manager):\n",
+    "    ops = document_manager.update([Document(page_content='This is a modified test document.')], ['1'])\n",
+    "    return document_manager\n",
+    "\n",
+    "def update_truncate_documents(document_manager):\n",
+    "    ops = document_manager.update_truncate([Document(page_content='This is the final test document.'),\n",
+    "                                            Document(page_content='This is another final test document')], \n",
+    "                                           ['1', '2'])\n",
+    "    return document_manager\n",
+    "\n",
+    "def document_manager_pipeline():\n",
+    "    document_manager = create_document_manager()\n",
+    "    document_manager = add_documents(document_manager)\n",
+    "    document_manager = update_documents(document_manager)\n",
+    "    document_manager = update_truncate_documents(document_manager)\n",
+    "    return document_manager"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af82d79d",
+   "metadata": {},
+   "source": [
+    "`Test vectorDB upsert`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "353d80ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document id: This is a test document., hash: 53a92d14131d800674aa83617843757f860d07dc33c2ced1e1391183908945d3\n",
+      "Document id: This is another test document., hash: 669ee43d4936ba74cee191c8552885aa98e40b4d17d630eedb9fc64bf0ec07b1\n",
+      "Document id: This is a third test document., hash: e664370f801474e643a87f3f903af1280eda09c3db80a90ca8cda1818d2250d2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba65061c388e4cb48a9a841aee7ceed8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Upserted vectors:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6a15ae8821d84a4da0199634e2f14849",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Upserted vectors:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d670ebeef0984265b2757cc4988ef5ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Upserted vectors:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Run\n",
+    "d = document_manager_pipeline()\n",
+    "\n",
+    "# Check \n",
+    "for doc,hash_ in d.lazy_load_all_docs():\n",
+    "    print(f\"Document id: {doc.page_content}, hash: {hash_}\")\n",
+    "\n",
+    "# Upsert\n",
+    "d.add_documents_to_vectorstore(vectorstore)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc6779a6",
+   "metadata": {},
+   "source": [
+    "`Concern`\n",
+    "\n",
+    "If we specify `hash` as `id` on write, I expect that the vectors are simply updated. But need to confirm.\n",
+    "\n",
+    "`vectorstore.add_texts(texts=[doc.page_content],metadatas=[doc.metadata],ids=[doc_hash])`\n",
+    "\n",
+    "I do not see an option for vector removal! "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03a8433d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adding very initial rough draft of the document manger.

On a high level it supports the following operations:
- Add
- Update
- UpdateTruncate

`Update` and `UpdateTruncate` differ in that `UpdateTruncate` deletes the set of documents that are not present in the new set of documents passed in. `Update` only updates the existing documents. 

The document manager currently returns the a list of operations that need to be performed by the user on the vector store. This can be integrated into the existing vector store interface by adding a new method in `VectorStore` that applies add, update and delete operations.

An example script is included in the changes which is an example of the interface. It is also runnable, and proves the correctness of the document manager.

@hwchase17