### PR TITLE
Simplify GraphQL Tool Initialization documentation by Removing 'llm' Argument

### DIFF
--- a/docs/extras/modules/agents/tools/integrations/graphql.ipynb
+++ b/docs/extras/modules/agents/tools/integrations/graphql.ipynb
@@ -52,7 +52,6 @@
     "tools = load_tools(\n",
     "    [\"graphql\"],\n",
     "    graphql_endpoint=\"https://swapi-graphql.netlify.app/.netlify/functions/index\",\n",
-    "    llm=llm,\n",
     ")\n",
     "\n",
     "agent = initialize_agent(\n",


### PR DESCRIPTION
This PR is aimed at enhancing the clarity of the documentation in the langchain project.

**Description**:
In the graphql.ipynb file, I have removed the unnecessary 'llm' argument from the initialization process of the GraphQL tool (of type _EXTRA_OPTIONAL_TOOLS). The 'llm' argument is not required for this process. Its presence could potentially confuse users. This modification simplifies the understanding of tool initialization and minimizes potential confusion.

**Issue**: Not applicable, as this is a documentation improvement.

**Dependencies**: None.

**I kindly request a review from the following maintainer**: @hinthornw, who is responsible for Agents / Tools / Toolkits.

No new integration is being added in this PR, hence no need for a test or an example notebook.

Please see the changes for more detail and let me know if any further modification is necessary.