### PR TITLE
fix: llm caching for replicate

### DIFF
--- a/langchain/llms/replicate.py
+++ b/langchain/llms/replicate.py
@@ -72,6 +72,7 @@ class Replicate(LLM):
     def _identifying_params(self) -> Mapping[str, Any]:
         """Get the identifying parameters."""
         return {
+            "model": self.model,
             **{"model_kwargs": self.model_kwargs},
         }
 


### PR DESCRIPTION
Caching wasn't accounting for which model was used so a result for the first executed model would return for the same prompt on a different model.

This was because `Replicate._identifying_params` did not include the `model` parameter.

FYI
- @cbh123
- @hwchase17
- @agola11
