### PR TITLE
Fixed bug7445  where a duplicate restuld_id is added to the vectorstore.

### DIFF
--- a/docs/extras/use_cases/agents/baby_agi.ipynb
+++ b/docs/extras/use_cases/agents/baby_agi.ipynb
@@ -343,7 +343,7 @@
     "                self.print_task_result(result)\n",
     "\n",
     "                # Step 3: Store the result in Pinecone\n",
-    "                result_id = f\"result_{task['task_id']}\"\n",
+    "                result_id = f\"result_{task['task_id']}_{num_iters}\"\n",
     "                self.vectorstore.add_texts(\n",
     "                    texts=[result],\n",
     "                    metadatas=[{\"task\": task[\"task_name\"]}],\n",

--- a/docs/extras/use_cases/agents/baby_agi_with_agent.ipynb
+++ b/docs/extras/use_cases/agents/baby_agi_with_agent.ipynb
@@ -358,7 +358,7 @@
     "                self.print_task_result(result)\n",
     "\n",
     "                # Step 3: Store the result in Pinecone\n",
-    "                result_id = f\"result_{task['task_id']}\"\n",
+    "                result_id = f\"result_{task['task_id']}_{num_iters}\"\n",
     "                self.vectorstore.add_texts(\n",
     "                    texts=[result],\n",
     "                    metadatas=[{\"task\": task[\"task_name\"]}],\n",


### PR DESCRIPTION

  - Description: updated BabyAGI examples to append the iteration to the result id to fix error storing data to vectorstore. 
  - Issue: 7445
  - Dependencies: no
  - Tag maintainer: @eyurtsev
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

This fix worked for me locally. Happy to take some feedback and iterate on a better solution. I was considering appending a uuid instead but didnt want to over complicate the example.
