### PR TITLE
Update the token_max value in mp_reduce

### DIFF
--- a/langchain/chains/combine_documents/map_reduce.py
+++ b/langchain/chains/combine_documents/map_reduce.py
@@ -10,8 +10,8 @@ from langchain.callbacks.manager import Callbacks
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.llm import LLMChain
 from langchain.docstore.document import Document
-
-
+from langchain.llms import openai
+max_tokens = openai.BaseOpenAI.modelname_to_contextsize("gpt-3.5-turbo-16k-0613") - 1000
 class CombineDocsProtocol(Protocol):
     """Interface for the combine_docs method."""
 
@@ -132,7 +132,7 @@ class MapReduceDocumentsChain(BaseCombineDocumentsChain):
     def combine_docs(
         self,
         docs: List[Document],
-        token_max: int = 3000,
+        token_max: int = max_tokens,
         callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> Tuple[str, dict]:
@@ -171,7 +171,7 @@ class MapReduceDocumentsChain(BaseCombineDocumentsChain):
         self,
         results: List[Dict],
         docs: List[Document],
-        token_max: int = 3000,
+        token_max: int = max_tokens,
         callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> Tuple[List[Document], dict]:
@@ -209,7 +209,7 @@ class MapReduceDocumentsChain(BaseCombineDocumentsChain):
         self,
         results: List[Dict],
         docs: List[Document],
-        token_max: int = 3000,
+        token_max: int = max_tokens,
         callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> Tuple[str, dict]:


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: When I use the gpt-3.5-turbo-16k model, I often encounter this ValueError 'A single document was so long it could not be combined' due to the small token_max.I always need to modify a larger value for token_max to resolve the issue.I hope to enhance the functionality by dynamically modifying the value of token_max through obtaining the model used by the current chain.
  - Issue: The issue of encountering frequent errors with long documents when using the large tokens model has been addressed and fixed.
  - Dependencies: We need a more dynamic way of obtaining the model name in order to retrieve the maximum tokens of the model. This aspect still requires further improvement.
  - Tag maintainer: @hwchase17 @dev2049 @vowelparrot

