### PR TITLE
Remove extra word in the introduction documentation

### DIFF
--- a/docs/docs_skeleton/docs/get_started/introduction.mdx
+++ b/docs/docs_skeleton/docs/get_started/introduction.mdx
@@ -9,7 +9,7 @@ sidebar_position: 0
 - **Agentic**: allow a language model to interact with its environment
 
 The main value props of LangChain are:
-1. **Components**: abstractions for working with language models, along with a collection of implementations for each abstraction. Components are modular and easy-to-use, whether you are using the using the rest of the LangChain framework or not
+1. **Components**: abstractions for working with language models, along with a collection of implementations for each abstraction. Components are modular and easy-to-use, whether you are using the rest of the LangChain framework or not
 2. **Off-the-shelf chains**: a structured assembly of components for accomplishing specific higher-level tasks
 
 Off-the-shelf chains make it easy to get started. For more complex applications and nuanced use-cases, components make it easy to customize existing chains or build new ones.


### PR DESCRIPTION
Removed an extra word in the introduction documentation, a simple typo