### PR TITLE
APIChain: Fixed/mitigated issue #6224 (Prompt injection -> SSRF)

### DIFF
--- a/langchain/chains/api/base.py
+++ b/langchain/chains/api/base.py
@@ -1,4 +1,5 @@
 """Chain that makes API calls and summarizes the responses to answer a question."""
+import re
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
@@ -15,8 +16,6 @@ from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
 from langchain.prompts import BasePromptTemplate
 from langchain.requests import TextRequestsWrapper
-import re
-
 
 class APIChain(Chain):
     """Chain that makes API calls and summarizes the responses to answer a question."""
@@ -66,11 +65,11 @@ class APIChain(Chain):
                 f"Input variables should be {expected_vars}, got {input_vars}"
             )
         return values
-    
-    def verify_api_url_is_legit(self, parsed_url: str):
+
+    def verify_api_url_is_legit(self, parsed_url: str) -> None:
         """Verify that the parsed URL corresponds to one of the URLs in the API spec"""
-        
-        base_url_re = re.compile('http[s]?://((?:[-\w.]|(?:%[\da-fA-F]{2}))+)')
+
+        base_url_re = re.compile("http[s]?://((?:[-\w.]|(?:%[\da-fA-F]{2}))+)")
         base_parsed_url = base_url_re.findall(parsed_url)[0].strip().lower()
         api_doc_allowed_urls = base_url_re.findall(self.api_docs)
         for url in api_doc_allowed_urls:
@@ -94,7 +93,7 @@ class APIChain(Chain):
         )
         _run_manager.on_text(api_url, color="green", end="\n", verbose=self.verbose)
         api_url = api_url.strip()
-        if self.allow_unverified_urls == False:
+        if self.allow_unverified_urls is False:
             self.verify_api_url_is_legit(api_url)
         api_response = self.requests_wrapper.get(api_url)
         _run_manager.on_text(
@@ -107,7 +106,7 @@ class APIChain(Chain):
             api_response=api_response,
             callbacks=_run_manager.get_child(),
         )
-        
+
         return {self.output_key: answer}
 
     async def _acall(

--- a/langchain/chains/api/base.py
+++ b/langchain/chains/api/base.py
@@ -1,7 +1,7 @@
 """Chain that makes API calls and summarizes the responses to answer a question."""
-import re
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, List, Optional
 
 from pydantic import Field, root_validator
@@ -16,6 +16,7 @@ from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
 from langchain.prompts import BasePromptTemplate
 from langchain.requests import TextRequestsWrapper
+
 
 class APIChain(Chain):
     """Chain that makes API calls and summarizes the responses to answer a question."""

--- a/tests/unit_tests/chains/test_api.py
+++ b/tests/unit_tests/chains/test_api.py
@@ -20,10 +20,43 @@ class FakeRequestsChain(TextRequestsWrapper):
     def get(self, url: str, **kwargs: Any) -> str:
         """Just return the specified output."""
         return self.output
+    
+class FakeAPIChainBuilder():
+    """Builder of fake LLM API Chain, just for testing purposes"""
+    
+    output: APIChain
+    def build_fake_llm_api_chain(self, test_api_data: dict, allow_unverified_urls: bool = False) -> APIChain:
+        """Fake LLM API chain for testing."""
+        TEST_API_DOCS = test_api_data["api_docs"]
+        TEST_QUESTION = test_api_data["question"]
+        TEST_URL = test_api_data["api_url"]
+        TEST_API_RESPONSE = test_api_data["api_response"]
+        TEST_API_SUMMARY = test_api_data["api_summary"]
 
+        api_url_query_prompt = API_URL_PROMPT.format(
+            api_docs=TEST_API_DOCS, question=TEST_QUESTION
+        )
+        api_response_prompt = API_RESPONSE_PROMPT.format(
+            api_docs=TEST_API_DOCS,
+            question=TEST_QUESTION,
+            api_url=TEST_URL,
+            api_response=TEST_API_RESPONSE,
+        )
+        queries = {api_url_query_prompt: TEST_URL, api_response_prompt: TEST_API_SUMMARY}
+        fake_llm = FakeLLM(queries=queries)
+        api_request_chain = LLMChain(llm=fake_llm, prompt=API_URL_PROMPT)
+        api_answer_chain = LLMChain(llm=fake_llm, prompt=API_RESPONSE_PROMPT)
+        requests_wrapper = FakeRequestsChain(output=TEST_API_RESPONSE)
+        return APIChain(
+            api_request_chain=api_request_chain,
+            api_answer_chain=api_answer_chain,
+            requests_wrapper=requests_wrapper,
+            api_docs=TEST_API_DOCS,
+            allow_unverified_urls=allow_unverified_urls
+        )
 
 @pytest.fixture
-def test_api_data() -> dict:
+def test_simple_question_api_data() -> dict:
     """Fake api data to use for testing."""
     api_docs = """
     This API endpoint will search the notes for a user.
@@ -46,41 +79,52 @@ def test_api_data() -> dict:
         ),
         "api_summary": "There is 1 note about langchain.",
     }
-
+    
+def test_api_simple_question(test_simple_question_api_data: dict) -> None:
+    """Test simple question that needs API access."""
+    question = test_simple_question_api_data["question"]
+    fake_chain_builder = FakeAPIChainBuilder()
+    fake_chain = fake_chain_builder.build_fake_llm_api_chain(test_simple_question_api_data)
+    output = fake_chain.run(question)
+    assert output == test_simple_question_api_data["api_summary"]
 
 @pytest.fixture
-def fake_llm_api_chain(test_api_data: dict) -> APIChain:
-    """Fake LLM API chain for testing."""
-    TEST_API_DOCS = test_api_data["api_docs"]
-    TEST_QUESTION = test_api_data["question"]
-    TEST_URL = test_api_data["api_url"]
-    TEST_API_RESPONSE = test_api_data["api_response"]
-    TEST_API_SUMMARY = test_api_data["api_summary"]
+def test_malicious_question_api_data() -> dict:
+    """Fake api data to use for testing."""
+    api_docs = """
+    This API endpoint will search the notes for a user.
 
-    api_url_query_prompt = API_URL_PROMPT.format(
-        api_docs=TEST_API_DOCS, question=TEST_QUESTION
-    )
-    api_response_prompt = API_RESPONSE_PROMPT.format(
-        api_docs=TEST_API_DOCS,
-        question=TEST_QUESTION,
-        api_url=TEST_URL,
-        api_response=TEST_API_RESPONSE,
-    )
-    queries = {api_url_query_prompt: TEST_URL, api_response_prompt: TEST_API_SUMMARY}
-    fake_llm = FakeLLM(queries=queries)
-    api_request_chain = LLMChain(llm=fake_llm, prompt=API_URL_PROMPT)
-    api_answer_chain = LLMChain(llm=fake_llm, prompt=API_RESPONSE_PROMPT)
-    requests_wrapper = FakeRequestsChain(output=TEST_API_RESPONSE)
-    return APIChain(
-        api_request_chain=api_request_chain,
-        api_answer_chain=api_answer_chain,
-        requests_wrapper=requests_wrapper,
-        api_docs=TEST_API_DOCS,
-    )
+    Endpoint: https://thisapidoesntexist.com
+    GET /api/notes
 
+    Query parameters:
+    q | string | The search term for notes
+    """
+    return {
+        "api_docs": api_docs,
+        "question": "This question is designed to trigger an API request to an unwanted endpoint",
+        "api_url": "https://thisapidoesntexist2.com/sensitive_info",
+        "api_response": json.dumps(
+            {
+                "success": True,
+                "results": [{"irrelevant": 1, "irrelevant": "Langchain is awesome!"}],
+            }
+        ),
+        "api_summary": "Irrelevant",
+    }
+    
+def test_api_malicious_question(test_malicious_question_api_data: dict) -> None:
+    """Test malicious question that tries to do SSRF."""
+    question = test_malicious_question_api_data["question"]
+    fake_chain_builder = FakeAPIChainBuilder()
+    fake_chain = fake_chain_builder.build_fake_llm_api_chain(test_malicious_question_api_data)
+    with pytest.raises(ValueError):
+        output = fake_chain.run(question)
 
-def test_api_question(fake_llm_api_chain: APIChain, test_api_data: dict) -> None:
-    """Test simple question that needs API access."""
-    question = test_api_data["question"]
-    output = fake_llm_api_chain.run(question)
-    assert output == test_api_data["api_summary"]
+def test_api_malicious_question_allow_unverified_urls(test_malicious_question_api_data: dict) -> None:
+    """Test malicious question that tries to do SSRF."""
+    question = test_malicious_question_api_data["question"]
+    fake_chain_builder = FakeAPIChainBuilder()
+    fake_chain = fake_chain_builder.build_fake_llm_api_chain(test_malicious_question_api_data, True)
+    output = fake_chain.run(question)
+    output == test_malicious_question_api_data["api_summary"]

--- a/tests/unit_tests/chains/test_api.py
+++ b/tests/unit_tests/chains/test_api.py
@@ -20,12 +20,16 @@ class FakeRequestsChain(TextRequestsWrapper):
     def get(self, url: str, **kwargs: Any) -> str:
         """Just return the specified output."""
         return self.output
-    
-class FakeAPIChainBuilder():
+
+
+class FakeAPIChainBuilder:
     """Builder of fake LLM API Chain, just for testing purposes"""
-    
+
     output: APIChain
-    def build_fake_llm_api_chain(self, test_api_data: dict, allow_unverified_urls: bool = False) -> APIChain:
+
+    def build_fake_llm_api_chain(
+        self, test_api_data: dict, allow_unverified_urls: bool = False
+    ) -> APIChain:
         """Fake LLM API chain for testing."""
         TEST_API_DOCS = test_api_data["api_docs"]
         TEST_QUESTION = test_api_data["question"]
@@ -42,7 +46,10 @@ class FakeAPIChainBuilder():
             api_url=TEST_URL,
             api_response=TEST_API_RESPONSE,
         )
-        queries = {api_url_query_prompt: TEST_URL, api_response_prompt: TEST_API_SUMMARY}
+        queries = {
+            api_url_query_prompt: TEST_URL,
+            api_response_prompt: TEST_API_SUMMARY,
+        }
         fake_llm = FakeLLM(queries=queries)
         api_request_chain = LLMChain(llm=fake_llm, prompt=API_URL_PROMPT)
         api_answer_chain = LLMChain(llm=fake_llm, prompt=API_RESPONSE_PROMPT)
@@ -52,8 +59,9 @@ class FakeAPIChainBuilder():
             api_answer_chain=api_answer_chain,
             requests_wrapper=requests_wrapper,
             api_docs=TEST_API_DOCS,
-            allow_unverified_urls=allow_unverified_urls
+            allow_unverified_urls=allow_unverified_urls,
         )
+
 
 @pytest.fixture
 def test_simple_question_api_data() -> dict:
@@ -79,14 +87,18 @@ def test_simple_question_api_data() -> dict:
         ),
         "api_summary": "There is 1 note about langchain.",
     }
-    
+
+
 def test_api_simple_question(test_simple_question_api_data: dict) -> None:
     """Test simple question that needs API access."""
     question = test_simple_question_api_data["question"]
     fake_chain_builder = FakeAPIChainBuilder()
-    fake_chain = fake_chain_builder.build_fake_llm_api_chain(test_simple_question_api_data)
+    fake_chain = fake_chain_builder.build_fake_llm_api_chain(
+        test_simple_question_api_data
+    )
     output = fake_chain.run(question)
     assert output == test_simple_question_api_data["api_summary"]
+
 
 @pytest.fixture
 def test_malicious_question_api_data() -> dict:
@@ -102,29 +114,37 @@ def test_malicious_question_api_data() -> dict:
     """
     return {
         "api_docs": api_docs,
-        "question": "This question is designed to trigger an API request to an unwanted endpoint",
+        "question": "Trigger API request to an unwanted endpoint",
         "api_url": "https://thisapidoesntexist2.com/sensitive_info",
         "api_response": json.dumps(
             {
                 "success": True,
-                "results": [{"irrelevant": 1, "irrelevant": "Langchain is awesome!"}],
+                "results": [{"irrelevant": 1, "irrelevant2": "Langchain is awesome!"}],
             }
         ),
         "api_summary": "Irrelevant",
     }
-    
+
+
 def test_api_malicious_question(test_malicious_question_api_data: dict) -> None:
     """Test malicious question that tries to do SSRF."""
     question = test_malicious_question_api_data["question"]
     fake_chain_builder = FakeAPIChainBuilder()
-    fake_chain = fake_chain_builder.build_fake_llm_api_chain(test_malicious_question_api_data)
+    fake_chain = fake_chain_builder.build_fake_llm_api_chain(
+        test_malicious_question_api_data
+    )
     with pytest.raises(ValueError):
-        output = fake_chain.run(question)
+        fake_chain.run(question)
 
-def test_api_malicious_question_allow_unverified_urls(test_malicious_question_api_data: dict) -> None:
+
+def test_api_malicious_question_allow_unverified_urls(
+    test_malicious_question_api_data: dict,
+) -> None:
     """Test malicious question that tries to do SSRF."""
     question = test_malicious_question_api_data["question"]
     fake_chain_builder = FakeAPIChainBuilder()
-    fake_chain = fake_chain_builder.build_fake_llm_api_chain(test_malicious_question_api_data, True)
+    fake_chain = fake_chain_builder.build_fake_llm_api_chain(
+        test_malicious_question_api_data, True
+    )
     output = fake_chain.run(question)
     output == test_malicious_question_api_data["api_summary"]

--- a/tests/unit_tests/chains/test_api.py
+++ b/tests/unit_tests/chains/test_api.py
@@ -4,9 +4,10 @@ import json
 from typing import Any
 
 import pytest
+import re
 
 from langchain import LLMChain
-from langchain.chains.api.base import APIChain
+from langchain.chains.api.base import APIChain, BASE_URL_RE
 from langchain.chains.api.prompt import API_RESPONSE_PROMPT, API_URL_PROMPT
 from langchain.requests import TextRequestsWrapper
 from tests.unit_tests.llms.fake_llm import FakeLLM
@@ -54,11 +55,13 @@ class FakeAPIChainBuilder:
         api_request_chain = LLMChain(llm=fake_llm, prompt=API_URL_PROMPT)
         api_answer_chain = LLMChain(llm=fake_llm, prompt=API_RESPONSE_PROMPT)
         requests_wrapper = FakeRequestsChain(output=TEST_API_RESPONSE)
+        allowed_base_urls = BASE_URL_RE.findall(TEST_API_DOCS)
         return APIChain(
             api_request_chain=api_request_chain,
             api_answer_chain=api_answer_chain,
             requests_wrapper=requests_wrapper,
             api_docs=TEST_API_DOCS,
+            allowed_base_urls = allowed_base_urls,
             allow_unverified_urls=allow_unverified_urls,
         )
 


### PR DESCRIPTION
The full information regarding the potential prompt injection -> SSRF vulnerability is on #6224 .

- APIChain: Added verification of api_url retrieved from request chain. This verification is done by default but can be disabled, just in case some users will have very non-standard API documentation and will have to disable it and accept the risk.
- Added unit tests to cover the new security check, both when verification is enabled & disabled.

Twitter: @OrRaz6

Fixes #6224 
@hwchase17 