### PR TITLE
fix(memory): allow internal chains to use memory

### DIFF
--- a/langchain/chains/sequential.py
+++ b/langchain/chains/sequential.py
@@ -62,6 +62,9 @@ class SequentialChain(Chain):
 
         for chain in chains:
             missing_vars = set(chain.input_keys).difference(known_variables)
+            if chain.memory:
+                missing_vars = missing_vars.difference(chain.memory.memory_variables)
+
             if missing_vars:
                 raise ValueError(
                     f"Missing required input keys: {missing_vars}, "


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->

Fixed #6768.

This is a workaround only. I think a better longer-term solution is for chains to declare how many input variables they *actually* need (as opposed to ones that are in the prompt, where some may be satisfied by the memory). Then, a wrapping chain can check the input match against the actual input variables.

@hwchase17 
