### PR TITLE
[Minor] Remove tagger from spacy sentencizer

### DIFF
--- a/langchain/text_splitter.py
+++ b/langchain/text_splitter.py
@@ -47,7 +47,7 @@ def _make_spacy_pipeline_for_splitting(pipeline: str) -> Any:  # avoid importing
         sentencizer = English()
         sentencizer.add_pipe("sentencizer")
     else:
-        sentencizer = spacy.load(pipeline, disable=["ner"])
+        sentencizer = spacy.load(pipeline, exclude=["ner", "tagger"])
     return sentencizer
 
 


### PR DESCRIPTION
@svlandeg gave me a tip for how to improve a bit on https://github.com/hwchase17/langchain/pull/7442 for some extra speed and memory gains. The tagger isn't needed for sentencization, so can be disabled too.

@baskaryan
