### PR TITLE
Remove backticks without clear purpose from docs

### DIFF
--- a/docs/snippets/modules/model_io/prompts/prompt_templates/get_started.mdx
+++ b/docs/snippets/modules/model_io/prompts/prompt_templates/get_started.mdx
@@ -69,7 +69,7 @@ You can create custom prompt templates that format the prompt in any way you wan
 
 ## Chat prompt template
 
-[Chat Models](../models/chat) take a list of `chat messages as` input - this list commonly referred to as a `prompt`.
+[Chat Models](../models/chat) take a list of chat messages as input - this list commonly referred to as a `prompt`.
 These chat messages differ from raw string (which you would pass into a [LLM](/docs/modules/model_io/models/llms) model) in that every message is associated with a `role`.
 
 For example, in OpenAI [Chat Completion API](https://platform.openai.com/docs/guides/chat/introduction), a chat message can be associated with the AI, human or system role. The model is supposed to follow instruction from system chat message more closely.


### PR DESCRIPTION
#### Description

- Removed two backticks surrounding the phrase "chat messages as"
- This phrase stood out among other formatted words/phrases such as `prompt`, `role`, `PromptTemplate`, etc., which all seem to have a clear function.
- `chat messages as`, formatted as such, confused me while reading, leading me to believe the backticks were misplaced.

#### Who can review?

@hwchase17
<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
