### PR TITLE
Fix LLM types so that they can be loaded from config dicts

### DIFF
--- a/langchain/llms/aleph_alpha.py
+++ b/langchain/llms/aleph_alpha.py
@@ -23,7 +23,7 @@ class AlephAlpha(LLM):
         .. code-block:: python
 
             from langchain.llms import AlephAlpha
-            alpeh_alpha = AlephAlpha(aleph_alpha_api_key="my-api-key")
+            aleph_alpha = AlephAlpha(aleph_alpha_api_key="my-api-key")
     """
 
     client: Any  #: :meta private:
@@ -199,7 +199,7 @@ class AlephAlpha(LLM):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "alpeh_alpha"
+        return "aleph_alpha"
 
     def _call(
         self,
@@ -220,7 +220,7 @@ class AlephAlpha(LLM):
         Example:
             .. code-block:: python
 
-                response = alpeh_alpha("Tell me a joke.")
+                response = aleph_alpha("Tell me a joke.")
         """
         from aleph_alpha_client import CompletionRequest, Prompt
 

--- a/langchain/llms/bananadev.py
+++ b/langchain/llms/bananadev.py
@@ -80,7 +80,7 @@ class Banana(LLM):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "banana"
+        return "bananadev"
 
     def _call(
         self,

--- a/langchain/llms/huggingface_text_gen_inference.py
+++ b/langchain/llms/huggingface_text_gen_inference.py
@@ -106,7 +106,7 @@ class HuggingFaceTextGenInference(LLM):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "hf_textgen_inference"
+        return "huggingface_textgen_inference"
 
     def _call(
         self,

--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -168,7 +168,7 @@ class LlamaCpp(LLM):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "llama.cpp"
+        return "llamacpp"
 
     def _get_parameters(self, stop: Optional[List[str]] = None) -> Dict[str, Any]:
         """

--- a/langchain/llms/mosaicml.py
+++ b/langchain/llms/mosaicml.py
@@ -86,7 +86,7 @@ class MosaicML(LLM):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "mosaicml"
+        return "mosaic"
 
     def _transform_prompt(self, prompt: str) -> str:
         """Transform prompt."""

--- a/langchain/llms/rwkv.py
+++ b/langchain/llms/rwkv.py
@@ -140,7 +140,7 @@ class RWKV(LLM, BaseModel):
     @property
     def _llm_type(self) -> str:
         """Return the type of llm."""
-        return "rwkv-4"
+        return "rwkv"
 
     def run_rnn(self, _tokens: List[str], newline_adj: int = 0) -> Any:
         AVOID_REPEAT_TOKENS = []


### PR DESCRIPTION
LLM configurations can be loaded from a Python dict (or JSON file deserialized as dict) using the [load_llm_from_config](https://github.com/hwchase17/langchain/blob/8e1a7a8646dd2e64400c2011fbdcc148127d8ffd/langchain/llms/loading.py#L12) function.

However, the type string in the `type_to_cls_dict` lookup dict differs from the type string defined in some LLM classes. This means that the LLM object can be saved, but not loaded again, because the type strings differ.