### PR TITLE
Update serpapi.py Support baidu list type answer_box

### DIFF
--- a/langchain/utilities/serpapi.py
+++ b/langchain/utilities/serpapi.py
@@ -129,6 +129,8 @@ class SerpAPIWrapper(BaseModel):
         """Process response from SerpAPI."""
         if "error" in res.keys():
             raise ValueError(f"Got error from SerpAPI: {res['error']}")
+        if "answer_box" in res.keys() and type(res["answer_box"]) == list:
+            res["answer_box"] = res["answer_box"][0]
         if "answer_box" in res.keys() and "answer" in res["answer_box"].keys():
             toret = res["answer_box"]["answer"]
         elif "answer_box" in res.keys() and "snippet" in res["answer_box"].keys():


### PR DESCRIPTION
Support baidu list type answer_box

From [this document](https://serpapi.com/baidu-answer-box), we can know that the answer_box attribute returned by the Baidu interface is a list, and the list contains only one Object, but an error will occur when the current code is executed.

So when answer_box is a list, we reset res["answer_box"] so that the code can execute successfully.