### PR TITLE
Run event handler inline if it's not an async function

### DIFF
--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import functools
 import logging
 import os
 import warnings
@@ -220,9 +219,7 @@ async def _ahandle_event_for_handler(
             if asyncio.iscoroutinefunction(event):
                 await event(*args, **kwargs)
             else:
-                await asyncio.get_event_loop().run_in_executor(
-                    None, functools.partial(event, *args, **kwargs)
-                )
+                event(*args, **kwargs)
     except NotImplementedError as e:
         if event_name == "on_chat_model_start":
             message_strings = [get_buffer_string(m) for m in args[1]]


### PR DESCRIPTION
When we try to run a callback as part of an async call, we can potentially get an async function.
- If that's the case, we should call await on it to make sure it's finished before we move on. 
- If it's not an async function, is a plain old function, and we should just call it.

This makes the setup slightly cleaner because it's not creating a new context several times for one callback.

@hwchase17, @agola11. Twitter username is @mariokostelac.