### PR TITLE
Fix run_inline to run hooks in the same context

### DIFF
--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -598,7 +598,7 @@ class AsyncCallbackManagerForLLMRun(AsyncRunManager, LLMManagerMixin):
     """Async callback manager for LLM run."""
 
     @property
-    def run_inline(self):
+    def run_inline(self) -> bool:
         return all(h.run_inline for h in self.handlers)
 
     async def on_llm_new_token(

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -597,6 +597,10 @@ class CallbackManagerForLLMRun(RunManager, LLMManagerMixin):
 class AsyncCallbackManagerForLLMRun(AsyncRunManager, LLMManagerMixin):
     """Async callback manager for LLM run."""
 
+    @property
+    def run_inline(self):
+        return all(h.run_inline for h in self.handlers)
+
     async def on_llm_new_token(
         self,
         token: str,

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -1284,13 +1284,40 @@ class AsyncCallbackManager(BaseCallbackManager):
 
         tasks = []
         managers = []
+        inline_handlers = [h for h in self.handlers if h.run_inline]
+        async_handlers = [h for h in self.handlers if not h.run_inline]
 
         for prompt in prompts:
             run_id_ = uuid4()
 
+            await _ahandle_event(
+                inline_handlers,
+                "on_llm_start",
+                "ignore_llm",
+                serialized,
+                [prompt],
+                run_id=run_id_,
+                parent_run_id=self.parent_run_id,
+                tags=self.tags,
+                metadata=self.metadata,
+                **kwargs,
+            )
+            managers.append(
+                AsyncCallbackManagerForLLMRun(
+                    run_id=run_id_,
+                    handlers=inline_handlers,
+                    inheritable_handlers=self.inheritable_handlers,
+                    parent_run_id=self.parent_run_id,
+                    tags=self.tags,
+                    inheritable_tags=self.inheritable_tags,
+                    metadata=self.metadata,
+                    inheritable_metadata=self.inheritable_metadata,
+                )
+            )
+
             tasks.append(
                 _ahandle_event(
-                    self.handlers,
+                    async_handlers,
                     "on_llm_start",
                     "ignore_llm",
                     serialized,
@@ -1306,7 +1333,7 @@ class AsyncCallbackManager(BaseCallbackManager):
             managers.append(
                 AsyncCallbackManagerForLLMRun(
                     run_id=run_id_,
-                    handlers=self.handlers,
+                    handlers=async_handlers,
                     inheritable_handlers=self.inheritable_handlers,
                     parent_run_id=self.parent_run_id,
                     tags=self.tags,
@@ -1340,13 +1367,40 @@ class AsyncCallbackManager(BaseCallbackManager):
         """
         tasks = []
         managers = []
+        inline_handlers = [h for h in self.handlers if h.run_inline]
+        async_handlers = [h for h in self.handlers if not h.run_inline]
 
         for message_list in messages:
             run_id_ = uuid4()
 
+            await _ahandle_event(
+                inline_handlers,
+                "on_chat_model_start",
+                "ignore_chat_model",
+                serialized,
+                [message_list],
+                run_id=run_id_,
+                parent_run_id=self.parent_run_id,
+                tags=self.tags,
+                metadata=self.metadata,
+                **kwargs,
+            )
+            managers.append(
+                AsyncCallbackManagerForLLMRun(
+                    run_id=run_id_,
+                    handlers=inline_handlers,
+                    inheritable_handlers=self.inheritable_handlers,
+                    parent_run_id=self.parent_run_id,
+                    tags=self.tags,
+                    inheritable_tags=self.inheritable_tags,
+                    metadata=self.metadata,
+                    inheritable_metadata=self.inheritable_metadata,
+                )
+            )
+
             tasks.append(
                 _ahandle_event(
-                    self.handlers,
+                    async_handlers,
                     "on_chat_model_start",
                     "ignore_chat_model",
                     serialized,
@@ -1362,7 +1416,7 @@ class AsyncCallbackManager(BaseCallbackManager):
             managers.append(
                 AsyncCallbackManagerForLLMRun(
                     run_id=run_id_,
-                    handlers=self.handlers,
+                    handlers=async_handlers,
                     inheritable_handlers=self.inheritable_handlers,
                     parent_run_id=self.parent_run_id,
                     tags=self.tags,

--- a/langchain/callbacks/manager.py
+++ b/langchain/callbacks/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import logging
 import os
 import warnings
@@ -10,6 +11,9 @@ from contextvars import ContextVar
 from typing import (
     Any,
     AsyncGenerator,
+    Awaitable,
+    Callable,
+    Coroutine,
     Dict,
     Generator,
     List,
@@ -306,29 +310,29 @@ def _handle_event(
                 raise e
 
 
-async def _ahandle_event_for_handler(
+def _ahandle_event_for_handler(
     handler: BaseCallbackHandler,
     event_name: str,
     ignore_condition_name: Optional[str],
     *args: Any,
     **kwargs: Any,
-) -> None:
+) -> Union[Awaitable, callable]:
     try:
         if ignore_condition_name is None or not getattr(handler, ignore_condition_name):
             event = getattr(handler, event_name)
             if asyncio.iscoroutinefunction(event):
-                await event(*args, **kwargs)
+                return event(*args, **kwargs)
             else:
                 if handler.run_inline:
-                    event(*args, **kwargs)
+                    return event(*args, **kwargs)
                 else:
-                    await asyncio.get_event_loop().run_in_executor(
+                    return asyncio.get_event_loop().run_in_executor(
                         None, functools.partial(event, *args, **kwargs)
                     )
     except NotImplementedError as e:
         if event_name == "on_chat_model_start":
             message_strings = [get_buffer_string(m) for m in args[1]]
-            await _ahandle_event_for_handler(
+            return _ahandle_event_for_handler(
                 handler,
                 "on_llm_start",
                 "ignore_llm",
@@ -349,27 +353,38 @@ async def _ahandle_event_for_handler(
             raise e
 
 
-async def _ahandle_event(
+def _ahandle_event(
     handlers: List[BaseCallbackHandler],
     event_name: str,
     ignore_condition_name: Optional[str],
     *args: Any,
     **kwargs: Any,
-) -> None:
+) -> Awaitable:
     """Generic event handler for AsyncCallbackManager."""
+    awaitables = []
     for handler in [h for h in handlers if h.run_inline]:
-        await _ahandle_event_for_handler(
+        res = _ahandle_event_for_handler(
             handler, event_name, ignore_condition_name, *args, **kwargs
         )
-    await asyncio.gather(
-        *(
-            _ahandle_event_for_handler(
-                handler, event_name, ignore_condition_name, *args, **kwargs
+        if inspect.isawaitable(res):
+            awaitables.append(res)
+        else:
+            fut = asyncio.get_event_loop().create_future()
+            fut.set_result(res)
+            awaitables.append(fut)
+    awaitables.append(
+        asyncio.gather(
+            *(
+                _ahandle_event_for_handler(
+                    handler, event_name, ignore_condition_name, *args, **kwargs
+                )
+                for handler in handlers
+                if not handler.run_inline
             )
-            for handler in handlers
-            if not handler.run_inline
         )
     )
+    return asyncio.wait(awaitables)
+
 
 
 BRM = TypeVar("BRM", bound="BaseRunManager")

--- a/tests/unit_tests/callbacks/test_callback_manager.py
+++ b/tests/unit_tests/callbacks/test_callback_manager.py
@@ -375,8 +375,8 @@ def test_run_inline_callback_manager() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_inline_async_handler_runs_concurrently() -> None:
-    """When run_inline=False, async callback manager should run concurrently."""
+async def test_async_callbacks_concurrency() -> None:
+    """When run_inline=False, async callback manager should run concurrently. And vice versa."""
 
     handler_duration = 0.1
 

--- a/tests/unit_tests/callbacks/test_callback_manager.py
+++ b/tests/unit_tests/callbacks/test_callback_manager.py
@@ -305,22 +305,36 @@ async def test_run_inline_async_callback_manager() -> None:
     manager = AsyncCallbackManager(handlers=[handler])
 
     run_managers = await manager.on_llm_start({}, ["prompt"], new_ctxval=1)
-    assert handler.last_observed_ctxval == 0, "on_llm_start should see the original value"
-    assert ctxvar.get() == 1, "on_llm_start should set the new value observable from this context"
+    assert (
+        handler.last_observed_ctxval == 0
+    ), "on_llm_start should see the original value"
+    assert (
+        ctxvar.get() == 1
+    ), "on_llm_start should set the new value observable from this context"
 
     for run_manager in run_managers:
         await run_manager.on_llm_end(LLMResult(generations=[]), new_ctxval=2)
     assert handler.last_observed_ctxval == 1
-    assert ctxvar.get() == 2, "on_llm_end should set the new value observable from this context"
+    assert (
+        ctxvar.get() == 2
+    ), "on_llm_end should set the new value observable from this context"
 
     for run_manager in run_managers:
         await run_manager.on_llm_error(Exception(), new_ctxval=3)
     assert handler.last_observed_ctxval == 2
-    assert ctxvar.get() == 3, "on_llm_end should set the new value observable from this context"
+    assert (
+        ctxvar.get() == 3
+    ), "on_llm_end should set the new value observable from this context"
 
-    await manager.on_chat_model_start({}, [[SystemMessage(content="prompt")]], new_ctxval=4)
-    assert handler.last_observed_ctxval == 3, "on_chat_model_start should see the original value"
-    assert ctxvar.get() == 4, "on_chat_model_start should set the new value observable from this context"
+    await manager.on_chat_model_start(
+        {}, [[SystemMessage(content="prompt")]], new_ctxval=4
+    )
+    assert (
+        handler.last_observed_ctxval == 3
+    ), "on_chat_model_start should see the original value"
+    assert (
+        ctxvar.get() == 4
+    ), "on_chat_model_start should set the new value observable from this context"
 
 
 def test_run_inline_callback_manager() -> None:
@@ -356,22 +370,34 @@ def test_run_inline_callback_manager() -> None:
     manager = CallbackManager(handlers=[handler])
 
     run_managers = manager.on_llm_start({}, ["prompt"], new_ctxval=1)
-    assert handler.last_observed_ctxval == 0, "on_llm_start should see the original value"
-    assert ctxvar.get() == 1, "on_llm_start should set the new value observable from this context"
+    assert (
+        handler.last_observed_ctxval == 0
+    ), "on_llm_start should see the original value"
+    assert (
+        ctxvar.get() == 1
+    ), "on_llm_start should set the new value observable from this context"
 
     for run_manager in run_managers:
         run_manager.on_llm_end(LLMResult(generations=[]), new_ctxval=2)
     assert handler.last_observed_ctxval == 1
-    assert ctxvar.get() == 2, "on_llm_end should set the new value observable from this context"
+    assert (
+        ctxvar.get() == 2
+    ), "on_llm_end should set the new value observable from this context"
 
     for run_manager in run_managers:
         run_manager.on_llm_error(Exception(), new_ctxval=3)
     assert handler.last_observed_ctxval == 2
-    assert ctxvar.get() == 3, "on_llm_end should set the new value observable from this context"
+    assert (
+        ctxvar.get() == 3
+    ), "on_llm_end should set the new value observable from this context"
 
     manager.on_chat_model_start({}, [[SystemMessage(content="prompt")]], new_ctxval=4)
-    assert handler.last_observed_ctxval == 3, "on_chat_model_start should see the original value"
-    assert ctxvar.get() == 4, "on_chat_model_start should set the new value observable from this context"
+    assert (
+        handler.last_observed_ctxval == 3
+    ), "on_chat_model_start should see the original value"
+    assert (
+        ctxvar.get() == 4
+    ), "on_chat_model_start should set the new value observable from this context"
 
 
 @pytest.mark.asyncio
@@ -400,16 +426,19 @@ async def test_async_callbacks_concurrency() -> None:
         async def on_llm_error(self, *args: Any, **kwargs: Any) -> None:
             await self._hook(*args, **kwargs)
 
-
     handler = CallbackHandler()
     manager = AsyncCallbackManager(handlers=[handler, handler])
     start_time = time.monotonic()
     await manager.on_llm_start({}, ["prompt"])
     duration = time.monotonic() - start_time
-    assert duration >= 2 * handler_duration, "on_llm_start should run serially when run_inline=False"
+    assert (
+        duration >= 2 * handler_duration
+    ), "on_llm_start should run serially when run_inline=False"
 
     handler.run_inline = False
     start_time = time.monotonic()
     await manager.on_llm_start({}, ["prompt"])
     duration = time.monotonic() - start_time
-    assert duration <= 1.5 * handler_duration, "on_llm_start should run serially when run_inline=True"
+    assert (
+        duration <= 1.5 * handler_duration
+    ), "on_llm_start should run serially when run_inline=True"

--- a/tests/unit_tests/callbacks/test_callback_manager.py
+++ b/tests/unit_tests/callbacks/test_callback_manager.py
@@ -1,17 +1,15 @@
 """Test CallbackManager."""
 import asyncio
 import contextvars
-import random
 import time
-from typing import Any, Dict, List, Optional, Tuple
-from uuid import UUID
+from typing import Any, List, Tuple
 
 import pytest
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.callbacks.manager import AsyncCallbackManager, CallbackManager
 from langchain.callbacks.stdout import StdOutCallbackHandler
-from langchain.schema import AgentAction, AgentFinish, BaseMessage, LLMResult
+from langchain.schema import AgentAction, AgentFinish, LLMResult
 from langchain.schema.messages import SystemMessage
 from tests.unit_tests.callbacks.fake_callback_handler import (
     BaseFakeCallbackHandler,
@@ -273,7 +271,8 @@ def test_callback_manager_configure(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_run_inline_async_callback_manager() -> None:
-    """When run_inline=True, async callback manager should run hooks in the main context."""
+    """When run_inline=True, async callback manager should run hooks in the main
+    context."""
 
     ctxvar: contextvars.ContextVar[int] = contextvars.ContextVar("var", default=0)
 
@@ -402,7 +401,8 @@ def test_run_inline_callback_manager() -> None:
 
 @pytest.mark.asyncio
 async def test_async_callbacks_concurrency() -> None:
-    """When run_inline=False, async callback manager should run concurrently. And vice versa."""
+    """When run_inline=False, async callback manager should run concurrently.
+    And vice versa."""
 
     handler_duration = 0.1
 


### PR DESCRIPTION
Since https://github.com/hwchase17/langchain/commit/e1b801be36d2d492eea071dcb594e966414b31cf, run_inline flags on callbacks (introduced in [PR](https://github.com/hwchase17/langchain/pull/6424)) are broken.

Because higher-level on_llm_start uses asyncio.gather, it's creates a task for given coroutines, and changes the hooks' context. Hence, it's not run inline and context is lost. Added test shows that if ran without changes in the manager.py.

This approach changes the interface of `_ahandle_event` to be synchronous method that returns an awaitable (I think it doesn't change much), which is a result of one `asyncio.wait` statement.

This ensures that `run_inline` hooks will be run before async hooks, but it doesn't ensure that relative order of inline hooks is preserved.

I'm not sure if that's a good approach, but posting it anyway so we can discuss the direction.