### PR TITLE
Permit Equivalence Checking

### DIFF
--- a/langchain/chains/base.py
+++ b/langchain/chains/base.py
@@ -556,6 +556,11 @@ class Chain(Serializable, ABC):
         _dict["_type"] = self._chain_type
         return _dict
 
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
     def save(self, file_path: Union[Path, str]) -> None:
         """Save the chain.
 


### PR DESCRIPTION
Currently you can't compare most chains.

Would fix #7484
```
from langchain.chains import TransformChain
def foo(val):
    return val
chain = TransformChain(transform=foo, input_variables=['foo'], output_variables=['foo'])
chain == chain

---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Cell In[13], line 1
----> 1 chain == chain

File /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pydantic/main.py:909, in pydantic.main.BaseModel.__eq__()

File ~/code/lc/lckg/langchain/chains/base.py:556, in Chain.dict(self, **kwargs)
    554     raise ValueError("Saving of memory is not yet supported.")
    555 _dict = super().dict(**kwargs)
--> 556 _dict["_type"] = self._chain_type
    557 return _dict

File ~/code/lc/lckg/langchain/chains/base.py:94, in Chain._chain_type(self)
     92 @property
     93 def _chain_type(self) -> str:
---> 94     raise NotImplementedError("Saving not supported for this chain type.")

NotImplementedError: Saving not supported for this chain type.
```