### PR TITLE
Fix sql_database.ipynb link

### DIFF
--- a/docs/extras/modules/agents/toolkits/sql_database.ipynb
+++ b/docs/extras/modules/agents/toolkits/sql_database.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# SQL Database Agent\n",
     "\n",
-    "This notebook showcases an agent designed to interact with a sql databases. The agent builds off of [SQLDatabaseChain](https://langchain.readthedocs.io/en/latest/modules/chains/examples/sqlite.html) and is designed to answer more general questions about a database, as well as recover from errors.\n",
+    "This notebook showcases an agent designed to interact with a sql databases. The agent builds off of [SQLDatabaseChain](https://python.langchain.com/docs/modules/chains/popular/sqlite) and is designed to answer more general questions about a database, as well as recover from errors.\n",
     "\n",
     "Note that, as this agent is in active development, all answers might not be correct. Additionally, it is not guaranteed that the agent won't perform DML statements on your database given certain questions. Be careful running it on sensitive data!\n",
     "\n",


### PR DESCRIPTION
Looks like the [SQLDatabaseChain](https://langchain.readthedocs.io/en/latest/modules/chains/examples/sqlite.html) in the SQL Database Agent page was broken I've change it to the SQL Chain page

cc: @agola11 @hwchase17
