### PR TITLE
Fix vertexai.py 'params' generation for 'init_vertexai'

### DIFF
--- a/langchain/llms/vertexai.py
+++ b/langchain/llms/vertexai.py
@@ -68,7 +68,7 @@ class _VertexAICommon(BaseModel):
     @classmethod
     def _try_init_vertexai(cls, values: Dict) -> None:
         allowed_params = ["project", "location", "credentials"]
-        params = {k: v for k, v in values.items() if v in allowed_params}
+        params = {k: v for k, v in values.items() if k in allowed_params}
         init_vertexai(**params)
         return None
 

--- a/langchain/llms/vertexai.py
+++ b/langchain/llms/vertexai.py
@@ -31,7 +31,7 @@ class _VertexAICommon(BaseModel):
     "among the top-k most probable tokens."
     stop: Optional[List[str]] = None
     "Optional list of stop words to use when generating."
-    project: Optional[str] = None
+    project_id: Optional[str] = None
     "The default GCP project to use when making Vertex API calls."
     location: str = "us-central1"
     "The default location to use when making API calls."
@@ -67,7 +67,7 @@ class _VertexAICommon(BaseModel):
 
     @classmethod
     def _try_init_vertexai(cls, values: Dict) -> None:
-        allowed_params = ["project", "location", "credentials"]
+        allowed_params = ["project_id", "location", "credentials"]
         params = {k: v for k, v in values.items() if k in allowed_params}
         init_vertexai(**params)
         return None


### PR DESCRIPTION
Fixed a bug that always constructed the 'params' dict for the 'init_vertexai' function as an empty dict.

Fixes # (issue)

#### Who can review?

Tag maintainers/contributors who might be interested:

@hwchase17
@agola11
