### PR TITLE
Fixed PGVector issue when SQLAlchemy is the driver

### DIFF
--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -5,6 +5,7 @@ import enum
 import logging
 import uuid
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+from urllib.parse import urlencode
 
 import sqlalchemy
 from pgvector.sqlalchemy import Vector
@@ -593,6 +594,9 @@ class PGVector(VectorStore):
         database: str,
         user: str,
         password: str,
+        **kwargs
     ) -> str:
         """Return connection string from database parameters."""
-        return f"postgresql+{driver}://{user}:{password}@{host}:{port}/{database}"
+        query_params = f"?{urlencode(kwargs)}" if kwargs else ""
+        driver = driver if driver == "sqlalchemy" else f"+{driver}"
+        return f"postgresql{driver}://{user}:{password}@{host}:{port}/{database}{query_params}"

--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -594,9 +594,9 @@ class PGVector(VectorStore):
         database: str,
         user: str,
         password: str,
-        **kwargs
+        query_params: dict = {}
     ) -> str:
         """Return connection string from database parameters."""
-        query_params = f"?{urlencode(kwargs)}" if kwargs else ""
+        query_params = f"?{urlencode(query_params)}" if query_params else ""
         driver = driver if driver == "sqlalchemy" else f"+{driver}"
         return f"postgresql{driver}://{user}:{password}@{host}:{port}/{database}{query_params}"


### PR DESCRIPTION
Using SQLAlchemy as the driver for PGVector's `connection_string_from_db_params` function fails with the following error:

```
NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgresql.sqlalchemy
```

This PR removes the `+{driver}` when `sqlalchemy` is used as the driver.

Additionally, this PR also adds support for query params in the connection string via the optional `query_params` param. 

Example:

```python
CONNECTION_STRING = PGVector.connection_string_from_db_params(
    driver="sqlalchemy", 
    host="dbhost.com",
    port=5432,
    database="dbname",
    user="user",
    password="pass",
    query_params={ # ← this is new
        "sslmode": "require"
    }
)'

print(CONNECTION_STRING)

# 'postgresql://user:pass@dbhost.com:5432/dbname?sslmode=require', 
```

Tested on Postgres 14, 15, and Supabase

@dev2049 ☝️