### PR TITLE
Modified PromptLayerChatOpenAI class to support function call

### DIFF
--- a/langchain/chat_models/promptlayer_openai.py
+++ b/langchain/chat_models/promptlayer_openai.py
@@ -48,7 +48,7 @@ class PromptLayerChatOpenAI(ChatOpenAI):
         from promptlayer.utils import get_api_key, promptlayer_api_request
 
         request_start_time = datetime.datetime.now().timestamp()
-        generated_responses = super()._generate(messages, stop, run_manager)
+        generated_responses = super()._generate(messages, stop, run_manager, **kwargs)
         request_end_time = datetime.datetime.now().timestamp()
         message_dicts, params = super()._create_message_dicts(messages, stop)
         for i, generation in enumerate(generated_responses.generations):


### PR DESCRIPTION
Introduction of newest function calling feature doesn't work properly with PromptLayerChatOpenAI model since on the `_generate` method, functions argument are not even getting passed to the `ChatOpenAI` base class which results in empty `ai_message.additional_kwargs` 

Fixes  #6365


  - @hwchase17
  - @agola11
