### PR TITLE
Removed handling for non-existent error in chromadb library

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -115,23 +115,12 @@ class Chroma(VectorStore):
                 "Could not import chromadb python package. "
                 "Please install it with `pip install chromadb`."
             )
-
-        for i in range(n_results, 0, -1):
-            try:
-                return self._collection.query(
-                    query_texts=query_texts,
-                    query_embeddings=query_embeddings,
-                    n_results=i,
-                    where=where,
-                    **kwargs,
-                )
-            except chromadb.errors.NotEnoughElementsException:
-                logger.error(
-                    f"Chroma collection {self._collection.name} "
-                    f"contains fewer than {i} elements."
-                )
-        raise chromadb.errors.NotEnoughElementsException(
-            f"No documents found for Chroma collection {self._collection.name}"
+        return self._collection.query(
+            query_texts=query_texts,
+            query_embeddings=query_embeddings,
+            n_results=n_results,
+            where=where,
+            **kwargs,
         )
 
     def add_texts(


### PR DESCRIPTION
The current version of chromadb handle the case of `n_result` is greater than the total number of elements in the collection. [chromadb PR](https://github.com/chroma-core/chroma/issues/301). So removed `NotEnoughElementException` that doesn't exists now.

#### Who can review?

Tag maintainers/contributors who might be interested:

- @hwchase17
- @dev2049

