### PR TITLE
Zapier - Add better error messaging for 401 responses

### DIFF
--- a/langchain/utilities/searx_search.py
+++ b/langchain/utilities/searx_search.py
@@ -322,7 +322,7 @@ class SearxSearchWrapper(BaseModel):
             str: The result of the query.
 
         Raises:
-            ValueError: If an error occured with the query.
+            ValueError: If an error occurred with the query.
 
 
         Example:

--- a/tests/unit_tests/tools/test_zapier.py
+++ b/tests/unit_tests/tools/test_zapier.py
@@ -1,5 +1,6 @@
 """Test building the Zapier tool, not running it."""
 from unittest.mock import MagicMock, patch
+
 import pytest
 import requests
 


### PR DESCRIPTION
Description: When a 401 response is given back by Zapier, hint to the end user why that may have occurred

- If an API Key was initialized with the wrapper, ask them to check their API Key value
- if an access token was initialized with the wrapper, ask them to check their access token or verify that it doesn't need to be refreshed.

Tag maintainer: @dev2049 