### PR TITLE
Fix conversational_retrieval combining with chat history affects the question and answer experience

### DIFF
--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -111,9 +111,12 @@ class BaseConversationalRetrievalChain(Chain):
         new_inputs = inputs.copy()
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
-        answer = self.combine_docs_chain.run(
-            input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
-        )
+        if chat_history_str:
+            answer = new_question
+        else:
+            answer = self.combine_docs_chain.run(
+                input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
+            )
         output: Dict[str, Any] = {self.output_key: answer}
         if self.return_source_documents:
             output["source_documents"] = docs
@@ -145,9 +148,12 @@ class BaseConversationalRetrievalChain(Chain):
         new_inputs = inputs.copy()
         new_inputs["question"] = new_question
         new_inputs["chat_history"] = chat_history_str
-        answer = await self.combine_docs_chain.arun(
-            input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
-        )
+        if chat_history_str:
+            answer = new_question
+        else:
+            answer = await self.combine_docs_chain.arun(
+                input_documents=docs, callbacks=_run_manager.get_child(), **new_inputs
+            )
         output: Dict[str, Any] = {self.output_key: answer}
         if self.return_source_documents:
             output["source_documents"] = docs


### PR DESCRIPTION
Fixes # (issue)
While using the ConversationalRetrievalChain, and specifically applying both condense_question_prompt and combine_docs_chain_kwargs parameters, I followed the official documentation to pass chat_history when invoking this chain. The program runs as expected, but the Q&A experience is less than optimal. I've identified two main issues:

When summarizing the question using condense_question, the response prompt generated by load_qa_chain is treated as 'Human' rather than 'AI'. Currently, I am remedying this by determining whether to pass the question to human_message or ai_message, based on whether chat_history is provided through an external interface.

Upon reviewing the code, I noticed that the answer is first generated by self.question_generator, but in reality, the desired answer initially comes from the prompt in combine_docs_chain_kwargs. However, this response is then re-fed into self.combine_docs_chain, leading to a situation of self-posed questions and self-given answers, which isn't ideal. The final answer from combine_docs_chain isn't what I'm looking for, and I see no need to go through another loop only to end up with an unsatisfactory answer. Thus, I wish to adjust the logic for obtaining the answer in the call and acall methods.

While my implementation might not be the most ideal, it considerably enhances the Q&A experience based on chat history in my project. I hope for official support on this issue and appreciate your help. Thank you!

Before submitting