### PR TITLE
fix: error handling in text extraction from pdf - Google Drive Document Loader

### DIFF
--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -284,18 +284,26 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         from PyPDF2 import PdfReader
 
         pdf_reader = PdfReader(BytesIO(content))
-
-        return [
-            Document(
-                page_content=page.extract_text(),
-                metadata={
-                    "source": f"https://drive.google.com/file/d/{id}/view",
-                    "title": f"{file.get('name')}",
-                    "page": i,
-                },
-            )
-            for i, page in enumerate(pdf_reader.pages)
-        ]
+        document = []
+        for i, page in enumerate(pdf_reader.pages):
+            try: 
+                page_content = page.extract_text()
+                if page_content:
+                    document.extend(
+                        Document(
+                            page_content=page_content,
+                            metadata={
+                                "source": f"https://drive.google.com/file/d/{id}/view",
+                                "title": f"{file.get('name')}",
+                                "page": i,
+                            },
+                        )
+                    )
+            except Exception as e:
+                print(f"Parsing problem in file {file.get('name')} at the {i} page")
+                pass
+        
+        return document
 
     def _load_file_from_ids(self) -> List[Document]:
         """Load files from a list of IDs."""


### PR DESCRIPTION
Fixing error handling in Google Driver Document Loader.  Some pdf files with invalid character formats will Raise an error in the `extract_text()` function of PyPdf2 interrupting the load of all documents inside a certain folder ID. With this fix the document loader will pass that page and proceed to the next. I also added a print to indicate which file and page of the Google Drive documents has a problem. Specially useful when loading Drive folders with large amounts of files.


#### Before submitting

#### Who can review?

Tag maintainers/contributors who might be interested:
@hwchase17 @eyurtsev

