### PR TITLE
Documentation Fix: Correct the example code output in the prompt templates doc

### DIFF
--- a/docs/snippets/modules/model_io/prompts/prompt_templates/get_started.mdx
+++ b/docs/snippets/modules/model_io/prompts/prompt_templates/get_started.mdx
@@ -16,7 +16,7 @@ prompt.format(product="colorful socks")
 <CodeOutputBlock lang="python">
 
 ```
-    I want you to act as a naming consultant for new companies.
+    You are a naming consultant for new companies.
     What is a good name for a company that makes colorful socks?
 ```
 


### PR DESCRIPTION
Documentation is showing the wrong example output for the prompt templates code snippet. This PR fixes that issue. 

<img width="933" alt="image" src="https://github.com/hwchase17/langchain/assets/3833303/0e31c965-5883-4ff9-9cf8-0c4e32ca2d00">
