### PR TITLE
Update chroma.py: Persist directory from client_settings if provided there

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -90,7 +90,9 @@ class Chroma(VectorStore):
             self._client = chromadb.Client(self._client_settings)
 
         self._embedding_function = embedding_function
-        self._persist_directory = self._client_settings.persist_directory or persist_directory
+        self._persist_directory = (
+            self._client_settings.persist_directory or persist_directory
+        )
         self._collection = self._client.get_or_create_collection(
             name=collection_name,
             embedding_function=self._embedding_function.embed_documents

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -90,7 +90,7 @@ class Chroma(VectorStore):
             self._client = chromadb.Client(self._client_settings)
 
         self._embedding_function = embedding_function
-        self._persist_directory = persist_directory
+        self._persist_directory = self._client_settings.persist_directory or persist_directory
         self._collection = self._client.get_or_create_collection(
             name=collection_name,
             embedding_function=self._embedding_function.embed_documents


### PR DESCRIPTION
Change details:
  - Description: When calling db.persist(), a check prevents from it proceeding as the constructor only sets member `_persist_directory` from parameters. But the ChromaDB client settings also has this parameter, and if the client_settings parameter is used without passing the persist_directory (which is optional), the `persist` method raises `ValueError` for not setting `_persist_directory`. This change fixes it by setting the member `_persist_directory` variable from client_settings if it is set, else uses the constructor parameter.
  - Issue: I didn't find any github issue of this, but I discovered it after calling the persist method
  - Dependencies: None
  - Tag maintainer: vectorstore related change - @rlancemartin, @eyurtsev
  - Twitter handle: Don't have one :(

*Additional discussion*: We may need to discuss the way I implemented the fallback using `or`.
