### PR TITLE
Remove `None` default value for FAISS relevance_score_fn

### DIFF
--- a/langchain/vectorstores/faiss.py
+++ b/langchain/vectorstores/faiss.py
@@ -78,9 +78,7 @@ class FAISS(VectorStore):
         index: Any,
         docstore: Docstore,
         index_to_docstore_id: Dict[int, str],
-        relevance_score_fn: Optional[
-            Callable[[float], float]
-        ] = _default_relevance_score_fn,
+        relevance_score_fn: Callable[[float], float] = _default_relevance_score_fn,
         normalize_L2: bool = False,
     ):
         """Initialize with necessary components."""
@@ -651,11 +649,6 @@ class FAISS(VectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs and their similarity scores on a scale from 0 to 1."""
-        if self.relevance_score_fn is None:
-            raise ValueError(
-                "normalize_score_fn must be provided to"
-                " FAISS constructor to normalize scores"
-            )
         docs_and_scores = self.similarity_search_with_score(
             query,
             k=k,

--- a/tests/integration_tests/vectorstores/test_faiss.py
+++ b/tests/integration_tests/vectorstores/test_faiss.py
@@ -195,12 +195,3 @@ def test_faiss_invalid_normalize_fn() -> None:
     )
     with pytest.warns(Warning, match="scores must be between"):
         docsearch.similarity_search_with_relevance_scores("foo", k=1)
-
-
-def test_missing_normalize_score_fn() -> None:
-    """Test doesn't perform similarity search without a normalize score function."""
-    with pytest.raises(ValueError):
-        texts = ["foo", "bar", "baz"]
-        faiss_instance = FAISS.from_texts(texts, FakeEmbeddings())
-        faiss_instance.relevance_score_fn = None
-        faiss_instance.similarity_search_with_relevance_scores("foo", k=2)


### PR DESCRIPTION
## Description

The type hint for `FAISS.__init__()`'s `relevance_score_fn` parameter allowed the parameter to be set to `None`. However, a default function is provided by the constructor. This led to an unnecessary check in the code, as well as a test to verify this check.

**ASSUMPTION**: There's no reason to ever set `relevance_score_fn` to `None`.

This PR changes the type hint and removes the unnecessary code.

## Tag Maintainer
@rlancemartin @eyurtsev 
