### PR TITLE
fix: remove callbacks arg from Tool and StructuredTool inferred schema

### DIFF
--- a/langchain/tools/base.py
+++ b/langchain/tools/base.py
@@ -82,7 +82,7 @@ def _get_filtered_args(
     """Get the arguments from a function's signature."""
     schema = inferred_model.schema()["properties"]
     valid_keys = signature(func).parameters
-    return {k: schema[k] for k in valid_keys if k not in ["run_manager", "callbacks"]}
+    return {k: schema[k] for k in valid_keys if k not in ("run_manager", "callbacks")}
 
 
 class _SchemaConfig:

--- a/langchain/tools/base.py
+++ b/langchain/tools/base.py
@@ -82,7 +82,7 @@ def _get_filtered_args(
     """Get the arguments from a function's signature."""
     schema = inferred_model.schema()["properties"]
     valid_keys = signature(func).parameters
-    return {k: schema[k] for k in valid_keys if k not in ["run_manager","callbacks"]}
+    return {k: schema[k] for k in valid_keys if k not in ["run_manager", "callbacks"]}
 
 
 class _SchemaConfig:

--- a/langchain/tools/base.py
+++ b/langchain/tools/base.py
@@ -82,7 +82,7 @@ def _get_filtered_args(
     """Get the arguments from a function's signature."""
     schema = inferred_model.schema()["properties"]
     valid_keys = signature(func).parameters
-    return {k: schema[k] for k in valid_keys if k != "run_manager"}
+    return {k: schema[k] for k in valid_keys if k not in ["run_manager","callbacks"]}
 
 
 class _SchemaConfig:
@@ -108,6 +108,8 @@ def create_schema_from_function(
     inferred_model = validated.model  # type: ignore
     if "run_manager" in inferred_model.__fields__:
         del inferred_model.__fields__["run_manager"]
+    if "callbacks" in inferred_model.__fields__:
+        del inferred_model.__fields__["callbacks"]
     # Pydantic adds placeholder virtual fields we need to strip
     valid_properties = _get_filtered_args(inferred_model, func)
     return _create_subset_model(

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -314,7 +314,6 @@ def test_tool_lambda_args_schema() -> None:
     expected_args = {"tool_input": {"type": "string"}}
     assert tool.args == expected_args
 
-
 def test_structured_tool_from_function_docstring() -> None:
     """Test that structured tools can be created from functions."""
 
@@ -391,6 +390,36 @@ def test_empty_args_decorator() -> None:
     assert empty_tool_input.name == "empty_tool_input"
     assert empty_tool_input.args == {}
     assert empty_tool_input.run({}) == "the empty result"
+    
+def test_structured_tool_from_function_callbacks() -> None:
+    """Test args and schema of structured tool when using callbacks."""
+
+    def foo(
+        bar: int, baz: str, callbacks: Optional[CallbackManagerForToolRun] = None
+    ) -> str:
+        """Docstring
+        Args:
+            bar: int
+            baz: str
+        """
+        raise "foo"
+
+    structured_tool = StructuredTool.from_function(foo)
+    
+    assert structured_tool.args == {
+        "bar": {"title": "Bar", "type": "integer"},
+        "baz": {"title": "Baz", "type": "string"},
+    }
+
+    assert structured_tool.args_schema.schema() == {
+        "properties": {
+            "bar": {"title": "Bar", "type": "integer"},
+            "baz": {"title": "Baz", "type": "string"},
+        },
+        "title": "fooSchemaSchema",
+        "type": "object",
+        "required": ["bar", "baz"],
+    }
 
 
 def test_named_tool_decorator() -> None:

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -401,7 +401,7 @@ def test_tool_from_function_with_run_manager() -> None:
     def foo(bar: str, callbacks: Optional[CallbackManagerForToolRun] = None) -> str:
         """Docstring
         Args:
-            tool_input: str
+            bar: str
         """
         assert callbacks is not None
         return "foo" + bar

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -393,7 +393,7 @@ def test_empty_args_decorator() -> None:
     assert empty_tool_input.run({}) == "the empty result"
 
 
-def test_structured_tool_from_function_callbacks() -> None:
+def test_structured_tool_from_function_with_callbacks() -> None:
     """Test args and schema of structured tool when using callbacks."""
 
     def foo(

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -404,7 +404,7 @@ def test_structured_tool_from_function_with_callbacks() -> None:
             bar: int
             baz: str
         """
-        raise "foo"
+        raise NotImplementedError()
 
     structured_tool = StructuredTool.from_function(foo)
 

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -403,6 +403,7 @@ def test_tool_from_function_with_run_manager() -> None:
         Args:
             tool_input: str
         """
+        assert callbacks is not None
         return "foo" + bar
 
     handler = FakeCallbackHandler()
@@ -422,6 +423,7 @@ def test_structured_tool_from_function_with_run_manager() -> None:
             bar: int
             baz: str
         """
+        assert callbacks is not None
         return str(bar) + baz
 
     handler = FakeCallbackHandler()

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -314,6 +314,7 @@ def test_tool_lambda_args_schema() -> None:
     expected_args = {"tool_input": {"type": "string"}}
     assert tool.args == expected_args
 
+
 def test_structured_tool_from_function_docstring() -> None:
     """Test that structured tools can be created from functions."""
 
@@ -390,7 +391,8 @@ def test_empty_args_decorator() -> None:
     assert empty_tool_input.name == "empty_tool_input"
     assert empty_tool_input.args == {}
     assert empty_tool_input.run({}) == "the empty result"
-    
+
+
 def test_structured_tool_from_function_callbacks() -> None:
     """Test args and schema of structured tool when using callbacks."""
 
@@ -405,7 +407,7 @@ def test_structured_tool_from_function_callbacks() -> None:
         raise "foo"
 
     structured_tool = StructuredTool.from_function(foo)
-    
+
     assert structured_tool.args == {
         "bar": {"title": "Bar", "type": "integer"},
         "baz": {"title": "Baz", "type": "string"},

--- a/tests/unit_tests/tools/test_base.py
+++ b/tests/unit_tests/tools/test_base.py
@@ -17,7 +17,6 @@ from langchain.tools.base import (
     BaseTool,
     SchemaAnnotationError,
     StructuredTool,
-    Tool,
     ToolException,
 )
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
@@ -410,6 +409,7 @@ def test_tool_from_function_with_run_manager() -> None:
     tool = Tool.from_function(foo, name="foo", description="Docstring")
 
     assert tool.run(tool_input={"bar": "bar"}, run_manager=[handler]) == "foobar"
+    assert tool.run("baz", run_manager=[handler]) == "foobaz"
 
 
 def test_structured_tool_from_function_with_run_manager() -> None:


### PR DESCRIPTION
Fixes #5456 

This PR removes the `callbacks` argument from a tool's schema when creating a `Tool` or `StructuredTool` with the `from_function` method and `infer_schema` is set to `True`. The `callbacks` argument is now removed in the `create_schema_from_function` and `_get_filtered_args` methods. As suggested by @vowelparrot, this fix provides a straightforward solution that minimally affects the existing implementation.

A test was added to verify that this change enables the expected use of `Tool` and `StructuredTool` when using a `CallbackManager` and inferring the tool's schema.

  - @hwchase17 