### PR TITLE
store template and template args in prompt output

### DIFF
--- a/langchain/prompts/base.py
+++ b/langchain/prompts/base.py
@@ -97,7 +97,12 @@ def check_valid_template(
 class StringPromptValueString(str):
     """Wrapper around a string that also stores the template args and template."""
 
-    def __new__(cls, text: str, template_args: Dict[str, Any], template: str):
+    template_args: Dict[str, Any]
+    template: BasePromptTemplate
+
+    def __new__(
+        cls, text: str, template_args: Dict[str, Any], template: BasePromptTemplate
+    ) -> StringPromptValueString:
         instance = super().__new__(cls, text)
         instance.template_args = template_args
         instance.template = template
@@ -107,7 +112,7 @@ class StringPromptValueString(str):
 class StringPromptValue(PromptValue):
     text: str
     template_args: Dict[str, Any]
-    template: str
+    template: BasePromptTemplate
 
     def to_string(self) -> str:
         """Return prompt as string."""
@@ -130,5 +135,5 @@ class StringPromptTemplate(BasePromptTemplate, ABC):
     def format_prompt(self, **kwargs: Any) -> PromptValue:
         """Create Chat Messages."""
         return StringPromptValue(
-            text=self.format(**kwargs), template_args=kwargs, template=self.template
+            text=self.format(**kwargs), template_args=kwargs, template=self
         )

--- a/langchain/prompts/chat.py
+++ b/langchain/prompts/chat.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, List, Sequence, Tuple, Type, TypeVar, Union
 from pydantic import Field, root_validator
 
 from langchain.load.serializable import Serializable
-from langchain.prompts.base import StringPromptTemplate
+from langchain.prompts.base import StringPromptTemplate, StringPromptValueString
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import (
     BasePromptTemplate,
@@ -111,7 +111,9 @@ class ChatMessagePromptTemplate(BaseStringMessagePromptTemplate):
     role: str
 
     def format(self, **kwargs: Any) -> BaseMessage:
-        text = self.prompt.format(**kwargs)
+        text = StringPromptValueString(
+            self.prompt.format(**kwargs), kwargs, self.prompt
+        )
         return ChatMessage(
             content=text, role=self.role, additional_kwargs=self.additional_kwargs
         )
@@ -119,19 +121,25 @@ class ChatMessagePromptTemplate(BaseStringMessagePromptTemplate):
 
 class HumanMessagePromptTemplate(BaseStringMessagePromptTemplate):
     def format(self, **kwargs: Any) -> BaseMessage:
-        text = self.prompt.format(**kwargs)
+        text = StringPromptValueString(
+            self.prompt.format(**kwargs), kwargs, self.prompt
+        )
         return HumanMessage(content=text, additional_kwargs=self.additional_kwargs)
 
 
 class AIMessagePromptTemplate(BaseStringMessagePromptTemplate):
     def format(self, **kwargs: Any) -> BaseMessage:
-        text = self.prompt.format(**kwargs)
+        text = StringPromptValueString(
+            self.prompt.format(**kwargs), kwargs, self.prompt
+        )
         return AIMessage(content=text, additional_kwargs=self.additional_kwargs)
 
 
 class SystemMessagePromptTemplate(BaseStringMessagePromptTemplate):
     def format(self, **kwargs: Any) -> BaseMessage:
-        text = self.prompt.format(**kwargs)
+        text = StringPromptValueString(
+            self.prompt.format(**kwargs), kwargs, self.prompt
+        )
         return SystemMessage(content=text, additional_kwargs=self.additional_kwargs)
 
 


### PR DESCRIPTION
This exposes the original template + variables used in prompts to downstream consumers such as the callbacks system or LLM libraries. It does this by altering the template-formatting system to use a subclass of `str` rather than just a `str`. This is the most pythonic way I could find to accomplish this (There is also UserString, but that doesn't subclass `str` so it fails `isinstance` checks)

What this specifically allows is that libraries that monitor API libraries like the OpenAI SDK, can look at the prompt that the API was called with (a completion text or a messages array) and inspect the objects to pull out the template (on `.template`) or the template arguments (on `.template_args`)

(I spent some time trying to do this with callbacks, but the problem I ran into is that you have access to the prompt + variables in `on_chain_start` but there isn't an easy way to tie this back to the actual request sent to the OpenAI and this data doesn't seem to be captured by `on_llm_start`, and these are called in a way that makes it hard to capture any data and have it visible from the openai `create()` methods)

If this approach feels right, I can go ahead and write some unit tests for it as a part of this PR.

Not sure who to tag for this, so tagging @baskaryan and @hwchase17 