### PR TITLE
Update Zapier Jupyter notebook to include brief OAuth example

### DIFF
--- a/docs/extras/modules/agents/tools/integrations/zapier.ipynb
+++ b/docs/extras/modules/agents/tools/integrations/zapier.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "2. User-facing (Oauth): for production scenarios where you are deploying an end-user facing application and LangChain needs access to end-user's exposed actions and connected accounts on Zapier.com\n",
     "\n",
-    "This quick start will focus on the server-side use case for brevity. Review [full docs](https://nla.zapier.com/start/) for user-facing oauth developer support.\n",
+    "This quick start will focus mostly on the server-side use case for brevity. Jump to [Example Using OAuth Access Token](#oauth) to see a short example how to set up Zapier for user-facing situations. Review [full docs](https://nla.zapier.com/start/) for full user-facing oauth developer support.\n",
     "\n",
     "This example goes over how to use the Zapier integration with a `SimpleSequentialChain`, then an `Agent`.\n",
     "In code, below:"
@@ -323,12 +323,34 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "09ff954e-45f2-4595-92ea-91627abde4a0",
    "metadata": {},
+   "source": [
+    "# <a id=\"oauth\">Example Using OAuth Access Token</a>\n",
+    "The below snippet shows how to initialize the wrapper with a procured OAuth access token. Note the argument being passed in as opposed to setting an environment variable. Review the [authentication docs](https://nla.zapier.com/docs/authentication/#oauth-credentials) for full user-facing oauth developer support.\n",
+    "\n",
+    "The developer is tasked with handling the OAuth handshaking to procure and refresh the access token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c6835c8",
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "llm = OpenAI(temperature=0)\n",
+    "zapier = ZapierNLAWrapper(zapier_nla_oauth_access_token='<fill in access token here>')\n",
+    "toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier)\n",
+    "agent = initialize_agent(\n",
+    "    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True\n",
+    ")\n",
+    "\n",
+    "agent.run(\n",
+    "    \"Summarize the last email I received regarding Silicon Valley Bank. Send the summary to the #test-zapier channel in slack.\"\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/docs/extras/modules/agents/tools/integrations/zapier.ipynb
+++ b/docs/extras/modules/agents/tools/integrations/zapier.ipynb
@@ -149,7 +149,7 @@
    "id": "bcdea831",
    "metadata": {},
    "source": [
-    "# Example with SimpleSequentialChain\n",
+    "## Example with SimpleSequentialChain\n",
     "If you need more explicit control, use a chain, like below."
    ]
   },
@@ -327,7 +327,7 @@
    "id": "09ff954e-45f2-4595-92ea-91627abde4a0",
    "metadata": {},
    "source": [
-    "# <a id=\"oauth\">Example Using OAuth Access Token</a>\n",
+    "## <a id=\"oauth\">Example Using OAuth Access Token</a>\n",
     "The below snippet shows how to initialize the wrapper with a procured OAuth access token. Note the argument being passed in as opposed to setting an environment variable. Review the [authentication docs](https://nla.zapier.com/docs/authentication/#oauth-credentials) for full user-facing oauth developer support.\n",
     "\n",
     "The developer is tasked with handling the OAuth handshaking to procure and refresh the access token."


### PR DESCRIPTION
Description: Adds a brief example of using an OAuth access token with the Zapier wrapper.  Also links to the Zapier documentation to learn more about OAuth flows.
Tag maintainer: @dev2049 