### PR TITLE
fixing gpt4all.py to use get_model_from_type instead of model_type

### DIFF
--- a/langchain/llms/gpt4all.py
+++ b/langchain/llms/gpt4all.py
@@ -153,7 +153,7 @@ class GPT4All(LLM):
         if values["n_threads"] is not None:
             # set n_threads
             values["client"].model.set_thread_count(values["n_threads"])
-        values["backend"] = values["client"].model_type
+        values["backend"] = values["client"].get_model_from_type
 
         return values
 


### PR DESCRIPTION
This  is to fix the error :   File "\AppData\Local\Programs\Python\Python311\Lib\site-packages\langchain\llms\gpt4all.py", line 156, in validate_environment
    values["backend"] = values["client"].model_type
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'GPT4All' object has no attribute 'model_type'

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes # (issue)

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
