### PR TITLE
fix link of callbacks on modules page

### DIFF
--- a/docs/docs_skeleton/docs/modules/index.mdx
+++ b/docs/docs_skeleton/docs/modules/index.mdx
@@ -16,5 +16,5 @@ Construct sequences of calls
 Let chains choose which tools to use given high-level directives
 #### [Memory](/docs/modules/memory/)
 Persist application state between runs of a chain
-#### [Callbacks](/docs/modules/callbacks/getting_started/)
+#### [Callbacks](/docs/modules/callbacks/)
 Log and stream intermediate steps of any chain


### PR DESCRIPTION
Since [Callbacks](https://python.langchain.com/docs/modules/callbacks/getting_started/) on [Modules](https://python.langchain.com/docs/modules/) went to a "Page Not Found".