### PR TITLE
Extend the QA use cases by DataChad example

### DIFF
--- a/docs/extras/use_cases/question_answering/index.mdx
+++ b/docs/extras/use_cases/question_answering/index.mdx
@@ -83,3 +83,4 @@ For examples to this done in an end-to-end manner, please see the following reso
 
 - [Semantic search over a group chat with Sources Notebook](/docs/use_cases/question_answering/semantic-search-over-chat.html): A notebook that semantically searches over a group chat conversation.
 - [Document context aware text splitting and QA](/docs/use_cases/question_answering/document-context-aware-QA.html): A notebook that shows context aware splitting on markdown files and SelfQueryRetriever for QA using the resulting metadata.
+- [DataChad](https://github.com/gustavz/DataChad): A streamlit app that let's you chat with any data source. Supporting both OpenAI and local mode ([tutorial](https://www.activeloop.ai/resources/data-chad-an-ai-app-with-lang-chain-deep-lake-to-chat-with-any-data/)).


### PR DESCRIPTION
  - Description: Add an use case example to question_answering section
  - Issue: tN/A
  - Dependencies: N/A
  - Tag maintainer: @hwchase17 
  - Twitter handle: @thegreatgustby
  
  @hwchase17 we had spoken in twitter dms (12th May) to include the project in the use-cases section.
  I forgot to do it since, so wanted to do it now. Hope it's still accepted.
  Thanks!