### PR TITLE
Add OpenAI organization ID to docs

### DIFF
--- a/docs/extras/modules/model_io/models/chat/integrations/openai.ipynb
+++ b/docs/extras/modules/model_io/models/chat/integrations/openai.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "522686de",
    "metadata": {
     "tags": []
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "62e0dbc3",
    "metadata": {
     "tags": []
@@ -42,24 +42,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4e5fe97e",
+   "metadata": {},
+   "source": [
+    "The above cell assumes that your OpenAI API key is set in your environment variables. If you would rather manually specify your API key and/or organization ID, use the following cell:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
+   "id": "396196f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat = ChatOpenAI(temperature=0, openai_api_key=\"YOUR_API_KEY\", openai_organization=\"YOUR_ORGANIZATION_ID\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ce16ad78-8e6f-48cd-954e-98be75eb5836",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AIMessage(content=\"J'aime programmer.\", additional_kwargs={}, example=False)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "messages = [\n",
     "    SystemMessage(\n",
@@ -84,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "180c5cc8",
    "metadata": {},
    "outputs": [],
@@ -99,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "fbb043e6",
    "metadata": {
     "tags": []
@@ -108,10 +115,10 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content=\"J'adore la programmation.\", additional_kwargs={})"
+       "AIMessage(content=\"J'adore la programmation.\", additional_kwargs={}, example=False)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/model_io/models/chat/integrations/openai.ipynb
+++ b/docs/extras/modules/model_io/models/chat/integrations/openai.ipynb
@@ -50,7 +50,8 @@
     "\n",
     "```python\n",
     "chat = ChatOpenAI(temperature=0, openai_api_key=\"YOUR_API_KEY\", openai_organization=\"YOUR_ORGANIZATION_ID\")\n",
-    "```"
+    "```\n",
+    "Remove the openai_organization parameter should it not apply to you."
    ]
   },
   {

--- a/docs/extras/modules/model_io/models/chat/integrations/openai.ipynb
+++ b/docs/extras/modules/model_io/models/chat/integrations/openai.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "522686de",
    "metadata": {
     "tags": []
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "62e0dbc3",
    "metadata": {
     "tags": []
@@ -46,27 +46,32 @@
    "id": "4e5fe97e",
    "metadata": {},
    "source": [
-    "The above cell assumes that your OpenAI API key is set in your environment variables. If you would rather manually specify your API key and/or organization ID, use the following cell:"
+    "The above cell assumes that your OpenAI API key is set in your environment variables. If you would rather manually specify your API key and/or organization ID, use the following code:\n",
+    "\n",
+    "```python\n",
+    "chat = ChatOpenAI(temperature=0, openai_api_key=\"YOUR_API_KEY\", openai_organization=\"YOUR_ORGANIZATION_ID\")\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "396196f6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chat = ChatOpenAI(temperature=0, openai_api_key=\"YOUR_API_KEY\", openai_organization=\"YOUR_ORGANIZATION_ID\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "ce16ad78-8e6f-48cd-954e-98be75eb5836",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=\"J'adore la programmation.\", additional_kwargs={}, example=False)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "messages = [\n",
     "    SystemMessage(\n",
@@ -91,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "180c5cc8",
    "metadata": {},
    "outputs": [],
@@ -106,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "fbb043e6",
    "metadata": {
     "tags": []
@@ -118,7 +123,7 @@
        "AIMessage(content=\"J'adore la programmation.\", additional_kwargs={}, example=False)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/extras/modules/model_io/models/llms/integrations/openai.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/openai.ipynb
@@ -29,19 +29,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "129a3275",
-   "metadata": {},
-   "source": [
-    "Should you need to specify your organization ID, you can use the following cell. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your default organization [here](https://platform.openai.com/account/api-keys).\n",
-    "\n",
-    "To specify your organization, you can use this:\n",
-    "```python\n",
-    "OPENAI_ORGANIZATION = getpass()\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "5472a7cd-af26-48ca-ae9b-5f6ae73c74d2",
@@ -57,11 +44,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "beba5985",
+   "id": "129a3275",
    "metadata": {},
    "source": [
-    "Use the following line if you need to specify your organization ID like above. Otherwise, skip this step.\n",
+    "Should you need to specify your organization ID, you can use the following cell. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your default organization [here](https://platform.openai.com/account/api-keys).\n",
+    "\n",
+    "To specify your organization, you can use this:\n",
     "```python\n",
+    "OPENAI_ORGANIZATION = getpass()\n",
+    "\n",
     "os.environ[\"OPENAI_ORGANIZATION\"] = OPENAI_ORGANIZATION\n",
     "```"
    ]
@@ -108,6 +99,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4fc152cd",
+   "metadata": {},
+   "source": [
+    "If you manually want to specify your OpenAI API key and/or organization ID, you can use the following:\n",
+    "```python\n",
+    "llm = OpenAI(openai_api_key=\"YOUR_API_KEY\", openai_organization=\"YOUR_ORGANIZATION_ID\")\n",
+    "```\n",
+    "Remove the openai_organization parameter should it not apply to you."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "a641dbd9",
@@ -130,7 +133,7 @@
     {
      "data": {
       "text/plain": [
-       "' Justin Beiber was born in 1994, so the NFL team that would have won the Super Bowl that year would be the San Francisco 49ers.'"
+       "' Justin Bieber was born in 1994, so the NFL team that won the Super Bowl in 1994 was the Dallas Cowboys.'"
       ]
      },
      "execution_count": 7,

--- a/docs/extras/modules/model_io/models/llms/integrations/openai.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/openai.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "5d71df86-8a17-4283-83d7-4e46e7c06c44",
    "metadata": {
     "tags": []
@@ -33,22 +33,17 @@
    "id": "129a3275",
    "metadata": {},
    "source": [
-    "Should you need to specify your organization ID, you can use the following cell. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your default organization [here](https://platform.openai.com/account/api-keys)."
+    "Should you need to specify your organization ID, you can use the following cell. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your default organization [here](https://platform.openai.com/account/api-keys).\n",
+    "\n",
+    "To specify your organization, you can use this:\n",
+    "```python\n",
+    "OPENAI_ORGANIZATION = getpass()\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d4a950cc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "OPENAI_ORGANIZATION = getpass()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "5472a7cd-af26-48ca-ae9b-5f6ae73c74d2",
    "metadata": {
     "tags": []
@@ -65,22 +60,15 @@
    "id": "beba5985",
    "metadata": {},
    "source": [
-    "Use the following cell if you need to specify your organization ID like above. Otherwise, skip this step."
+    "Use the following line if you need to specify your organization ID like above. Otherwise, skip this step.\n",
+    "```python\n",
+    "os.environ[\"OPENAI_ORGANIZATION\"] = OPENAI_ORGANIZATION\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "98eee2d6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ[\"OPENAI_ORGANIZATION\"] = OPENAI_ORGANIZATION"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "6fb585dd",
    "metadata": {
     "tags": []
@@ -93,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "035dea0f",
    "metadata": {
     "tags": []
@@ -109,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "3f3458d9",
    "metadata": {
     "tags": []
@@ -121,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "a641dbd9",
    "metadata": {
     "tags": []
@@ -133,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "9f844993",
    "metadata": {
     "tags": []
@@ -142,10 +130,10 @@
     {
      "data": {
       "text/plain": [
-       "' Justin Bieber was born in 1994, so the NFL team that won the Super Bowl in that year was the Dallas Cowboys.'"
+       "' Justin Beiber was born in 1994, so the NFL team that would have won the Super Bowl that year would be the San Francisco 49ers.'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -166,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "55142cec",
    "metadata": {},
    "outputs": [],
@@ -191,7 +179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {

--- a/docs/extras/modules/model_io/models/llms/integrations/openai.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/openai.ipynb
@@ -14,20 +14,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5d71df86-8a17-4283-83d7-4e46e7c06c44",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get a token: https://platform.openai.com/account/api-keys\n",
     "\n",
@@ -37,8 +29,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "129a3275",
+   "metadata": {},
+   "source": [
+    "Should you need to specify your organization ID, you can use the following cell. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your default organization [here](https://platform.openai.com/account/api-keys)."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "id": "d4a950cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OPENAI_ORGANIZATION = getpass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5472a7cd-af26-48ca-ae9b-5f6ae73c74d2",
    "metadata": {
     "tags": []
@@ -51,8 +61,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "beba5985",
+   "metadata": {},
+   "source": [
+    "Use the following cell if you need to specify your organization ID like above. Otherwise, skip this step."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "id": "98eee2d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"OPENAI_ORGANIZATION\"] = OPENAI_ORGANIZATION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "6fb585dd",
    "metadata": {
     "tags": []
@@ -65,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "035dea0f",
    "metadata": {
     "tags": []
@@ -81,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "3f3458d9",
    "metadata": {
     "tags": []
@@ -93,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "a641dbd9",
    "metadata": {
     "tags": []
@@ -114,7 +142,7 @@
     {
      "data": {
       "text/plain": [
-       "' Justin Bieber was born in 1994, so we are looking for the Super Bowl winner from that year. The Super Bowl in 1994 was Super Bowl XXVIII, and the winner was the Dallas Cowboys.'"
+       "' Justin Bieber was born in 1994, so the NFL team that won the Super Bowl in that year was the Dallas Cowboys.'"
       ]
      },
      "execution_count": 10,

--- a/docs/snippets/get_started/quickstart/openai_setup.mdx
+++ b/docs/snippets/get_started/quickstart/openai_setup.mdx
@@ -10,10 +10,24 @@ Accessing the API requires an API key, which you can get by creating an account 
 export OPENAI_API_KEY="..."
 ```
 
+Should you need to specify a Organization ID, you can set the environment variable by running:
+
+```bash
+export OPENAI_ORGANIZATION="..."
+```
+
 If you'd prefer not to set an environment variable you can pass the key in directly via the `openai_api_key` named parameter when initiating the OpenAI LLM class:
 
 ```python
 from langchain.llms import OpenAI
 
 llm = OpenAI(openai_api_key="...")
+```
+
+Similarly, you can set the organization ID via the `openai_organization` named parameter:
+
+```python
+from langchain.llms import OpenAI
+
+llm = OpenAI(openai_api_key="...", openai_organization="...")
 ```

--- a/docs/snippets/get_started/quickstart/openai_setup.mdx
+++ b/docs/snippets/get_started/quickstart/openai_setup.mdx
@@ -10,24 +10,10 @@ Accessing the API requires an API key, which you can get by creating an account 
 export OPENAI_API_KEY="..."
 ```
 
-Should you need to specify a Organization ID, you can set the environment variable by running:
-
-```bash
-export OPENAI_ORGANIZATION="..."
-```
-
 If you'd prefer not to set an environment variable you can pass the key in directly via the `openai_api_key` named parameter when initiating the OpenAI LLM class:
 
 ```python
 from langchain.llms import OpenAI
 
 llm = OpenAI(openai_api_key="...")
-```
-
-Similarly, you can set the organization ID via the `openai_organization` named parameter:
-
-```python
-from langchain.llms import OpenAI
-
-llm = OpenAI(openai_api_key="...", openai_organization="...")
 ```


### PR DESCRIPTION
Description: I added an example of how to reference the OpenAI API Organization ID, because I couldn't find it before. In the example, it is mentioned how to achieve this using environment variables as well as parameters for the OpenAI()-class
Issue: -
Dependencies: -
Tag maintainer: @baskaryan
Twitter @schop-rob