### PR TITLE
Update get_started.mdx

### DIFF
--- a/docs/snippets/modules/model_io/models/chat/get_started.mdx
+++ b/docs/snippets/modules/model_io/models/chat/get_started.mdx
@@ -16,7 +16,7 @@ If you'd prefer not to set an environment variable you can pass the key in direc
 ```python
 from langchain.chat_models import ChatOpenAI
 
-chat = ChatOpenAI(open_api_key="...")
+chat = ChatOpenAI(openai_api_key="...")
 ```
 
 otherwise you can initialize without any params:


### PR DESCRIPTION
typo in chat = ChatOpenAI(open_api_key="...") should be openai_api_key

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
