### PR TITLE
add supported properties for notiondb document loader's metadata

### DIFF
--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -109,7 +109,7 @@ class NotionDBLoader(BaseLoader):
                 value = prop_data["url"]
             elif prop_type == "unique_id":
                 value = (
-                    f"{prop_data['unique_id']['prefix']}-{prop_data['unique_id']['number']}"
+                    f'{prop_data["unique_id"]["prefix"]}-{prop_data["unique_id"]["number"]}'
                     if prop_data["unique_id"]
                     else None
                 )

--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -114,9 +114,7 @@ class NotionDBLoader(BaseLoader):
                     else None
                 )
             elif prop_type == "status":
-                value = (
-                    prop_data["status"]["name"] if prop_data["status"] else None
-                )
+                value = prop_data["status"]["name"] if prop_data["status"] else None
             elif prop_type == "people":
                 value = (
                     [item["name"] for item in prop_data["people"]]

--- a/langchain/document_loaders/notiondb.py
+++ b/langchain/document_loaders/notiondb.py
@@ -107,6 +107,22 @@ class NotionDBLoader(BaseLoader):
                 )
             elif prop_type == "url":
                 value = prop_data["url"]
+            elif prop_type == "unique_id":
+                value = (
+                    f"{prop_data['unique_id']['prefix']}-{prop_data['unique_id']['number']}"
+                    if prop_data["unique_id"]
+                    else None
+                )
+            elif prop_type == "status":
+                value = (
+                    prop_data["status"]["name"] if prop_data["status"] else None
+                )
+            elif prop_type == "people":
+                value = (
+                    [item["name"] for item in prop_data["people"]]
+                    if prop_data["people"]
+                    else []
+                )
             else:
                 value = None
 


### PR DESCRIPTION
fix #7569

add following properties for Notion DB document loader's metadata
- `unique_id`
- `status`
- `people`

@rlancemartin, @eyurtsev (Since this is a change related to `DataLoaders`)