### PR TITLE
searx_search: updated tools and doc

### DIFF
--- a/docs/extras/ecosystem/integrations/searx.mdx
+++ b/docs/extras/ecosystem/integrations/searx.mdx
@@ -67,4 +67,24 @@ tools = load_tools(["searx-search-results-json"],
                     num_results=5)
 ```
 
-For more information on tools, see [this page](/docs/modules/agents/tools/getting_started.md)
+#### Quickly creating tools
+
+This examples showcases a quick way to create multiple tools from the same
+wrapper.
+
+```python
+from langchain.tools.searx_search.tool import SearxSearchResults
+
+wrapper = SearxSearchWrapper(searx_host="**")
+github_tool = SearxSearchResults(name="Github", wrapper=wrapper,
+                            kwargs = {
+                                "engines": ["github"],
+                                })
+
+arxiv_tool = SearxSearchResults(name="Arxiv", wrapper=wrapper,
+                            kwargs = {
+                                "engines": ["arxiv"]
+                                })
+```
+
+For more information on tools, see [this page](../modules/agents/tools/getting_started.md)

--- a/langchain/tools/searx_search/tool.py
+++ b/langchain/tools/searx_search/tool.py
@@ -1,5 +1,5 @@
 """Tool for the SearxNG search API."""
-from typing import Optional
+from typing import Optional, Any
 
 from pydantic import Extra
 
@@ -7,7 +7,7 @@ from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
-from langchain.tools.base import BaseTool
+from langchain.tools.base import BaseTool, Field
 from langchain.utilities.searx_search import SearxSearchWrapper
 
 
@@ -21,6 +21,7 @@ class SearxSearchRun(BaseTool):
         "Input should be a search query."
     )
     wrapper: SearxSearchWrapper
+    kwargs: dict[Any, Any] = Field(default_factory=dict)
 
     def _run(
         self,
@@ -28,7 +29,7 @@ class SearxSearchRun(BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool."""
-        return self.wrapper.run(query)
+        return self.wrapper.run(query, **self.kwargs)
 
     async def _arun(
         self,
@@ -36,7 +37,7 @@ class SearxSearchRun(BaseTool):
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool asynchronously."""
-        return await self.wrapper.arun(query)
+        return await self.wrapper.arun(query, **self.kwargs)
 
 
 class SearxSearchResults(BaseTool):
@@ -50,6 +51,7 @@ class SearxSearchResults(BaseTool):
     )
     wrapper: SearxSearchWrapper
     num_results: int = 4
+    kwargs: dict[Any, Any] = Field(default_factory=dict)
 
     class Config:
         """Pydantic config."""
@@ -62,7 +64,7 @@ class SearxSearchResults(BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool."""
-        return str(self.wrapper.results(query, self.num_results))
+        return str(self.wrapper.results(query, self.num_results, **self.kwargs))
 
     async def _arun(
         self,
@@ -70,4 +72,4 @@ class SearxSearchResults(BaseTool):
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool asynchronously."""
-        return (await self.wrapper.aresults(query, self.num_results)).__str__()
+        return (await self.wrapper.aresults(query, self.num_results, **self.kwargs)).__str__()

--- a/langchain/tools/searx_search/tool.py
+++ b/langchain/tools/searx_search/tool.py
@@ -1,5 +1,5 @@
 """Tool for the SearxNG search API."""
-from typing import Optional, Any
+from typing import Optional
 
 from pydantic import Extra
 
@@ -21,7 +21,7 @@ class SearxSearchRun(BaseTool):
         "Input should be a search query."
     )
     wrapper: SearxSearchWrapper
-    kwargs: dict[Any, Any] = Field(default_factory=dict)
+    kwargs: dict = Field(default_factory=dict)
 
     def _run(
         self,
@@ -51,7 +51,7 @@ class SearxSearchResults(BaseTool):
     )
     wrapper: SearxSearchWrapper
     num_results: int = 4
-    kwargs: dict[Any, Any] = Field(default_factory=dict)
+    kwargs: dict = Field(default_factory=dict)
 
     class Config:
         """Pydantic config."""
@@ -72,4 +72,6 @@ class SearxSearchResults(BaseTool):
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool asynchronously."""
-        return (await self.wrapper.aresults(query, self.num_results, **self.kwargs)).__str__()
+        return (
+            await self.wrapper.aresults(query, self.num_results, **self.kwargs)
+        ).__str__()

--- a/langchain/utilities/searx_search.py
+++ b/langchain/utilities/searx_search.py
@@ -120,7 +120,8 @@ Public searxNG instances often use a rate limiter for API usage, so you might wa
 use a self hosted instance and disable the rate limiter.
 
 If you are self-hosting an instance you can customize the rate limiter for your
-own network as described `here <https://github.com/searxng/searxng/pull/2129>`_.
+own network as described
+`here <https://docs.searxng.org/src/searx.botdetection.html#limiter-src>`_.
 
 
 For a list of public SearxNG instances see https://searx.space/


### PR DESCRIPTION
- Allows using the  same wrapper to create multiple tools
```python
wrapper = SearxSearchWrapper(searx_host="**")
github_tool = SearxSearchResults(name="Github",
                            wrapper=wrapper,
                            kwargs = {
                                "engines": ["github"],
                                })

arxiv_tool = SearxSearchResults(name="Arxiv",
                            wrapper=wrapper,
                            kwargs = {
                                "engines": ["arxiv"]
                                })
```

- Updated link to searx documentation

  Agents / Tools / Toolkits
  - @hwchase17


