### PR TITLE
Fix syntax erros in documentation

### DIFF
--- a/langchain/vectorstores/milvus.py
+++ b/langchain/vectorstores/milvus.py
@@ -89,9 +89,9 @@ class Milvus(VectorStore):
         embedding = OpenAIEmbeddings()
         # Connect to a milvus instance on localhost
         milvus_store = Milvus(
-            embedding_function: Embeddings,
+            embedding_function = Embeddings,
             collection_name = "LangChainCollection",
-            drop_old: True,
+            drop_old = True,
         )
 
     Raises:


### PR DESCRIPTION

- Description: Tiny documentation fix. In Python, when defining function parameters or providing arguments to a function or class constructor, we do not use the `:` character.
- Issue: N/A
- Dependencies: N/A,
- Tag maintainer: @rlancemartin, @eyurtsev
- Twitter handle: @mogaal

