### PR TITLE
update MosaicML inputs and outputs

### DIFF
--- a/docs/extras/modules/data_connection/text_embedding/integrations/openai.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/openai.ipynb
@@ -121,14 +121,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56b327cc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "aaad49f8",
    "metadata": {},
    "outputs": [],
@@ -136,49 +128,13 @@
     "# if you are behind an explicit proxy, you can use the OPENAI_PROXY environment variable to pass through\n",
     "os.environ[\"OPENAI_PROXY\"] = \"http://proxy.yourcompany.com:8080\""
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "9446c288",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "docs = [text] * 5"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4e8d4873",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "b2afbb90",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "res = embeddings.embed_documents([text * 200], chunk_size=10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7397f4d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "Python 3.11.1 64-bit",
    "language": "python",
-   "name": "venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -190,7 +146,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.1"
   },
   "vscode": {
    "interpreter": {

--- a/docs/extras/modules/data_connection/text_embedding/integrations/openai.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/openai.ipynb
@@ -121,6 +121,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "56b327cc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "aaad49f8",
    "metadata": {},
    "outputs": [],
@@ -128,13 +136,49 @@
     "# if you are behind an explicit proxy, you can use the OPENAI_PROXY environment variable to pass through\n",
     "os.environ[\"OPENAI_PROXY\"] = \"http://proxy.yourcompany.com:8080\""
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "9446c288",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs = [text] * 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e8d4873",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b2afbb90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = embeddings.embed_documents([text * 200], chunk_size=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7397f4d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.11.1 64-bit",
+   "display_name": "venv",
    "language": "python",
-   "name": "python3"
+   "name": "venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -146,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.3"
   },
   "vscode": {
    "interpreter": {

--- a/langchain/llms/mosaicml.py
+++ b/langchain/llms/mosaicml.py
@@ -122,7 +122,7 @@ class MosaicML(LLM):
 
         prompt = self._transform_prompt(prompt)
 
-        payload = {"input_strings": [prompt]}
+        payload = {"inputs": [prompt]}
         payload.update(_model_kwargs)
         payload.update(kwargs)
 
@@ -160,15 +160,15 @@ class MosaicML(LLM):
             # The inference API has changed a couple of times, so we add some handling
             # to be robust to multiple response formats.
             if isinstance(parsed_response, dict):
-                if "data" in parsed_response:
-                    output_item = parsed_response["data"]
-                elif "output" in parsed_response:
-                    output_item = parsed_response["output"]
+                output_keys = ["data", "output", "outputs"]
+                for key in output_keys:
+                    if key in parsed_response:
+                        output_item = parsed_response[key]
+                        break
                 else:
                     raise ValueError(
-                        f"No key data or output in response: {parsed_response}"
+                        f"No valid key ({', '.join(output_keys)}) in response: {parsed_response}"
                     )
-
                 if isinstance(output_item, list):
                     text = output_item[0]
                 else:

--- a/langchain/llms/mosaicml.py
+++ b/langchain/llms/mosaicml.py
@@ -167,7 +167,8 @@ class MosaicML(LLM):
                         break
                 else:
                     raise ValueError(
-                        f"No valid key ({', '.join(output_keys)}) in response: {parsed_response}"
+                        f"No valid key ({', '.join(output_keys)}) in response:"
+                        f" {parsed_response}"
                     )
                 if isinstance(output_item, list):
                     text = output_item[0]


### PR DESCRIPTION
As of today (July 7, 2023), the [MosaicML API](https://docs.mosaicml.com/en/latest/inference.html#text-completion-requests) uses `"inputs"` for the prompt

![image](https://github.com/hwchase17/langchain/assets/6849766/58b1fb1b-a11d-4f28-8b7a-03b36b9df2d8)

but we have

https://github.com/hwchase17/langchain/blob/0ed2da70200ada39f5319f604b4c5248bc98e81b/langchain/llms/mosaicml.py#L125

Furthermore, the output should be inside the `"outputs"` key

![image](https://github.com/hwchase17/langchain/assets/6849766/d60190d4-0e01-4ea1-9ff4-a7f1bb105aa4)

but we have

https://github.com/hwchase17/langchain/blob/0ed2da70200ada39f5319f604b4c5248bc98e81b/langchain/llms/mosaicml.py#L163-L170

This PR adds support for this new format.

`<rant>`
It is beyond me, why they apparently have versioned their API (endpoints look like `https://models.hosted-on.mosaicml.hosting/mpt-7b-instruct/v1/predict`; note the `v1` in there), but just keep changing the API without upping the version number. There is a good reason for
https://github.com/hwchase17/langchain/blob/0ed2da70200ada39f5319f604b4c5248bc98e81b/langchain/llms/mosaicml.py#L160-L161
`</rant>`

CC @hwchase17, @baskaryan