### PR TITLE
Added matching async load func to PlaywrightURLLoader

### DIFF
--- a/langchain/document_loaders/url_playwright.py
+++ b/langchain/document_loaders/url_playwright.py
@@ -88,7 +88,7 @@ class PlaywrightURLLoader(BaseLoader):
         return docs
 
     async def aload(self) -> List[Document]:
-        """Load the specified URLs using Playwright and create Document instances asynchronously.
+        """Load the specified URLs with Playwright and create Documents asynchronously.
         Use this function when in a jupyter notebook environment.
 
         Returns:

--- a/langchain/document_loaders/url_playwright.py
+++ b/langchain/document_loaders/url_playwright.py
@@ -86,3 +86,43 @@ class PlaywrightURLLoader(BaseLoader):
                         raise e
             browser.close()
         return docs
+
+    async def aload(self) -> List[Document]:
+        """Load the specified URLs using Playwright and create Document instances asynchronously.
+        Use this function when in a jupyter notebook environment.
+
+        Returns:
+            List[Document]: A list of Document instances with loaded content.
+        """
+        from playwright.async_api import async_playwright
+        from unstructured.partition.html import partition_html
+
+        docs: List[Document] = list()
+
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=self.headless)
+            for url in self.urls:
+                try:
+                    page = await browser.new_page()
+                    await page.goto(url)
+
+                    for selector in self.remove_selectors or []:
+                        elements = await page.locator(selector).all()
+                        for element in elements:
+                            if await element.is_visible():
+                                await element.evaluate("element => element.remove()")
+
+                    page_source = await page.content()
+                    elements = partition_html(text=page_source)
+                    text = "\n\n".join([str(el) for el in elements])
+                    metadata = {"source": url}
+                    docs.append(Document(page_content=text, metadata=metadata))
+                except Exception as e:
+                    if self.continue_on_failure:
+                        logger.error(
+                            f"Error fetching or processing {url}, exception: {e}"
+                        )
+                    else:
+                        raise e
+            await browser.close()
+        return docs

--- a/tests/integration_tests/document_loaders/test_url_playwright.py
+++ b/tests/integration_tests/document_loaders/test_url_playwright.py
@@ -1,4 +1,5 @@
 """Tests for the Playwright URL loader"""
+import pytest
 
 from langchain.document_loaders import PlaywrightURLLoader
 
@@ -18,4 +19,23 @@ def test_playwright_url_loader() -> None:
         headless=True,
     )
     docs = loader.load()
+    assert len(docs) > 0
+
+
+@pytest.mark.asyncio
+async def test_playwright_async_url_loader() -> None:
+    """Test Playwright async URL loader."""
+    urls = [
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://goo.gl/maps/NDSHwePEyaHMFGwh8",
+        "https://techmeme.com",
+        "https://techcrunch.com",
+    ]
+    loader = PlaywrightURLLoader(
+        urls=urls,
+        remove_selectors=["header", "footer"],
+        continue_on_failure=False,
+        headless=True,
+    )
+    docs = await loader.aload()
     assert len(docs) > 0


### PR DESCRIPTION

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes # (issue)

The existing PlaywrightURLLoader load() function uses a synchronous browser which is not compatible with jupyter.
This PR adds a sister function aload() which can be run insisde a notebook.

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
