### PR TITLE
Using batches for update document with a new function in ChromaDB

### DIFF
--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -517,15 +517,15 @@ class Chroma(VectorStore):
             document_id (str): ID of the document to update.
             document (Document): Document to update.
         """
-        return self.update_document_batch([document_id], [document])
+        return self.update_documents([document_id], [document])
 
-    def update_document_batch(
-        self, document_ids: List[str], documents: List[Document]
+    def update_documents(
+        self, ids: List[str], documents: List[Document]
     ) -> None:
         """Update a document in the collection.
 
         Args:
-            document_ids (List[str]): List of ids of the document to update.
+            ids (List[str]): List of ids of the document to update.
             documents (List[Document]): List of documents to update.
         """
         text = [document.page_content for document in documents]
@@ -537,7 +537,7 @@ class Chroma(VectorStore):
         embeddings = self._embedding_function.embed_documents(text)
 
         self._collection.update(
-            ids=document_ids,
+            ids=ids,
             embeddings=embeddings,
             documents=text,
             metadatas=metadata,

--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -519,9 +519,7 @@ class Chroma(VectorStore):
         """
         return self.update_documents([document_id], [document])
 
-    def update_documents(
-        self, ids: List[str], documents: List[Document]
-    ) -> None:
+    def update_documents(self, ids: List[str], documents: List[Document]) -> None:
         """Update a document in the collection.
 
         Args:

--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -517,19 +517,30 @@ class Chroma(VectorStore):
             document_id (str): ID of the document to update.
             document (Document): Document to update.
         """
-        text = document.page_content
-        metadata = document.metadata
+        return self.update_document_batch([document_id], [document])
+
+    def update_document_batch(
+        self, document_ids: List[str], documents: List[Document]
+    ) -> None:
+        """Update a document in the collection.
+
+        Args:
+            document_ids (List[str]): List of ids of the document to update.
+            documents (List[Document]): List of documents to update.
+        """
+        text = [document.page_content for document in documents]
+        metadata = [document.metadata for document in documents]
         if self._embedding_function is None:
             raise ValueError(
                 "For update, you must specify an embedding function on creation."
             )
-        embeddings = self._embedding_function.embed_documents([text])
+        embeddings = self._embedding_function.embed_documents(text)
 
         self._collection.update(
-            ids=[document_id],
+            ids=document_ids,
             embeddings=embeddings,
-            documents=[text],
-            metadatas=[metadata],
+            documents=text,
+            metadatas=metadata,
         )
 
     @classmethod


### PR DESCRIPTION
https://github.com/hwchase17/langchain/blob/2a4b32dee24c22159805f643b87eece107224951/langchain/vectorstores/chroma.py#L355-L375

Currently, the defined update_document function only takes a single document and its ID for updating. However, Chroma can update multiple documents by taking a list of IDs and documents for batch updates. If we update 'update_document' function both document_id and document can be `Union[str, List[str]]` but we need to do type check. Because embed_documents and update functions takes List for text and document_ids variables. I believe that, writing a new function is the best option.

I update the Chroma vectorstore with refreshed information from my website every 20 minutes. Updating the update_document function to perform simultaneous updates for each changed piece of information would significantly reduce the update time in such use cases. 

For my case I update a total of 8810 chunks. Updating these 8810 individual chunks using the current function takes a total of 8.5 minutes. However, if we process the inputs in batches and update them collectively, all 8810 separate chunks can be updated in just 1 minute. This significantly reduces the time it takes for users of actively used chatbots to access up-to-date information.

I can add an integration test and an example for the documentation for the new update_document_batch function.

@hwchase17 

[berkedilekoglu](https://twitter.com/berkedilekoglu)