### PR TITLE
docs: commented out `editUrl` option

### DIFF
--- a/docs/docs_skeleton/docusaurus.config.js
+++ b/docs/docs_skeleton/docusaurus.config.js
@@ -87,7 +87,6 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-//          editUrl: "https://github.com/hwchase17/langchain/edit/master/docs/",
           remarkPlugins: [
             [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           ],

--- a/docs/docs_skeleton/docusaurus.config.js
+++ b/docs/docs_skeleton/docusaurus.config.js
@@ -87,7 +87,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/hwchase17/langchain/edit/master/docs/",
+//          editUrl: "https://github.com/hwchase17/langchain/edit/master/docs/",
           remarkPlugins: [
             [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           ],


### PR DESCRIPTION
docs: commented out the `editUrl` option

This removes the “Edit this page” link at the end of pages. See this link on this [page](https://python.langchain.com/docs/modules/data_connection/retrievers/), for example.

This link does not work.

New refactoring makes the docs structure the "hand-make" structure. The compiled pages do not map directly to the original page files. There should be a manually supported dictionary to map pages which is not here now.

  - @hwchase17
  - @dev2049

