### PR TITLE
Update supabase match_docs ddl and notebook to use expected id type

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/supabase.ipynb
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/supabase.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "       CREATE FUNCTION match_documents(query_embedding vector(1536), match_count int)\n",
     "           RETURNS TABLE(\n",
-    "               id bigint,\n",
+    "               id uuid,\n",
     "               content text,\n",
     "               metadata jsonb,\n",
     "               -- we return matched vectors to enable maximal marginal relevance searches\n",

--- a/langchain/vectorstores/supabase.py
+++ b/langchain/vectorstores/supabase.py
@@ -315,7 +315,7 @@ class SupabaseVectorStore(VectorStore):
         CREATE FUNCTION match_documents_embeddings(query_embedding vector(1536),
                                                    match_count int)
             RETURNS TABLE(
-                id bigint,
+                id uuid,
                 content text,
                 metadata jsonb,
                 embedding vector(1536),


### PR DESCRIPTION
  - Description: Switch supabase match function DDL to use expected uuid type instead of bigint
  - Issue: https://github.com/hwchase17/langchain/issues/6743, https://github.com/hwchase17/langchain/issues/7179
  - Tag maintainer:  @rlancemartin, @eyurtsev
  - Twitter handle: https://twitter.com/ShantanuNair