### PR TITLE
FLARE Example notebook: switch to named arg to pass pydantic validation

### DIFF
--- a/docs/extras/modules/chains/additional/flare.ipynb
+++ b/docs/extras/modules/chains/additional/flare.ipynb
@@ -111,7 +111,7 @@
     "        raise NotImplementedError()\n",
     "\n",
     "\n",
-    "retriever = SerperSearchRetriever(GoogleSerperAPIWrapper())"
+    "retriever = SerperSearchRetriever(search=GoogleSerperAPIWrapper())"
    ]
   },
   {

--- a/docs/extras/modules/chains/additional/flare.ipynb
+++ b/docs/extras/modules/chains/additional/flare.ipynb
@@ -56,7 +56,8 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ[\"SERPER_API_KEY\"] = \"\""
+    "os.environ[\"SERPER_API_KEY\"] = \"\"",
+    "os.environ[\"OPENAI_API_KEY\"] = \"\""
    ]
   },
   {
@@ -77,7 +78,7 @@
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.llms import OpenAI\n",
     "from langchain.schema import Document\n",
-    "from typing import Any"
+    "from typing import Any, List"
    ]
   },
   {
@@ -96,8 +97,8 @@
    "outputs": [],
    "source": [
     "class SerperSearchRetriever(BaseRetriever):\n",
-    "    def __init__(self, search):\n",
-    "        self.search = search\n",
+    "\n",
+    "    search: GoogleSerperAPIWrapper = None\n",
     "\n",
     "    def _get_relevant_documents(self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any) -> List[Document]:\n",
     "        return [Document(page_content=self.search.run(query))]\n",


### PR DESCRIPTION
Adding the name of the parameter to comply with latest requirements by Pydantic usage for BaseModels.