### PR TITLE
fix: fullfill openai params when embedding

### DIFF
--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -97,8 +97,8 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             embeddings = OpenAIEmbeddings(
                 deployment="your-embeddings-deployment-name",
                 model="your-embeddings-model-name",
-                api_base="https://your-endpoint.openai.azure.com/",
-                api_type="azure",
+                openai_api_base="https://your-endpoint.openai.azure.com/",
+                openai_api_type="azure",
             )
             text = "This is a test query."
             query_result = embeddings.embed_query(text)

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -251,15 +251,18 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             results[indices[i]].append(batched_embeddings[i])
             num_tokens_in_batch[indices[i]].append(len(tokens[i]))
 
+        # fullfill openai params
+        params = self._invocation_params
+        params['engine'] = self.deployment or params['engine']
+        params['request_timeout'] = self.request_timeout or params['request_timeout']
+        params['headers'] = self.headers or params['headers']
         for i in range(len(texts)):
             _result = results[i]
             if len(_result) == 0:
                 average = embed_with_retry(
                     self,
                     input="",
-                    engine=self.deployment,
-                    request_timeout=self.request_timeout,
-                    headers=self.headers,
+                    **params,
                 )["data"][0]["embedding"]
             else:
                 average = np.average(_result, axis=0, weights=num_tokens_in_batch[i])
@@ -277,12 +280,15 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 # See: https://github.com/openai/openai-python/issues/418#issuecomment-1525939500
                 # replace newlines, which can negatively affect performance.
                 text = text.replace("\n", " ")
+            # fullfill openai params
+            params = self._invocation_params
+            params['engine'] = engine or params['engine']
+            params['request_timeout'] = self.request_timeout or params['request_timeout']
+            params['headers'] = self.headers or params['headers']
             return embed_with_retry(
                 self,
                 input=[text],
-                engine=engine,
-                request_timeout=self.request_timeout,
-                headers=self.headers,
+                **params,
             )["data"][0]["embedding"]
 
     def embed_documents(

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -251,19 +251,16 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             results[indices[i]].append(batched_embeddings[i])
             num_tokens_in_batch[indices[i]].append(len(tokens[i]))
 
-        # fullfill openai params
-        params = self._invocation_params
-        params['engine'] = self.deployment or params['engine']
-        params['request_timeout'] = self.request_timeout or params['request_timeout']
-        params['headers'] = self.headers or params['headers']
         for i in range(len(texts)):
             _result = results[i]
             if len(_result) == 0:
                 average = embed_with_retry(
                     self,
                     input="",
-                    **params,
-                )["data"][0]["embedding"]
+                    **self._invocation_params,
+                )[
+                    "data"
+                ][0]["embedding"]
             else:
                 average = np.average(_result, axis=0, weights=num_tokens_in_batch[i])
             embeddings[i] = (average / np.linalg.norm(average)).tolist()
@@ -280,16 +277,13 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 # See: https://github.com/openai/openai-python/issues/418#issuecomment-1525939500
                 # replace newlines, which can negatively affect performance.
                 text = text.replace("\n", " ")
-            # fullfill openai params
-            params = self._invocation_params
-            params['engine'] = engine or params['engine']
-            params['request_timeout'] = self.request_timeout or params['request_timeout']
-            params['headers'] = self.headers or params['headers']
             return embed_with_retry(
                 self,
                 input=[text],
-                **params,
-            )["data"][0]["embedding"]
+                **self._invocation_params,
+            )[
+                "data"
+            ][0]["embedding"]
 
     def embed_documents(
         self, texts: List[str], chunk_size: Optional[int] = 0


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes #5822 
I upgrade my langchain lib by execute `pip install -U langchain`, and the verion is 0.0.192。But i found that openai.api_base not working. I use azure openai service as openai backend, the openai.api_base is very import for me. I hava compared tag/0.0.192 and tag/0.0.191, and figure out that:
![image](https://github.com/hwchase17/langchain/assets/6478745/e183fdb2-8224-45c9-b3b4-26d62823999a)
openai params is moved inside `_invocation_params` function，and used in some openai invoke:
![image](https://github.com/hwchase17/langchain/assets/6478745/5a55a048-5fa9-4bf4-aaef-3902226bec5e)
![image](https://github.com/hwchase17/langchain/assets/6478745/85b8cebc-eeb8-4538-a525-814719c8f8df)
but still some case not covered like:
![image](https://github.com/hwchase17/langchain/assets/6478745/e0297620-f2b2-4f4f-98bd-d0ed19022dac)

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

Tag maintainers/contributors who might be interested:
@hwchase17 

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
