### PR TITLE
ChatVertexAI broken - Fix error with sending context in params

### DIFF
--- a/langchain/chat_models/vertexai.py
+++ b/langchain/chat_models/vertexai.py
@@ -129,8 +129,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         context = history.system_message.content if history.system_message else None
         params = {**self._default_params, **kwargs}
         if not self.is_codey_model:
-            params["context"] = context
-        chat = self.client.start_chat(**params)
+            chat = self.client.start_chat(context=context,**params)
+        else:
+            chat = self.client.start_chat(**params)
         for pair in history.history:
             chat._history.append((pair.question.content, pair.answer.content))
         response = chat.send_message(question.content, **params)

--- a/langchain/chat_models/vertexai.py
+++ b/langchain/chat_models/vertexai.py
@@ -129,7 +129,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         context = history.system_message.content if history.system_message else None
         params = {**self._default_params, **kwargs}
         if not self.is_codey_model:
-            chat = self.client.start_chat(context=context,**params)
+            chat = self.client.start_chat(context=context, **params)
         else:
             chat = self.client.start_chat(**params)
         for pair in history.history:


### PR DESCRIPTION
vertex Ai chat is broken right now. That is because context is in params and chat.send_message doesn't accept that as a params.

  - Closes issue  [ChatVertexAI Error: _ChatSessionBase.send_message() got an unexpected keyword argument 'context' #6610](https://github.com/hwchase17/langchain/issues/6610)

@dev2049

