### PR TITLE
Add support for filters and namespaces in similarity search in Pinecone similarity_score_threshold

### DIFF
--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -166,7 +166,8 @@ class Pinecone(VectorStore):
         k: int = 4,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        return self.similarity_search_with_score(query, k)
+        kwargs.pop("score_threshold")
+        return self.similarity_search_with_score(query, k, **kwargs)
 
     def max_marginal_relevance_search_by_vector(
         self,

--- a/langchain/vectorstores/pinecone.py
+++ b/langchain/vectorstores/pinecone.py
@@ -166,7 +166,7 @@ class Pinecone(VectorStore):
         k: int = 4,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        kwargs.pop("score_threshold")
+        kwargs.pop("score_threshold", None)
         return self.similarity_search_with_score(query, k, **kwargs)
 
     def max_marginal_relevance_search_by_vector(


### PR DESCRIPTION
At the moment, pinecone vectorStore does not support filters and namespaces when using similarity_score_threshold search type. 
In this PR, I've implemented that. It passes all the kwargs except "score_threshold" as that is not a supported argument for method "similarity_search_with_score".

Tag maintainers/contributors who might be interested:

@dev2049 @baskaryan  @rlancemartin @eyurtsev 
