### PR TITLE
Enabled Azure Active Directory token-based auth access to OpenAI completions

### DIFF
--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -621,10 +621,7 @@ class AzureOpenAI(BaseOpenAI):
             "OPENAI_API_VERSION",
         )
         values["openai_api_type"] = get_from_dict_or_env(
-            values,
-            "openai_api_type",
-            "OPENAI_API_TYPE",
-            "azure"
+            values, "openai_api_type", "OPENAI_API_TYPE", "azure"
         )
         return values
 

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -610,7 +610,7 @@ class AzureOpenAI(BaseOpenAI):
 
     deployment_name: str = ""
     """Deployment name to use."""
-    openai_api_type: str = "azure"
+    openai_api_type: str = ""
     openai_api_version: str = ""
 
     @root_validator()

--- a/langchain/llms/openai.py
+++ b/langchain/llms/openai.py
@@ -624,6 +624,7 @@ class AzureOpenAI(BaseOpenAI):
             values,
             "openai_api_type",
             "OPENAI_API_TYPE",
+            "azure"
         )
         return values
 


### PR DESCRIPTION
With AzureOpenAI openai_api_type defaulted to "azure" the logic in utils' get_from_dict_or_env() function triggered by the root validator never looks to environment for the user's runtime openai_api_type values. This inhibits folks using token-based auth, or really any auth model other than "azure."

By removing the "default" value, this allows environment variables to be pulled at runtime for the openai_api_type and thus enables the other api_types which are expected to work.