### PR TITLE
Allow PyPDFLoader to restrict page range loaded

### DIFF
--- a/docs/snippets/modules/data_connection/document_loaders/how_to/pdf.mdx
+++ b/docs/snippets/modules/data_connection/document_loaders/how_to/pdf.mdx
@@ -1,6 +1,6 @@
 ## Using PyPDF
 
-Load PDF using `pypdf` into array of documents, where each document contains the page content and metadata with `page` number.
+Load PDF using `pypdf` into array of documents, where each document contains the page content and metadata with `page` number. Use `start_page` and `end_page` to limit the page range imported.
 
 
 ```bash

--- a/langchain/document_loaders/pdf.py
+++ b/langchain/document_loaders/pdf.py
@@ -100,7 +100,12 @@ class PyPDFLoader(BasePDFLoader):
     Loader also stores page numbers in metadatas.
     """
 
-    def __init__(self, file_path: str) -> None:
+    def __init__(
+        self,
+        file_path: str,
+        start_page: Optional[int] = None,
+        end_page: Optional[int] = None,
+    ) -> None:
         """Initialize with file path."""
         try:
             import pypdf  # noqa:F401
@@ -109,6 +114,8 @@ class PyPDFLoader(BasePDFLoader):
                 "pypdf package not found, please install it with " "`pip install pypdf`"
             )
         self.parser = PyPDFParser()
+        self.start_page = start_page
+        self.end_page = end_page
         super().__init__(file_path)
 
     def load(self) -> List[Document]:
@@ -120,7 +127,9 @@ class PyPDFLoader(BasePDFLoader):
     ) -> Iterator[Document]:
         """Lazy load given path as pages."""
         blob = Blob.from_path(self.file_path)
-        yield from self.parser.parse(blob)
+        yield from self.parser.parse(
+            blob, start_page=self.start_page, end_page=self.end_page
+        )
 
 
 class PyPDFium2Loader(BasePDFLoader):

--- a/tests/integration_tests/document_loaders/test_pdf.py
+++ b/tests/integration_tests/document_loaders/test_pdf.py
@@ -64,6 +64,21 @@ def test_pypdf_loader() -> None:
     docs = loader.load()
     assert len(docs) == 16
 
+    loader = PyPDFLoader(str(file_path), start_page=5)
+
+    docs = loader.load()
+    assert len(docs) == 11
+
+    loader = PyPDFLoader(str(file_path), start_page=5, end_page=8)
+
+    docs = loader.load()
+    assert len(docs) == 4
+
+    loader = PyPDFLoader(str(file_path), end_page=8)
+
+    docs = loader.load()
+    assert len(docs) == 9
+
 
 def test_pypdfium2_loader() -> None:
     """Test PyPDFium2Loader."""


### PR DESCRIPTION
When loading PDFs, I've needed to use manual workarounds to restrict page sections loaded. This is either to exclude pages that are confusing the retriever, such as tables of contents or references or to only include relevant sections of books. This PR replicates my data-cleaning workarounds.

#### Who can review?

  @eyurtsev
  @hwchase17
