### PR TITLE
Re-add Support for SQLAlchemy <1.4

### DIFF
--- a/langchain/vectorstores/analyticdb.py
+++ b/langchain/vectorstores/analyticdb.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type
 
 from sqlalchemy import REAL, Column, String, Table, create_engine, insert, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, TEXT
-from sqlalchemy.engine import Row
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -58,6 +57,14 @@ class AnalyticDB(VectorStore):
         self.pre_delete_collection = pre_delete_collection
         self.logger = logger or logging.getLogger(__name__)
         self.__post_init__()
+
+        try:
+            from sqlalchemy.engine import Row
+        except ImportError:
+            raise ImportError(
+                "Could not import Row from sqlalchemy.engine. "
+                "Please 'pip install sqlalchemy>=1.4'."
+            )
 
     def __post_init__(
         self,

--- a/langchain/vectorstores/analyticdb.py
+++ b/langchain/vectorstores/analyticdb.py
@@ -58,14 +58,6 @@ class AnalyticDB(VectorStore):
         self.logger = logger or logging.getLogger(__name__)
         self.__post_init__()
 
-        try:
-            from sqlalchemy.engine import Row
-        except ImportError:
-            raise ImportError(
-                "Could not import Row from sqlalchemy.engine. "
-                "Please 'pip install sqlalchemy>=1.4'."
-            )
-
     def __post_init__(
         self,
     ) -> None:
@@ -274,7 +266,7 @@ class AnalyticDB(VectorStore):
                 "Could not import Row from sqlalchemy.engine. "
                 "Please 'pip install sqlalchemy>=1.4'."
             )
-            
+
         filter_condition = ""
         if filter is not None:
             conditions = [

--- a/langchain/vectorstores/analyticdb.py
+++ b/langchain/vectorstores/analyticdb.py
@@ -267,6 +267,14 @@ class AnalyticDB(VectorStore):
         filter: Optional[dict] = None,
     ) -> List[Tuple[Document, float]]:
         # Add the filter if provided
+        try:
+            from sqlalchemy.engine import Row
+        except ImportError:
+            raise ImportError(
+                "Could not import Row from sqlalchemy.engine. "
+                "Please 'pip install sqlalchemy>=1.4'."
+            )
+            
         filter_condition = ""
         if filter is not None:
             conditions = [


### PR DESCRIPTION
Support for SQLAlchemy 1.3 was removed in version 0.0.203 by change #6086. Re-adding support.

  - Description: Imports SQLAlchemy Row at class creation time instead of at init to support SQLAlchemy <1.4. This is the only breaking change and was introduced in version 0.0.203 #6086.
  
  A similar change was merged before: https://github.com/hwchase17/langchain/pull/4647
  
  - Dependencies: Reduces SQLAlchemy dependency to > 1.3
  - Tag maintainer: @rlancemartin, @eyurtsev, @hwchase17, @wangxuqi
