### PR TITLE
HuggingFaceEndpoint incorrectly assumes that the endpoint returns the prompt prepended to the response

### DIFF
--- a/langchain/llms/huggingface_endpoint.py
+++ b/langchain/llms/huggingface_endpoint.py
@@ -136,10 +136,7 @@ class HuggingFaceEndpoint(LLM):
             raise ValueError(
                 f"Error raised by inference API: {generated_text['error']}"
             )
-        if self.task == "text-generation":
-            # Text generation return includes the starter text.
-            text = generated_text[0]["generated_text"][len(prompt) :]
-        elif self.task == "text2text-generation":
+        if self.task == "text-generation" or self.task == "text2text-generation":
             text = generated_text[0]["generated_text"]
         elif self.task == "summarization":
             text = generated_text[0]["summary_text"]


### PR DESCRIPTION
  - Description: HuggingFaceEndpoint truncates the text because it assumes the endpoint returns the prompt together with generated text (but that's not the case, so the the code wrongly truncates the answer)
  - Issue: Fixes #7353 
  - Dependencies: None
  - Tag maintainer: @baskaryan
  - Twitter handle: @juanan

This issue has also been discussed here:
https://huggingface.co/tiiuae/falcon-40b-instruct/discussions/51