### PR TITLE
fix(docs): broken link for OpenLLM

### DIFF
--- a/docs/extras/ecosystem/integrations/openllm.mdx
+++ b/docs/extras/ecosystem/integrations/openllm.mdx
@@ -67,4 +67,4 @@ llm("What is the difference between a duck and a goose? And why there are so man
 ### Usage
 
 For a more detailed walkthrough of the OpenLLM Wrapper, see the
-[example notebook](../modules/models/llms/integrations/openllm.ipynb)
+[example notebook](/docs/modules/model_io/models/llms/integrations/openllm.html)


### PR DESCRIPTION
This link for the notebook of OpenLLM is not migrated to the new format

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change,
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
