### PR TITLE
Fixes KeyError in AmazonKendraRetriever initializer

### DIFF
--- a/langchain/retrievers/kendra.py
+++ b/langchain/retrievers/kendra.py
@@ -188,7 +188,7 @@ class AmazonKendraRetriever(BaseRetriever):
 
     @root_validator(pre=True)
     def create_client(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if values["client"] is not None:
+        if values.get("client") is not None:
             return values
 
         try:


### PR DESCRIPTION
### Description
argument variable client is marked as required in commit 81e5b1ad362e9e6ec955b6a54776322af82050d0 which breaks the default way of initialization providing only index_id. This commit avoid KeyError exception when it is initialized without a client variable
### Dependencies
no dependency required
### Tag maintainer
@baskaryan

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
