### PR TITLE
SelfQueryRetriever fails if lark is not installed, but the failure message is not meaningful

### DIFF
--- a/langchain/chains/query_constructor/parser.py
+++ b/langchain/chains/query_constructor/parser.py
@@ -7,12 +7,17 @@ try:
     check_package_version("lark", gte_version="1.1.5")
     from lark import Lark, Transformer, v_args
 except ImportError:
+    # Added by Rajib
+    # If lark is not installed, need to provide a meaningful
+    # error to the user to let them know to install lark
+    raise Exception("Could not import lark python package..Please install lark with pip install lark")
 
-    def v_args(*args: Any, **kwargs: Any) -> Any:  # type: ignore
-        return lambda _: None
-
-    Transformer = object  # type: ignore
-    Lark = object  # type: ignore
+    # Commented by Rajib - The below piece of code does not look relevant
+    # def v_args(*args: Any, **kwargs: Any) -> Any:  # type: ignore
+    #     return lambda _: None
+    #
+    # Transformer = object  # type: ignore
+    # Lark = object  # type: ignore
 
 from langchain.chains.query_constructor.ir import (
     Comparator,

--- a/langchain/chains/query_constructor/parser.py
+++ b/langchain/chains/query_constructor/parser.py
@@ -7,7 +7,7 @@ try:
     check_package_version("lark", gte_version="1.1.5")
     from lark import Lark, Transformer, v_args
 except ImportError:
-    # Added by Rajib
+    # Added by Rajib - to include import error
     # If lark is not installed, need to provide a meaningful
     # error to the user to let them know to install lark
     raise Exception("Could not import lark python package..Please install lark with pip install lark")


### PR DESCRIPTION
  - Description: When we execute SelfQueryRetriever, it will fail if lark is not imported. But the failure message is not meaningful. It just says "TypeError: 'NoneType' object is not callable". This change will provide a meaningful message to import lark
  - Issue: N/A
  - Dependencies: None
  - Tag maintainer: @rlancemartin, @eyurtsev
  - Twitter handle: N/A