### PR TITLE
Fix openai proxy error

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -387,9 +387,9 @@ class ChatOpenAI(BaseChatModel):
             "model": self.model_name,
         }
         if self.openai_proxy:
-            openai_creds["proxy"] = (
-                {"http": self.openai_proxy, "https": self.openai_proxy},
-            )
+            import openai
+
+            openai.proxy = {"http": self.openai_proxy, "https": self.openai_proxy}  # type: ignore[assignment]  # noqa: E501
         return {**openai_creds, **self._default_params}
 
     @property

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -197,10 +197,12 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             "api_version": self.openai_api_version,
         }
         if self.openai_proxy:
-            openai_args["proxy"] = {
+            import openai
+
+            openai.proxy = {
                 "http": self.openai_proxy,
                 "https": self.openai_proxy,
-            }
+            }  # type: ignore[assignment]  # noqa: E501
         return openai_args
 
     # please refer to

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -451,10 +451,9 @@ class BaseOpenAI(BaseLLM):
             "organization": self.openai_organization,
         }
         if self.openai_proxy:
-            openai_creds["proxy"] = {
-                "http": self.openai_proxy,
-                "https": self.openai_proxy,
-            }
+            import openai
+
+            openai.proxy = {"http": self.openai_proxy, "https": self.openai_proxy}  # type: ignore[assignment]  # noqa: E501
         return {**openai_creds, **self._default_params}
 
     @property


### PR DESCRIPTION
Fixes proxy error.
Since openai does not parse proxy parameters and uses openai.proxy directly, the proxy method needs to be modified.

https://github.com/openai/openai-python/blob/7610c5adfaebe3ffdb9927a551a741a3fab1b62e/openai/api_requestor.py#LL90

#### Who can review?
  @hwchase17 - project lead

  Models
  - @hwchase17
  - @agola11
