### PR TITLE
Correct AzureSearch Vector Store not applying search_kwargs when searching

### DIFF
--- a/langchain/vectorstores/azuresearch.py
+++ b/langchain/vectorstores/azuresearch.py
@@ -243,11 +243,11 @@ class AzureSearch(VectorStore):
     ) -> List[Document]:
         search_type = kwargs.get("search_type", self.search_type)
         if search_type == "similarity":
-            docs = self.vector_search(query, k=k)
+            docs = self.vector_search(query, k=k, **kwargs)
         elif search_type == "hybrid":
-            docs = self.hybrid_search(query, k=k)
+            docs = self.hybrid_search(query, k=k, **kwargs)
         elif search_type == "semantic_hybrid":
-            docs = self.semantic_hybrid_search(query, k=k)
+            docs = self.semantic_hybrid_search(query, k=k, **kwargs)
         else:
             raise ValueError(f"search_type of {search_type} not allowed.")
         return docs


### PR DESCRIPTION
Fixes #6131 

Simply passes kwargs forward from similarity_search to helper functions so that search_kwargs are applied to search as originally intended.  See bug for repro steps.

#### Who can review?
  @hwchase17
  @dev2049 

Twitter: poshporcupine