### PR TITLE
fix(langchain): fix _parse_input function

### DIFF
--- a/langchain/tools/json/tool.py
+++ b/langchain/tools/json/tool.py
@@ -20,7 +20,7 @@ def _parse_input(text: str) -> List[Union[str, int]]:
     """Parse input of the form data["key1"][0]["key2"] into a list of keys."""
     _res = re.findall(r"\[.*?]", text)
     # strip the brackets and quotes, convert to int if possible
-    res = [i[1:-1].replace('"', "") for i in _res]
+    res = [i[1:-1].replace('"', "").replace("'","") for i in _res]
     res = [int(i) if i.isdigit() else i for i in res]
     return res
 


### PR DESCRIPTION
In the "langchain/tools/json/tool.py" file, fixed the _parse_input function to properly handle single quotes.

Resolves issue #5759.


#### Before submitting

<!-- If you're adding a new integration, please include:

1. I've added some tests but I couldn't get poetry to work, still troubleshooting


#### Who can review?

Tag maintainers/contributors who might be interested:

  Agents / Tools / Toolkits
  - @vowelparrot

