### PR TITLE
refactor confluence loader to reduce http requests

### DIFF
--- a/libs/langchain/langchain/document_loaders/confluence.py
+++ b/libs/langchain/langchain/document_loaders/confluence.py
@@ -273,7 +273,7 @@ class ConfluenceLoader(BaseLoader):
         docs = []
 
         expands = [content_format.value]
-        if not include_archived_content:
+        if not include_restricted_content:
             # expand restrictions for `self.is_public_page()`
             expands.append("restrictions.read.restrictions.user")
             expands.append("restrictions.read.restrictions.group")

--- a/libs/langchain/langchain/document_loaders/confluence.py
+++ b/libs/langchain/langchain/document_loaders/confluence.py
@@ -344,9 +344,7 @@ class ConfluenceLoader(BaseLoader):
                     ),
                     before_sleep=before_sleep_log(logger, logging.WARNING),
                 )(self.confluence.get_page_by_id)
-                page = get_page(
-                    page_id=page_id, expand=",".join([*expands, "version"])
-                )
+                page = get_page(page_id=page_id, expand=",".join([*expands, "version"]))
                 if not include_restricted_content and not self.is_public_page(page):
                     continue
                 doc = self.process_page(

--- a/libs/langchain/langchain/document_loaders/confluence.py
+++ b/libs/langchain/langchain/document_loaders/confluence.py
@@ -418,7 +418,7 @@ class ConfluenceLoader(BaseLoader):
 
     def is_public_page(self, page: dict) -> bool:
         """Check if a page is publicly accessible."""
-        restrictions = page['restrictions']
+        restrictions = page["restrictions"]
 
         return (
             page["status"] == "current"

--- a/libs/langchain/tests/unit_tests/document_loaders/test_confluence.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_confluence.py
@@ -111,7 +111,7 @@ class TestConfluenceLoader:
         documents = confluence_loader.load(page_ids=mock_page_ids)
 
         assert mock_confluence.get_page_by_id.call_count == 2
-        assert mock_confluence.get_all_restrictions_for_content.call_count == 2
+        assert mock_confluence.get_all_restrictions_for_content.call_count == 0
 
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
@@ -214,6 +214,7 @@ class TestConfluenceLoader:
                 "editui": f"/pages/resumedraft.action?draftId={page_id}",
                 "webui": f"/spaces/{self.MOCK_SPACE_KEY}/overview",
             },
+            "restrictions": self._get_mock_page_restrictions(page_id),
         }
 
     def _get_mock_page_restrictions(self, page_id: str) -> Dict:


### PR DESCRIPTION
`ConfluenceLoader` fetches the restrictions for each page in `is_public_page()` without backoff retries. This can cause the `requests.exceptions.HTTPError: Rate limit exceeded.` error.

Expand the restrictions of pages when getting page contents to reduce the http requests.

#### Who can review?

Tag maintainers/contributors who might be interested:@eyurtsev
