### PR TITLE
Fixed an unhandled error that was raised when DynamoDB did not have any chat history.

### DIFF
--- a/langchain/memory/chat_message_histories/dynamodb.py
+++ b/langchain/memory/chat_message_histories/dynamodb.py
@@ -44,6 +44,7 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
         """Retrieve the messages from DynamoDB"""
         from botocore.exceptions import ClientError
 
+        response = None
         try:
             response = self.table.get_item(Key={"SessionId": self.session_id})
         except ClientError as error:


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.



After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

The current version of chat history with DynamoDB doesn't handle the case correctly when a table has no chat history. This change solves this error handling.

<!-- Remove if not applicable -->

Fixes https://github.com/hwchase17/langchain/issues/6088

#### Who can review?

Tag maintainers/contributors who might be interested:

@hwchase17

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
