### PR TITLE
Fix broken links in autonomous agents docs

### DIFF
--- a/docs/extras/use_cases/autonomous_agents/index.mdx
+++ b/docs/extras/use_cases/autonomous_agents/index.mdx
@@ -11,13 +11,13 @@ usage of LangChain's collection of tools.
 
 ## Baby AGI ([Original Repo](https://github.com/yoheinakajima/babyagi))
 
-- [Baby AGI](./baby_agi.html): a notebook implementing BabyAGI as LLM Chains
-- [Baby AGI with Tools](./baby_agi_with_agent.html): building off the above notebook, this example substitutes in an agent with tools as the execution tools, allowing it to actually take actions.
+- [Baby AGI](./autonomous_agents/baby_agi.html): a notebook implementing BabyAGI as LLM Chains
+- [Baby AGI with Tools](./autonomous_agents/baby_agi_with_agent.html): building off the above notebook, this example substitutes in an agent with tools as the execution tools, allowing it to actually take actions.
 
 
 ## AutoGPT ([Original Repo](https://github.com/Significant-Gravitas/Auto-GPT))
-- [AutoGPT](./autogpt.html): a notebook implementing AutoGPT in LangChain primitives
-- [WebSearch Research Assistant](./marathon_times.html): a notebook showing how to use AutoGPT plus specific tools to act as research assistant that can use the web.
+- [AutoGPT](./autonomous_agents/autogpt.html): a notebook implementing AutoGPT in LangChain primitives
+- [WebSearch Research Assistant](./autonomous_agents/marathon_times.html): a notebook showing how to use AutoGPT plus specific tools to act as research assistant that can use the web.
 
 ## MetaPrompt ([Original Repo](https://github.com/ngoodman/metaprompt))
-- [Meta-Prompt](./meta_prompt.html): a notebook implementing Meta-Prompt in LangChain primitives
+- [Meta-Prompt](./autonomous_agents/meta_prompt.html): a notebook implementing Meta-Prompt in LangChain primitives


### PR DESCRIPTION
Fixes broken links here:  
https://python.langchain.com/docs/use_cases/autonomous_agents.html

#### Who can review?

Tag maintainers/contributors who might be interested:

  Agents / Tools / Toolkits
  - @hwchase17