### PR TITLE
Add into chat agent prompt to not prefix json blob with "json"

### DIFF
--- a/langchain/agents/chat/prompt.py
+++ b/langchain/agents/chat/prompt.py
@@ -5,7 +5,7 @@ Specifically, this json should have a `action` key (with the name of the tool to
 
 The only values that should be in the "action" field are: {tool_names}
 
-The $JSON_BLOB should only contain a SINGLE action, do NOT return a list of multiple actions. Here is an example of a valid $JSON_BLOB:
+The $JSON_BLOB should only contain a SINGLE action, do NOT return a list of multiple actions. Do NOT prefix your response with the word json. Here is an example of a valid $JSON_BLOB:
 
 ```
 {{{{


### PR DESCRIPTION
Fix bug where LLM was prefixing action JSON with the word "json" causing agent to not be able parse the action/action_input in the JSON. 

Response from ChatOpenAI LLM was:
```
json
{
"action": "Calculator",
"action_input": "25% of 300"
}
```

Bot asked me to submit pull request for this fix to issue I filed: https://github.com/hwchase17/langchain/issues/7554

This was breaking the DeepLeaning/Langchain tutorial on Agents: https://learn.deeplearning.ai/langchain/lesson/7/agents

@hinthornw