### PR TITLE
Order messages in PostgresChatMessageHistory

### DIFF
--- a/langchain/memory/chat_message_histories/postgres.py
+++ b/langchain/memory/chat_message_histories/postgres.py
@@ -49,7 +49,7 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the messages from PostgreSQL"""
-        query = f"SELECT message FROM {self.table_name} WHERE session_id = %s;"
+        query = f"SELECT message FROM {self.table_name} WHERE session_id = %s ORDER BY id;"
         self.cursor.execute(query, (self.session_id,))
         items = [record["message"] for record in self.cursor.fetchall()]
         messages = messages_from_dict(items)

--- a/langchain/memory/chat_message_histories/postgres.py
+++ b/langchain/memory/chat_message_histories/postgres.py
@@ -49,7 +49,9 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the messages from PostgreSQL"""
-        query = f"SELECT message FROM {self.table_name} WHERE session_id = %s ORDER BY id;"
+        query = (
+            f"SELECT message FROM {self.table_name} WHERE session_id = %s ORDER BY id;"
+        )
         self.cursor.execute(query, (self.session_id,))
         items = [record["message"] for record in self.cursor.fetchall()]
         messages = messages_from_dict(items)


### PR DESCRIPTION
Fixes issue: https://github.com/hwchase17/langchain/issues/6829

This guarantees message history is in the correct order. 

@hwchase17 
