### PR TITLE
Add start index to metadata in TextSplitter

### DIFF
--- a/docs/modules/indexes/text_splitters/getting_started.ipynb
+++ b/docs/modules/indexes/text_splitters/getting_started.ipynb
@@ -12,7 +12,8 @@
     "\n",
     "- `length_function`: how the length of chunks is calculated. Defaults to just counting number of characters, but it's pretty common to pass a token counter here.\n",
     "- `chunk_size`: the maximum size of your chunks (as measured by the length function).\n",
-    "- `chunk_overlap`: the maximum overlap between chunks. It can be nice to have some overlap to maintain some continuity between chunks (eg do a sliding window)."
+    "- `chunk_overlap`: the maximum overlap between chunks. It can be nice to have some overlap to maintain some continuity between chunks (eg do a sliding window).\n",
+    "- `add_start_index` : wether to include the starting position of each chunk within the original document in the metadata. "
    ]
   },
   {
@@ -49,6 +50,7 @@
     "    chunk_size = 100,\n",
     "    chunk_overlap  = 20,\n",
     "    length_function = len,\n",
+    "    add_start_index = True,\n",
     ")"
    ]
   },
@@ -62,8 +64,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "page_content='Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and' lookup_str='' metadata={} lookup_index=0\n",
-      "page_content='of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans.' lookup_str='' metadata={} lookup_index=0\n"
+      "page_content='Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and' metadata={'start_index': 0}\n",
+      "page_content='of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans.' metadata={'start_index': 82}\n"
      ]
     }
    ],
@@ -90,7 +92,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/tests/unit_tests/test_text_splitter.py
+++ b/tests/unit_tests/test_text_splitter.py
@@ -118,6 +118,21 @@ def test_create_documents_with_metadata() -> None:
     assert docs == expected_docs
 
 
+def test_create_documents_with_start_index() -> None:
+    """Test create documents method."""
+    texts = ["foo bar baz 123"]
+    splitter = CharacterTextSplitter(
+        separator=" ", chunk_size=7, chunk_overlap=3, add_start_index=True
+    )
+    docs = splitter.create_documents(texts)
+    expected_docs = [
+        Document(page_content="foo bar", metadata={"start_index": 0}),
+        Document(page_content="bar baz", metadata={"start_index": 4}),
+        Document(page_content="baz 123", metadata={"start_index": 8}),
+    ]
+    assert docs == expected_docs
+
+
 def test_metadata_not_shallow() -> None:
     """Test that metadatas are not shallow."""
     texts = ["foo bar"]


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

#### Add start index to metadata in TextSplitter

- Modified method `create_documents` to track start position of each chunk
- The `start_index` is included in the metadata if the `add_start_index` parameter in the class constructor is set to `True`

This enables referencing back to the original document, particularly useful when a specific chunk is retrieved.

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

Tag maintainers/contributors who might be interested:
@eyurtsev @agola11
<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
