### PR TITLE
Add better warnings when ref or inputs are passed but not used

### DIFF
--- a/langchain/evaluation/comparison/eval_chain.py
+++ b/langchain/evaluation/comparison/eval_chain.py
@@ -81,13 +81,31 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMChain):
         default_factory=PairwiseStringResultOutputParser
     )
 
+    @property
+    def requires_reference(self) -> bool:
+        return "reference" in self.prompt.input_variables
+
+    @property
+    def requires_input(self) -> bool:
+        return True
+
+    @property
+    def _skip_reference_warning(self) -> str:
+        """Warning to show when reference is ignored."""
+        return (
+            f"Ignoring reference in {self.__class__.__name__}, as it is not expected."
+            "\nTo use a reference, initialize PairwiseStringEvalChain with"
+            " `requires_reference=True` or with a prompt with 'reference' as an"
+            " input variable."
+        )
+
     @classmethod
     def from_llm(
         cls,
         llm: BaseLanguageModel,
         *,
         prompt: Optional[PromptTemplate] = None,
-        require_reference: bool = False,
+        requires_reference: bool = False,
         **kwargs: Any,
     ) -> PairwiseStringEvalChain:
         """Initialize the PairwiseStringEvalChain from an LLM.
@@ -95,7 +113,7 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMChain):
         Args:
             llm (BaseLanguageModel): The LLM to use.
             prompt (PromptTemplate, optional): The prompt to use.
-            require_reference (bool, optional): Whether to require a reference
+            requires_reference (bool, optional): Whether to require a reference
                 string. Defaults to False.
             **kwargs (Any): Additional keyword arguments.
 
@@ -104,13 +122,13 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMChain):
         """
         expected_input_vars = {"prediction", "prediction_b", "input"}
         if prompt is None:
-            if require_reference:
+            if requires_reference:
                 expected_input_vars.add("reference")
                 prompt_ = PROMPT_WITH_REFERENCE
             else:
                 prompt_ = PROMPT
         else:
-            if require_reference:
+            if requires_reference:
                 expected_input_vars.add("reference")
             prompt_ = prompt
 
@@ -132,17 +150,17 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMChain):
             "prediction": prediction,
             "prediction_b": prediction_b,
         }
-        if "input" in self.prompt.input_variables:
+        if self.requires_input:
             if not input:
                 raise ValueError("Input is require for this comparison evaluator")
             input_["input"] = input
-        if "reference" in self.prompt.input_variables:
+        if self.requires_reference:
             if reference is None:
                 raise ValueError("Reference is required for this comparison evaluator")
             input_["reference"] = reference
         return input_
 
-    def evaluate_string_pairs(
+    def _evaluate_string_pairs(
         self,
         *,
         prediction: str,
@@ -178,7 +196,7 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMChain):
         )
         return result["text"]
 
-    async def aevaluate_string_pairs(
+    async def _aevaluate_string_pairs(
         self,
         *,
         prediction: str,

--- a/langchain/evaluation/qa/eval_chain.py
+++ b/langchain/evaluation/qa/eval_chain.py
@@ -42,6 +42,14 @@ def _parse_string_eval_output(text: str) -> dict:
 class QAEvalChain(LLMChain, StringEvaluator):
     """LLM Chain specifically for evaluating question answering."""
 
+    @property
+    def requires_reference(self) -> bool:
+        return True
+
+    @property
+    def requires_input(self) -> bool:
+        return True
+
     @classmethod
     def from_llm(
         cls, llm: BaseLanguageModel, prompt: PromptTemplate = PROMPT, **kwargs: Any
@@ -91,7 +99,7 @@ class QAEvalChain(LLMChain, StringEvaluator):
 
         return self.apply(inputs, callbacks=callbacks)
 
-    def evaluate_strings(
+    def _evaluate_strings(
         self,
         *,
         prediction: str,
@@ -119,7 +127,7 @@ class QAEvalChain(LLMChain, StringEvaluator):
         )[0]
         return _parse_string_eval_output(result["text"])
 
-    async def aevaluate_strings(
+    async def _aevaluate_strings(
         self,
         *,
         prediction: str,
@@ -137,6 +145,14 @@ class QAEvalChain(LLMChain, StringEvaluator):
 
 class ContextQAEvalChain(LLMChain, StringEvaluator):
     """LLM Chain specifically for evaluating QA w/o GT based on context"""
+
+    @property
+    def requires_reference(self) -> bool:
+        return True
+
+    @property
+    def requires_input(self) -> bool:
+        return True
 
     @classmethod
     def _validate_input_vars(cls, prompt: PromptTemplate) -> None:
@@ -194,7 +210,7 @@ class ContextQAEvalChain(LLMChain, StringEvaluator):
 
         return self.apply(inputs, callbacks=callbacks)
 
-    def evaluate_strings(
+    def _evaluate_strings(
         self,
         *,
         prediction: str,
@@ -209,7 +225,7 @@ class ContextQAEvalChain(LLMChain, StringEvaluator):
         )[0]
         return _parse_string_eval_output(result["text"])
 
-    async def aevaluate_strings(
+    async def _aevaluate_strings(
         self,
         *,
         prediction: str,

--- a/langchain/evaluation/schema.py
+++ b/langchain/evaluation/schema.py
@@ -1,15 +1,63 @@
 """Interfaces to be implemented by general evaluators."""
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Optional
+from warnings import warn
+
+logger = logging.getLogger(__name__)
 
 
-class StringEvaluator(ABC):
+class _EvalArgsMixin:
+    """Mixin for checking evaluation arguments."""
+
+    @property
+    def requires_reference(self) -> bool:
+        """Whether this evaluator requires a reference label."""
+        return False
+
+    @property
+    def requires_input(self) -> bool:
+        """Whether this evaluator requires an input string."""
+        return False
+
+    @property
+    def _skip_input_warning(self) -> str:
+        """Warning to show when input is ignored."""
+        return f"Ignoring input in {self.__class__.__name__}, as it is not expected."
+
+    @property
+    def _skip_reference_warning(self) -> str:
+        """Warning to show when reference is ignored."""
+        return (
+            f"Ignoring reference in {self.__class__.__name__}, as it is not expected."
+        )
+
+    def _check_evaluation_args(
+        self,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+    ) -> None:
+        if self.requires_input and input is None:
+            raise ValueError(f"{self.__class__.__name__} requires an input string.")
+        elif input is not None and not self.requires_input:
+            warn(self._skip_input_warning)
+        else:
+            pass
+        if self.requires_reference and reference is None:
+            raise ValueError(f"{self.__class__.__name__} requires a reference string.")
+        elif reference is not None and not self.requires_reference:
+            warn(self._skip_reference_warning)
+        else:
+            pass
+
+
+class StringEvaluator(_EvalArgsMixin, ABC):
     """Protocol for evaluating strings."""
 
     @abstractmethod
-    def evaluate_strings(
+    def _evaluate_strings(
         self,
         *,
         prediction: str,
@@ -29,7 +77,7 @@ class StringEvaluator(ABC):
             dict: The evaluation results containing the score or value.
         """
 
-    async def aevaluate_strings(
+    async def _aevaluate_strings(
         self,
         *,
         prediction: str,
@@ -54,12 +102,61 @@ class StringEvaluator(ABC):
             "async aevaluate_strings method."
         )
 
+    def evaluate_strings(
+        self,
+        *,
+        prediction: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Evaluate Chain or LLM output, based on optional input and label.
 
-class PairwiseStringEvaluator(ABC):
+        Args:
+            prediction (str): the LLM or chain prediction to evaluate.
+            reference (Optional[str], optional): the reference label
+                to evaluate against.
+            input (Optional[str], optional): the input to consider during evaluation
+            **kwargs: additional keyword arguments, including callbacks, tags, etc.
+        Returns:
+            dict: The evaluation results containing the score or value.
+        """
+        self._check_evaluation_args(reference=reference, input=input)
+        return self._evaluate_strings(
+            prediction=prediction, reference=reference, input=input, **kwargs
+        )
+
+    async def aevaluate_strings(
+        self,
+        *,
+        prediction: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Asynchronously evaluate Chain or LLM output, based on optional
+          input and label.
+
+        Args:
+            prediction (str): the LLM or chain prediction to evaluate.
+            reference (Optional[str], optional): the reference label
+                 to evaluate against.
+            input (Optional[str], optional): the input to consider during evaluation
+            **kwargs: additional keyword arguments, including callbacks, tags, etc.
+        Returns:
+            dict: The evaluation results containing the score or value.
+        """
+        self._check_evaluation_args(reference=reference, input=input)
+        return await self._aevaluate_strings(
+            prediction=prediction, reference=reference, input=input, **kwargs
+        )
+
+
+class PairwiseStringEvaluator(_EvalArgsMixin, ABC):
     """A protocol for comparing the output of two models."""
 
     @abstractmethod
-    def evaluate_string_pairs(
+    def _evaluate_string_pairs(
         self,
         *,
         prediction: str,
@@ -84,7 +181,7 @@ class PairwiseStringEvaluator(ABC):
                 other information.
         """
 
-    async def aevaluate_string_pairs(
+    async def _aevaluate_string_pairs(
         self,
         *,
         prediction: str,
@@ -111,4 +208,70 @@ class PairwiseStringEvaluator(ABC):
         raise NotImplementedError(
             f"{self.__class__.__name__} hasn't implemented an async "
             "aevaluate_string_pairs method."
+        )
+
+    def evaluate_string_pairs(
+        self,
+        *,
+        prediction: str,
+        prediction_b: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Evaluate the output string pairs.
+
+        Args:
+            prediction (str): The output string from the first model.
+            prediction_b (str): The output string from the second model.
+            reference (str, optional): The expected output / reference
+                string. Defaults to None.
+            input (str, optional): The input string. Defaults to None.
+            **kwargs (Any): Additional keyword arguments, such
+                as callbacks and optional reference strings.
+
+        Returns:
+            dict: A dictionary containing the preference, scores, and/or
+                other information.
+        """
+        self._check_evaluation_args(reference=reference, input=input)
+        return self._evaluate_string_pairs(
+            prediction=prediction,
+            prediction_b=prediction_b,
+            reference=reference,
+            input=input,
+            **kwargs,
+        )
+
+    async def aevaluate_string_pairs(
+        self,
+        *,
+        prediction: str,
+        prediction_b: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Evaluate the output string pairs.
+
+        Args:
+            prediction (str): The output string from the first model.
+            prediction_b (str): The output string from the second model.
+            reference (str, optional): The expected output / reference
+                string. Defaults to None.
+            input (str, optional): The input string. Defaults to None.
+            **kwargs (Any): Additional keyword arguments, such
+                as callbacks and optional reference strings.
+
+        Returns:
+            dict: A dictionary containing the preference, scores, and/or
+                other information.
+        """
+        self._check_evaluation_args(reference=reference, input=input)
+        return await self._aevaluate_string_pairs(
+            prediction=prediction,
+            prediction_b=prediction_b,
+            reference=reference,
+            input=input,
+            **kwargs,
         )

--- a/tests/unit_tests/evaluation/comparison/test_eval_chain.py
+++ b/tests/unit_tests/evaluation/comparison/test_eval_chain.py
@@ -1,6 +1,8 @@
 """Test the comparison chains."""
 
 
+import pytest
+
 from langchain.evaluation.comparison.eval_chain import PairwiseStringEvalChain
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
@@ -30,10 +32,30 @@ def test_pairwise_string_comparison_chain() -> None:
     )
     assert res["value"] == "A"
     assert res["score"] == 1
-    res = chain.evaluate_string_pairs(
-        prediction="I like pie.",
-        prediction_b="I hate pie.",
-        input="What is your favorite food?",
-    )
+    with pytest.warns(UserWarning, match=chain._skip_reference_warning):
+        res = chain.evaluate_string_pairs(
+            prediction="I like pie.",
+            prediction_b="I hate pie.",
+            input="What is your favorite food?",
+            reference="I enjoy pie.",
+        )
     assert res["value"] == "B"
     assert res["score"] == 0
+
+
+def test_pairwise_string_comparison_chain_missing_ref() -> None:
+    llm = FakeLLM(
+        queries={
+            "a": "The values are the same.\n[[C]]",
+            "b": "A is clearly better than b.\n[[A]]",
+            "c": "B is clearly better than a.\n[[B]]",
+        },
+        sequential_responses=True,
+    )
+    chain = PairwiseStringEvalChain.from_llm(llm=llm, requires_reference=True)
+    with pytest.raises(ValueError):
+        chain.evaluate_string_pairs(
+            prediction="I like pie.",
+            prediction_b="I love pie.",
+            input="What is your favorite food?",
+        )

--- a/tests/unit_tests/evaluation/criteria/test_eval_chain.py
+++ b/tests/unit_tests/evaluation/criteria/test_eval_chain.py
@@ -1,6 +1,8 @@
 """Test the criteria eval chain."""
 
 
+import pytest
+
 from langchain.evaluation.criteria.eval_chain import (
     _SUPPORTED_CRITERIA,
     CriteriaEvalChain,
@@ -25,10 +27,24 @@ def test_criteria_eval_chain() -> None:
         ),
         criteria={"my criterion": "my criterion description"},
     )
-    result = chain.evaluate_strings(
-        prediction="my prediction", reference="my reference", input="my input"
-    )
+    with pytest.warns(UserWarning, match=chain._skip_reference_warning):
+        result = chain.evaluate_strings(
+            prediction="my prediction", reference="my reference", input="my input"
+        )
     assert result["reasoning"] == "The meaning of life"
+
+
+def test_criteria_eval_chain_missing_reference() -> None:
+    chain = CriteriaEvalChain.from_llm(
+        llm=FakeLLM(
+            queries={"text": "The meaning of life\nY"},
+            sequential_responses=True,
+        ),
+        requires_reference=True,
+        criteria={"my criterion": "my criterion description"},
+    )
+    with pytest.raises(ValueError):
+        chain.evaluate_strings(prediction="my prediction", input="my input")
 
 
 def test_implements_string_protocol() -> None:


### PR DESCRIPTION
If a string evaluator doesn't want references, it currently silently ignores any that are passed in. This PR proposes to warn once if they're provided. It does so via a mixin.

Other options we could do:
- Separate classes for criteria with references and comparisons with references - I don't love this because all the combinations lead to class explosion and the class names themselves are ugly (CriteriaWithReferencesNoLabels, etc.)
- Raise errors if they're provided - I don't like this because it requires more checks when running evaluators over a dataset, but would be more explicit.
- Decide at calling time -> could be a lot of partial prompt insertions that makes it more brittle. Would make a single "run" potentially have two results that are fundamentally different evaluations