### PR TITLE
add FunctionMessage support to `_convert_dict_to_message()` in OpenAI chat model

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -106,6 +106,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         return AIMessage(content=content, additional_kwargs=additional_kwargs)
     elif role == "system":
         return SystemMessage(content=_dict["content"])
+    elif role == "function":
+        return FunctionMessage(content=_dict["content"], name=_dict["name"])
     else:
         return ChatMessage(content=_dict["content"], role=role)
 

--- a/tests/unit_tests/chat_models/test_openai.py
+++ b/tests/unit_tests/chat_models/test_openai.py
@@ -13,13 +13,13 @@ from langchain.schema import (
 def test_function_message_dict_to_function_message() -> None:
     content = json.dumps({"result": "Example #1"})
     name = "test_function"
-    result = _convert_dict_to_message({
-        "role": "function",
-        "name": name,
-        "content": content,
-    })
+    result = _convert_dict_to_message(
+        {
+            "role": "function",
+            "name": name,
+            "content": content,
+        }
+    )
     assert isinstance(result, FunctionMessage)
     assert result.name == name
     assert result.content == content
-
-

--- a/tests/unit_tests/chat_models/test_openai.py
+++ b/tests/unit_tests/chat_models/test_openai.py
@@ -1,0 +1,25 @@
+"""Test OpenAI Chat API wrapper."""
+
+import json
+
+from langchain.chat_models.openai import (
+    _convert_dict_to_message,
+)
+from langchain.schema import (
+    FunctionMessage,
+)
+
+
+def test_function_message_dict_to_function_message() -> None:
+    content = json.dumps({"result": "Example #1"})
+    name = "test_function"
+    result = _convert_dict_to_message({
+        "role": "function",
+        "name": name,
+        "content": content,
+    })
+    assert isinstance(result, FunctionMessage)
+    assert result.name == name
+    assert result.content == content
+
+


### PR DESCRIPTION
Already supported in the reverse operation in `_convert_message_to_dict()`, this just provides parity.

@hwchase17
@agola11

