### PR TITLE
Extend `ArgillaCallbackHandler` support

### DIFF
--- a/langchain/callbacks/argilla_callback.py
+++ b/langchain/callbacks/argilla_callback.py
@@ -220,9 +220,9 @@ class ArgillaCallbackHandler(BaseCallbackHandler):
     def on_chain_start(
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
-        """If the key `input` is in `inputs`, then save it in `self.prompts` using 
-        either the `parent_run_id` or the `run_id` as the key. This is done so that 
-        we don't log the same input prompt twice, once when the LLM starts and once 
+        """If the key `input` is in `inputs`, then save it in `self.prompts` using
+        either the `parent_run_id` or the `run_id` as the key. This is done so that
+        we don't log the same input prompt twice, once when the LLM starts and once
         when the chain starts.
         """
         if "input" in inputs:
@@ -241,9 +241,14 @@ class ArgillaCallbackHandler(BaseCallbackHandler):
         log the outputs to Argilla, and pop the run from `self.prompts`. The behavior
         differs if the output is a list or not.
         """
-        if not any(key in self.prompts for key in [str(kwargs["parent_run_id"]), str(kwargs["run_id"])]):
+        if not any(
+            key in self.prompts
+            for key in [str(kwargs["parent_run_id"]), str(kwargs["run_id"])]
+        ):
             return
-        prompts = self.prompts.get(str(kwargs["parent_run_id"])) or self.prompts.get(str(kwargs["run_id"]))
+        prompts = self.prompts.get(str(kwargs["parent_run_id"])) or self.prompts.get(
+            str(kwargs["run_id"])
+        )
         for chain_output_key, chain_output_val in outputs.items():
             if isinstance(chain_output_val, list):
                 # Creates the records and adds them to the `FeedbackDataset`
@@ -255,7 +260,7 @@ class ArgillaCallbackHandler(BaseCallbackHandler):
                                 "response": output["text"].strip(),
                             },
                         }
-                        for prompt, output in zip(prompts, chain_output_val)
+                        for prompt, output in zip(prompts, chain_output_val)  # type: ignore
                     ]
                 )
             else:
@@ -264,7 +269,7 @@ class ArgillaCallbackHandler(BaseCallbackHandler):
                     records=[
                         {
                             "fields": {
-                                "prompt": " ".join(prompts),
+                                "prompt": " ".join(prompts),  # type: ignore
                                 "response": chain_output_val.strip(),
                             },
                         }

--- a/langchain/callbacks/argilla_callback.py
+++ b/langchain/callbacks/argilla_callback.py
@@ -260,7 +260,9 @@ class ArgillaCallbackHandler(BaseCallbackHandler):
                                 "response": output["text"].strip(),
                             },
                         }
-                        for prompt, output in zip(prompts, chain_output_val)  # type: ignore
+                        for prompt, output in zip(
+                            prompts, chain_output_val  # type: ignore
+                        )
                     ]
                 )
             else:


### PR DESCRIPTION
Hi again @agola11! 🤗

## What's in this PR?

After playing around with different chains we noticed that some chains were using different `output_key`s and we were just handling some, so we've extended the support to any output, either if it's a Python list or a string.

Kudos to @dvsrepo for spotting this!