### PR TITLE
Fix VectorStoreMemory when used with CombinedMemory

### DIFF
--- a/langchain/memory/vectorstore.py
+++ b/langchain/memory/vectorstore.py
@@ -19,7 +19,7 @@ class VectorStoreRetrieverMemory(BaseMemory):
     memory_key: str = "history"  #: :meta private:
     """Key name to locate the memories in the result of load_memory_variables."""
 
-    input_key: Optional[str] = None
+    input_key: str = "input"
     """Key name to index the inputs to load_memory_variables."""
 
     return_docs: bool = False
@@ -54,8 +54,8 @@ class VectorStoreRetrieverMemory(BaseMemory):
         self, inputs: Dict[str, Any], outputs: Dict[str, str]
     ) -> List[Document]:
         """Format context from this conversation to buffer."""
-        # Each document should only include the current turn, not the chat history
-        filtered_inputs = {k: v for k, v in inputs.items() if k != self.memory_key}
+        # Each document should only include the current turn, not the chat history, and not the other memory input
+        filtered_inputs = {k: v for k, v in inputs.items() if k != self.memory_key and k == self.input_key}
         texts = [
             f"{k}: {v}"
             for k, v in list(filtered_inputs.items()) + list(outputs.items())


### PR DESCRIPTION
Fix VectorStoreMemory mixing the other memory input when used in CombinedMemory

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->



#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

Fixes Issue when using multiple memory
When we used multiple memory, VectorStoreMemory together with ConversationBufferWindowMemory, the VectorStoreMemory history is mixed up with ConversationBufferWindowMemory

```python
vectorstore_memory = VectorStoreRetrieverMemory(input_key="input", memory_key="related_conv", retriever=retriever)
conv_memory = ConversationBufferWindowMemory(input_key="input", memory_key="previous_conv", k=1)
memory = CombinedMemory(memories=[conv_memory, vectorstore_memory])
```

`related_conv` contains `input + previous_conv + response`
#### Who can review?
Tag maintainers/contributors who might be interested:
@dev2049

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
