### PR TITLE
Fix missing chain classname in StdOutCallbackHandler.on_chain_start

### DIFF
--- a/langchain/callbacks/stdout.py
+++ b/langchain/callbacks/stdout.py
@@ -37,7 +37,7 @@ class StdOutCallbackHandler(BaseCallbackHandler):
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
         """Print out that we are entering a chain."""
-        class_name = serialized.get("id", ["<unknown>"])[-1]
+        class_name = serialized.get("name", serialized.get("id", ["<unknown>"])[-1])
         print(f"\n\n\033[1m> Entering new {class_name} chain...\033[0m")
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:

--- a/langchain/callbacks/stdout.py
+++ b/langchain/callbacks/stdout.py
@@ -37,7 +37,7 @@ class StdOutCallbackHandler(BaseCallbackHandler):
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
         """Print out that we are entering a chain."""
-        class_name = serialized.get("name", "")
+        class_name = serialized.get("id", ["<unknown>"])[-1]
         print(f"\n\n\033[1m> Entering new {class_name} chain...\033[0m")
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:


### PR DESCRIPTION
Retrieves the name of the class from new location as of commit 18af149e91e62b3ac7728ddea420688d41043734

#### Before submitting

#### Who can review?

Tag maintainers/contributors who might be interested:

  Tracing / Callbacks
  - @agola11
