### PR TITLE
Motorhead memory updates, including delete session method and ability to save intermediate_steps

### DIFF
--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -21,7 +21,7 @@ class BaseChatMemory(BaseMemory, ABC):
     ) -> Tuple[str, str]:
         
         if "intermediate_steps" in outputs.keys():
-            intermediate_steps = outputs[intermediate_steps]
+            intermediate_steps = outputs["intermediate_steps"]
             outputs.pop("intermediate_steps")
             self.intermediate_steps = intermediate_steps
 

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import Any, Dict, Optional, Tuple
 
 from pydantic import Field
-
+import json
 from langchain.memory.chat_message_histories.in_memory import ChatMessageHistory
 from langchain.memory.utils import get_prompt_input_key
 from langchain.schema import BaseChatMessageHistory, BaseMemory
@@ -43,7 +43,7 @@ class BaseChatMemory(BaseMemory, ABC):
         self.chat_memory.add_user_message(input_str)
         self.chat_memory.add_ai_message(output_str)
         if self.intermediate_steps:
-            self.chat_memory.add_agent_message(self.intermediate_steps)
+            self.chat_memory.add_agent_message(json.dumps(self.intermediate_steps))
 
     def clear(self) -> None:
         """Clear memory contents."""

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -14,6 +14,7 @@ class BaseChatMemory(BaseMemory, ABC):
     output_key: Optional[str] = None
     intermediate_steps_key: Optional[str] = None
     return_messages: bool = False
+    intermediate_steps: Optional[str] = None
 
     def _get_input_output(
         self, inputs: Dict[str, Any], outputs: Dict[str, str]

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -43,7 +43,7 @@ class BaseChatMemory(BaseMemory, ABC):
         self.chat_memory.add_user_message(input_str)
         self.chat_memory.add_ai_message(output_str)
         if self.intermediate_steps:
-            self.chat_memory.add_agent_message(json.dumps(self.intermediate_steps))
+            self.chat_memory.add_agent_message(json.dumps([x[0].to_dict() for x in self.intermediate_steps]))
 
     def clear(self) -> None:
         """Clear memory contents."""

--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -8,7 +8,7 @@ from langchain.schema import get_buffer_string
 MANAGED_URL = "https://api.getmetal.io/v1/motorhead"
 # LOCAL_URL = "http://localhost:8080"
 
-
+MotorheadMemory()
 class MotorheadMemory(BaseChatMemory):
     url: str = MANAGED_URL
     timeout = 3000
@@ -81,8 +81,8 @@ class MotorheadMemory(BaseChatMemory):
                     {"role": "AI", "content": f"{output_str}"},
                 ]
         if self.intermediate_steps:
-            message = message + {"role": "Agent", "content": f"{self.intermediate_steps}"}
-            
+            message = message + [{"role": "Agent", "content": f"{self.intermediate_steps}"}]
+
         requests.post(
             f"{self.url}/sessions/{self.session_id}/memory",
             timeout=self.timeout,

--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -58,7 +58,7 @@ class MotorheadMemory(BaseChatMemory):
                 self.chat_memory.add_ai_message(message["content"])
             if message["role"] == "Agent":
                 self.chat_memory.add_agent_message(message["content"])
-            else:
+            if message["role"] == "Human":
                 self.chat_memory.add_user_message(message["content"])
 
         if context and context != "NONE":

--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -8,7 +8,7 @@ from langchain.schema import get_buffer_string
 MANAGED_URL = "https://api.getmetal.io/v1/motorhead"
 # LOCAL_URL = "http://localhost:8080"
 
-)
+
 class MotorheadMemory(BaseChatMemory):
     url: str = MANAGED_URL
     timeout = 3000

--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -8,7 +8,7 @@ from langchain.schema import get_buffer_string
 MANAGED_URL = "https://api.getmetal.io/v1/motorhead"
 # LOCAL_URL = "http://localhost:8080"
 
-MotorheadMemory()
+)
 class MotorheadMemory(BaseChatMemory):
     url: str = MANAGED_URL
     timeout = 3000

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -59,6 +59,13 @@ class AgentAction:
     tool_input: Union[str, dict]
     log: str
 
+    def to_dict(self):
+        return {
+            "tool": self.tool,
+            "tool_input": self.tool_input,
+            "log": self.log,
+        }
+
 
 class AgentFinish(NamedTuple):
     """Agent's return value."""

--- a/langchain/schema.py
+++ b/langchain/schema.py
@@ -24,7 +24,7 @@ RUN_KEY = "__run"
 
 
 def get_buffer_string(
-    messages: List[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
+    messages: List[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI", agent_prefix: str = "Agent"
 ) -> str:
     """Get buffer string of messages."""
     string_messages = []
@@ -33,6 +33,8 @@ def get_buffer_string(
             role = human_prefix
         elif isinstance(m, AIMessage):
             role = ai_prefix
+        elif isinstance(m, AgentMessage):
+            role = agent_prefix
         elif isinstance(m, SystemMessage):
             role = "System"
         elif isinstance(m, FunctionMessage):
@@ -110,6 +112,15 @@ class AIMessage(BaseMessage):
         """Type of the message, used for serialization."""
         return "ai"
 
+class AgentMessage(BaseMessage):
+    """Type of message that is spoken by the Agent."""
+
+    example: bool = False
+
+    @property
+    def type(self) -> str:
+        """Type of the message, used for serialization."""
+        return "agent"
 
 class SystemMessage(BaseMessage):
     """Type of message that is a system message."""
@@ -290,6 +301,10 @@ class BaseChatMessageHistory(ABC):
     def add_ai_message(self, message: str) -> None:
         """Add an AI message to the store"""
         self.add_message(AIMessage(content=message))
+    
+    def add_agent_message(self, message: str) -> None:
+        """Add an Agent message to the store"""
+        self.add_message(AgentMessage(content=message))
 
     def add_message(self, message: BaseMessage) -> None:
         """Add a self-created message to the store"""


### PR DESCRIPTION
A few small updates made in this PR, all related to memory, with a focus on motorhead for now:

* Delete session method was missing, so I added one in
* Saving intermediate_steps into memory was not permitted, so I added it as a property to the BaseChatMemory so that it doesn't conflict with the return statements of _get_input_output
* I added a new type in the schema, called AgentMessage, which is responsible for creating the intermediate_steps
* I added a to_dict() method to AgentAction to enable serialization.