### PR TITLE
Just corrected a small inconsistency on a doc page

### DIFF
--- a/docs/snippets/modules/chains/foundational/sequential_chains.mdx
+++ b/docs/snippets/modules/chains/foundational/sequential_chains.mdx
@@ -100,7 +100,7 @@ template = """You are a playwright. Given the title of play and the era it is se
 Title: {title}
 Era: {era}
 Playwright: This is a synopsis for the above play:"""
-prompt_template = PromptTemplate(input_variables=["title", 'era'], template=template)
+prompt_template = PromptTemplate(input_variables=["title", "era"], template=template)
 synopsis_chain = LLMChain(llm=llm, prompt=prompt_template, output_key="synopsis")
 ```
 


### PR DESCRIPTION
### Just corrected a small inconsistency on a doc page (not exactly a typo, per se)
  - Description: There was inconsistency due to the use of single quotes at one place on the [Squential Chains](https://python.langchain.com/docs/modules/chains/foundational/sequential_chains) page of the docs, 
  - Issue: NA,
  - Dependencies: NA,
  - Tag maintainer: @dev2049,
  - Twitter handle: kambleakash0
