### PR TITLE
Update `langchain.chains.create_extraction_chain_pydantic` to parse results successfully

### DIFF
--- a/langchain/chains/openai_functions/extraction.py
+++ b/langchain/chains/openai_functions/extraction.py
@@ -61,7 +61,7 @@ def create_extraction_chain_pydantic(
 
     openai_schema = pydantic_schema.schema()
     openai_schema = _resolve_schema_references(
-        openai_schema, openai_schema["definitions"]
+        openai_schema, openai_schema.get("definitions", {})
     )
 
     function = _get_extraction_function(openai_schema)

--- a/langchain/chains/openai_functions/extraction.py
+++ b/langchain/chains/openai_functions/extraction.py
@@ -59,7 +59,7 @@ def create_extraction_chain_pydantic(
     class PydanticSchema(BaseModel):
         info: List[pydantic_schema]  # type: ignore
 
-    openai_schema = PydanticSchema.schema()
+    openai_schema = pydantic_schema.schema()
     openai_schema = _resolve_schema_references(
         openai_schema, openai_schema["definitions"]
     )


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
 
- Description: 
  - The current code uses `PydanticSchema.schema()` and `_get_extraction_function` at the same time. As a result, a response from OpenAI has two nested `info`, and `PydanticAttrOutputFunctionsParser` fails to parse it. This PR will use the pydantic class given as an arg instead.
- Issue: no related issue yet
- Dependencies: no dependency change
- Tag maintainer: @dev2049
- Twitter handle: @shotarok28
 
