### PR TITLE
Raise an exception in MRKL if no tool is provided.

### DIFF
--- a/langchain/agents/mrkl/base.py
+++ b/langchain/agents/mrkl/base.py
@@ -124,6 +124,10 @@ class ZeroShotAgent(Agent):
     @classmethod
     def _validate_tools(cls, tools: Sequence[BaseTool]) -> None:
         validate_tools_single_input(cls.__name__, tools)
+        if len(tools) == 0:
+            raise ValueError(
+                f"Got no tools for {cls.__name__}. At least one tool must be provided."
+            )
         for tool in tools:
             if tool.description is None:
                 raise ValueError(

--- a/tests/unit_tests/agents/test_serialization.py
+++ b/tests/unit_tests/agents/test_serialization.py
@@ -4,11 +4,18 @@ from tempfile import TemporaryDirectory
 from langchain.agents.agent_types import AgentType
 from langchain.agents.initialize import initialize_agent, load_agent
 from langchain.llms.fake import FakeListLLM
+from langchain.agents.tools import Tool
 
 
 def test_mrkl_serialization() -> None:
     agent = initialize_agent(
-        [],
+        [        
+            Tool(
+                name="Test tool",
+                func=lambda x: x,
+                description="Test description",
+            )
+        ],
         FakeListLLM(responses=[]),
         agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
         verbose=True,

--- a/tests/unit_tests/agents/test_serialization.py
+++ b/tests/unit_tests/agents/test_serialization.py
@@ -9,7 +9,7 @@ from langchain.agents.tools import Tool
 
 def test_mrkl_serialization() -> None:
     agent = initialize_agent(
-        [        
+        [
             Tool(
                 name="Test tool",
                 func=lambda x: x,


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

Implemented validation for cases where no tools are provided. 
This change allows for the handling of scenarios where certain MRKL tools, such as Zapier Natural Language Actions, may not support any tools. With this validation, we prevent unnecessary chaining of API usage. 

This pull request is partially related to issue #5977.


#### Who can review?

@vowelparrot
