### PR TITLE
Fix little typo in summarize.ipynb

### DIFF
--- a/docs/modules/chains/index_examples/summarize.ipynb
+++ b/docs/modules/chains/index_examples/summarize.ipynb
@@ -328,7 +328,7 @@
     "\n",
     "**Multi input prompt**\n",
     "\n",
-    "You can also use prompt with multi input. In this example, we will use a MapReduce chain to answer specifc question about our code."
+    "You can also use prompt with multi input. In this example, we will use a MapReduce chain to answer specific question about our code."
    ]
   },
   {


### PR DESCRIPTION
#### Description 

Hello, I found a little typo while reading your documentation. This PR is just fixing a typo in the documentation at `Chains > How-To guides > Summarization`.

