### PR TITLE
docs(agents/agent_types) Fix ReAct link index.mdx

### DIFF
--- a/docs/docs_skeleton/docs/modules/agents/agent_types/index.mdx
+++ b/docs/docs_skeleton/docs/modules/agents/agent_types/index.mdx
@@ -12,7 +12,7 @@ Here are the agents available in LangChain.
 
 ### [Zero-shot ReAct](/docs/modules/agents/agent_types/react.html)
 
-This agent uses the [ReAct](https://arxiv.org/pdf/2205.00445.pdf) framework to determine which tool to use
+This agent uses the [ReAct](https://react-lm.github.io/) framework to determine which tool to use
 based solely on the tool's description. Any number of tools can be provided.
 This agent requires that a description is provided for each tool.
 


### PR DESCRIPTION
  - Description: Fix ReAct paper link which currently goes to [MRKL](https://arxiv.org/pdf/2205.00445.pdf) paper instead of the [ReAct paper](https://react-lm.github.io/). The [ReAct agent type page](https://python.langchain.com/docs/modules/agents/agent_types/react.html) links to the paper correctly.
  - Issue: -
  - Dependencies: -
  - Tag maintainer: @baskaryan
  - Twitter handle: @finnless