### PR TITLE
Replace stop clause with shorter, pythonic alternative

### DIFF
--- a/langchain/llms/huggingface_pipeline.py
+++ b/langchain/llms/huggingface_pipeline.py
@@ -179,7 +179,7 @@ class HuggingFacePipeline(LLM):
                 f"Got invalid task {self.pipeline.task}, "
                 f"currently only {VALID_TASKS} are supported"
             )
-        if stop is not None:
+        if stop:
             # This is a bit hacky, but I can't figure out a better way to enforce
             # stop tokens when making calls to huggingface_hub.
             text = enforce_stop_tokens(text, stop)


### PR DESCRIPTION
Replace this comment with:
  - Description: Replace `if var is not None:` with `if var:`, a concise and pythonic alternative
  - Issue: N/A
  - Dependencies: None
  - Tag maintainer: Unsure
  - Twitter handle: N/A