### PR TITLE
fix links to prompt templates and example selectors

### DIFF
--- a/docs/docs_skeleton/docs/modules/model_io/prompts/index.mdx
+++ b/docs/docs_skeleton/docs/modules/model_io/prompts/index.mdx
@@ -8,5 +8,5 @@ A **prompt** refers to the input to the model.
 This input is often constructed from multiple components.
 LangChain provides several classes and functions to make constructing and working with prompts easy.
 
-- [Prompt templates](/docs/modules/prompts/prompt_templates/): Parametrize model inputs
-- [Example selectors](/docs/modules/prompts/example_selectors/): Dynamically select examples to include in prompts
+- [Prompt templates](/docs/modules/model_io/prompts/prompt_templates/): Parametrize model inputs
+- [Example selectors](/docs/modules/model_io/prompts/example_selectors/): Dynamically select examples to include in prompts


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes # 
links to prompt templates and example selectors on the [Prompts](https://python.langchain.com/docs/modules/model_io/prompts/) page are invalid.

#### Before submitting
Just a small note that I tried to run `make docs_clean` and other related commands before PR written [here](https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md#build-documentation-locally), it gives me an error:
```bash
langchain % make docs_clean
Traceback (most recent call last):
  File "/Users/masafumi/Downloads/langchain/.venv/bin/make", line 5, in <module>
    from scripts.proto import main
ModuleNotFoundError: No module named 'scripts'
make: *** [docs_clean] Error 1
# Poetry (version 1.5.1)
# Python 3.9.13
```
I couldn't figure out how to fix this, so I didn't run those command. But links should work.

#### Who can review?

Tag maintainers/contributors who might be interested:
@hwchase17

Similar issue #6323