### PR TITLE
Scale cosine distance to 0-1

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -228,7 +228,23 @@ class Chroma(VectorStore):
         k: int = 4,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        return self.similarity_search_with_score(query, k)
+        """Return docs and relevance scores in the range [0, 1].
+
+        0 is dissimilar, 1 is most similar.
+
+        Args:
+            query: input text
+            k: Number of Documents to return. Defaults to 4.
+            **kwargs: kwargs to be passed to similarity search. Should include:
+                score_threshold: Optional, a floating point value between 0 to 1 to
+                    filter the resulting set of retrieved docs
+
+        Returns:
+            List of Tuples of (doc, similarity_score)
+        """
+
+        docs_and_scores = self.similarity_search_with_score(query, k)
+        return [(doc, 1.0 - score) for doc, score in docs_and_scores]
 
     def max_marginal_relevance_search_by_vector(
         self,

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -463,7 +463,6 @@ class Chroma(VectorStore):
         client_settings: Optional[chromadb.config.Settings] = None,
         client: Optional[chromadb.Client] = None,
         collection_metadata: Optional[Dict] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
         **kwargs: Any,
     ) -> Chroma:
         """Create a Chroma vectorstore from a raw documents.
@@ -480,7 +479,6 @@ class Chroma(VectorStore):
             ids (Optional[List[str]]): List of document IDs. Defaults to None.
             client_settings (Optional[chromadb.config.Settings]): Chroma client settings
             collection_metadata (Optional[Dict]): Collection configurations. Defaults to None.
-            relevance_score_fn (Optional[Callable[[float], float]]): Function to be applied on the relevance score.
 
         Returns:
             Chroma: Chroma vectorstore.
@@ -492,7 +490,7 @@ class Chroma(VectorStore):
             client_settings=client_settings,
             client=client,
             collection_metadata=collection_metadata,
-            relevance_score_fn=relevance_score_fn,
+            **kwargs,
         )
         chroma_collection.add_texts(texts=texts, metadatas=metadatas, ids=ids)
         return chroma_collection
@@ -508,7 +506,6 @@ class Chroma(VectorStore):
         client_settings: Optional[chromadb.config.Settings] = None,
         client: Optional[chromadb.Client] = None,  # Add this line
         collection_metadata: Optional[Dict] = None,
-        relevance_score_fn: Optional[Callable[[float], float]] = None,
         **kwargs: Any,
     ) -> Chroma:
         """Create a Chroma vectorstore from a list of documents.
@@ -524,7 +521,7 @@ class Chroma(VectorStore):
             embedding (Optional[Embeddings]): Embedding function. Defaults to None.
             client_settings (Optional[chromadb.config.Settings]): Chroma client settings
             collection_metadata (Optional[Dict]): Collection configurations. Defaults to None.
-            relevance_score_fn (Optional[Callable[[float], float]]): Function to be applied on the relevance score.
+
         Returns:
             Chroma: Chroma vectorstore.
         """
@@ -540,5 +537,5 @@ class Chroma(VectorStore):
             client_settings=client_settings,
             client=client,
             collection_metadata=collection_metadata,
-            relevance_score_fn=relevance_score_fn,
+            **kwargs,
         )

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -209,3 +209,17 @@ def test_chroma_update_document() -> None:
     ]
     assert new_embedding == embedding.embed_documents([updated_content])[0]
     assert new_embedding != old_embedding
+
+
+def test_chroma_with_relevance_score() -> None:
+    """Test to make sure the relevance score is scaled to 0-1."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection",
+        texts=texts,
+        embedding=FakeEmbeddings(),
+        metadatas=metadatas,
+    )
+    output = docsearch.similarity_search_with_relevance_scores("foo", k=1)
+    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 1.0)]

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -220,6 +220,31 @@ def test_chroma_with_relevance_score() -> None:
         texts=texts,
         embedding=FakeEmbeddings(),
         metadatas=metadatas,
+        collection_metadata={"hnsw:space": "l2"},
     )
-    output = docsearch.similarity_search_with_relevance_scores("foo", k=1)
-    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 1.0)]
+    output = docsearch.similarity_search_with_relevance_scores("foo", k=3)
+    assert output == [
+        (Document(page_content="foo", metadata={"page": "0"}), 1.0),
+        (Document(page_content="bar", metadata={"page": "1"}), 0.8),
+        (Document(page_content="baz", metadata={"page": "2"}), 0.5),
+    ]
+
+
+def test_chroma_with_relevance_score_custom_normalization_fn() -> None:
+    """Test searching with relevance score and custom normalization function."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection",
+        texts=texts,
+        embedding=FakeEmbeddings(),
+        metadatas=metadatas,
+        relevance_score_fn=lambda d: d * 0,
+        collection_metadata={"hnsw:space": "l2"},
+    )
+    output = docsearch.similarity_search_with_relevance_scores("foo", k=3)
+    assert output == [
+        (Document(page_content="foo", metadata={"page": "0"}), -0.0),
+        (Document(page_content="bar", metadata={"page": "1"}), -0.0),
+        (Document(page_content="baz", metadata={"page": "2"}), -0.0),
+    ]


### PR DESCRIPTION
Fix - "_similarity_search_with_relevance_scores" is called by VectorStore base class and should return relevance score between 0 and 1, not the distance.

<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

<!-- Remove if not applicable -->

Fixes #6481 

#### Before submitting

<!-- If you're adding a new integration, please include:

1. a test for the integration - favor unit tests that does not rely on network access.
2. an example notebook showing its use


See contribution guidelines for more information on how to write tests, lint
etc:

https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
-->

#### Who can review?

Tag maintainers/contributors who might be interested: @dev2049 

<!-- For a quicker response, figure out the right person to tag with @

  @hwchase17 - project lead

  Tracing / Callbacks
  - @agola11

  Async
  - @agola11

  DataLoaders
  - @eyurtsev

  Models
  - @hwchase17
  - @agola11

  Agents / Tools / Toolkits
  - @hwchase17

  VectorStores / Retrievers / Memory
  - @dev2049

 -->
