### PR TITLE
Allow FAISS score_threshold

### DIFF
--- a/langchain/retrievers/contextual_compression.py
+++ b/langchain/retrievers/contextual_compression.py
@@ -51,9 +51,7 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
         """
         docs = await self.base_retriever.aget_relevant_documents(query)
         if docs:
-            compressed_docs = await self.base_compressor.acompress_documents(
-                docs, query
-            )
+            compressed_docs = await self.base_compressor.acompress_documents(docs, query)
             return list(compressed_docs)
         else:
             return []

--- a/langchain/retrievers/contextual_compression.py
+++ b/langchain/retrievers/contextual_compression.py
@@ -34,8 +34,11 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
             Sequence of relevant documents
         """
         docs = self.base_retriever.get_relevant_documents(query)
-        compressed_docs = self.base_compressor.compress_documents(docs, query)
-        return list(compressed_docs)
+        if docs:
+            compressed_docs = self.base_compressor.compress_documents(docs, query)
+            return list(compressed_docs)
+        else:
+            return []
 
     async def aget_relevant_documents(self, query: str) -> List[Document]:
         """Get documents relevant for a query.
@@ -47,5 +50,8 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
             List of relevant documents
         """
         docs = await self.base_retriever.aget_relevant_documents(query)
-        compressed_docs = await self.base_compressor.acompress_documents(docs, query)
-        return list(compressed_docs)
+        if docs:
+            compressed_docs = await self.base_compressor.acompress_documents(docs, query)
+            return list(compressed_docs)
+        else:
+            return []

--- a/langchain/retrievers/contextual_compression.py
+++ b/langchain/retrievers/contextual_compression.py
@@ -33,19 +33,6 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
         Returns:
             Sequence of relevant documents
         """
-        if self.base_retriever.search_type == "similarity_score_threshold":
-            docs_and_similarities = (
-                self.base_retriever.vectorstore.similarity_search_with_relevance_scores(
-                    query, **self.base_retriever.search_kwargs
-                )
-            )
-            docs = [doc for doc, score in docs_and_similarities]
-            compressed_docs = self.base_compressor.compress_documents(docs, query)
-            compressed_docs_with_scores = zip(
-                compressed_docs, [score for doc, score in docs_and_similarities]
-            )
-            return list(compressed_docs_with_scores)
-
         docs = self.base_retriever.get_relevant_documents(query)
         if docs:
             compressed_docs = self.base_compressor.compress_documents(docs, query)
@@ -62,19 +49,6 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
         Returns:
             List of relevant documents
         """
-        if self.base_retriever.search_type == "similarity_score_threshold":
-            docs_and_similarities = await self.base_retriever.vectorstore.asimilarity_search_with_relevance_scores(
-                query, **self.base_retriever.search_kwargs
-            )
-            docs = [doc for doc, score in docs_and_similarities]
-            compressed_docs = await self.base_compressor.acompress_documents(
-                docs, query
-            )
-            compressed_docs_with_scores = zip(
-                compressed_docs, [score for doc, score in docs_and_similarities]
-            )
-            return list(compressed_docs_with_scores)
-
         docs = await self.base_retriever.aget_relevant_documents(query)
         if docs:
             compressed_docs = await self.base_compressor.acompress_documents(

--- a/langchain/retrievers/contextual_compression.py
+++ b/langchain/retrievers/contextual_compression.py
@@ -33,6 +33,19 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
         Returns:
             Sequence of relevant documents
         """
+        if self.base_retriever.search_type == "similarity_score_threshold":
+            docs_and_similarities = (
+                self.base_retriever.vectorstore.similarity_search_with_relevance_scores(
+                    query, **self.base_retriever.search_kwargs
+                )
+            )
+            docs = [doc for doc, score in docs_and_similarities]
+            compressed_docs = self.base_compressor.compress_documents(docs, query)
+            compressed_docs_with_scores = zip(
+                compressed_docs, [score for doc, score in docs_and_similarities]
+            )
+            return list(compressed_docs_with_scores)
+
         docs = self.base_retriever.get_relevant_documents(query)
         if docs:
             compressed_docs = self.base_compressor.compress_documents(docs, query)
@@ -49,9 +62,24 @@ class ContextualCompressionRetriever(BaseRetriever, BaseModel):
         Returns:
             List of relevant documents
         """
+        if self.base_retriever.search_type == "similarity_score_threshold":
+            docs_and_similarities = await self.base_retriever.vectorstore.asimilarity_search_with_relevance_scores(
+                query, **self.base_retriever.search_kwargs
+            )
+            docs = [doc for doc, score in docs_and_similarities]
+            compressed_docs = await self.base_compressor.acompress_documents(
+                docs, query
+            )
+            compressed_docs_with_scores = zip(
+                compressed_docs, [score for doc, score in docs_and_similarities]
+            )
+            return list(compressed_docs_with_scores)
+
         docs = await self.base_retriever.aget_relevant_documents(query)
         if docs:
-            compressed_docs = await self.base_compressor.acompress_documents(docs, query)
+            compressed_docs = await self.base_compressor.acompress_documents(
+                docs, query
+            )
             return list(compressed_docs)
         else:
             return []

--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -159,8 +159,8 @@ class VectorStore(ABC):
             ]
             if len(docs_and_similarities) == 0:
                 warnings.warn(
-                    f"No relevant docs were retrieved using the relevance score\
-                          threshold {score_threshold}"
+                    "No relevant docs were retrieved using the relevance score"
+                    f" threshold {score_threshold}"
                 )
         return docs_and_similarities
 

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -185,6 +185,7 @@ class FAISS(VectorStore):
         k: int = 4,
         filter: Optional[Dict[str, Any]] = None,
         fetch_k: int = 20,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query.
 
@@ -194,6 +195,9 @@ class FAISS(VectorStore):
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
             fetch_k: (Optional[int]) Number of Documents to fetch before filtering.
                       Defaults to 20.
+            **kwargs: kwargs to be passed to similarity search. Can include:
+                score_threshold: Optional, a floating point value between 0 to 1 to
+                    filter the resulting set of retrieved docs
 
         Returns:
             List of documents most similar to the query text and L2 distance
@@ -218,6 +222,14 @@ class FAISS(VectorStore):
                     docs.append((doc, scores[0][j]))
             else:
                 docs.append((doc, scores[0][j]))
+
+        score_threshold = kwargs.get("score_threshold")
+        if score_threshold is not None:
+            docs = [
+                (doc, similarity)
+                for doc, similarity in docs
+                if similarity >= score_threshold
+            ]
         return docs[:k]
 
     def similarity_search_with_score(


### PR DESCRIPTION
Allow FAISS's similarity_search_with_score_by_vector to accept kwargs, specifically: `score_threshold`.
Fixes error for document compression users in cases where there are no relevant docs - for instance:  

```
human_message: "hi" (<--  will return no relevant docs depending on score_threshold)
> IndexError: index 0 is out of bounds for axis 0 with size 0
```

Combined with the new merger_retriever, FAISS users can now perform more granular vectorstore retrieving based on score_threshold:  

```
store_1 = st[0][1].as_retriever(search_type="similarity_score_threshold", search_kwargs={"score_threshold": .8, "k": 3})
store_2 = st[1][1].as_retriever(search_type="similarity_score_threshold", search_kwargs={"score_threshold": .3, "k": 3})
store_3 = st[2][1].as_retriever(search_type="similarity_score_threshold", search_kwargs={"score_threshold": .5, "k": 3})

merged = MergerRetriever(retrievers=[store_1, store_2, store_3])
pipeline_compressor = prep_compressor()
compression_retriever = ContextualCompressionRetriever(base_compressor=pipeline_compressor, base_retriever=merged)

chain = ConversationalRetrievalChain.from_llm(OpenAI(temperature=0), chain_type="stuff", retriever=compression_retriever)
```

@dev2049 or @hwchase17 would appreciate a check if available. Thanks. 
