### PR TITLE
feature: token based text splitter relative chunk overlap argument

### DIFF
--- a/tests/integration_tests/test_text_splitter.py
+++ b/tests/integration_tests/test_text_splitter.py
@@ -105,3 +105,29 @@ def test_sentence_transformers_multiple_tokens() -> None:
         - splitter.maximum_tokens_per_chunk
     )
     assert expected == actual
+
+
+def test_relative_chunk_overlap_parameter_must_be_in_the_zero_to_one_range() -> None:
+    with pytest.raises(ValueError):
+        SentenceTransformersTokenTextSplitter(relative_chunk_overlap=2.0)
+
+
+def test_relative_chunk_overlap_yields_a_single_chunk() -> None:
+    relative_chunk_overlap = 0.5
+    splitter = SentenceTransformersTokenTextSplitter(
+        relative_chunk_overlap=relative_chunk_overlap
+    )
+    text = "is "  # one token
+
+    count_start_and_end_tokens = 2
+    text_multiplication_factor = round(
+        relative_chunk_overlap
+        * (splitter.maximum_tokens_per_chunk - count_start_and_end_tokens)
+    )
+    text_to_embed_becomes_a_single_chunk = text_multiplication_factor * text
+    text_to_embed_becomes_two_chunks = (
+        splitter.maximum_tokens_per_chunk - count_start_and_end_tokens + 1
+    ) * text
+
+    assert len(splitter.split_text(text=text_to_embed_becomes_a_single_chunk)) == 1
+    assert len(splitter.split_text(text=text_to_embed_becomes_two_chunks)) == 2


### PR DESCRIPTION
For SentenceTransformersTokenTextSplitter text splitter.

Adds a new parameter `relative_chunk_overlap` for the `SentenceTransformersTokenTextSplitter` constructor. The parameter sets the chunk overlap using a relative factor, e.g. for a model where the token limit is 100, a `relative_chunk_overlap=0.5` implies that `chunk_overlap=50`.

#### Who can review?

@hwchase17 @dev2049
