### PR TITLE
Fix AsyncFinalIteratorCallbackHandler's token yield issue with streaming enabled

### DIFF
--- a/langchain/callbacks/streaming_aiter_final_only.py
+++ b/langchain/callbacks/streaming_aiter_final_only.py
@@ -83,6 +83,6 @@ class AsyncFinalIteratorCallbackHandler(AsyncIteratorCallbackHandler):
                     self.queue.put_nowait(t)
             return
 
-        # If yes, then put tokens from now on
-        if self.answer_reached:
+        # If answer is not yet reached, then put the token in the queue
+        if not self.answer_reached:
             self.queue.put_nowait(token)


### PR DESCRIPTION
When utilizing the AsyncFinalIteratorCallbackHandler in conjunction with streaming functionality, the handler.aiter() failed to yield new tokens that were being generated.

@agola11

The code snippet provided below highlights the issue:

```python
async def wrap_done(fn: Awaitable, event: asyncio.Event):
    try:
        await fn
    except Exception:
        print("Exception in wrap_done")
    finally:
        event.set()

async def create_query_handler(query: str) -> AsyncIterable[str]:
    tools = []
    handler = AsyncFinalIteratorCallbackHandler()
    llm = ChatOpenAI(temperature=0, model="gpt-3.5-turbo", verbose=True, streaming=True, callbacks=[
        handler
    ])
    agent = initialize_agent(tools=tools, llm=llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=True)
    template = PromptTemplate.from_template("".join([
        "You're are Jeff. Please respond to my queries and then laugh at me"  
    ]))

    task = asyncio.create_task(wrap_done(
        agent.arun(template.format(query=query, podcast_name=namespace)),
        handler.done)
    )

    async for token in handler.aiter():
        print(token, end="")
        yield f"data: {token}\n\n"

    await task
```
