### PR TITLE
Add API Header for Amazon API Gateway Authentication

### DIFF
--- a/langchain/llms/amazon_api_gateway.py
+++ b/langchain/llms/amazon_api_gateway.py
@@ -30,6 +30,9 @@ class AmazonAPIGateway(LLM):
     api_url: str
     """API Gateway URL"""
 
+    headers: Optional[Dict] = None
+    """API Gateway HTTP Headers to send, e.g. for authentication"""
+
     model_kwargs: Optional[Dict] = None
     """Key word arguments to pass to the model."""
 
@@ -85,6 +88,7 @@ class AmazonAPIGateway(LLM):
         try:
             response = requests.post(
                 self.api_url,
+                headers=self.headers,
                 json=payload,
             )
             text = self.content_handler.transform_output(response)


### PR DESCRIPTION
Add API Headers support for Amazon API Gateway to enable Authentication using DynamoDB.

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
