### PR TITLE
fix(langchain): fix reading a list of dict from json file

### DIFF
--- a/langchain/tools/json/tool.py
+++ b/langchain/tools/json/tool.py
@@ -37,6 +37,8 @@ class JsonSpec(BaseModel):
         if not path.exists():
             raise FileNotFoundError(f"File not found: {path}")
         dict_ = json.loads(path.read_text())
+        if isinstance(dict_, list):
+            dict_ = dict(enumerate(dict_))
         return cls(dict_=dict_)
 
     def keys(self, text: str) -> str:


### PR DESCRIPTION
This commit allows a list of dictionaries to be read from a json file.

Resolves #5706 

No additional tests implemented as I'm not very familiar with the tests yet, can suggest creating a list of dictionaries then asserting the values


  - @vowelparrot

