### PR TITLE
Fix for Serializable class to include name, used in StdOutCallbackHan…

### DIFF
--- a/langchain/load/serializable.py
+++ b/langchain/load/serializable.py
@@ -9,6 +9,7 @@ class BaseSerialized(TypedDict):
 
     lc: int
     id: List[str]
+    name: str
 
 
 class SerializedConstructor(BaseSerialized):
@@ -109,6 +110,7 @@ class Serializable(BaseModel, ABC):
             "lc": 1,
             "type": "constructor",
             "id": [*self.lc_namespace, self.__class__.__name__],
+            "name": self.__class__.__name__,
             "kwargs": lc_kwargs
             if not secrets
             else _replace_secrets(lc_kwargs, secrets),
@@ -149,15 +151,19 @@ def to_json_not_implemented(obj: object) -> SerializedNotImplemented:
         SerializedNotImplemented
     """
     _id: List[str] = []
+    _name: str = ""
     try:
         if hasattr(obj, "__name__"):
             _id = [*obj.__module__.split("."), obj.__name__]
+            _name = obj.__name__
         elif hasattr(obj, "__class__"):
             _id = [*obj.__class__.__module__.split("."), obj.__class__.__name__]
+            _name = obj.__class__.__name__
     except Exception:
         pass
     return {
         "lc": 1,
         "type": "not_implemented",
         "id": _id,
+        "name": _name,
     }

--- a/tests/unit_tests/load/__snapshots__/test_dump.ambr
+++ b/tests/unit_tests/load/__snapshots__/test_dump.ambr
@@ -8,6 +8,7 @@
       "test_dump",
       "Person"
     ],
+    "name": "Person",
     "kwargs": {
       "secret": {
         "lc": 1,
@@ -30,6 +31,7 @@
       "test_dump",
       "SpecialPerson"
     ],
+    "name": "SpecialPerson",
     "kwargs": {
       "another_secret": {
         "lc": 1,
@@ -62,6 +64,7 @@
       "llm",
       "LLMChain"
     ],
+    "name": "LLMChain",
     "kwargs": {
       "llm": {
         "lc": 1,
@@ -72,6 +75,7 @@
           "openai",
           "OpenAI"
         ],
+        "name": "OpenAI",
         "kwargs": {
           "model": "davinci",
           "temperature": 0.5,
@@ -93,6 +97,7 @@
           "prompt",
           "PromptTemplate"
         ],
+        "name": "PromptTemplate",
         "kwargs": {
           "input_variables": [
             "name"
@@ -116,6 +121,7 @@
       "llm",
       "LLMChain"
     ],
+    "name": "LLMChain",
     "kwargs": {
       "llm": {
         "lc": 1,
@@ -126,6 +132,7 @@
           "openai",
           "ChatOpenAI"
         ],
+        "name": "ChatOpenAI",
         "kwargs": {
           "model": "davinci",
           "temperature": 0.5,
@@ -147,6 +154,7 @@
           "chat",
           "ChatPromptTemplate"
         ],
+        "name": "ChatPromptTemplate",
         "kwargs": {
           "input_variables": [
             "name"
@@ -161,6 +169,7 @@
                 "chat",
                 "HumanMessagePromptTemplate"
               ],
+              "name": "HumanMessagePromptTemplate",
               "kwargs": {
                 "prompt": {
                   "lc": 1,
@@ -171,6 +180,7 @@
                     "prompt",
                     "PromptTemplate"
                   ],
+                  "name": "PromptTemplate",
                   "kwargs": {
                     "input_variables": [
                       "name"
@@ -199,6 +209,7 @@
       "llm",
       "LLMChain"
     ],
+    "name": "LLMChain",
     "kwargs": {
       "llm": {
         "lc": 1,
@@ -209,6 +220,7 @@
           "openai",
           "OpenAI"
         ],
+        "name": "OpenAI",
         "kwargs": {
           "model": "davinci",
           "temperature": 0.5,
@@ -227,7 +239,8 @@
               "api_resources",
               "completion",
               "Completion"
-            ]
+            ],
+            "name": "Completion"
           }
         }
       },
@@ -240,6 +253,7 @@
           "prompt",
           "PromptTemplate"
         ],
+        "name": "PromptTemplate",
         "kwargs": {
           "input_variables": [
             "name"
@@ -263,6 +277,7 @@
       "openai",
       "OpenAI"
     ],
+    "name": "OpenAI",
     "kwargs": {
       "model": "davinci",
       "temperature": 0.7,


### PR DESCRIPTION
Fix for Serializable class to include name, used in StdOutCallbackHandler, WandBTracer

  - Description: Fixes the Serializable class to include 'name' attribute (class_name) in the dict created, 
     This is used in Callbacks, specifically the StdOutCallbackHandler and the WandBTracer.
  - Issue: As described in [7524](https://github.com/hwchase17/langchain/issues/7524)
  - Dependencies: None
  - Tag maintainer: SInce this is related to the callback module, tagging @agola11

Comments: 
  - I feel that having 'name' as a separate attribute does help.

