### PR TITLE
Obey handler.raise_error in _ahandle_event_for_handler

### DIFF
--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -238,6 +238,8 @@ async def _ahandle_event_for_handler(
         else:
             logger.warning(f"Error in {event_name} callback: {e}")
     except Exception as e:
+        if handler.raise_error:
+            raise e
         logger.warning(f"Error in {event_name} callback: {e}")
 
 


### PR DESCRIPTION
Obey `handler.raise_error` in `_ahandle_event_for_handler`

Exceptions for async callbacks were only logged as warnings, also when `raise_error = True`

#### Who can review?

  @hwchase17

   @agola11
