### PR TITLE
Synchronize metadata types between pgvector.add_texts() and pgvector.similarity_search_with_score_by_vector()

### DIFF
--- a/langchain/vectorstores/pgvector.py
+++ b/langchain/vectorstores/pgvector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import enum
 import logging
 import uuid
+import json
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 import sqlalchemy
@@ -400,7 +401,7 @@ class PGVector(VectorStore):
             (
                 Document(
                     page_content=result.EmbeddingStore.document,
-                    metadata=result.EmbeddingStore.cmetadata,
+                    metadata=json.loads(result.EmbeddingStore.cmetadata),
                 ),
                 result.distance if self.embedding_function is not None else None,
             )


### PR DESCRIPTION
…similarity_search_with_score_by_vector()

pgvector.add_texts() stored metadata to postgresql is from dict to string, but pgvector.similarity_search_with_score_by_vector() get metadata just string from database, when struct Document object, report error:
```
pydantic.error_wrappers.ValidationError: 1 validation error for Document
metadata
  value is not a valid dict (type=type_error.dict)
```
