### PR TITLE
Qdrant: Add vectors to already existing collection & static vector size

### DIFF
--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -394,6 +394,8 @@ class Qdrant(VectorStore):
         wal_config: Optional[common_types.WalConfigDiff] = None,
         quantization_config: Optional[common_types.QuantizationConfig] = None,
         init_from: Optional[common_types.InitFrom] = None,
+        recreate_collection: Optional[bool] = True,
+        vector_size: Optional[int] = None,
         **kwargs: Any,
     ) -> Qdrant:
         """Construct Qdrant wrapper from a list of texts.
@@ -475,6 +477,13 @@ class Qdrant(VectorStore):
                 Params for quantization, if None - quantization will be disabled
             init_from:
                 Use data stored in another collection to initialize this collection
+            recreate_collection:
+                Default is True. If True - recreate collection with provided data.
+                Set to False if you want to upsert data to an existing collection
+                Note: collection_name must be provided if recreate_collection is set to False
+            vector_size:
+                Size (dimensions) of the vectors. If not provided, it will be automatically 
+                inferred from the provided embeddings on init of collection
             **kwargs:
                 Additional arguments passed directly into REST client initialization
 
@@ -504,13 +513,6 @@ class Qdrant(VectorStore):
 
         from qdrant_client.http import models as rest
 
-        # Just do a single quick embedding to get vector size
-        partial_embeddings = embedding.embed_documents(texts[:1])
-        vector_size = len(partial_embeddings[0])
-
-        collection_name = collection_name or uuid.uuid4().hex
-        distance_func = distance_func.upper()
-
         client = qdrant_client.QdrantClient(
             location=location,
             url=url,
@@ -526,23 +528,38 @@ class Qdrant(VectorStore):
             **kwargs,
         )
 
-        client.recreate_collection(
-            collection_name=collection_name,
-            vectors_config=rest.VectorParams(
-                size=vector_size,
-                distance=rest.Distance[distance_func],
-            ),
-            shard_number=shard_number,
-            replication_factor=replication_factor,
-            write_consistency_factor=write_consistency_factor,
-            on_disk_payload=on_disk_payload,
-            hnsw_config=hnsw_config,
-            optimizers_config=optimizers_config,
-            wal_config=wal_config,
-            quantization_config=quantization_config,
-            init_from=init_from,
-            timeout=timeout,  # type: ignore[arg-type]
-        )
+        collection_name = collection_name or uuid.uuid4().hex
+        collection_exists = False
+
+        if init_from is None and collection_name is not None:
+            all = client.get_collections()
+            for collection in all.collections:
+                if collection.name == collection_name:
+                    collection_exists = True
+                    break
+
+        if not collection_exists or recreate_collection is True or init_from is not None:
+            if vector_size is None:
+                # Just do a single quick embedding to get vector size
+                partial_embeddings = embedding.embed_documents(texts[:1])
+                vector_size = len(partial_embeddings[0])
+            client.recreate_collection(
+                collection_name=collection_name,
+                vectors_config=rest.VectorParams(
+                    size=vector_size,
+                    distance=rest.Distance[distance_func.upper()],
+                ),
+                shard_number=shard_number,
+                replication_factor=replication_factor,
+                write_consistency_factor=write_consistency_factor,
+                on_disk_payload=on_disk_payload,
+                hnsw_config=hnsw_config,
+                optimizers_config=optimizers_config,
+                wal_config=wal_config,
+                quantization_config=quantization_config,
+                init_from=init_from,
+                timeout=timeout,  # type: ignore[arg-type]
+            )
 
         texts_iterator = iter(texts)
         metadatas_iterator = iter(metadatas or [])


### PR DESCRIPTION
Problem:
Whenever we add vectors to an existing qdrant collection that collection gets deleted and re-created from scratch.
But if we want to add vectors to an existing collection in a later stage, then it's not possible with the current implementation.

This PR solves this issue without breaking the already existing behavior. It adds the ability to add more vectors to an already existing collection via an optional flag. 

In addition to that this PR adds the ability to configure a fixed vector size , eliminating the need to make a quick single embedding just to figure out the vector size.

So this PR introduces the following two flags:

`recreate_collection = Optional[int]`

`vector_size = Optional[bool]`

How this solution works:
1. It checks if collection exists, if not, continue like before this PR (recreate collection)
2. if collection exists, and recreate_collection=False, and init_from=None then do not execute `recreate_collection()`

Before continuing I'd like to hear your feedback and thoughts which is the reason why this PR is in draft and doesn't provide the other required parts (tests, etc), yet.
