### PR TITLE
docs: Fix wrong usage code

### DIFF
--- a/docs/snippets/get_started/quickstart/llm.mdx
+++ b/docs/snippets/get_started/quickstart/llm.mdx
@@ -7,7 +7,7 @@ llm = OpenAI(temperature=0.9)
 And now we can pass in text and get predictions!
 
 ```python
-llm.predict("What would be a good company name for a company that makes colorful socks?")
+llm("What would be a good company name for a company that makes colorful socks?")
 # >> Feetful of Fun
 ```
 


### PR DESCRIPTION
# Description

In the latest langchain version, the `predict()` method seems to be deprecated. Now we just call LLM object again to send some prompt or content as the changes shown.