### PR TITLE
clarify about api key

### DIFF
--- a/langchain/chat_models/jinachat.py
+++ b/langchain/chat_models/jinachat.py
@@ -109,7 +109,8 @@ class JinaChat(BaseChatModel):
     image chat capabilities in comparison to other LLM APIs.
 
     To use, you should have the ``openai`` python package installed, and the
-    environment variable ``JINACHAT_API_KEY`` set with your API key.
+    environment variable ``JINACHAT_API_KEY`` set to your API key, which you
+    can generate at https://chat.jina.ai/api.
 
     Any parameters that are valid to be passed to the openai.create call can be passed
     in, even if not explicitly saved on this class.


### PR DESCRIPTION
I found it unclear, where to get the API keys for JinaChat. Mentioning this in the docstring should be helpful.
#7490 

Twitter handle: benji1a

@delgermurun

