### PR TITLE
Fix for ModuleNotFoundError while running langchain-server. Issue #5833

### DIFF
--- a/langchain/server.py
+++ b/langchain/server.py
@@ -2,7 +2,7 @@
 import subprocess
 from pathlib import Path
 
-from langchain.cli.main import get_docker_compose_command
+from langchainplus_sdk.cli.main import get_docker_compose_command
 
 
 def main() -> None:


### PR DESCRIPTION
This PR fixes the error
`ModuleNotFoundError: No module named 'langchain.cli'`
Fixes https://github.com/hwchase17/langchain/issues/5833 (issue)