### PR TITLE
Fix for #6431 - chatprompt template with partial variables throws validation error

### DIFF
--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -168,6 +168,8 @@ class ChatPromptTemplate(BaseChatPromptTemplate, ABC):
         for message in messages:
             if isinstance(message, BaseMessagePromptTemplate):
                 input_vars.update(message.input_variables)
+        if "partial_variables" in values:
+            input_vars = input_vars - set(values["partial_variables"])
         if "input_variables" in values:
             if input_vars != set(values["input_variables"]):
                 raise ValueError(

--- a/tests/unit_tests/prompts/test_chat.py
+++ b/tests/unit_tests/prompts/test_chat.py
@@ -163,14 +163,30 @@ def test_infer_variables() -> None:
     prompt = ChatPromptTemplate(messages=messages)
     assert prompt.input_variables == ["foo"]
 
+
 def test_chat_valid_with_partial_variables() -> None:
-    messages = [HumanMessagePromptTemplate.from_template("Do something with {question} using {context} giving it like {formatins}")]
-    prompt = ChatPromptTemplate(messages=messages, input_variables=["question", "context"], partial_variables={"formatins": "some structure"})
+    messages = [
+        HumanMessagePromptTemplate.from_template(
+            "Do something with {question} using {context} giving it like {formatins}"
+        )
+    ]
+    prompt = ChatPromptTemplate(
+        messages=messages,
+        input_variables=["question", "context"],
+        partial_variables={"formatins": "some structure"},
+    )
     assert set(prompt.input_variables) == set(["question", "context"])
     assert prompt.partial_variables == {"formatins": "some structure"}
 
+
 def test_chat_valid_infer_variables() -> None:
-    messages = [HumanMessagePromptTemplate.from_template("Do something with {question} using {context} giving it like {formatins}")]
-    prompt = ChatPromptTemplate(messages=messages, partial_variables={"formatins": "some structure"})
+    messages = [
+        HumanMessagePromptTemplate.from_template(
+            "Do something with {question} using {context} giving it like {formatins}"
+        )
+    ]
+    prompt = ChatPromptTemplate(
+        messages=messages, partial_variables={"formatins": "some structure"}
+    )
     assert set(prompt.input_variables) == set(["question", "context"])
     assert prompt.partial_variables == {"formatins": "some structure"}

--- a/tests/unit_tests/prompts/test_chat.py
+++ b/tests/unit_tests/prompts/test_chat.py
@@ -162,3 +162,15 @@ def test_infer_variables() -> None:
     messages = [HumanMessagePromptTemplate.from_template("{foo}")]
     prompt = ChatPromptTemplate(messages=messages)
     assert prompt.input_variables == ["foo"]
+
+def test_chat_valid_with_partial_variables() -> None:
+    messages = [HumanMessagePromptTemplate.from_template("Do something with {question} using {context} giving it like {formatins}")]
+    prompt = ChatPromptTemplate(messages=messages, input_variables=["question", "context"], partial_variables={"formatins": "some structure"})
+    assert prompt.input_variables == ["question", "context"]
+    assert prompt.partial_variables == ["formatins"]
+
+def test_chat_valid_infer_variables() -> None:
+    messages = [HumanMessagePromptTemplate.from_template("Do something with {question} using {context} giving it like {formatins}")]
+    prompt = ChatPromptTemplate(messages=messages, partial_variables={"formatins": "some structure"})
+    assert prompt.input_variables == ["question", "context"]
+    assert prompt.partial_variables == ["formatins"]

--- a/tests/unit_tests/prompts/test_chat.py
+++ b/tests/unit_tests/prompts/test_chat.py
@@ -166,11 +166,11 @@ def test_infer_variables() -> None:
 def test_chat_valid_with_partial_variables() -> None:
     messages = [HumanMessagePromptTemplate.from_template("Do something with {question} using {context} giving it like {formatins}")]
     prompt = ChatPromptTemplate(messages=messages, input_variables=["question", "context"], partial_variables={"formatins": "some structure"})
-    assert prompt.input_variables == ["question", "context"]
-    assert prompt.partial_variables == ["formatins"]
+    assert set(prompt.input_variables) == set(["question", "context"])
+    assert prompt.partial_variables == {"formatins": "some structure"}
 
 def test_chat_valid_infer_variables() -> None:
     messages = [HumanMessagePromptTemplate.from_template("Do something with {question} using {context} giving it like {formatins}")]
     prompt = ChatPromptTemplate(messages=messages, partial_variables={"formatins": "some structure"})
-    assert prompt.input_variables == ["question", "context"]
-    assert prompt.partial_variables == ["formatins"]
+    assert set(prompt.input_variables) == set(["question", "context"])
+    assert prompt.partial_variables == {"formatins": "some structure"}


### PR DESCRIPTION
W.r.t recent changes, ChatPromptTemplate does not accepting partial variables. This PR should fix that issue.


Fixes #6431




#### Who can review?



  @hwchase17


