### PR TITLE
Add support for the endpoint URL in DynamoDBChatMesasgeHistory

### DIFF
--- a/docs/modules/memory/examples/dynamodb_chat_message_history.ipynb
+++ b/docs/modules/memory/examples/dynamodb_chat_message_history.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "91c6a7ef",
    "metadata": {},
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3f608be0",
    "metadata": {},
@@ -19,6 +21,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "030d784f",
    "metadata": {},
@@ -72,11 +75,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1a9b310b",
    "metadata": {},
    "source": [
-    "## DynamoDBChatMessageHistory"
+    "## DynamoDBChatMessageHistory "
    ]
   },
   {
@@ -118,6 +122,30 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "955f1b15",
+   "metadata": {},
+   "source": [
+    "## DynamoDBChatMessageHistory with Custom Endpoint URL\n",
+    "\n",
+    "Sometimes it is useful to specify the URL to the AWS endpoint to connect to. For instance, when you are running locally against [Localstack](https://localstack.cloud/). For those cases you can specify the URL via the `endpoint_url` parameter in the constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "225713c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.memory.chat_message_histories import DynamoDBChatMessageHistory\n",
+    "\n",
+    "history = DynamoDBChatMessageHistory(table_name=\"SessionTable\", session_id=\"0\", endpoint_url=\"http://localhost.localstack.cloud:4566\")"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3b33c988",
    "metadata": {},

--- a/docs/modules/memory/examples/dynamodb_chat_message_history.ipynb
+++ b/docs/modules/memory/examples/dynamodb_chat_message_history.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "91c6a7ef",
    "metadata": {},
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3f608be0",
    "metadata": {},
@@ -21,7 +19,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "030d784f",
    "metadata": {},
@@ -75,12 +72,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1a9b310b",
    "metadata": {},
    "source": [
-    "## DynamoDBChatMessageHistory "
+    "## DynamoDBChatMessageHistory"
    ]
   },
   {
@@ -122,7 +118,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "955f1b15",
    "metadata": {},

--- a/langchain/memory/chat_message_histories/dynamodb.py
+++ b/langchain/memory/chat_message_histories/dynamodb.py
@@ -21,12 +21,19 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
         table_name: name of the DynamoDB table
         session_id: arbitrary key that is used to store the messages
             of a single chat session.
+        endpoint_url: URL of the AWS endpoint to connect to. This argument
+            is optional and useful for test purposes, like using Localstack.
+            If you plan to use AWS cloud service, you normally don't have to 
+            worry about setting the endpoint_url.
     """
 
-    def __init__(self, table_name: str, session_id: str):
+    def __init__(self, table_name: str, session_id: str, endpoint_url: str = None):
         import boto3
 
-        client = boto3.resource("dynamodb")
+        if endpoint_url:
+            client = boto3.resource("dynamodb", endpoint_url=endpoint_url)
+        else:
+            client = boto3.resource("dynamodb")
         self.table = client.Table(table_name)
         self.session_id = session_id
 

--- a/langchain/memory/chat_message_histories/dynamodb.py
+++ b/langchain/memory/chat_message_histories/dynamodb.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from langchain.schema import (
     BaseChatMessageHistory,
@@ -23,11 +23,13 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
             of a single chat session.
         endpoint_url: URL of the AWS endpoint to connect to. This argument
             is optional and useful for test purposes, like using Localstack.
-            If you plan to use AWS cloud service, you normally don't have to 
+            If you plan to use AWS cloud service, you normally don't have to
             worry about setting the endpoint_url.
     """
 
-    def __init__(self, table_name: str, session_id: str, endpoint_url: str = None):
+    def __init__(
+        self, table_name: str, session_id: str, endpoint_url: Optional[str] = None
+    ):
         import boto3
 
         if endpoint_url:


### PR DESCRIPTION
This PR adds the possibility of specifying the endpoint URL to AWS in the DynamoDBChatMessageHistory, so that it is possible to target not only the AWS cloud services, but also a local installation.

Specifying the endpoint URL, which is normally not done when addressing the cloud services, is very helpful when targeting a local instance (like [Localstack](https://localstack.cloud/)) when running local tests.

Fixes #5835

#### Who can review?

Tag maintainers/contributors who might be interested: @dev2049

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
