### PR TITLE
[Document fix] Fix an expired link qa_benchmarking_pg.ipynb

### DIFF
--- a/docs/extras/guides/evaluation/qa_benchmarking_pg.ipynb
+++ b/docs/extras/guides/evaluation/qa_benchmarking_pg.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Here we go over how to benchmark performance on a question answering task over a Paul Graham essay.\n",
     "\n",
-    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://langchain.readthedocs.io/en/latest/tracing.html) for an explanation of what tracing is and how to set it up."
+    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/docs/modules/callbacks/how_to/tracing) for an explanation of what tracing is and how to set it up."
    ]
   },
   {


### PR DESCRIPTION
## Change description

  - Description: Fix an expired link that points to the readthedocs site. 
  - Dependencies: No
  - Tag maintainer: @baskaryan 