### PR TITLE
Fixes incorrect docstore creation in faiss.py

### DIFF
--- a/langchain/vectorstores/annoy.py
+++ b/langchain/vectorstores/annoy.py
@@ -310,9 +310,13 @@ class Annoy(VectorStore):
             metadata = metadatas[i] if metadatas else {}
             documents.append(Document(page_content=text, metadata=metadata))
         index_to_id = {i: str(uuid.uuid4()) for i in range(len(documents))}
-        docstore = InMemoryDocstore(
-            {index_to_id[i]: doc for i, doc in enumerate(documents)}
-        )
+
+        if len(index_to_id) != len(documents):
+            raise Exception(
+                f"{len(index_to_id)} ids provided for {len(documents)} documents. Each document should have an id."
+            )
+
+        docstore = InMemoryDocstore(dict(zip(index_to_id.values(), documents)))
         return cls(embedding.embed_query, index, metric, docstore, index_to_id)
 
     @classmethod

--- a/langchain/vectorstores/annoy.py
+++ b/langchain/vectorstores/annoy.py
@@ -310,13 +310,9 @@ class Annoy(VectorStore):
             metadata = metadatas[i] if metadatas else {}
             documents.append(Document(page_content=text, metadata=metadata))
         index_to_id = {i: str(uuid.uuid4()) for i in range(len(documents))}
-
-        if len(index_to_id) != len(documents):
-            raise Exception(
-                f"{len(index_to_id)} ids provided for {len(documents)} documents. Each document should have an id."
-            )
-
-        docstore = InMemoryDocstore(dict(zip(index_to_id.values(), documents)))
+        docstore = InMemoryDocstore(
+            {index_to_id[i]: doc for i, doc in enumerate(documents)}
+        )
         return cls(embedding.embed_query, index, metric, docstore, index_to_id)
 
     @classmethod

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -512,7 +512,9 @@ class FAISS(VectorStore):
             metadata = metadatas[i] if metadatas else {}
             documents.append(Document(page_content=text, metadata=metadata))
         index_to_id = dict(enumerate(ids))
-        docstore = InMemoryDocstore(dict(zip(index_to_id.values(), documents)))
+        docstore = InMemoryDocstore(
+            {index_to_id[i]: doc for i, doc in enumerate(documents)}
+        )
         return cls(
             embedding.embed_query,
             index,

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -512,9 +512,13 @@ class FAISS(VectorStore):
             metadata = metadatas[i] if metadatas else {}
             documents.append(Document(page_content=text, metadata=metadata))
         index_to_id = dict(enumerate(ids))
-        docstore = InMemoryDocstore(
-            {index_to_id[i]: doc for i, doc in enumerate(documents)}
-        )
+
+        if len(index_to_id) != len(documents):
+            raise Exception(
+                f"{len(index_to_id)} ids provided for {len(documents)} documents. Each document should have an id."
+            )
+
+        docstore = InMemoryDocstore(dict(zip(index_to_id.values(), documents)))
         return cls(
             embedding.embed_query,
             index,

--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -515,7 +515,8 @@ class FAISS(VectorStore):
 
         if len(index_to_id) != len(documents):
             raise Exception(
-                f"{len(index_to_id)} ids provided for {len(documents)} documents. Each document should have an id."
+                f"{len(index_to_id)} ids provided for {len(documents)} documents."
+                " Each document should have an id."
             )
 
         docstore = InMemoryDocstore(dict(zip(index_to_id.values(), documents)))


### PR DESCRIPTION
  - **Description**: Current implementation assumes that the length of `texts` and `ids` should be same but if the passed `ids` length is not equal to the passed length of `texts`, current code `dict(zip(index_to_id.values(), documents))` is not failing or giving any warning and silently creating docstores only for the passed `ids` i.e. if `ids = ['A']` and `texts=["I love Open Source","I love langchain"]` then only one `docstore` will be created. But either two docstores should be created assuming same id value for all the elements of `texts` or an error should be raised.
  
  - **Issue**: My change fixes this by using dictionary comprehension instead of `zip`. This was if lengths of `ids` and `texts` mismatches an explicit `IndexError` will be raised.
  
@rlancemartin, @eyurtsev
