### PR TITLE
Update chat agents' output parser to extract action by regex

### DIFF
--- a/tests/unit_tests/agents/test_chat.py
+++ b/tests/unit_tests/agents/test_chat.py
@@ -1,0 +1,47 @@
+"""Unittests for langchain.agents.chat package."""
+from typing import Tuple
+
+from langchain.agents.chat.output_parser import ChatOutputParser
+from langchain.schema import AgentAction
+
+output_parser = ChatOutputParser()
+
+
+def get_action_and_input(text: str) -> Tuple[str, str]:
+    output = output_parser.parse(text)
+    if isinstance(output, AgentAction):
+        return output.tool, str(output.tool_input)
+    else:
+        return "Final Answer", output.return_values["output"]
+
+
+def test_parse_with_language() -> None:
+    llm_output = """I can use the `foo` tool to achieve the goal.
+
+    Action:
+    ```json
+    {
+      "action": "foo",
+      "action_input": "bar"
+    }
+    ```
+    """
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "foo"
+    assert action_input == "bar"
+
+
+def test_parse_without_language() -> None:
+    llm_output = """I can use the `foo` tool to achieve the goal.
+
+    Action:
+    ```
+    {
+      "action": "foo",
+      "action_input": "bar"
+    }
+    ```
+    """
+    action, action_input = get_action_and_input(llm_output)
+    assert action == "foo"
+    assert action_input == "bar"


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->

Currently `ChatOutputParser` extracts actions by splitting the text on "```", and then load the second part as a json string.

But sometimes the LLM will wrap the action in markdown code block like:

````markdown
```json
{
  "action": "foo",
  "action_input": "bar"
}
```
````

Splitting text on "```" will cause `OutputParserException` in such case.

This PR changes the behaviour to extract the `$JSON_BLOB` by regex, so that it can handle both ` ``` ``` ` and ` ```json ``` `

@hinthornw
