### PR TITLE
Fix steamship import error

### DIFF
--- a/langchain/tools/steamship_image_generation/tool.py
+++ b/langchain/tools/steamship_image_generation/tool.py
@@ -25,6 +25,7 @@ from langchain.callbacks.manager import (
 from langchain.tools import BaseTool
 from langchain.tools.steamship_image_generation.utils import make_image_public
 from langchain.utils import get_from_dict_or_env
+from steamship import Steamship
 
 if TYPE_CHECKING:
     pass
@@ -44,10 +45,6 @@ SUPPORTED_IMAGE_SIZES = {
 
 
 class SteamshipImageGenerationTool(BaseTool):
-    try:
-        from steamship import Steamship
-    except ImportError:
-        pass
 
     """Tool used to generate images from a text-prompt."""
     model_name: ModelName

--- a/langchain/tools/steamship_image_generation/tool.py
+++ b/langchain/tools/steamship_image_generation/tool.py
@@ -25,10 +25,9 @@ from langchain.callbacks.manager import (
 from langchain.tools import BaseTool
 from langchain.tools.steamship_image_generation.utils import make_image_public
 from langchain.utils import get_from_dict_or_env
-from steamship import Steamship
 
 if TYPE_CHECKING:
-    pass
+    from steamship import Steamship
 
 
 class ModelName(str, Enum):
@@ -47,6 +46,7 @@ SUPPORTED_IMAGE_SIZES = {
 class SteamshipImageGenerationTool(BaseTool):
 
     """Tool used to generate images from a text-prompt."""
+
     model_name: ModelName
     size: Optional[str] = "512x512"
     steamship: Steamship


### PR DESCRIPTION
Description: Fix steamship import error

When running multi_modal_output_agent:
field "steamship" not yet prepared so type is still a ForwardRef, you might need to call SteamshipImageGenerationTool.update_forward_refs().

Tag maintainer: @hinthornw

