### PR TITLE
Changed generate_prompt.py

### DIFF
--- a/langchain/evaluation/qa/generate_prompt.py
+++ b/langchain/evaluation/qa/generate_prompt.py
@@ -18,7 +18,7 @@ These questions should be detailed and be based explicitly on information in the
 {doc}
 <End Document>"""
 output_parser = RegexParser(
-    regex=r"QUESTION: (.*?)\nANSWER: (.*)", output_keys=["query", "answer"]
+    regex=r"QUESTION: (.*?)\n+ANSWER: (.*)", output_keys=["query", "answer"]
 )
 PROMPT = PromptTemplate(
     input_variables=["doc"], template=template, output_parser=output_parser


### PR DESCRIPTION
Modified regex for Fix: ValueError: Could not parse output

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: ValueError: Could not parse output:  RegexParser(regex='QUESTION: (.*?)\\nANSWER: (.*)', output_keys=['query', 'answer'], default_output_key=None)
  
![Web capture_23-6-2023_17623_colab](https://github.com/hwchase17/langchain/assets/29744661/291432ff-5472-44d4-abb8-d53c4e2e96f7)

  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
