### PR TITLE
Add example for chatting with multiple documents by referencing their IDs in a DB

### DIFF
--- a/docs/extras/modules/agents/toolkits/multi_doc_chat_with_self_querying_retriever.ipynb
+++ b/docs/extras/modules/agents/toolkits/multi_doc_chat_with_self_querying_retriever.ipynb
@@ -1,0 +1,385 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi Doc Chat with reference by ID using the [Self Querying Retriever](https://python.langchain.com/docs/modules/data_connection/retrievers/how_to/self_query)\n",
+    "\n",
+    "This notebook demonstrates how to chat with multiple documents by referencing them by their IDs in your database.\n",
+    "\n",
+    "Example Query: `How are @doc:bw456 and @doc:cg789 different in their main ideas on learning?`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings.openai import OpenAIEmbeddings\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.vectorstores import Chroma\n",
+    "from langchain.document_loaders import TextLoader\n",
+    "from langchain.docstore.document import Document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Created a chunk of size 506, which is longer than the specified 500\n",
+      "Created a chunk of size 793, which is longer than the specified 500\n"
+     ]
+    }
+   ],
+   "source": [
+    "text_splitter = CharacterTextSplitter(chunk_size=500, chunk_overlap=0)\n",
+    "\n",
+    "files = [\n",
+    "    {\n",
+    "        \"path\": \"/home/bharath/Projects/langchain-experiments/Behaviorism.txt\",\n",
+    "        \"id\": \"bw456\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"path\": \"/home/bharath/Projects/langchain-experiments/Cognitivism.txt\",\n",
+    "        \"id\": \"cg789\",\n",
+    "    },\n",
+    "]\n",
+    "docs = []\n",
+    "\n",
+    "for file in files:\n",
+    "    loader = TextLoader(file[\"path\"])\n",
+    "    documents = loader.load()\n",
+    "    chunks = text_splitter.split_documents(documents)\n",
+    "\n",
+    "    for chunkIndex, chunk in enumerate(chunks):\n",
+    "        docs.append(\n",
+    "            Document(\n",
+    "                page_content=chunk.page_content,\n",
+    "                metadata={\n",
+    "                    \"id\": file[\"id\"],\n",
+    "                    \"source\": chunk.metadata[\"source\"],\n",
+    "                    \"chunkIndex\": chunkIndex,\n",
+    "                },\n",
+    "            )\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = Chroma.from_documents(docs, OpenAIEmbeddings())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the self querying retriever by passing it the metadata attributes of the documents you want to reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.llms import OpenAI\n",
+    "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
+    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "\n",
+    "metadata_field_info = [\n",
+    "    AttributeInfo(\n",
+    "        name=\"id\",\n",
+    "        description=\"The ID of the doc\",\n",
+    "        type=\"string\",\n",
+    "    ),\n",
+    "    AttributeInfo(\n",
+    "        name=\"source\",\n",
+    "        description=\"The path to the file of the source document\",\n",
+    "        type=\"string\",\n",
+    "    ),\n",
+    "]\n",
+    "document_content_description = \"Info of a doc\"\n",
+    "llm = OpenAI(temperature=0)\n",
+    "retriever = SelfQueryRetriever.from_llm(\n",
+    "    llm, db, document_content_description, metadata_field_info, verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the retirever we create a Retrieval QA Chain that can apply appropriate metadata filters to the documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.chains.conversation.memory import ConversationBufferWindowMemory\n",
+    "from langchain.chains import RetrievalQAWithSourcesChain\n",
+    "\n",
+    "# chat completion llm\n",
+    "llm = ChatOpenAI(\n",
+    "    model_name='gpt-3.5-turbo-0613',\n",
+    "    temperature=0.7\n",
+    ")\n",
+    "\n",
+    "# retrieval qa chain\n",
+    "qa = RetrievalQAWithSourcesChain.from_chain_type(\n",
+    "    llm=llm,\n",
+    "    chain_type=\"stuff\",\n",
+    "    retriever=retriever,\n",
+    "    return_source_documents=True\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a tool that uses the QA chain to answer questions about a single doc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.agents import Tool\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "\n",
+    "class DocQaInput(BaseModel):\n",
+    "    question: str = Field()\n",
+    "\n",
+    "def docQA(question):\n",
+    "    return qa({\"question\": question})\n",
+    "\n",
+    "tools = [\n",
+    "    Tool(\n",
+    "        name='Doc Info',\n",
+    "        func=docQA,\n",
+    "        args_schema=DocQaInput,\n",
+    "        description=(\n",
+    "            'use this tool to answer queries about a single doc'\n",
+    "        )\n",
+    "    )\n",
+    "]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a chat agent using the `STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION` agent type that uses the tool we just made.\n",
+    "\n",
+    "We can chat with this agent with queries that reference the documents by their IDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new  chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mThought: The user query references two different documents, \"bw456\" and \"cg789\". To answer the question, I will need to create a task for each document and combine the results to identify the differences in their main ideas on learning.\n",
+      "\n",
+      "Action 1: Retrieve information about the first document.\n",
+      "```\n",
+      "{\n",
+      "  \"action\": \"Doc Info\",\n",
+      "  \"action_input\": {\n",
+      "    \"question\": \"What are the main ideas on learning in @doc:bw456?\"\n",
+      "  }\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Observation 1: The result will contain information about the main ideas on learning in document \"bw456\".\n",
+      "\n",
+      "Action 2: Retrieve information about the second document.\n",
+      "```\n",
+      "{\n",
+      "  \"action\": \"Doc Info\",\n",
+      "  \"action_input\": {\n",
+      "    \"question\": \"What are the main ideas on learning in @doc:cg789?\"\n",
+      "  }\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Observation 2: The result will contain information about the main ideas on learning in document \"cg789\".\n",
+      "\n",
+      "Thought: Now that we have retrieved the main ideas on learning from both documents, we can combine the results and identify the differences.\n",
+      "\n",
+      "Action: Combine the results from both tasks to identify the differences in the main ideas on learning between the two documents.\n",
+      "\u001b[0m"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/bharath/Projects/langchain-my-fork/langchain/chains/llm.py:275: UserWarning: The predict_and_parse method is deprecated, instead pass an output parser directly to LLMChain.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query='learning' filter=Comparison(comparator=<Comparator.EQ: 'eq'>, attribute='id', value='bw456') limit=None\n",
+      "\n",
+      "Observation: \u001b[36;1m\u001b[1;3m{'question': 'What are the main ideas on learning in @doc:bw456?', 'answer': 'The main ideas on learning in @doc:bw456 are behaviorism and its two main types of conditioning: classical conditioning and operant conditioning. Classical conditioning involves pairing a specific action or stimulus with an automatic behavioral response, while operant conditioning uses positive and negative reinforcements to encourage or discourage specific behaviors. Positive reinforcement is a consequence that aims to strengthen or encourage certain behavior by providing a reward. \\n', 'sources': '/home/bharath/Projects/langchain-experiments/Behaviorism.txt', 'source_documents': [Document(page_content='Behaviorism', metadata={'id': 'bw456', 'source': '/home/bharath/Projects/langchain-experiments/Behaviorism.txt', 'chunkIndex': 0}), Document(page_content='Our behavior is learned through a process called conditioning. Conditioning is a learning process that can lead to habits and is the result of training ourselves to react a certain way in different scenarios.1 Behaviorism presents two main types of conditioning:', metadata={'id': 'bw456', 'source': '/home/bharath/Projects/langchain-experiments/Behaviorism.txt', 'chunkIndex': 3}), Document(page_content='Classical Conditioning: A learning technique that unconsciously pairs a specific action, or stimulus, with the resulting automatic behavioral response. When the action or stimulus is repeated, the automatic behavioral response is eventually learned to be associated with the action.1', metadata={'id': 'bw456', 'source': '/home/bharath/Projects/langchain-experiments/Behaviorism.txt', 'chunkIndex': 6}), Document(page_content='Operant Conditioning: A learning technique that employs positive and negative reinforcements in the form of rewards or punishments to encourage an individual to pick up or stop a specific behavior. It is sometimes referred to as instrumental conditioning.1\\n\\nPositive Reinforcement: A consequence that aims to strengthen or encourage certain behavior, such as providing a reward for doing something well.', metadata={'id': 'bw456', 'source': '/home/bharath/Projects/langchain-experiments/Behaviorism.txt', 'chunkIndex': 7})]}\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mBoth documents have main ideas on learning, but I can only see the information for document \"bw456\". Let me retrieve the information for document \"cg789\" as well.\n",
+      "\n",
+      "Action 2: Retrieve information about the second document.\n",
+      "```\n",
+      "{\n",
+      "  \"action\": \"Doc Info\",\n",
+      "  \"action_input\": {\n",
+      "    \"question\": \"What are the main ideas on learning in @doc:cg789?\"\n",
+      "  }\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Observation 2: The result will contain information about the main ideas on learning in document \"cg789\".\n",
+      "\n",
+      "Thought: Now that we have retrieved the main ideas on learning from both documents, we can combine the results and identify the differences.\n",
+      "\n",
+      "Action: Combine the results from both tasks to identify the differences in the main ideas on learning between the two documents.\n",
+      "\n",
+      "\u001b[0mquery='learning' filter=Comparison(comparator=<Comparator.EQ: 'eq'>, attribute='id', value='cg789') limit=None\n",
+      "\n",
+      "Observation: \u001b[36;1m\u001b[1;3m{'question': 'What are the main ideas on learning in @doc:cg789?', 'answer': 'The main ideas on learning in the document \"cg789\" are:\\n- Learning is a process of organizing information into conceptualized models.\\n- Instructions should be organized, sequenced, and presented in a manner that is understandable and meaningful to the learner.\\n- Retention and recall are important to build schemas in the brain.\\n- Memory is supported by organizing learning material.\\n- Teachers must provide tools that help the learner\\'s brain process information.\\n- Cognitivism is a learning theory that focuses on how information is received, organized, stored, and retrieved by the mind.\\n- Cognitivism views learning as internal mental processes and emphasizes the active involvement of learners in processing information.\\n- Key principles of cognitive learning theory include understanding how learners process information.\\n- Cognitivism developed as a reaction to Behaviorism and gained prominence in the 1950s, with Piaget\\'s views having a significant impact.\\n- Knowledge is viewed as symbolic mental constructs or schemata in cognitive learning theory.\\n- Changes in learners\\' schemata lead to learning.\\n- Cognitive psychologists and educators are interested in applying knowledge about how the brain works in the classroom.\\n', 'sources': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'source_documents': [Document(page_content='Learning is a process of organizing information into conceptualized models.\\nInstructions should be organized, sequenced and presented in a manner that\\nis understandable and meaningful to the learner.\\nRetention and recall is important to build schema’s in the brain.\\nMemory is supported by organizing learning material.\\nTeachers must provide tools that help learner’s brain process information.', metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 3}), Document(page_content='Cognitivism\\nCognitivism is a learning theory that focusses on how information is received, organized, stored and retrieved by the mind. It uses the mind as an information processer, like a computer. Therefore, cognitivism looks beyond observable behaviour, viewing learning as internal mental processes. In this view, learners are actively involved in the way they process information. Knowledge, memory, thinking, and problem solving are areas for development.', metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 0}), Document(page_content='Key principles and classroom implications\\nThe main principles underpinning the cognitive learning theory are:', metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 2}), Document(page_content=\"History\\nCognitivist theory developed as a reaction to Behaviorism and gained credence in the 1950s. Cognitivists objected to behaviorists because they felt that behaviorists thought learning was simply a reaction to a stimulus and ignored the idea that thinking plays an important role. Although many researchers contributed to the development of the learning theory (e.g. Bruner, Vygotsky, Bloom, Ausubel), Piaget’s views had a tremendous impact. Spurred by the work of Piaget (Constructivism), knowledge is viewed as symbolic mental constructs, or schemata. When a learners' schemata are changed, learning takes place. As neuroscientists continue to discover more about how the brain works, cognitive psychologists and educators are concerned with how to use that knowledge in the classroom.\", metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 1})]}\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mI apologize for the confusion. Let me retrieve the information for document \"cg789\" as well.\n",
+      "\n",
+      "Action 2: Retrieve information about the second document.\n",
+      "```\n",
+      "{\n",
+      "  \"action\": \"Doc Info\",\n",
+      "  \"action_input\": {\n",
+      "    \"question\": \"What are the main ideas on learning in @doc:cg789?\"\n",
+      "  }\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "Observation 2: The result will contain information about the main ideas on learning in document \"cg789\".\n",
+      "\n",
+      "Thought: Now that we have retrieved the main ideas on learning from both documents, we can combine the results and identify the differences.\n",
+      "\n",
+      "Action: Combine the results from both tasks to identify the differences in the main ideas on learning between the two documents.\n",
+      "\n",
+      "\u001b[0mquery='learning' filter=Comparison(comparator=<Comparator.EQ: 'eq'>, attribute='id', value='cg789') limit=None\n",
+      "\n",
+      "Observation: \u001b[36;1m\u001b[1;3m{'question': 'What are the main ideas on learning in @doc:cg789?', 'answer': \"The main ideas on learning in @doc:cg789 are that learning is a process of organizing information into conceptualized models, instructions should be organized and presented in a manner that is understandable and meaningful to the learner, retention and recall are important for building schemas in the brain, memory is supported by organizing learning material, and teachers should provide tools that help the learner's brain process information. Cognitivism is a learning theory that focuses on how information is received, organized, stored, and retrieved by the mind, viewing learning as internal mental processes. The main principles of the cognitive learning theory are not provided in the extracted parts. Cognitivist theory developed as a reaction to Behaviorism, with cognitivists emphasizing the role of thinking in learning. Piaget's views had a significant impact on the development of the learning theory, with knowledge viewed as symbolic mental constructs or schemata. As neuroscientists continue to discover more about how the brain works, cognitive psychologists and educators are interested in applying that knowledge in the classroom.\\n\", 'sources': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'source_documents': [Document(page_content='Learning is a process of organizing information into conceptualized models.\\nInstructions should be organized, sequenced and presented in a manner that\\nis understandable and meaningful to the learner.\\nRetention and recall is important to build schema’s in the brain.\\nMemory is supported by organizing learning material.\\nTeachers must provide tools that help learner’s brain process information.', metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 3}), Document(page_content='Cognitivism\\nCognitivism is a learning theory that focusses on how information is received, organized, stored and retrieved by the mind. It uses the mind as an information processer, like a computer. Therefore, cognitivism looks beyond observable behaviour, viewing learning as internal mental processes. In this view, learners are actively involved in the way they process information. Knowledge, memory, thinking, and problem solving are areas for development.', metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 0}), Document(page_content='Key principles and classroom implications\\nThe main principles underpinning the cognitive learning theory are:', metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 2}), Document(page_content=\"History\\nCognitivist theory developed as a reaction to Behaviorism and gained credence in the 1950s. Cognitivists objected to behaviorists because they felt that behaviorists thought learning was simply a reaction to a stimulus and ignored the idea that thinking plays an important role. Although many researchers contributed to the development of the learning theory (e.g. Bruner, Vygotsky, Bloom, Ausubel), Piaget’s views had a tremendous impact. Spurred by the work of Piaget (Constructivism), knowledge is viewed as symbolic mental constructs, or schemata. When a learners' schemata are changed, learning takes place. As neuroscientists continue to discover more about how the brain works, cognitive psychologists and educators are concerned with how to use that knowledge in the classroom.\", metadata={'id': 'cg789', 'source': '/home/bharath/Projects/langchain-experiments/Cognitivism.txt', 'chunkIndex': 1})]}\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3m{\n",
+      "  \"action\": \"Final Answer\",\n",
+      "  \"action_input\": \"The main ideas on learning in document 'bw456' are behaviorism and its two main types of conditioning: classical conditioning and operant conditioning. Classical conditioning involves pairing a specific action or stimulus with an automatic behavioral response, while operant conditioning uses positive and negative reinforcements to encourage or discourage specific behaviors. Positive reinforcement is a consequence that aims to strengthen or encourage certain behavior by providing a reward. \n",
+      "\n",
+      "The main ideas on learning in document 'cg789' are that learning is a process of organizing information into conceptualized models, instructions should be organized and presented in a manner that is understandable and meaningful to the learner, retention and recall are important for building schemas in the brain, memory is supported by organizing learning material, and teachers should provide tools that help the learner's brain process information. Cognitivism is a learning theory that focuses on how information is received, organized, stored, and retrieved by the mind, viewing learning as internal mental processes. The main principles of the cognitive learning theory are not provided in the extracted parts. Cognitivist theory developed as a reaction to Behaviorism, with cognitivists emphasizing the role of thinking in learning. Piaget's views had a significant impact on the development of the learning theory, with knowledge viewed as symbolic mental constructs or schemata. As neuroscientists continue to discover more about how the brain works, cognitive psychologists and educators are interested in applying that knowledge in the classroom.\"\n",
+      "}\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "{\n",
+      "  \"action\": \"Final Answer\",\n",
+      "  \"action_input\": \"The main ideas on learning in document 'bw456' are behaviorism and its two main types of conditioning: classical conditioning and operant conditioning. Classical conditioning involves pairing a specific action or stimulus with an automatic behavioral response, while operant conditioning uses positive and negative reinforcements to encourage or discourage specific behaviors. Positive reinforcement is a consequence that aims to strengthen or encourage certain behavior by providing a reward. \n",
+      "\n",
+      "The main ideas on learning in document 'cg789' are that learning is a process of organizing information into conceptualized models, instructions should be organized and presented in a manner that is understandable and meaningful to the learner, retention and recall are important for building schemas in the brain, memory is supported by organizing learning material, and teachers should provide tools that help the learner's brain process information. Cognitivism is a learning theory that focuses on how information is received, organized, stored, and retrieved by the mind, viewing learning as internal mental processes. The main principles of the cognitive learning theory are not provided in the extracted parts. Cognitivist theory developed as a reaction to Behaviorism, with cognitivists emphasizing the role of thinking in learning. Piaget's views had a significant impact on the development of the learning theory, with knowledge viewed as symbolic mental constructs or schemata. As neuroscientists continue to discover more about how the brain works, cognitive psychologists and educators are interested in applying that knowledge in the classroom.\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain.agents import initialize_agent\n",
+    "from langchain.agents.agent_types import AgentType\n",
+    "\n",
+    "agent = initialize_agent(\n",
+    "    agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,\n",
+    "    tools=tools,\n",
+    "    llm=llm,\n",
+    "    verbose=True,\n",
+    "    max_iterations=3,\n",
+    "    early_stopping_method='generate',\n",
+    "    memory=ConversationBufferWindowMemory(\n",
+    "        memory_key='chat_history',\n",
+    "        k=5,\n",
+    "        return_messages=True\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "QUERY=\"\"\"\\\n",
+    "Instructions:\n",
+    "If the query references multiple docs then:\n",
+    "1. create a task for each doc\n",
+    "2. combine the results from each task.\n",
+    "\n",
+    "User Query:\n",
+    "How are @doc:bw456 and @doc:cg789 different in their main ideas on learning?\n",
+    "\"\"\"\n",
+    "\n",
+    "result = agent(QUERY)\n",
+    "print(result[\"output\"])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
An example of chatting with multiple docs with reference to their IDs in a DB. Here's an example:
```
How are @doc:bw456 and @doc:cg789 different in their main ideas on learning?
```

This example uses the [Self Querying Retriever](https://python.langchain.com/docs/modules/data_connection/retrievers/how_to/self_query/) with a `RetrieverQAWithSourcesChain` to create a tool that answers questions on a single doc.

The `STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION` agent uses this tool to create actions for each doc and then answers the user's query.

My Twitter handle 😬: [27upon2](https://twitter.com/27upon2)

#### Who can review?
 @hwchase17 