### PR TITLE
[VectorStores][FAISS] Score threshold implementation fix

### DIFF
--- a/langchain/vectorstores/utils.py
+++ b/langchain/vectorstores/utils.py
@@ -1,10 +1,17 @@
 """Utility functions for working with vectors and vectorstores."""
 
+from enum import Enum
 from typing import List
 
 import numpy as np
 
 from langchain.math_utils import cosine_similarity
+
+
+class MetricType(Enum):
+    INNER_PRODUCT = "inner_product"
+    L2 = "L2"
+    JACCARD = "jaccard"
 
 
 def maximal_marginal_relevance(


### PR DESCRIPTION
# Description: 
Support different metric types for FAISS (and adds generic enum for different vector stores) and fixes bug for score threshold filtering

Currently FAISS implementation will filter out scores that are less than the score threshold (for L2, but it should keep these scores, see issue below). If the index is constructed using inner product or jaccard e.g. it should use ge. 

# Issue
https://github.com/hwchase17/langchain/issues/6526

# Tag maintainer:
DataLoaders / VectorStores / Retrievers:
@rlancemartin, @eyurtsev
