### PR TITLE
Add `_similarity_search_with_relevance_scores` in `Pinecone`

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -160,6 +160,14 @@ class Pinecone(VectorStore):
         )
         return [doc for doc, _ in docs_and_scores]
 
+    def _similarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        return self.similarity_search_with_score(query, k)
+
     def max_marginal_relevance_search_by_vector(
         self,
         embedding: List[float],


### PR DESCRIPTION
Just so it is consistent with other `VectorStore` classes.

This is a follow-up of #6056 which also discussed the potential of adding `similarity_search_by_vector_returning_embeddings` that we will continue the discussion here.

potentially related: #6286 


#### Who can review?

Tag maintainers/contributors who might be interested: @rlancemartin 

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
