### PR TITLE
Align cassio versions between examples for Cassandra integration

### DIFF
--- a/docs/extras/modules/memory/integrations/cassandra_chat_message_history.ipynb
+++ b/docs/extras/modules/memory/integrations/cassandra_chat_message_history.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"cassio>=0.0.6\""
+    "!pip install \"cassio>=0.0.7\""
    ]
   },
   {


### PR DESCRIPTION
Just reducing confusion by requiring cassio>=0.0.7 consistently across examples.