### PR TITLE
LlamaCppEmbeddings not under langchain.llms

### DIFF
--- a/langchain/llms/llamacpp.py
+++ b/langchain/llms/llamacpp.py
@@ -20,8 +20,8 @@ class LlamaCpp(LLM):
     Example:
         .. code-block:: python
 
-            from langchain.llms import LlamaCppEmbeddings
-            llm = LlamaCppEmbeddings(model_path="/path/to/llama/model")
+            from langchain.llms import LlamaCpp
+            llm = LlamaCpp(model_path="/path/to/llama/model")
     """
 
     client: Any  #: :meta private:


### PR DESCRIPTION
Description: doc string suggests `from langchain.llms import LlamaCppEmbeddings` under `LlamaCpp()` class example but `LlamaCppEmbeddings` is not in `langchain.llms`
Issue: None open
Tag maintainer: @baskaryan 