### PR TITLE
Fix broken link from Marqo Ecosystem

### DIFF
--- a/docs/extras/ecosystem/integrations/marqo.md
+++ b/docs/extras/ecosystem/integrations/marqo.md
@@ -28,4 +28,4 @@ To import this vectorstore:
 from langchain.vectorstores import Marqo
 ```
 
-For a more detailed walkthrough of the Marqo wrapper and some of its unique features, see [this notebook](../modules/data_connection/vectorstores/integrations/marqo.ipynb)
+For a more detailed walkthrough of the Marqo wrapper and some of its unique features, see [this notebook](/docs/modules/data_connection/vectorstores/integrations/marqo.html)


### PR DESCRIPTION
Small fix to a link from the Marqo page in the ecosystem.

The link was not updated correctly when the documentation structure changed to html pages instead of links to notebooks.
