### PR TITLE
Wheynelau/json double quote

### DIFF
--- a/langchain/tools/json/tool.py
+++ b/langchain/tools/json/tool.py
@@ -20,7 +20,7 @@ def _parse_input(text: str) -> List[Union[str, int]]:
     """Parse input of the form data["key1"][0]["key2"] into a list of keys."""
     _res = re.findall(r"\[.*?]", text)
     # strip the brackets and quotes, convert to int if possible
-    res = [i[1:-1].replace('"', "") for i in _res]
+    res = [i[1:-1].replace('"', "").replace("'","") for i in _res]
     res = [int(i) if i.isdigit() else i for i in res]
     return res
 

--- a/tests/unit_tests/tools/test_json.py
+++ b/tests/unit_tests/tools/test_json.py
@@ -30,6 +30,10 @@ def test_json_spec_value() -> None:
     assert spec.value('data["baz"]') == "{'test': {'foo': [1, 2, 3]}}"
     assert spec.value('data["baz"]["test"]') == "{'foo': [1, 2, 3]}"
     assert spec.value('data["baz"]["test"]["foo"]') == "[1, 2, 3]"
+    assert spec.value("data['foo']") == "bar"
+    assert spec.value("data['baz']") == "{'test': {'foo': [1, 2, 3]}}"
+    assert spec.value("data['baz']['test']") == "{'foo': [1, 2, 3]}"
+    assert spec.value("data['baz']['test']['foo']") == "[1, 2, 3]"
 
 
 def test_json_spec_value_max_length() -> None:


### PR DESCRIPTION
In the "langchain/tools/json/tool.py" file, fixed the _parse_input function to properly handle single quotes. I've added a second .replace() to replace the single quotes. This is a workaround I can suggest.

Resolves issue #5759 

Test:
1. Added different orderings of quotes in test_json.py
2. Was unable to run poetry but tested in notebook


  - @vowelparrot

