### PR TITLE
update cube_semantic.py

### DIFF
--- a/langchain/document_loaders/cube_semantic.py
+++ b/langchain/document_loaders/cube_semantic.py
@@ -50,7 +50,7 @@ class CubeSemanticLoader(BaseLoader):
         docs = []
 
         for cube in cubes:
-            if cube.get("type") != "view":
+            if cube.get("type") == "view":
                 continue
 
             cube_name = cube.get("name")


### PR DESCRIPTION
changed condition to  "continue" only if type == view or else get the cube,measure and dimension values from dict


  - Description: changed condition to  "continue" only if type == view or else get the cube,measure and dimension values 
                         from dictionary, 
  - Issue: the issue was that the condition type!=view will meet the condition and skip all iterations because of the "continue" thus not extracting cube_name,dimension and measures from the cube iterator,
  - Dependencies: no dependencies,
  - Tag maintainer: @rlancemartin, @eyurtsev,
  - Twitter handle: I am fine without any mention haha. 


If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
