### PR TITLE
Iterate through filtered file types instead of all listed files

### DIFF
--- a/langchain/document_loaders/googledrive.py
+++ b/langchain/document_loaders/googledrive.py
@@ -216,7 +216,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             _files = files
 
         returns = []
-        for file in files:
+        for file in _files:
             if file["trashed"] and not self.load_trashed_files:
                 continue
             elif file["mimeType"] == "application/vnd.google-apps.document":


### PR DESCRIPTION
# Iterate through filtered file types instead of all listed files

Fixes https://github.com/hwchase17/langchain/issues/6257

https://github.com/hwchase17/langchain/pull/4926 originally added the functionality to filter by file type, storing the filtered files in `_files`

https://github.com/hwchase17/langchain/pull/5220 removed the functionality when adding code to filter trashed files by using the `files` variables instead of the `_files` variable.

This PR simply adds the functionality back by using `_files` again.

#### Who can review?

@hwchase17 - project lead
@eyurtsev