### PR TITLE
Fixed validation error when credentials_profile_name, or region_name is not passed

### DIFF
--- a/langchain/retrievers/kendra.py
+++ b/langchain/retrievers/kendra.py
@@ -213,14 +213,14 @@ class AmazonKendraRetriever(BaseRetriever):
         try:
             import boto3
 
-            if values["credentials_profile_name"] is not None:
+            if values.get("credentials_profile_name"):
                 session = boto3.Session(profile_name=values["credentials_profile_name"])
             else:
                 # use default credentials
                 session = boto3.Session()
 
             client_params = {}
-            if values["region_name"] is not None:
+            if values.get("region_name"):
                 client_params["region_name"] = values["region_name"]
 
             values["client"] = session.client("kendra", **client_params)


### PR DESCRIPTION
## Summary
This PR corrects the checks for credentials_profile_name, and region_name attributes. This was causing validation exceptions when either of these values were missing during creation of the retriever class. 

Fixes #7571 

#### Requested reviewers:
@baskaryan 

