### PR TITLE
Fix IndexError in RecursiveCharacterTextSplitter

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -423,7 +423,7 @@ class RecursiveCharacterTextSplitter(TextSplitter):
         final_chunks = []
         # Get appropriate separator to use
         separator = separators[-1]
-        new_separators = None
+        new_separators = []
         for i, _s in enumerate(separators):
             if _s == "":
                 separator = _s
@@ -445,7 +445,7 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                     merged_text = self._merge_splits(_good_splits, _separator)
                     final_chunks.extend(merged_text)
                     _good_splits = []
-                if new_separators is None:
+                if not new_separators:
                     final_chunks.append(s)
                 else:
                     other_info = self._split_text(s, new_separators)

--- a/tests/unit_tests/test_text_splitter.py
+++ b/tests/unit_tests/test_text_splitter.py
@@ -1,5 +1,6 @@
 """Test text splitting functionality."""
 from typing import List
+
 import pytest
 
 from langchain.docstore.document import Document

--- a/tests/unit_tests/test_text_splitter.py
+++ b/tests/unit_tests/test_text_splitter.py
@@ -182,7 +182,6 @@ def test_iterative_text_splitter() -> None:
 This is a weird text to write, but gotta test the splittingggg some how.
 
 Bye!\n\n-H."""
-    # ["\n\n", "\n", " ", ""]
     splitter = RecursiveCharacterTextSplitter(chunk_size=10, chunk_overlap=1)
     output = splitter.split_text(text)
     expected_output = [


### PR DESCRIPTION
Fixes (not reported) an error that may occur in some cases in the RecursiveCharacterTextSplitter.

An empty `new_separators` array ([]) would end up in the else path of the condition below and used in a function where it is expected to be non empty.

```python
if new_separators is None:
    ...
else:
   # _split_text() expects this array to be non-empty!
   other_info = self._split_text(s, new_separators)

```
resulting in an `IndexError`

```python
def _split_text(self, text: str, separators: List[str]) -> List[str]:
        """Split incoming text and return chunks."""
        final_chunks = []
        # Get appropriate separator to use
>       separator = separators[-1]
E       IndexError: list index out of range

langchain/text_splitter.py:425: IndexError
```

#### Who can review?
@hwchase17 @eyurtsev 

