### PR TITLE
fix: OpenAI and AzureChatOpenAI variables conflict

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -38,7 +38,7 @@ from langchain.schema import (
     HumanMessage,
     SystemMessage,
 )
-from langchain.utils import get_from_dict_or_env
+from langchain.utils import get_from_dict_or_env, get_openai_default_values
 
 if TYPE_CHECKING:
     import tiktoken
@@ -220,6 +220,9 @@ class ChatOpenAI(BaseChatModel):
         try:
             import openai
 
+            # restore values that may have been changed from other `chat_models`
+            for k, v in get_openai_default_values().items():
+                setattr(openai, k, v)
         except ImportError:
             raise ValueError(
                 "Could not import openai python package. "

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -35,7 +35,7 @@ from langchain.callbacks.manager import (
 )
 from langchain.llms.base import BaseLLM
 from langchain.schema import Generation, LLMResult
-from langchain.utils import get_from_dict_or_env
+from langchain.utils import get_from_dict_or_env, get_openai_default_values
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +235,9 @@ class BaseOpenAI(BaseLLM):
         try:
             import openai
 
+            # restore values that may have been changed from other `chat_models`
+            for k, v in get_openai_default_values().items():
+                setattr(openai, k, v)
             openai.api_key = openai_api_key
             if openai_api_base:
                 openai.api_base = openai_api_base

--- a/langchain/utils.py
+++ b/langchain/utils.py
@@ -5,7 +5,7 @@ import importlib
 import json
 import os
 import subprocess
-from functools import cache
+from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from requests import HTTPError, Response
@@ -136,7 +136,7 @@ def guard_import(
     return module
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_openai_default_values(
     var_names: List[str] = ["openai.api_type", "openai.api_base", "openai.api_version"]
 )->Dict[str, str]:


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

Fixes #5422.
Issue arises when using ChatOpenAI/OpenAI (llm) and AzureChatOpenAI one after another, as the latter modifies some default `openai` vars such as `openai.api_base` which end up raising an error when calling openai services.

Proposed solution is to read the default values and store them. As the `openai` module can easily be imported and changed before `langchain` come into context, my proposal is to run (once) the import in a fresh sub-process, get the default variables we need, and then caching the result. 
Alternatively one can hard-code these values like so 
```python
  openai.api_type = "open_ai"
  openai.api_base = "https://api.openai.com/v1"
  openai.api_version = None
```
But they might change if OpenAI decides so.

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->
Not sure how to add tests as it requires making the request and hence having keys and endpoint setup for azure. Is there any dry-run code infrastructure I can leverage to do so..? 

#### Who can review?

@vowelparrot (apologies if the tag is misplaced, I am not sure who to add for this). 

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
