### PR TITLE
Intermediate combine results in output of BaseConversationalRetrievalChain

### DIFF
--- a/langchain/chains/combine_documents/map_rerank.py
+++ b/langchain/chains/combine_documents/map_rerank.py
@@ -134,9 +134,10 @@ class MapRerankDocumentsChain(BaseCombineDocumentsChain):
                 extra_info[key] = document.metadata[key]
         if self.return_intermediate_steps:
             extra_info["intermediate_steps"] = results
-        
-        if document.metadata.get('source'):
-            output[self.answer_key] = f"""{output[self.answer_key]}\nSOURCES: {document.metadata.get('source')}"""
+
+        source = document.metadata.get('source')
+        if source is not None:
+            output[self.answer_key] = f"""{output[self.answer_key]}\nSOURCES: {source}"""
         
         return output[self.answer_key], extra_info
 

--- a/langchain/chains/combine_documents/map_rerank.py
+++ b/langchain/chains/combine_documents/map_rerank.py
@@ -134,6 +134,10 @@ class MapRerankDocumentsChain(BaseCombineDocumentsChain):
                 extra_info[key] = document.metadata[key]
         if self.return_intermediate_steps:
             extra_info["intermediate_steps"] = results
+        
+        if document.metadata.get('source'):
+            output[self.answer_key] = f"""{output[self.answer_key]}\nSOURCES: {document.metadata.get('source')}"""
+        
         return output[self.answer_key], extra_info
 
     @property

--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -124,7 +124,8 @@ class BaseConversationalRetrievalChain(Chain):
             output["source_documents"] = docs
         if self.return_generated_question:
             output["generated_question"] = new_question
-        if self.combine_docs_chain.return_intermediate_steps:
+        if hasattr(self.combine_docs_chain, 'return_intermediate_steps') and \
+        self.combine_docs_chain.return_intermediate_steps:
             output['combine_intermediate_steps'] = answer_info.get('intermediate_steps')
             
         return output


### PR DESCRIPTION
Add intermediate_steps from combine_docs_chain's results to the output of BaseConversationalRetrievalChain when combine_docs_chain.return_intermediate_steps is True. This can help while debugging and in some subsequent analyses.