### PR TITLE
Allow GoogleDrive to authenticate via application default credentials on Cloud Run/GCE etc without service key

### DIFF
--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -92,6 +92,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         # Adapted from https://developers.google.com/drive/api/v3/quickstart/python
         try:
             from google.auth.transport.requests import Request
+            from google.auth import default
             from google.oauth2 import service_account
             from google.oauth2.credentials import Credentials
             from google_auth_oauthlib.flow import InstalledAppFlow
@@ -116,6 +117,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
+            elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+                creds, project = default()
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
                     str(self.credentials_path), SCOPES

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -119,6 +119,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 creds.refresh(Request())
             elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
                 creds, project = default()
+                creds = creds.with_scopes(SCOPES)
                 # no need to write to file
                 if creds:
                     return creds

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -119,7 +119,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 creds.refresh(Request())
             elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
                 creds, project = default()
-                self.token_path = Path("/tmp") / "token.json"
+                # no need to write to file
+                return creds
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
                     str(self.credentials_path), SCOPES

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -120,7 +120,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
                 creds, project = default()
                 # no need to write to file
-                return creds
+                if creds:
+                    return creds
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
                     str(self.credentials_path), SCOPES

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -119,6 +119,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 creds.refresh(Request())
             elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
                 creds, project = default()
+                self.token_path = Path("/tmp") / "token.json"
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
                     str(self.credentials_path), SCOPES

--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -9,6 +9,7 @@
 # 4. For service accounts visit
 #   https://cloud.google.com/iam/docs/service-accounts-create
 
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -91,8 +92,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         """Load credentials."""
         # Adapted from https://developers.google.com/drive/api/v3/quickstart/python
         try:
-            from google.auth.transport.requests import Request
             from google.auth import default
+            from google.auth.transport.requests import Request
             from google.oauth2 import service_account
             from google.oauth2.credentials import Credentials
             from google_auth_oauthlib.flow import InstalledAppFlow


### PR DESCRIPTION
@eyurtsev

The existing GoogleDrive implementation always needs a service account to be available at the credentials location.  When running on GCP services such as Cloud Run, a service account already exists in the metadata of the service, so no physical key is necessary.  This change adds a check to see if it is running in such an environment, and uses that authentication instead. 
