### PR TITLE
Text splitter for Markdown files by header

### DIFF
--- a/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
+++ b/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
@@ -42,8 +42,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "7fa9012b",
+   "execution_count": 3,
+   "id": "19c044f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,17 +52,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "41722f5e",
+   "execution_count": 4,
+   "id": "a20c5475",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': ''}}\n"
      ]
     }
    ],
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59f5e663",
+   "id": "36f29056",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "832c3ded",
+   "id": "34521b8e",
    "metadata": {},
    "source": [
     "`Test case 2`"
@@ -105,17 +105,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "c47fd042",
+   "execution_count": 3,
+   "id": "b78617b2",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'This is an introductory paragraph.', 'metadata': {'Header 2': 'Overview', 'Header 1': 'Introduction'}}\n",
-      "{'content': 'This is a detailed paragraph.', 'metadata': {'Header 2': 'Details', 'Header 1': 'Introduction'}}\n",
-      "{'content': 'This is the conclusion.', 'metadata': {'Header 2': 'Details', 'Header 1': 'Conclusion'}}\n"
+      "{'content': 'This is an introductory paragraph.', 'metadata': {'Header 2': 'Overview', 'Header 1': ''}}\n",
+      "{'content': 'This is a detailed paragraph.', 'metadata': {'Header 2': 'Details', 'Header 1': ''}}\n",
+      "{'content': 'This is the conclusion.', 'metadata': {'Header 2': 'Details', 'Header 1': ''}}\n"
      ]
     }
    ],
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39db6eec",
+   "id": "22cfdeab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c295fe76",
+   "id": "f1f74dfa",
    "metadata": {},
    "source": [
     "`Test case 3`"
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1ca1f09c",
+   "id": "17813ab7",
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8bbbfe0",
+   "id": "d994ccba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b56744b6",
+   "id": "add24254",
    "metadata": {},
    "source": [
     "`Test case 4`"
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9484a79e",
+   "id": "20907fb7",
    "metadata": {},
    "outputs": [
     {
@@ -236,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfba1a31",
+   "id": "b42c68af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4c8fef4",
+   "id": "aea887e5",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -256,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "04c93e70",
+   "id": "a5f9b993",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -264,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5df2d238",
+   "id": "ef1e75ee",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -272,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8c15f2d",
+   "id": "99aeb8c7",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -370,39 +370,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b961e316",
+   "id": "c0f2870e",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "37165da3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5a9040b1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1c820f1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "57a55162",
+   "execution_count": 20,
+   "id": "6e48eb0c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,6 +386,393 @@
     "from langchain.text_splitter import TextSplitter\n",
     "from typing import Dict, Any, List, Optional, Tuple, Union\n",
     "\n",
+    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
+    "    \"\"\"Implementation of splitting markdown based on user-supplied delimiters.\n",
+    "    The text associated with each delimiter is returned w/ delimier as metadata.\"\"\"\n",
+    "\n",
+    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count(\"#\")))\n",
+    "\n",
+    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
+    "        pattern = \"|\".join(\n",
+    "            \"(%s\\\\s*(.*))\" % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\"\n",
+    "        )\n",
+    "\n",
+    "        chunks = []\n",
+    "        current_metadata = {name: \"\" for sep, name in self.splits if name}\n",
+    "        current_content = []\n",
+    "\n",
+    "        for line in text.splitlines(keepends=True):\n",
+    "            stripped_line = line.lstrip()  # strip leading spaces\n",
+    "            match = re.match(pattern, stripped_line)\n",
+    "\n",
+    "            if match:\n",
+    "                if current_content:\n",
+    "                    chunks.append(\n",
+    "                        {\n",
+    "                            \"content\": \"\".join(current_content).strip(),\n",
+    "                            \"metadata\": dict(current_metadata),\n",
+    "                        }\n",
+    "                    )\n",
+    "                    current_content = []\n",
+    "\n",
+    "                for sep, name in self.splits:\n",
+    "                    if stripped_line.startswith(sep):\n",
+    "                        if name is not None:\n",
+    "                            # Update the rest of the line (after the separator) as the value for that header\n",
+    "                            current_metadata[name] = stripped_line[len(sep):].strip()\n",
+    "                            \n",
+    "                            # Clear out metadata for all headers lower in hierarchy\n",
+    "                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
+    "                            for header, index in [(name_, index) for index, (sep_, name_) in enumerate(self.splits) if name_]:\n",
+    "                                if index > current_header_index:\n",
+    "                                    current_metadata[header] = ''\n",
+    "\n",
+    "                        # Remove matched separator from the line to avoid confusing next header levels\n",
+    "                        stripped_line = stripped_line[len(sep):].lstrip()\n",
+    "                        break\n",
+    "\n",
+    "            elif not stripped_line and (\"\\n\", None) in self.splits:\n",
+    "                if current_content:\n",
+    "                    chunks.append(\n",
+    "                        {\n",
+    "                            \"content\": \"\".join(current_content).strip(),\n",
+    "                            \"metadata\": dict(current_metadata),\n",
+    "                        }\n",
+    "                    )\n",
+    "                    current_content = []\n",
+    "\n",
+    "            elif stripped_line:\n",
+    "                current_content.append(line)  # append the original line (with leading spaces if any)\n",
+    "\n",
+    "        if current_content:\n",
+    "            chunks.append(\n",
+    "                {\n",
+    "                    \"content\": \"\".join(current_content).strip(),\n",
+    "                    \"metadata\": dict(current_metadata),\n",
+    "                }\n",
+    "            )\n",
+    "        return [chunk for chunk in chunks if chunk[\"content\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "7ad61aeb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': ''}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Doc\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "    \n",
+    "# Test case 1\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    " \n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "633664ca",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6ca3059",
+   "metadata": {},
+   "source": [
+    "`Modified Code`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "495b72b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': '', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': ''}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
+    "    \n",
+    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
+    "\n",
+    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
+    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
+    "        chunks = []\n",
+    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
+    "        current_content = []\n",
+    "        \n",
+    "        for line in text.splitlines(keepends=True):\n",
+    "            stripped_line = line.strip()\n",
+    "            match = re.match(pattern, stripped_line)\n",
+    "\n",
+    "            if match:\n",
+    "                if current_content:\n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(),\n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    current_content = []\n",
+    "\n",
+    "                for sep, name in self.splits:\n",
+    "                    if stripped_line.startswith(sep):\n",
+    "                        if name is not None:\n",
+    "                            current_metadata[name] = stripped_line.lstrip(sep).strip()\n",
+    "                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
+    "                            for header_index, (sep_, name) in enumerate(self.splits):\n",
+    "                                if header_index > current_header_index:\n",
+    "                                    if name:\n",
+    "                                        current_metadata[name] = ''\n",
+    "                        break\n",
+    "            elif not stripped_line and (\"\\n\", None) in self.splits:\n",
+    "                if current_content:\n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(),\n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    current_content = []\n",
+    "            elif stripped_line:\n",
+    "                current_content.append(line)\n",
+    "        \n",
+    "        if current_content:\n",
+    "            chunks.append({\n",
+    "                'content': ''.join(current_content).strip(),\n",
+    "                'metadata': dict(current_metadata)\n",
+    "            })\n",
+    "        return [chunk for chunk in chunks if chunk['content']]\n",
+    "\n",
+    "\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "    \n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    " \n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "7ea97813",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': '', 'Header 1': ''}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': ''}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
+    "    \n",
+    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
+    "\n",
+    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
+    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
+    "        chunks = []\n",
+    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
+    "        current_content = []\n",
+    "\n",
+    "        def remove_prefix(text, prefix):\n",
+    "            if text.startswith(prefix):\n",
+    "                return text[len(prefix):]\n",
+    "            return text\n",
+    "        \n",
+    "        for line in text.splitlines(keepends=True):\n",
+    "            stripped_line = line.strip()\n",
+    "            match = re.match(pattern, stripped_line)\n",
+    "\n",
+    "            if match:\n",
+    "                if current_content:\n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(),\n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    current_content = []\n",
+    "\n",
+    "                for sep, name in self.splits:\n",
+    "                    if stripped_line.startswith(sep):\n",
+    "                        if name is not None:\n",
+    "                            current_metadata[name] = remove_prefix(stripped_line, sep).strip()\n",
+    "                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
+    "                            for header_index, (sep_, name) in enumerate(self.splits):\n",
+    "                                if header_index > current_header_index:\n",
+    "                                    if name:\n",
+    "                                        current_metadata[name] = ''\n",
+    "                        break\n",
+    "            elif not stripped_line and (\"\\n\", None) in self.splits:\n",
+    "                if current_content:\n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(),\n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    current_content = []\n",
+    "            elif stripped_line:\n",
+    "                current_content.append(line)\n",
+    "        \n",
+    "        if current_content:\n",
+    "            chunks.append({\n",
+    "                'content': ''.join(current_content).strip(),\n",
+    "                'metadata': dict(current_metadata)\n",
+    "            })\n",
+    "        return [chunk for chunk in chunks if chunk['content']]\n",
+    "\n",
+    "\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "    \n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    " \n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62863736",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c32428a9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b41cc955",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "c3504dc6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Three levels\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
+    "\n",
+    "# Test case 3\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    "\n",
+    "# TODO: Reset header 3 Boo as empty\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5af59a89",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78fdd026",
+   "metadata": {},
+   "source": [
+    "`Original Code`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "9f865704",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+     ]
+    }
+   ],
+   "source": [
     "class MarkdownHeaderTextSplitter(TextSplitter):\n",
     "    \n",
     "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
@@ -471,7 +834,6 @@
     "                            # TODO: This is brittle since there can be many header names\n",
     "                            #if sep == \"#\":\n",
     "                            #    current_metadata[\"Header 2\"] = ''   \n",
-    "                            ''' '''\n",
     "                            if sep == \"#\":\n",
     "                                # clear out metadata for all headers lower in hierarchy\n",
     "                                current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
@@ -480,15 +842,6 @@
     "                                    header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
     "                                    if header_index and header_index[0] > current_header_index:\n",
     "                                        del current_metadata[header]\n",
-    "                                        \n",
-    "                            if sep == \"#\":\n",
-    "                            # clear out metadata for all headers lower in hierarchy\n",
-    "                            current_metadata_keys = list(current_metadata.keys())\n",
-    "                            for header in current_metadata_keys:\n",
-    "                                header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
-    "                                if header_index and header_index[0] > 0: # All headers with index higher than 0 are lower in hierarchy than '#'\n",
-    "                                    del current_metadata[header]\n",
-    "\n",
     "                        break\n",
     "            \n",
     "            # If the line is empty (i.e., only contains whitespace, or is completely empty) \n",
@@ -531,6 +884,58 @@
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "d9edb507",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Three levels\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
+    "\n",
+    "# Test case 3\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    "\n",
+    "# TODO: Reset header 3 Boo as empty\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a578b61",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f610ceaa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
+++ b/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
@@ -7,11 +7,11 @@
    "source": [
     "# MarkdownHeaderTextSplitter\n",
     "\n",
-    "The objective is to split a MD file by aribrary delimiters and store context associated delimiters as metadata.\n",
+    "The objective is to split a markdown file by aribrary delimiters.\n",
     "\n",
-    "Given this example:\n",
-    "\n",
-    "--- \n",
+    "Each text split is associated with its associated delimiters as metadata.\n",
+    " \n",
+    "**Given this example:**\n",
     "\n",
     "# Foo\n",
     "\n",
@@ -25,12 +25,15 @@
     "\n",
     "Hi this is Molly\n",
     "\n",
-    "--- \n",
-    "\n",
-    "We expect: \n",
+    "**And these delimiters:**\n",
     "\n",
     "```\n",
     "[(\"#\", \"Header 1\"), (\"##\", \"Header 2\"), (\"\\n\", None)]\n",
+    "```\n",
+    "\n",
+    "**We expect:** \n",
+    "\n",
+    "```\n",
     "{\"content\": \"Hi this is Jim\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
     "{\"content\": \"Hi this is Joe\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
     "{\"content\": \"Hi this is Molly\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Baz\"}},\n",
@@ -39,19 +42,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "dd9cffe5",
+   "execution_count": 4,
+   "id": "7fa9012b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import re\n",
-    "from typing import Dict, List, Optional, Tuple, Union"
+    "from langchain.text_splitter import MarkdownHeaderTextSplitter"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "34a886ef",
+   "id": "41722f5e",
    "metadata": {},
    "outputs": [
     {
@@ -65,100 +67,6 @@
     }
    ],
    "source": [
-    "class MarkdownHeaderTextSplitter():\n",
-    "    \n",
-    "    def __init__(self, splits: List[Tuple[str, Optional[str]]]):\n",
-    "        \n",
-    "        # Sort by seperator length and the number of \"#\"\n",
-    "        # E.g.,  Ensure \"###\" will come before \"##\" and \"#\"\n",
-    "        # TODO: Both means of sorting may not be required \n",
-    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
-    "\n",
-    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
-    "        \n",
-    "        # Regex matches any of the separators in self.splits (except for the newline)\n",
-    "        # (Newlines create line breaks, which we may want to split, or separate MD headers and their contents)\n",
-    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
-    "        \n",
-    "        # Text chunk with metadata\n",
-    "        chunks = []\n",
-    "        \n",
-    "        # Keys are names of metadata \n",
-    "        #current_metadata = {name: '' for sep, name in self.splits if name is not None}\n",
-    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
-    "        current_content = []\n",
-    "        \n",
-    "        # Split by newlines, but preserve the exact formatting of the original text\n",
-    "        for line in text.splitlines(keepends=True):\n",
-    "            \n",
-    "            # Removes any leading or trailing whitespace\n",
-    "            stripped_line = line.strip()  \n",
-    "            \n",
-    "            # Match current line of text against the regular expression pattern\n",
-    "            match = re.match(pattern, stripped_line)\n",
-    "            \n",
-    "            # If the line starts w/ a separator defined in splits (like \"#\" or \"##\"), it will be a match\n",
-    "            # Start of a new chunk of content\n",
-    "            if match:\n",
-    "                \n",
-    "                # See if we have accumulated content from previous lines \n",
-    "                if current_content:  \n",
-    "                    \n",
-    "                    # If so, append it as a chunk and write the chunk since we hit a new seperator\n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(), \n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    # Reset the content  \n",
-    "                    current_content = []  \n",
-    "                    \n",
-    "                # Check for the seperator\n",
-    "                for sep, name in self.splits:\n",
-    "                    if stripped_line.startswith(sep):\n",
-    "                        if name is not None:\n",
-    "                            # Update the rest of the line (after the separator) as the value for that header\n",
-    "                            current_metadata[name] = stripped_line[len(sep):].strip()\n",
-    "                            \n",
-    "                            # If the separator is \"#\", it also clears out the metadata for \"Header 2\"\n",
-    "                            # A new \"Header 1\" implies a new section of the document\n",
-    "                            # TODO: This is brittle since there can be many header names\n",
-    "                            #if sep == \"#\":\n",
-    "                            #    current_metadata[\"Header 2\"] = ''   \n",
-    "                            if sep == \"#\":\n",
-    "                                # clear out metadata for all headers lower in hierarchy\n",
-    "                                current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
-    "                                current_metadata_keys = list(current_metadata.keys())\n",
-    "                                for header in current_metadata_keys:\n",
-    "                                    header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
-    "                                    if header_index and header_index[0] > current_header_index:\n",
-    "                                        del current_metadata[header]\n",
-    "                        break\n",
-    "            \n",
-    "            # If the line is empty (i.e., only contains whitespace, or is completely empty) \n",
-    "            # and newline (\"\\n\") is one of the separators, it appends the current content to \n",
-    "            # the chunks list as a new chunk, and resets the current_content to an empty list  \n",
-    "            elif not stripped_line and (\"\\n\", None) in self.splits:  \n",
-    "                \n",
-    "                # If we have accumulated content, append it as a chunk\n",
-    "                if current_content:  \n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(), \n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    current_content = []  # reset the content\n",
-    "            \n",
-    "            # Apend non-empty lines\n",
-    "            elif stripped_line:  \n",
-    "                current_content.append(stripped_line)\n",
-    "        \n",
-    "        # Append the last chunk\n",
-    "        if current_content:\n",
-    "            chunks.append({\n",
-    "                'content': ''.join(current_content).strip(), \n",
-    "                'metadata': dict(current_metadata)\n",
-    "            })\n",
-    "        return [chunk for chunk in chunks if chunk['content']]\n",
-    "\n",
     "# Doc\n",
     "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
     "    \n",
@@ -173,6 +81,226 @@
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59f5e663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{\"content\": \"Hi this is Jim\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
+    "{\"content\": \"Hi this is Joe\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
+    "{\"content\": \"Hi this is Molly\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Baz\"}},"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "832c3ded",
+   "metadata": {},
+   "source": [
+    "`Test case 2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c47fd042",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'This is an introductory paragraph.', 'metadata': {'Header 2': 'Overview', 'Header 1': 'Introduction'}}\n",
+      "{'content': 'This is a detailed paragraph.', 'metadata': {'Header 2': 'Details', 'Header 1': 'Introduction'}}\n",
+      "{'content': 'This is the conclusion.', 'metadata': {'Header 2': 'Details', 'Header 1': 'Conclusion'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    "markdown_document = '# Introduction\\n\\n## Overview\\n\\nThis is an introductory paragraph.\\\n",
+    "\\n\\n## Details\\n\\nThis is a detailed paragraph.\\n\\n# Conclusion\\n\\nThis is the conclusion.'\n",
+    "\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39db6eec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expected\n",
+    "{'content': 'This is an introductory paragraph.', 'metadata': {'Header 2': 'Overview', 'Header 1': 'Introduction'}}\n",
+    "{'content': 'This is a detailed paragraph.', 'metadata': {'Header 2': 'Details', 'Header 1': 'Introduction'}}\n",
+    "{'content': 'This is the conclusion.', 'metadata': {'Header 1': 'Conclusion'}}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c295fe76",
+   "metadata": {},
+   "source": [
+    "`Test case 3`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1ca1f09c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Text under H3.', 'metadata': {'Header 3': 'H3', 'Header 2': 'H2', 'Header 1': 'H1'}}\n",
+      "{'content': 'Text under H2_2.', 'metadata': {'Header 3': 'H3', 'Header 2': 'H2_2', 'Header 1': 'H1_2'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    "markdown_document = '# H1\\n\\n## H2\\n\\n### H3\\n\\nText under H3.\\n\\n# H1_2\\n\\n## H2_2\\n\\nText under H2_2.'\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8bbbfe0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{'content': 'Text under H3.', 'metadata': {'Header 3': 'H3', 'Header 2': 'H2', 'Header 1': 'H1'}}\n",
+    "{'content': 'Text under H2_2.', 'metadata': {'Header 2': 'H2_2', 'Header 1': 'H1_2'}}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b56744b6",
+   "metadata": {},
+   "source": [
+    "`Test case 4`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9484a79e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Paragraph under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
+      "{'content': 'Paragraph 2 under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
+      "{'content': 'Paragraph under new Heading 1.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'New Heading 1'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    "markdown_document = '# Heading 1\\n\\n## Heading 2\\n\\nParagraph under Heading 2.\\\n",
+    "\\n\\nParagraph 2 under Heading 2.\\n\\n# New Heading 1\\n\\nParagraph under new Heading 1.'\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfba1a31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{'content': 'Paragraph under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
+    "{'content': 'Paragraph 2 under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
+    "{'content': 'Paragraph under new Heading 1.', 'metadata': {'Header 1': 'New Heading 1'}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4c8fef4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04c93e70",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5df2d238",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8c15f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "19abdaa8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'content': 'Hi this is Jim',\n",
+       "  'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}},\n",
+       " {'content': 'Hi this is Joe',\n",
+       "  'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}},\n",
+       " {'content': 'Hi this is Molly',\n",
+       "  'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chunked_docs"
    ]
   },
   {
@@ -242,10 +370,167 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57a55162",
+   "id": "b961e316",
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37165da3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a9040b1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1c820f1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57a55162",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from langchain.text_splitter import TextSplitter\n",
+    "from typing import Dict, Any, List, Optional, Tuple, Union\n",
+    "\n",
+    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
+    "    \n",
+    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
+    "        \n",
+    "        # Sort by seperator length and the number of \"#\"\n",
+    "        # E.g.,  Ensure \"###\" will come before \"##\" and \"#\"\n",
+    "        # TODO: Both means of sorting may not be required \n",
+    "        \"\"\"Create a new TextSplitter.\"\"\"\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
+    "\n",
+    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
+    "        \n",
+    "        # Regex matches any of the separators in self.splits (except for the newline)\n",
+    "        # (Newlines create line breaks, which we may want to split, or separate MD headers and their contents)\n",
+    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
+    "        \n",
+    "        # Text chunk with metadata\n",
+    "        chunks = []\n",
+    "        \n",
+    "        # Keys are names of metadata \n",
+    "        #current_metadata = {name: '' for sep, name in self.splits if name is not None}\n",
+    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
+    "        current_content = []\n",
+    "        \n",
+    "        # Split by newlines, but preserve the exact formatting of the original text\n",
+    "        for line in text.splitlines(keepends=True):\n",
+    "            \n",
+    "            # Removes any leading or trailing whitespace\n",
+    "            stripped_line = line.strip()  \n",
+    "            \n",
+    "            # Match current line of text against the regular expression pattern\n",
+    "            match = re.match(pattern, stripped_line)\n",
+    "            \n",
+    "            # If the line starts w/ a separator defined in splits (like \"#\" or \"##\"), it will be a match\n",
+    "            # Start of a new chunk of content\n",
+    "            if match:\n",
+    "                \n",
+    "                # See if we have accumulated content from previous lines \n",
+    "                if current_content:  \n",
+    "                    \n",
+    "                    # If so, append it as a chunk and write the chunk since we hit a new seperator\n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(), \n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    # Reset the content  \n",
+    "                    current_content = []  \n",
+    "                    \n",
+    "                # Check for the seperator\n",
+    "                for sep, name in self.splits:\n",
+    "                    if stripped_line.startswith(sep):\n",
+    "                        if name is not None:\n",
+    "                            # Update the rest of the line (after the separator) as the value for that header\n",
+    "                            current_metadata[name] = stripped_line[len(sep):].strip()\n",
+    "                            \n",
+    "                            # If the separator is \"#\", it also clears out the metadata for \"Header 2\"\n",
+    "                            # A new \"Header 1\" implies a new section of the document\n",
+    "                            # TODO: This is brittle since there can be many header names\n",
+    "                            #if sep == \"#\":\n",
+    "                            #    current_metadata[\"Header 2\"] = ''   \n",
+    "                            ''' '''\n",
+    "                            if sep == \"#\":\n",
+    "                                # clear out metadata for all headers lower in hierarchy\n",
+    "                                current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
+    "                                current_metadata_keys = list(current_metadata.keys())\n",
+    "                                for header in current_metadata_keys:\n",
+    "                                    header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
+    "                                    if header_index and header_index[0] > current_header_index:\n",
+    "                                        del current_metadata[header]\n",
+    "                                        \n",
+    "                            if sep == \"#\":\n",
+    "                            # clear out metadata for all headers lower in hierarchy\n",
+    "                            current_metadata_keys = list(current_metadata.keys())\n",
+    "                            for header in current_metadata_keys:\n",
+    "                                header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
+    "                                if header_index and header_index[0] > 0: # All headers with index higher than 0 are lower in hierarchy than '#'\n",
+    "                                    del current_metadata[header]\n",
+    "\n",
+    "                        break\n",
+    "            \n",
+    "            # If the line is empty (i.e., only contains whitespace, or is completely empty) \n",
+    "            # and newline (\"\\n\") is one of the separators, it appends the current content to \n",
+    "            # the chunks list as a new chunk, and resets the current_content to an empty list  \n",
+    "            elif not stripped_line and (\"\\n\", None) in self.splits:  \n",
+    "                \n",
+    "                # If we have accumulated content, append it as a chunk\n",
+    "                if current_content:  \n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(), \n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    current_content = []  # reset the content\n",
+    "            \n",
+    "            # Apend non-empty lines\n",
+    "            elif stripped_line:  \n",
+    "                current_content.append(stripped_line)\n",
+    "        \n",
+    "        # Append the last chunk\n",
+    "        if current_content:\n",
+    "            chunks.append({\n",
+    "                'content': ''.join(current_content).strip(), \n",
+    "                'metadata': dict(current_metadata)\n",
+    "            })\n",
+    "        return [chunk for chunk in chunks if chunk['content']]\n",
+    "\n",
+    "# Doc\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "    \n",
+    "# Test case 1\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    " \n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
+++ b/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
@@ -7,11 +7,7 @@
    "source": [
     "# MarkdownHeaderTextSplitter\n",
     "\n",
-    "The objective is to split a markdown file:\n",
-    "\n",
-    "(1) by a specified set of headers\n",
-    "\n",
-    "(2) include these headers in the split metadata\n",
+    "The objective is to split a markdown file by a specified set of headers.\n",
     " \n",
     "**Given this example:**\n",
     "\n",
@@ -19,8 +15,7 @@
     "\n",
     "## Bar\n",
     "\n",
-    "Hi this is Jim\n",
-    "\n",
+    "Hi this is Jim  \n",
     "Hi this is Joe\n",
     "\n",
     "## Baz\n",
@@ -30,20 +25,25 @@
     "**Written as:**\n",
     "\n",
     "```\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "md = '# Foo\\n\\n ## Bar\\n\\nHi this is Jim  \\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
     "```\n",
     "\n",
-    "**And specified header delimiters:**\n",
+    "**If we want to split on specified headers:**\n",
     "```\n",
     "[(\"#\", \"Header 1\"),(\"##\", \"Header 2\")]\n",
     "```\n",
     "\n",
-    "**We expect:** \n",
+    "**Then we expect:** \n",
     "```\n",
-    "{\"content\": \"Hi this is Jim\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
-    "{\"content\": \"Hi this is Joe\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
-    "{\"content\": \"Hi this is Molly\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Baz\"}},\n",
-    "```"
+    "{'content': 'Hi this is Jim  \\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+    "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n",
+    "```\n",
+    "\n",
+    "**Options:**\n",
+    " \n",
+    "This also includes `return_each_line` in case a user want to perform other types of aggregation. \n",
+    "\n",
+    "If `return_each_line=True`, each line and associated header metadata are returned. "
    ]
   },
   {
@@ -53,16 +53,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import re\n",
-    "from langchain.text_splitter import TextSplitter\n",
-    "from typing import Dict, Any, List, Optional, Tuple, Union\n",
     "from langchain.text_splitter import MarkdownHeaderTextSplitter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec8d8053",
+   "metadata": {},
+   "source": [
+    "`Test case 1`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a20c5475",
+   "id": "5cd0a66c",
    "metadata": {},
    "outputs": [
     {
@@ -84,8 +89,9 @@
     "    (\"#\", \"Header 1\"),\n",
     "    (\"##\", \"Header 2\"),\n",
     "]\n",
-    " \n",
+    "\n",
     "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=True)\n",
+    "\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
@@ -93,15 +99,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "908b4ab7",
+   "execution_count": 4,
+   "id": "67d25a1c",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim\\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Jim  \\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
       "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
      ]
     }
@@ -123,8 +129,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "17813ab7",
+   "execution_count": 5,
+   "id": "2183c96a",
    "metadata": {},
    "outputs": [
     {
@@ -159,15 +165,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "8f17fa80",
+   "execution_count": 6,
+   "id": "c3f4690f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim\\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Jim  \\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
       "{'content': 'Hi this is Lance', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo'}}\n",
       "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
      ]
@@ -189,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "id": "20907fb7",
    "metadata": {},
    "outputs": [
@@ -221,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "id": "9858ea51",
    "metadata": {},
    "outputs": [
@@ -229,7 +235,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim\\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Jim  \\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
       "{'content': 'Hi this is Lance', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo'}}\n",
       "{'content': 'Hi this is John', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo', 'Header 4': 'Bim'}}\n",
       "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
@@ -262,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "id": "8af8f9a2",
    "metadata": {},
    "outputs": [
@@ -270,8 +276,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Markdown[9] is a lightweight markup language for creating formatted text using a plain-text editor. John Gruber created Markdown in 2004 as a markup language that is appealing to human readers in its source code form.[9]\\nMarkdown is widely used in blogging, instant messaging, online forums, collaborative software, documentation pages, and readme files.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'History'}}\n",
-      "{'content': 'As Markdown popularity grew rapidly, many Markdown implementations appeared, driven mostly by the need for\\nadditional features such as tables, footnotes, definition lists,[note 1] and Markdown inside HTML blocks.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Rise and divergence'}}\n",
+      "{'content': 'Markdown[9] is a lightweight markup language for creating formatted text using a plain-text editor. John Gruber created Markdown in 2004 as a markup language that is appealing to human readers in its source code form.[9]  \\nMarkdown is widely used in blogging, instant messaging, online forums, collaborative software, documentation pages, and readme files.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'History'}}\n",
+      "{'content': 'As Markdown popularity grew rapidly, many Markdown implementations appeared, driven mostly by the need for  \\nadditional features such as tables, footnotes, definition lists,[note 1] and Markdown inside HTML blocks.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Rise and divergence'}}\n",
       "{'content': 'From 2012, a group of people, including Jeff Atwood and John MacFarlane, launched what Atwood characterised as a standardisation effort.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Rise and divergence', 'Header 4': 'Standardization'}}\n",
       "{'content': 'Implementations of Markdown are available for over a dozen programming languages.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Implementations'}}\n"
      ]

--- a/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
+++ b/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "70e9b619",
+   "metadata": {},
+   "source": [
+    "# MarkdownHeaderTextSplitter\n",
+    "\n",
+    "The objective is to split a MD file by aribrary delimiters and store context associated delimiters as metadata.\n",
+    "\n",
+    "Given this example:\n",
+    "\n",
+    "--- \n",
+    "\n",
+    "# Foo\n",
+    "\n",
+    "## Bar\n",
+    "\n",
+    "Hi this is Jim\n",
+    "\n",
+    "Hi this is Joe\n",
+    "\n",
+    "## Baz\n",
+    "\n",
+    "Hi this is Molly\n",
+    "\n",
+    "--- \n",
+    "\n",
+    "We expect: \n",
+    "\n",
+    "```\n",
+    "[(\"#\", \"Header 1\"), (\"##\", \"Header 2\"), (\"\\n\", None)]\n",
+    "{\"content\": \"Hi this is Jim\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
+    "{\"content\": \"Hi this is Joe\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
+    "{\"content\": \"Hi this is Molly\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Baz\"}},\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dd9cffe5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from typing import Dict, List, Optional, Tuple, Union"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "34a886ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "class MarkdownHeaderTextSplitter():\n",
+    "    \n",
+    "    def __init__(self, splits: List[Tuple[str, Optional[str]]]):\n",
+    "        \n",
+    "        # Sort by seperator length and the number of \"#\"\n",
+    "        # E.g.,  Ensure \"###\" will come before \"##\" and \"#\"\n",
+    "        # TODO: Both means of sorting may not be required \n",
+    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
+    "\n",
+    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
+    "        \n",
+    "        # Regex matches any of the separators in self.splits (except for the newline)\n",
+    "        # (Newlines create line breaks, which we may want to split, or separate MD headers and their contents)\n",
+    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
+    "        \n",
+    "        # Text chunk with metadata\n",
+    "        chunks = []\n",
+    "        \n",
+    "        # Keys are names of metadata \n",
+    "        #current_metadata = {name: '' for sep, name in self.splits if name is not None}\n",
+    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
+    "        current_content = []\n",
+    "        \n",
+    "        # Split by newlines, but preserve the exact formatting of the original text\n",
+    "        for line in text.splitlines(keepends=True):\n",
+    "            \n",
+    "            # Removes any leading or trailing whitespace\n",
+    "            stripped_line = line.strip()  \n",
+    "            \n",
+    "            # Match current line of text against the regular expression pattern\n",
+    "            match = re.match(pattern, stripped_line)\n",
+    "            \n",
+    "            # If the line starts w/ a separator defined in splits (like \"#\" or \"##\"), it will be a match\n",
+    "            # Start of a new chunk of content\n",
+    "            if match:\n",
+    "                \n",
+    "                # See if we have accumulated content from previous lines \n",
+    "                if current_content:  \n",
+    "                    \n",
+    "                    # If so, append it as a chunk and write the chunk since we hit a new seperator\n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(), \n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    # Reset the content  \n",
+    "                    current_content = []  \n",
+    "                    \n",
+    "                # Check for the seperator\n",
+    "                for sep, name in self.splits:\n",
+    "                    if stripped_line.startswith(sep):\n",
+    "                        if name is not None:\n",
+    "                            # Update the rest of the line (after the separator) as the value for that header\n",
+    "                            current_metadata[name] = stripped_line[len(sep):].strip()\n",
+    "                            \n",
+    "                            # If the separator is \"#\", it also clears out the metadata for \"Header 2\"\n",
+    "                            # A new \"Header 1\" implies a new section of the document\n",
+    "                            # TODO: This is brittle since there can be many header names\n",
+    "                            #if sep == \"#\":\n",
+    "                            #    current_metadata[\"Header 2\"] = ''   \n",
+    "                            if sep == \"#\":\n",
+    "                                # clear out metadata for all headers lower in hierarchy\n",
+    "                                current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
+    "                                current_metadata_keys = list(current_metadata.keys())\n",
+    "                                for header in current_metadata_keys:\n",
+    "                                    header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
+    "                                    if header_index and header_index[0] > current_header_index:\n",
+    "                                        del current_metadata[header]\n",
+    "                        break\n",
+    "            \n",
+    "            # If the line is empty (i.e., only contains whitespace, or is completely empty) \n",
+    "            # and newline (\"\\n\") is one of the separators, it appends the current content to \n",
+    "            # the chunks list as a new chunk, and resets the current_content to an empty list  \n",
+    "            elif not stripped_line and (\"\\n\", None) in self.splits:  \n",
+    "                \n",
+    "                # If we have accumulated content, append it as a chunk\n",
+    "                if current_content:  \n",
+    "                    chunks.append({\n",
+    "                        'content': ''.join(current_content).strip(), \n",
+    "                        'metadata': dict(current_metadata)\n",
+    "                    })\n",
+    "                    current_content = []  # reset the content\n",
+    "            \n",
+    "            # Apend non-empty lines\n",
+    "            elif stripped_line:  \n",
+    "                current_content.append(stripped_line)\n",
+    "        \n",
+    "        # Append the last chunk\n",
+    "        if current_content:\n",
+    "            chunks.append({\n",
+    "                'content': ''.join(current_content).strip(), \n",
+    "                'metadata': dict(current_metadata)\n",
+    "            })\n",
+    "        return [chunk for chunk in chunks if chunk['content']]\n",
+    "\n",
+    "# Doc\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "    \n",
+    "# Test case 1\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    " \n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "081361fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is JimHi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test case 2\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "]\n",
+    "\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "636d0b76",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Three levels\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
+    "\n",
+    "# Test case 3\n",
+    "splits = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "    (\"\\n\", None)\n",
+    "]\n",
+    "\n",
+    "# TODO: Reset header 3 Boo as empty\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57a55162",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
+++ b/docs/modules/indexes/text_splitters/examples/markdown_header_metadata.ipynb
@@ -7,9 +7,11 @@
    "source": [
     "# MarkdownHeaderTextSplitter\n",
     "\n",
-    "The objective is to split a markdown file by aribrary delimiters.\n",
+    "The objective is to split a markdown file:\n",
     "\n",
-    "Each text split is associated with its associated delimiters as metadata.\n",
+    "(1) by a specified set of headers\n",
+    "\n",
+    "(2) include these headers in the split metadata\n",
     " \n",
     "**Given this example:**\n",
     "\n",
@@ -24,15 +26,19 @@
     "## Baz\n",
     "\n",
     "Hi this is Molly\n",
-    "\n",
-    "**And these delimiters:**\n",
+    " \n",
+    "**Written as:**\n",
     "\n",
     "```\n",
-    "[(\"#\", \"Header 1\"), (\"##\", \"Header 2\"), (\"\\n\", None)]\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "```\n",
+    "\n",
+    "**And specified header delimiters:**\n",
+    "```\n",
+    "[(\"#\", \"Header 1\"),(\"##\", \"Header 2\")]\n",
     "```\n",
     "\n",
     "**We expect:** \n",
-    "\n",
     "```\n",
     "{\"content\": \"Hi this is Jim\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
     "{\"content\": \"Hi this is Joe\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
@@ -42,17 +48,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "19c044f0",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import re\n",
+    "from langchain.text_splitter import TextSplitter\n",
+    "from typing import Dict, Any, List, Optional, Tuple, Union\n",
     "from langchain.text_splitter import MarkdownHeaderTextSplitter"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "a20c5475",
    "metadata": {},
    "outputs": [
@@ -60,9 +69,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': ''}}\n"
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
      ]
     }
    ],
@@ -71,13 +80,12 @@
     "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
     "    \n",
     "# Test case 1\n",
-    "splits = [\n",
+    "headers_to_split_on = [\n",
     "    (\"#\", \"Header 1\"),\n",
     "    (\"##\", \"Header 2\"),\n",
-    "    (\"\\n\", None)\n",
     "]\n",
     " \n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=True)\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
@@ -85,66 +93,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "36f29056",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "{\"content\": \"Hi this is Jim\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
-    "{\"content\": \"Hi this is Joe\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Bar\"}},\n",
-    "{\"content\": \"Hi this is Molly\", metadata={\"Header 1\": \"Foo\", \"Header 2\": \"Baz\"}},"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "34521b8e",
-   "metadata": {},
-   "source": [
-    "`Test case 2`"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
-   "id": "b78617b2",
+   "id": "908b4ab7",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'This is an introductory paragraph.', 'metadata': {'Header 2': 'Overview', 'Header 1': ''}}\n",
-      "{'content': 'This is a detailed paragraph.', 'metadata': {'Header 2': 'Details', 'Header 1': ''}}\n",
-      "{'content': 'This is the conclusion.', 'metadata': {'Header 2': 'Details', 'Header 1': ''}}\n"
+      "{'content': 'Hi this is Jim\\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
      ]
     }
    ],
    "source": [
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    "markdown_document = '# Introduction\\n\\n## Overview\\n\\nThis is an introductory paragraph.\\\n",
-    "\\n\\n## Details\\n\\nThis is a detailed paragraph.\\n\\n# Conclusion\\n\\nThis is the conclusion.'\n",
-    "\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=False)\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22cfdeab",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Expected\n",
-    "{'content': 'This is an introductory paragraph.', 'metadata': {'Header 2': 'Overview', 'Header 1': 'Introduction'}}\n",
-    "{'content': 'This is a detailed paragraph.', 'metadata': {'Header 2': 'Details', 'Header 1': 'Introduction'}}\n",
-    "{'content': 'This is the conclusion.', 'metadata': {'Header 1': 'Conclusion'}}"
    ]
   },
   {
@@ -152,12 +118,12 @@
    "id": "f1f74dfa",
    "metadata": {},
    "source": [
-    "`Test case 3`"
+    "`Test case 2`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "id": "17813ab7",
    "metadata": {},
    "outputs": [
@@ -165,34 +131,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Text under H3.', 'metadata': {'Header 3': 'H3', 'Header 2': 'H2', 'Header 1': 'H1'}}\n",
-      "{'content': 'Text under H2_2.', 'metadata': {'Header 3': 'H3', 'Header 2': 'H2_2', 'Header 1': 'H1_2'}}\n"
+      "{'content': 'Text under H3.', 'metadata': {'Header 1': 'H1', 'Header 2': 'H2', 'Header 3': 'H3'}}\n",
+      "{'content': 'Text under H2_2.', 'metadata': {'Header 1': 'H1_2', 'Header 2': 'H2_2'}}\n"
      ]
     }
    ],
    "source": [
-    "splits = [\n",
+    "headers_to_split_on = [\n",
     "    (\"#\", \"Header 1\"),\n",
     "    (\"##\", \"Header 2\"),\n",
     "    (\"###\", \"Header 3\"),\n",
-    "    (\"\\n\", None)\n",
     "]\n",
     "markdown_document = '# H1\\n\\n## H2\\n\\n### H3\\n\\nText under H3.\\n\\n# H1_2\\n\\n## H2_2\\n\\nText under H2_2.'\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=False)\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d994ccba",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "{'content': 'Text under H3.', 'metadata': {'Header 3': 'H3', 'Header 2': 'H2', 'Header 1': 'H1'}}\n",
-    "{'content': 'Text under H2_2.', 'metadata': {'Header 2': 'H2_2', 'Header 1': 'H1_2'}}"
    ]
   },
   {
@@ -200,12 +154,42 @@
    "id": "add24254",
    "metadata": {},
    "source": [
-    "`Test case 4`"
+    "`Test case 3`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
+   "id": "8f17fa80",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': 'Hi this is Jim\\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly' \n",
+    "    \n",
+    "headers_to_split_on = [\n",
+    "    (\"#\", \"Header 1\"),\n",
+    "    (\"##\", \"Header 2\"),\n",
+    "    (\"###\", \"Header 3\"),\n",
+    "]\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=False)\n",
+    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
+    "for chunk in chunked_docs:\n",
+    "    print(chunk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "id": "20907fb7",
    "metadata": {},
    "outputs": [
@@ -213,729 +197,101 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Paragraph under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
-      "{'content': 'Paragraph 2 under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
-      "{'content': 'Paragraph under new Heading 1.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'New Heading 1'}}\n"
+      "{'content': 'Hi this is Jim', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
      ]
     }
    ],
    "source": [
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    "markdown_document = '# Heading 1\\n\\n## Heading 2\\n\\nParagraph under Heading 2.\\\n",
-    "\\n\\nParagraph 2 under Heading 2.\\n\\n# New Heading 1\\n\\nParagraph under new Heading 1.'\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=True)\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b42c68af",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "{'content': 'Paragraph under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
-    "{'content': 'Paragraph 2 under Heading 2.', 'metadata': {'Header 2': 'Heading 2', 'Header 1': 'Heading 1'}}\n",
-    "{'content': 'Paragraph under new Heading 1.', 'metadata': {'Header 1': 'New Heading 1'}}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aea887e5",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a5f9b993",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ef1e75ee",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "99aeb8c7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "19abdaa8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'content': 'Hi this is Jim',\n",
-       "  'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}},\n",
-       " {'content': 'Hi this is Joe',\n",
-       "  'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}},\n",
-       " {'content': 'Hi this is Molly',\n",
-       "  'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "chunked_docs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "081361fd",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': 'Hi this is JimHi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Test case 2\n",
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "]\n",
-    "\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
-    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
-    "for chunk in chunked_docs:\n",
-    "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "636d0b76",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Three levels\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
-    "\n",
-    "# Test case 3\n",
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"###\", \"Header 3\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    "\n",
-    "# TODO: Reset header 3 Boo as empty\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
-    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
-    "for chunk in chunked_docs:\n",
-    "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c0f2870e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "6e48eb0c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import re\n",
-    "from langchain.text_splitter import TextSplitter\n",
-    "from typing import Dict, Any, List, Optional, Tuple, Union\n",
-    "\n",
-    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
-    "    \"\"\"Implementation of splitting markdown based on user-supplied delimiters.\n",
-    "    The text associated with each delimiter is returned w/ delimier as metadata.\"\"\"\n",
-    "\n",
-    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
-    "        super().__init__(**kwargs)\n",
-    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count(\"#\")))\n",
-    "\n",
-    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
-    "        pattern = \"|\".join(\n",
-    "            \"(%s\\\\s*(.*))\" % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\"\n",
-    "        )\n",
-    "\n",
-    "        chunks = []\n",
-    "        current_metadata = {name: \"\" for sep, name in self.splits if name}\n",
-    "        current_content = []\n",
-    "\n",
-    "        for line in text.splitlines(keepends=True):\n",
-    "            stripped_line = line.lstrip()  # strip leading spaces\n",
-    "            match = re.match(pattern, stripped_line)\n",
-    "\n",
-    "            if match:\n",
-    "                if current_content:\n",
-    "                    chunks.append(\n",
-    "                        {\n",
-    "                            \"content\": \"\".join(current_content).strip(),\n",
-    "                            \"metadata\": dict(current_metadata),\n",
-    "                        }\n",
-    "                    )\n",
-    "                    current_content = []\n",
-    "\n",
-    "                for sep, name in self.splits:\n",
-    "                    if stripped_line.startswith(sep):\n",
-    "                        if name is not None:\n",
-    "                            # Update the rest of the line (after the separator) as the value for that header\n",
-    "                            current_metadata[name] = stripped_line[len(sep):].strip()\n",
-    "                            \n",
-    "                            # Clear out metadata for all headers lower in hierarchy\n",
-    "                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
-    "                            for header, index in [(name_, index) for index, (sep_, name_) in enumerate(self.splits) if name_]:\n",
-    "                                if index > current_header_index:\n",
-    "                                    current_metadata[header] = ''\n",
-    "\n",
-    "                        # Remove matched separator from the line to avoid confusing next header levels\n",
-    "                        stripped_line = stripped_line[len(sep):].lstrip()\n",
-    "                        break\n",
-    "\n",
-    "            elif not stripped_line and (\"\\n\", None) in self.splits:\n",
-    "                if current_content:\n",
-    "                    chunks.append(\n",
-    "                        {\n",
-    "                            \"content\": \"\".join(current_content).strip(),\n",
-    "                            \"metadata\": dict(current_metadata),\n",
-    "                        }\n",
-    "                    )\n",
-    "                    current_content = []\n",
-    "\n",
-    "            elif stripped_line:\n",
-    "                current_content.append(line)  # append the original line (with leading spaces if any)\n",
-    "\n",
-    "        if current_content:\n",
-    "            chunks.append(\n",
-    "                {\n",
-    "                    \"content\": \"\".join(current_content).strip(),\n",
-    "                    \"metadata\": dict(current_metadata),\n",
-    "                }\n",
-    "            )\n",
-    "        return [chunk for chunk in chunks if chunk[\"content\"]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "7ad61aeb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': ''}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Doc\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
-    "    \n",
-    "# Test case 1\n",
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    " \n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
-    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
-    "for chunk in chunked_docs:\n",
-    "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "633664ca",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "d6ca3059",
+   "id": "9c448431",
    "metadata": {},
    "source": [
-    "`Modified Code`"
+    "`Test case 4`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "495b72b8",
+   "execution_count": 12,
+   "id": "9858ea51",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': '', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': ''}}\n"
+      "{'content': 'Hi this is Jim\\nHi this is Joe', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar'}}\n",
+      "{'content': 'Hi this is Lance', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo'}}\n",
+      "{'content': 'Hi this is John', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Bar', 'Header 3': 'Boo', 'Header 4': 'Bim'}}\n",
+      "{'content': 'Hi this is Molly', 'metadata': {'Header 1': 'Foo', 'Header 2': 'Baz'}}\n"
      ]
     }
    ],
    "source": [
-    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
+    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n #### Bim \\n\\n Hi this is John \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
     "    \n",
-    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
-    "        super().__init__(**kwargs)\n",
-    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
-    "\n",
-    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
-    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
-    "        chunks = []\n",
-    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
-    "        current_content = []\n",
-    "        \n",
-    "        for line in text.splitlines(keepends=True):\n",
-    "            stripped_line = line.strip()\n",
-    "            match = re.match(pattern, stripped_line)\n",
-    "\n",
-    "            if match:\n",
-    "                if current_content:\n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(),\n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    current_content = []\n",
-    "\n",
-    "                for sep, name in self.splits:\n",
-    "                    if stripped_line.startswith(sep):\n",
-    "                        if name is not None:\n",
-    "                            current_metadata[name] = stripped_line.lstrip(sep).strip()\n",
-    "                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
-    "                            for header_index, (sep_, name) in enumerate(self.splits):\n",
-    "                                if header_index > current_header_index:\n",
-    "                                    if name:\n",
-    "                                        current_metadata[name] = ''\n",
-    "                        break\n",
-    "            elif not stripped_line and (\"\\n\", None) in self.splits:\n",
-    "                if current_content:\n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(),\n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    current_content = []\n",
-    "            elif stripped_line:\n",
-    "                current_content.append(line)\n",
-    "        \n",
-    "        if current_content:\n",
-    "            chunks.append({\n",
-    "                'content': ''.join(current_content).strip(),\n",
-    "                'metadata': dict(current_metadata)\n",
-    "            })\n",
-    "        return [chunk for chunk in chunks if chunk['content']]\n",
-    "\n",
-    "\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly' \n",
-    "    \n",
-    "splits = [\n",
+    "headers_to_split_on = [\n",
     "    (\"#\", \"Header 1\"),\n",
     "    (\"##\", \"Header 2\"),\n",
     "    (\"###\", \"Header 3\"),\n",
-    "    (\"\\n\", None)\n",
+    "    (\"####\", \"Header 4\"),\n",
     "]\n",
     " \n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=False)\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "id": "7ea97813",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': '', 'Header 1': ''}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': ''}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
-    "    \n",
-    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
-    "        super().__init__(**kwargs)\n",
-    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
-    "\n",
-    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
-    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
-    "        chunks = []\n",
-    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
-    "        current_content = []\n",
-    "\n",
-    "        def remove_prefix(text, prefix):\n",
-    "            if text.startswith(prefix):\n",
-    "                return text[len(prefix):]\n",
-    "            return text\n",
-    "        \n",
-    "        for line in text.splitlines(keepends=True):\n",
-    "            stripped_line = line.strip()\n",
-    "            match = re.match(pattern, stripped_line)\n",
-    "\n",
-    "            if match:\n",
-    "                if current_content:\n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(),\n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    current_content = []\n",
-    "\n",
-    "                for sep, name in self.splits:\n",
-    "                    if stripped_line.startswith(sep):\n",
-    "                        if name is not None:\n",
-    "                            current_metadata[name] = remove_prefix(stripped_line, sep).strip()\n",
-    "                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
-    "                            for header_index, (sep_, name) in enumerate(self.splits):\n",
-    "                                if header_index > current_header_index:\n",
-    "                                    if name:\n",
-    "                                        current_metadata[name] = ''\n",
-    "                        break\n",
-    "            elif not stripped_line and (\"\\n\", None) in self.splits:\n",
-    "                if current_content:\n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(),\n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    current_content = []\n",
-    "            elif stripped_line:\n",
-    "                current_content.append(line)\n",
-    "        \n",
-    "        if current_content:\n",
-    "            chunks.append({\n",
-    "                'content': ''.join(current_content).strip(),\n",
-    "                'metadata': dict(current_metadata)\n",
-    "            })\n",
-    "        return [chunk for chunk in chunks if chunk['content']]\n",
-    "\n",
-    "\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly' \n",
-    "    \n",
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"###\", \"Header 3\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    " \n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
-    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
-    "for chunk in chunked_docs:\n",
-    "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "62863736",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c32428a9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b41cc955",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "c3504dc6",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Three levels\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
-    "\n",
-    "# Test case 3\n",
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"###\", \"Header 3\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    "\n",
-    "# TODO: Reset header 3 Boo as empty\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
-    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
-    "for chunk in chunked_docs:\n",
-    "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5af59a89",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "78fdd026",
+   "id": "bba6eb9e",
    "metadata": {},
    "source": [
-    "`Original Code`"
+    "`Test case 5`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "9f865704",
+   "execution_count": 13,
+   "id": "8af8f9a2",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
+      "{'content': 'Markdown[9] is a lightweight markup language for creating formatted text using a plain-text editor. John Gruber created Markdown in 2004 as a markup language that is appealing to human readers in its source code form.[9]\\nMarkdown is widely used in blogging, instant messaging, online forums, collaborative software, documentation pages, and readme files.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'History'}}\n",
+      "{'content': 'As Markdown popularity grew rapidly, many Markdown implementations appeared, driven mostly by the need for\\nadditional features such as tables, footnotes, definition lists,[note 1] and Markdown inside HTML blocks.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Rise and divergence'}}\n",
+      "{'content': 'From 2012, a group of people, including Jeff Atwood and John MacFarlane, launched what Atwood characterised as a standardisation effort.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Rise and divergence', 'Header 4': 'Standardization'}}\n",
+      "{'content': 'Implementations of Markdown are available for over a dozen programming languages.', 'metadata': {'Header 1': 'Intro', 'Header 2': 'Implementations'}}\n"
      ]
     }
    ],
    "source": [
-    "class MarkdownHeaderTextSplitter(TextSplitter):\n",
+    "markdown_document = '# Intro \\n\\n    ## History \\n\\n Markdown[9] is a lightweight markup language for creating formatted text using a plain-text editor. John Gruber created Markdown in 2004 as a markup language that is appealing to human readers in its source code form.[9] \\n\\n Markdown is widely used in blogging, instant messaging, online forums, collaborative software, documentation pages, and readme files. \\n\\n ## Rise and divergence \\n\\n As Markdown popularity grew rapidly, many Markdown implementations appeared, driven mostly by the need for \\n\\n additional features such as tables, footnotes, definition lists,[note 1] and Markdown inside HTML blocks. \\n\\n #### Standardization \\n\\n From 2012, a group of people, including Jeff Atwood and John MacFarlane, launched what Atwood characterised as a standardisation effort. \\n\\n ## Implementations \\n\\n Implementations of Markdown are available for over a dozen programming languages.'\n",
     "    \n",
-    "    def __init__(self, splits: List[Tuple[str, Optional[str]]], **kwargs: Any):\n",
-    "        \n",
-    "        # Sort by seperator length and the number of \"#\"\n",
-    "        # E.g.,  Ensure \"###\" will come before \"##\" and \"#\"\n",
-    "        # TODO: Both means of sorting may not be required \n",
-    "        \"\"\"Create a new TextSplitter.\"\"\"\n",
-    "        super().__init__(**kwargs)\n",
-    "        self.splits = sorted(splits, key=lambda x: (-len(x[0]), -x[0].count('#')))\n",
-    "\n",
-    "    def split_text(self, text: str) -> List[Dict[str, Union[str, str]]]:\n",
-    "        \n",
-    "        # Regex matches any of the separators in self.splits (except for the newline)\n",
-    "        # (Newlines create line breaks, which we may want to split, or separate MD headers and their contents)\n",
-    "        pattern = '|'.join('(%s\\\\s*(.*))' % re.escape(sep) for sep, _ in self.splits if sep != \"\\n\")\n",
-    "        \n",
-    "        # Text chunk with metadata\n",
-    "        chunks = []\n",
-    "        \n",
-    "        # Keys are names of metadata \n",
-    "        #current_metadata = {name: '' for sep, name in self.splits if name is not None}\n",
-    "        current_metadata = {name: '' for sep, name in self.splits if name}\n",
-    "        current_content = []\n",
-    "        \n",
-    "        # Split by newlines, but preserve the exact formatting of the original text\n",
-    "        for line in text.splitlines(keepends=True):\n",
-    "            \n",
-    "            # Removes any leading or trailing whitespace\n",
-    "            stripped_line = line.strip()  \n",
-    "            \n",
-    "            # Match current line of text against the regular expression pattern\n",
-    "            match = re.match(pattern, stripped_line)\n",
-    "            \n",
-    "            # If the line starts w/ a separator defined in splits (like \"#\" or \"##\"), it will be a match\n",
-    "            # Start of a new chunk of content\n",
-    "            if match:\n",
-    "                \n",
-    "                # See if we have accumulated content from previous lines \n",
-    "                if current_content:  \n",
-    "                    \n",
-    "                    # If so, append it as a chunk and write the chunk since we hit a new seperator\n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(), \n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    # Reset the content  \n",
-    "                    current_content = []  \n",
-    "                    \n",
-    "                # Check for the seperator\n",
-    "                for sep, name in self.splits:\n",
-    "                    if stripped_line.startswith(sep):\n",
-    "                        if name is not None:\n",
-    "                            # Update the rest of the line (after the separator) as the value for that header\n",
-    "                            current_metadata[name] = stripped_line[len(sep):].strip()\n",
-    "                            \n",
-    "                            # If the separator is \"#\", it also clears out the metadata for \"Header 2\"\n",
-    "                            # A new \"Header 1\" implies a new section of the document\n",
-    "                            # TODO: This is brittle since there can be many header names\n",
-    "                            #if sep == \"#\":\n",
-    "                            #    current_metadata[\"Header 2\"] = ''   \n",
-    "                            if sep == \"#\":\n",
-    "                                # clear out metadata for all headers lower in hierarchy\n",
-    "                                current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]\n",
-    "                                current_metadata_keys = list(current_metadata.keys())\n",
-    "                                for header in current_metadata_keys:\n",
-    "                                    header_index = [index for index, (_, name) in enumerate(self.splits) if name == header]\n",
-    "                                    if header_index and header_index[0] > current_header_index:\n",
-    "                                        del current_metadata[header]\n",
-    "                        break\n",
-    "            \n",
-    "            # If the line is empty (i.e., only contains whitespace, or is completely empty) \n",
-    "            # and newline (\"\\n\") is one of the separators, it appends the current content to \n",
-    "            # the chunks list as a new chunk, and resets the current_content to an empty list  \n",
-    "            elif not stripped_line and (\"\\n\", None) in self.splits:  \n",
-    "                \n",
-    "                # If we have accumulated content, append it as a chunk\n",
-    "                if current_content:  \n",
-    "                    chunks.append({\n",
-    "                        'content': ''.join(current_content).strip(), \n",
-    "                        'metadata': dict(current_metadata)\n",
-    "                    })\n",
-    "                    current_content = []  # reset the content\n",
-    "            \n",
-    "            # Apend non-empty lines\n",
-    "            elif stripped_line:  \n",
-    "                current_content.append(stripped_line)\n",
-    "        \n",
-    "        # Append the last chunk\n",
-    "        if current_content:\n",
-    "            chunks.append({\n",
-    "                'content': ''.join(current_content).strip(), \n",
-    "                'metadata': dict(current_metadata)\n",
-    "            })\n",
-    "        return [chunk for chunk in chunks if chunk['content']]\n",
-    "\n",
-    "# Doc\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ## Baz\\n\\n Hi this is Molly' \n",
-    "    \n",
-    "# Test case 1\n",
-    "splits = [\n",
-    "    (\"#\", \"Header 1\"),\n",
-    "    (\"##\", \"Header 2\"),\n",
-    "    (\"\\n\", None)\n",
-    "]\n",
-    " \n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
-    "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
-    "for chunk in chunked_docs:\n",
-    "    print(chunk)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "d9edb507",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': 'Hi this is Jim', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Joe', 'metadata': {'Header 3': '', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Lance', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Bar', 'Header 1': 'Foo'}}\n",
-      "{'content': 'Hi this is Molly', 'metadata': {'Header 3': 'Boo', 'Header 2': 'Baz', 'Header 1': 'Foo'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Three levels\n",
-    "markdown_document = '# Foo\\n\\n    ## Bar\\n\\nHi this is Jim\\n\\nHi this is Joe\\n\\n ### Boo \\n\\n Hi this is Lance \\n\\n ## Baz\\n\\n Hi this is Molly'\n",
-    "\n",
-    "# Test case 3\n",
-    "splits = [\n",
+    "headers_to_split_on = [\n",
     "    (\"#\", \"Header 1\"),\n",
     "    (\"##\", \"Header 2\"),\n",
     "    (\"###\", \"Header 3\"),\n",
-    "    (\"\\n\", None)\n",
+    "    (\"####\", \"Header 4\"),\n",
     "]\n",
-    "\n",
-    "# TODO: Reset header 3 Boo as empty\n",
-    "markdown_splitter = MarkdownHeaderTextSplitter(splits=splits)\n",
+    " \n",
+    "markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on,return_each_line=False)\n",
     "chunked_docs = markdown_splitter.split_text(markdown_document)\n",
     "for chunk in chunked_docs:\n",
     "    print(chunk)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1a578b61",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f610ceaa",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -310,29 +310,13 @@ class MarkdownHeaderTextSplitter(TextSplitter):
                     if stripped_line.startswith(sep):
                         if name is not None:
                             # Update the rest of the line (after the separator) as the value for that header
-                            current_metadata[name] = stripped_line[len(sep) :].strip()
-
-                            # If the separator is "#", it also clears out the metadata for "Header 2"
-                            # A new "Header 1" implies a new section of the document
-                            if sep == "#":
-                                # Clear out metadata for all headers lower in hierarchy
-                                current_header_index = [
-                                    index
-                                    for index, (sep_, _) in enumerate(self.splits)
-                                    if sep_ == sep
-                                ][0]
-                                current_metadata_keys = list(current_metadata.keys())
-                                for header in current_metadata_keys:
-                                    header_index = [
-                                        index
-                                        for index, (_, name) in enumerate(self.splits)
-                                        if name == header
-                                    ]
-                                    if (
-                                        header_index
-                                        and header_index[0] > current_header_index
-                                    ):
-                                        del current_metadata[header]
+                            current_metadata[name] = stripped_line[len(sep):].strip()
+                            
+                            # clear out metadata for all headers lower in hierarchy
+                            current_header_index = [index for index, (sep_, _) in enumerate(self.splits) if sep_ == sep][0]
+                            for header, index in [(name_, index) for index, (sep_, name_) in enumerate(self.splits) if name_]:
+                                if index > current_header_index:
+                                    current_metadata[header] = ''
                         break
 
             # If the line is empty (i.e., only contains whitespace, or is completely empty)

--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -276,13 +276,13 @@ class MarkdownHeaderTextSplitter:
         )
 
     def aggregate_lines_to_chunks(
-        self, lines: List[Dict[str, Union[str, Dict[str, Any]]]]
-    ) -> List[Dict[str, Union[str, Dict[str, Any]]]]:
+        self, lines: List[Dict[str, Union[str, Dict[str, str]]]]
+    ) -> List[Dict[str, Union[str, Dict[str, str]]]]:
         """Combine lines with common metadata into chunks
         Args:
             lines: Line of text / associated header metadata
         """
-        aggregated_chunks: List[Dict[str, Union[str, Dict[str, Any]]]] = []
+        aggregated_chunks: List[Dict[str, Union[str, Dict[str, str]]]] = []
 
         for line in lines:
             if (
@@ -330,15 +330,14 @@ class MarkdownHeaderTextSplitter:
                         current_header_level = sep.count("#")
 
                         # Pop out headers of lower or same level from the stack
-                        while (
-                            header_stack
-                            and header_stack[-1]["level"] >= current_header_level
-                        ):
-                            # We have encountered a new header at the same or higher level
-                            popped_header = header_stack.pop()
-                            # Clear the metadata for the popped header in initial_metadata
-                            if popped_header["name"] in initial_metadata:
-                                initial_metadata.pop(popped_header["name"])
+                        while header_stack:
+                            assert isinstance(header_stack[-1]["level"], int), "Expected int"
+                            if header_stack[-1]["level"] >= current_header_level:
+                                # We have encountered a new header at the same or higher level
+                                popped_header = header_stack.pop()
+                                # Clear the metadata for the popped header in initial_metadata
+                                if popped_header["name"] in initial_metadata:
+                                    initial_metadata.pop(popped_header["name"])
 
                         # Push the current header to the stack
                         header = {


### PR DESCRIPTION
This creates a new kind of text splitter for markdown files.

The user can supply a set of headers that they want to split the file on.

We define a new text splitter class, `MarkdownHeaderTextSplitter`, that does a few things:

(1) For each line, it determines the associated set of user-specified headers 
(2) It groups lines with common headers into splits

See notebook for example usage and test cases. 