### PR TITLE
Return run info from run evaluator

### DIFF
--- a/langchain/evaluation/agents/trajectory_eval_chain.py
+++ b/langchain/evaluation/agents/trajectory_eval_chain.py
@@ -199,7 +199,7 @@ The following is the expected answer. Use this to measure correctness:
         llm: BaseLanguageModel,
         agent_tools: Optional[Sequence[BaseTool]] = None,
         output_parser: Optional[TrajectoryOutputParser] = None,
-        return_reasoning: bool = False,
+        return_reasoning: bool = True,
         **kwargs: Any,
     ) -> "TrajectoryEvalChain":
         """Create a TrajectoryEvalChain object from a language model chain.
@@ -325,6 +325,9 @@ The following is the expected answer. Use this to measure correctness:
         agent_trajectory: Sequence[Tuple[AgentAction, str]],
         reference: Optional[str] = None,
         callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Evaluate a trajectory.
@@ -347,7 +350,14 @@ The following is the expected answer. Use this to measure correctness:
             "answer": prediction,
             "reference": reference,
         }
-        return self(inputs=inputs, callbacks=callbacks, **kwargs)
+        return self.__call__(
+            inputs=inputs,
+            callbacks=callbacks,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
+            return_only_outputs=True,
+        )
 
     async def _aevaluate_agent_trajectory(
         self,
@@ -357,6 +367,9 @@ The following is the expected answer. Use this to measure correctness:
         agent_trajectory: Sequence[Tuple[AgentAction, str]],
         reference: Optional[str] = None,
         callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Asynchronously evaluate a trajectory.
@@ -382,5 +395,8 @@ The following is the expected answer. Use this to measure correctness:
         return await self.acall(
             inputs=inputs,
             callbacks=callbacks,
-            **kwargs,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
+            return_only_outputs=True,
         )

--- a/langchain/evaluation/comparison/eval_chain.py
+++ b/langchain/evaluation/comparison/eval_chain.py
@@ -1,7 +1,7 @@
 """Base classes for comparing the output of two models."""
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Extra, Field
 
@@ -10,7 +10,7 @@ from langchain.chains.llm import LLMChain
 from langchain.evaluation.comparison.prompt import PROMPT, PROMPT_WITH_REFERENCE
 from langchain.evaluation.schema import LLMEvalChain, PairwiseStringEvaluator
 from langchain.prompts.prompt import PromptTemplate
-from langchain.schema import BaseOutputParser
+from langchain.schema import RUN_KEY, BaseOutputParser
 from langchain.schema.language_model import BaseLanguageModel
 
 
@@ -68,7 +68,7 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
     ...        " there are two hydrogen atoms and one oxygen atom."
     ...     referenc = "The chemical formula for water is H2O.",
     ... )
-    >>> print(result["text"])
+    >>> print(result)
     # {
     #    "value": "B",
     #    "comment": "Both responses accurately state"
@@ -78,6 +78,7 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
     # }
     """
 
+    output_key: str = "results"  #: :meta private:
     output_parser: BaseOutputParser = Field(
         default_factory=PairwiseStringResultOutputParser
     )
@@ -166,6 +167,13 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
             input_["reference"] = reference
         return input_
 
+    def _prepare_output(self, result: dict) -> dict:
+        """Prepare the output."""
+        parsed = result[self.output_key]
+        if RUN_KEY in result:
+            parsed[RUN_KEY] = result[RUN_KEY]
+        return parsed
+
     def _evaluate_string_pairs(
         self,
         *,
@@ -174,6 +182,9 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
         input: Optional[str] = None,
         reference: Optional[str] = None,
         callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Evaluate whether output A is preferred to output B.
@@ -198,9 +209,11 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
         result = self(
             inputs=input_,
             callbacks=callbacks,
-            **kwargs,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
         )
-        return result["text"]
+        return self._prepare_output(result)
 
     async def _aevaluate_string_pairs(
         self,
@@ -210,6 +223,9 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
         reference: Optional[str] = None,
         input: Optional[str] = None,
         callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Asynchronously evaluate whether output A is preferred to output B.
@@ -234,6 +250,8 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
         result = await self.acall(
             inputs=input_,
             callbacks=callbacks,
-            **kwargs,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
         )
-        return result["text"]
+        return self._prepare_output(result)

--- a/langchain/evaluation/criteria/eval_chain.py
+++ b/langchain/evaluation/criteria/eval_chain.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from pydantic import Extra, Field
 
+from langchain.callbacks.manager import Callbacks
 from langchain.chains.constitutional_ai.models import ConstitutionalPrinciple
 from langchain.chains.llm import LLMChain
 from langchain.evaluation.criteria.prompt import PROMPT, PROMPT_WITH_REFERENCES
 from langchain.evaluation.schema import LLMEvalChain, StringEvaluator
-from langchain.schema import BaseOutputParser, BasePromptTemplate
+from langchain.schema import RUN_KEY, BaseOutputParser, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 
 
@@ -143,6 +144,7 @@ class CriteriaEvalChain(StringEvaluator, LLMEvalChain, LLMChain):
     """The parser to use to map the output to a structured result."""
     criterion_name: str
     """The name of the criterion being evaluated."""
+    output_key: str = "results"  #: :meta private:
 
     class Config:
         """Configuration for the QAEvalChain."""
@@ -318,12 +320,23 @@ class CriteriaEvalChain(StringEvaluator, LLMEvalChain, LLMChain):
             input_["reference"] = reference
         return input_
 
+    def _prepare_output(self, result: dict) -> dict:
+        """Prepare the output."""
+        parsed = result[self.output_key]
+        if RUN_KEY in result:
+            parsed[RUN_KEY] = result[RUN_KEY]
+        return parsed
+
     def _evaluate_strings(
         self,
         *,
         prediction: str,
         reference: Optional[str] = None,
         input: Optional[str] = None,
+        callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Evaluate a prediction against the criteria.
@@ -360,7 +373,14 @@ class CriteriaEvalChain(StringEvaluator, LLMEvalChain, LLMChain):
             )
         """
         input_ = self._get_eval_input(prediction, reference, input)
-        return self(input_, **kwargs)["text"]
+        result = self(
+            input_,
+            callbacks=callbacks,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
+        )
+        return self._prepare_output(result)
 
     async def _aevaluate_strings(
         self,
@@ -368,6 +388,10 @@ class CriteriaEvalChain(StringEvaluator, LLMEvalChain, LLMChain):
         prediction: str,
         reference: Optional[str] = None,
         input: Optional[str] = None,
+        callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Asynchronously evaluate a prediction against the criteria.
@@ -404,8 +428,14 @@ class CriteriaEvalChain(StringEvaluator, LLMEvalChain, LLMChain):
             )
         """
         input_ = self._get_eval_input(prediction, reference, input)
-        result = await self.acall(input_, **kwargs)
-        return result["text"]
+        result = await self.acall(
+            input_,
+            callbacks=callbacks,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
+        )
+        return self._prepare_output(result)
 
 
 class LabeledCriteriaEvalChain(CriteriaEvalChain):

--- a/langchain/evaluation/qa/eval_chain.py
+++ b/langchain/evaluation/qa/eval_chain.py
@@ -10,6 +10,7 @@ from langchain.callbacks.manager import Callbacks
 from langchain.chains.llm import LLMChain
 from langchain.evaluation.qa.eval_prompt import CONTEXT_PROMPT, COT_PROMPT, PROMPT
 from langchain.evaluation.schema import LLMEvalChain, StringEvaluator
+from langchain.schema import RUN_KEY
 from langchain.schema.language_model import BaseLanguageModel
 
 
@@ -43,6 +44,8 @@ def _parse_string_eval_output(text: str) -> dict:
 
 class QAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
     """LLM Chain specifically for evaluating question answering."""
+
+    output_key: str = "results"  #: :meta private:
 
     class Config:
         """Configuration for the QAEvalChain."""
@@ -114,6 +117,12 @@ class QAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
 
         return self.apply(inputs, callbacks=callbacks)
 
+    def _prepare_output(self, result: dict) -> dict:
+        parsed_result = _parse_string_eval_output(result[self.output_key])
+        if RUN_KEY in result:
+            parsed_result[RUN_KEY] = result[RUN_KEY]
+        return parsed_result
+
     def _evaluate_strings(
         self,
         *,
@@ -121,6 +130,7 @@ class QAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
         reference: Optional[str] = None,
         input: Optional[str] = None,
         callbacks: Callbacks = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """Evaluate Chain or LLM output, based on optional input and label.
@@ -131,16 +141,22 @@ class QAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
                 to evaluate against.
             input (Optional[str], optional): the input to consider during evaluation
             callbacks (Callbacks, optional): the callbacks to use for tracing.
+            include_run_info (bool, optional): whether to include run info in the
+                returned results.
             **kwargs: additional keyword arguments, including callbacks, tags, etc.
         Returns:
             dict: The evaluation results containing the score or value.
         """
-        result = self.evaluate(
-            examples=[{"query": input, "answer": reference}],
-            predictions=[{"result": prediction}],
+        result = self(
+            {
+                "query": input,
+                "answer": reference,
+                "result": prediction,
+            },
             callbacks=callbacks,
-        )[0]
-        return _parse_string_eval_output(result["text"])
+            include_run_info=include_run_info,
+        )
+        return self._prepare_output(result)
 
     async def _aevaluate_strings(
         self,
@@ -149,13 +165,15 @@ class QAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
         reference: Optional[str] = None,
         input: Optional[str] = None,
         callbacks: Callbacks = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         result = await self.acall(
             inputs={"query": input, "answer": reference, "result": prediction},
             callbacks=callbacks,
+            include_run_info=include_run_info,
         )
-        return _parse_string_eval_output(result["text"])
+        return self._prepare_output(result)
 
 
 class ContextQAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
@@ -237,20 +255,32 @@ class ContextQAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
 
         return self.apply(inputs, callbacks=callbacks)
 
+    def _prepare_output(self, result: dict) -> dict:
+        parsed_result = _parse_string_eval_output(result[self.output_key])
+        if RUN_KEY in result:
+            parsed_result[RUN_KEY] = result[RUN_KEY]
+        return parsed_result
+
     def _evaluate_strings(
         self,
         *,
         prediction: str,
         reference: Optional[str] = None,
         input: Optional[str] = None,
+        callbacks: Callbacks = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
-        result = self.evaluate(
-            examples=[{"query": input, "context": reference}],
-            predictions=[{"result": prediction}],
-            callbacks=kwargs.get("callbacks"),
-        )[0]
-        return _parse_string_eval_output(result["text"])
+        result = self(
+            {
+                "query": input,
+                "context": reference,
+                "result": prediction,
+            },
+            callbacks=callbacks,
+            include_run_info=include_run_info,
+        )
+        return self._prepare_output(result)
 
     async def _aevaluate_strings(
         self,
@@ -258,13 +288,16 @@ class ContextQAEvalChain(LLMChain, StringEvaluator, LLMEvalChain):
         prediction: str,
         reference: Optional[str] = None,
         input: Optional[str] = None,
+        callbacks: Callbacks = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         result = await self.acall(
             inputs={"query": input, "context": reference, "result": prediction},
-            callbacks=kwargs.get("callbacks"),
+            callbacks=callbacks,
+            include_run_info=include_run_info,
         )
-        return _parse_string_eval_output(result["text"])
+        return self._prepare_output(result)
 
 
 class CotQAEvalChain(ContextQAEvalChain):

--- a/langchain/evaluation/run_evaluators/string_run_evaluator.py
+++ b/langchain/evaluation/run_evaluators/string_run_evaluator.py
@@ -292,12 +292,12 @@ class StringRunEvaluatorChain(Chain, RunEvaluator):
             )
         return evaluate_strings_inputs
 
-    def _prepare_output(self, output: Dict[str, Any]) -> EvaluationResult:
+    def _prepare_output(self, output: Dict[str, Any]) -> Dict[str, Any]:
         evaluation_result = EvaluationResult(key=self.name, **output)
         if RUN_KEY in output:
             # TODO: Not currently surfaced. Update
             evaluation_result.evaluator_info[RUN_KEY] = output[RUN_KEY]
-        return evaluation_result
+        return {"feedback": evaluation_result}
 
     def _call(
         self,
@@ -311,9 +311,9 @@ class StringRunEvaluatorChain(Chain, RunEvaluator):
         chain_output = self.string_evaluator.evaluate_strings(
             **evaluate_strings_inputs,
             callbacks=callbacks,
+            include_run_info=True,
         )
-        evaluation_result = self._prepare_output(chain_output)
-        return {"feedback": evaluation_result}
+        return self._prepare_output(chain_output)
 
     async def _acall(
         self,
@@ -327,22 +327,31 @@ class StringRunEvaluatorChain(Chain, RunEvaluator):
         chain_output = await self.string_evaluator.aevaluate_strings(
             **evaluate_strings_inputs,
             callbacks=callbacks,
+            include_run_info=True,
         )
-        evaluation_result = self._prepare_output(chain_output)
-        return {"feedback": evaluation_result}
+        return self._prepare_output(chain_output)
+
+    def _prepare_evaluator_output(self, output: Dict[str, Any]) -> EvaluationResult:
+        feedback: EvaluationResult = output["feedback"]
+        if RUN_KEY not in feedback.evaluator_info:
+            feedback.evaluator_info[RUN_KEY] = output[RUN_KEY]
+        return output
 
     def evaluate_run(
         self, run: Run, example: Optional[Example] = None
     ) -> EvaluationResult:
         """Evaluate an example."""
-        return self({"run": run, "example": example})["feedback"]
+        result = self({"run": run, "example": example}, include_run_info=True)
+        return self._prepare_evaluator_output(result)
 
     async def aevaluate_run(
         self, run: Run, example: Optional[Example] = None
     ) -> EvaluationResult:
         """Evaluate an example."""
-        result = await self.acall({"run": run, "example": example})
-        return result["feedback"]
+        result = await self.acall(
+            {"run": run, "example": example}, include_run_info=True
+        )
+        return self._prepare_evaluator_output(result)
 
     # TODO: Delete
     @classmethod

--- a/langchain/evaluation/string_distance/base.py
+++ b/langchain/evaluation/string_distance/base.py
@@ -12,6 +12,7 @@ from langchain.callbacks.manager import (
 )
 from langchain.chains.base import Chain
 from langchain.evaluation.schema import PairwiseStringEvaluator, StringEvaluator
+from langchain.schema import RUN_KEY
 
 
 def _load_rapidfuzz() -> Any:
@@ -70,6 +71,12 @@ class _RapidFuzzChainMixin(Chain):
             List[str]: The output keys.
         """
         return ["score"]
+
+    def _prepare_output(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        result = {"score": result["score"]}
+        if RUN_KEY in result:
+            result[RUN_KEY] = result[RUN_KEY].dict()
+        return result
 
     @staticmethod
     def _get_metric(distance: str) -> Callable:
@@ -215,6 +222,9 @@ class StringDistanceEvalChain(_RapidFuzzChainMixin, StringEvaluator):
         reference: Optional[str] = None,
         input: Optional[str] = None,
         callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """
@@ -233,8 +243,12 @@ class StringDistanceEvalChain(_RapidFuzzChainMixin, StringEvaluator):
         result = self(
             inputs={"prediction": prediction, "reference": reference},
             callbacks=callbacks,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
         )
-        return {"score": result["score"]}
+
+        return self._prepare_output(result)
 
     async def _aevaluate_strings(
         self,
@@ -243,6 +257,9 @@ class StringDistanceEvalChain(_RapidFuzzChainMixin, StringEvaluator):
         reference: Optional[str] = None,
         input: Optional[str] = None,
         callbacks: Callbacks = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """
@@ -262,8 +279,11 @@ class StringDistanceEvalChain(_RapidFuzzChainMixin, StringEvaluator):
         result = await self.acall(
             inputs={"prediction": prediction, "reference": reference},
             callbacks=callbacks,
+            tags=tags,
+            metadata=metadata,
+            include_run_info=include_run_info,
         )
-        return {"score": result["score"]}
+        return self._prepare_output(result)
 
 
 class PairwiseStringDistanceEvalChain(_RapidFuzzChainMixin, PairwiseStringEvaluator):
@@ -327,6 +347,7 @@ class PairwiseStringDistanceEvalChain(_RapidFuzzChainMixin, PairwiseStringEvalua
         callbacks: Callbacks = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """
@@ -348,8 +369,9 @@ class PairwiseStringDistanceEvalChain(_RapidFuzzChainMixin, PairwiseStringEvalua
             callbacks=callbacks,
             tags=tags,
             metadata=metadata,
+            include_run_info=include_run_info,
         )
-        return {"score": result["score"]}
+        return self._prepare_output(result)
 
     async def _aevaluate_string_pairs(
         self,
@@ -359,6 +381,7 @@ class PairwiseStringDistanceEvalChain(_RapidFuzzChainMixin, PairwiseStringEvalua
         callbacks: Callbacks = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        include_run_info: bool = False,
         **kwargs: Any,
     ) -> dict:
         """
@@ -380,5 +403,6 @@ class PairwiseStringDistanceEvalChain(_RapidFuzzChainMixin, PairwiseStringEvalua
             callbacks=callbacks,
             tags=tags,
             metadata=metadata,
+            include_run_info=include_run_info,
         )
-        return {"score": result["score"]}
+        return self._prepare_output(result)

--- a/tests/unit_tests/evaluation/qa/test_eval_chain.py
+++ b/tests/unit_tests/evaluation/qa/test_eval_chain.py
@@ -25,8 +25,8 @@ def test_eval_chain() -> None:
 
     outputs = fake_qa_eval_chain.evaluate([example, example], [prediction, prediction])
     assert outputs[0] == outputs[1]
-    assert "text" in outputs[0]
-    assert outputs[0]["text"] == "foo"
+    assert fake_qa_eval_chain.output_key in outputs[0]
+    assert outputs[0][fake_qa_eval_chain.output_key] == "foo"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Optionally return run info. This is added to the feedback to link feedback and source run.

Depends on the new loading and config workflow slightly