### PR TITLE
prevent DuckDuckGoSearchAPIWrapper from consuming top result

### DIFF
--- a/langchain/utilities/duckduckgo_search.py
+++ b/langchain/utilities/duckduckgo_search.py
@@ -49,14 +49,15 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
                 safesearch=self.safesearch,
                 timelimit=self.time,
             )
-            if results is None or next(results, None) is None:
+            if results is None:
                 return ["No good DuckDuckGo Search Result was found"]
             snippets = []
             for i, res in enumerate(results, 1):
-                snippets.append(res["body"])
-                if i == self.max_results:
+                if res is not None:
+                    snippets.append(res["body"])
+                if len(snippets) == self.max_results:
                     break
-            return snippets
+        return snippets
 
     def run(self, query: str) -> str:
         snippets = self.get_snippets(query)
@@ -84,7 +85,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
                 safesearch=self.safesearch,
                 timelimit=self.time,
             )
-            if results is None or next(results, None) is None:
+            if results is None:
                 return [{"Result": "No good DuckDuckGo Search Result was found"}]
 
             def to_metadata(result: Dict) -> Dict[str, str]:
@@ -96,7 +97,8 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
 
             formatted_results = []
             for i, res in enumerate(results, 1):
-                formatted_results.append(to_metadata(res))
-                if i == num_results:
+                if res is not None:
+                    formatted_results.append(to_metadata(res))
+                if len(formatted_results) == num_results:
                     break
-            return formatted_results
+        return formatted_results


### PR DESCRIPTION
remove the `next` call that checks for None on the results generator

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: remove the `next` call that checks for None on the results generator
  - Issue: #6724 ,
  - Dependencies: none,
  - Tag maintainer: @vowelparrot,
  - Twitter handle: gabrielaltay
  - 
If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
