### PR TITLE
Update bedrock.py - support of other endpoint url (esp. for users of …

### DIFF
--- a/langchain/llms/bedrock.py
+++ b/langchain/llms/bedrock.py
@@ -95,6 +95,9 @@ class Bedrock(LLM):
     model_kwargs: Optional[Dict] = None
     """Key word arguments to pass to the model."""
 
+    endpoint_url: Optional[str] = None
+    """Needed if you don't want to default to us-east-1 endpoint"""
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -120,6 +123,8 @@ class Bedrock(LLM):
             client_params = {}
             if values["region_name"]:
                 client_params["region_name"] = values["region_name"]
+            if values["endpoint_url"]:
+                client_params["endpoint_url"] = values["endpoint_url"]
 
             values["client"] = session.client("bedrock", **client_params)
 


### PR DESCRIPTION
Added an _endpoint_url_ attribute to Bedrock(LLM) class - I have access to Bedrock only via us-west-2 endpoint and needed to change the endpoint url, this could be useful to other users 

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
