### PR TITLE
Add missing word in comment

### DIFF
--- a/docs/extras/modules/agents/agent_types/openai_multi_functions_agent.ipynb
+++ b/docs/extras/modules/agents/agent_types/openai_multi_functions_agent.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Do this so we can exactly what's going on under the hood\n",
+    "# Do this so we can see exactly what's going on under the hood\n",
     "import langchain\n",
     "langchain.debug = True"
    ]


### PR DESCRIPTION
Changed

```
# Do this so we can exactly what's going on under the hood
```
to
```
# Do this so we can see exactly what's going on under the hood
```