### PR TITLE
FIX: backslash escaped

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -716,21 +716,21 @@ class RecursiveCharacterTextSplitter(TextSplitter):
         elif language == Language.LATEX:
             return [
                 # First, try to split along Latex sections
-                "\n\\chapter{",
-                "\n\\section{",
-                "\n\\subsection{",
-                "\n\\subsubsection{",
+                "\n\\\chapter{",
+                "\n\\\section{",
+                "\n\\\subsection{",
+                "\n\\\subsubsection{",
                 # Now split by environments
-                "\n\\begin{enumerate}",
-                "\n\\begin{itemize}",
-                "\n\\begin{description}",
-                "\n\\begin{list}",
-                "\n\\begin{quote}",
-                "\n\\begin{quotation}",
-                "\n\\begin{verse}",
-                "\n\\begin{verbatim}",
+                "\n\\\begin{enumerate}",
+                "\n\\\begin{itemize}",
+                "\n\\\begin{description}",
+                "\n\\\begin{list}",
+                "\n\\\begin{quote}",
+                "\n\\\begin{quotation}",
+                "\n\\\begin{verse}",
+                "\n\\\begin{verbatim}",
                 ## Now split by math environments
-                "\n\\begin{align}",
+                "\n\\\begin{align}",
                 "$$",
                 "$",
                 # Now split by the normal type of lines


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

LatexTextSplitter needs to use "\n\\\chapter" when separators are escaped, such as "\n\\\chapter", otherwise it will report an error: (re.error: bad escape \c at position 1 (line 2, column 1))


Fixes # (issue)

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use

re.error: bad escape \c at position 1 (line 2, column 1)

See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

@hwchase17  @dev2049 

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
