### PR TITLE
Fix different naming of params for chain type

### DIFF
--- a/langchain/chains/question_answering/__init__.py
+++ b/langchain/chains/question_answering/__init__.py
@@ -86,7 +86,7 @@ def _load_stuff_chain(
 
 def _load_map_reduce_chain(
     llm: BaseLanguageModel,
-    question_prompt: Optional[BasePromptTemplate] = None,
+    prompt: Optional[BasePromptTemplate] = None,
     combine_prompt: Optional[BasePromptTemplate] = None,
     combine_document_variable_name: str = "summaries",
     map_reduce_document_variable_name: str = "context",
@@ -99,7 +99,7 @@ def _load_map_reduce_chain(
     **kwargs: Any,
 ) -> MapReduceDocumentsChain:
     _question_prompt = (
-        question_prompt or map_reduce_prompt.QUESTION_PROMPT_SELECTOR.get_prompt(llm)
+        prompt or map_reduce_prompt.QUESTION_PROMPT_SELECTOR.get_prompt(llm)
     )
     _combine_prompt = (
         combine_prompt or map_reduce_prompt.COMBINE_PROMPT_SELECTOR.get_prompt(llm)
@@ -162,9 +162,9 @@ def _load_map_reduce_chain(
 
 def _load_refine_chain(
     llm: BaseLanguageModel,
-    question_prompt: Optional[BasePromptTemplate] = None,
+    prompt: Optional[BasePromptTemplate] = None,
     refine_prompt: Optional[BasePromptTemplate] = None,
-    document_variable_name: str = "context_str",
+    document_variable_name: str = "context",
     initial_response_name: str = "existing_answer",
     refine_llm: Optional[BaseLanguageModel] = None,
     verbose: Optional[bool] = None,
@@ -173,7 +173,7 @@ def _load_refine_chain(
     **kwargs: Any,
 ) -> RefineDocumentsChain:
     _question_prompt = (
-        question_prompt or refine_prompts.QUESTION_PROMPT_SELECTOR.get_prompt(llm)
+        prompt or refine_prompts.QUESTION_PROMPT_SELECTOR.get_prompt(llm)
     )
     _refine_prompt = refine_prompt or refine_prompts.REFINE_PROMPT_SELECTOR.get_prompt(
         llm


### PR DESCRIPTION
# Changed and Fixed what?
Renaming the parameters in different chain type.

To enable smooth and error-free invocation of `RetrievalQA.from_chain_type` functions with different chain types, and to make the usage more intuitive.


# Problem description

`RetrievalQA.from_chain_type` can execute successfully with `stuff` chain type.

However, it cannot use with `map_reduce`, `refine`.

If we use `RetrievalQA.from_chain_type()` with `map_reduce` or `refine` chain type, we will get `ValidationError`:

## Code
```python
prompt_template = """
Use the following pieces of context to answer the question, if you don't know the answer, leave it blank don't try to make up an answer.

{context}

Question: {question}
Answer in JSON representations
"""

QA_PROMPT = PromptTemplate(
    template=prompt_template,
    input_variables=['context', 'question']
)

chain_type_kwargs = {'prompt': QA_PROMPT, 'verbose': True}

qa_cahin = RetrievalQA.from_chain_type(
    llm=OpenAI(temperature=0.2),
    chain_type='refine',
    retriever=db.as_retriever(),
    chain_type_kwargs=chain_type_kwargs
)
```

## Result
```
ValidationError: 1 validation error for RefineDocumentsChain
prompt
  extra fields not permitted (type=value_error.extra)
```

---

# Source of error

Check the [source code](https://github.com/hwchase17/langchain/blob/d85f57ef9cbbbd5e512e064fb81c531b28c6591c/langchain/chains/question_answering/__init__.py#L146)

The different types have **different naming of parameter** as following:

* stuff

```python
def _load_stuff_chain(
    llm: BaseLanguageModel,
    prompt: Optional[BasePromptTemplate] = None,
    document_variable_name: str = "context",
    verbose: Optional[bool] = None,
    callback_manager: Optional[BaseCallbackManager] = None,
    **kwargs: Any,
) -> StuffDocumentsChain:
```

* map_reduce

```python
def _load_map_reduce_chain(
    llm: BaseLanguageModel,
    question_prompt: Optional[BasePromptTemplate] = None,
    combine_prompt: Optional[BasePromptTemplate] = None,
    combine_document_variable_name: str = "summaries",
    map_reduce_document_variable_name: str = "context",
    collapse_prompt: Optional[BasePromptTemplate] = None,
    reduce_llm: Optional[BaseLanguageModel] = None,
    collapse_llm: Optional[BaseLanguageModel] = None,
    verbose: Optional[bool] = None,
    callback_manager: Optional[BaseCallbackManager] = None,
    **kwargs: Any,
) -> MapReduceDocumentsChain:
```

* refine

```python
def _load_refine_chain(
    llm: BaseLanguageModel,
    question_prompt: Optional[BasePromptTemplate] = None,
    refine_prompt: Optional[BasePromptTemplate] = None,
    document_variable_name: str = "context_str",
    initial_response_name: str = "existing_answer",
    refine_llm: Optional[BaseLanguageModel] = None,
    verbose: Optional[bool] = None,
    callback_manager: Optional[BaseCallbackManager] = None,
    **kwargs: Any,
) -> RefineDocumentsChain:
```

---

If want to use different chaint type, we should:

```python
prompt_template = """
Use the following pieces of context to answer the question, if you don't know the answer, leave it blank don't try to make up an answer.

{context_str}

Question: {question}
Answer in JSON representations
"""

QA_PROMPT = PromptTemplate(
    template=prompt_template,
    input_variables=['context_str', 'question']
)

chain_type_kwargs = {'question_prompt': QA_PROMPT, 'verbose': True}

qa_cahin = RetrievalQA.from_chain_type(
    llm=OpenAI(temperature=0.2),
    chain_type='refine',
    retriever=db.as_retriever(),
    chain_type_kwargs=chain_type_kwargs
)
```

There're a confusing in the different naming of parameters.

* `context` vs `context_str`
* `prompt` vs `question_prompt`

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
