### PR TITLE
Reduce the number of LLM parsing error with conversational chats

### DIFF
--- a/libs/langchain/langchain/agents/conversational_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational_chat/output_parser.py
@@ -47,6 +47,8 @@ class ConvoOutputParser(AgentOutputParser):
         except Exception as e:
             # If any other exception is raised during parsing, also raise an
             # OutputParserException
+            if '"action": "Final Answer"' in text:
+                return AgentFinish({"output": text}, text)
             raise OutputParserException(f"Could not parse LLM output: {text}") from e
 
     @property


### PR DESCRIPTION
A lot of times, when the LLM responses a Final Answer with markdown in the answer text (e.g. asking the LLM to write some code), the parser raises an OutputParserException("Could not parse LLM output: ..."), when the answer from the LLM is totally acceptable.

This change should reduce the number of such occurances.


  - Description: Reduce the number of LLM parsing error with conversational chats, 
  - Issue: the issue #1358 ,
  - Dependencies: None,
  - Tag maintainer: @hinthornw @baskaryan,
 
For example, this response from gpt-turbo-3.5 for "How to convert a list of dict to a JSON in Python" seems totally acceptable as the final answer, but will raise the OutputParserException, even with `handle_parsing_errors=True`. This PR fixes it.
![Screenshot 2023-07-12 101547](https://github.com/hwchase17/langchain/assets/40119257/f87555b2-7782-4274-a714-72c11082df98)

