### PR TITLE
Fix exporting GCP Vertex Matching Engine from vectorstores

### DIFF
--- a/langchain/vectorstores/__init__.py
+++ b/langchain/vectorstores/__init__.py
@@ -25,6 +25,7 @@ from langchain.vectorstores.typesense import Typesense
 from langchain.vectorstores.vectara import Vectara
 from langchain.vectorstores.weaviate import Weaviate
 from langchain.vectorstores.zilliz import Zilliz
+from langchain.vectorstores.matching_engine import MatchingEngine
 
 __all__ = [
     "Redis",
@@ -56,4 +57,5 @@ __all__ = [
     "Clickhouse",
     "ClickhouseSettings",
     "Tigris",
+    "MatchingEngine",
 ]

--- a/langchain/vectorstores/__init__.py
+++ b/langchain/vectorstores/__init__.py
@@ -10,6 +10,7 @@ from langchain.vectorstores.docarray import DocArrayHnswSearch, DocArrayInMemory
 from langchain.vectorstores.elastic_vector_search import ElasticVectorSearch
 from langchain.vectorstores.faiss import FAISS
 from langchain.vectorstores.lancedb import LanceDB
+from langchain.vectorstores.matching_engine import MatchingEngine
 from langchain.vectorstores.milvus import Milvus
 from langchain.vectorstores.mongodb_atlas import MongoDBAtlasVectorSearch
 from langchain.vectorstores.myscale import MyScale, MyScaleSettings
@@ -25,7 +26,6 @@ from langchain.vectorstores.typesense import Typesense
 from langchain.vectorstores.vectara import Vectara
 from langchain.vectorstores.weaviate import Weaviate
 from langchain.vectorstores.zilliz import Zilliz
-from langchain.vectorstores.matching_engine import MatchingEngine
 
 __all__ = [
     "Redis",


### PR DESCRIPTION
The Vertex Matching Engine docs include [the line](https://github.com/hwchase17/langchain/blob/b177a29d3f942eeccf85814f0f628c32509b9b6a/docs/modules/indexes/vectorstores/examples/matchingengine.ipynb?short_path=54ebfde#L32) `from langchain.vectorstores import MatchingEngine` which doesn't work as it wasn't added to the vectorestores module exports.



  - @dev2049
