### PR TITLE
Qdrant: Ability to add vectors to already existing collection & set vector size

### DIFF
--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -614,9 +614,10 @@ class Qdrant(VectorStore):
             init_from:
                 Use data stored in another collection to initialize this collection
             recreate_collection:
-                Default is True. If True - collection will be first deleted and then created again with new data.
-                Set to False if you want to upsert data to an existing collection
-                Note: collection_name must be provided if recreate_collection is set to False
+                Default is True. If True - collection will be first deleted and then
+                created again with new data. Set to False if you want to upsert data
+                to an existing collection Note: collection_name must be provided if
+                recreate_collection is set to False
             vector_size:
                 Size (dimensions) of the vectors. If not provided, it will be automatically
                 inferred from the provided embeddings on init of collection

--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -655,6 +655,21 @@ class Qdrant(VectorStore):
         distance_func = distance_func.upper()
         collection_exists = False
 
+        client = qdrant_client.QdrantClient(
+            location=location,
+            url=url,
+            port=port,
+            grpc_port=grpc_port,
+            prefer_grpc=prefer_grpc,
+            https=https,
+            api_key=api_key,
+            prefix=prefix,
+            timeout=timeout,
+            host=host,
+            path=path,
+            **kwargs,
+        )
+
         # determine if collection exists
         if (
             init_from is None
@@ -671,21 +686,6 @@ class Qdrant(VectorStore):
         if vector_size is None:
             partial_embeddings = embedding.embed_documents(texts[:1])
             vector_size = len(partial_embeddings[0])
-
-        client = qdrant_client.QdrantClient(
-            location=location,
-            url=url,
-            port=port,
-            grpc_port=grpc_port,
-            prefer_grpc=prefer_grpc,
-            https=https,
-            api_key=api_key,
-            prefix=prefix,
-            timeout=timeout,
-            host=host,
-            path=path,
-            **kwargs,
-        )
 
         vectors_config = rest.VectorParams(
             size=vector_size,

--- a/langchain/vectorstores/qdrant.py
+++ b/langchain/vectorstores/qdrant.py
@@ -619,10 +619,10 @@ class Qdrant(VectorStore):
                 to an existing collection Note: collection_name must be provided if
                 recreate_collection is set to False
             vector_size:
-                Size (dimensions) of the vectors. If not provided, it will be automatically
-                inferred from the provided embeddings on init of collection
-                Note: if you do not provide a vector size one initial embedding
-                will be performed to detemine the vector size
+                Size (dimensions) of the vectors. If not provided, it will be
+                automatically inferred from the provided embeddings on init of
+                collection Note: if you do not provide a vector size one initial
+                embedding will be performed to detemine the vector size
             **kwargs:
                 Additional arguments passed directly into REST client initialization
 

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -103,6 +103,110 @@ def test_qdrant_add_documents(batch_size: int, vector_name: Optional[str]) -> No
         Document(page_content="foo")
     ]
 
+def test_qdrant_from_texts_add_to_existing_collection() -> None:
+    """Test from texts adds to existing collection."""
+    from qdrant_client import QdrantClient
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        vec_store = Qdrant.from_texts(
+            ["abc", "def"],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=False,
+        )
+        del vec_store
+
+        vec_store = Qdrant.from_texts(
+            ["foo", "bar"],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=False,
+        )
+        del vec_store
+        
+        client = QdrantClient(path=str(tmpdir))
+        assert 4 == client.count("test_collection").count
+
+def test_qdrant_from_documents_add_to_existing_collection() -> None:
+    """Test from documents adds to existing collection."""
+    from qdrant_client import QdrantClient
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        vec_store = Qdrant.from_documents(
+            [Document(page_content="abc"), Document(page_content="def")],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=False,
+        )
+        del vec_store
+
+        vec_store = Qdrant.from_documents(
+            [Document(page_content="foo"), Document(page_content="bar")],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=False,
+        )
+        del vec_store
+        
+        client = QdrantClient(path=str(tmpdir))
+        assert 4 == client.count("test_collection").count
+
+def test_qdrant_from_texts_recreates_collecton() -> None:
+    """Test from texts recreates collection."""
+    from qdrant_client import QdrantClient
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        vec_store = Qdrant.from_texts(
+            ["abc", "def"],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=True,
+        )
+        del vec_store
+
+        vec_store = Qdrant.from_texts(
+            ["foo", "bar"],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=True,
+        )
+        del vec_store
+        
+        client = QdrantClient(path=str(tmpdir))
+        assert 2 == client.count("test_collection").count
+
+def test_qdrant_from_documents_recreates_collecton() -> None:
+    """Test from documents recreates collection."""
+    from qdrant_client import QdrantClient
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        vec_store = Qdrant.from_documents(
+            [Document(page_content="abc"), Document(page_content="def")],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=True,
+        )
+        del vec_store
+
+        vec_store = Qdrant.from_documents(
+            [Document(page_content="foo"), Document(page_content="bar")],
+            ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            recreate_collection=True,
+        )
+        del vec_store
+        
+        client = QdrantClient(path=str(tmpdir))
+        assert 2 == client.count("test_collection").count
+
 
 @pytest.mark.parametrize("batch_size", [1, 64])
 def test_qdrant_add_texts_returns_all_ids(batch_size: int) -> None:

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -7,6 +7,7 @@ from qdrant_client.http import models as rest
 
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
+from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.vectorstores import Qdrant
 from tests.integration_tests.vectorstores.fake_embeddings import (
     ConsistentFakeEmbeddings,
@@ -103,6 +104,7 @@ def test_qdrant_add_documents(batch_size: int, vector_name: Optional[str]) -> No
         Document(page_content="foo")
     ]
 
+
 def test_qdrant_from_texts_add_to_existing_collection() -> None:
     """Test from texts adds to existing collection."""
     from qdrant_client import QdrantClient
@@ -125,9 +127,10 @@ def test_qdrant_from_texts_add_to_existing_collection() -> None:
             recreate_collection=False,
         )
         del vec_store
-        
+
         client = QdrantClient(path=str(tmpdir))
         assert 4 == client.count("test_collection").count
+
 
 def test_qdrant_from_documents_add_to_existing_collection() -> None:
     """Test from documents adds to existing collection."""
@@ -151,9 +154,10 @@ def test_qdrant_from_documents_add_to_existing_collection() -> None:
             recreate_collection=False,
         )
         del vec_store
-        
+
         client = QdrantClient(path=str(tmpdir))
         assert 4 == client.count("test_collection").count
+
 
 def test_qdrant_from_texts_recreates_collecton() -> None:
     """Test from texts recreates collection."""
@@ -177,9 +181,10 @@ def test_qdrant_from_texts_recreates_collecton() -> None:
             recreate_collection=True,
         )
         del vec_store
-        
+
         client = QdrantClient(path=str(tmpdir))
         assert 2 == client.count("test_collection").count
+
 
 def test_qdrant_from_documents_recreates_collecton() -> None:
     """Test from documents recreates collection."""
@@ -203,9 +208,28 @@ def test_qdrant_from_documents_recreates_collecton() -> None:
             recreate_collection=True,
         )
         del vec_store
-        
+
         client = QdrantClient(path=str(tmpdir))
         assert 2 == client.count("test_collection").count
+
+
+def test_qdrant_set_vector_size() -> None:
+    """Test from documents recreates collection."""
+    from qdrant_client import QdrantClient
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        vec_store = Qdrant.from_texts(
+            ["foo bar"],
+            embedding=ConsistentFakeEmbeddings(),
+            collection_name="test_collection",
+            path=str(tmpdir),
+            vector_size=10,
+        )
+        del vec_store
+
+        client = QdrantClient(path=str(tmpdir))
+        collection = client.get_collection("test_collection")
+        assert 10 == collection.config.params.vectors.size
 
 
 @pytest.mark.parametrize("batch_size", [1, 64])

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -227,8 +227,11 @@ def test_qdrant_set_vector_size() -> None:
         del vec_store
 
         client = QdrantClient(path=str(tmpdir))
-        collection = client.get_collection("test_collection")
-        assert 10 == collection.config.params.vectors.size
+        collection = client.get_collection(collection_name="test_collection")
+        if isinstance(collection.config.params.vectors, rest.VectorParams):
+            assert 10 == collection.config.params.vectors.size
+        else:
+            raise ValueError("params.vectors must be an instance of VectorParams")
 
 
 @pytest.mark.parametrize("batch_size", [1, 64])

--- a/tests/integration_tests/vectorstores/test_qdrant.py
+++ b/tests/integration_tests/vectorstores/test_qdrant.py
@@ -7,7 +7,6 @@ from qdrant_client.http import models as rest
 
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
-from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.vectorstores import Qdrant
 from tests.integration_tests.vectorstores.fake_embeddings import (
     ConsistentFakeEmbeddings,


### PR DESCRIPTION
Problem:
Whenever we add vectors to an existing qdrant collection that collection gets deleted and re-created from scratch if we use for example `VectorstoreIndexCreator()`.

This PR solves this issue and adds further automatisation abilities without breaking the already existing behavior.

In addition to that this PR adds the ability to configure a fixed vector size, eliminating the need to make a single embedding just to figure out the vector size and further reducing api usage resulting in reduced costs for end-users.

So this PR introduces the following two flags:

`recreate_collection = Optional[bool]`

`vector_size = Optional[int]`

How this solution works:

If recreate_collection=False, it checks if collection exists, if not, continue like before this PR ((re)create collection)
if collection exists, and recreate_collection=False, and init_from=None then do not execute recreate_collection()

VectorstoreIndexCreator code example (after PR):

```python
        VectorstoreIndexCreator(
            vectorstore_cls=Qdrant,
            text_splitter=RecursiveCharacterTextSplitter(
                chunk_size=int(os.environ.get('CHUNK_SIZE_TOKENS', 400)),
                separators=sepList,
                chunk_overlap=0,
                length_function=get_tokens,
            ),
            vectorstore_kwargs=dict(
                host=os.environ.get('QDRANT_HOST', 'qdrant'),
                port=int(os.environ.get('QDRANT_PORT', '6333')),
                grpc_port=int(os.environ.get('QDRANT_GRPC_PORT', '6334')),
                prefer_grpc=bool(os.environ.get('QDRANT_PREFER_GRPC', 'True')),
                collection_name=self.request.collection_name,
                recreate_collection=False, # <-- this is new, default value is True
                vector_size=int(os.environ.get('VECTOR_DIMENSIONS', '1536')), # <-- this is new, default value is None
            ),
        ).from_documents(self.documents)
```

--

Maintainer responsibilities:
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
