### PR TITLE
Removes unnecessary backslash escaping for backticks in python

### DIFF
--- a/langchain/output_parsers/format_instructions.py
+++ b/langchain/output_parsers/format_instructions.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-STRUCTURED_FORMAT_INSTRUCTIONS = """The output should be a markdown code snippet formatted in the following schema, including the leading and trailing "\`\`\`json" and "\`\`\`":
+STRUCTURED_FORMAT_INSTRUCTIONS = """The output should be a markdown code snippet formatted in the following schema, including the leading and trailing "```json" and "```":
 
 ```json
 {{


### PR DESCRIPTION
Fixed python deprecation warning:
    DeprecationWarning: invalid escape sequence '`'
    
   backticks (`) do not have special meaning in python strings and should not be escaped. 

-- @spazm on twitter

### Who can review:

@nfcampos ported this change from javascript, @hwchase17 wrote the original STRUCTURED_FORMAT_INSTRUCTIONS, 
