### PR TITLE
Bug fix related to base vectorstore's metadata.

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -87,7 +87,7 @@ class VectorStore(ABC):
         """
         # TODO: Handle the case where the user doesn't provide ids on the Collection
         texts = [doc.page_content for doc in documents]
-        metadatas = [doc.metadata for doc in documents]
+        metadatas = [doc.metadata.copy() for doc in documents]
         return self.add_texts(texts, metadatas, **kwargs)
 
     async def aadd_documents(
@@ -102,7 +102,7 @@ class VectorStore(ABC):
             List[str]: List of IDs of the added texts.
         """
         texts = [doc.page_content for doc in documents]
-        metadatas = [doc.metadata for doc in documents]
+        metadatas = [doc.metadata.copy() for doc in documents]
         return await self.aadd_texts(texts, metadatas, **kwargs)
 
     def search(self, query: str, search_type: str, **kwargs: Any) -> List[Document]:
@@ -332,7 +332,7 @@ class VectorStore(ABC):
     ) -> VST:
         """Return VectorStore initialized from documents and embeddings."""
         texts = [d.page_content for d in documents]
-        metadatas = [d.metadata for d in documents]
+        metadatas = [d.metadata.copy() for d in documents]
         return cls.from_texts(texts, embedding, metadatas=metadatas, **kwargs)
 
     @classmethod
@@ -344,7 +344,7 @@ class VectorStore(ABC):
     ) -> VST:
         """Return VectorStore initialized from documents and embeddings."""
         texts = [d.page_content for d in documents]
-        metadatas = [d.metadata for d in documents]
+        metadatas = [d.metadata.copy() for d in documents]
         return await cls.afrom_texts(texts, embedding, metadatas=metadatas, **kwargs)
 
     @classmethod


### PR DESCRIPTION
If I use Pinecone to create a vectorbase, by calling from_documents:
```python
    vectorstore = Pinecone.from_documents(
        documents=source_chunks, embedding=embedding, index_name='apple')
```
 the vectors of the same source, have the same content. 
![image](https://github.com/hwchase17/langchain/assets/44468894/28c9576c-c3d1-493f-b594-54f5adb43309)

Issue also described here: https://stackoverflow.com/questions/76401057/why-does-pinecone-repeatedly-return-the-same-result-from-my-series-of-documents

This happens because when I create documents like this:
```python
    source_chunks = []
    for source in docs:
        for chunk in splitter.split_text(source.page_content):
            source_chunks.append(
                Document(page_content=chunk, metadata=source.metadata))
```
the source.metadata is not copied by default. To enforce that, I need to use `Document(page_content=chunk, metadata=source.metadata.copy()))`.

Although this is a user implementation issue, such a thing can happen quite often. To prevent this, we can make sure that the metadata dict is copied by default. 

After wasting 2 hours of my time trying to find out why am I getting dublicate responses on similarity search, I realized that this should be addressed. 

Let me know what you think.
Thanks!
