### PR TITLE
Update web_base.py  _fetch() method For SiteMapLoader

### DIFF
--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -96,7 +96,7 @@ class WebBaseLoader(BaseLoader):
     ) -> str:
         
         # For SiteMap SSL verification
-        if not self.request_kwargs['verify']:
+        if not self.requests_kwargs['verify']:
             connector = aiohttp.TCPConnector(ssl=False)
         else:
             connector = None

--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -96,7 +96,7 @@ class WebBaseLoader(BaseLoader):
     ) -> str:
         
         # For SiteMap SSL verification
-        if not self.requests_kwargs['verify']:
+        if not self.requests_kwargs.get('verify', True):
             connector = aiohttp.TCPConnector(ssl=False)
         else:
             connector = None

--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -94,7 +94,14 @@ class WebBaseLoader(BaseLoader):
     async def _fetch(
         self, url: str, retries: int = 3, cooldown: int = 2, backoff: float = 1.5
     ) -> str:
-        async with aiohttp.ClientSession() as session:
+        
+        # For SiteMap SSL verification
+        if not self.request_kwargs['verify']:
+            connector = aiohttp.TCPConnector(ssl=False)
+        else:
+            connector = None
+            
+        async with aiohttp.ClientSession(connector=connector) as session:
             for i in range(retries):
                 try:
                     async with session.get(

--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -94,13 +94,12 @@ class WebBaseLoader(BaseLoader):
     async def _fetch(
         self, url: str, retries: int = 3, cooldown: int = 2, backoff: float = 1.5
     ) -> str:
-        
         # For SiteMap SSL verification
-        if not self.requests_kwargs.get('verify', True):
+        if not self.requests_kwargs.get("verify", True):
             connector = aiohttp.TCPConnector(ssl=False)
         else:
             connector = None
-            
+
         async with aiohttp.ClientSession(connector=connector) as session:
             for i in range(retries):
                 try:


### PR DESCRIPTION
A must-include for SiteMap Loader to avoid the SSL verification error. Setting the 'verify' to False by ``` sitemap_loader.requests_kwargs = {"verify": False}``` does not bypass the SSL verification in some websites.

There are websites (https:// researchadmin.asu.edu/ sitemap.xml) where setting "verify" to False as shown below would not work:
sitemap_loader.requests_kwargs = {"verify": False} 

We need this merge to tell the Session to use a connector with a specific argument about SSL:
 \# For SiteMap SSL verification
if not self.request_kwargs['verify']:
    connector = aiohttp.TCPConnector(ssl=False)
else:
    connector = None
 
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

Fixes #5483 

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

Tag maintainers/contributors who might be interested:

@hwchase17 
@eyurtsev 
