### PR TITLE
Fix buggy output from GraphQAChain

### DIFF
--- a/langchain/chains/graph_qa/base.py
+++ b/langchain/chains/graph_qa/base.py
@@ -79,7 +79,6 @@ class GraphQAChain(Chain):
         for entity in entities:
             all_triplets.extend(self.graph.get_entity_knowledge(entity))
         context = "\n".join(all_triplets)
-
         _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
         _run_manager.on_text(context, color="green", end="\n", verbose=self.verbose)
         result = self.qa_chain(

--- a/langchain/chains/graph_qa/base.py
+++ b/langchain/chains/graph_qa/base.py
@@ -75,9 +75,11 @@ class GraphQAChain(Chain):
         )
         entities = get_entities(entity_string)
         context = ""
+        all_triplets = []
         for entity in entities:
-            triplets = self.graph.get_entity_knowledge(entity)
-            context += "\n".join(triplets) + "\n"
+            all_triplets.extend(self.graph.get_entity_knowledge(entity))
+        context = "\n".join(all_triplets)
+
         _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
         _run_manager.on_text(context, color="green", end="\n", verbose=self.verbose)
         result = self.qa_chain(

--- a/langchain/chains/graph_qa/base.py
+++ b/langchain/chains/graph_qa/base.py
@@ -77,7 +77,7 @@ class GraphQAChain(Chain):
         context = ""
         for entity in entities:
             triplets = self.graph.get_entity_knowledge(entity)
-            context += "\n".join(triplets)
+            context += "\n".join(triplets) + "\n"
         _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
         _run_manager.on_text(context, color="green", end="\n", verbose=self.verbose)
         result = self.qa_chain(


### PR DESCRIPTION
fixes https://github.com/hwchase17/langchain/issues/7289
A simple fix of the buggy output of `graph_qa`. If we have several entities with triplets then the last entry of `triplets` for a given entity merges with the first entry of the `triplets` of the next entity.

## Example
```
from langchain.llms import OpenAI
from langchain.indexes import GraphIndexCreator
from langchain.chains import GraphQAChain
from langchain.prompts import PromptTemplate
import os

text = "Apple announced the Vision Pro in 2023."

openai_api_key = os.getenv("OPENAI_API_KEY")

index_creator = GraphIndexCreator(llm=OpenAI(openai_api_key=openai_api_key, temperature=0))
graph = index_creator.from_text(text)
chain = GraphQAChain.from_llm(
    OpenAI(temperature=0, openai_api_key=openai_api_key),
    graph=graph, 
    verbose=True
)

chain.run("When did Apple announce the Vision Pro?")

# output pre-fix
Entities Extracted:
Apple, Vision Pro
Full Context:
Apple announced Vision ProVision Pro was announced in 2023

> Finished chain.

# output post-fix
Entities Extracted:
Apple, Vision Pro
Full Context:
Apple announced Vision Pro
Vision Pro was announced in 2023


> Finished chain.

```


@baskaryan
