### PR TITLE
Fixed typo missing "use"

### DIFF
--- a/docs/modules/indexes/retrievers/examples/vectorstore.ipynb
+++ b/docs/modules/indexes/retrievers/examples/vectorstore.ipynb
@@ -99,13 +99,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2d958271",
    "metadata": {},
    "source": [
     "## Similarity Score Threshold Retrieval\n",
     "\n",
-    "You can also a retrieval method that sets a similarity score threshold and only returns documents with a score above that threshold"
+    "You can also use a retrieval method that sets a similarity score threshold and only returns documents with a score above that threshold"
    ]
   },
   {


### PR DESCRIPTION
<!--
Fixed a simple typo on https://python.langchain.com/en/latest/modules/indexes/retrievers/examples/vectorstore.html where the word "use" was missing.

#### Who can review?

Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
