### PR TITLE
feat: add similarity_search_by_vector_with_relevance_scores to Pineco…

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -113,28 +113,9 @@ class Pinecone(VectorStore):
         Returns:
             List of Documents most similar to the query and score for each
         """
-        if namespace is None:
-            namespace = self._namespace
-        query_obj = self._embedding_function(query)
-        docs = []
-        results = self._index.query(
-            [query_obj],
-            top_k=k,
-            include_metadata=True,
-            namespace=namespace,
-            filter=filter,
+        return self.similarity_search_by_vector_with_relevance_scores(
+            [self._embedding_function(query)], k, filter, namespace
         )
-        for res in results["matches"]:
-            metadata = res["metadata"]
-            if self._text_key in metadata:
-                text = metadata.pop(self._text_key)
-                score = res["score"]
-                docs.append((Document(page_content=text, metadata=metadata), score))
-            else:
-                logger.warning(
-                    f"Found document with no `{self._text_key}` key. Skipping."
-                )
-        return docs
     
     def similarity_search_by_vector_with_relevance_scores(
         self,


### PR DESCRIPTION
Following on from #6056, the underlying langchain VectorStore class doesn't have a method called 
`similarity_search_by_vector_with_relevance_scores` to allow getting a handle on the relevance scores when querying by vector, similarly to how it is done with `similarity_search` and `similarity_search_with_relevance_scores`.

Since adding such an abstract method to the base `VectorStore` class would require implementing it for all `VectorStores`, I haven't done that here. As a baby step towards the larger task, I have just added `similarity_search_by_vector_with_relevance_scores` to the `Pinecone` vector store.

#### Who can review?

Tag maintainers/contributors who might be interested:

VectorStores / Retrievers / Memory
  - @dev2049
