### PR TITLE
Session deletion method in motorhead memory

### DIFF
--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -88,7 +88,5 @@ class MotorheadMemory(BaseChatMemory):
         super().save_context(inputs, outputs)
 
     def delete_session(self):
-        """ Delete a session """
-        requests.delete(
-            f"{self.url}/sessions/{self.session_id}/memory"
-        )
+        """Delete a session"""
+        requests.delete(f"{self.url}/sessions/{self.session_id}/memory")

--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -86,3 +86,9 @@ class MotorheadMemory(BaseChatMemory):
             headers=self.__get_headers(),
         )
         super().save_context(inputs, outputs)
+
+    def delete_session(self):
+        """ Delete a session """
+        requests.delete(
+            f"{self.url}/sessions/{self.session_id}/memory"
+        )

--- a/langchain/memory/motorhead_memory.py
+++ b/langchain/memory/motorhead_memory.py
@@ -87,6 +87,6 @@ class MotorheadMemory(BaseChatMemory):
         )
         super().save_context(inputs, outputs)
 
-    def delete_session(self):
+    def delete_session(self) -> None:
         """Delete a session"""
         requests.delete(f"{self.url}/sessions/{self.session_id}/memory")


### PR DESCRIPTION
Motorhead Memory module didn't support deletion of a session.  Added a method to enable deletion.  

@hwchase17
