### PR TITLE
Allow ids instead of keys for Redis vectorstore

### DIFF
--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -210,7 +210,8 @@ class Redis(VectorStore):
             List[str]: List of ids added to the vectorstore
         """
 
-        assert not (keys and ids), "`ids` and `keys` cannot be provided at the same time."
+        if keys and ids:
+            raise ValueError("`ids` and `keys` cannot be provided at the same time.")
 
         _ids = []
         prefix = _redis_prefix(self.index_name)

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -212,7 +212,7 @@ class Redis(VectorStore):
 
         assert not (keys and ids), "`ids` and `keys` cannot be provided at the same time."
 
-        ids = []
+        _ids = []
         prefix = _redis_prefix(self.index_name)
 
         # Write data to redis
@@ -237,7 +237,7 @@ class Redis(VectorStore):
                     self.metadata_key: json.dumps(metadata),
                 },
             )
-            ids.append(key)
+            _ids.append(key)
 
             # Write batch
             if i % batch_size == 0:
@@ -245,7 +245,7 @@ class Redis(VectorStore):
 
         # Cleanup final batch
         pipeline.execute()
-        return ids
+        return _ids
 
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any

--- a/tests/integration_tests/vectorstores/test_redis.py
+++ b/tests/integration_tests/vectorstores/test_redis.py
@@ -38,6 +38,16 @@ def test_redis(texts: List[str]) -> None:
 
 def test_redis_new_vector(texts: List[str]) -> None:
     """Test adding a new document"""
+    ids = [str(i) for i in range(len(texts))]
+    docsearch = Redis.from_texts(texts, FakeEmbeddings(), redis_url=TEST_REDIS_URL)
+    docsearch.add_texts(["foo"], ids=ids)
+    output = docsearch.similarity_search("foo", k=2)
+    assert output == TEST_RESULT
+    assert drop(docsearch.index_name)
+
+
+def test_redis_new_vector_with_static_ids(texts: List[str]) -> None:
+    """Test adding a new document"""
     docsearch = Redis.from_texts(texts, FakeEmbeddings(), redis_url=TEST_REDIS_URL)
     docsearch.add_texts(["foo"])
     output = docsearch.similarity_search("foo", k=2)


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

#### Before submitting

Redis maintains keys which have more semantics than just an identifier. As a user of langchain, I'm interested in assigning IDs to the documents that I'm ingesting, but I don't want to manually define the Redis keys with index names, key pattern, etc. manually. 

This is a problem especially when I ingest the same text multiple times (during deployment or development processes), because it will duplicate the entries with generated keys.


#### with this submission
I can specify IDs when I `add_documents` or `add_texts` and the IDs will replace the UUID part of the keys.

### More comments
For now, I added `ids` in additions to `keys` but happy to remove `keys` if allowed. Open to any other suggestions to solve the problem

#### Who can review?

Tag maintainers/contributors who might be interested:
@dev2049 @DvirDukhan

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
