### PR TITLE
Add support to pinecone vectorstore for similarity_score_threshold

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -95,17 +95,13 @@ class Pinecone(VectorStore):
         self._index.upsert(vectors=docs, namespace=namespace, batch_size=batch_size)
         return ids
 
-    def similarity_search_with_relevance_scores(
+    def _similarity_search_with_relevance_scores(
         self,
         query: str,
         k: int = 4,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        return [
-            a
-            for a in self.similarity_search_with_score(query, k=k)
-            if a[1] > kwargs["score_threshold"]
-        ]
+        return self.similarity_search_with_score(query, k=k)
 
     def similarity_search_with_score(
         self,

--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -95,6 +95,14 @@ class Pinecone(VectorStore):
         self._index.upsert(vectors=docs, namespace=namespace, batch_size=batch_size)
         return ids
 
+    def similarity_search_with_relevance_scores(
+            self,
+            query: str,
+            k: int = 4,
+            **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        return [a for a in self.similarity_search_with_score(query, k=k) if a[1] > kwargs["score_threshold"]]
+
     def similarity_search_with_score(
         self,
         query: str,

--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -96,12 +96,16 @@ class Pinecone(VectorStore):
         return ids
 
     def similarity_search_with_relevance_scores(
-            self,
-            query: str,
-            k: int = 4,
-            **kwargs: Any,
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        return [a for a in self.similarity_search_with_score(query, k=k) if a[1] > kwargs["score_threshold"]]
+        return [
+            a
+            for a in self.similarity_search_with_score(query, k=k)
+            if a[1] > kwargs["score_threshold"]
+        ]
 
     def similarity_search_with_score(
         self,

--- a/tests/integration_tests/vectorstores/test_pinecone.py
+++ b/tests/integration_tests/vectorstores/test_pinecone.py
@@ -207,9 +207,10 @@ class TestPinecone:
         index_stats = self.index.describe_index_stats()
         assert index_stats["namespaces"][index_name]["vector_count"] == len(texts) * 2
 
-
     @pytest.mark.vcr()
-    def test_from_texts_with_relevance_score_filtering(self, embedding_openai: OpenAIEmbeddings) -> None:
+    def test_from_texts_with_relevance_score_filtering(
+        self, embedding_openai: OpenAIEmbeddings
+    ) -> None:
         """Test end to end construction and search with scores and IDs."""
         texts = ["foo", "bar", "baz"]
         metadatas = [{"page": i} for i in range(len(texts))]

--- a/tests/integration_tests/vectorstores/test_pinecone.py
+++ b/tests/integration_tests/vectorstores/test_pinecone.py
@@ -206,3 +206,22 @@ class TestPinecone:
         )
         index_stats = self.index.describe_index_stats()
         assert index_stats["namespaces"][index_name]["vector_count"] == len(texts) * 2
+
+
+    @pytest.mark.vcr()
+    def test_from_texts_with_relevance_score_filtering(self, embedding_openai: OpenAIEmbeddings) -> None:
+        """Test end to end construction and search with scores and IDs."""
+        texts = ["foo", "bar", "baz"]
+        metadatas = [{"page": i} for i in range(len(texts))]
+        docsearch = Pinecone.from_texts(
+            texts,
+            embedding_openai,
+            index_name=index_name,
+            metadatas=metadatas,
+            namespace=namespace_name,
+        )
+        output = docsearch.similarity_search_with_relevance_scores(
+            "foo", k=3, namespace=namespace_name, score_threshold=0.9
+        )
+
+        assert output[0][0] == Document(page_content="foo", metadata={"page": 0.0})


### PR DESCRIPTION
At the moment pinecone vectorStore does not support similarity_score_threshold search type in RetrievalQA. 
It extends VectorStore. VectorStore has a function called similarity_search_with_relevance_scores. This function calls the function _similarity_search_with_relevance_scores which is expected to be implemented by child classes. 
However this is not implemented in pinecone. 

In this PR I implement it. After this PR is merged similarity_score_threshold search type in RetrievalQA works perfect

I have also included a test. 

#### Who can review?

Tag maintainers/contributors who might be interested:

@dev2049

