### PR TITLE
arxiv: Correct name of search client attribute to 'arxiv_search' from incorrect 'arxiv_client'

### DIFF
--- a/langchain/utilities/arxiv.py
+++ b/langchain/utilities/arxiv.py
@@ -32,7 +32,7 @@ class ArxivAPIWrapper(BaseModel):
 
     """
 
-    arxiv_client: Any  #: :meta private:
+    arxiv_search: Any  #: :meta private:
     arxiv_exceptions: Any  # :meta private:
     top_k_results: int = 3
     ARXIV_MAX_QUERY_LENGTH = 300


### PR DESCRIPTION
+ this private attribute is referenced as `arxiv_search` in internal usage and is set when verifying the environment

twitter: @spazm 


#### Who can review?

Any of @hwchase17, @leo-gan, or @bongsang might be interested in reviewing.

+ Mismatch between `arxiv_client` attribute vs `arxiv_search` in validation and usage is present in the initial commit by @hwchase17.  
+ @leo-gan has made most of the edits.
+ @bongsang implemented pdf download.
