### PR TITLE
Support params on GoogleSearchApiWrapper (#6810)

### DIFF
--- a/langchain/utilities/google_search.py
+++ b/langchain/utilities/google_search.py
@@ -100,12 +100,18 @@ class GoogleSearchAPIWrapper(BaseModel):
 
         return " ".join(snippets)
 
-    def results(self, query: str, num_results: int) -> List[Dict]:
+    def results(
+        self,
+        query: str,
+        num_results: int,
+        search_params: Optional[Dict[str, str]] = None,
+    ) -> List[Dict]:
         """Run query through GoogleSearch and return metadata.
 
         Args:
             query: The query to search for.
             num_results: The number of results to return.
+            search_params: Parameters to be passed on search
 
         Returns:
             A list of dictionaries with the following keys:
@@ -114,7 +120,9 @@ class GoogleSearchAPIWrapper(BaseModel):
                 link - The link to the result.
         """
         metadata_results = []
-        results = self._google_search_results(query, num=num_results)
+        results = self._google_search_results(
+            query, num=num_results, **(search_params or {})
+        )
         if len(results) == 0:
             return [{"Result": "No good Google Search Result was found"}]
         for result in results:

--- a/tests/integration_tests/utilities/test_googlesearch_api.py
+++ b/tests/integration_tests/utilities/test_googlesearch_api.py
@@ -17,3 +17,14 @@ def test_no_result_call() -> None:
     )
     print(type(output))
     assert "No good Google Search Result was found" == output
+
+
+def test_result_with_params_call() -> None:
+    """Test that call gives the correct answer with extra params."""
+    search = GoogleSearchAPIWrapper()
+    output = search.results(
+        query="What was Obama's first name?",
+        num_results=5,
+        search_params={"cr": "us", "safe": "active"},
+    )
+    assert len(output)


### PR DESCRIPTION
## Description
Support search params in GoogleSearchApiWrapper's result call, for the extra filtering on search,
to support extra query parameters that google cse provides:
https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list?hl=ko

## Issue
#6810 

## Dependencies
None

## Maintainer
@dev2049 
