### PR TITLE
Add spacy sentencizer

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -34,19 +34,19 @@ logger = logging.getLogger(__name__)
 TS = TypeVar("TS", bound="TextSplitter")
 
 
-def _make_spacy_pipeline_for_splitting(pipeline: str) -> object:  # avoid importing spacy
+def _make_spacy_pipeline_for_splitting(pipeline: str) -> Any:  # avoid importing spacy
     try:
         import spacy
     except ImportError:
         raise ImportError(
             "Spacy is not installed, please install it with `pip install spacy`."
         )
-    if pipeline == 'sentencizer':
+    if pipeline == "sentencizer":
         from spacy.lang.en import English
         sentencizer = English()
         sentencizer.add_pipe("sentencizer")
     else:
-        sentencizer = spacy.load(pipeline, disable=['ner'])
+        sentencizer = spacy.load(pipeline, disable=["ner"])
     return sentencizer
 
 

--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -1026,8 +1026,12 @@ class NLTKTextSplitter(TextSplitter):
 
 
 class SpacyTextSplitter(TextSplitter):
-    """Implementation of splitting text that looks at sentences using Spacy."""
+    """Implementation of splitting text that looks at sentences using Spacy.
 
+    
+    Per default, Spacy's `en_core_web_sm` model is used. For a faster, but
+    potentially less accurate splitting, you can use `pipeline='sentencizer'`.
+    """
     def __init__(
         self, separator: str = "\n\n", pipeline: str = "en_core_web_sm", **kwargs: Any
     ) -> None:

--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -43,6 +43,7 @@ def _make_spacy_pipeline_for_splitting(pipeline: str) -> Any:  # avoid importing
         )
     if pipeline == "sentencizer":
         from spacy.lang.en import English
+
         sentencizer = English()
         sentencizer.add_pipe("sentencizer")
     else:
@@ -1028,10 +1029,11 @@ class NLTKTextSplitter(TextSplitter):
 class SpacyTextSplitter(TextSplitter):
     """Implementation of splitting text that looks at sentences using Spacy.
 
-    
+
     Per default, Spacy's `en_core_web_sm` model is used. For a faster, but
     potentially less accurate splitting, you can use `pipeline='sentencizer'`.
     """
+
     def __init__(
         self, separator: str = "\n\n", pipeline: str = "en_core_web_sm", **kwargs: Any
     ) -> None:
@@ -1072,4 +1074,3 @@ class LatexTextSplitter(RecursiveCharacterTextSplitter):
         """Initialize a LatexTextSplitter."""
         separators = self.get_separators_for_language(Language.LATEX)
         super().__init__(separators=separators, **kwargs)
-

--- a/tests/integration_tests/test_nlp_text_splitters.py
+++ b/tests/integration_tests/test_nlp_text_splitters.py
@@ -26,8 +26,8 @@ def test_nltk_text_splitter() -> None:
     assert output == expected_output
 
 
-@pytest.mark.parametrize('pipeline', ['sentencizer', 'en_core_web_sm'])
-def test_spacy_text_splitter(pipeline) -> None:
+@pytest.mark.parametrize("pipeline", ["sentencizer", "en_core_web_sm"])
+def test_spacy_text_splitter(pipeline: str) -> None:
     """Test splitting by sentence using Spacy."""
     text = "This is sentence one. And this is sentence two."
     separator = "|||"

--- a/tests/integration_tests/test_nlp_text_splitters.py
+++ b/tests/integration_tests/test_nlp_text_splitters.py
@@ -26,11 +26,13 @@ def test_nltk_text_splitter() -> None:
     assert output == expected_output
 
 
-def test_spacy_text_splitter() -> None:
+@pytest.mark.parametrize('pipeline', ['sentencizer'])#, 'en_core_web_sm'])
+def test_spacy_text_splitter(pipeline) -> None:
     """Test splitting by sentence using Spacy."""
     text = "This is sentence one. And this is sentence two."
     separator = "|||"
-    splitter = SpacyTextSplitter(separator=separator)
+    splitter = SpacyTextSplitter(separator=separator, pipeline=pipeline)
     output = splitter.split_text(text)
     expected_output = [f"This is sentence one.{separator}And this is sentence two."]
     assert output == expected_output
+

--- a/tests/integration_tests/test_nlp_text_splitters.py
+++ b/tests/integration_tests/test_nlp_text_splitters.py
@@ -35,4 +35,3 @@ def test_spacy_text_splitter(pipeline: str) -> None:
     output = splitter.split_text(text)
     expected_output = [f"This is sentence one.{separator}And this is sentence two."]
     assert output == expected_output
-

--- a/tests/integration_tests/test_nlp_text_splitters.py
+++ b/tests/integration_tests/test_nlp_text_splitters.py
@@ -26,7 +26,7 @@ def test_nltk_text_splitter() -> None:
     assert output == expected_output
 
 
-@pytest.mark.parametrize('pipeline', ['sentencizer'])#, 'en_core_web_sm'])
+@pytest.mark.parametrize('pipeline', ['sentencizer', 'en_core_web_sm'])
 def test_spacy_text_splitter(pipeline) -> None:
     """Test splitting by sentence using Spacy."""
     text = "This is sentence one. And this is sentence two."


### PR DESCRIPTION
`SpacyTextSplitter` currently uses spacy's statistics-based `en_core_web_sm` model for sentence splitting. This is a good splitter, but it's also pretty slow, and in this case it's doing a lot of work that's not needed given that the spacy parse is then just thrown away.
However, there is also a simple rules-based spacy sentencizer. Using this is at least an order of magnitude faster than using `en_core_web_sm` according to my local tests.
Also, spacy sentence tokenization based on `en_core_web_sm` can be sped up in this case by not doing the NER stage. This shaves some cycles too, both when loading the model and when parsing the text.

Consequently, this PR adds the option to use the basic spacy sentencizer, and it disables the NER stage for the current approach, *which is kept as the default*.

Lastly, when extracting the tokenized sentences, the `text` attribute is called directly instead of doing the string conversion, which is IMO a bit more idiomatic.

@baskaryan