### PR TITLE
Provided default values for tags and inheritable_tags args in BaseRun…

### DIFF
--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -379,8 +379,8 @@ class BaseRunManager(RunManagerMixin):
         handlers: List[BaseCallbackHandler],
         inheritable_handlers: List[BaseCallbackHandler],
         parent_run_id: Optional[UUID] = None,
-        tags: List[str]=[],
-        inheritable_tags: List[str]=[],
+        tags: Optional[List[str]] = None,
+        inheritable_tags: Optional[List[str]] = None,
     ) -> None:
         """Initialize the run manager.
 
@@ -391,15 +391,15 @@ class BaseRunManager(RunManagerMixin):
                 The list of inheritable handlers.
             parent_run_id (UUID, optional): The ID of the parent run.
                 Defaults to None.
-            tags (List[str]): The list of tags.
-            inheritable_tags (List[str]): The list of inheritable tags.
+            tags (Optional[List[str]]): The list of tags.
+            inheritable_tags (Optional[List[str]]): The list of inheritable tags.
         """
         self.run_id = run_id
         self.handlers = handlers
         self.inheritable_handlers = inheritable_handlers
-        self.tags = tags
-        self.inheritable_tags = inheritable_tags
         self.parent_run_id = parent_run_id
+        self.tags = tags or []
+        self.inheritable_tags = inheritable_tags or []
 
     @classmethod
     def get_noop_manager(cls: Type[BRM]) -> BRM:

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -379,8 +379,8 @@ class BaseRunManager(RunManagerMixin):
         handlers: List[BaseCallbackHandler],
         inheritable_handlers: List[BaseCallbackHandler],
         parent_run_id: Optional[UUID] = None,
-        tags: List[str],
-        inheritable_tags: List[str],
+        tags: List[str]=[],
+        inheritable_tags: List[str]=[],
     ) -> None:
         """Initialize the run manager.
 


### PR DESCRIPTION
…Manager

To avoid the error message:

TypeError: BaseRunManager.__init__() missing 2 required keyword-only arguments: 'tags' and 'inheritable_tags'

when running AsyncCallbackManagerForChainRun (from langchain.callbacks.manager import AsyncCallbackManagerForChainRun), provided default values for tags and inheritable_tages of empty lists in manager.py BaseRunManager.


  - Description: In manager.py, `BaseRunManager`, default values were provided for the `__init__` args `tags` and `inheritable_tags`. They default to empty lists (`[]`).
  - Issue: When trying to use Nvidia NeMo Guardrails with LangChain, the following exception was raised:
  
```
[autoreload of chatbot failed: Traceback (most recent call last):
  File "C:\Users\Siraj\anaconda3\envs\redacre_test_1\lib\site-packages\IPython\extensions\autoreload.py", line 276, in check
    superreload(m, reload, self.old_objects)
  File "C:\Users\Siraj\anaconda3\envs\redacre_test_1\lib\site-packages\IPython\extensions\autoreload.py", line 475, in superreload
    module = reload(module)
  File "C:\Users\Siraj\anaconda3\envs\redacre_test_1\lib\importlib\__init__.py", line 169, in reload
    _bootstrap._exec(spec, module)
  File "<frozen importlib._bootstrap>", line 619, in _exec
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\Users\Siraj\Documents\Personal\Work\Aurelio\20230530 Red Acre\automationai\backend\chatbot\automationai\chatbot.py", line 9, in <module>
    from nemoguardrails import LLMRails, RailsConfig
  File "C:\Users\Siraj\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\__init__.py", line 17, in <module>
    from .rails import LLMRails, RailsConfig
  File "C:\Users\Siraj\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\rails\__init__.py", line 17, in <module>
    from .llm.llmrails import LLMRails
  File "C:\Users\Siraj\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\rails\llm\llmrails.py", line 26, in <module>
    from nemoguardrails.actions.llm.generation import LLMGenerationActions
TypeError: BaseRunManager.__init__() missing 2 required keyword-only arguments: 'tags' and 'inheritable_tags'
]
Traceback (most recent call last):

  File ~\anaconda3\envs\redacre_test_1\lib\site-packages\spyder_kernels\py3compat.py:356 in compat_exec
    exec(code, globals, locals)

  File c:\users\siraj\documents\personal\work\aurelio\20230530 red acre\automationai\backend\chatbot\automationai\sra_test_1.py:8
    from chatbot import Chatbot

  File ~\Documents\Personal\Work\Aurelio\20230530 Red Acre\automationai\backend\chatbot\automationai\chatbot.py:9
    from nemoguardrails import LLMRails, RailsConfig

  File ~\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\__init__.py:17
    from .rails import LLMRails, RailsConfig

  File ~\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\rails\__init__.py:17
    from .llm.llmrails import LLMRails

  File ~\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\rails\llm\llmrails.py:26
    from nemoguardrails.actions.llm.generation import LLMGenerationActions

  File ~\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\actions\llm\generation.py:46
    from nemoguardrails.logging.callbacks import logging_callbacks

  File ~\anaconda3\envs\redacre_test_1\lib\site-packages\nemoguardrails\logging\callbacks.py:237
    logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(

TypeError: BaseRunManager.__init__() missing 2 required keyword-only arguments: 'tags' and 'inheritable_tags'
```
I was using the NeMo Guardrails `LLMRails` module to create an app objects:

`self.app = LLMRails(config, verbose =True)`

The I tried to use:

`bot_message = self.app.generate_async(prompt=self.sys_msg, messages=history)`

The LLMRails` class makes use of `LLMGenerationActions`, which comes from:

`from nemoguardrails.actions.llm.generation import LLMGenerationActions`

In the generations.py module we have:

`from nemoguardrails.logging.callbacks import logging_callbacks`

and in callbacks.py, we have 

`from langchain.callbacks.manager import AsyncCallbackManagerForChainRun`

and the code (Let's call this 'Code A'):

```
logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
    run_id=uuid.uuid4(),
    parent_run_id=None,
    handlers=handlers,
    inheritable_handlers=handlers,
)
```

In the LangChain manager.py module, the class `AsyncCallbackManagerForChainRun` inherits the `AsyncRunManager` class, which in turn inherits the `BaseRunManager` class, which previously had (let's call this 'Code B'):

```
def __init__(
        self,
        *,
        run_id: UUID,
        handlers: List[BaseCallbackHandler],
        inheritable_handlers: List[BaseCallbackHandler],
        parent_run_id: Optional[UUID] = None,
        tags: List[str],
        inheritable_tags: List[str],
    )
```
  
  As you can see, Code A fails to provide the tags and inheritable_tags arguments. My guess was that these can be optional arguments, but perhaps I'm wrong. So, I changed Code B to:
  
```
  def __init__(
        self,
        *,
        run_id: UUID,
        handlers: List[BaseCallbackHandler],
        inheritable_handlers: List[BaseCallbackHandler],
        parent_run_id: Optional[UUID] = None,
        tags: List[str]=[],
        inheritable_tags: List[str]=[],
    )
```
  
  - Dependencies: The fix doesn't require any dependencies. Although to recreate the issue you probably need to install Nvidia NeMo Guardrails.
  - Tag maintainer: @agola11 @vowelparrot
  - Twitter handle: n/a.


