### PR TITLE
Update GmailSendMessage tool description

### DIFF
--- a/langchain/tools/gmail/send_message.py
+++ b/langchain/tools/gmail/send_message.py
@@ -39,7 +39,7 @@ class SendMessageSchema(BaseModel):
 class GmailSendMessage(GmailBaseTool):
     name: str = "send_gmail_message"
     description: str = (
-        "Use this tool to send email messages." " The input is the message, recipents"
+        "Use this tool to send email messages." " The input is the message, list of recipents"
     )
 
     def _prepare_message(


### PR DESCRIPTION
Added keyword to the description of the GmailSendMessage tool to prevent errors related to the wrong type of variables given to the tool (`str` instead of `List[str]`)

Fixes #6234 

#### Who can review?

Tag maintainers/contributors who might be interested:

@hwchase17 