### PR TITLE
Zep Authentication

### DIFF
--- a/langchain/memory/chat_message_histories/zep.py
+++ b/langchain/memory/chat_message_histories/zep.py
@@ -37,7 +37,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
     summarizes, embeds, indexes, and enriches conversational AI chat
     histories, and exposes them via simple, low-latency APIs.
 
-    For server installation instructions and more, see: https://getzep.github.io/
+    For server installation instructions and more, see: https://docs.getzep.com/deployment/quickstart/
 
     This class is a thin wrapper around the zep-python package. Additional
     Zep functionality is exposed via the `zep_summary` and `zep_messages`

--- a/langchain/memory/chat_message_histories/zep.py
+++ b/langchain/memory/chat_message_histories/zep.py
@@ -25,6 +25,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         zep_chat_history = ZepChatMessageHistory(
             session_id=session_id,
             url=ZEP_API_URL,
+            api_key=<your_api_key>,
         )
 
         # Use a standard ConversationBufferMemory to encapsulate the Zep chat history
@@ -37,7 +38,8 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
     summarizes, embeds, indexes, and enriches conversational AI chat
     histories, and exposes them via simple, low-latency APIs.
 
-    For server installation instructions and more, see: https://docs.getzep.com/deployment/quickstart/
+    For server installation instructions and more, see:
+    https://docs.getzep.com/deployment/quickstart/
 
     This class is a thin wrapper around the zep-python package. Additional
     Zep functionality is exposed via the `zep_summary` and `zep_messages`
@@ -51,6 +53,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         self,
         session_id: str,
         url: str = "http://localhost:8000",
+        api_key: Optional[str] = None,
     ) -> None:
         try:
             from zep_python import ZepClient
@@ -60,7 +63,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
                 "Please install it with `pip install zep-python`."
             )
 
-        self.zep_client = ZepClient(base_url=url)
+        self.zep_client = ZepClient(base_url=url, api_key=api_key)
         self.session_id = session_id
 
     @property

--- a/langchain/retrievers/zep.py
+++ b/langchain/retrievers/zep.py
@@ -20,7 +20,7 @@ class ZepRetriever(BaseRetriever):
     histories, and exposes them via simple, low-latency APIs.
 
     For server installation instructions, see:
-    https://getzep.github.io/deployment/quickstart/
+    https://docs.getzep.com/deployment/quickstart/
     """
 
     def __init__(

--- a/langchain/retrievers/zep.py
+++ b/langchain/retrievers/zep.py
@@ -27,6 +27,7 @@ class ZepRetriever(BaseRetriever):
         self,
         session_id: str,
         url: str,
+        api_key: Optional[str] = None,
         top_k: Optional[int] = None,
     ):
         try:
@@ -37,7 +38,7 @@ class ZepRetriever(BaseRetriever):
                 "Please install it with `pip install zep-python`."
             )
 
-        self.zep_client = ZepClient(base_url=url)
+        self.zep_client = ZepClient(base_url=url, api_key=api_key)
         self.session_id = session_id
         self.top_k = top_k
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ pandas = {version = "^2.0.1", optional = true}
 telethon = {version = "^1.28.5", optional = true}
 neo4j = {version = "^5.8.1", optional = true}
 psychicapi = {version = "^0.5", optional = true}
-zep-python = {version=">=0.31", optional=true}
+zep-python = {version=">=0.32", optional=true}
 langkit = {version = ">=0.0.1.dev3, <0.1.0", optional = true}
 chardet = {version="^5.1.0", optional=true}
 requests-toolbelt = {version = "^1.0.0", optional = true}


### PR DESCRIPTION
- 2markdown loader (#4796)
- Add dev option (#4828)
- Add Support for Flexible Input Format for LLM and Chat Model Runs (#4805)
- Typos (#4851)
- Remove unnecessary comment (#4845)
- bump 172 (#4864)
- Hugging Face Loader: Add lazy load (#4799)
- Fix TypeError in Vectorstore Redis class methods (#4857)
- Add beautiful soup 4 to extended testing extra (#4869)
- Remove unused variables in Milvus vectorstore (#4868)
- Update getting_started.ipynb (#4850)
- docs `retriever` improvements (#4430)
- fix homepage typo (#4883)
- Tiny code review and docs fix for Docugami DataLoader (#4877)
- feat(Add FastAPI + Vercel deployment option): (#4520)
- Bold Crumbs (#4876)
- ConversationalChatAgent: Allow customizing `TEMPLATE_TOOL_RESPONSE` (#2361)
- Faiss no avx2 (#4895)
- Add a generic document loader (#4875)
- Add html parsers (#4874)
- Cadlabs/python tool sanitization (#4754)
- Zep memory (#4898)
- Update gallery (#4873)
- Fix AzureOpenAI embeddings documentation example. model -> deployment (#4389)
- Update getting_started.md (#4482)
- docs: text splitters improvements (#4490)
- Harrison/serper api bug (#4902)
- Harrison/faiss norm (#4903)
- Harrison/improved retry tool (#4842)
- Harrison/unified objectives (#4905)
- bump version to 173 (#4910)
- Load specific file types from Google Drive (issue #4878) (#4926)
- API update: Engines -> Models (#4915)
- feat #4479: TextLoader auto detect encoding and improved exceptions (#4927)
- Fix bilibili (#4860)
- Add human message as input variable to chat agent prompt creation (#4542)
- add alias for model (#4553)
- dont error on sql import (#4647)
- docs: compound ecosystem and integrations (#4870)
- Update GPT4ALL integration (#4567)
- FIX: GPTCache cache_obj creation loop (#4827)
- Redis kwargs fix (#4936)
- Update redis integration tests (#4937)
- docs supabase update (#4935)
- Correct typo in APIChain example notebook (Farenheit -> Fahrenheit) (#4938)
- fix: error in gptcache example nb (#4930)
- Update custom_multi_action_agent.ipynb (#4931)
- docs: added `ecosystem/dependents` page (#4941)
- docs: vectorstores, different updates and fixes (#4939)
- Chatconv agent: output parser exception (#4923)
- Zep Retriever - Vector Search Over Chat History (#4533)
- Fix get_num_tokens for Anthropic models (#4911)
- NIT: Instead of hardcoding k in each definition, define it as a param above. (#2675)
- [nit] Simplify Spark Creation Validation Check A Little Bit (#4761)
- Fix for syntax when setting search_path for Snowflake database (#4747)
- Harrison/spell executor (#4914)
- Add Spark SQL support (#4602) (#4956)
- Support Databricks in SQLDatabase (#4702)
- Fixed assumptions misspelling (#4961)
- Update tutorials.md (#4960)
- Update planner_prompt.py (#4967)
- power bi api wrapper integration tests & bug fix (#4983)
- bump v0.0.174 (#4988)
- Remove autoreload in examples (#4994)
- Bug fixes and error handling in Redis - Vectorstore (#4932)
- Add async search with relevance score (#4558)
- Make test gha workflow manually runnable (#4998)
- Adds 'IN' metadata filter for pgvector for checking set presence (#4982)
- Update python.py (#4971)
- PGVector logger message level (#4920)
- feature/4493 Improve Evernote Document Loader (#4577)
- Fix graphql tool (#4984)
- changed ValueError to ImportError (#5006)
- docs: Big Mendable Improvements (#4964)
- added instruction about pip install google-gerativeai (#5004)
- Update the GPTCache example (#4985)
- Revert "API update: Engines -> Models (#4915)" (#5008)
- Add self query translator for weaviate vectorstore (#4804)
- Check for single prompt in __call__ method of the BaseLLM class (#4892)
- Add logs command (#5007)
- fix prompt saving (#4987)
- Streaming only final output of agent (#2483) (#4630)
- bump v175 (#5041)
- Fix annoying typo in docs (#5029)
- Add documentation for Databricks integration (#5013)
- DOC: Misspelling in agents.rst documentation (#5038)
- change to type checking (#5062)
- Harrison/psychic (#5063)
- bump to 176 (#5064)
- move docs
- feat: batch multiple files in a single Unstructured API request (#4525)
- preserve language in conversation retrieval (#4969)
- docs: `Deployments` page moved into `Ecosystem/` (#4949)
- Separate Runner Functions from Client (#5079)
- Add 'get_token_ids' method (#4784)
- Improved query, print & exception handling in REPL Tool (#4997)
- Harrison/neo4j (#5078)
- Bump 177 (#5095)
- fix: revert docarray explicit transitive dependencies and use extras instead (#5015)
- Improving Resilience of MRKL Agent (#5014)
-  Improve pinecone hybrid search retriever adding metadata support (#5098)
- Add the usage of SSL certificates for Elasticsearch and user password authentication (#5058)
- add get_top_k_cosine_similarity method to get max top k score and index (#5059)
- PowerBI major refinement in working of tool and tweaks in the rest (#5090)
- fix: add_texts method of Weaviate vector store creats wrong embeddings (#4933)
- update langchainplus client and docker file to reflect port changes (#5005)
- Fixed import error for AutoGPT e.g. from langchain.experimental.auton… (#5101)
- Update serpapi.py (#4947)
- changed ValueError to ImportError (#5103)
- fix: assign current_time to datetime.now() if current_time is None (#5045)
- Add Mastodon toots loader (#5036)
- Add OpenLM LLM multi-provider (#4993)
- Pass Dataset Name by Name not Position (#5108)
- Fixes issue #5072 - adds additional support to Weaviate (#5085)
- Improve effeciency of TextSplitter.split_documents, iterate once (#5111)
- WhyLabs callback (#4906)
- Add AzureCognitiveServicesToolkit to call Azure Cognitive Services API (#5012)
- Add link to Psychic from document loaders documentation page (#5115)
- bump 178 (#5130)
- docs: fix minor typo + add wikipedia package installation part in human_input_llm.ipynb (#5118)
- solving #2887 (#5127)
- Improve PlanningOutputParser whitespace handling (#5143)
- Add ElasticsearchEmbeddings class for generating embeddings using Elasticsearch models (#3401)
- Adding Weather Loader (#5056)
- Add MosaicML inference endpoints (#4607)
- Empty check before pop (#4929)
- Add async versions of predict() and predict_messages() (#4867)
- fix: fix current_time=Now bug for aadd_documents in TimeWeightedRetriever (#5155)
- Docs: updated getting_started.md (#5151)
- Clarification of the reference to the "get_text_legth" function in ge… (#5154)
- docs: added missed `document_loaders` examples (#5150)
- Add Typesense vector store (#1674)
- Vectara (#5069)
- Beam (#4996)
- Update rellm_experimental.ipynb (#5189)
- example usage (#5182)
- adjust docarray docstrings (#5185)
- bump 179 (#5200)
- Harrison/modelscope (#5156)
- Reuse `length_func` in `MapReduceDocumentsChain` (#5181)
- Update Cypher QA prompt (#5173)
- Improve weaviate vectorstore docs (#5201)
- tfidf retriever (#5114)
- standardize json parsing (#5168)
- fixing total cost finetuned model giving zero (#5144)
- Fixes scope of query Session in PGVector (#5194)
- Output parsing variation allowance (#5178)
- Allow readthedoc loader to pass custom html tag (#5175)
- Add Iugu document loader (#5162)
- Add Joplin document loader (#5153)
- nit (#5208)
- add option to pass openai key to langchain plus command (#5213)
- Log warning (#5192)
- Add Delete Session Method (#5193)
- Add 'status' command to get server status (#5197)
- Harrison/vertex (#5049)
- fix a mistake in concepts.md (#5222)
- Create async copy of from_text() inside GraphIndexCreator. (#5214)
- Remove API key from docs (#5223)
- Change Default GoogleDriveLoader Behavior to not Load Trashed Files (issue #5104) (#5220)
- Allow to specify ID when adding to the FAISS vectorstore. (#5190)
- Bibtex integration for document loader and retriever (#5137)
- Add MiniMax embeddings (#5174)
- Weaviate: Add QnA with sources example (#5247)
- Fix typo in docstring of RetryWithErrorOutputParser (#5244)
- bump 180 (#5248)
- remove extra "\n" to ensure that the format of the description, examp… (#5232)
- Resolve error in StructuredOutputParser docs (#5240)
- Added the option of specifying a proxy for the OpenAI API (#5246)
- OpenSearch top k parameter fix (#5216)
- Fixed regression in JoplinLoader's get note url (#5265)
- Docs link custom agent page in getting started (#5250)
- Zep sdk version (#5267)
- Add C Transformers for GGML Models (#5218)
- Add visible_only and strict_mode options to ClickTool (#4088)
- Add Multi-CSV/DF support in CSV and DataFrame Toolkits (#5009)
- OpenAI lint (#5273)
- Added pipline args to `HuggingFacePipeline.from_model_id` (#5268)
- Support bigquery dialect - SQL (#5261)
- feat: add Momento as a standard cache and chat message history provider (#5221)
- Fixed typo: 'ouput' to 'output' in all documentation (#5272)
- Tedma4/twilio tool (#5136)
- LLM wrapper for Databricks (#5142)
- Add an example to make the prompt more robust (#5291)
- Update CONTRIBUTION guidelines and PR Template (#5140)
- Fixed passing creds to VertexAI LLM (#5297)
- bump 181 (#5302)
- Better docs for weaviate hybrid search (#5290)
- Add instructions to pyproject.toml (#5138)
- docs: improve flow of llm caching notebook (#5309)
- Fix typos (#5323)
- docs: added link to LangChain Handbook (#5311)
- add enum output parser (#5165)
- add enum output parser (#5165)
- Add Chainlit to deployment options (#5314)
- Fixing blank thoughts in verbose for "_Exception" Action (#5331)
- fix: remove empty lines that cause InvalidRequestError (#5320)
- Sample Notebook for DynamoDB Chat Message History (#5351)
- added cosmos kwargs option (#5292)
- feat: support for shopping search in SerpApi (#5259)
- Add SKLearnVectorStore (#5305)
- bump 182 (#5364)
- Fixes iter error in FAISS add_embeddings call (#5367)
- revert bad json (#5370)
- bump to 183 (#5372)
- Add path validation to DirectoryLoader (#5327)
- Fix: Handle empty documents in ContextualCompressionRetriever (Issue #5304) (#5306)
- handle json parsing errors (#5371)
- Use Default Factory (#5380)
- Update PR template with Twitter handle request (#5382)
- fix: Blob.from_data mimetype is lost (#5395)
- Add async support to routing chains (#5373)
- Fix update_document function, add test and documentation. (#5359)
- Update llamacpp demonstration notebook (#5344)
- Removed deprecated llm attribute for load_chain (#5343)
- Harrison/llamacpp (#5402)
- Add pagination for Vertex AI embeddings (#5325)
- Reformat openai proxy setting as code (#5330)
- Harrison/deep infra (#5403)
- Harrison/prediction guard update (#5404)
- Implemented appending arbitrary messages (#5293)
- docs: `ecosystem/integrations` update 2 (#5282)
- docs: `ecosystem/integrations` update 1 (#5219)
- Harrison/datetime parser (#4693)
- bump version 184 (#5407)
- Add ToolException that a tool can throw. (#5050)
- Harrison/text splitter (#5417)
- New Trello document loader (#4767)
- DocumentLoader for GitHub (#5408)
- Harrison/spark reader (#5405)
- Set old LCTracer to default to port 8000 (#5381)
- Rename and fix typo in lancedb (#5425)
- Harrison/condense q llm (#5438)
- adding MongoDBAtlasVectorSearch (#5338)
- Add more code splitters (go, rst, js, java, cpp, scala, ruby, php, swift, rust) (#5171)
- bump 185 (#5442)
- fix (#5457)
- bump 186 (#5459)
- Fixed docstring in faiss.py for load_local (#5440)
- Removes duplicated call from langchain/client/langchain.py (#5449)
- `encoding_kwargs` for InstructEmbeddings (#5450)
- MRKL output parser no longer breaks well formed queries (#5432)
- docs: cleaning (#5413)
- Added async _acall to FakeListLLM (#5439)
- Feat: Add batching to Qdrant (#5443)
- Update psychicapi version (#5471)
- Add maximal relevance search to SKLearnVectorStore (#5430)
- add simple test for imports (#5461)
- Ability to specify credentials wihen using Google BigQuery as a data loader (#5466)
- convert the parameter 'text' to uppercase in the function 'parse' of the class BooleanOutputParser (#5397)
- added n_threads functionality for gpt4all (#5427)
- Allow for async use of SelfAskWithSearchChain (#5394)
- Allow ElasticsearchEmbeddings to create a connection with ES Client object (#5321)
- SQLite-backed Entity Memory (#5129)
- py tracer fixes (#5377)
- Harrison/html splitter (#5468)
- Feature: Qdrant filters supports (#5446)
- Add matching engine vectorstore (#3350)
- code splitter docs (#5480)
- Bedrock llm and embeddings (#5464)
- add more vars to text splitter (#5503)
- bump 187 (#5504)
- Add Feedback Methods + Evaluation examples (#5166)
- Add allow_download as attribute for GPT4All (#5512)
- added DeepLearing.AI course link (#5518)
- Skips creating boto client for Bedrock if passed in constructor (#5523)
- Add Managed Motorhead (#5507)
- Replace enumerate with zip. (#5527)
- Add minor fixes for PySpark Document Loader Docs (#5525)
- docs: unstructured no longer requires installing detectron2 from source (#5524)
- Replace list comprehension with generator. (#5526)
- Add param requests_kwargs for WebBaseLoader (#5485)
- Replace loop appends with list comprehension. (#5528)
- [retrievers][knn] Replace loop appends with list comprehension. (#5529)
- Fix wrong class instantiation in docs MMR example (#5501)
- Add texts with embeddings to PGVector wrapper (#5500)
- make BaseEntityStore inherit from BaseModel (#5478)
- docs `ecosystem/integrations` update 3 (#5470)
- feat(integrations): Add WandbTracer (#4521)
- add maxcompute (#5533)
- add brave search util (#5538)
- Corrects inconsistently misspelled variable name. (#5559)
- Qdrant self query (#5567)
- bump 188 (#5568)
- make the elasticsearch api support version which below 8.x (#5495)
- Fix typo in docugami.ipynb (#5571)
- Add missing comma in conv chat agent prompt json (#5573)
- Fix bedrock auth validation (#5574)
- Documentation fixes (linting and broken links) (#5563)
- nit (#5578)
- Fix SQLAlchemy truncating text when it is too big (#5206)
- docs(integration): update colab and external links in WandbTracing docs (#5602)
- Rm Template Title (#5616)
- human approval callback (#5581)
- Es knn index search  5346 (#5569)
- Fix: Qdrant ids (#5515)
- Dev2049/add argilla callback (#5621)
- bump 189 (#5620)
- fix chroma update_document to embed entire documents, fixes a characer-wise embedding bug (#5584)
- Fix bedrock llm boto3 client instantiation (#5629)
- Update Tracer Auth / Reduce Num Calls (#5517)
- fix import issue (#5636)
- feat: add `UnstructuredExcelLoader` for `.xlsx` and `.xls` files (#5617)
- Fixed multi input prompt for MapReduceChain (#4979)
- docs: `modules` pages simplified (#5116)
- minor refactor GenerativeAgentMemory (#5315)
- pref: reduce DB query error rate (#5339)
- Update confluence.py to return spaces between elements (#5383)
- Implements support for Personal Access Token Authentication in the ConfluenceLoader (#5385)
- Adds the option to pass the original prompt into the AgentExecutor for PlanAndExecute agents (#5401)
- QuickFix for FinalStreamingStdOutCallbackHandler: Ignore new lines & white spaces (#5497)
- Add parameters to send_message() call for vertexai chat models (PaLM2) (#5566)
- handle single arg to and/or (#5637)
- docs `ecosystem/integrations` update 4 (#5590)
- nit: pgvector python example notebook, fix variable reference (#5595)
- Harrison/update azure nb (#5665)
- Harrison/pubmed integration (#5664)
- removing client+namespace in favor of collection (#5610)
- fix: correct momento chat history notebook typo and title (#5646)
- Created fix for 5475 (#5659)
- FileCallbackHandler (#5589)
- refactor: BaseStringMessagePromptTemplate from_template method  (#5332)
- Update youtube.py - Fix metadata validation error in YoutubeLoader (#5479)
- Improve Error Messaging for APOC Procedure Failure in Neo4jGraph (#5547)
- Support similarity_score_threshold retrieval with Chroma (#5655)
- This fixes issue #5651 - GPT4All wrapper loading issue (#5657)
- Add args_schema to google_places tool (#5680)
- Harrison/pipeline prompt (#5540)
- Added Dependencies Status, Open issues and releases badges in Readme.md (#5681)
- SQL agent : Improved prompt engineering prevents agent guessing database column names. (#5671)
- Retitles Bedrock doc to appear in correct alphabetical order in site nav (#5639)
- Update MongoDBChatMessageHistory to create an index on SessionId (#5632)
- Raise an exception in MKRL and Chat Output Parsers if parsing text which contains both an action and a final answer (#5609)
- refactor: extract token text splitter function (#5179)
- sqlalchemy MovedIn20Warning declarative_base DEPRICATION fix  (#5676)
- top_k and top_p transposed in vertexai (#5673)
- bump version to 190 (#5704)
- Addresses GPT4All wrapper model_type attribute issues  #5720. (#5743)
- docs: Added Deploying LLMs into production + a new ecosystem (#4047)
- Adding support to save multiple memories at a time. Cuts save time by … (#5172)
- Cypher search: Check if generated Cypher is provided in backticks (#5541)
- Zep Hybrid Search (#5742)
- Removes unnecessary backslash escaping for backticks in python (#5751)
- Fix a typo in the documentation for the Slack document loader (#5745)
- Error in documentation: Chroma constructor (#5731)
- Integrate Clickhouse as Vector Store (#5650)
- Create OpenAIWhisperParser for generating Documents from audio files (#5580)
- docs: `ecosystem/integrations` update 5 (#5752)
- docs: updated `ecosystem/dependents` (#5753)
- Add class attribute "return_generated_question" to class "BaseConversationalRetrievalChain" (#5749)
- Add aviary support (#5661)
- cohere retries (#5757)
- Strips whitespace and \n from loc before filtering urls from sitemap (#5728)
- Harrison/youtube multi language (#5758)
- fix markdown text splitter horizontal lines (#5625)
- Tracing Group (#5326)
- Update tutorials.md (#5761)
- feat: Support for `Tigris` Vector Database for vector search (#5703)
- Scores are explained in vectorestore docs (#5613)
- bump ver 191 (#5766)
- Use client from LCP-SDK (#5695)
- fix ver 191 (#5784)
- Set Falsey (#5783)
- Attribute support for html tags (#5782)
- support returning run info for llms, chat models and chains (#5666)
- fixing from_documents method of the MongoDB Atlas vector store (#5794)
- Revise DATABRICKS_API_TOKEN as DATABRICKS_TOKEN (#5796)
- YoutubeAudioLoader and updates to OpenAIWhisperParser (#5772)
- Base RunEvaluator Chain (#5750)
- [Docs][Hotfix] Fix broken links (#5800)
- Add UTF-8 json ouput support while langchain.debug is set to True. (#5802)
- WIP: openai settings (#5792)
- added support for different types in ResponseSchema class (#5789)
- fixed faiss integ tests (#5808)
- add doc about reusing MongoDBAtlasVectorSearch (#5805)
- Update adding_memory.ipynb (#5806)
- rm docs mongo (#5811)
- bump ver to 192 (#5812)
- fix: fullfill openai params when embedding (#5821)
- bump version to 193 (#5838)
- Add in the async methods and link the run id (#5810)
- feat: issue-5712 add sleep tool (#5715)
- Rm extraneous args to the trace group helper (#5801)
- FIX: backslash escaped (#5815)
- Add DeepInfra embeddings integration with tests and examples, better exception handling for Deep Infra LLM (#5854)
- Add how to use a custom scraping function with the sitemap loader. (#5847)
- feat: Add `UnstructuredCSVLoader` for CSV files (#5844)
- Add logging in PBI tool (#5841)
- Add additional VertexAI Params (#5837)
- Update microsoft loader example with docx2txt dependency (#5832)
- docs: add Shale Protocol integration guide (#5814)
- qdrant vector store - search with relevancy scores (#5781)
- Update to Getting Started docs page for Memory (#5855)
- Fix exporting GCP Vertex Matching Engine from vectorstores (#5793)
- Add knn and query search field options to ElasticKnnSearch (#5641)
- propagate callbacks to ConversationalRetrievalChain (#5572)
- Fix serialization issue with W&B (#5693)
- Added SingleStoreDB Vector Store (#5619)
- Refactor and update databricks integration page (#5575)
- Implement saving and loading of RetrievalQA chain (#5818)
- Harrison/fauna loader (#5864)
- Harrison/nebula graph (#5865)
- bump version to 194 (#5866)
- fix: update qa_chain doc for "chai_type" (#5877)
- Update run eval imports in init (#5858)
- Fix the shortcut conflict for document page search (#5874)
- Fixes model arguments for amazon models (#5896)
- Feature/add AWS Kendra Index Retriever (#5856)
- Use LCP Client in Tracer (#5908)
- Create snowflake Loader (#5825)
- arxiv: Correct name of search client attribute to 'arxiv_search' from incorrect 'arxiv_client' (#5917)
- Fix typo (#5894)
- Baseten integration (#5862)
- Add start index to metadata in TextSplitter (#5912)
- Fix openai proxy error (#5914)
- Fix the issue where the parameters passed to VertexAI ignored #5889 (#5891)
- Add support for the endpoint URL in DynamoDBChatMesasgeHistory (#5836)
- Expose full params in Qdrant (#5947)
- fixes to docs (#5919)
- bump ver to 195 (#5949)
- Add load() to snowflake loader (#5956)
- LOTR: Lord of the Retrievers. A retriever that merge several retrievers together applying document_formatters to them. (#5798)
- bump version to 196 (#5988)
- Fix: SnowflakeLoader returning empty documents (#5967)
- Fixed typo missing "use" (#5991)
- add test for structured tools (#5989)
- Fix handling of missing action & input for async MRKL agent (#5985)
- Add additional parameters to Graph Cypher Chain  (#5979)
- Add a new vector store - AwaDB  (#5971) (#5992)
- Create Airtable loader (#5958)
- feat: Add `UnstructuredXMLLoader` for `.xml` files (#5955)
- Update to Vectara integration (#5950)
- fix: use model token limit not tokenizer ditto (#5939)
- Fix: Grammer fix in documentation (#5925)
- Fix IndexError in RecursiveCharacterTextSplitter (#5902)
- add ocr_languages param for ConfluenceLoader.load() (#5823)
- Harrison/arxiv fix (#5993)
- Obey handler.raise_error in _ahandle_event_for_handler (#6001)
- support kwargs (#5990)
- bump version to 197 (#6007)
- Update databricks.md (#6006)
- [APIChain] enhance the robustness or url (#6008)
- feat: :sparkles: Added filtering option to FAISS vectorstore (#5966)
- fix: TypeError when loading confluence pages by cql (#5878)
- Harrison/embaas (#6010)
- I before E (#6015)
- nc/load (#5733)
- Update check (#6020)
- Langchain decorators (#6017)
- Remove from PR template (#6018)
- add from_documents interface in awadb vector store (#6023)
- Harrison/hologres (#6012)
- Update MongoDB Atlas support docs (#6022)
- add dashscope text embedding (#5929)
- Harrison/cognitive search (#6011)
- bump ver to 198 (#6026)
- Mongo db doc fix (#6042)
- embaas title
- comment out
- chore: spedd up integration test by using smaller model (#6044)
- Text splitter for Markdown files by header (#5860)
- Log tracer errors (#6066)
- Add embaas document extraction api endpoints  (#6048)
- improve tools (#6062)
- propogate kwargs fully (#6076)
- Enable serialization for anthropic (#6049)
- turn off repr (#6078)
- Use Run object from SDK (#6067)
- Fix for ModuleNotFoundError while running langchain-server. Issue #5833 (#6077)
- Add tests and update notebook for MarkdownHeaderTextSplitter (#6069)
- support functions (#6099)
- convert tools to openai (#6100)
- Implement `max_marginal_relevance_search` in `VectorStore` of Pinecone (#6056)
- bump version to 199 (#6102)
- Harrison/notebook functions (#6103)
- Add support for tags (#5898)
- support streaming for functions (#6115)
- Return session name in runner response (#6112)
- add functions agent (#6113)
- bump ver to 200 (#6130)
- Add Run Collector Callback (#6133)
- Update Name (#6136)
- Update readthedocs_documentation.ipynb (#6148)
- typo: 'following following' to 'following' (#6163)
- Add docs for tags (#6155)
-  feat: Add support for the Solidity language (#6054)
- feat: add content_format param to ConfluenceLoader.load() (#5922)
- count tokens for new OpenAI model versions (#6195)
- Fix typo `pandocs` to `pandoc` (#6203)
- Harrison/use functions agent (#6185)
- bump version to 201 (#6233)
- Add Tags for LLMs (#6229)
- Feature/add acreom loader (#5780)
- Support chat history persistence in AutoGPT (#5716)
- Improve Error Message for failed callback (#6247)
- Harrison/openai functions (#6223)
- Harrison/openai functions (#6261)
- Fix: change the chatgpt plugin retriever metadata format (#5920)
- Update output format of MosaicML endpoint to be more flexible (#6060)
- ArxivAPIWrapper - doc_content_chars_max (#6063)
- bump to 202 (#6262)
- Doc refactor (#6300)
- rm ignore_vercel (#6302)
- update api link (#6303)
- update readme (#6304)
- basic redirect (#6309)
- more redirect (#6314)
- Update dev container (#6189)
- Del linkcheck readme (#6317)
- Fixes #6282 (#6283)
- nit (#6305)
- Improve the performance of add_texts interface and upgrade the AwaDB from 0.3.2 to 0.3.3 (#6316)
- fix eval guide links (#6319)
- Harrison/deeplake new features (#6263)
- Better Entity Memory code documentation (#6318)
- Handle Managed Motorhead Data Key (#6169)
- changed height in the nb example (#6327)
- fix links to prompt templates and example selectors (#6332)
- DocArray as a Retriever (#6031)
- make modelname_to_contextsize as a staticmethod (#6040)
- Improve AnalyticDB Vector Store implementation without affecting user  (#6086)
- Add oobabooga/text-generation-webui support as a llm (#5997)
- Allow GoogleDrive to authenticate via application default credentials on Cloud Run/GCE etc without service key (#6035)
- qdrant: search by vector (#6043)
- Harrison/error zero tools (#6340)
- Harrison/faiss score (#6341)
- Custom Anthropic API URL (#6221)
- fix spelling
- Make lckwargs private (#6344)
- fix titles in documentation
- update web_base.py to have verify option (#6107)
- Add new openai 0613 model costs (#6110)
- Add ignore vercel preview script (#6320)
- Harrison/mmr support for opensearch (#6349)
- Update MD header text splitter notebook (#6339)
- Add self query retriever example with MD header splitting (#6359)
- bump 203 (#6372)
- Guardrails output parser: Pass LLM api for reasking (#6089)
- Harrison/gdrive enhancements (#6375)
- Extend `ArgillaCallbackHandler` support (#6153)
- Add the ability to run the map_reduce chains  process results step as async  (#6181)
- fix link of callbacks on modules page (#6323)
- Fixed PermissionError on windows (#6170)
- searx - docs
- Harrison/myscale self query (#6376)
- Harrison/metaphor search fix (#6387)
- Harrison/zep mem (#6388)
- Fix class promotion (#6187)
- Harrison/functions docs improvements (#6389)
- Add option to save/load graph cypher QA (#6219)
- Fix output final text for HuggingFaceTextGenInference when streaming (#6211)
- OpenAI functions dont work with async streaming... #6225 (#6226)
- searx_search: updated tools and doc (#6276)
- Fix integration tests for Faiss vector store (#6281)
- [hotfix] Deep Lake fails on newer version due to hardcode (#6383)
- Fix latest clickhouse vector schema change  (#6385)
- Fix typo in the CAI critique prompt (#6123)
- Correct AzureSearch Vector Store not applying search_kwargs when searching (#6132)
- Fixed an unhandled error that was raised when DynamoDB did not have any chat history. (#6141)
- Fix LLM types so that they can be loaded from config dicts (#6235)
- add max_context_size property in BaseOpenAI (#6239)
- Add markdown to specify important arguments (#6246)
- Update web_base.ipynb for guiding purposes (#6248)
- Iterate through filtered file types instead of all listed files (#6258)
- Fixes typo in Vectara.similarity_search (#6277)
- - Fix pass system_message argument in new feature openai_functions_agent (#6297)
- Added gpt-3.5-turbo 0613 16k and 16k-0613 pricing (#6287)
- rm pandas from arize (#6392)
- Harrison/typesense fix (#6391)
- Harrison/chroma fix (#6390)
- Update web_base.py  _fetch() method For SiteMapLoader (#6256)
- support memory for functions (#6165)
- fix prod docs build (#6402)
- Docs nit (#6350)
- changes to llm chain (#6328)
- Harrison/refactor functions (#6408)
- bump version to 205 (#6410)
- Include placeholder value for all secrets, not just kwargs (#6421)
- remove mongo
- expose docs chains (#6453)
- Run eval in eval mode (#6447)
- Update arize_callback.py (#6433)
- Add Trajectory Eval RunEvaluator (#6449)
- fix anthropic chat model mutating input list (#6457)
- Remove extra word in the introduction documentation (#6450)
- Add example for question answering over documents with OpenAI Function Agent (#6448)
- Add `_similarity_search_with_relevance_scores` in `Pinecone` (#6446)
- Update web_base.ipynb (#6430)
- Remove backticks without clear purpose from docs (#6442)
- Fix Custom LLM Agent example (#6429)
- Update introduction.mdx (#6425)
- docs `retrievers` fixes (#6299)
- Fixed a link typo /-/route -> /-/routes. and change endpoint format (#6186)
- Incorrect argument count handling (#5543)
- Harrison/functions in retrieval (#6463)
- Fix for #6431 - chatprompt template with partial variables giing validation error (#6456)
- Update SinglStoreDB vectorstore (#6423)
- Fix broken links in autonomous agents docs (#6398)
- Fix the issue where ANTHROPIC_API_URL set in environment is not takin… (#6400)
- Improve error message (#6275)
- Harrison/unstructured page number (#6464)
- feat: use latest duckduckgo_search API to call (#6409)
- fix: llm caching for replicate (#6396)
- Update serpapi.py Support baidu list type answer_box (#6386)
- fix neo4j schema query (#6381)
- bump version to 206 (#6465)
- add FunctionMessage support to `_convert_dict_to_message()` in OpenAI chat model (#6382)
- fix openai qa chain (#6487)
- Add Alibaba Cloud OpenSearch as a new vector store (#6154)
- release 207 (#6488)
- fix: change ddg to DDGS (#6480)
- improve documentation on base chain (#6468)
- Vector store support for Cassandra (#6426)
- Update notebook for MD header splitter and create new cookbook (#6399)
- docs/fix links (#6498)
- Fix link (#6501)
- Documentation Fix: Correct the example code output in the prompt templates doc (#6496)
- Fixed: 'readible' -> readable (#6492)
- Make streamlit import optional (#6510)
- Fix typo in docstring of format_tool_to_openai_function (#6479)
- typo(llamacpp.ipynb): 'condiser' -> 'consider' (#6474)
- Export trajectory eval fn (#6509)
- Update index.mdx (#6326)
- Add KuzuQAChain (#6454)
- Be able to use Codey models on Vertex AI (#6354)
- Add async support for HuggingFaceTextGenInference (#6507)
- Feat: Add a prompt template parameter to qa with structure chains (#6495)
- Integrate Rockset as Vectorstore (#6216)
- Fix issue with non-list `To` header in GmailSendMessage Tool (#6242)
- Update model token mappings/cost to include 0613 models (#6122)
- Infino integration for simplified logs, metrics & search across LLM data & token usage (#6218)
- Harrison/multi tool (#6518)
- bump to ver 208 (#6540)
- Relax string input mapper check (#6544)
- [Feature][VectorStore] Support StarRocks as vector db (#6119)
- Minor Grammar Fixes in Docs and Comments (#6536)
- Remove unintended double negation in docstring (#6541)
- update pr tmpl (#6552)
- feat: faiss filter from list (#6537)
- Wait for all futures (#6554)
- Fix whatsappchatloader - enable parsing new datetime format on WhatsApp chat (#6555)
- Remove duplicate databricks entries in ecosystem integrations (#6569)
- Change Data Loader Namespace (#6568)
- Detailed using the Twilio tool to send messages with 3rd party apps incl. WhatsApp (#6562)
- add motherduck docs (#6572)
- Upgrade the version of AwaDB and add some new interfaces (#6565)
- feat: interfaces for async embeddings, implement async openai (#6563)
- Add OpenLLM wrapper(#6578)
- Add AzureML endpoint LLM wrapper (#6580)
- Add missing word in comment (#6587)
- Clarifai integration (#5954)
- bump 209 (#6593)
- Fix callback forwarding in async plan method for OpenAI function agent (#6584)
- MD header text splitter returns Documents (#6571)
- add mongo (HOLD) (#6437)
- Allow callback handlers to opt into being run inline (#6424)
- StreamlitCallbackHandler (#6315)
- added redis method to delete entries by keys (#6222)
- Loader for OpenCityData and minor cleanups to Pandas, Airtable loaders (#6301)
- Add tags in agent initialization (#6559)
- Session to project (#6249)
- fix: remove callbacks arg from Tool and StructuredTool inferred schema (#6483)
- bump 210 (#6656)
- Openapi to openai (#6658)
- bump 211 (#6660)
- openapi_openai docstring (#6661)
- Create merge loader that combines documents from a set of loaders (#6659)
- Add delete and ensure add_texts performs upsert (w/ ID optional) (#6126)
- Recursive URL loader (#6455)
- ChatVertexAI broken - Fix error with sending context in params (#6652)
- Dev2049/bump 212 (#6665)
- fix(docs): broken link for OpenLLM (#6622)
- Fix grammar mistake in base.py in planners (#6611)
- Fix ray-project/Aviary integration (#6607)
- Fix Typo (#6595)
- Fix typo in myscale_self_query.ipynb (#6601)
- fix minor typo in vector_db_qa.mdx (#6604)
- Kendra retriever api (#6616)
- PowerBI: catch outdated token (#6634)
- update chroma notebook (#6664)
- openapi -> openai nit (#6667)
- adds doc_content_chars_max argument to WikipediaLoader (#6645)
- chroma nb close img tag (#6669)
- Changed generate_prompt.py (#6644)
- added docstrings where they missed (#6626)
- Wiki loader lint (#6670)
- Just corrected a small inconsistency on a doc page (#6603)
- Fix openapi parameter parsing (#6676)
- Amazon API Gateway hosted LLM (#6673)
- Session deletion method in motorhead memory (#6609)
- Harrison/optional ids opensearch (#6684)
-  Add caching to BaseChatModel (issue #1644) (#5089)
- bump to version 213 (#6688)
- Make bs4 a local import in recursive_url_loader.py (#6693)
- bump v214 (#6694)
- split up batch llm calls into separate runs (#5804)
- bump version to 215 (#6719)
- Fix Multi Functions Agent Tracing (#6702)
- fix chroma _similarity_search_with_relevance_scores missing `kwargs` … (#6708)
- Fix Typo in LangChain MyScale Integration  Doc (#6705)
- updated sql_database.py for returning sorted table names. (#6692)
- Fix WhatsAppChatLoader : Enable parsing additional formats (#6663)
- feat: added tqdm progress bar to UnstructuredURLLoader (#6600)
- feat: Add `UnstructuredRSTLoader` (#6594)
- beautifulsoup get_text kwargs in WebBaseLoader (#6591)
- Added a MHTML document loader (#6311)
- correct docs site links
- zep api_key auth

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
