### PR TITLE
Handle kwargs in FAISS.load_local()

### DIFF
--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -620,7 +620,11 @@ class FAISS(VectorStore):
 
     @classmethod
     def load_local(
-        cls, folder_path: str, embeddings: Embeddings, index_name: str = "index"
+        cls,
+        folder_path: str,
+        embeddings: Embeddings,
+        index_name: str = "index",
+        **kwargs: Any,
     ) -> FAISS:
         """Load FAISS index, docstore, and index_to_docstore_id from disk.
 
@@ -640,7 +644,9 @@ class FAISS(VectorStore):
         # load docstore and index_to_docstore_id
         with open(path / "{index_name}.pkl".format(index_name=index_name), "rb") as f:
             docstore, index_to_docstore_id = pickle.load(f)
-        return cls(embeddings.embed_query, index, docstore, index_to_docstore_id)
+        return cls(
+            embeddings.embed_query, index, docstore, index_to_docstore_id, **kwargs
+        )
 
     def _similarity_search_with_relevance_scores(
         self,


### PR DESCRIPTION
- Description: This allows parameters such as `relevance_score_fn` to be passed to the `FAISS` constructor via the `load_local()` class method.
-  Tag maintainer: @rlancemartin @eyurtsev 
