### PR TITLE
Update in_memory.py to fix "TypeError: keywords must be strings"

### DIFF
--- a/langchain/docstore/in_memory.py
+++ b/langchain/docstore/in_memory.py
@@ -17,7 +17,7 @@ class InMemoryDocstore(Docstore, AddableMixin):
         overlapping = set(texts).intersection(self._dict)
         if overlapping:
             raise ValueError(f"Tried to add ids that already exist: {overlapping}")
-        self._dict.update(texts)
+        self._dict = {**self._dict, **texts}
 
     def search(self, search: str) -> Union[str, Document]:
         """Search via direct lookup."""

--- a/langchain/docstore/in_memory.py
+++ b/langchain/docstore/in_memory.py
@@ -17,7 +17,7 @@ class InMemoryDocstore(Docstore, AddableMixin):
         overlapping = set(texts).intersection(self._dict)
         if overlapping:
             raise ValueError(f"Tried to add ids that already exist: {overlapping}")
-        self._dict = dict(self._dict, **texts)
+        self._dict.update(texts)
 
     def search(self, search: str) -> Union[str, Document]:
         """Search via direct lookup."""


### PR DESCRIPTION
Update in_memory.py to fix "TypeError: keywords must be strings" on certain dictionaries

Simple fix to prevent a "TypeError: keywords must be strings" error I encountered in my use case.

@baskaryan 

Thanks! Hope useful!