### PR TITLE
[Bug fix] Fix the chat memory to save the result when output text is nested in json

### DIFF
--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -16,7 +16,7 @@ class BaseChatMemory(BaseMemory, ABC):
     return_messages: bool = False
 
     def _get_input_output(
-        self, inputs: Dict[str, Any], outputs: Dict[str, str]
+        self, inputs: Dict[str, Any], outputs: Dict[str, Any]
     ) -> Tuple[str, str]:
         if self.input_key is None:
             prompt_input_key = get_prompt_input_key(inputs, self.memory_variables)
@@ -43,7 +43,7 @@ class BaseChatMemory(BaseMemory, ABC):
             output_key = self.output_key
         return inputs[prompt_input_key], outputs[output_key]
 
-    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, Any]) -> None:
         """Save context from this conversation to buffer."""
         input_str, output_str = self._get_input_output(inputs, outputs)
         self.chat_memory.add_user_message(input_str)

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from typing import Any, Dict, Optional, Tuple
+import warnings
 
 from pydantic import Field
 
@@ -25,6 +26,19 @@ class BaseChatMemory(BaseMemory, ABC):
             if len(outputs) != 1:
                 raise ValueError(f"One output key expected, got {outputs.keys()}")
             output_key = list(outputs.keys())[0]
+            if isinstance(outputs[output_key], Dict):
+                outputs = outputs[output_key]
+                if "result" in outputs:
+                    output_key = "result"
+                elif "answer" in outputs:
+                    output_key = "answer"
+                elif "output" in outputs:
+                    output_key = "output"
+                else:
+                    output_key = list(outputs.keys())[0]
+                warnings.warn(
+                    f"Extract the text from the nested output with the key `{output_key}`"
+                )
         else:
             output_key = self.output_key
         return inputs[prompt_input_key], outputs[output_key]

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -1,6 +1,6 @@
+import warnings
 from abc import ABC
 from typing import Any, Dict, Optional, Tuple
-import warnings
 
 from pydantic import Field
 
@@ -37,7 +37,7 @@ class BaseChatMemory(BaseMemory, ABC):
                 else:
                     output_key = list(outputs.keys())[0]
                 warnings.warn(
-                    f"Extract the text from the nested output with the key `{output_key}`"
+                   f"Extract the text from the nested output with key `{output_key}`"
                 )
         else:
             output_key = self.output_key

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -37,7 +37,7 @@ class BaseChatMemory(BaseMemory, ABC):
                 else:
                     output_key = list(outputs.keys())[0]
                 warnings.warn(
-                   f"Extract the text from the nested output with key `{output_key}`"
+                    f"Extract the text from the nested output with key `{output_key}`"
                 )
         else:
             output_key = self.output_key


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

I used the`RetrievalQA` chain with the argument `return_source_documents=True` as part of the tools in the agent framework with conversation buffer memory. It turns out at the last step, the output text is still nested in json like `{...,'output':{'result': ..., 'source_documents':...}}` and then it caused the error in the `self.chat_memory.add_ai_message(output_str)` which only expects the output to be only string type. 

So I added another check to parse out the final output text if the `output`(original output key) is still the `Dict` type and apply some heuristics to retrieve the text with the new assumed output key based on the common output keys in common chains.

<!-- Remove if not applicable -->

Fixes # (issue)

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?
@vowelparrot @hwchase17 

Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @vowelparrot

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
