### PR TITLE
added template repo for CI/CD deployment on Google Cloud Run

### DIFF
--- a/docs/extras/guides/deployments/template_repos.mdx
+++ b/docs/extras/guides/deployments/template_repos.mdx
@@ -51,6 +51,10 @@ A minimal example of how to deploy LangChain to [Fly.io](https://fly.io/) using 
 
 A minimal example on how to deploy LangChain to DigitalOcean App Platform.
 
+## [CI/CD Google Cloud Build + Dockerfile + Serverless Google Cloud Run](https://github.com/g-emarco/github-assistant)
+
+Boilerplate LangChain project on how to deploy to Google Cloud Run using Docker with Cloud Build CI/CD pipeline
+
 ## [Google Cloud Run](https://github.com/homanp/gcp-langchain)
 
 A minimal example on how to deploy LangChain to Google Cloud Run.


### PR DESCRIPTION
Replace this comment with:
  - Description: added documentation for a template repo that helps dockerizing and deploying a LangChain using a Cloud Build CI/CD pipeline to Google Cloud build serverless
  - Issue: None,
  - Dependencies: None,
  - Tag maintainer: @baskaryan,
  - Twitter handle: EdenEmarco177

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.
