### PR TITLE
fix intermediate step over length

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -422,9 +422,11 @@ class Agent(BaseSingleActionAgent):
         for action, observation in intermediate_steps:
             thoughts.append(action.log)
             thoughts.append(f"\n{self.observation_prefix}{observation}\n{self.llm_prefix}")
-            if self.length_function(thoughts)>self.scratchpad_max_size:
-                thoughts.pop(0)
-                thoughts.pop(0)
+        total_length = self.length_function("".join(thoughts))
+        while total_length>self.scratchpad_max_size:
+            thoughts.pop(0)
+            thoughts.pop(0)
+            total_length = self.length_function("".join(thoughts))
         return "".join(thoughts)
 
     def plan(

--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -387,7 +387,7 @@ class Agent(BaseSingleActionAgent):
     llm_chain: LLMChain
     output_parser: AgentOutputParser
     allowed_tools: Optional[List[str]] = None
-    scratchpad_max_size: int = 3000
+    scratchpad_max_size: int = 5000
     length_function: Callable[[str], int] = len
 
     def dict(self, **kwargs: Any) -> Dict:


### PR DESCRIPTION
<!--
fix the problem of agent_scratchpad over length
-->
fix the problem of agent_scratchpad over length, during using 'CONVERSATIONAL_REACT_DESCRIPTION' agent. 
This problem is caused by the simple concatenation of intermediate_steps in Function '_construct_scratchpad', so I changed this to ignore the earliest intermediate_steps.

Note: This fix add two parameters in Agent class:
 - scratchpad_max_size: the max size of constructed agent_scratchpad.
 - length_function: the length function used to count the length of agent_scratchpad.


#### Who can review?

Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

   @hwchase17 - project lead

  Agents / Tools / Toolkits
  - @vowelparrot

 -->
