### PR TITLE
Improvement/add finish reason to generation info in chat open ai

### DIFF
--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -388,9 +388,7 @@ class ChatOpenAI(BaseChatModel):
             message = _convert_dict_to_message(res["message"])
             gen = ChatGeneration(
                 message=message,
-                generation_info=dict(
-                    finish_reason=res.get("finish_reason")
-                )
+                generation_info=dict(finish_reason=res.get("finish_reason")),
             )
             generations.append(gen)
         llm_output = {"token_usage": response["usage"], "model_name": self.model_name}

--- a/langchain/chat_models/openai.py
+++ b/langchain/chat_models/openai.py
@@ -386,7 +386,12 @@ class ChatOpenAI(BaseChatModel):
         generations = []
         for res in response["choices"]:
             message = _convert_dict_to_message(res["message"])
-            gen = ChatGeneration(message=message)
+            gen = ChatGeneration(
+                message=message,
+                generation_info=dict(
+                    finish_reason=res.get("finish_reason")
+                )
+            )
             generations.append(gen)
         llm_output = {"token_usage": response["usage"], "model_name": self.model_name}
         return ChatResult(generations=generations, llm_output=llm_output)

--- a/langchain/schema/output.py
+++ b/langchain/schema/output.py
@@ -36,6 +36,11 @@ class ChatGeneration(Generation):
     message: BaseMessage
     """The message output by the chat model."""
 
+    generation_info: Optional[Dict[str, Any]] = None
+    """Raw response from the provider. May include things like the 
+        reason for finishing or token log probabilities.
+    """
+
     @root_validator
     def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Set the text attribute to be the contents of the message."""

--- a/langchain/schema/output.py
+++ b/langchain/schema/output.py
@@ -36,11 +36,6 @@ class ChatGeneration(Generation):
     message: BaseMessage
     """The message output by the chat model."""
 
-    generation_info: Optional[Dict[str, Any]] = None
-    """Raw response from the provider. May include things like the 
-        reason for finishing or token log probabilities.
-    """
-
     @root_validator
     def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Set the text attribute to be the contents of the message."""


### PR DESCRIPTION
Description:  ChatOpenAI model does not return finish_reason in generation_info.
Issue: #2702
Dependencies: None
Tag maintainer: @baskaryan 

Thank you