### PR TITLE
Update scenexplain.py to use new API endpoint

### DIFF
--- a/langchain/utilities/scenexplain.py
+++ b/langchain/utilities/scenexplain.py
@@ -25,7 +25,7 @@ class SceneXplainAPIWrapper(BaseSettings, BaseModel):
 
     scenex_api_key: str = Field(..., env="SCENEX_API_KEY")
     scenex_api_url: str = (
-        "https://us-central1-causal-diffusion.cloudfunctions.net/describe"
+        "https://api.scenex.jina.ai/v1/describe"
     )
 
     def _describe_image(self, image: str) -> str:


### PR DESCRIPTION
  - Description: Update SceneXplain API endpoint URL (taken from official docs: https://scenex.jina.ai/api)
  - Issue: The old sceneXplain API endpoint: "https://us-central1-causal-diffusion.cloudfunctions.net/describe" is deprecated and now returns 500 internal error codes.
  - Dependencies: N/A
  - Tag maintainer: @hinthornw
  - Twitter handle: @deoxykev