### PR TITLE
Fix: Grammer fix in documentation

### DIFF
--- a/docs/modules/agents/agent_executors/examples/agent_vectorstore.ipynb
+++ b/docs/modules/agents/agent_executors/examples/agent_vectorstore.ipynb
@@ -14,6 +14,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9b22020a",
    "metadata": {},
@@ -139,6 +140,7 @@
    "source": []
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c0a6c031",
    "metadata": {},
@@ -229,7 +231,7 @@
     }
    ],
    "source": [
-    "agent.run(\"What did biden say about ketanji brown jackson is the state of the union address?\")"
+    "agent.run(\"What did biden say about ketanji brown jackson in the state of the union address?\")"
    ]
   },
   {
@@ -271,6 +273,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "787a9b5e",
    "metadata": {},
@@ -279,6 +282,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9161ba91",
    "metadata": {},
@@ -396,6 +400,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "49a0cbbe",
    "metadata": {},

--- a/docs/modules/agents/toolkits/examples/vectorstore.ipynb
+++ b/docs/modules/agents/toolkits/examples/vectorstore.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "18ada398-dce6-4049-9b56-fc0ede63da9c",
    "metadata": {},
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "eecb683b-3a46-4b9d-81a3-7caefbfec1a1",
    "metadata": {},
@@ -88,6 +90,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f4814175-964d-42f1-aa9d-22801ce1e912",
    "metadata": {},
@@ -123,6 +126,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8a38ad10",
    "metadata": {},
@@ -165,7 +169,7 @@
     }
    ],
    "source": [
-    "agent_executor.run(\"What did biden say about ketanji brown jackson is the state of the union address?\")"
+    "agent_executor.run(\"What did biden say about ketanji brown jackson in the state of the union address?\")"
    ]
   },
   {
@@ -203,10 +207,11 @@
     }
    ],
    "source": [
-    "agent_executor.run(\"What did biden say about ketanji brown jackson is the state of the union address? List the source.\")"
+    "agent_executor.run(\"What did biden say about ketanji brown jackson in the state of the union address? List the source.\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ca07707",
    "metadata": {},
@@ -255,6 +260,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "71680984-edaf-4a63-90f5-94edbd263550",
    "metadata": {},
@@ -299,7 +305,7 @@
     }
    ],
    "source": [
-    "agent_executor.run(\"What did biden say about ketanji brown jackson is the state of the union address?\")"
+    "agent_executor.run(\"What did biden say about ketanji brown jackson in the state of the union address?\")"
    ]
   },
   {


### PR DESCRIPTION
Fix for grammatical errors in the documentation of `vectorstore`.  
@vowelparrot
