### PR TITLE
Add docs for setting MapReduceChain token_max arg

### DIFF
--- a/docs/snippets/modules/chains/popular/summarize.mdx
+++ b/docs/snippets/modules/chains/popular/summarize.mdx
@@ -174,6 +174,22 @@ chain({"input_documents": docs}, return_only_outputs=True)
 
 </CodeOutputBlock>
 
+## `MapReduceChain` - Adjusting for different context sizes and `token_max`
+
+The MapReduceChain uses a `token_max` arg to decide the limit of tokens the reduce step can take in. The chain effectively chunks up and condenses inputs until they drop below the `token_max` threshold.
+Once below this `token_max`, the chain will run the reduce step. By default `token_max` is set to `3000` tokens.
+
+You may want to change this when dealing with models with larger/smaller context sizes. This arg also acts as a sliding scale between how much you want to condense inputs before passing them to the reduce step vs how many tokens you want to leave for generation in the reduce step.
+Eg: If you have 16k tokens and you set the `token_max` to 5k, your inputs will be condensed until they together are at most 5k tokens, but leave 11k tokens for the final output generation.
+
+Do not confuse this with `max_tokens` which is the maximum tokens you can get from a model's generation.
+
+You can set the `token_max` like so:
+
+```python
+chain({"input_documents": docs, 'token_max': 12000}, return_only_outputs=True)
+```
+
 ## The custom `MapReduceChain`
 
 **Multi input prompt**

--- a/docs/snippets/modules/chains/popular/summarize.mdx
+++ b/docs/snippets/modules/chains/popular/summarize.mdx
@@ -174,22 +174,6 @@ chain({"input_documents": docs}, return_only_outputs=True)
 
 </CodeOutputBlock>
 
-## `MapReduceChain` - Adjusting for different context sizes and `token_max`
-
-The MapReduceChain uses a `token_max` arg to decide the limit of tokens the reduce step can take in. The chain effectively chunks up and condenses inputs until they drop below the `token_max` threshold.
-Once below this `token_max`, the chain will run the reduce step. By default `token_max` is set to `3000` tokens.
-
-You may want to change this when dealing with models with larger/smaller context sizes. This arg also acts as a sliding scale between how much you want to condense inputs before passing them to the reduce step vs how many tokens you want to leave for generation in the reduce step.
-Eg: If you have 16k tokens and you set the `token_max` to 5k, your inputs will be condensed until they together are at most 5k tokens, but leave 11k tokens for the final output generation.
-
-Do not confuse this with `max_tokens` which is the maximum tokens you can get from a model's generation.
-
-You can set the `token_max` like so:
-
-```python
-chain({"input_documents": docs, 'token_max': 12000}, return_only_outputs=True)
-```
-
 ## The custom `MapReduceChain`
 
 **Multi input prompt**
@@ -313,6 +297,27 @@ map_reduce.run(input_text=code, question="Which function has a better time compl
 ```
 
 </CodeOutputBlock>
+
+## `MapReduceChain` - Adjusting for different context sizes and `token_max`
+
+The ReduceDocumentsChain uses a `token_max` arg to decide the maximum limit of tokens the reduce step can take in. The MapReduceChain effectively chunks up and condenses inputs until they drop below the `token_max` threshold.
+Once below this `token_max`, the chain will run the reduce step. By default `token_max` is set to `3000` tokens.
+
+You may want to change this when dealing with models with larger/smaller context sizes. This arg also acts as a sliding scale between how much you want to condense inputs before passing them to the reduce step vs how many tokens you want to leave for generation in the reduce step.
+Eg: If you have 16k tokens and you set the `token_max` to 5k, your inputs will be condensed until they together are at most 5k tokens, but leave 11k tokens for the final output generation.
+
+Do not confuse this with `max_tokens` which is the maximum tokens you can get from a model's generation.
+
+You can set the `token_max` like so when creating a `ReduceDocumentsChain`:
+
+```python
+reduce_documents_chain = ReduceDocumentsChain(
+        combine_documents_chain=combine_documents_chain,
+        collapse_documents_chain=collapse_chain,
+        token_max=token_max,
+        verbose=verbose,
+    )
+```
 
 ## The `refine` Chain
 


### PR DESCRIPTION
- Description: Add docs on how to set and use the token_max arg for MapReduceChains
- Issue: Several issues have been repeatedly raised regarding this, since it is non-intuitive how to pass this arg. This makes usage with larger models such as gpt-3.5-turbo-16k much easier. I also explain how it's a sliding scale between how much the inputs will be summarized vs tokens left for generation.
- Tag maintainer: @baskaryan @hwchase17
- Twitter handle: More PRs incoming! :) https://twitter.com/ShantanuNair

Related Github discussion: https://github.com/hwchase17/langchain/discussions/2746
Related issues: https://github.com/hwchase17/langchain/issues/1349, https://github.com/hwchase17/langchain/issues/7043, https://github.com/hwchase17/langchain/issues/434, https://github.com/hwchase17/langchain/issues/6397, https://github.com/hwchase17/langchain/issues/6714, https://github.com/hwchase17/langchain/issues/6191
