### PR TITLE
Feat: Add a prompt template parameter to qa with structure chains

### DIFF
--- a/docs/extras/modules/chains/additional/openai_functions_retrieval_qa.ipynb
+++ b/docs/extras/modules/chains/additional/openai_functions_retrieval_qa.ipynb
@@ -135,7 +135,7 @@
     {
      "data": {
       "text/plain": [
-       "'{\\n  \"answer\": \"The President expressed strong condemnation of Russia\\'s actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia\\'s invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment to defend NATO countries. The President also mentioned taking robust action through sanctions and releasing oil reserves to mitigate gas prices. Overall, the President conveyed a message of solidarity with Ukraine and determination to protect American interests.\",\\n  \"sources\": [\"0-pl\", \"4-pl\", \"5-pl\", \"6-pl\"]\\n}'"
+       "'{\\n  \"answer\": \"The President expressed strong condemnation of Russia\\'s actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia\\'s invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment of the United States and its allies to defend NATO countries. The President also mentioned the imposition of sanctions on Russia and the release of oil reserves to help mitigate gas prices. Overall, the President\\'s message conveyed a firm stance against Russia\\'s aggression and a commitment to supporting Ukraine and protecting American interests.\",\\n  \"sources\": [\"0-pl\", \"4-pl\", \"5-pl\", \"6-pl\"]\\n}'"
       ]
      },
      "execution_count": 11,
@@ -376,7 +376,7 @@
     {
      "data": {
       "text/plain": [
-       "CustomResponseSchema(answer='He announced the closure of American airspace to all Russian flights, further isolating Russia and adding economic pressure. The Russian economy is suffering, with the Ruble losing 30% of its value and the stock market losing 40%. The US is providing military, economic, and humanitarian assistance to Ukraine. American forces are not engaged in conflict with Russian forces in Ukraine but are deployed to defend NATO allies. The US and its allies are enforcing economic sanctions on Russia, cutting off its largest banks from the international financial system and limiting its access to technology. The US Department of Justice is forming a task force to go after the crimes of Russian oligarchs.', countries_referenced=['Russia', 'Ukraine'], sources=['4-pl', '5-pl', '2-pl', '3-pl'])"
+       "CustomResponseSchema(answer=\"He announced that American airspace will be closed off to all Russian flights, further isolating Russia and adding an additional squeeze on their economy. The Ruble has lost 30% of its value and the Russian stock market has lost 40% of its value. He stated that Putin alone is to blame for Russia's reeling economy. The United States and its allies are providing support to Ukraine in the form of military assistance, economic assistance, and humanitarian assistance. The United States is giving more than $1 Billion in direct assistance to Ukraine. He made it clear that American forces are not engaged and will not engage in conflict with Russian forces in Ukraine, but they are deployed to defend NATO Allies in case Putin decides to keep moving west. He also mentioned that the United States has mobilized ground forces, air squadrons, and ship deployments to protect NATO countries including Poland, Romania, Latvia, Lithuania, and Estonia. He emphasized that the United States and its allies will defend every inch of territory of NATO countries with the full force of their collective power. He acknowledged that the Ukrainians are fighting back with courage and that Putin has unleashed violence and chaos. He assured that while Putin may make gains on the battlefield, he will pay a continuing high price over the long run. He praised the proud Ukrainian people for their determination to not tolerate anyone who tries to take their country backwards. He mentioned that Putin's attack on Ukraine was premeditated and unprovoked, and that he rejected repeated efforts at diplomacy. He highlighted the extensive preparation and coalition-building efforts made by the United States and other freedom-loving nations to confront Putin. He stated that the free world is holding Putin accountable for his aggression. He mentioned that powerful economic sanctions are being enforced, including cutting off Russia's largest banks from the international financial system and preventing Russia's central bank from defending the Russian Ruble. He also mentioned that the U.S. Department of Justice is assembling a dedicated task force to go after the crimes of Russian oligarchs, and that the United States and its European allies are taking actions to seize the ill-begotten gains of Russian oligarchs and corrupt leaders.\", countries_referenced=['AMERICAN', 'RUSSIA', 'UKRAINE', 'POLAND', 'ROMANIA', 'LATVIA', 'LITHUANIA', 'ESTONIA', 'FRANCE', 'GERMANY', 'ITALY', 'UNITED KINGDOM', 'CANADA', 'JAPAN', 'KOREA', 'AUSTRALIA', 'NEW ZEALAND', 'SWITZERLAND'], sources=['4-pl', '5-pl', '2-pl', '3-pl'])"
       ]
      },
      "execution_count": 23,
@@ -405,14 +405,14 @@
     "    HumanMessage(content=\"Answer question using the following context\"),\n",
     "    HumanMessagePromptTemplate.from_template(\"{context}\"),\n",
     "    HumanMessagePromptTemplate.from_template(\"Question: {question}\"),\n",
-    "    HumanMessage(content=\"Tips: Make sure to answer in the correct format. Add the countries mentioned in the sources parameter as well.\"),\n",
+    "    HumanMessage(content=\"Tips: Make sure to answer in the correct format. Return all countries in uppercase characters.\"),\n",
     "]\n",
     "\n",
     "chain_prompt = ChatPromptTemplate(messages=prompt_messages)\n",
     "\n",
     "qa_chain_pydantic = create_qa_with_structure_chain(llm, CustomResponseSchema, output_parser=\"pydantic\", prompt=chain_prompt)\n",
     "final_qa_chain_pydantic = StuffDocumentsChain(\n",
-    "    llm_chain=qa_chain_pydantic, \n",
+    "    llm_chain=qa_chain_pydantic,\n",
     "    document_variable_name='context',\n",
     "    document_prompt=doc_prompt,\n",
     ")\n",

--- a/docs/extras/modules/chains/additional/openai_functions_retrieval_qa.ipynb
+++ b/docs/extras/modules/chains/additional/openai_functions_retrieval_qa.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "f059012e",
    "metadata": {},
    "outputs": [],
@@ -28,20 +28,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "f10b831c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using embedded DuckDB without persistence: data will be transient\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "loader = TextLoader(\"../../state_of_the_union.txt\")\n",
+    "loader = TextLoader(\"../../state_of_the_union.txt\", encoding=\"utf-8\")\n",
     "documents = loader.load()\n",
     "text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
     "texts = text_splitter.split_documents(documents)\n",
@@ -53,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "70f3a38c",
    "metadata": {},
    "outputs": [],
@@ -66,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "7b3e1731",
    "metadata": {},
    "outputs": [],
@@ -76,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "70a9ccff",
    "metadata": {},
    "outputs": [],
@@ -86,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "efcdb6fb",
    "metadata": {},
    "outputs": [],
@@ -99,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "64a08263",
    "metadata": {},
    "outputs": [],
@@ -113,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "cb876c97",
    "metadata": {},
    "outputs": [],
@@ -126,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "a75bad9b",
    "metadata": {},
    "outputs": [],
@@ -136,17 +128,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "9a60f109",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'{\\n  \"answer\": \"The President expressed strong condemnation of Russia\\'s actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia\\'s invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment of the United States and its allies to defend NATO countries. The President also mentioned the imposition of sanctions on Russia and the release of oil reserves to help mitigate gas prices. Overall, the President\\'s message conveyed a firm stance against Russia\\'s aggression and a commitment to supporting Ukraine and protecting American interests.\",\\n  \"sources\": [\"0-pl\", \"4-pl\", \"5-pl\", \"6-pl\"]\\n}'"
+       "'{\\n  \"answer\": \"The President expressed strong condemnation of Russia\\'s actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia\\'s invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment to defend NATO countries. The President also mentioned taking robust action through sanctions and releasing oil reserves to mitigate gas prices. Overall, the President conveyed a message of solidarity with Ukraine and determination to protect American interests.\",\\n  \"sources\": [\"0-pl\", \"4-pl\", \"5-pl\", \"6-pl\"]\\n}'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -167,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "3559727f",
    "metadata": {},
    "outputs": [],
@@ -177,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "5a7997d1",
    "metadata": {},
    "outputs": [],
@@ -191,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "79368e40",
    "metadata": {},
    "outputs": [],
@@ -204,17 +196,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "6b8641de",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "AnswerWithSources(answer=\"The President expressed strong condemnation of Russia's actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia's invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment of the United States and its allies to defend NATO countries. The President also mentioned the imposition of sanctions on Russia and the release of oil reserves to help mitigate gas prices. Overall, the President's message conveyed a firm stance against Russia's aggression and support for Ukraine.\", sources=['0-pl', '4-pl', '5-pl', '6-pl'])"
+       "AnswerWithSources(answer=\"The President expressed strong condemnation of Russia's actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia's invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment to defend NATO countries. The President also mentioned taking robust action through sanctions and releasing oil reserves to mitigate gas prices. Overall, the President conveyed a message of solidarity with Ukraine and determination to protect American interests.\", sources=['0-pl', '4-pl', '5-pl', '6-pl'])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -235,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "18e5f090",
    "metadata": {},
    "outputs": [],
@@ -260,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "975c3c2b",
    "metadata": {},
    "outputs": [],
@@ -275,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "784aee3a",
    "metadata": {},
    "outputs": [],
@@ -286,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "dfd0ccc1",
    "metadata": {},
    "outputs": [
@@ -299,7 +291,7 @@
        " 'answer': '{\\n  \"answer\": \"The President nominated Ketanji Brown Jackson as a Circuit Court of Appeals Judge and praised her as one of the nation\\'s top legal minds who will continue Justice Breyer\\'s legacy of excellence.\",\\n  \"sources\": [\"31-pl\"]\\n}'}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -310,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "c93f805b",
    "metadata": {},
    "outputs": [],
@@ -321,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "5d8612c0",
    "metadata": {},
    "outputs": [
@@ -336,7 +328,7 @@
        " 'answer': '{\\n  \"answer\": \"The President honored Justice Stephen Breyer for his service as an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court.\",\\n  \"sources\": [\"31-pl\"]\\n}'}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -346,18 +338,21 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ac9e4626",
    "metadata": {},
    "source": [
     "## Using your own output schema\n",
     "\n",
-    "We can change the outputs of our chain by passing in our own schema. The values and descriptions of this schema will inform the function we pass to the OpenAI API, meaning it won't just affect how we parse outputs but will also change the OpenAI output itself. For example we can add a `countries_referenced` parameter to our schema and describe what we want this parameter to mean, and that'll cause the OpenAI output to include a description of a speaker in the response."
+    "We can change the outputs of our chain by passing in our own schema. The values and descriptions of this schema will inform the function we pass to the OpenAI API, meaning it won't just affect how we parse outputs but will also change the OpenAI output itself. For example we can add a `countries_referenced` parameter to our schema and describe what we want this parameter to mean, and that'll cause the OpenAI output to include a description of a speaker in the response.\n",
+    "\n",
+    "In addition to the previous example, we can also add a custom prompt to the chain. This will allow you to add additional context to the response, which can be useful for question answering."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "f34a48f8",
    "metadata": {},
    "outputs": [],
@@ -366,22 +361,25 @@
     "\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
-    "from langchain.chains.openai_functions import create_qa_with_structure_chain"
+    "from langchain.chains.openai_functions import create_qa_with_structure_chain\n",
+    "\n",
+    "from langchain.prompts.chat import ChatPromptTemplate, HumanMessagePromptTemplate\n",
+    "from langchain.schema import SystemMessage, HumanMessage"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "5647c161",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "CustomResponseSchema(answer=\"He announced that American airspace will be closed off to all Russian flights, further isolating Russia and adding economic pressure. The Ruble has lost 30% of its value and the Russian stock market has lost 40% of its value. He also mentioned providing support to Ukraine in terms of military, economic, and humanitarian assistance. The US is giving more than $1 billion in direct assistance to Ukraine. He clarified that US forces are not engaged in conflict with Russian forces in Ukraine but are deployed to defend NATO allies. He emphasized that Putin's actions have consequences and that the free world is holding him accountable through economic sanctions and targeting Russian oligarchs.\", countries_referenced=['Russia', 'Ukraine'], sources=['4-pl', '5-pl', '2-pl', '3-pl'])"
+       "CustomResponseSchema(answer='He announced the closure of American airspace to all Russian flights, further isolating Russia and adding economic pressure. The Russian economy is suffering, with the Ruble losing 30% of its value and the stock market losing 40%. The US is providing military, economic, and humanitarian assistance to Ukraine. American forces are not engaged in conflict with Russian forces in Ukraine but are deployed to defend NATO allies. The US and its allies are enforcing economic sanctions on Russia, cutting off its largest banks from the international financial system and limiting its access to technology. The US Department of Justice is forming a task force to go after the crimes of Russian oligarchs.', countries_referenced=['Russia', 'Ukraine'], sources=['4-pl', '5-pl', '2-pl', '3-pl'])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -396,7 +394,23 @@
     "        ..., description=\"List of sources used to answer the question\"\n",
     "    )\n",
     "\n",
-    "qa_chain_pydantic = create_qa_with_structure_chain(llm, CustomResponseSchema, output_parser=\"pydantic\")\n",
+    "\n",
+    "prompt_messages = [\n",
+    "    SystemMessage(\n",
+    "        content=(\n",
+    "            \"You are a world class algorithm to answer \"\n",
+    "            \"questions in a specific format.\"\n",
+    "        )\n",
+    "    ),\n",
+    "    HumanMessage(content=\"Answer question using the following context\"),\n",
+    "    HumanMessagePromptTemplate.from_template(\"{context}\"),\n",
+    "    HumanMessagePromptTemplate.from_template(\"Question: {question}\"),\n",
+    "    HumanMessage(content=\"Tips: Make sure to answer in the correct format. Add the countries mentioned in the sources parameter as well.\"),\n",
+    "]\n",
+    "\n",
+    "chain_prompt = ChatPromptTemplate(messages=prompt_messages)\n",
+    "\n",
+    "qa_chain_pydantic = create_qa_with_structure_chain(llm, CustomResponseSchema, output_parser=\"pydantic\", prompt=chain_prompt)\n",
     "final_qa_chain_pydantic = StuffDocumentsChain(\n",
     "    llm_chain=qa_chain_pydantic, \n",
     "    document_variable_name='context',\n",
@@ -409,21 +423,13 @@
     "query = \"What did he say about russia\"\n",
     "retrieval_qa_pydantic.run(query)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b822ef59",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -435,7 +441,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/chains/additional/openai_functions_retrieval_qa.ipynb
+++ b/docs/extras/modules/chains/additional/openai_functions_retrieval_qa.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 25,
    "id": "f059012e",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 26,
    "id": "f10b831c",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 27,
    "id": "70f3a38c",
    "metadata": {},
    "outputs": [],
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 28,
    "id": "7b3e1731",
    "metadata": {},
    "outputs": [],
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 29,
    "id": "70a9ccff",
    "metadata": {},
    "outputs": [],
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 30,
    "id": "efcdb6fb",
    "metadata": {},
    "outputs": [],
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 31,
    "id": "64a08263",
    "metadata": {},
    "outputs": [],
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 32,
    "id": "cb876c97",
    "metadata": {},
    "outputs": [],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 33,
    "id": "a75bad9b",
    "metadata": {},
    "outputs": [],
@@ -128,17 +128,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 34,
    "id": "9a60f109",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'{\\n  \"answer\": \"The President expressed strong condemnation of Russia\\'s actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia\\'s invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment of the United States and its allies to defend NATO countries. The President also mentioned the imposition of sanctions on Russia and the release of oil reserves to help mitigate gas prices. Overall, the President\\'s message conveyed a firm stance against Russia\\'s aggression and a commitment to supporting Ukraine and protecting American interests.\",\\n  \"sources\": [\"0-pl\", \"4-pl\", \"5-pl\", \"6-pl\"]\\n}'"
+       "'{\\n  \"answer\": \"The President expressed strong condemnation of Russia\\'s actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia\\'s invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment to defend NATO countries. The President also mentioned taking robust action through sanctions and releasing oil reserves to mitigate gas prices. Overall, the President conveyed a message of solidarity with Ukraine and determination to protect American interests.\",\\n  \"sources\": [\"0-pl\", \"4-pl\", \"5-pl\", \"6-pl\"]\\n}'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 35,
    "id": "3559727f",
    "metadata": {},
    "outputs": [],
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 36,
    "id": "5a7997d1",
    "metadata": {},
    "outputs": [],
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 37,
    "id": "79368e40",
    "metadata": {},
    "outputs": [],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 38,
    "id": "6b8641de",
    "metadata": {},
    "outputs": [
@@ -206,7 +206,7 @@
        "AnswerWithSources(answer=\"The President expressed strong condemnation of Russia's actions in Ukraine and announced measures to isolate Russia and provide support to Ukraine. He stated that Russia's invasion of Ukraine will have long-term consequences for Russia and emphasized the commitment to defend NATO countries. The President also mentioned taking robust action through sanctions and releasing oil reserves to mitigate gas prices. Overall, the President conveyed a message of solidarity with Ukraine and determination to protect American interests.\", sources=['0-pl', '4-pl', '5-pl', '6-pl'])"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 39,
    "id": "18e5f090",
    "metadata": {},
    "outputs": [],
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 40,
    "id": "975c3c2b",
    "metadata": {},
    "outputs": [],
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 41,
    "id": "784aee3a",
    "metadata": {},
    "outputs": [],
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 42,
    "id": "dfd0ccc1",
    "metadata": {},
    "outputs": [
@@ -291,7 +291,7 @@
        " 'answer': '{\\n  \"answer\": \"The President nominated Ketanji Brown Jackson as a Circuit Court of Appeals Judge and praised her as one of the nation\\'s top legal minds who will continue Justice Breyer\\'s legacy of excellence.\",\\n  \"sources\": [\"31-pl\"]\\n}'}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -302,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 43,
    "id": "c93f805b",
    "metadata": {},
    "outputs": [],
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 44,
    "id": "5d8612c0",
    "metadata": {},
    "outputs": [
@@ -328,7 +328,7 @@
        " 'answer': '{\\n  \"answer\": \"The President honored Justice Stephen Breyer for his service as an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court.\",\\n  \"sources\": [\"31-pl\"]\\n}'}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 45,
    "id": "f34a48f8",
    "metadata": {},
    "outputs": [],
@@ -369,17 +369,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 46,
    "id": "5647c161",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "CustomResponseSchema(answer=\"He announced that American airspace will be closed off to all Russian flights, further isolating Russia and adding an additional squeeze on their economy. The Ruble has lost 30% of its value and the Russian stock market has lost 40% of its value. He stated that Putin alone is to blame for Russia's reeling economy. The United States and its allies are providing support to Ukraine in the form of military assistance, economic assistance, and humanitarian assistance. The United States is giving more than $1 Billion in direct assistance to Ukraine. He made it clear that American forces are not engaged and will not engage in conflict with Russian forces in Ukraine, but they are deployed to defend NATO Allies in case Putin decides to keep moving west. He also mentioned that the United States has mobilized ground forces, air squadrons, and ship deployments to protect NATO countries including Poland, Romania, Latvia, Lithuania, and Estonia. He emphasized that the United States and its allies will defend every inch of territory of NATO countries with the full force of their collective power. He acknowledged that the Ukrainians are fighting back with courage and that Putin has unleashed violence and chaos. He assured that while Putin may make gains on the battlefield, he will pay a continuing high price over the long run. He praised the proud Ukrainian people for their determination to not tolerate anyone who tries to take their country backwards. He mentioned that Putin's attack on Ukraine was premeditated and unprovoked, and that he rejected repeated efforts at diplomacy. He highlighted the extensive preparation and coalition-building efforts made by the United States and other freedom-loving nations to confront Putin. He stated that the free world is holding Putin accountable for his aggression. He mentioned that powerful economic sanctions are being enforced, including cutting off Russia's largest banks from the international financial system and preventing Russia's central bank from defending the Russian Ruble. He also mentioned that the U.S. Department of Justice is assembling a dedicated task force to go after the crimes of Russian oligarchs, and that the United States and its European allies are taking actions to seize the ill-begotten gains of Russian oligarchs and corrupt leaders.\", countries_referenced=['AMERICAN', 'RUSSIA', 'UKRAINE', 'POLAND', 'ROMANIA', 'LATVIA', 'LITHUANIA', 'ESTONIA', 'FRANCE', 'GERMANY', 'ITALY', 'UNITED KINGDOM', 'CANADA', 'JAPAN', 'KOREA', 'AUSTRALIA', 'NEW ZEALAND', 'SWITZERLAND'], sources=['4-pl', '5-pl', '2-pl', '3-pl'])"
+       "CustomResponseSchema(answer=\"He announced that American airspace will be closed off to all Russian flights, further isolating Russia and adding an additional squeeze on their economy. The Ruble has lost 30% of its value and the Russian stock market has lost 40% of its value. He also mentioned that Putin alone is to blame for Russia's reeling economy. The United States and its allies are providing support to Ukraine in their fight for freedom, including military, economic, and humanitarian assistance. The United States is giving more than $1 billion in direct assistance to Ukraine. He made it clear that American forces are not engaged and will not engage in conflict with Russian forces in Ukraine, but they are deployed to defend NATO allies in case Putin decides to keep moving west. He also mentioned that Putin's attack on Ukraine was premeditated and unprovoked, and that the West and NATO responded by building a coalition of freedom-loving nations to confront Putin. The free world is holding Putin accountable through powerful economic sanctions, cutting off Russia's largest banks from the international financial system, and preventing Russia's central bank from defending the Russian Ruble. The U.S. Department of Justice is also assembling a task force to go after the crimes of Russian oligarchs.\", countries_referenced=['AMERICA', 'RUSSIA', 'UKRAINE'], sources=['4-pl', '5-pl', '2-pl', '3-pl'])"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -405,7 +405,7 @@
     "    HumanMessage(content=\"Answer question using the following context\"),\n",
     "    HumanMessagePromptTemplate.from_template(\"{context}\"),\n",
     "    HumanMessagePromptTemplate.from_template(\"Question: {question}\"),\n",
-    "    HumanMessage(content=\"Tips: Make sure to answer in the correct format. Return all countries in uppercase characters.\"),\n",
+    "    HumanMessage(content=\"Tips: Make sure to answer in the correct format. Return all of the countries mentioned in the sources in uppercase characters.\"),\n",
     "]\n",
     "\n",
     "chain_prompt = ChatPromptTemplate(messages=prompt_messages)\n",

--- a/langchain/chains/openai_functions/qa_with_structure.py
+++ b/langchain/chains/openai_functions/qa_with_structure.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Type, Union, Optional
+from typing import Any, List, Optional, Type, Union
 
 from pydantic import BaseModel, Field
 
@@ -9,9 +9,10 @@ from langchain.output_parsers.openai_functions import (
     OutputFunctionsParser,
     PydanticOutputFunctionsParser,
 )
+from langchain.prompts import PromptTemplate
 from langchain.prompts.chat import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain.schema import BaseLLMOutputParser, HumanMessage, SystemMessage
-from langchain.prompts import PromptTemplate
+
 
 class AnswerWithSources(BaseModel):
     """An answer to the question being asked, with sources."""

--- a/langchain/chains/openai_functions/qa_with_structure.py
+++ b/langchain/chains/openai_functions/qa_with_structure.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Type, Union
+from typing import Any, List, Type, Union, Optional
 
 from pydantic import BaseModel, Field
 
@@ -11,7 +11,7 @@ from langchain.output_parsers.openai_functions import (
 )
 from langchain.prompts.chat import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain.schema import BaseLLMOutputParser, HumanMessage, SystemMessage
-
+from langchain.prompts import PromptTemplate
 
 class AnswerWithSources(BaseModel):
     """An answer to the question being asked, with sources."""
@@ -26,6 +26,7 @@ def create_qa_with_structure_chain(
     llm: BaseLanguageModel,
     schema: Union[dict, Type[BaseModel]],
     output_parser: str = "base",
+    prompt: Optional[Union[PromptTemplate, ChatPromptTemplate]] = None,
 ) -> LLMChain:
     if output_parser == "pydantic":
         if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
@@ -65,7 +66,7 @@ def create_qa_with_structure_chain(
         HumanMessagePromptTemplate.from_template("Question: {question}"),
         HumanMessage(content="Tips: Make sure to answer in the correct format"),
     ]
-    prompt = ChatPromptTemplate(messages=messages)
+    prompt = prompt or ChatPromptTemplate(messages=messages)
 
     chain = LLMChain(
         llm=llm,


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain! Your PR will appear in our release under the title you set. Please make sure it highlights your valuable contribution.

Replace this with a description of the change, the issue it fixes (if applicable), and relevant context. List any dependencies required for this change.

After you're done, someone will review your PR. They may suggest improvements. If no one reviews your PR within a few days, feel free to @-mention the same people again, as notifications can get lost.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle!
-->

## Description of Changes
This pull request introduces a new feature to the LangChain QA Retrieval Chains with Structures. The change involves adding a prompt template as an optional parameter for the RetrievalQA chains that utilize the recently implemented OpenAI Functions.

The main purpose of this enhancement is to provide users with the ability to input a more customizable prompt to the chain. By introducing a prompt template as an optional parameter, users can tailor the prompt to their specific needs and context, thereby improving the flexibility and effectiveness of the RetrievalQA chains.

## Changes Made
- Created a new optional parameter, "prompt", for the RetrievalQA with structure chains.
- Added an example to the RetrievalQA with sources notebook.

My twitter handle is @El_Rey_Zero