### PR TITLE
Throw error if trying to deserialize python prompts

### DIFF
--- a/langchain/prompts/loading.py
+++ b/langchain/prompts/loading.py
@@ -1,5 +1,4 @@
 """Load prompts from disk."""
-import importlib
 import json
 import logging
 from pathlib import Path
@@ -142,17 +141,11 @@ def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
         with open(file_path, "r") as f:
             config = yaml.safe_load(f)
     elif file_path.suffix == ".py":
-        spec = importlib.util.spec_from_loader(
-            "prompt", loader=None, origin=str(file_path)
+        raise ValueError(
+            "Python prompt serialization is no longer supported due to security issues."
+            "Use JSON or YAML instead. See:"
+            "https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/prompt_serialization"
         )
-        if spec is None:
-            raise ValueError("could not load spec")
-        helper = importlib.util.module_from_spec(spec)
-        with open(file_path, "rb") as f:
-            exec(f.read(), helper.__dict__)
-        if not isinstance(helper.PROMPT, BasePromptTemplate):
-            raise ValueError("Did not get object of type BasePromptTemplate.")
-        return helper.PROMPT
     else:
         raise ValueError(f"Got unsupported file type {file_path.suffix}")
     # Load the prompt from the config now.


### PR DESCRIPTION
Removes the ability to deserialize Python prompts and throws an error informing of the security issues with a link to documentation on how to use JSON and YAML instead. 

The docs don't even talk about Python, and the saving function in the base prompt class doesn't support saving to Python either. I'm guessing this is something left in for backwards compatibility, but I think due to the CVEs we should just remove it. 


Fixes #6627
Fixes #4849