### PR TITLE
json parser for when 3 backtiks are missing

### DIFF
--- a/langchain/output_parsers/json.py
+++ b/langchain/output_parsers/json.py
@@ -9,7 +9,12 @@ from langchain.schema import OutputParserException
 
 def parse_json_markdown(json_string: str) -> dict:
     # Try to find JSON string within triple backticks
-    match = re.search(r"```(json)?(.*?)```", json_string, re.DOTALL)
+
+    # The amount of backticks at the end of the LLM response can vary,
+    # so we use a regex to match what we want even if we have fewer than 3 backticks
+    # As a tradeoff, we might fetch some backticks in the command below: match.group(2)
+    # We will get rid of them using rstrip() later
+    match = re.search(r"```(json)?(.*)(`{1,3})?", json_string, re.DOTALL)
 
     # If no match found, assume the entire string is a JSON string
     if match is None:
@@ -17,6 +22,8 @@ def parse_json_markdown(json_string: str) -> dict:
     else:
         # If match found, use the content within the backticks
         json_str = match.group(2)
+        # In case we have picked some trailing backticks, get rid of them
+        json_str = json_str.rstrip("`")
 
     # Strip whitespace and newlines from the start and end
     json_str = json_str.strip()

--- a/langchain/output_parsers/json.py
+++ b/langchain/output_parsers/json.py
@@ -23,7 +23,7 @@ def parse_json_markdown(json_string: str) -> dict:
         # If match found, use the content within the backticks
         json_str = match.group(2)
         # In case we have picked some trailing backticks, get rid of them
-        json_str = json_str.rstrip("`")
+        json_str = json_str.strip().rstrip("`")
 
     # Strip whitespace and newlines from the start and end
     json_str = json_str.strip()

--- a/tests/unit_tests/output_parsers/test_json.py
+++ b/tests/unit_tests/output_parsers/test_json.py
@@ -89,6 +89,18 @@ TEXT_BEFORE_AND_AFTER = """Action: Testing
 ```
 This should do the trick"""
 
+TWO_BACKTICKS_IN_THE_END = """```json
+{
+    "foo": "bar"
+}
+``"""
+
+ONE_BACKTICK_IN_THE_END = """```json
+{
+    "foo": "bar"
+}
+`"""
+
 TEST_CASES = [
     GOOD_JSON,
     JSON_WITH_NEW_LINES,
@@ -99,6 +111,8 @@ TEST_CASES = [
     NO_TICKS_WHITE_SPACE,
     TEXT_BEFORE,
     TEXT_AFTER,
+    TWO_BACKTICKS_IN_THE_END,
+    ONE_BACKTICK_IN_THE_END,
 ]
 
 


### PR DESCRIPTION
Fixes #3455 and #2276.

The parse_json_markdown function expects a JSON string within triple backticks.

However, even though it's instructed this way, LLM's responses sometimes come with fewer that 3 backticks (as also described in the issue 3455.

You can try using this string as input to test:

json_string = '\n\nRESPONSE\n--------------------\n```json\n{\n    "action": "Current Search",\n    "action_input": "Atividades de lazer em Recife"\n}\n``'


#### Who can review?

Tag maintainers/contributors who might be interested:
@vowelparrot
