### PR TITLE
minor bug fix: properly await AsyncRunManager's  method call in MulitRouteChain

### DIFF
--- a/langchain/chains/router/base.py
+++ b/langchain/chains/router/base.py
@@ -102,7 +102,7 @@ class MultiRouteChain(Chain):
         inputs: Dict[str, Any],
         run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
     ) -> Dict[str, Any]:
-        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
         callbacks = _run_manager.get_child()
         route = await self.router_chain.aroute(inputs, callbacks=callbacks)
 

--- a/langchain/chains/router/base.py
+++ b/langchain/chains/router/base.py
@@ -106,7 +106,7 @@ class MultiRouteChain(Chain):
         callbacks = _run_manager.get_child()
         route = await self.router_chain.aroute(inputs, callbacks=callbacks)
 
-        _run_manager.on_text(
+        await _run_manager.on_text(
             str(route.destination) + ": " + str(route.next_inputs), verbose=self.verbose
         )
         if not route.destination:


### PR DESCRIPTION
This simply awaits `AsyncRunManager`'s method call in `MulitRouteChain`.  Noticed this while playing around with Langchain's implementation of `MultiPromptChain`.  @baskaryan 

cheers
