### PR TITLE
Adjusted OpenAI cost calculation

### DIFF
--- a/langchain/callbacks/openai_info.py
+++ b/langchain/callbacks/openai_info.py
@@ -96,7 +96,7 @@ def get_openai_token_cost_for_model(
             f"Unknown model: {model_name}. Please provide a valid OpenAI model name."
             "Known models are: " + ", ".join(MODEL_COST_PER_1K_TOKENS.keys())
         )
-    return MODEL_COST_PER_1K_TOKENS[model_name] * num_tokens / 1000
+    return MODEL_COST_PER_1K_TOKENS[model_name] * (num_tokens / 1000)
 
 
 class OpenAICallbackHandler(BaseCallbackHandler):


### PR DESCRIPTION
Added parentheses to ensure the division operation is performed before multiplication. This now correctly calculates the cost by dividing the number of tokens by 1000 first (to get the cost per token), and then multiplies it with the model's cost per 1k tokens @agola11 