### PR TITLE
Add new chain qa_with_references_and_verbatim

### DIFF
--- a/docs/docs/integrations/chains/qa_with_reference_and_verbatim.ipynb
+++ b/docs/docs/integrations/chains/qa_with_reference_and_verbatim.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4993da90",
+   "metadata": {},
+   "source": [
+    "# QA with reference\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pprados/langchain-qa_with_references/blob/master/qa_with_reference_and_verbatim.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf56f04",
+   "metadata": {},
+   "source": [
+    "We believe that hallucinations pose a major problem in the adoption of LLMs (Language Model Models). It is imperative to provide a simple and quick solution that allows the user to verify the coherence of the answers to the questions they are asked.\n",
+    "\n",
+    "The conventional approach is to provide a list of URLs of the documents that helped in answering (see qa_with_source). However, this approach is unsatisfactory in several scenarios:\n",
+    "\n",
+    "1. The question is asked about a PDF of over 100 pages. Each fragment comes from the same document, but from where?\n",
+    "2. Some documents do not have URLs (data retrieved from a database or other loaders).\n",
+    "\n",
+    "It appears essential to have a means of retrieving all references to the actual data sources used by the model to answer the question. \n",
+    "\n",
+    "This includes:\n",
+    "- The precise list of documents used for the answer (the `Documents`, along with their metadata that may contain page numbers, slide numbers, or any other information allowing the retrieval of the fragment in the original document).\n",
+    "- The excerpts of text used for the answer in each fragment. Even if a fragment is used, the LLM only utilizes a small portion to generate the answer. Access to these verbatim excerpts helps to quickly ascertain the validity of the answer.\n",
+    "\n",
+    "We propose a new pipeline: `qa_with_reference` for this purpose. It is a Question/Answer type pipeline that returns the list of documents used, and in the metadata, the list of verbatim excerpts exploited to produce the answer.\n",
+    "\n",
+    "*At this time, only the `map_reduce` chain type car extract the verbatim excerpts.*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "730b0fd3-82d3-439a-87b8-3ef77d9d1d6c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-11-06T12:39:22.005634758Z",
+     "start_time": "2023-11-06T12:39:19.006453887Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q 'langchain-experimental' --upgrade pip  openai tiktoken"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install -q  python-dotenv\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = \"XXXXX\""
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "d60381b7ca806d6d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d181ff19",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-11-06T12:45:28.578231803Z",
+     "start_time": "2023-11-06T12:45:28.571603635Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.llms import OpenAI\n",
+    "from langchain.schema import Document\n",
+    "\n",
+    "llm = OpenAI(\n",
+    "    max_tokens=1500,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d935867c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-11-06T12:45:31.959915788Z",
+     "start_time": "2023-11-06T12:45:29.035033057Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "To answer \"he eats apples, he eats pears, he eats carrots.\", the LLM use:\n",
+      "Document 0\n",
+      "- \"he eats apples\"\n",
+      "- \"he eats pears.\"\n",
+      "Document 1\n",
+      "- \"he eats carrots.\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_experimental.chains import QAWithReferencesAndVerbatimsChain\n",
+    "\n",
+    "chain_type = \"map_reduce\"\n",
+    "qa_chain = QAWithReferencesAndVerbatimsChain.from_chain_type(\n",
+    "    llm=llm,\n",
+    "    chain_type=chain_type,\n",
+    ")\n",
+    "\n",
+    "question = \"what does it eat?\"\n",
+    "bodies = [\n",
+    "    \"he eats apples and plays football.\" \"My name is Philippe.\" \"he eats pears.\",\n",
+    "    \"he eats carrots. I like football.\",\n",
+    "    \"The Earth is round.\",\n",
+    "]\n",
+    "docs = [\n",
+    "    Document(page_content=body, metadata={\"id\": i}) for i, body in enumerate(bodies)\n",
+    "]\n",
+    "\n",
+    "answer = qa_chain(\n",
+    "    inputs={\n",
+    "        \"docs\": docs,\n",
+    "        \"question\": question,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(f'To answer \"{answer[\"answer\"]}\", the LLM use:')\n",
+    "for doc in answer[\"source_documents\"]:\n",
+    "    print(f\"Document {doc.metadata['id']}\")\n",
+    "    for verbatim in doc.metadata.get(\"verbatims\", []):\n",
+    "        print(f'- \"{verbatim}\"')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "296c49aa",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-11-06T12:45:40.269265983Z",
+     "start_time": "2023-11-06T12:45:31.943845958Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q chromadb wikipedia\n",
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from langchain.retrievers import WikipediaRetriever\n",
+    "from langchain.vectorstores import Chroma\n",
+    "\n",
+    "question = \"what is the Machine learning?\"\n",
+    "\n",
+    "wikipedia_retriever = WikipediaRetriever()\n",
+    "vectorstore = Chroma(\n",
+    "    embedding_function=OpenAIEmbeddings(),\n",
+    ")\n",
+    "docs = wikipedia_retriever.get_relevant_documents(question)\n",
+    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "\n",
+    "split_docs = RecursiveCharacterTextSplitter(\n",
+    "    chunk_size=500, chunk_overlap=10\n",
+    ").split_documents(docs)\n",
+    "\n",
+    "vectorstore.add_documents(split_docs)\n",
+    "retriever = vectorstore.as_retriever()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "6e9e8e2a",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-11-06T12:45:47.003018015Z",
+     "start_time": "2023-11-06T12:45:40.274007200Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For the question \"what is the Machine learning?\", to answer \"Machine learning (ML) is a field of study in artificial intelligence concerned with the development and study of statistical algorithms that can effectively generalize and thus perform tasks without explicit instructions.\", the LLM use:\n",
+      "Source \u001B[94mhttps://en.wikipedia.org/wiki/Machine_learning\u001B[0m\n",
+      "-  \"\u001B[92mMachine learning (ML) is a field of study in artificial intelligence concerned with the development and study of statistical algorithms that can effectively generalize and thus perform tasks without explicit instructions.\u001B[0m\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_experimental.chains import (\n",
+    "    RetrievalQAWithReferencesAndVerbatimsChain,\n",
+    ")\n",
+    "from typing import Literal, List\n",
+    "\n",
+    "chain_type: Literal[\"stuff\", \"map_reduce\", \"map_rerank\", \"refine\"] = \"map_reduce\"\n",
+    "\n",
+    "qa_chain = RetrievalQAWithReferencesAndVerbatimsChain.from_chain_type(\n",
+    "    llm=llm,\n",
+    "    chain_type=chain_type,\n",
+    "    retriever=retriever,\n",
+    "    reduce_k_below_max_tokens=True,\n",
+    ")\n",
+    "result = qa_chain(\n",
+    "    inputs={\n",
+    "        \"question\": question,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def merge_result_by_urls(result):\n",
+    "    references = {}\n",
+    "    for doc in result[\"source_documents\"]:\n",
+    "        source = doc.metadata.get(\"source\", [])\n",
+    "        verbatims_for_source: List[str] = doc.metadata.get(source, [])\n",
+    "        verbatims_for_source.extend(doc.metadata.get(\"verbatims\", []))\n",
+    "        references[source] = verbatims_for_source\n",
+    "    return references\n",
+    "\n",
+    "\n",
+    "print(f'For the question \"{question}\", to answer \"{result[\"answer\"]}\", the LLM use:')\n",
+    "references = merge_result_by_urls(result)\n",
+    "# Print the result\n",
+    "for source, verbatims in references.items():\n",
+    "    print(f\"Source \\033[94m{source}\\033[0m\")\n",
+    "    for verbatim in verbatims:\n",
+    "        print(f'-  \"\\033[92m{verbatim}\\033[0m\"')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "c65515ad36cf5010"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "langchain-qa_with_references",
+   "language": "python",
+   "display_name": "langchain-qa_with_references"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/base.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/base.py
@@ -1,0 +1,338 @@
+"""Question answering with references over documents."""
+
+import inspect
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
+
+from langchain.base_language import BaseLanguageModel
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.chains.base import Chain
+from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
+from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
+from langchain.chains.combine_documents.reduce import ReduceDocumentsChain
+from langchain.chains.combine_documents.stuff import StuffDocumentsChain
+from langchain.chains.llm import LLMChain
+from langchain.docstore.document import Document
+from langchain.pydantic_v1 import Extra
+from langchain.schema import BaseOutputParser, BasePromptTemplate, OutputParserException
+
+from .loading import (
+    load_qa_with_references_chain,
+)
+from .map_reduce_prompts import (
+    COMBINE_PROMPT,
+    EXAMPLE_PROMPT,
+    QUESTION_PROMPT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# TOTRY: Add in VectorStoreIndexWrapper.query_with_references()
+# TOTRY: Add in VectorStoreIndexWrapper.query_with_references_and_verbatims()
+class BaseQAWithReferencesChain(Chain, ABC):
+    combine_documents_chain: BaseCombineDocumentsChain
+
+    """Chain to use to combine documents."""
+    question_key: str = "question"  #: :meta private:
+    input_docs_key: str = "docs"  #: :meta private:
+    answer_key: str = "answer"  #: :meta private:
+    source_documents_key: str = "source_documents"  #: :meta private:
+    chain_type: str  #: :meta private:
+    output_parser: Optional[BaseOutputParser] = None
+
+    @classmethod
+    def from_llm(
+        cls,
+        llm: BaseLanguageModel,
+        document_prompt: BasePromptTemplate = EXAMPLE_PROMPT,
+        question_prompt: BasePromptTemplate = QUESTION_PROMPT,
+        combine_prompt: BasePromptTemplate = COMBINE_PROMPT,
+        **kwargs: Any,
+    ) -> "BaseQAWithReferencesChain":
+        """Construct the chain from an LLM."""
+        llm_question_chain = LLMChain(llm=llm, prompt=question_prompt)
+        llm_combine_chain = LLMChain(llm=llm, prompt=combine_prompt)
+        combine_results_chain = StuffDocumentsChain(
+            llm_chain=llm_combine_chain,
+            document_prompt=document_prompt,
+            document_variable_name="summaries",
+        )
+        reduce_documents_chain = ReduceDocumentsChain(
+            combine_documents_chain=combine_results_chain
+        )
+        combine_document_chain = MapReduceDocumentsChain(
+            llm_chain=llm_question_chain,
+            reduce_documents_chain=reduce_documents_chain,
+            document_variable_name="context",
+            return_intermediate_steps=True,
+        )
+        return cls(
+            combine_documents_chain=combine_document_chain,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_chain_type(
+        cls,
+        llm: BaseLanguageModel,
+        chain_type: str = "stuff",
+        chain_type_kwargs: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> "BaseQAWithReferencesChain":
+        """Load chain from chain type."""
+        _chain_kwargs = chain_type_kwargs or {}
+        combine_document_chain = load_qa_with_references_chain(
+            llm,
+            chain_type=chain_type,
+            **_chain_kwargs,
+        )
+        if chain_type == "map_rerank" and "output_parser" not in kwargs:
+            from .map_rerank_prompts import rerank_reference_parser
+
+            kwargs["output_parser"] = rerank_reference_parser
+
+        return cls(
+            combine_documents_chain=combine_document_chain,
+            chain_type=chain_type,
+            **kwargs,
+        )
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Expect input key.
+
+        :meta private:
+        """
+        return [self.question_key]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Return output key.
+
+        :meta private:
+        """
+        _output_keys = [self.answer_key, self.source_documents_key]
+        return _output_keys
+
+    def _split_sources(self, answer: str) -> Tuple[str, str]:
+        """Split sources from answer."""
+        if re.search(r"SOURCES?:", answer, re.IGNORECASE):
+            answer, sources = re.split(
+                r"SOURCES?:|QUESTION:\s", answer, flags=re.IGNORECASE
+            )[:2]
+            sources = re.split(r"\n", sources)[0].strip()
+        else:
+            sources = ""
+        return answer, sources
+
+    @abstractmethod
+    def _get_docs(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        run_manager: CallbackManagerForChainRun,
+    ) -> List[Document]:
+        """Get docs to run questioning over."""
+
+    def _process_reference(
+        self, answers: Dict[str, Any], docs: List[Document], references: Any
+    ) -> Set[int]:
+        # With the map_rerank mode, use extra parameter for map_rerank to identify
+        # the corresponding document.
+        if "_idx" in answers:
+            references.documents_ids.add(answers["_idx"])
+
+        documents_idx = set()
+        for str_doc_id in references.documents_ids:
+            m = re.match(r"(?:_idx_)?(\d+)", str_doc_id.strip())
+            if m:
+                documents_idx.add(int(m[1]))
+            else:
+                pass
+        return documents_idx
+
+    def _process_results(
+        self,
+        answers: Dict[str, Any],
+        docs: List[Document],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Tuple[str, Set[int]]:
+        idx = set()
+        answer = answers[self.combine_documents_chain.output_key]
+        # At this time (version 0.0.273), the output_parser is not
+        # automatically called.
+        # We must extract this parser to analyse the response.
+        parser: Optional[BaseOutputParser] = self.output_parser
+        llm_chain: Optional[LLMChain] = None
+        if not parser:
+            if self.chain_type == "map_rerank":
+                # self.combine_documents_chain.llm_chain.prompt.output_parser
+                assert self.output_parser
+            elif self.chain_type == "map_reduce":
+                llm_chain = cast(
+                    Any, self.combine_documents_chain
+                ).collapse_document_chain.llm_chain
+            elif self.chain_type == "refine":
+                llm_chain = cast(Any, self.combine_documents_chain).refine_llm_chain
+            else:
+                # Simple chain
+                llm_chain = cast(Any, self.combine_documents_chain).llm_chain
+        if llm_chain:
+            parser = llm_chain.prompt.output_parser
+        assert parser
+
+        try:
+            references = parser.parse(answer)
+            answer = references.response
+
+            idx = self._process_reference(answers, docs, references)
+
+            for doc in docs:
+                del doc.metadata["_idx"]
+            return answer, idx
+        except (OutputParserException, ValueError) as e:
+            # Probably that the answer has been cut off.
+            raise OutputParserException(
+                "The response is probably cut off. Change the `max_tokens` parameter "
+                "or reduce the temperature.\n" + str(e)
+            ).with_traceback(e.__traceback__)
+        # except Exception as e:
+        #     if run_manager:
+        #         run_manager.on_chain_error(e)
+        #     raise e
+
+    @abstractmethod
+    async def _aget_docs(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        run_manager: AsyncCallbackManagerForChainRun,
+    ) -> List[Document]:
+        """Get docs to run questioning over."""
+
+    def _call(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        accepts_run_manager = (
+            "run_manager" in inspect.signature(self._get_docs).parameters
+        )
+        if accepts_run_manager:
+            docs = self._get_docs(inputs, run_manager=_run_manager)
+        else:
+            docs = self._get_docs(inputs)  # type: ignore[call-arg]
+
+        # Inject position in the list
+        # To avoid confusion with other id, add a prefix
+        for idx, doc in enumerate(docs):
+            doc.metadata["_idx"] = f"_idx_{idx}"
+
+        answers = self.combine_documents_chain(
+            {
+                self.combine_documents_chain.input_key: docs,
+                self.question_key: inputs[self.question_key],
+                **inputs,
+            },
+            callbacks=_run_manager.get_child(),
+        )
+        answer, all_idx = self._process_results(answers, docs)
+        selected_docs = [docs[idx] for idx in all_idx if idx < len(docs)]
+
+        return {
+            self.answer_key: answer,
+            self.source_documents_key: selected_docs,
+        }
+
+    async def _acall(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
+        accepts_run_manager = (
+            "run_manager" in inspect.signature(self._aget_docs).parameters
+        )
+        if accepts_run_manager:
+            docs = await self._aget_docs(inputs, run_manager=_run_manager)
+        else:
+            docs = await self._aget_docs(inputs)  # type: ignore[call-arg]
+
+        # Inject position in the list
+        for idx, doc in enumerate(docs):
+            doc.metadata["_idx"] = idx
+
+        await self.combine_documents_chain.arun(
+            input_documents=docs, callbacks=_run_manager.get_child(), **inputs
+        )
+        answers = await self.combine_documents_chain.acall(
+            {
+                self.combine_documents_chain.input_key: docs,
+                self.question_key: inputs[self.question_key],
+                **inputs,
+            },
+            callbacks=_run_manager.get_child(),
+        )
+        answer, all_idx = self._process_results(answers, docs)
+        selected_docs = [docs[idx] for idx in all_idx if idx < len(docs)]
+
+        return {
+            self.answer_key: answer,
+            self.source_documents_key: selected_docs,
+        }
+
+
+class QAWithReferencesChain(BaseQAWithReferencesChain):
+    """
+    This chain extracts the information from the documents that was used to answer the
+    question. The output `source_documents` contains only the documents that were used,
+    and for each one.
+
+    The result["source_documents"] returns only the list of documents used.
+    Then it is possible to find the page of a PDF, or the chapter of a markdown.
+    """
+
+    input_docs_key: str = "docs"  #: :meta private:
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Expect input key.
+
+        :meta private:
+        """
+        return [self.input_docs_key, self.question_key]
+
+    def _get_docs(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        run_manager: CallbackManagerForChainRun,
+    ) -> List[Document]:
+        """Get docs to run questioning over."""
+        return inputs.pop(self.input_docs_key)
+
+    async def _aget_docs(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        run_manager: AsyncCallbackManagerForChainRun,
+    ) -> List[Document]:
+        """Get docs to run questioning over."""
+        return inputs.pop(self.input_docs_key)
+
+    @property
+    def _chain_type(self) -> str:
+        return "qa_with_references_chain"

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/loading.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/loading.py
@@ -1,0 +1,230 @@
+"""Load question answering with reference chains."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Protocol
+
+from langchain.base_language import BaseLanguageModel
+from langchain.chains import ReduceDocumentsChain
+from langchain.chains.combine_documents import map_reduce, map_rerank, refine, stuff
+from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
+from langchain.chains.llm import LLMChain
+from langchain.schema.prompt_template import BasePromptTemplate
+
+from . import (
+    map_reduce_prompts,
+    map_rerank_prompts,
+    refine_prompts,
+    stuff_prompt,
+)
+
+
+class LoadingCallable(Protocol):
+    """Interface for loading the combine documents chain."""
+
+    def __call__(
+        self, llm: BaseLanguageModel, **kwargs: Any
+    ) -> BaseCombineDocumentsChain:
+        """Callable to load the combine documents chain."""
+
+
+def _get_verbosity() -> bool:
+    from langchain.globals import get_verbose
+
+    return get_verbose()
+
+
+def _load_stuff_chain(
+    llm: BaseLanguageModel,
+    prompt: BasePromptTemplate = stuff_prompt.PROMPT,
+    document_prompt: BasePromptTemplate = stuff_prompt.EXAMPLE_PROMPT,
+    document_variable_name: str = "summaries",
+    verbose: bool = _get_verbosity(),
+    **kwargs: Any,
+) -> stuff.StuffDocumentsChain:
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
+
+    return stuff.StuffDocumentsChain(
+        llm_chain=llm_chain,
+        document_variable_name=document_variable_name,
+        document_prompt=document_prompt,
+        verbose=verbose,
+        **kwargs,
+    )
+
+
+def _load_map_reduce_chain(
+    llm: BaseLanguageModel,
+    question_prompt: BasePromptTemplate = map_reduce_prompts.QUESTION_PROMPT,
+    combine_prompt: BasePromptTemplate = map_reduce_prompts.COMBINE_PROMPT,
+    document_prompt: BasePromptTemplate = map_reduce_prompts.EXAMPLE_PROMPT,
+    combine_document_variable_name: str = "summaries",
+    map_reduce_document_variable_name: str = "context",
+    collapse_prompt: Optional[BasePromptTemplate] = None,
+    reduce_llm: Optional[BaseLanguageModel] = None,
+    collapse_llm: Optional[BaseLanguageModel] = None,
+    verbose: bool = _get_verbosity(),
+    token_max: int = 3000,
+    **kwargs: Any,
+) -> map_reduce.MapReduceDocumentsChain:
+    map_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
+    _reduce_llm = reduce_llm or llm
+    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt, verbose=verbose)
+    combine_documents_chain = stuff.StuffDocumentsChain(
+        llm_chain=reduce_chain,
+        document_variable_name=combine_document_variable_name,
+        document_prompt=document_prompt,
+        verbose=verbose,
+    )
+    if collapse_prompt is None:
+        collapse_chain = None
+        if collapse_llm is not None:
+            raise ValueError(
+                "collapse_llm provided, but collapse_prompt was not: please "
+                "provide one or stop providing collapse_llm."
+            )
+    else:
+        _collapse_llm = collapse_llm or llm
+        collapse_chain = stuff.StuffDocumentsChain(
+            llm_chain=LLMChain(
+                llm=_collapse_llm,
+                prompt=collapse_prompt,
+                verbose=verbose,
+            ),
+            document_variable_name=combine_document_variable_name,
+            document_prompt=document_prompt,
+        )
+    reduce_documents_chain = ReduceDocumentsChain(
+        combine_documents_chain=combine_documents_chain,
+        collapse_documents_chain=collapse_chain,
+        token_max=token_max,
+        verbose=verbose,
+    )
+    return map_reduce.MapReduceDocumentsChain(
+        llm_chain=map_chain,
+        reduce_documents_chain=reduce_documents_chain,
+        document_variable_name=map_reduce_document_variable_name,
+        verbose=verbose,
+        return_intermediate_steps=True,
+        **kwargs,
+    )
+
+
+def _load_refine_chain(
+    llm: BaseLanguageModel,
+    question_prompt: BasePromptTemplate = refine_prompts.INITIAL_QA_PROMPT,
+    refine_prompt: BasePromptTemplate = refine_prompts.REFINE_PROMPT,
+    document_prompt: BasePromptTemplate = refine_prompts.EXAMPLE_PROMPT,
+    document_variable_name: str = "context_str",
+    initial_response_name: str = "existing_answer",
+    refine_llm: Optional[BaseLanguageModel] = None,
+    verbose: bool = _get_verbosity(),
+    **kwargs: Any,
+) -> refine.RefineDocumentsChain:
+    initial_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
+    _refine_llm = refine_llm or llm
+    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt, verbose=verbose)
+    return refine.RefineDocumentsChain(
+        initial_llm_chain=initial_chain,
+        refine_llm_chain=refine_chain,
+        document_variable_name=document_variable_name,
+        initial_response_name=initial_response_name,
+        document_prompt=document_prompt,
+        verbose=verbose,
+        return_intermediate_steps=True,
+        **kwargs,
+    )
+
+
+def _load_map_rerank_chain(
+    llm: BaseLanguageModel,
+    prompt: BasePromptTemplate = map_rerank_prompts.PROMPT,
+    verbose: bool = False,
+    document_variable_name: str = "context",
+    rank_key: str = "score",
+    answer_key: str = "answer",
+    **kwargs: Any,
+) -> map_rerank.MapRerankDocumentsChain:
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
+    if "metadata_keys" in kwargs:
+        new_list = kwargs["metadata_keys"].copy()
+        new_list.append("_idx")
+        kwargs["metadata_keys"] = new_list
+    else:
+        kwargs["metadata_keys"] = ["_idx"]
+    return map_rerank.MapRerankDocumentsChain(
+        llm_chain=llm_chain,
+        rank_key=rank_key,
+        answer_key=answer_key,
+        document_variable_name=document_variable_name,
+        **kwargs,
+    )
+
+
+def load_qa_with_references_chain(
+    llm: BaseLanguageModel,
+    chain_type: str = "stuff",
+    verbose: Optional[bool] = None,
+    **kwargs: Any,
+) -> BaseCombineDocumentsChain:
+    """Load question answering with only referenced documents.
+
+    The result["source_documents"] returns only the list of documents used.
+
+    Args:
+        llm: Language Model to use in the chain.
+        chain_type: Type of document combining chain to use. Should be one of "stuff",
+            "map_reduce", "refine" and "map_rerank".
+        verbose: Whether chains should be run in verbose mode or not. Note that this
+            applies to all chains that make up the final chain.
+
+    Returns:
+        A chain to use for question answering with references.
+    """
+    loader_mapping: Mapping[str, LoadingCallable] = {
+        "stuff": _load_stuff_chain,
+        "map_reduce": _load_map_reduce_chain,
+        "refine": _load_refine_chain,
+        "map_rerank": _load_map_rerank_chain,
+    }
+    if chain_type not in loader_mapping:
+        raise ValueError(
+            f"Got unsupported chain type: {chain_type}. "
+            f"Should be one of {loader_mapping.keys()}"
+        )
+    _func: LoadingCallable = loader_mapping[chain_type]
+    return _func(llm, verbose=verbose, **kwargs)
+
+
+def load_qa_with_references_and_retriever_chain(
+    llm: BaseLanguageModel,
+    chain_type: str = "stuff",
+    verbose: Optional[bool] = None,
+    **kwargs: Any,
+) -> BaseCombineDocumentsChain:
+    """Load question answering with only referenced documents.
+
+    The result["source_documents"] returns only the list of documents used.
+
+    Args:
+        llm: Language Model to use in the chain.
+        chain_type: Type of document combining chain to use. Should be one of "stuff",
+            "map_reduce", "refine" and "map_rerank".
+        verbose: Whether chains should be run in verbose mode or not. Note that this
+            applies to all chains that make up the final chain.
+
+    Returns:
+        A chain to use for question answering with references.
+    """
+    loader_mapping: Mapping[str, LoadingCallable] = {
+        "stuff": _load_stuff_chain,
+        "map_reduce": _load_map_reduce_chain,
+        "refine": _load_refine_chain,
+        "map_rerank": _load_map_rerank_chain,
+    }
+    if chain_type not in loader_mapping:
+        raise ValueError(
+            f"Got unsupported chain type: {chain_type}. "
+            f"Should be one of {loader_mapping.keys()}"
+        )
+    _func: LoadingCallable = loader_mapping[chain_type]
+    return _func(llm, verbose=verbose, **kwargs)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/map_reduce_prompts.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/map_reduce_prompts.py
@@ -1,0 +1,56 @@
+# flake8: noqa
+
+from langchain.prompts import PromptTemplate
+from langchain.retrievers.multi_query import LineListOutputParser
+from .references import references_parser, References, empty_value
+
+_map_verbatim_parser = LineListOutputParser()
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Content: {page_content}\n" "Ids: {_idx}",
+    input_variables=["page_content", "_idx"],
+)
+
+_question_prompt_template = """
+Use the following portion of a long document to see if any of the text is relevant to answer the question.
+---
+{context}
+---
+
+Question: {question}
+
+Extract all verbatims from texts relevant to answering the question in separate strings else output an empty array.
+{format_instructions}
+
+"""
+
+QUESTION_PROMPT = PromptTemplate(
+    template=_question_prompt_template,
+    input_variables=["context", "question"],
+    partial_variables={
+        "format_instructions": _map_verbatim_parser.get_format_instructions()
+    },
+    output_parser=_map_verbatim_parser,
+)
+
+_combine_prompt_template = """Given the following extracts from several documents, 
+a question and not prior knowledge. 
+
+QUESTION: {question}
+=========
+{summaries}
+=========
+If you are not confident with your answer, say '{empty_value}'. 
+{format_instructions}
+FINAL ANSWER:"""
+COMBINE_PROMPT = PromptTemplate(
+    template=_combine_prompt_template,
+    input_variables=["summaries", "question"],
+    partial_variables={
+        "format_instructions": references_parser.get_format_instructions(),
+        "empty_value": empty_value,
+        # "response_example_1": str(_response_example_1),
+        # "response_example_2": str(_response_example_2),
+    },
+    output_parser=references_parser,
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/map_rerank_prompts.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/map_rerank_prompts.py
@@ -1,0 +1,70 @@
+# flake8: noqa
+from typing import Type
+
+from langchain.output_parsers import RegexParser
+from langchain.prompts import PromptTemplate
+from langchain.schema import BaseOutputParser
+from .references import References
+
+_rank_parser = RegexParser(
+    regex=r"(.*)\n?Score: (\d*)",
+    output_keys=["answer", "score"],
+)
+
+
+class ReferenceOutputParser(BaseOutputParser[References]):
+    """Parse an output using a pydantic model."""
+
+    pydantic_object: Type[References] = References
+    """The pydantic model to parse."""
+
+    def parse(self, text: str) -> References:
+        return References(response=text)
+
+    def get_format_instructions(self) -> str:
+        return ""
+
+    @property
+    def _type(self) -> str:
+        return "reference"
+
+
+rerank_reference_parser = ReferenceOutputParser()
+
+prompt_template = """
+Given the following extracts from several documents, a question and not prior knowledge. 
+
+How to determine the score:
+- Higher is a better answer
+- Better responds fully to the asked question, with sufficient level of detail
+- If you do not know the answer based on the context, that should be a score of 0
+- Don't be overconfident!
+
+Process step by step:
+- extract the references ("IDS")
+- answers the question
+- calculates a score of how fully it answered the user's question
+- creates a final answer
+
+The ids must be only in the form '_idx_<number>'.
+This should be in the following format:
+Question: [question here]
+Helpful Answer: [json answer here]
+Score: [always to the next line, score between 0 and 100]
+
+Context:
+---------
+{context}
+---------
+Question: {question}
+Helpful Answer:"""
+PROMPT = PromptTemplate(
+    template=prompt_template,
+    input_variables=["context", "question"],
+    output_parser=_rank_parser,
+)
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Content: {page_content}\nIds: {_idx}\n",
+    input_variables=["page_content", "_idx"],
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/references.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/references.py
@@ -1,0 +1,87 @@
+import logging
+import re
+from typing import Set
+
+from langchain.output_parsers import PydanticOutputParser
+from langchain.pydantic_v1 import BaseModel, Extra
+from langchain.schema import BaseOutputParser
+
+logger = logging.getLogger(__name__)
+
+# To optimize the consumption of tokens, it's better to use only 'text', without json.
+# Else the schema consume ~300 tokens and the response 20 tokens by step
+_OPTIMIZE = True  # Experimental
+
+
+class References(BaseModel):
+    """
+    Response and referenced documents.
+    """
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+
+    response: str
+    """ The response """
+    documents_ids: Set[str] = set()
+    """ The list of documents used to response """
+
+    def __str__(self) -> str:
+        if _OPTIMIZE:
+            return f'{self.response}\nIDS:{",".join(map(str, self.documents_ids))}'
+        else:
+            return self.json()  # Pydantic 1
+
+
+references_parser: BaseOutputParser
+if _OPTIMIZE:
+
+    class _ReferencesParser(BaseOutputParser):
+        """An optimised parser for Reference.
+        It's more effective than the pydantic approach
+        """
+
+        @property
+        def lc_serializable(self) -> bool:
+            return True
+
+        @property
+        def _type(self) -> str:
+            """Return the type key."""
+            return "reference_parser"
+
+        def get_format_instructions(self) -> str:
+            return (
+                "Your response should be in the form:\n"
+                "Answer: the response.\n"
+                "At the start of a new line 'IDS:' followed by a comma-separated "
+                "list of document identifiers used "
+                "in the response. The ids must have the form _idx_<number>.\n"
+                # "\n"
+                # "Answer: my response\n"
+                # "IDS: _idx_1, _idx_2\n\n"
+            )
+
+        def parse(self, text: str) -> References:
+            regex = r"(?i)(?:Answer:)?(.*)\sIDS:(.*)"
+            match = re.search(regex, text)
+            if match:
+                ids: Set[str] = set()
+                for str_doc_id in match[2].split(","):
+                    m = re.match(r"\s*(?:_idx_)?(\d+)\s*", str_doc_id.strip())
+                    if m:
+                        ids.add(m[1])
+
+                return References(response=match[1].strip(), documents_ids=ids)
+            else:
+                raise ValueError(f"Could not parse output: {text}")
+
+    references_parser = _ReferencesParser()
+    empty_value = "I don't know"
+else:
+    references_parser = PydanticOutputParser(pydantic_object=References)
+    empty_value = References(
+        response="I don't know", documents_ids=set()
+    ).json()  # Pydantic 1

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/refine_prompts.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/refine_prompts.py
@@ -1,0 +1,75 @@
+# flake8: noqa
+from langchain.prompts import PromptTemplate
+
+from .references import references_parser, empty_value
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Content: {page_content}\n" "ids: {_idx}\n",
+    input_variables=["page_content", "_idx"],
+)
+
+_initial_qa_prompt_template = """
+Context information is below. 
+---------------------
+{context_str}
+---------------------
+Process step by step:
+- ignore prior knowledge
+- extract references ("IDS")
+- create a final answer
+- produce the json result
+
+Given the context information the question: {question}
+
+If you don't know the answer, just say '{empty_value}', without references IDS. 
+Don't try to make up an answer.
+
+The ids must be only in the form '_idx_<number>'.
+{format_instructions}
+"""
+
+INITIAL_QA_PROMPT = PromptTemplate(
+    input_variables=["context_str", "question"],
+    template=_initial_qa_prompt_template,
+    partial_variables={
+        "format_instructions": references_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=references_parser,
+)
+
+_refine_prompt_template = """
+Given the context information and not prior knowledge answer, the question: {question}
+
+We have provided an existing JSON answer with the list of documents with associated ids: 
+{existing_answer}
+
+We have the opportunity to refine the existing answer (only if needed) with some more context below.
+------------
+{context_str}
+------------
+Given the new context, refine the original answer to better answer the question. 
+If you don't know how to refine the original answer, does not modify the answer.
+
+Process step by step:
+- use only the context to answer to refine the original answer to better answer the question. ONLY if you do update it,
+append the new IDS from the existing answser IDS as well. 
+- produce the result
+
+ALWAYS return a "IDS" part in your answer. 
+If the context isn't useful, return the original answer and the original IDS.
+
+If you don't know the answer, just say '{empty_value}'. Don't try to make up an answer.
+
+{format_instructions}
+"""
+
+REFINE_PROMPT = PromptTemplate(
+    input_variables=["question", "existing_answer", "context_str"],
+    template=_refine_prompt_template,
+    partial_variables={
+        "format_instructions": references_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=references_parser,
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/retrieval.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/retrieval.py
@@ -1,0 +1,67 @@
+"""Question-answering with sources over an index."""
+
+from typing import Any, Dict, List
+
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.chains.combine_documents.stuff import StuffDocumentsChain
+from langchain.docstore.document import Document
+from langchain.pydantic_v1 import Field
+from langchain.schema import BaseRetriever
+
+from .base import (
+    BaseQAWithReferencesChain,
+)
+
+
+class RetrievalQAWithReferencesChain(BaseQAWithReferencesChain):
+    """Question-answering result with referenced documents.
+
+    This implementation allows you to retrieve the list of documents.
+    The implementation uses fewer tokens and correctly handles recursive map_reduces.
+    """
+
+    retriever: BaseRetriever = Field(exclude=True)
+    """Index to connect to."""
+    reduce_k_below_max_tokens: bool = False
+    """Reduce the number of results to return from store based on tokens limit"""
+    max_tokens_limit: int = 3375
+    """Restrict the docs to return from store based on tokens,
+    enforced only for StuffDocumentChain and if reduce_k_below_max_tokens is to true"""
+
+    def _reduce_tokens_below_limit(self, docs: List[Document]) -> List[Document]:
+        num_docs = len(docs)
+
+        if self.reduce_k_below_max_tokens and isinstance(
+            self.combine_documents_chain, StuffDocumentsChain
+        ):
+            tokens = [
+                self.combine_documents_chain.llm_chain._get_num_tokens(doc.page_content)
+                for doc in docs
+            ]
+            token_count = sum(tokens[:num_docs])
+            while token_count > self.max_tokens_limit:
+                num_docs -= 1
+                token_count -= tokens[num_docs]
+
+        return docs[:num_docs]
+
+    def _get_docs(
+        self, inputs: Dict[str, Any], *, run_manager: CallbackManagerForChainRun
+    ) -> List[Document]:
+        question = inputs[self.question_key]
+        docs = self.retriever.get_relevant_documents(
+            question, callbacks=run_manager.get_child()
+        )
+        return self._reduce_tokens_below_limit(docs)
+
+    async def _aget_docs(
+        self, inputs: Dict[str, Any], *, run_manager: AsyncCallbackManagerForChainRun
+    ) -> List[Document]:
+        question = inputs[self.question_key]
+        docs = await self.retriever.aget_relevant_documents(
+            question, callbacks=run_manager.get_child()
+        )
+        return self._reduce_tokens_below_limit(docs)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references/stuff_prompt.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references/stuff_prompt.py
@@ -1,0 +1,38 @@
+# flake8: noqa
+
+
+from langchain.prompts import PromptTemplate
+from .references import references_parser, References, empty_value
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Content: {page_content}\n" "Ids: {_idx}",
+    input_variables=["page_content", "_idx"],
+)
+
+_template = """Given the following extracts from several documents, a question and not prior knowledge. 
+Process step by step:
+- for each documents extract the references ("IDS")
+- creates a final answer
+- produces the json result
+
+If you don't know the answer, just say '{empty_value}'. Don't try to make up an answer.
+ALWAYS return a "IDS" part in your answer in another line.
+
+QUESTION: {question}
+=========
+{summaries}
+=========
+The ids must be only in the form '_idx_<number>'.
+{format_instructions}
+FINAL ANSWER: 
+"""
+
+PROMPT = PromptTemplate(
+    template=_template,
+    input_variables=["summaries", "question"],
+    partial_variables={
+        "format_instructions": references_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=references_parser,
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/base.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/base.py
@@ -1,0 +1,212 @@
+"""Question answering with references and verbatims over documents."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Set, cast
+
+from langchain.base_language import BaseLanguageModel
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.chains import ReduceDocumentsChain
+from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
+from langchain.chains.combine_documents.stuff import StuffDocumentsChain
+from langchain.chains.llm import LLMChain
+from langchain.docstore.document import Document
+from langchain.schema import BasePromptTemplate, OutputParserException
+
+from ..qa_with_references.base import BaseQAWithReferencesChain
+from .loading import (
+    load_qa_with_references_chain,
+)
+from .map_reduce_prompts import (
+    COMBINE_PROMPT,
+    EXAMPLE_PROMPT,
+    QUESTION_PROMPT,
+)
+from .verbatims import Verbatims, verbatims_parser
+
+logger = logging.getLogger(__name__)
+
+
+class BaseQAWithReferencesAndVerbatimsChain(BaseQAWithReferencesChain):
+    original_verbatim: bool = False
+    """ Set to true to extract the verbatim in the document (via regex) """
+
+    def _process_reference(
+        self, answers: Dict[str, Any], docs: List[Document], references: Any
+    ) -> Set[int]:
+        idx = set()
+        try:
+            verbatims = cast(Verbatims, references)
+            # With the map_rerank mode, use extra parameter for map_rerank to identify
+            # the corresponding document.
+            if "_idx" in answers:
+                # Use extra parameter for map_rerank to identify the corresponding
+                # document.
+                # Fix the ids of the selected document.
+                verbatims.documents[0].ids = [answers["_idx"]]
+
+            # Inject verbatims and get idx
+            for ref_doc in verbatims.documents:
+                for str_doc_id in ref_doc.ids:
+                    m = re.match(r"_idx_(\d+)", str_doc_id)
+                    if not m:
+                        logger.debug(f"Detected invalid ids '{str_doc_id}'")
+                        continue
+                    doc_id = int(m[1])
+                    if 0 <= doc_id < len(docs):  # Guard
+                        if ref_doc.verbatims:
+                            # Search the real verbatim if possible
+                            if self.original_verbatim:
+                                original_verbatim = ref_doc.original_verbatims(
+                                    docs[doc_id].page_content
+                                )
+                            else:
+                                original_verbatim = ref_doc.verbatims
+                            if original_verbatim:
+                                idx.add(doc_id)
+                                docs[doc_id].metadata["verbatims"] = original_verbatim
+                            elif "verbatims" not in docs[doc_id].metadata:
+                                logger.debug(
+                                    f"Verbatim not confirmed in original document\n"
+                                    f"{ref_doc.verbatims}"
+                                )
+                                # docs[doc_id].metadata["verbatims"] =ref_doc.verbatims
+            return idx
+        except OutputParserException as e:
+            logger.debug(f"Exception during parsing: {e}")
+            # return idx
+            raise
+
+    @property
+    def _chain_type(self) -> str:
+        return "qa_with_references_and_verbatims_chain"
+
+    @classmethod
+    def from_llm(
+        cls,
+        llm: BaseLanguageModel,
+        document_prompt: BasePromptTemplate = EXAMPLE_PROMPT,
+        question_prompt: BasePromptTemplate = QUESTION_PROMPT,
+        combine_prompt: BasePromptTemplate = COMBINE_PROMPT,
+        **kwargs: Any,
+    ) -> BaseQAWithReferencesChain:
+        """Construct the chain from an LLM."""
+        llm_question_chain = LLMChain(llm=llm, prompt=question_prompt)
+        llm_combine_chain = LLMChain(llm=llm, prompt=combine_prompt)
+        combine_results_chain = StuffDocumentsChain(
+            llm_chain=llm_combine_chain,
+            document_prompt=document_prompt,
+            document_variable_name="summaries",
+        )
+        reduce_documents_chain = ReduceDocumentsChain(
+            combine_documents_chain=combine_results_chain
+        )
+
+        combine_document_chain = MapReduceDocumentsChain(
+            llm_chain=llm_question_chain,
+            reduce_documents_chain=reduce_documents_chain,
+            document_variable_name="context",
+            return_intermediate_steps=True,
+        )
+        return cls(
+            combine_documents_chain=combine_document_chain,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_chain_type(
+        cls,
+        llm: BaseLanguageModel,
+        chain_type: str = "stuff",
+        chain_type_kwargs: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> BaseQAWithReferencesChain:
+        """Load chain from chain type."""
+        _chain_kwargs = chain_type_kwargs or {}
+        combine_document_chain = load_qa_with_references_chain(
+            llm,
+            chain_type=chain_type,
+            **_chain_kwargs,
+        )
+        if chain_type == "map_rerank" and "output_parser" not in kwargs:
+            kwargs["output_parser"] = verbatims_parser
+
+        return cls(
+            combine_documents_chain=combine_document_chain,
+            chain_type=chain_type,
+            **kwargs,
+        )
+
+
+class QAWithReferencesAndVerbatimsChain(BaseQAWithReferencesAndVerbatimsChain):
+    """
+    Question answering with references and verbatims over documents.
+
+    This chain extracts the information from the documents that was used to answer the
+    question. The output `source_documents` contains only the documents that were used,
+    and for each one, only the text fragments that were used to answer are included.
+    If possible, the list of text fragments that justify the answer is added to
+    `metadata['verbatims']` for each document.
+    Then it is possible to find the page of a PDF, or the chapter of a markdown.
+
+    The incogenent of this chain, and that this consumes output tokens.
+
+    A sample result of usage with Wikipedia, may be:
+    ```
+    For the question "what can you say about ukraine?",
+    to answer "Ukraine has an illegal and unprovoked invasion inside its territory,
+    and its citizens show courage and are fighting against it. It is believed that
+    the capital city of Kyiv, which is home to 2.8 million people, is a target.",
+    the LLM use:
+    Source https://www.defense.gov/News/Transcripts/...
+    -  "when it comes to conducting their illegal and unprovoked invasion inside
+    Ukraine."
+    Source https://www.whitehouse.gov/briefing-room/...
+    - "to the fearless and skilled Ukrainian fighters who are standing in the
+    breach"
+    - "You got to admit, you have -- must be amazed at the courage of this country"
+    Source https://www.whitehouse.gov/briefing-room/...
+    -  "believe that they will target Ukraine's capital, Kyiv, a city of 2.8 million
+    innocent people."
+    Source https://www.whitehouse.gov/briefing-room/...
+    -  "believe that they will target Ukraine's capital, Kyiv, a city of 2.8 million
+    innocent people."
+    ```
+    """
+
+    input_docs_key: str = "docs"  #: :meta private:
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Expect input key.
+
+        :meta private:
+        """
+        return [self.input_docs_key, self.question_key]
+
+    def _get_docs(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        run_manager: CallbackManagerForChainRun,
+    ) -> List[Document]:
+        """Get docs to run questioning over."""
+        return inputs.pop(self.input_docs_key)
+
+    async def _aget_docs(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        run_manager: AsyncCallbackManagerForChainRun,
+    ) -> List[Document]:
+        """Get docs to run questioning over."""
+        return inputs.pop(self.input_docs_key)
+
+    @property
+    def _chain_type(self) -> str:
+        return "qa_with_references_and_verbatim_chain"

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/loading.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/loading.py
@@ -1,0 +1,232 @@
+"""Load question answering with reference and verbatim chains."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Protocol
+
+from langchain.base_language import BaseLanguageModel
+from langchain.chains.combine_documents import map_reduce, map_rerank, refine, stuff
+from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
+from langchain.chains.combine_documents.reduce import ReduceDocumentsChain
+from langchain.chains.llm import LLMChain
+from langchain.schema.prompt_template import BasePromptTemplate
+
+from . import (
+    map_reduce_prompts,
+    map_rerank_prompts,
+    refine_prompts,
+    stuff_prompt,
+)
+
+
+def _get_verbosity() -> bool:
+    from langchain.globals import get_verbose
+
+    return get_verbose()
+
+
+class LoadingCallable(Protocol):
+    """Interface for loading the combine documents chain."""
+
+    def __call__(
+        self, llm: BaseLanguageModel, **kwargs: Any
+    ) -> BaseCombineDocumentsChain:
+        """Callable to load the combine documents chain."""
+
+
+def _load_stuff_chain(
+    llm: BaseLanguageModel,
+    prompt: BasePromptTemplate = stuff_prompt.PROMPT,
+    document_prompt: BasePromptTemplate = stuff_prompt.EXAMPLE_PROMPT,
+    document_variable_name: str = "summaries",
+    verbose: bool = _get_verbosity(),
+    **kwargs: Any,
+) -> stuff.StuffDocumentsChain:
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
+
+    return stuff.StuffDocumentsChain(
+        llm_chain=llm_chain,
+        document_variable_name=document_variable_name,
+        document_prompt=document_prompt,
+        verbose=verbose,
+        **kwargs,
+    )
+
+
+def _load_map_reduce_chain(
+    llm: BaseLanguageModel,
+    question_prompt: BasePromptTemplate = map_reduce_prompts.QUESTION_PROMPT,
+    combine_prompt: BasePromptTemplate = map_reduce_prompts.COMBINE_PROMPT,
+    document_prompt: BasePromptTemplate = map_reduce_prompts.EXAMPLE_PROMPT,
+    combine_document_variable_name: str = "summaries",
+    map_reduce_document_variable_name: str = "context",
+    collapse_prompt: Optional[BasePromptTemplate] = None,
+    reduce_llm: Optional[BaseLanguageModel] = None,
+    collapse_llm: Optional[BaseLanguageModel] = None,
+    verbose: bool = _get_verbosity(),
+    token_max: int = 3000,
+    **kwargs: Any,
+) -> map_reduce.MapReduceDocumentsChain:
+    map_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
+    _reduce_llm = reduce_llm or llm
+    reduce_chain = LLMChain(llm=_reduce_llm, prompt=combine_prompt, verbose=verbose)
+    combine_documents_chain = stuff.StuffDocumentsChain(
+        llm_chain=reduce_chain,
+        document_variable_name=combine_document_variable_name,
+        document_prompt=document_prompt,
+        verbose=verbose,
+    )
+    if collapse_prompt is None:
+        collapse_chain = None
+        if collapse_llm is not None:
+            raise ValueError(
+                "collapse_llm provided, but collapse_prompt was not: please "
+                "provide one or stop providing collapse_llm."
+            )
+    else:
+        _collapse_llm = collapse_llm or llm
+        collapse_chain = stuff.StuffDocumentsChain(
+            llm_chain=LLMChain(
+                llm=_collapse_llm,
+                prompt=collapse_prompt,
+                verbose=verbose,
+            ),
+            document_variable_name=combine_document_variable_name,
+            document_prompt=document_prompt,
+        )
+    reduce_documents_chain = ReduceDocumentsChain(
+        combine_documents_chain=combine_documents_chain,
+        collapse_documents_chain=collapse_chain,
+        token_max=token_max,
+        verbose=verbose,
+    )
+    return map_reduce.MapReduceDocumentsChain(
+        llm_chain=map_chain,
+        reduce_documents_chain=reduce_documents_chain,
+        document_variable_name=map_reduce_document_variable_name,
+        verbose=verbose,
+        return_intermediate_steps=True,
+        **kwargs,
+    )
+
+
+def _load_refine_chain(
+    llm: BaseLanguageModel,
+    question_prompt: BasePromptTemplate = refine_prompts.INITIAL_QA_PROMPT,
+    refine_prompt: BasePromptTemplate = refine_prompts.REFINE_PROMPT,
+    document_prompt: BasePromptTemplate = refine_prompts.EXAMPLE_PROMPT,
+    document_variable_name: str = "context_str",
+    initial_response_name: str = "existing_answer",
+    refine_llm: Optional[BaseLanguageModel] = None,
+    verbose: bool = _get_verbosity(),
+    **kwargs: Any,
+) -> refine.RefineDocumentsChain:
+    initial_chain = LLMChain(llm=llm, prompt=question_prompt, verbose=verbose)
+    _refine_llm = refine_llm or llm
+    refine_chain = LLMChain(llm=_refine_llm, prompt=refine_prompt, verbose=verbose)
+    return refine.RefineDocumentsChain(
+        initial_llm_chain=initial_chain,
+        refine_llm_chain=refine_chain,
+        document_variable_name=document_variable_name,
+        initial_response_name=initial_response_name,
+        document_prompt=document_prompt,
+        verbose=verbose,
+        return_intermediate_steps=True,
+        **kwargs,
+    )
+
+
+def _load_map_rerank_chain(
+    llm: BaseLanguageModel,
+    prompt: BasePromptTemplate = map_rerank_prompts.PROMPT,
+    verbose: bool = False,
+    document_variable_name: str = "context",
+    rank_key: str = "score",
+    answer_key: str = "answer",
+    **kwargs: Any,
+) -> map_rerank.MapRerankDocumentsChain:
+    llm_chain = LLMChain(llm=llm, prompt=prompt, verbose=verbose)
+    if "metadata_keys" in kwargs:
+        new_list = kwargs["metadata_keys"].copy()
+        new_list.append("_idx")
+        kwargs["metadata_keys"] = new_list
+    else:
+        kwargs["metadata_keys"] = ["_idx"]
+    return map_rerank.MapRerankDocumentsChain(
+        llm_chain=llm_chain,
+        rank_key=rank_key,
+        answer_key=answer_key,
+        document_variable_name=document_variable_name,
+        **kwargs,
+    )
+
+
+def load_qa_with_references_chain(
+    llm: BaseLanguageModel,
+    chain_type: str = "stuff",
+    verbose: Optional[bool] = None,
+    **kwargs: Any,
+) -> BaseCombineDocumentsChain:
+    """Load question answering with only referenced documents and verbatims.
+
+    The result["source_documents"] returns only the list of documents used, enriched
+    if possible with the text extract used (doc.metadata["verbatims"]).
+
+    Args:
+        llm: Language Model to use in the chain.
+        chain_type: Type of document combining chain to use. Should be one of "stuff",
+            "map_reduce", "refine" and "map_rerank".
+        verbose: Whether chains should be run in verbose mode or not. Note that this
+            applies to all chains that make up the final chain.
+
+    Returns:
+        A chain to use for question answering with references and verbatims.
+    """
+    loader_mapping: Mapping[str, LoadingCallable] = {
+        "stuff": _load_stuff_chain,
+        "map_reduce": _load_map_reduce_chain,
+        "refine": _load_refine_chain,
+        "map_rerank": _load_map_rerank_chain,
+    }
+    if chain_type not in loader_mapping:
+        raise ValueError(
+            f"Got unsupported chain type: {chain_type}. "
+            f"Should be one of {loader_mapping.keys()}"
+        )
+    _func: LoadingCallable = loader_mapping[chain_type]
+    return _func(llm, verbose=verbose, **kwargs)
+
+
+def load_qa_with_references_and_retriever_chain(
+    llm: BaseLanguageModel,
+    chain_type: str = "stuff",
+    verbose: Optional[bool] = None,
+    **kwargs: Any,
+) -> BaseCombineDocumentsChain:
+    """Load question answering with only referenced documents and verbatims.
+
+    The result["source_documents"] returns only the list of documents used, enriched
+    if possible with the text extract used (doc.metadata["verbatims"]).
+
+    Args:
+        llm: Language Model to use in the chain.
+        chain_type: Type of document combining chain to use. Should be one of "stuff",
+            "map_reduce", "refine" and "map_rerank".
+        verbose: Whether chains should be run in verbose mode or not. Note that this
+            applies to all chains that make up the final chain.
+
+    Returns:
+        A chain to use for question answering with references and verbatims.
+    """
+    loader_mapping: Mapping[str, LoadingCallable] = {
+        "stuff": _load_stuff_chain,
+        "map_reduce": _load_map_reduce_chain,
+        "refine": _load_refine_chain,
+        "map_rerank": _load_map_rerank_chain,
+    }
+    if chain_type not in loader_mapping:
+        raise ValueError(
+            f"Got unsupported chain type: {chain_type}. "
+            f"Should be one of {loader_mapping.keys()}"
+        )
+    _func: LoadingCallable = loader_mapping[chain_type]
+    return _func(llm, verbose=verbose, **kwargs)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/map_reduce_prompts.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/map_reduce_prompts.py
@@ -1,0 +1,64 @@
+# flake8: noqa
+
+from langchain.prompts import PromptTemplate
+from langchain.retrievers.multi_query import LineListOutputParser
+
+from .verbatims import VerbatimsFromDoc, verbatims_parser, Verbatims, empty_value
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Ids: {_idx}\n" "Content: {page_content}\n",
+    input_variables=["page_content", "_idx"],
+)
+
+_map_verbatim_parser = LineListOutputParser()
+
+_question_prompt_template = """
+Use the following portion of a long document to see if any of the text is relevant to answer the question.
+---
+{context}
+---
+
+Question: {question}
+
+Extract all verbatims from texts relevant to answering the question in separate strings else output an empty array.
+If you are not confident with your answer, say '{empty_value}'. 
+{format_instructions}
+
+"""
+
+QUESTION_PROMPT = PromptTemplate(
+    template=_question_prompt_template,
+    input_variables=["context", "question"],
+    partial_variables={
+        "format_instructions": _map_verbatim_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=_map_verbatim_parser,
+)
+
+_combine_prompt_template = """Given the following extracts from several documents, 
+a question and not prior knowledge. 
+
+Process step by step:
+- extract all verbatims
+- extract all associated ids
+- create a final response with these verbatims
+- If you are not confident with your answer, say '{empty_value}'. 
+- produces the json result
+
+QUESTION: {question}
+=========
+{summaries}
+=========
+If you are not confident with your answer, say 'I don't know'. 
+{format_instructions}
+FINAL ANSWER:"""
+COMBINE_PROMPT = PromptTemplate(
+    template=_combine_prompt_template,
+    input_variables=["summaries", "question"],
+    partial_variables={
+        "format_instructions": verbatims_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=verbatims_parser,
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/map_rerank_prompts.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/map_rerank_prompts.py
@@ -1,0 +1,59 @@
+# flake8: noqa
+from langchain.output_parsers import PydanticOutputParser, RegexParser
+from langchain.prompts import PromptTemplate
+from langchain.schema import BaseOutputParser
+
+from .verbatims import VerbatimsFromDoc, Verbatims, verbatims_parser, empty_value
+
+_rank_parser = RegexParser(
+    regex=r"(.*)\n?Score: (\d*)",
+    output_keys=["answer", "score"],
+)
+
+prompt_template = """
+Given the following extracts from several documents, a question and not prior knowledge. 
+
+How to determine the score:
+- Higher is a better answer
+- Better responds fully to the asked question, with sufficient level of detail
+- If you do not know the answer based on the context, that should be a score of 0
+- Don't be overconfident!
+
+The ids must be only in the form '_idx_<number>'.
+
+Process step by step:
+- extract the references ("IDS")
+- extract all the verbatims from the texts only if they are relevant to answering the question, in a list of strings 
+- answers the question
+- If you are not confident with your answer, say '{empty_value}'. 
+- calculates a score of how fully it answered the user's question
+- creates a final answer
+
+The ids must be only in the form '_idx_<number>'.
+{format_instructions}
+
+This should be in the following format:
+Question: [question here]
+Helpful Answer: [json answer here]
+Score: [to the next line, score between 0 and 100]
+
+Context:
+---------
+{context}
+---------
+Question: {question}
+Helpful Answer:"""
+PROMPT = PromptTemplate(
+    template=prompt_template,
+    input_variables=["context", "question"],
+    partial_variables={
+        "format_instructions": verbatims_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=_rank_parser,
+)
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Content: {page_content}\nIds: {_idx}",
+    input_variables=["page_content", "_idx"],
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/refine_prompts.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/refine_prompts.py
@@ -1,0 +1,79 @@
+# flake8: noqa
+from langchain.prompts import PromptTemplate
+from .verbatims import verbatims_parser, empty_value
+
+EXAMPLE_PROMPT = PromptTemplate(
+    template="ids: {_idx}\n" "Content: {page_content}\n",
+    input_variables=["page_content", "_idx"],
+)
+
+_initial_qa_prompt_template = """
+Context information is below. 
+---------------------
+{context_str}
+---------------------
+Process step by step:
+- ignore prior knowledge
+- extract references ("IDS")
+- extract all the exact verbatims from the texts only if they are relevant to answering the question, in a list of strings 
+- create a final answer
+- produce the json result
+
+Given the context information the question: {question}
+
+If you don't know the answer, just say '{empty_value}', without references, and does not extract any verbatim. 
+Don't try to make up an answer.
+
+The ids must be only in the form '_idx_<number>'.
+{format_instructions}
+"""
+
+INITIAL_QA_PROMPT = PromptTemplate(
+    input_variables=["context_str", "question"],
+    template=_initial_qa_prompt_template,
+    partial_variables={
+        "format_instructions": verbatims_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=verbatims_parser,
+)
+
+_refine_prompt_template = """
+Given the context information and not prior knowledge answer, the question: {question}
+
+We have provided an existing JSON answer with the list of documents with associated ids and verbatims of texts: 
+{existing_answer}
+
+We have the opportunity to refine the existing answer (only if needed) with some more context below.
+------------
+{context_str}
+------------
+Given the new context, refine the original answer to better answer the question. 
+If you don't know how to refine the original answer, does not modify the answer.
+
+Process step by step:
+- ignore prior knowledge
+- with the new context 
+    - extract references of the new context ("IDS")
+    - add all the exact verbatims from the texts of the new context, only if they are relevant to answering the question, in a list of strings 
+- refine the original answer to better answer the question. ONLY if you do update it
+- append the new IDS and add verbatims of texts from the existing answser IDS as well. 
+- produce the result
+
+ALWAYS return a "IDS" part in your answer. 
+If the context isn't useful, return the original answer.
+
+If you don't know the answer, just say '{empty_value}'. Don't try to make up an answer.
+
+{format_instructions}
+"""
+
+REFINE_PROMPT = PromptTemplate(
+    input_variables=["question", "existing_answer", "context_str"],
+    template=_refine_prompt_template,
+    partial_variables={
+        "format_instructions": verbatims_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=verbatims_parser,
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/retrieval.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/retrieval.py
@@ -1,0 +1,17 @@
+"""Question-answering with sources over an index."""
+
+from ..qa_with_references.retrieval import RetrievalQAWithReferencesChain
+from .base import (
+    BaseQAWithReferencesAndVerbatimsChain,
+)
+
+
+class RetrievalQAWithReferencesAndVerbatimsChain(
+    RetrievalQAWithReferencesChain, BaseQAWithReferencesAndVerbatimsChain
+):
+    """Question-answering with referenced documents and verbatim.
+
+    This implementation allows you to retrieve the list of documents, enriched with
+    the verbatim metadata.
+    The implementation uses fewer tokens and correctly handles recursive map_reduces.
+    """

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/stuff_prompt.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/stuff_prompt.py
@@ -1,0 +1,39 @@
+# flake8: noqa
+
+
+from langchain.prompts import PromptTemplate
+from .verbatims import verbatims_parser, Verbatims, VerbatimsFromDoc, empty_value
+
+_template = """Given the following extracts from several documents, a question and not prior knowledge. 
+Process step by step:
+- for each documents:
+    - extract the references ("IDS")
+    - extract all the verbatims from the texts only if they are relevant to answering the question, in a list of strings  
+- creates a final answer
+- produces the json result
+
+If you don't know the answer, just say '{empty_value}'. Don't try to make up an answer.
+ALWAYS return a "IDS" part in your answer in another line.
+
+QUESTION: {question}
+=========
+{summaries}
+=========
+The ids must be only in the form '_idx_<number>'.
+{format_instructions}
+FINAL ANSWER: 
+"""
+
+PROMPT = PromptTemplate(
+    template=_template,
+    input_variables=["summaries", "question"],
+    partial_variables={
+        "format_instructions": verbatims_parser.get_format_instructions(),
+        "empty_value": empty_value,
+    },
+    output_parser=verbatims_parser,
+)
+EXAMPLE_PROMPT = PromptTemplate(
+    template="Content: {page_content}\n" "idx: {_idx}",
+    input_variables=["page_content", "_idx"],
+)

--- a/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/verbatims.py
+++ b/libs/experimental/langchain_experimental/chains/qa_with_references_and_verbatims/verbatims.py
@@ -1,0 +1,69 @@
+import logging
+import re
+from typing import List, Optional
+
+from langchain.output_parsers import PydanticOutputParser
+from langchain.pydantic_v1 import BaseModel
+from langchain.schema import BaseOutputParser
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_original_verbatim(verbatim: str, page_content: str) -> Optional[str]:
+    """The exact format of verbatim may be changed by the LLM.
+    Extract only the words of the verbatim, and try to find a sequence
+    of same words in the original document.
+    """
+    only_words = filter(len, re.split(r"[^\w]+", verbatim))
+    regex_for_words_in_same_oder = r"(?i)" + r"\b\b[^\w]+".join(only_words)
+    regex_for_words_in_same_oder += r"\b\s*[.!?:;]?"  # Optional end of sentence
+    match = re.search(regex_for_words_in_same_oder, page_content, re.IGNORECASE)
+    if match:
+        return match[0].strip()
+    return None  # No verbatim found in the original document
+
+
+class VerbatimsFromDoc(BaseModel):
+    ids: List[str]
+    """ The position of the document in the original list """
+    verbatims: List[str]
+    """ All verbatims for this document """
+
+    def original_verbatims(self, page_content: str) -> List[str]:
+        result = []
+        for j, verbatim in enumerate(self.verbatims):
+            original_verbatim = _extract_original_verbatim(
+                verbatim=verbatim, page_content=page_content
+            )
+            if original_verbatim:
+                result.append(original_verbatim)
+            else:
+                logger.debug(f'Ignore verbatim "{verbatim}"')
+        return result
+
+    def __str__(self) -> str:
+        return "\n".join(
+            [f'"{v}"' for v in [re.sub(r"\s", " ", v) for v in self.verbatims]]
+        )
+
+
+class Verbatims(BaseModel):
+    """
+    Response, references and verbatims object.
+    """
+
+    response: str
+    """ The response """
+    documents: List[VerbatimsFromDoc]
+    """ The list of documents and verbatims"""
+
+
+verbatims_from_doc_parser: BaseOutputParser = PydanticOutputParser(
+    pydantic_object=VerbatimsFromDoc
+)
+verbatims_parser: BaseOutputParser = PydanticOutputParser(pydantic_object=Verbatims)
+empty_value: str = Verbatims(
+    response="I don't known", documents=[]
+).json()  # Pydantic 1
+
+""" A parser for this object """

--- a/libs/experimental/tests/integration_tests/chains/test_integration_qa_with_references.py
+++ b/libs/experimental/tests/integration_tests/chains/test_integration_qa_with_references.py
@@ -1,0 +1,304 @@
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
+
+import pytest
+from langchain.callbacks import StdOutCallbackHandler
+from langchain.callbacks.base import Callbacks
+from langchain.document_loaders import DirectoryLoader, TextLoader
+from langchain.document_loaders.base import BaseLoader
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.indexes import VectorstoreIndexCreator
+from langchain.llms import BaseLLM
+from langchain.retrievers import WebResearchRetriever
+from langchain.schema import BaseRetriever, Document
+from langchain.schema.embeddings import Embeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter, TextSplitter
+from langchain.vectorstores import Chroma
+
+from langchain_experimental.chains.qa_with_references.retrieval import (
+    RetrievalQAWithReferencesChain,
+)
+
+logger = logging.getLogger(__name__)
+
+samples = {
+    # "apify": [
+    #     "How do I use langchain?",
+    # ]
+    # "docs": [
+    #     "How do I use langchain?",
+    # ],
+    # "google": [
+    #     "what is the Machine learning?",
+    #     "what is say about Matrix multiplication ?",
+    #     "what is the most popular language among data scientists?",
+    #     "How do I make money?",
+    # ],
+    "wikipedia": [
+        "what is the Machine learning?",
+        "what is say about Matrix multiplication ?",
+        "what is the most popular language among data scientists?",
+    ],
+}
+
+# %%
+VERBOSE_PROMPT = False
+VERBOSE_RESULT = False
+USE_CACHE = True
+CHUNK_SIZE = 500
+CHUNK_OVERLAP = 5
+TEMPERATURE = 0.0
+MAX_TOKENS = 1500
+REDUCE_K_BELOW_MAX_TOKENS = False
+ALL_CHAIN_TYPE = ["stuff", "map_reduce", "refine", "map_rerank"]
+ALL_SAMPLES = sorted({(k, v) for k, ls in samples.items() for v in ls})
+
+# To test a selected combinaison, activate these values
+# ALL_CHAIN_TYPE = [ "stuff",]
+# ALL_SAMPLES = [("google", "how can i be better at football?")]
+
+CALLBACKS: Callbacks = []
+
+if VERBOSE_PROMPT or VERBOSE_RESULT:
+
+    class ExStdOutCallbackHandler(StdOutCallbackHandler):
+        def on_text(
+            self,
+            text: str,
+            color: Optional[str] = None,
+            end: str = "",
+            **kwargs: Any,
+        ) -> None:
+            if VERBOSE_PROMPT:
+                print("====")
+                super().on_text(text=text, color=color, end=end)
+
+        def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
+            """Ajoute une trace des outputs du llm"""
+            if VERBOSE_RESULT:
+                print("\n\033[1m> Finished chain with\033[0m")
+                knows_keys = {
+                    "answer",
+                    "output_text",
+                    "text",
+                    "result",
+                    "outputs",
+                    "output",
+                }
+                if "outputs" in outputs:
+                    print("\n\033[33m")
+                    print(
+                        "\n---\n".join(
+                            [text["text"].strip() for text in outputs["outputs"]]
+                        )
+                    )
+                    print("\n\033[0m")
+                elif knows_keys.intersection(outputs):
+                    # Prend la première cles en intersection
+                    print(
+                        f"\n\033[33m{outputs[next(iter(knows_keys.intersection(outputs)))]}\n\033[0m"
+                    )
+                else:
+                    pass
+
+    CALLBACKS = [ExStdOutCallbackHandler()]
+
+
+def _init_llm(temperature: float = TEMPERATURE, max_token: int = MAX_TOKENS) -> BaseLLM:
+    import langchain
+    from dotenv import load_dotenv
+    from langchain.cache import SQLiteCache
+
+    load_dotenv()
+
+    if USE_CACHE:
+        langchain.llm_cache = SQLiteCache(
+            database_path="/tmp/cache_qa_with_reference.db"
+        )
+    llm = langchain.llms.OpenAI(
+        temperature=temperature,
+        max_tokens=max_token,
+        # cache=False,
+    )
+    return llm
+
+
+_cache_retriever: Dict[Tuple[str, str], BaseRetriever] = {}
+
+
+def _get_retriever(
+    provider: str, question: str, splitter: TextSplitter, llm: BaseLLM
+) -> BaseRetriever:
+    cache_retriever = _cache_retriever.get((provider, question))
+    if cache_retriever:
+        return cache_retriever
+    import dotenv
+
+    dotenv.load_dotenv(override=True)
+    retriever: BaseRetriever
+    import langchain
+
+    loader: BaseLoader
+    embeding_function: Embeddings = OpenAIEmbeddings()
+    f = Path(tempfile.gettempdir(), "test_chroma.db")
+    shutil.rmtree(f, ignore_errors=True)
+
+    if provider == "wikipedia":
+        retriever = langchain.retrievers.WikipediaRetriever(wiki_client=None)
+        docs = retriever.get_relevant_documents(question)
+        split_docs = splitter.split_documents(docs)
+        vectorstore = Chroma(
+            embedding_function=embeding_function,
+            persist_directory=str(f.name),
+        )
+        vectorstore.add_documents(split_docs)
+        retriever = vectorstore.as_retriever()
+
+    elif provider == "google":
+        if "GOOGLE_API_KEY" not in os.environ or "GOOGLE_CSE_ID" not in os.environ:
+            pytest.skip("GOOGLE_API_KEY and GOOGLE_CSE_ID must be set")
+        try:
+            import googleapiclient  # type: ignore # noqa: F401
+            import html2text  # type: ignore # noqa: F401
+
+            # Search
+            from langchain import GoogleSearchAPIWrapper
+
+            # Initialize
+            vectorstore = Chroma(
+                embedding_function=embeding_function,
+                persist_directory=str(f),
+            )
+            retriever = WebResearchRetriever.from_llm(
+                vectorstore=vectorstore,
+                llm=llm,
+                search=GoogleSearchAPIWrapper(),
+                text_splitter=cast(RecursiveCharacterTextSplitter, splitter),
+            )
+        except ImportError:
+            pytest.skip("Use pip install google-api-python-client html2text")
+
+    elif provider == "docs":
+        loader = DirectoryLoader("../../", glob="**/*.md", loader_cls=TextLoader)
+        index = VectorstoreIndexCreator(
+            vectorstore_cls=Chroma,
+            text_splitter=splitter,
+            # embedding=_embedding,
+            vectorstore_kwargs={},
+        ).from_loaders([loader])
+        retriever = index.vectorstore.as_retriever(search_kwargs={"k": 4})
+    elif provider == "apify":
+        if "APIFY_API_TOKEN" not in os.environ:
+            pytest.skip("APIFY_API_TOKEN must be set")
+
+        try:
+            from langchain.utilities import ApifyWrapper
+
+            apify = ApifyWrapper()
+            loader = apify.call_actor(
+                actor_id="apify/website-content-crawler",
+                run_input={"startUrls": [{"url": "https://en.wikipedia.org/"}]},
+                dataset_mapping_function=lambda item: Document(
+                    page_content=item["text"] or "", metadata={"source": item["url"]}
+                ),
+            )
+            index = VectorstoreIndexCreator(
+                vectorstore_cls=Chroma,
+                text_splitter=splitter,
+                embedding=embeding_function,
+                vectorstore_kwargs={},
+            ).from_loaders([loader])
+            retriever = index.vectorstore.as_retriever(search_kwargs={"k": 4})
+        except ImportError:
+            pytest.skip("Use pip install apify-client")
+    else:
+        raise ValueError()
+    _cache_retriever[(provider, question)] = retriever
+    return retriever
+
+
+def _merge_result_by_urls(answer: Dict[str, Any]) -> Dict[str, List[str]]:
+    references: Dict[str, List[str]] = {}
+    for doc in answer["source_documents"]:
+        source = doc.metadata.get("source", [])
+        verbatims_for_source: List[str] = doc.metadata.get(source, [])
+        verbatims_for_source.extend(doc.metadata.get("verbatims", []))
+        references[source] = verbatims_for_source
+    return references
+
+
+def _test_qa_with_reference_chain(
+    cls: Type,
+    provider: str,
+    chain_type: str,
+    question: str,
+    max_token: int,
+    chunk_size: int,
+    chunk_overlap: int,
+    kwargs: Dict[str, Any] = {},
+) -> None:
+    try:
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size, chunk_overlap=chunk_overlap
+        )
+
+        llm = _init_llm(max_token=max_token)
+        retriever = _get_retriever(
+            provider=provider,
+            question=question,
+            splitter=splitter,
+            llm=llm,
+        )
+
+        qa_chain = cls.from_chain_type(
+            llm=llm,
+            chain_type=chain_type,
+            retriever=retriever,
+            **kwargs,
+        )
+        answer = qa_chain(
+            inputs={
+                "question": question,
+            },
+            callbacks=CALLBACKS,
+        )
+        print(f'Question "{question}"\n' f'{answer["answer"]}\n\n')
+        if "sources" in answer:
+            # Old QA with sources
+            print(f'Source "{answer["sources"]}"')
+            for doc in answer.get("source_documents", []):
+                print(f'- Doc {doc.metadata["source"]}')
+        else:
+            references = _merge_result_by_urls(answer)
+            # Print the result
+            for source, verbatims in references.items():
+                print(f"Source {source}")
+                for verbatim in verbatims:
+                    print(f'-  "{verbatim}"')
+    except ImportError as e:
+        pytest.skip(f"Import error {e}")
+
+
+@pytest.mark.parametrize("chain_type", ALL_CHAIN_TYPE)
+# @pytest.mark.parametrize("provider,question",
+#                          sorted({(k, l) for k, ls in samples.items() for l in ls}))
+@pytest.mark.parametrize("provider,question", ALL_SAMPLES)
+def test_qa_with_references_chain(
+    provider: str, chain_type: str, question: str
+) -> None:
+    _test_qa_with_reference_chain(
+        cls=RetrievalQAWithReferencesChain,
+        provider=provider,
+        chain_type=chain_type,
+        question=question,
+        max_token=2000,
+        chunk_size=CHUNK_SIZE,
+        chunk_overlap=CHUNK_OVERLAP,
+        kwargs={
+            "reduce_k_below_max_tokens": REDUCE_K_BELOW_MAX_TOKENS,
+        },
+    )

--- a/libs/experimental/tests/integration_tests/chains/test_integration_qa_with_references_and_verbatims.py
+++ b/libs/experimental/tests/integration_tests/chains/test_integration_qa_with_references_and_verbatims.py
@@ -1,0 +1,30 @@
+import pytest
+
+from langchain_experimental.chains.qa_with_references_and_verbatims import (
+    retrieval,
+)
+from tests.integration_tests.chains.test_integration_qa_with_references import (
+    ALL_CHAIN_TYPE,
+    ALL_SAMPLES,
+    CHUNK_OVERLAP,
+    CHUNK_SIZE,
+    REDUCE_K_BELOW_MAX_TOKENS,
+    _test_qa_with_reference_chain,
+)
+
+
+@pytest.mark.parametrize("chain_type", ALL_CHAIN_TYPE)
+@pytest.mark.parametrize("provider,question", ALL_SAMPLES)
+def test_qa_with_reference_chain(provider: str, question: str, chain_type: str) -> None:
+    _test_qa_with_reference_chain(
+        cls=retrieval.RetrievalQAWithReferencesAndVerbatimsChain,
+        provider=provider,
+        chain_type=chain_type,
+        question=question,
+        max_token=2000,
+        chunk_size=CHUNK_SIZE,
+        chunk_overlap=CHUNK_OVERLAP,
+        kwargs={
+            "reduce_k_below_max_tokens": REDUCE_K_BELOW_MAX_TOKENS,
+        },
+    )

--- a/libs/experimental/tests/integration_tests/chains/test_integration_qa_with_sources.py
+++ b/libs/experimental/tests/integration_tests/chains/test_integration_qa_with_sources.py
@@ -1,0 +1,29 @@
+import pytest
+from langchain.chains import RetrievalQAWithSourcesChain
+
+from tests.integration_tests.chains.test_integration_qa_with_references import (
+    ALL_CHAIN_TYPE,
+    ALL_SAMPLES,
+    REDUCE_K_BELOW_MAX_TOKENS,
+    _test_qa_with_reference_chain,
+)
+
+
+@pytest.mark.parametrize("chain_type", ALL_CHAIN_TYPE)
+# @pytest.mark.parametrize("provider,question",
+#                          sorted({(k, l) for k, ls in samples.items() for l in ls}))
+@pytest.mark.parametrize("provider,question", ALL_SAMPLES)
+def test_qa_with_sources_chain(provider: str, question: str, chain_type: str) -> None:
+    _test_qa_with_reference_chain(
+        cls=RetrievalQAWithSourcesChain,
+        provider=provider,
+        chain_type=chain_type,
+        question=question,
+        max_token=1000,
+        chunk_size=200,
+        chunk_overlap=0,
+        kwargs={
+            "return_source_documents": True,
+            "reduce_k_below_max_tokens": REDUCE_K_BELOW_MAX_TOKENS,
+        },
+    )

--- a/libs/experimental/tests/unit_tests/chains/test_qa_with_references.py
+++ b/libs/experimental/tests/unit_tests/chains/test_qa_with_references.py
@@ -1,0 +1,239 @@
+import logging
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import pytest
+from langchain.callbacks import StdOutCallbackHandler
+from langchain.callbacks.manager import Callbacks
+from langchain.llms import BaseLLM
+from langchain.schema import Document, OutputParserException
+
+from langchain_experimental.chains.qa_with_references.base import (
+    QAWithReferencesChain,
+)
+from tests.unit_tests.fake_llm import FakeLLM
+
+FAKE_LLM = True
+VERBOSE_PROMPT = False
+VERBOSE_RESULT = False
+USE_CACHE = True
+CHUNK_SIZE = 500
+CHUNK_OVERLAP = 5
+TEMPERATURE = 0.0
+MAX_TOKENS = 2000
+ALL_CHAIN_TYPE = ["stuff", "map_reduce", "refine", "map_rerank"]
+
+CALLBACKS: Callbacks = []
+
+logger = logging.getLogger(__name__)
+
+if VERBOSE_PROMPT or VERBOSE_RESULT:
+
+    class ExStdOutCallbackHandler(StdOutCallbackHandler):
+        def on_text(
+            self,
+            text: str,
+            color: Optional[str] = None,
+            end: str = "",
+            **kwargs: Any,
+        ) -> None:
+            if VERBOSE_PROMPT:
+                print("====")
+                super().on_text(text=text, color=color, end=end)
+
+        def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
+            """Ajoute une trace des outputs du llm"""
+            if VERBOSE_RESULT:
+                print("\n\033[1m> Finished chain with\033[0m")
+                knows_keys = {
+                    "answer",
+                    "output_text",
+                    "text",
+                    "result",
+                    "outputs",
+                    "output",
+                }
+                if "outputs" in outputs:
+                    print("\n\033[33m")
+                    print(
+                        "\n---\n".join(
+                            [text["text"].strip() for text in outputs["outputs"]]
+                        )
+                    )
+                    print("\n\033[0m")
+                elif knows_keys.intersection(outputs):
+                    # Prend la première cles en intersection
+                    print(
+                        f"\n\033[33m{outputs[next(iter(knows_keys.intersection(outputs)))]}\n\033[0m"
+                    )
+                else:
+                    pass
+
+    CALLBACKS = [ExStdOutCallbackHandler()]
+
+
+def init_llm(
+    queries: Dict[int, str],
+    max_token: int = MAX_TOKENS,
+) -> BaseLLM:
+    if FAKE_LLM:
+        return FakeLLM(
+            queries=queries,
+            sequential_responses=True,
+        )
+    else:
+        import langchain
+        from dotenv import load_dotenv
+        from langchain.cache import SQLiteCache
+
+        load_dotenv()
+
+        if USE_CACHE:
+            langchain.llm_cache = SQLiteCache(
+                database_path="/tmp/cache_qa_with_reference.db"
+            )
+        llm = langchain.OpenAI(
+            temperature=TEMPERATURE,
+            max_tokens=max_token,
+            # cache=False,
+        )
+        return llm
+
+
+def compare_words_of_responses(response: str, assert_response: str) -> bool:
+    """The exact format of verbatim may be changed by the LLM.
+    Extract only the words of the verbatim, and try to find a sequence
+    of same words in the original document.
+    """
+    only_words = filter(len, re.split(r"[^\w]+", assert_response))
+    regex_for_words_in_same_oder = (
+        r"(?i)\b" + r"\b[^\w]+".join(only_words) + r"\b" r"\s*[.!?:;]?"
+    )
+    match = re.search(regex_for_words_in_same_oder, response, re.IGNORECASE)
+    if match:
+        return True
+    return False  # No verbatim found in the original document
+
+
+def compare_responses(responses: List[str], assert_responses: List[str]) -> bool:
+    for response, assert_response in zip(responses, assert_responses):
+        if not compare_words_of_responses(response, assert_response):
+            return False
+    return True
+
+
+@pytest.mark.parametrize(
+    "question,docs,map_responses",
+    [
+        (
+            "what does he eat?",
+            [
+                Document(
+                    page_content="The night is black.",
+                    metadata={},
+                ),
+                Document(
+                    page_content="He eats\napples and plays football. "
+                    "My name is Philippe. He eats pears.",
+                    metadata={},
+                ),
+                Document(
+                    page_content="He eats carrots. I like football.",
+                    metadata={},
+                ),
+                Document(
+                    page_content="The Earth is round.",
+                    metadata={},
+                ),
+            ],
+            {
+                "stuff": (
+                    {
+                        0: "```\n"
+                        "He eats apples, pears and carrots.\n"
+                        "IDS: _idx_1, _idx_2\n"
+                        "```\n",
+                    },
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "map_reduce": (
+                    {
+                        0: 'Output: {"lines": []}',
+                        1: 'Output: {"lines": ["_idx_1: He eats apples", '
+                        '"_idx_3: He eats pears"]}',
+                        2: 'Output: {"lines": ["_idx_1: He eats carrots."]}',
+                        3: 'Output: {"lines": []}',
+                        4: " He eats apples, pears, and carrots.\n"
+                        "IDS: _idx_1, _idx_3, _idx_2\n",
+                    },
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "refine": (
+                    {
+                        0: "Answer: I don't know.\nIDS:\n",
+                        1: "Answer: He eats apples, pears "
+                        "and plays football.\nIDS: _idx_1\n",
+                        2: "Answer: He eats apples, pears, carrots "
+                        "and plays football.\nIDS: _idx_1, _idx_2\n",
+                        3: "Answer: He eats apples, pears, carrots "
+                        "and plays football.\nIDS: _idx_1, _idx_2, _idx_3\n",
+                    },
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "map_rerank": (
+                    {
+                        0: "This document does not answer the question\n" "Score: 0\n",
+                        1: "apples and pears\nScore: 100\n",
+                        2: "carrots\nScore: 100\n",
+                        3: "This document does not answer the question.\n" "Score: 0\n",
+                        4: "apples and pears\n",
+                    },
+                    r"(?i).*\bapples\b.*\bpears",
+                    {1},
+                ),
+            },
+        ),
+    ],
+)
+@pytest.mark.parametrize("chain_type", ALL_CHAIN_TYPE)
+def test_qa_with_reference_chain(
+    question: str,
+    docs: List[Document],
+    map_responses: Dict[str, Tuple[Dict[int, str], str, Set[int]]],
+    chain_type: str,
+) -> None:
+    queries, expected_answer, references = map_responses[chain_type]
+    llm = init_llm(queries)
+
+    for i in range(0, 2):  # Retry if error ?
+        try:
+            qa_chain = QAWithReferencesChain.from_chain_type(
+                llm=llm,
+                chain_type=chain_type,
+            )
+            answer = qa_chain(
+                inputs={
+                    "docs": docs,
+                    "question": question,
+                },
+                callbacks=CALLBACKS,
+            )
+            answer_of_question = answer["answer"]
+            if not answer_of_question:
+                logger.warning("Return nothing. Retry")
+                continue
+            assert re.match(expected_answer, answer_of_question)
+            for ref, original in zip(references, answer["source_documents"]):
+                assert docs[ref] is original, "Return incorrect original document"
+            break
+        except OutputParserException:
+            llm.cache = False
+            logger.warning("Parsing error. Retry")
+            continue  # Retry
+
+    else:
+        print(f"response after {i + 1} tries.")
+        assert not "Impossible to receive a correct response"

--- a/libs/experimental/tests/unit_tests/chains/test_qa_with_references_and_verbatims.py
+++ b/libs/experimental/tests/unit_tests/chains/test_qa_with_references_and_verbatims.py
@@ -1,0 +1,205 @@
+import re
+from typing import Dict, List, Set, Tuple
+
+import pytest
+from langchain.schema import Document, OutputParserException
+
+from langchain_experimental.chains.qa_with_references_and_verbatims.base import (
+    QAWithReferencesAndVerbatimsChain,
+)
+from tests.unit_tests.chains.test_qa_with_references import (
+    ALL_CHAIN_TYPE,
+    CALLBACKS,
+    compare_responses,
+    init_llm,
+    logger,
+)
+
+
+@pytest.mark.parametrize(
+    "question,docs,map_responses",
+    [
+        (
+            "what does he eat?",
+            [
+                Document(
+                    page_content="The night is black.",
+                    metadata={},
+                ),
+                Document(
+                    page_content="He eats\napples and plays football. "
+                    "My name is Philippe. He eats pears.",
+                    metadata={},
+                ),
+                Document(
+                    page_content="He eats carrots. I like football.",
+                    metadata={},
+                ),
+                Document(
+                    page_content="The Earth is round.",
+                    metadata={},
+                ),
+            ],
+            {
+                "stuff": (
+                    {
+                        0: "```\n"
+                        '{"response": "He eats apples, pears and carrots.", '
+                        '"documents": [{"ids": ["_idx_1", "_idx_2"], '
+                        '"verbatims": ['
+                        '"He eats apples and plays football.", '
+                        '"He eats pears.", '
+                        '"He eats carrots."]}]}'
+                        "```"
+                    },
+                    [
+                        ["He eats\napples and plays football.", "He eats pears."],
+                        [
+                            "He eats carrots.",
+                        ],
+                    ],
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "map_reduce": (
+                    {
+                        0: 'Output: {"ids": [], "verbatims": []}',
+                        1: "Output:\n"
+                        '{"ids": ["_idx_1", "_idx_2"], '
+                        '"verbatims": ["He eats apples", "He eats pears"]}',
+                        2: "Output: \n"
+                        '{"ids": ["_idx_0"], '
+                        '"verbatims": ["He eats carrots."]}',
+                        3: 'Output: {"ids": [], "verbatims": []}',
+                        4: '{"response": "He eats apples, He eats pears, '
+                        'He eats carrots.", "documents": '
+                        '[{"ids": ["_idx_0"], "verbatims": '
+                        '["He eats carrots."]}, '
+                        '{"ids": ["_idx_1", "_idx_2"], '
+                        '"verbatims": ["He eats apples", "He eats pears"]}]}',
+                        5: "He eats apples, He eats pears, He eats carrots.",
+                    },
+                    [["eats apples", "eats pears"], ["eats carrots"]],
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "refine": (
+                    {
+                        0: "The output would be:\n"
+                        '{"response": '
+                        '"I don\'t know", '
+                        '"documents": ['
+                        '{"ids": ["_idx_0"], "verbatims": []}]}',
+                        1: '{"response": "He eats apples and pears.", '
+                        '"documents": [{"ids": ['
+                        '"_idx_0", "_idx_1"], '
+                        '"verbatims": ['
+                        '"He eats apples and plays football.", '
+                        '"He eats pears."]}]}',
+                        2: "The output would be:\n"
+                        '{"response": "He eats apples, pears, and carrots.", '
+                        '"documents": ['
+                        '{"ids": ["_idx_0", "_idx_1", "_idx_2", "_idx_3"], '
+                        '"verbatims": ["He eats apples and plays football.", '
+                        '"He eats pears.", "He eats carrots. '
+                        'I like football.","The Earth is round."]}]}',
+                        3: "The output would be:\n"
+                        '{"response": "He eats apples, pears, and carrots.", '
+                        '"documents": ['
+                        '{"ids": ["_idx_0", "_idx_1", "_idx_2", "_idx_3"], '
+                        '"verbatims": ['
+                        '"He eats apples and plays football.", '
+                        '"He eats pears.", '
+                        '"He eats carrots. I like football.",'
+                        '"The Earth is round."]}]}',
+                    },
+                    [
+                        [],
+                        # ["eats apples", "eats pears"],
+                        ["eats carrots"],
+                    ],
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "map_rerank": (
+                    {
+                        0: '{"response": "This document does not answer '
+                        'the question", "documents": []}\n'
+                        "Score: 0",
+                        1: '{"response": "apples and pears", '
+                        '"documents": [{"ids": ["99"], '
+                        '"verbatims": ["He eats apples", '
+                        '"He eats pears"]}]}\n'
+                        "Score: 100",
+                        2: '{"response": "carrots", '
+                        '"documents": ['
+                        '{"ids": ["99"], '
+                        '"verbatims": ["He eats carrots"]}]}\n'
+                        "Score: 100",
+                        3: '{"response": "This document does not '
+                        'answer the question", '
+                        '"documents": []}\n'
+                        "Score: 0",
+                        4: ' {"response": "apples and pears", '
+                        '"documents": [{"ids": ["99"], '
+                        '"verbatims": ["He eats apples", '
+                        '"He eats pears"]}]}',
+                    },
+                    [
+                        ["He eats\napples", "He eats pears."],
+                    ],
+                    r"(?i).*\bapples\b.*\bpears",
+                    {1},
+                ),
+            },
+        ),
+    ],
+)
+@pytest.mark.parametrize("chain_type", ALL_CHAIN_TYPE)
+def test_qa_with_reference_and_verbatims_chain(
+    question: str,
+    docs: List[Document],
+    map_responses: Dict[str, Tuple[Dict[int, str], List[List[str]], str, Set[int]]],
+    chain_type: str,
+) -> None:
+    # chain_type = "map_reduce"  # stuff, map_reduce, refine, map_rerank
+
+    queries, verbatims, expected_answer, references = map_responses[chain_type]
+    llm = init_llm(queries)
+
+    for i in range(0, 2):  # Retry if empty ?
+        try:
+            qa_chain = QAWithReferencesAndVerbatimsChain.from_chain_type(
+                llm=llm,
+                chain_type=chain_type,
+                original_verbatim=True,
+            )
+            answer = qa_chain(
+                inputs={
+                    "docs": docs,
+                    "question": question,
+                },
+                callbacks=CALLBACKS,
+            )
+            answer_of_question = answer["answer"]
+            if not answer_of_question:
+                logger.warning("Return nothing. Retry")
+                llm.cache = False
+                continue
+            assert re.match(expected_answer, answer_of_question)
+            for ref, original, assert_verbatims in zip(
+                references, answer["source_documents"], verbatims
+            ):
+                assert docs[ref] is original, "Return incorrect original document"
+                assert compare_responses(
+                    original.metadata.get("verbatims", []), assert_verbatims
+                ), "Return incorrect verbatims"
+            break
+        except OutputParserException as e:
+            llm.cache = False
+            logger.warning("Parsing error. Retry", e)
+            continue  # Retry
+    else:
+        print(f"Response is Empty after {i + 1} tries.")
+        assert False, "Impossible to receive a response"
+    print(f"response après {i}")

--- a/libs/experimental/tests/unit_tests/chains/test_qa_with_sources.py
+++ b/libs/experimental/tests/unit_tests/chains/test_qa_with_sources.py
@@ -1,0 +1,168 @@
+import re
+from typing import Dict, List, Set, Tuple
+
+import pytest
+from langchain.chains import QAWithSourcesChain
+from langchain.schema import Document, OutputParserException
+
+from tests.unit_tests.chains.test_qa_with_references import (
+    ALL_CHAIN_TYPE,
+    CALLBACKS,
+    init_llm,
+    logger,
+)
+
+
+@pytest.mark.parametrize(
+    "question,docs,map_responses",
+    [
+        (
+            "what does he eat?",
+            [
+                Document(
+                    page_content="He eats\napples and plays football. "
+                    "My name is Philippe. He eats pears.",
+                    metadata={"source": "http:www.sample.fr/2"},
+                ),
+                Document(
+                    page_content="The night is black.",
+                    metadata={"source": "http:www.sample.fr/1"},
+                ),
+                Document(
+                    page_content="He eats carrots. I like football.",
+                    metadata={"source": "http:www.sample.fr/3"},
+                ),
+                Document(
+                    page_content="The Earth is round.",
+                    metadata={"source": "http:www.sample.fr/1"},
+                ),
+            ],
+            {
+                "stuff": (
+                    {
+                        0: " He eats apples, pears and carrots.\n"
+                        "SOURCES: http:www.sample.fr/2, http:www.sample.fr/3"
+                    },
+                    [
+                        ["He eats\napples and plays football.", "He eats pears."],
+                        [
+                            "He eats carrots.",
+                        ],
+                    ],
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "map_reduce": (
+                    {
+                        0: "None",
+                        1: "He eats apples and pears.",
+                        2: "He eats carrots.",
+                        3: "None",
+                        4: " He eats apples, pears and carrots.\n"
+                        "SOURCES: http:www.sample.fr/2, http:www.sample.fr/3",
+                    },
+                    [["eats apples", "eats pears"], ["eats carrots"]],
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "refine": (
+                    {
+                        0: "He eats apples and pears.",
+                        1: "He eats apples, pears, and other fruits.",
+                        2: '"He eats apples, pears, carrots, and other fruits.\n'
+                        "Source: http:www.sample.fr/3"
+                        'I like football.","The Earth is round."]}]}',
+                        3: "He eats apples, pears, carrots, and other fruits "
+                        "and vegetables.\n"
+                        "Source: http:www.sample.fr/3",
+                    },
+                    [
+                        [],
+                        # ["eats apples", "eats pears"],
+                        ["eats carrots"],
+                    ],
+                    r"(?i).*\bapples\b.*\bpears\b.*\bcarrots\b",
+                    {1, 2},
+                ),
+                "map_rerank": (
+                    {
+                        0: '{"response": "This document does not answer '
+                        'the question", "documents": []}\n'
+                        "Score: 0",
+                        1: '{"response": "apples and pears", '
+                        '"documents": [{"ids": ["99"], '
+                        '"verbatims": ["He eats apples", '
+                        '"He eats pears"]}]}\n'
+                        "Score: 100",
+                        2: '{"response": "carrots", '
+                        '"documents": ['
+                        '{"ids": ["99"], '
+                        '"verbatims": ["He eats carrots"]}]}\n'
+                        "Score: 100",
+                        3: '{"response": "This document does not '
+                        'answer the question", '
+                        '"documents": []}\n'
+                        "Score: 0",
+                        4: ' {"response": "apples and pears", '
+                        '"documents": [{"ids": ["99"], '
+                        '"verbatims": ["He eats apples", '
+                        '"He eats pears"]}]}',
+                    },
+                    [
+                        ["He eats\napples", "He eats pears."],
+                    ],
+                    r"(?i).*\bapples\b.*\bpears",
+                    {1},
+                ),
+            },
+        ),
+    ],
+)
+@pytest.mark.parametrize("chain_type", ALL_CHAIN_TYPE)
+def test_qa_with_sources_chain(
+    question: str,
+    docs: List[Document],
+    map_responses: Dict[str, Tuple[Dict[int, str], List[List[str]], str, Set[int]]],
+    chain_type: str,
+) -> None:
+    # chain_type = "map_reduce"  # stuff, map_reduce, refine, map_rerank
+
+    queries, verbatims, expected_answer, references = map_responses[chain_type]
+    llm = init_llm(queries)
+
+    for i in range(0, 2):  # Retry if empty ?
+        try:
+            qa_chain = QAWithSourcesChain.from_chain_type(
+                llm=llm,
+                chain_type=chain_type,
+                return_source_documents=True,
+            )
+            answer = qa_chain(
+                inputs={
+                    "docs": docs,
+                    "question": question,
+                },
+                callbacks=CALLBACKS,
+            )
+            answer_of_question = answer["answer"].strip()
+            if not answer_of_question:
+                logger.warning("Return nothing. Retry")
+                llm.cache = False
+                continue
+
+            # Old QA with sources
+            print(f'Source "{answer["sources"]}"')
+            for doc in answer.get("source_documents", []):
+                print(f'- Doc {doc.metadata["source"]}')
+
+            assert re.match(expected_answer, answer_of_question)
+
+            break
+        except OutputParserException:
+            llm.cache = False
+            logger.warning("Parsing error. Retry")
+            continue  # Retry
+    else:
+        print(f"Response is Empty after {i + 1} tries.")
+        assert False, "Impossible to receive a response"
+    print(f"response après {i}")

--- a/libs/experimental/tests/unit_tests/fake_llm.py
+++ b/libs/experimental/tests/unit_tests/fake_llm.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional, cast
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
-
-from langchain_experimental.pydantic_v1 import validator
+from langchain.pydantic_v1 import validator
 
 
 class FakeLLM(LLM):


### PR DESCRIPTION

# Description:
This chain returns the selected documents used for the response. Then, it's possible to extract all meta-data 
for these documents, to generate a markdown link or other stuff.

It's not easy to manage the links of sources. Langchain proposed a qa_with_source, but this chain returns only a
list of URL. It's not possible to extract other informations about the metadata, like the filename or others stuff.

I propose a solution to this problem: return the Documents, and let development do what it wants with it.

This pull-request proposes a new implementation of the original chain `qa_with_source`.
Now, the implementation `qa_with_reference` returns the list of documents used for the response.
Then, it's possible to use all meta-data for these documents, to generate a Markdown link (with filename/title and URL) or what you want.

To do that, I inject a UUID in the meta-data, and ask to return a list of UUID in the response. Then, it's easy to find the corresponding document.

In another [branch](https://github.com/pprados/langchain/tree/pprados/qa_with_references_rewrite_qa_with_sources), 
I have reimplemented the origin `qa_with_source` to extend the `qa_with_reference`.

# Tag maintainer:
- @baskaryan

# Dependencies:
- no

# Twitter handle: 
- @pprados