### PR TITLE
fix(typo): Clarify the point of `llm_chain`

### DIFF
--- a/langchain/chains/conversational_retrieval/base.py
+++ b/langchain/chains/conversational_retrieval/base.py
@@ -245,11 +245,11 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain):
             )
             prompt = PromptTemplate.from_template(template)
             llm = OpenAI()
-            llm_chain = LLMChain(llm=llm, prompt=prompt)
+            question_generator_chain = LLMChain(llm=llm, prompt=prompt)
             chain = ConversationalRetrievalChain(
                 combine_docs_chain=combine_docs_chain,
                 retriever=retriever,
-                question_generator=question_generator,
+                question_generator=question_generator_chain,
             )
     """
 


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/hwchase17/langchain/pull/7080 by @hwchase17.

In the example (visible on [the online documentation](https://api.python.langchain.com/en/latest/chains/langchain.chains.conversational_retrieval.base.ConversationalRetrievalChain.html#langchain-chains-conversational-retrieval-base-conversationalretrievalchain)), the `llm_chain` variable is unused as opposed to being used for the question generator. This change makes it clearer.