### PR TITLE
Guardrails output parser: Pass LLM api for reasking

### DIFF
--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -8,6 +8,8 @@ from langchain.schema import BaseOutputParser
 class GuardrailsOutputParser(BaseOutputParser):
     guard: Any
     api: Optional[Callable]
+    args: Any
+    kwargs: Any
 
     @property
     def _type(self) -> str:
@@ -19,6 +21,8 @@ class GuardrailsOutputParser(BaseOutputParser):
         rail_file: str,
         num_reasks: int = 1,
         api: Optional[Callable] = None,
+        *args,
+        **kwargs,
     ) -> GuardrailsOutputParser:
         try:
             from guardrails import Guard
@@ -28,7 +32,9 @@ class GuardrailsOutputParser(BaseOutputParser):
                 "Install it by running `pip install guardrails-ai`."
             )
         return cls(guard=Guard.from_rail(rail_file, num_reasks=num_reasks),
-                   api=api)
+                   api=api,
+                   args=args,
+                   kwargs=kwargs)
 
     @classmethod
     def from_rail_string(
@@ -36,6 +42,8 @@ class GuardrailsOutputParser(BaseOutputParser):
         rail_str: str,
         num_reasks: int = 1,
         api: Optional[Callable] = None,
+        *args,
+        **kwargs,
     ) -> GuardrailsOutputParser:
         try:
             from guardrails import Guard
@@ -45,10 +53,12 @@ class GuardrailsOutputParser(BaseOutputParser):
                 "Install it by running `pip install guardrails-ai`."
             )
         return cls(guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks),
-                   api=api)
+                   api=api,
+                   args=args,
+                   kwargs=kwargs)
 
     def get_format_instructions(self) -> str:
         return self.guard.raw_prompt.format_instructions
 
     def parse(self, text: str) -> Dict:
-        return self.guard.parse(text, llm_api=self.api)
+        return self.guard.parse(text, llm_api=self.api, *self.args, **self.kwargs)

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 from langchain.schema import BaseOutputParser
 
@@ -21,8 +21,8 @@ class GuardrailsOutputParser(BaseOutputParser):
         rail_file: str,
         num_reasks: int = 1,
         api: Optional[Callable] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> GuardrailsOutputParser:
         try:
             from guardrails import Guard
@@ -31,10 +31,12 @@ class GuardrailsOutputParser(BaseOutputParser):
                 "guardrails-ai package not installed. "
                 "Install it by running `pip install guardrails-ai`."
             )
-        return cls(guard=Guard.from_rail(rail_file, num_reasks=num_reasks),
-                   api=api,
-                   args=args,
-                   kwargs=kwargs)
+        return cls(
+            guard=Guard.from_rail(rail_file, num_reasks=num_reasks),
+            api=api,
+            args=args,
+            kwargs=kwargs,
+        )
 
     @classmethod
     def from_rail_string(
@@ -42,8 +44,8 @@ class GuardrailsOutputParser(BaseOutputParser):
         rail_str: str,
         num_reasks: int = 1,
         api: Optional[Callable] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> GuardrailsOutputParser:
         try:
             from guardrails import Guard
@@ -52,10 +54,12 @@ class GuardrailsOutputParser(BaseOutputParser):
                 "guardrails-ai package not installed. "
                 "Install it by running `pip install guardrails-ai`."
             )
-        return cls(guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks),
-                   api=api,
-                   args=args,
-                   kwargs=kwargs)
+        return cls(
+            guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks),
+            api=api,
+            args=args,
+            kwargs=kwargs,
+        )
 
     def get_format_instructions(self) -> str:
         return self.guard.raw_prompt.format_instructions

--- a/langchain/output_parsers/rail_parser.py
+++ b/langchain/output_parsers/rail_parser.py
@@ -1,31 +1,24 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Callable, Optional
 
 from langchain.schema import BaseOutputParser
 
 
 class GuardrailsOutputParser(BaseOutputParser):
     guard: Any
+    api: Optional[Callable]
 
     @property
     def _type(self) -> str:
         return "guardrails"
 
     @classmethod
-    def from_rail(cls, rail_file: str, num_reasks: int = 1) -> GuardrailsOutputParser:
-        try:
-            from guardrails import Guard
-        except ImportError:
-            raise ValueError(
-                "guardrails-ai package not installed. "
-                "Install it by running `pip install guardrails-ai`."
-            )
-        return cls(guard=Guard.from_rail(rail_file, num_reasks=num_reasks))
-
-    @classmethod
-    def from_rail_string(
-        cls, rail_str: str, num_reasks: int = 1
+    def from_rail(
+        cls,
+        rail_file: str,
+        num_reasks: int = 1,
+        api: Optional[Callable] = None,
     ) -> GuardrailsOutputParser:
         try:
             from guardrails import Guard
@@ -34,10 +27,28 @@ class GuardrailsOutputParser(BaseOutputParser):
                 "guardrails-ai package not installed. "
                 "Install it by running `pip install guardrails-ai`."
             )
-        return cls(guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks))
+        return cls(guard=Guard.from_rail(rail_file, num_reasks=num_reasks),
+                   api=api)
+
+    @classmethod
+    def from_rail_string(
+        cls,
+        rail_str: str,
+        num_reasks: int = 1,
+        api: Optional[Callable] = None,
+    ) -> GuardrailsOutputParser:
+        try:
+            from guardrails import Guard
+        except ImportError:
+            raise ValueError(
+                "guardrails-ai package not installed. "
+                "Install it by running `pip install guardrails-ai`."
+            )
+        return cls(guard=Guard.from_rail_string(rail_str, num_reasks=num_reasks),
+                   api=api)
 
     def get_format_instructions(self) -> str:
         return self.guard.raw_prompt.format_instructions
 
     def parse(self, text: str) -> Dict:
-        return self.guard.parse(text)
+        return self.guard.parse(text, llm_api=self.api)


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes https://github.com/ShreyaR/guardrails/issues/155 

Enables guardrails reasking by specifying an LLM api in the output parser.