### PR TITLE
Add JSON Lines support to JSONLoader

### DIFF
--- a/docs/docs_skeleton/docs/modules/data_connection/document_loaders/how_to/json.mdx
+++ b/docs/docs_skeleton/docs/modules/data_connection/document_loaders/how_to/json.mdx
@@ -2,6 +2,8 @@
 
 >[JSON (JavaScript Object Notation)](https://en.wikipedia.org/wiki/JSON) is an open standard file format and data interchange format that uses human-readable text to store and transmit data objects consisting of attribute–value pairs and arrays (or other serializable values).
 
+>[JSON Lines](https://jsonlines.org/) is a file format where each line is a valid JSON value.
+
 import Example from "@snippets/modules/data_connection/document_loaders/how_to/json.mdx"
 
 <Example/>

--- a/docs/extras/modules/data_connection/document_loaders/integrations/example_data/facebook_chat_messages.jsonl
+++ b/docs/extras/modules/data_connection/document_loaders/integrations/example_data/facebook_chat_messages.jsonl
@@ -1,0 +1,3 @@
+{"sender_name": "User 2", "timestamp_ms": 1675597571851, "content": "Bye!"}
+{"sender_name": "User 1", "timestamp_ms": 1675597435669, "content": "Oh no worries! Bye"}
+{"sender_name": "User 2", "timestamp_ms": 1675596277579, "content": "No Im sorry it was my mistake, the blue one is not for sale"}

--- a/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
+++ b/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
@@ -78,10 +78,13 @@ pprint(data)
 
 </CodeOutputBlock>
 
+
 ## Using `JSONLoader`
 
 Suppose we are interested in extracting the values under the `content` field within the `messages` key of the JSON data. This can easily be done through the `JSONLoader` as shown below.
 
+
+### JSON file
 
 ```python
 loader = JSONLoader(
@@ -113,6 +116,81 @@ pprint(data)
 ```
 
 </CodeOutputBlock>
+
+
+### JSON Lines file
+
+If you want to load documents from a JSON Lines file, you pass `json_lines=True`
+and specify `jq_schema` to extract `page_content` from a single JSON object.
+
+```python
+file_path = './example_data/facebook_chat_messages.jsonl'
+pprint(Path(file_path).read_text())
+```
+
+<CodeOutputBlock lang="python">
+
+```
+    ('{"sender_name": "User 2", "timestamp_ms": 1675597571851, "content": "Bye!"}\n'
+     '{"sender_name": "User 1", "timestamp_ms": 1675597435669, "content": "Oh no '
+     'worries! Bye"}\n'
+     '{"sender_name": "User 2", "timestamp_ms": 1675596277579, "content": "No Im '
+     'sorry it was my mistake, the blue one is not for sale"}\n')
+```
+
+</CodeOutputBlock>
+
+
+```python
+loader = JSONLoader(
+    file_path='./example_data/facebook_chat_messages.jsonl',
+    jq_schema='.content',
+    json_lines=True)
+
+data = loader.load()
+```
+
+```python
+pprint(data)
+```
+
+<CodeOutputBlock lang="python">
+
+```
+    [Document(page_content='Bye!', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 1}),
+     Document(page_content='Oh no worries! Bye', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 2}),
+     Document(page_content='No Im sorry it was my mistake, the blue one is not for sale', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 3})]
+```
+
+</CodeOutputBlock>
+
+
+Another option is set `jq_schema='.'` and provide `content_key`:
+
+```python
+loader = JSONLoader(
+    file_path='./example_data/facebook_chat_messages.jsonl',
+    jq_schema='.',
+    content_key='sender_name',
+    json_lines=True)
+
+data = loader.load()
+```
+
+```python
+pprint(data)
+```
+
+<CodeOutputBlock lang="python">
+
+```
+    [Document(page_content='User 2', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 1}),
+     Document(page_content='User 1', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 2}),
+     Document(page_content='User 2', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 3})]
+```
+
+</CodeOutputBlock>
+
 
 ## Extracting metadata
 

--- a/langchain/document_loaders/json_loader.py
+++ b/langchain/document_loaders/json_loader.py
@@ -36,8 +36,8 @@ class JSONLoader(BaseLoader):
             metadata_func (Callable[Dict, Dict]): A function that takes in the JSON
                 object extracted by the jq_schema and the default metadata and returns
                 a dict of the updated metadata.
-            text_content (bool): Boolean flag to indicates whether the content is in
-                string format, default to True
+            text_content (bool): Boolean flag to indicate whether the content is in
+                string format, default to True.
         """
         try:
             import jq  # noqa:F401

--- a/langchain/document_loaders/json_loader.py
+++ b/langchain/document_loaders/json_loader.py
@@ -58,7 +58,7 @@ class JSONLoader(BaseLoader):
 
     def load(self) -> List[Document]:
         """Load and return documents from the JSON file."""
-        docs = []
+        docs: List[Document] = []
         if self._json_lines:
             with self.file_path.open(encoding="utf-8") as f:
                 for line in f:
@@ -69,7 +69,7 @@ class JSONLoader(BaseLoader):
             self._parse(self.file_path.read_text(), docs)
         return docs
 
-    def _parse(self, content: str, docs: List[Document]):
+    def _parse(self, content: str, docs: List[Document]) -> None:
         """Convert given content to documents."""
         data = self._jq_schema.input(json.loads(content))
 

--- a/tests/unit_tests/document_loaders/test_json_loader.py
+++ b/tests/unit_tests/document_loaders/test_json_loader.py
@@ -5,8 +5,9 @@ from pytest_mock import MockerFixture
 from langchain.docstore.document import Document
 from langchain.document_loaders.json_loader import JSONLoader
 
+pytestmark = pytest.mark.requires("jq")
 
-@pytest.mark.requires("jq")
+
 def test_load_valid_string_content(mocker: MockerFixture) -> None:
     file_path = "/workspaces/langchain/test.json"
     expected_docs = [
@@ -19,9 +20,12 @@ def test_load_valid_string_content(mocker: MockerFixture) -> None:
             metadata={"source": file_path, "seq_num": 2},
         ),
     ]
+
     mocker.patch("builtins.open", mocker.mock_open())
-    mock_csv_reader = mocker.patch("pathlib.Path.read_text")
-    mock_csv_reader.return_value = '[{"text": "value1"}, {"text": "value2"}]'
+    mocker.patch(
+        "pathlib.Path.read_text",
+        return_value='[{"text": "value1"}, {"text": "value2"}]',
+    )
 
     loader = JSONLoader(file_path=file_path, jq_schema=".[].text", text_content=True)
     result = loader.load()
@@ -29,7 +33,6 @@ def test_load_valid_string_content(mocker: MockerFixture) -> None:
     assert result == expected_docs
 
 
-@pytest.mark.requires("jq")
 def test_load_valid_dict_content(mocker: MockerFixture) -> None:
     file_path = "/workspaces/langchain/test.json"
     expected_docs = [
@@ -42,11 +45,14 @@ def test_load_valid_dict_content(mocker: MockerFixture) -> None:
             metadata={"source": file_path, "seq_num": 2},
         ),
     ]
+
     mocker.patch("builtins.open", mocker.mock_open())
-    mock_csv_reader = mocker.patch("pathlib.Path.read_text")
-    mock_csv_reader.return_value = """
-        [{"text": "value1"}, {"text": "value2"}]
-    """
+    mocker.patch(
+        "pathlib.Path.read_text",
+        return_value="""
+            [{"text": "value1"}, {"text": "value2"}]
+        """,
+    )
 
     loader = JSONLoader(file_path=file_path, jq_schema=".[]", text_content=False)
     result = loader.load()
@@ -54,7 +60,6 @@ def test_load_valid_dict_content(mocker: MockerFixture) -> None:
     assert result == expected_docs
 
 
-@pytest.mark.requires("jq")
 def test_load_valid_bool_content(mocker: MockerFixture) -> None:
     file_path = "/workspaces/langchain/test.json"
     expected_docs = [
@@ -67,13 +72,16 @@ def test_load_valid_bool_content(mocker: MockerFixture) -> None:
             metadata={"source": file_path, "seq_num": 2},
         ),
     ]
+
     mocker.patch("builtins.open", mocker.mock_open())
-    mock_csv_reader = mocker.patch("pathlib.Path.read_text")
-    mock_csv_reader.return_value = """
-        [
-            {"flag": false}, {"flag": true}
-        ]
-    """
+    mocker.patch(
+        "pathlib.Path.read_text",
+        return_value="""
+            [
+                {"flag": false}, {"flag": true}
+            ]
+        """,
+    )
 
     loader = JSONLoader(file_path=file_path, jq_schema=".[].flag", text_content=False)
     result = loader.load()
@@ -81,7 +89,6 @@ def test_load_valid_bool_content(mocker: MockerFixture) -> None:
     assert result == expected_docs
 
 
-@pytest.mark.requires("jq")
 def test_load_valid_numeric_content(mocker: MockerFixture) -> None:
     file_path = "/workspaces/langchain/test.json"
     expected_docs = [
@@ -94,13 +101,16 @@ def test_load_valid_numeric_content(mocker: MockerFixture) -> None:
             metadata={"source": file_path, "seq_num": 2},
         ),
     ]
+
     mocker.patch("builtins.open", mocker.mock_open())
-    mock_csv_reader = mocker.patch("pathlib.Path.read_text")
-    mock_csv_reader.return_value = """
-        [
-            {"num": 99}, {"num": 99.5}
-        ]
-    """
+    mocker.patch(
+        "pathlib.Path.read_text",
+        return_value="""
+            [
+                {"num": 99}, {"num": 99.5}
+            ]
+        """,
+    )
 
     loader = JSONLoader(file_path=file_path, jq_schema=".[].num", text_content=False)
     result = loader.load()
@@ -108,14 +118,16 @@ def test_load_valid_numeric_content(mocker: MockerFixture) -> None:
     assert result == expected_docs
 
 
-@pytest.mark.requires("jq")
 def test_load_invalid_test_content(mocker: MockerFixture) -> None:
     file_path = "/workspaces/langchain/test.json"
+
     mocker.patch("builtins.open", mocker.mock_open())
-    mock_csv_reader = mocker.patch("pathlib.Path.read_text")
-    mock_csv_reader.return_value = """
-        [{"text": "value1"}, {"text": "value2"}]
-    """
+    mocker.patch(
+        "pathlib.Path.read_text",
+        return_value="""
+            [{"text": "value1"}, {"text": "value2"}]
+        """,
+    )
 
     loader = JSONLoader(file_path=file_path, jq_schema=".[]", text_content=True)
 

--- a/tests/unit_tests/document_loaders/test_json_loader.py
+++ b/tests/unit_tests/document_loaders/test_json_loader.py
@@ -1,5 +1,5 @@
 import io
-from typing import Dict, Any
+from typing import Any, Dict
 
 import pytest
 from pytest import raises

--- a/tests/unit_tests/document_loaders/test_json_loader.py
+++ b/tests/unit_tests/document_loaders/test_json_loader.py
@@ -1,4 +1,5 @@
 import io
+from typing import Dict, Any
 
 import pytest
 from pytest import raises
@@ -175,7 +176,7 @@ def test_load_jsonlines(mocker: MockerFixture) -> None:
         {"jq_schema": ".[]", "content_key": "text"},
     ),
 )
-def test_load_jsonlines_list(params, mocker: MockerFixture) -> None:
+def test_load_jsonlines_list(params: Dict, mocker: MockerFixture) -> None:
     file_path = "/workspaces/langchain/test.json"
     expected_docs = [
         Document(
@@ -243,7 +244,9 @@ def test_load_empty_jsonlines(mocker: MockerFixture) -> None:
         ),
     ),
 )
-def test_json_meta(patch_func, patch_func_value, kwargs, mocker):
+def test_json_meta(
+    patch_func: str, patch_func_value: Any, kwargs: Dict, mocker: MockerFixture
+) -> None:
     mocker.patch("builtins.open", mocker.mock_open())
     mocker.patch(patch_func, return_value=patch_func_value)
 
@@ -259,7 +262,7 @@ def test_json_meta(patch_func, patch_func_value, kwargs, mocker):
         ),
     ]
 
-    def metadata_func(record: dict, metadata: dict):
+    def metadata_func(record: Dict, metadata: Dict) -> Dict:
         metadata["x"] = f"{record['text']}-meta"
         return metadata
 


### PR DESCRIPTION
**Description**:

The JSON Lines format is used by some services such as OpenAI and HuggingFace. It's also a convenient alternative to CSV.

This PR adds JSON Lines support to `JSONLoader` and also updates related tests.

**Tag maintainer**: @rlancemartin, @eyurtsev.

PS I was not able to build docs locally so didn't update related section.
