### PR TITLE
Fix conversational_retrieval combining with chat history affects the question and answer experience

### DIFF
--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -112,12 +112,12 @@ class BaseConversationalRetrievalChain(Chain):
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
         if chat_history_str:
-            output: Dict[str, Any] = {self.output_key: new_question}
+            output = {self.output_key: new_question}
         else:
             answer = self.combine_docs_chain.run(
                 input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
             )
-            output: Dict[str, Any] = {self.output_key: answer}
+            output = {self.output_key: answer}
         if self.return_source_documents:
             output["source_documents"] = docs
         if self.return_generated_question:
@@ -149,12 +149,12 @@ class BaseConversationalRetrievalChain(Chain):
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
         if chat_history_str:
-            output: Dict[str, Any] = {self.output_key: new_question}
+            output = {self.output_key: new_question}
         else:
             answer = await self.combine_docs_chain.arun(
                 input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
             )
-            output: Dict[str, Any] = {self.output_key: answer}
+            output = {self.output_key: answer}
         if self.return_source_documents:
             output["source_documents"] = docs
         if self.return_generated_question:

--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -111,10 +111,13 @@ class BaseConversationalRetrievalChain(Chain):
         new_inputs = inputs.copy()
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
-        answer = self.combine_docs_chain.run(
-            input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
-        )
-        output: Dict[str, Any] = {self.output_key: answer}
+        if chat_history_str:
+            output: Dict[str, Any] = {self.output_key: new_question}
+        else:
+            answer = self.combine_docs_chain.run(
+                input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
+            )
+            output: Dict[str, Any] = {self.output_key: answer}
         if self.return_source_documents:
             output["source_documents"] = docs
         if self.return_generated_question:
@@ -145,10 +148,13 @@ class BaseConversationalRetrievalChain(Chain):
         new_inputs = inputs.copy()
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
-        answer = await self.combine_docs_chain.arun(
-            input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
-        )
-        output: Dict[str, Any] = {self.output_key: answer}
+        if chat_history_str:
+            output: Dict[str, Any] = {self.output_key: new_question}
+        else:
+            answer = await self.combine_docs_chain.arun(
+                input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
+            )
+            output: Dict[str, Any] = {self.output_key: answer}
         if self.return_source_documents:
             output["source_documents"] = docs
         if self.return_generated_question:


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
While using the ConversationalRetrievalChain, and specifically applying both condense_question_prompt and combine_docs_chain_kwargs parameters, I followed the official documentation to pass chat_history when invoking this chain. The program runs as expected, but the Q&A experience is less than optimal. I've identified two main issues:

When summarizing the question using condense_question, the response prompt generated by load_qa_chain is treated as 'Human' rather than 'AI'. Currently, I am remedying this by determining whether to pass the question to human_message or ai_message, based on whether chat_history is provided through an external interface.

Upon reviewing the code, I noticed that the answer is first generated by self.question_generator, but in reality, the desired answer initially comes from the prompt in combine_docs_chain_kwargs. However, this response is then re-fed into self.combine_docs_chain, leading to a situation of self-posed questions and self-given answers, which isn't ideal. The final answer from combine_docs_chain isn't what I'm looking for, and I see no need to go through another loop only to end up with an unsatisfactory answer. Thus, I wish to adjust the logic for obtaining the answer in the call and acall methods.

While my implementation might not be the most ideal, it considerably enhances the Q&A experience based on chat history in my project. I hope for official support on this issue and appreciate your help. Thank you!
#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?
@hwchase17 Please review my code and provide your guidance
Tag maintainers/contributors who might be interested:

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
