### PR TITLE
feat: Add `UnstructuredCSVLoader` for CSV files

### DIFF
--- a/docs/modules/indexes/document_loaders/examples/csv.ipynb
+++ b/docs/modules/indexes/document_loaders/examples/csv.ipynb
@@ -29,7 +29,6 @@
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -45,7 +44,6 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -76,7 +74,6 @@
    "cell_type": "code",
    "execution_count": 28,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -96,7 +93,6 @@
    "cell_type": "code",
    "execution_count": 29,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -152,6 +148,211 @@
    "source": [
     "print(data)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `UnstructuredCSVLoader`\n",
+    "\n",
+    "You can also load the table using the `UnstructuredCSVLoader`. One advantage of using `UnstructuredCSVLoader` is that if you use it in `\"elements\"` mode, an HTML representation of the table will be available in the metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders.csv_loader import UnstructuredCSVLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = UnstructuredCSVLoader(file_path='example_data/mlb_teams_2012.csv', mode=\"elements\")\n",
+    "docs = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<table border=\"1\" class=\"dataframe\">\n",
+      "  <tbody>\n",
+      "    <tr>\n",
+      "      <td>Nationals</td>\n",
+      "      <td>81.34</td>\n",
+      "      <td>98</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Reds</td>\n",
+      "      <td>82.20</td>\n",
+      "      <td>97</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Yankees</td>\n",
+      "      <td>197.96</td>\n",
+      "      <td>95</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Giants</td>\n",
+      "      <td>117.62</td>\n",
+      "      <td>94</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Braves</td>\n",
+      "      <td>83.31</td>\n",
+      "      <td>94</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Athletics</td>\n",
+      "      <td>55.37</td>\n",
+      "      <td>94</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Rangers</td>\n",
+      "      <td>120.51</td>\n",
+      "      <td>93</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Orioles</td>\n",
+      "      <td>81.43</td>\n",
+      "      <td>93</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Rays</td>\n",
+      "      <td>64.17</td>\n",
+      "      <td>90</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Angels</td>\n",
+      "      <td>154.49</td>\n",
+      "      <td>89</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Tigers</td>\n",
+      "      <td>132.30</td>\n",
+      "      <td>88</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Cardinals</td>\n",
+      "      <td>110.30</td>\n",
+      "      <td>88</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Dodgers</td>\n",
+      "      <td>95.14</td>\n",
+      "      <td>86</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>White Sox</td>\n",
+      "      <td>96.92</td>\n",
+      "      <td>85</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Brewers</td>\n",
+      "      <td>97.65</td>\n",
+      "      <td>83</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Phillies</td>\n",
+      "      <td>174.54</td>\n",
+      "      <td>81</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Diamondbacks</td>\n",
+      "      <td>74.28</td>\n",
+      "      <td>81</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Pirates</td>\n",
+      "      <td>63.43</td>\n",
+      "      <td>79</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Padres</td>\n",
+      "      <td>55.24</td>\n",
+      "      <td>76</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Mariners</td>\n",
+      "      <td>81.97</td>\n",
+      "      <td>75</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Mets</td>\n",
+      "      <td>93.35</td>\n",
+      "      <td>74</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Blue Jays</td>\n",
+      "      <td>75.48</td>\n",
+      "      <td>73</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Royals</td>\n",
+      "      <td>60.91</td>\n",
+      "      <td>72</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Marlins</td>\n",
+      "      <td>118.07</td>\n",
+      "      <td>69</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Red Sox</td>\n",
+      "      <td>173.18</td>\n",
+      "      <td>69</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Indians</td>\n",
+      "      <td>78.43</td>\n",
+      "      <td>68</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Twins</td>\n",
+      "      <td>94.08</td>\n",
+      "      <td>66</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Rockies</td>\n",
+      "      <td>78.06</td>\n",
+      "      <td>64</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Cubs</td>\n",
+      "      <td>88.19</td>\n",
+      "      <td>61</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <td>Astros</td>\n",
+      "      <td>60.65</td>\n",
+      "      <td>55</td>\n",
+      "    </tr>\n",
+      "  </tbody>\n",
+      "</table>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(docs[0].metadata[\"text_as_html\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -170,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/langchain/document_loaders/__init__.py
+++ b/langchain/document_loaders/__init__.py
@@ -19,7 +19,7 @@ from langchain.document_loaders.chatgpt import ChatGPTLoader
 from langchain.document_loaders.college_confidential import CollegeConfidentialLoader
 from langchain.document_loaders.confluence import ConfluenceLoader
 from langchain.document_loaders.conllu import CoNLLULoader
-from langchain.document_loaders.csv_loader import CSVLoader
+from langchain.document_loaders.csv_loader import CSVLoader, UnstructuredCSVLoader
 from langchain.document_loaders.dataframe import DataFrameLoader
 from langchain.document_loaders.diffbot import DiffbotLoader
 from langchain.document_loaders.directory import DirectoryLoader
@@ -222,6 +222,7 @@ __all__ = [
     "TwitterTweetLoader",
     "UnstructuredAPIFileIOLoader",
     "UnstructuredAPIFileLoader",
+    "UnstructuredCSVLoader",
     "UnstructuredEPubLoader",
     "UnstructuredEmailLoader",
     "UnstructuredExcelLoader",

--- a/langchain/document_loaders/csv_loader.py
+++ b/langchain/document_loaders/csv_loader.py
@@ -1,8 +1,12 @@
 import csv
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
+from langchain.document_loaders.unstructured import (
+    UnstructuredFileLoader,
+    validate_unstructured_version,
+)
 
 
 class CSVLoader(BaseLoader):
@@ -61,3 +65,18 @@ class CSVLoader(BaseLoader):
                 docs.append(doc)
 
         return docs
+
+
+class UnstructuredCSVLoader(UnstructuredFileLoader):
+    """Loader that uses unstructured to load CSV files."""
+
+    def __init__(
+        self, file_path: str, mode: str = "single", **unstructured_kwargs: Any
+    ):
+        validate_unstructured_version(min_unstructured_version="0.6.8")
+        super().__init__(file_path=file_path, mode=mode, **unstructured_kwargs)
+
+    def _get_elements(self) -> List:
+        from unstructured.partition.csv import partition_csv
+
+        return partition_csv(filename=self.file_path, **self.unstructured_kwargs)

--- a/tests/integration_tests/document_loaders/test_csv_loader.py
+++ b/tests/integration_tests/document_loaders/test_csv_loader.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+
+from langchain.document_loaders import UnstructuredCSVLoader
+
+EXAMPLE_DIRECTORY = file_path = Path(__file__).parent.parent / "examples"
+
+
+def test_unstructured_csv_loader() -> None:
+    """Test unstructured loader."""
+    file_path = os.path.join(EXAMPLE_DIRECTORY, "stanley-cups.csv")
+    loader = UnstructuredCSVLoader(str(file_path))
+    docs = loader.load()
+
+    assert len(docs) == 1

--- a/tests/integration_tests/examples/stanley-cups.csv
+++ b/tests/integration_tests/examples/stanley-cups.csv
@@ -1,0 +1,5 @@
+Stanley Cups,,
+Team,Location,Stanley Cups
+Blues,STL,1
+Flyers,PHI,2
+Maple Leafs,TOR,13


### PR DESCRIPTION
### Summary

Adds an `UnstructuredCSVLoader` for loading CSVs. One advantage of using `UnstructuredCSVLoader` relative to the standard `CSVLoader` is that if you use `UnstructuredCSVLoader` in `"elements"` mode, an HTML representation of the table will be available in the metadata.

#### Who can review?

@hwchase17
 @eyurtsev