### PR TITLE
fix: rename the invalid function name of GoogleSerperResults Tool for OpenAIFunctionCall

### DIFF
--- a/langchain/tools/google_serper/tool.py
+++ b/langchain/tools/google_serper/tool.py
@@ -44,7 +44,7 @@ class GoogleSerperResults(BaseTool):
     """Tool that has capability to query the Serper.dev Google Search API
     and get back json."""
 
-    name = "Google Serrper Results JSON"
+    name = "google_serrper_results_json"
     description = (
         "A low-cost Google Search API."
         "Useful for when you need to answer questions about current events."


### PR DESCRIPTION
- Description: rename the invalid function name of GoogleSerperResults Tool for OpenAIFunctionCall
- Tag maintainer: @hinthornw

When I use the GoogleSerperResults in OpenAIFunctionCall agent, the following error occurs:
```shell
openai.error.InvalidRequestError: 'Google Serrper Results JSON' does not match '^[a-zA-Z0-9_-]{1,64}$' - 'functions.0.name'
```

So I rename the GoogleSerperResults's property "name" from "Google Serrper Results JSON" to "google_serrper_results_json" just like GoogleSerperRun's name: "google_serper", and it works.
I guess this should be reasonable.