### PR TITLE
Add ignore vercel preview script

### DIFF
--- a/docs/docs_skeleton/ignore_build.sh
+++ b/docs/docs_skeleton/ignore_build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ $VERCEL_GIT_COMMIT_REF = __docs__* ]] ; then
+  # Proceed with the build
+	echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
skip building preview of docs for anything branch that doesn't start with `__docs__`. will eventually update to look at code diff directories but patching for now