### PR TITLE
Fix a typo in the documentation for the Slack document loader

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/slack.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/slack.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "# Optionally set your Slack URL. This will give you proper URLs in the docs sources.\n",
     "SLACK_WORKSPACE_URL = \"https://xxx.slack.com\"\n",
-    "LOCAL_ZIPFILE = \"\" # Paste the local paty to your Slack zip file here.\n",
+    "LOCAL_ZIPFILE = \"\" # Paste the local path to your Slack zip file here.\n",
     "\n",
     "loader = SlackDirectoryLoader(LOCAL_ZIPFILE, SLACK_WORKSPACE_URL)"
    ]


### PR DESCRIPTION
Fixes a typo I noticed while reading the docs.