### PR TITLE
add UnstructuredRSTLoader

### DIFF
--- a/langchain/document_loaders/rst.py
+++ b/langchain/document_loaders/rst.py
@@ -1,0 +1,35 @@
+import os
+from typing import List
+
+from langchain.docstore.document import Document
+from langchain.document_loaders.base import BaseLoader
+
+
+class UnstructuredRSTLoader(BaseLoader):
+    """Loads .rst file and convert it into a Document"""
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+
+    def load(self) -> List[Document]:
+        try:
+            from docutils import core
+        except ImportError:
+            raise ImportError(
+                "Could not import 'core' from docutils Python package. "
+                "Please install it with `pip install docutils`."
+            )
+
+        with open(self.file_path, "r") as file:
+            data = file.read()
+
+        html = core.publish_parts(data, writer_name="html")["html_body"]
+
+        metadata = {
+            "source": self.file_path,
+            "file_path": self.file_path,
+            "file_name": os.path.basename(self.file_path),
+            "file_type": ".rst",
+        }
+        doc = Document(page_content=html, metadata=metadata)
+        return [doc]

--- a/tests/unit_tests/document_loaders/test_docs/unstructured_rst_loader/valid.rst
+++ b/tests/unit_tests/document_loaders/test_docs/unstructured_rst_loader/valid.rst
@@ -1,0 +1,8 @@
+=========
+My Title
+=========
+
+This is a paragraph.
+
+- And this
+- is a list

--- a/tests/unit_tests/document_loaders/test_rst.py
+++ b/tests/unit_tests/document_loaders/test_rst.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from langchain.document_loaders.rst import UnstructuredRSTLoader
+
+PARENT_DIR = Path(__file__).parent / "test_docs" / "unstructured_rst_loader"
+
+
+@pytest.mark.requires("docutils")
+def test_load_valid_file() -> None:
+    loader = UnstructuredRSTLoader((PARENT_DIR / "valid.rst").as_posix())
+    documents = loader.load()
+    assert len(documents) == 1
+    assert len(documents[0].page_content) != 0
+
+
+@pytest.mark.requires("docutils")
+def test_empty_file() -> None:
+    loader = UnstructuredRSTLoader((PARENT_DIR / "empty.rst").as_posix())
+    documents = loader.load()
+    assert len(documents) == 1
+    assert len(documents[0].page_content) == 0


### PR DESCRIPTION
This change loads an .rst file and converts it into a langchain Document

It requires docutils, but only when the class is initialized. I also included an import error to follow best practices.

I also added tests but I tried running any test (not even mine) I always got this error so I will leave that to someone more experienced with tests than I am:
argparse.ArgumentError: argument --snapshot-update: conflicting option string: --snapshot-update
make: *** [Makefile:41: test] Error 1

@eyurtsev 