### PR TITLE
Add Run Collector Callback

### DIFF
--- a/langchain/callbacks/tracers/run_collector.py
+++ b/langchain/callbacks/tracers/run_collector.py
@@ -1,0 +1,20 @@
+"""A tracer that collects all nested runs in a list."""
+from typing import Any, List
+
+from langchain.callbacks.tracers.base import BaseTracer
+from langchain.callbacks.tracers.schemas import Run
+
+
+class RunStackCallbackHandler(BaseTracer):
+    """A tracer that collects all nested runs in a list.
+
+    Useful for inspection and for evaluation."""
+
+    name = "run-collector_callback_handler"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.traced_runs: List[Run] = []
+
+    def _persist_run(self, run: Run) -> None:
+        self.traced_runs.append(run)


### PR DESCRIPTION
Add a callback handler that can collect nested run objects. Useful for evaluation.