### PR TITLE
Fix: OpenAIFunctionsAgent often returns python as a tool in planning, when argument parsing fails

### DIFF
--- a/langchain/agents/openai_functions_agent/base.py
+++ b/langchain/agents/openai_functions_agent/base.py
@@ -112,10 +112,13 @@ def _parse_ai_message(message: BaseMessage) -> Union[AgentAction, AgentFinish]:
         try:
             _tool_input = json.loads(function_call["arguments"])
         except JSONDecodeError:
-            raise OutputParserException(
-                f"Could not parse tool input: {function_call} because "
-                f"the `arguments` is not valid JSON."
-            )
+            if function_name == "python":
+                _tool_input = {"__arg1": function_call["arguments"]}
+            else:
+                raise OutputParserException(
+                    f"Could not parse tool input: {function_call} because "
+                    f"the `arguments` is not valid JSON."
+                )
 
         # HACK HACK HACK:
         # The code that encodes tool input into Open AI uses a special variable


### PR DESCRIPTION
  - Description: With OpenAIFunctionsAgent, often a plan includes `python` as a tool, whose `arguments` is a `str` of the code to execute. In such a case, `_parse_ai_message` fails due to `JSONDecodeError`. This PR does a hack to fix the problem by creating `{"__arg1": arguments}` following the existing hack. I'm unsure when the arguments become string, so I put a condition to do that only for `python` as a tool.
  - Tag maintainer: @hinthornw
  - Twitter handle: mapped

