### PR TITLE
ChromaDB relevance score fn

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -470,6 +470,7 @@ class Chroma(VectorStore):
             persist_directory=persist_directory,
             client_settings=client_settings,
             client=client,
+            **kwargs,
         )
         chroma_collection.add_texts(texts=texts, metadatas=metadatas, ids=ids)
         return chroma_collection

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -513,6 +513,7 @@ class Chroma(VectorStore):
             persist_directory=persist_directory,
             client_settings=client_settings,
             client=client,
+            **kwargs,
         )
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:


### PR DESCRIPTION
## Description

This PR adds a `relevance_score_fn` to `Chroma.__init__()` that allows developers to pass in a custom function to map relevance scores to [0,1]. This code follows the pattern set by `FAISS`.

Other changes made:
    - `Chroma.from_{documents,texts}()` pass `kwargs` through to the constructor

## Tag maintainer
@rlancemartin @eyurtsev 