### PR TITLE
fix: Chroma filter symbols not supporting LIKE and CONTAIN

### DIFF
--- a/langchain/retrievers/self_query/chroma.py
+++ b/langchain/retrievers/self_query/chroma.py
@@ -16,6 +16,8 @@ class ChromaTranslator(Visitor):
 
     allowed_operators = [Operator.AND, Operator.OR]
     """Subset of allowed logical operators."""
+    allowed_comparators = [Comparator.EQ, Comparator.GT, Comparator.GTE, Comparator.LT, Comparator.LTE]
+    """Subset of allowed logical comparators."""
 
     def _format_func(self, func: Union[Operator, Comparator]) -> str:
         self._validate_func(func)

--- a/langchain/retrievers/self_query/chroma.py
+++ b/langchain/retrievers/self_query/chroma.py
@@ -16,7 +16,13 @@ class ChromaTranslator(Visitor):
 
     allowed_operators = [Operator.AND, Operator.OR]
     """Subset of allowed logical operators."""
-    allowed_comparators = [Comparator.EQ, Comparator.GT, Comparator.GTE, Comparator.LT, Comparator.LTE]
+    allowed_comparators = [
+        Comparator.EQ,
+        Comparator.GT,
+        Comparator.GTE,
+        Comparator.LT,
+        Comparator.LTE,
+    ]
     """Subset of allowed logical comparators."""
 
     def _format_func(self, func: Union[Operator, Comparator]) -> str:


### PR DESCRIPTION
Fixing issue with SelfQueryRetriever due to unsupported LIKE and CONTAIN comparators in Chroma's WHERE filter statements. This pull request introduces a redefined set of comparators in Chroma to address the problem and make it compatible with SelfQueryRetriever. For information on the comparators supported by Chroma's filter, please refer to https://docs.trychroma.com/usage-guide#using-where-filters.
<img width="495" alt="image" src="https://github.com/hwchase17/langchain/assets/22267652/34789191-0293-4f63-9bdf-ad1e1f2567c4">

