### PR TITLE
fix(pipeline prompt): support  PipelinePrompt format missing varable

### DIFF
--- a/langchain/prompts/pipeline.py
+++ b/langchain/prompts/pipeline.py
@@ -8,7 +8,7 @@ from langchain.schema import PromptValue
 
 
 def _get_inputs(inputs: dict, input_variables: List[str]) -> dict:
-    return {k: inputs[k] for k in input_variables}
+    return {k: inputs.get(k, "") for k in input_variables}
 
 
 class PipelinePromptTemplate(BasePromptTemplate):

--- a/tests/unit_tests/prompts/test_pipeline_prompt.py
+++ b/tests/unit_tests/prompts/test_pipeline_prompt.py
@@ -43,3 +43,30 @@ def test_partial_with_chat_prompts() -> None:
     assert pipeline_prompt.input_variables == ["bar"]
     output = pipeline_prompt.format_prompt(bar="okay")
     assert output.to_messages()[0].content == "jim okay"
+
+
+def test_missing_variable() -> None:
+    prompt_a = PromptTemplate.from_template("{foo}")
+    prompt_b = PromptTemplate.from_template("okay {bar}")
+    prompt_c = PromptTemplate.from_template("{A} {B}")
+    pipeline_prompt = PipelinePromptTemplate(
+        final_prompt=prompt_c, pipeline_prompts=[("A", prompt_a), ("B", prompt_b)]
+    )
+    output = pipeline_prompt.format(foo="jim")
+
+    print(output)
+    assert output == "jim okay "
+
+
+def test_missing_variable_jinja2() -> None:
+    prompt_a = PromptTemplate.from_template("{{foo}}", template_format="jinja2")
+    prompt_b = PromptTemplate.from_template("okay {{bar}}", template_format="jinja2")
+    prompt_c = PromptTemplate.from_template("{{A}} {{B}}", template_format="jinja2")
+    pipeline_prompt = PipelinePromptTemplate(
+        final_prompt=prompt_c,
+        pipeline_prompts=[("A", prompt_a), ("B", prompt_b)],
+    )
+    output = pipeline_prompt.format(foo="jim")
+
+    print(output)
+    assert output == "jim okay "


### PR DESCRIPTION
Replace this comment with:
  - Description: fixed the bug where PipelinePromptTemplate throws an error when input variable is missing, 
  - Issue: the issue #7016 it fixes (if applicable),
  - Dependencies: none
  - Tag maintainer: @dev2049
  - Twitter handle: 
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @dev2049
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @dev2049
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @vowelparrot
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
