### PR TITLE
added index retreival from redis search

### DIFF
--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -298,7 +298,7 @@ class Redis(VectorStore):
         base_query = (
             f"{hybrid_fields}=>[KNN {k} @{self.vector_key} $vector AS vector_score]"
         )
-        return_fields = [self.metadata_key, self.content_key, "vector_score"]
+        return_fields = [self.metadata_key, self.content_key, "vector_score","id"]
         return (
             Query(base_query)
             .return_fields(*return_fields)
@@ -341,6 +341,7 @@ class Redis(VectorStore):
                     page_content=result.content, metadata=json.loads(result.metadata)
                 ),
                 float(result.vector_score),
+                result.id
             )
             for result in results.docs
         ]

--- a/langchain/vectorstores/redis.py
+++ b/langchain/vectorstores/redis.py
@@ -256,7 +256,7 @@ class Redis(VectorStore):
             List[Document]: A list of documents that are most similar to the query text.
         """
         docs_and_scores = self.similarity_search_with_score(query, k=k)
-        return [doc for doc, _ in docs_and_scores]
+        return [doc for doc,_,_ in docs_and_scores]
 
     def similarity_search_limit_score(
         self, query: str, k: int = 4, score_threshold: float = 0.2, **kwargs: Any
@@ -283,7 +283,7 @@ class Redis(VectorStore):
 
         """
         docs_and_scores = self.similarity_search_with_score(query, k=k)
-        return [doc for doc, score in docs_and_scores if score < score_threshold]
+        return [doc for doc,score,_ in docs_and_scores if score < score_threshold]
 
     def _prepare_query(self, k: int) -> Query:
         try:
@@ -309,7 +309,7 @@ class Redis(VectorStore):
 
     def similarity_search_with_score(
         self, query: str, k: int = 4
-    ) -> List[Tuple[Document, float]]:
+    ) -> List[Tuple[Document, float, str]]:
         """Return docs most similar to query.
 
         Args:
@@ -364,7 +364,7 @@ class Redis(VectorStore):
                 " Redis constructor to normalize scores"
             )
         docs_and_scores = self.similarity_search_with_score(query, k=k)
-        return [(doc, self.relevance_score_fn(score)) for doc, score in docs_and_scores]
+        return [(doc, self.relevance_score_fn(score)) for doc, score,_ in docs_and_scores]
 
     @classmethod
     def from_texts_return_keys(


### PR DESCRIPTION


Replace this comment with:
  - Description: change consists retrieval of document id from redis search for semantic search of redis vectorstore
  - Issue: It helps to gather the document id for further processing of the filtered data in redis database
  - Dependencies: no dependancies
  - Tag maintainer: @rlancemartin, @eyurtsev


