### PR TITLE
Fix SQLAlchemy LLM cache clear

### DIFF
--- a/langchain/cache.py
+++ b/langchain/cache.py
@@ -180,6 +180,7 @@ class SQLAlchemyCache(BaseCache):
         """Clear cache."""
         with Session(self.engine) as session:
             session.query(self.cache_schema).delete()
+            session.commit()
 
 
 class SQLiteCache(SQLAlchemyCache):

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -139,6 +139,26 @@ def test_chat_model_caching_params() -> None:
         )
 
 
+def test_llm_cache_clear() -> None:
+    prompt = "How are you?"
+    response = "Test response"
+    cached_response = "Cached test response"
+    llm = FakeListLLM(responses=[response])
+    if langchain.llm_cache:
+        langchain.llm_cache.update(
+            prompt=prompt,
+            llm_string=create_llm_string(llm),
+            return_val=[Generation(text=cached_response)],
+        )
+        langchain.llm_cache.clear()
+        assert llm(prompt) == response
+    else:
+        raise ValueError(
+            "The cache not set. This should never happen, as the pytest fixture "
+            "`set_cache_and_teardown` always sets the cache."
+        )
+
+
 def create_llm_string(llm: Union[BaseLLM, BaseChatModel]) -> str:
     _dict: Dict = llm.dict()
     _dict["stop"] = None


### PR DESCRIPTION
Fixes #7652 

Description: 
This is a fix for clearing the cache for SQL Alchemy based LLM caches. 

The langchain.llm_cache.clear() did not take effect for SQLite cache. 
Reason: it didn't commit the deletion database change.

See SQLAlchemy documentation for proper usage:
https://docs.sqlalchemy.org/en/20/orm/session_basics.html#opening-and-closing-a-session
https://docs.sqlalchemy.org/en/20/orm/session_basics.html#deleting

@hwchase17 @baskaryan 
