### PR TITLE
Add missing token_max in reduce.py acombine_docs

### DIFF
--- a/langchain/chains/combine_documents/reduce.py
+++ b/langchain/chains/combine_documents/reduce.py
@@ -193,7 +193,7 @@ class ReduceDocumentsChain(BaseCombineDocumentsChain):
             element returned is a dictionary of other keys to return.
         """
         result_docs, extra_return_dict = self._collapse(
-            docs, token_max, callbacks=callbacks, **kwargs
+            docs, token_max=token_max, callbacks=callbacks, **kwargs
         )
         return self.combine_documents_chain.combine_docs(
             docs=result_docs, callbacks=callbacks, **kwargs
@@ -222,7 +222,7 @@ class ReduceDocumentsChain(BaseCombineDocumentsChain):
             element returned is a dictionary of other keys to return.
         """
         result_docs, extra_return_dict = await self._acollapse(
-            docs, token_max, callbacks=callbacks, **kwargs
+            docs, token_max=token_max, callbacks=callbacks, **kwargs
         )
         return await self.combine_documents_chain.acombine_docs(
             docs=result_docs, callbacks=callbacks, **kwargs

--- a/langchain/chains/combine_documents/reduce.py
+++ b/langchain/chains/combine_documents/reduce.py
@@ -222,7 +222,7 @@ class ReduceDocumentsChain(BaseCombineDocumentsChain):
             element returned is a dictionary of other keys to return.
         """
         result_docs, extra_return_dict = await self._acollapse(
-            docs, callbacks=callbacks, **kwargs
+            docs, token_max, callbacks=callbacks, **kwargs
         )
         return await self.combine_documents_chain.acombine_docs(
             docs=result_docs, callbacks=callbacks, **kwargs


### PR DESCRIPTION
Replace this comment with:
  - Description: reduce.py reduce chain implementation's acombine_docs call does not propagate token_max. Without this, the async call will end up using 3000 tokens, the default, for the collapse chain.
  - Tag maintainer: @hwchase17 @agola11 @baskaryan 
  - Twitter handle: https://twitter.com/ShantanuNair

Related PR: https://github.com/hwchase17/langchain/pull/7201 and https://github.com/hwchase17/langchain/pull/7204