### PR TITLE
perf(openai): changed base model to gpt-3.5-turbo 

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -132,7 +132,7 @@ class BaseOpenAI(BaseLLM):
         return True
 
     client: Any  #: :meta private:
-    model_name: str = Field("text-davinci-003", alias="model")
+    model_name: str = Field("gpt-3.5-turbo", alias="model")
     """Model name to use."""
     temperature: float = 0.7
     """What sampling temperature to use."""


### PR DESCRIPTION
I've changed the base model in OpenAI Class to gpt-3.5-turbo. It was already changed in ChatOpenAI class.

Let me know if there was any reason why you kept text-davinci-003 which is 10 times more costly and not that smart in OpenAI Class and not in ChatOpenAI :D 


@hwchase17
@agola11


