### PR TITLE
docs(agents/toolkits): Fix error in document_comparison_toolkit.ipynb

### DIFF
--- a/docs/extras/modules/agents/toolkits/document_comparison_toolkit.ipynb
+++ b/docs/extras/modules/agents/toolkits/document_comparison_toolkit.ipynb
@@ -17,16 +17,7 @@
    "execution_count": 1,
    "id": "8632a37c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/harrisonchase/.pyenv/versions/3.9.1/envs/langchain/lib/python3.9/site-packages/deeplake/util/check_latest_version.py:32: UserWarning: A newer version of deeplake (3.6.5) is available. It's recommended that you update to the latest version using `pip install -U deeplake`.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pydantic import BaseModel, Field\n",
     "\n",


### PR DESCRIPTION
Replace this comment with:
  - Description: Removes unneeded output warning in documentation at https://python.langchain.com/docs/modules/agents/toolkits/document_comparison_toolkit
  - Issue: -
  - Dependencies: -
  - Tag maintainer: @baskaryan
  - Twitter handle: @finnless

