### PR TITLE
Add enum fields to parameters when constructing openai function requests

### DIFF
--- a/langchain/tools/convert_to_openai.py
+++ b/langchain/tools/convert_to_openai.py
@@ -14,12 +14,50 @@ class FunctionDescription(TypedDict):
     """The parameters of the function."""
 
 
+def add_enum_properties(prop: dict, definitions: dict) -> None:
+    """Add enum key to properties for openai_function from pydantic format."""
+    if "$ref" in prop:
+        # when Field is not assigned
+        ref_def_key = prop["$ref"].split("/")[-1]
+        ref_def = definitions.get(ref_def_key, {})
+        if "enum" in ref_def:
+            prop["enum"] = ref_def["enum"]
+            del prop["$ref"]
+    elif "allOf" in prop:
+        # when Field is assigned
+        if len(prop["allOf"]) == 1 and "$ref" in prop["allOf"][0]:
+            ref_def_key = prop["allOf"][0]["$ref"].split("/")[-1]
+            ref_def = definitions.get(ref_def_key, {})
+            if "enum" in ref_def:
+                prop["enum"] = ref_def["enum"]
+                del prop["allOf"]
+    elif "anyOf" in prop:
+        # union of enums
+        # only resolve enums if all $ref is enum
+        aggregated_enums_set = set()
+        for any_of_prop in prop["anyOf"]:
+            if "$ref" in any_of_prop:
+                ref_def_key = any_of_prop["$ref"].split("/")[-1]
+                ref_def = definitions.get(ref_def_key, {})
+                if "enum" in ref_def:
+                    aggregated_enums_set.update(ref_def["enum"])
+            else:
+                break
+        else:
+            prop["enum"] = sorted(aggregated_enums_set)
+            del prop["anyOf"]
+
+
 def format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     """Format tool into the OpenAI function API."""
     if isinstance(tool, StructuredTool):
         schema_ = tool.args_schema.schema()
         # Bug with required missing for structured tools.
         required = sorted(schema_["properties"])  # BUG WORKAROUND
+
+        for prop in schema_["properties"].values():
+            add_enum_properties(prop=prop, definitions=schema_.get("definitions", {}))
+
         return {
             "name": tool.name,
             "description": tool.description,

--- a/tests/unit_tests/tools/test_convert_to_openai.py
+++ b/tests/unit_tests/tools/test_convert_to_openai.py
@@ -1,0 +1,190 @@
+"""Test functionality of converting tools to OpenAI Functions."""
+from enum import Enum
+from typing import Set, Union
+
+from pydantic import BaseModel, Field
+
+from langchain.agents import Tool
+from langchain.tools import StructuredTool
+from langchain.tools.convert_to_openai import (
+    add_enum_properties,
+    format_tool_to_openai_function,
+)
+
+
+class EnumStub1(str, Enum):
+    example1 = "example1"
+    example2 = "example2"
+    example3 = "example3"
+
+
+class EnumStub2(str, Enum):
+    example3 = "example3"
+    example4 = "example4"
+    example5 = "example5"
+
+
+class ArgStub(BaseModel):
+    standard_enum: EnumStub1
+    field_enum: EnumStub1 = Field(default=EnumStub1.example1)
+    union_enum: Union[EnumStub1, EnumStub2]
+    union_field_enum: Union[EnumStub1, EnumStub2] = Field(default=EnumStub1.example3)
+    non_enum: Union[EnumStub1, str]  # type str engulfs EnumStub1
+
+
+def _test_enum(enum_key: str, result: Set[Union[EnumStub1, EnumStub2]]) -> None:
+    arg_stub_schema = ArgStub.schema()
+
+    assert "properties" in arg_stub_schema
+    assert "definitions" in arg_stub_schema
+    assert enum_key in arg_stub_schema["properties"]
+
+    enum_schema = arg_stub_schema["properties"][enum_key]
+    add_enum_properties(
+        prop=enum_schema, definitions=arg_stub_schema.get("definitions", {})
+    )
+
+    assert set(enum_schema["enum"]) == result
+
+
+def test_add_standard_enum_properties() -> None:
+    """Test that a standard enum fields can be added into functions."""
+
+    # $ref case
+    _test_enum(
+        "standard_enum",
+        {
+            EnumStub1.example1,
+            EnumStub1.example2,
+            EnumStub1.example3,
+        },
+    )
+
+
+def test_add_field_enum_properties() -> None:
+    """Test that a enum fields with field info can be added into functions."""
+
+    # allOf case
+    _test_enum(
+        "field_enum",
+        {
+            EnumStub1.example1,
+            EnumStub1.example2,
+            EnumStub1.example3,
+        },
+    )
+
+
+def test_add_union_enum_properties() -> None:
+    """Test union enums fields."""
+
+    # anyOf case
+    _test_enum(
+        "union_enum",
+        {
+            EnumStub1.example1,
+            EnumStub1.example2,
+            EnumStub1.example3,
+            EnumStub2.example3,
+            EnumStub2.example4,
+            EnumStub2.example5,
+        },
+    )
+
+
+def test_add_union_field_enum_properties() -> None:
+    """Test that a union enums fields with field info can be added into functions."""
+
+    # anyOf case
+    _test_enum(
+        "union_field_enum",
+        {
+            EnumStub1.example1,
+            EnumStub1.example2,
+            EnumStub1.example3,
+            EnumStub2.example3,
+            EnumStub2.example4,
+            EnumStub2.example5,
+        },
+    )
+
+
+def test_add_non_enum_properties() -> None:
+    """Test that a union that looks like enum but are not will not be added 
+    into functions."""
+    arg_stub_schema = ArgStub.schema()
+
+    assert "properties" in arg_stub_schema
+    assert "definitions" in arg_stub_schema
+    assert "non_enum" in arg_stub_schema["properties"]
+
+    enum_schema = arg_stub_schema["properties"]["non_enum"]
+    add_enum_properties(
+        prop=enum_schema, definitions=arg_stub_schema.get("definitions", {})
+    )
+
+    assert "enum" not in enum_schema
+
+
+def test_tool_to_openai_function() -> None:
+    """Test that a tool can be converted into functions."""
+
+    def search(query: str) -> str:
+        return ""
+
+    tool = Tool(name="Search", func=search, description="Search tool")
+    openai_func_desc = format_tool_to_openai_function(tool)
+
+    assert "name" in openai_func_desc and openai_func_desc["name"] == "Search"
+    assert (
+        "description" in openai_func_desc
+        and openai_func_desc["description"] == "Search tool"
+    )
+    assert "parameters" in openai_func_desc and openai_func_desc["parameters"] == {
+        "type": "object",
+        "properties": {
+            "__arg1": {"title": "__arg1", "type": "string"},
+        },
+        "required": ["__arg1"],
+    }
+
+
+def test_structured_tool_to_openai_function() -> None:
+    """Test that a structured tool can be converted into functions."""
+
+    def concat(a: Union[EnumStub1, EnumStub2], b: EnumStub1) -> str:
+        """Concatenate enum together!"""
+        return a + b
+
+    tool = StructuredTool.from_function(func=concat)
+    openai_func_desc = format_tool_to_openai_function(tool)
+
+    assert "name" in openai_func_desc and openai_func_desc["name"] == "concat"
+    assert "parameters" in openai_func_desc and openai_func_desc["parameters"] == {
+        "type": "object",
+        "properties": {
+            "a": {
+                "title": "A",
+                "enum": sorted(
+                    {
+                        EnumStub1.example1,
+                        EnumStub1.example2,
+                        EnumStub1.example3,
+                        EnumStub2.example3,
+                        EnumStub2.example4,
+                        EnumStub2.example5,
+                    }
+                ),
+            },
+            "b": {
+                "enum": sorted(
+                    {
+                        EnumStub1.example1,
+                        EnumStub1.example2,
+                        EnumStub1.example3,
+                    }
+                )
+            },
+        },
+        "required": ["a", "b"],
+    }

--- a/tests/unit_tests/tools/test_convert_to_openai.py
+++ b/tests/unit_tests/tools/test_convert_to_openai.py
@@ -110,7 +110,7 @@ def test_add_union_field_enum_properties() -> None:
 
 
 def test_add_non_enum_properties() -> None:
-    """Test that a union that looks like enum but are not will not be added 
+    """Test that a union that looks like enum but are not will not be added
     into functions."""
     arg_stub_schema = ArgStub.schema()
 


### PR DESCRIPTION
**Description:** Added `add_enum_properties` into `format_tool_to_openai_function` which adds enum details from `tools.arg_schema.schema()` into OpenAI Functions API requests, to make the response more relevant; similar to how enum is used in [this tutorial](https://platform.openai.com/docs/guides/gpt/function-calling) for the `["celsius", "fahrenheit"]`. 

There are several cases where an enum in the parameters where pydantic handles differently not as a simple `"enum"` key in the schema, most were covered in the unit test here `tests/unit_tests/tools/test_convert_to_openai.py`.

**Issue:** None
**Dependencies:** N/A
**Tag maintainers:** @vowelparrot
**Twitter handle:** ZhiHaoLow

It's my first time here, if there are any things that need amendment please let me know. 

OpenAI Functions seems promising and fun and hope I can contribute more! 😄 