### PR TITLE
docs(retrievers/get-started): Fix broken state_of_the_union.txt link

### DIFF
--- a/docs/snippets/modules/data_connection/retrievers/get_started.mdx
+++ b/docs/snippets/modules/data_connection/retrievers/get_started.mdx
@@ -66,7 +66,7 @@ from langchain.chains import RetrievalQA
 from langchain.llms import OpenAI
 ```
 
-Next in the generic setup, let's specify the document loader we want to use. You can download the `state_of_the_union.txt` file [here](https://github.com/hwchase17/langchain/blob/master/docs/modules/state_of_the_union.txt)
+Next in the generic setup, let's specify the document loader we want to use. You can download the `state_of_the_union.txt` file [here](https://github.com/hwchase17/langchain/blob/master/docs/extras/modules/state_of_the_union.txt)
 
 
 ```python


### PR DESCRIPTION
Thank you for this awesome library.

- Description: Fix broken link in documentation 
- Issue:
  - https://python.langchain.com/docs/modules/data_connection/retrievers/#get-started
  - <img width="786" alt="image" src="https://github.com/hwchase17/langchain/assets/21273221/d8bd15dd-e73e-48b9-b034-2fdbcd0cbaea">
  - Click *here*, then see "File not found"
  - the URL: https://github.com/hwchase17/langchain/blob/master/docs/modules/state_of_the_union.txt
  - I think the right one is https://github.com/hwchase17/langchain/blob/master/docs/extras/modules/state_of_the_union.txt
- Dependencies: -
- Tag maintainer: @baskaryan
- Twitter handle: -

<!-- 
If no one reviews your PR within a few days, feel free to @-mention the same people again.
 -->
