### PR TITLE
Using batches for Chroma update_document

### DIFF
--- a/docs/modules/indexes/vectorstores/examples/chroma.ipynb
+++ b/docs/modules/indexes/vectorstores/examples/chroma.ipynb
@@ -27,20 +27,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "42080f37-8fd1-4cec-acd9-15d2b03b2f4d",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get a token: https://platform.openai.com/account/api-keys\n",
     "\n",
@@ -51,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "id": "c7a94d6c-b4d4-4498-9bdd-eb50c92b85c5",
    "metadata": {
     "tags": []
@@ -363,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "id": "a559c3f1",
    "metadata": {},
    "outputs": [],
@@ -371,19 +363,26 @@
     "# Import Document class\n",
     "from langchain.docstore.document import Document\n",
     "\n",
-    "# Initial document content and id\n",
-    "initial_content = \"This is an initial document content\"\n",
-    "document_id = \"doc1\"\n",
+    "# Initial document contents and ids\n",
+    "initial_content_1 = \"This is an initial document content 1\"\n",
+    "document_id_1 = \"doc1\"\n",
+    "\n",
+    "initial_content_2 = \"This is an initial document content 2\"\n",
+    "document_id_2 = \"doc2\"\n",
     "\n",
     "# Create an instance of Document with initial content and metadata\n",
-    "original_doc = Document(page_content=initial_content, metadata={\"page\": \"0\"})\n",
+    "original_doc = [Document(page_content=initial_content_1, metadata={\"page\": \"0\"}),Document(page_content=initial_content_2, metadata={\"page\": \"1\"})]\n",
+    "\n",
+    "# Create a list for document ids\n",
+    "\n",
+    "document_ids = [document_id_1,document_id_2]\n",
     "\n",
     "# Initialize a Chroma instance with the original document\n",
     "new_db = Chroma.from_documents(\n",
     "    collection_name=\"test_collection\",\n",
-    "    documents=[original_doc],\n",
+    "    documents=original_doc,\n",
     "    embedding=OpenAIEmbeddings(),  # using the same embeddings as before\n",
-    "    ids=[document_id],\n",
+    "    ids=document_ids,\n",
     ")"
    ]
   },
@@ -398,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 8,
    "id": "55e48056",
    "metadata": {},
    "outputs": [
@@ -406,26 +405,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This is the updated document content {'page': '1'}\n"
+      "This is the updated document content 1 {'page': '1'}\n",
+      "This is the updated document content 2 {'page': '2'}\n"
      ]
     }
    ],
    "source": [
-    "# Updated document content\n",
-    "updated_content = \"This is the updated document content\"\n",
+    "# Updated document contents\n",
+    "updated_content_1 = \"This is the updated document content 1\"\n",
+    "\n",
+    "updated_content_2 = \"This is the updated document content 2\"\n",
     "\n",
     "# Create a new Document instance with the updated content\n",
-    "updated_doc = Document(page_content=updated_content, metadata={\"page\": \"1\"})\n",
+    "updated_doc = [Document(page_content=updated_content_1, metadata={\"page\": \"1\"}),Document(page_content=updated_content_2, metadata={\"page\": \"2\"})]\n",
     "\n",
     "# Update the document in the Chroma instance by passing the document id and the updated document\n",
-    "new_db.update_document(document_id=document_id, document=updated_doc)\n",
+    "new_db.update_document(document_ids=document_ids, documents=updated_doc)\n",
     "\n",
-    "# Now, let's retrieve the updated document using similarity search\n",
-    "output = new_db.similarity_search(updated_content, k=1)\n",
+    "# Now, let's retrieve the updated document 1 using similarity search\n",
+    "output = new_db.similarity_search(updated_content_1, k=1)\n",
+    "\n",
+    "# Print the content of the retrieved document\n",
+    "print(output[0].page_content, output[0].metadata)\n",
+    "\n",
+    "# Now, let's retrieve the updated document 2 using similarity search\n",
+    "output = new_db.similarity_search(updated_content_2, k=1)\n",
     "\n",
     "# Print the content of the retrieved document\n",
     "print(output[0].page_content, output[0].metadata)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06466fcd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -444,7 +460,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -352,26 +352,28 @@ class Chroma(VectorStore):
             )
         self._client.persist()
 
-    def update_document(self, document_id: str, document: Document) -> None:
+    def update_document(
+        self, document_ids: List[str], documents: List[Document]
+    ) -> None:
         """Update a document in the collection.
 
         Args:
-            document_id (str): ID of the document to update.
-            document (Document): Document to update.
+            document_ids (List[str]): IDs of the document to update.
+            documents (List[Document]): Documents to update.
         """
-        text = document.page_content
-        metadata = document.metadata
+        text = [document.page_content for document in documents]
+        metadata = [document.metadata for document in documents]
         if self._embedding_function is None:
             raise ValueError(
                 "For update, you must specify an embedding function on creation."
             )
-        embeddings = self._embedding_function.embed_documents([text])
+        embeddings = self._embedding_function.embed_documents(text)
 
         self._collection.update(
-            ids=[document_id],
+            ids=document_ids,
             embeddings=embeddings,
-            documents=[text],
-            metadatas=[metadata],
+            documents=text,
+            metadatas=metadata,
         )
 
     @classmethod

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -195,7 +195,7 @@ def test_chroma_update_document() -> None:
     updated_doc = Document(page_content=updated_content, metadata={"page": "0"})
 
     # Update the document in the Chroma instance
-    docsearch.update_document(document_id=document_id, document=updated_doc)
+    docsearch.update_document(document_ids=[document_id], documents=[updated_doc])
 
     # Perform a similarity search with the updated content
     output = docsearch.similarity_search(updated_content, k=1)


### PR DESCRIPTION
https://github.com/hwchase17/langchain/blob/2a4b32dee24c22159805f643b87eece107224951/langchain/vectorstores/chroma.py#L355-L375

Currently, the defined update_document function only takes a single document and its ID for updating. However, Chroma can update multiple documents by taking a list of IDs and documents for batch updates. 

I update the Chroma vectorstore with refreshed information from my website every 20 minutes. Updating the update_document function to perform simultaneous updates for each changed piece of information would significantly reduce the update time in such use cases. 

For my case I update a total of 8810 chunks. Updating these 8810 individual chunks using the current function takes a total of 8.5 minutes. However, if we process the inputs in batches and update them collectively, all 8810 separate chunks can be updated in just 1 minute. This significantly reduces the time it takes for users of actively used chatbots to access up-to-date information.

I also updated the integration test and the examples provided in the documentation for the new update_document function.

@hwchase17 

my twitter: [berkedilekoglu](https://twitter.com/berkedilekoglu)