### PR TITLE
Feature: Add ``from_embeddings`` class method to Chroma

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -145,6 +145,7 @@ class Chroma(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
+        embeddings: Optional[List[List[float]]] = None,
         ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> List[str]:
@@ -161,7 +162,6 @@ class Chroma(VectorStore):
         # TODO: Handle the case where the user doesn't provide ids on the Collection
         if ids is None:
             ids = [str(uuid.uuid1()) for _ in texts]
-        embeddings = None
         if embeddings is None and self._embedding_function is not None:
             embeddings = self._embedding_function.embed_documents(list(texts))
 
@@ -593,7 +593,8 @@ class Chroma(VectorStore):
         Otherwise, the data will be ephemeral in-memory.
 
         Args:
-            text_embeddings (List[Tuple[str, List[float]]]): List of tuples with texts and embeddings (list of floats).
+            text_embeddings (List[Tuple[str, List[float]]]): List of tuples with texts
+            and embeddings (list of floats).
             metadatas (Optional[List[dict]]): List of metadatas. Defaults to None.
             collection_name (str): Name of the collection to create.
             persist_directory (Optional[str]): Directory to persist the collection.

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -578,7 +578,7 @@ class Chroma(VectorStore):
     def from_embeddings(
         cls: Type[Chroma],
         text_embeddings: List[Tuple[str, List[float]]],
-        embedding: Optional[Embeddings] = None,
+        embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
         ids: Optional[List[str]] = None,
         collection_name: str = _LANGCHAIN_DEFAULT_COLLECTION_NAME,
@@ -599,7 +599,8 @@ class Chroma(VectorStore):
             collection_name (str): Name of the collection to create.
             persist_directory (Optional[str]): Directory to persist the collection.
             ids (Optional[List[str]]): List of document IDs. Defaults to None.
-            embedding (Optional[Embeddings]): Embedding function. Defaults to None.
+            embedding (Embeddings): Embedding function that was used to create
+            the embeddings. Defaults to None.
             client_settings (Optional[chromadb.config.Settings]): Chroma client settings
 
         Returns:

--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -162,7 +162,7 @@ class Chroma(VectorStore):
         if ids is None:
             ids = [str(uuid.uuid1()) for _ in texts]
         embeddings = None
-        if self._embedding_function is not None:
+        if embeddings is None and self._embedding_function is not None:
             embeddings = self._embedding_function.embed_documents(list(texts))
 
         if metadatas:
@@ -573,6 +573,51 @@ class Chroma(VectorStore):
             collection_metadata=collection_metadata,
             **kwargs,
         )
+
+    @classmethod
+    def from_embeddings(
+        cls: Type[Chroma],
+        text_embeddings: List[Tuple[str, List[float]]],
+        embedding: Optional[Embeddings] = None,
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        collection_name: str = _LANGCHAIN_DEFAULT_COLLECTION_NAME,
+        persist_directory: Optional[str] = None,
+        client_settings: Optional[Any] = None,
+        client: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> Chroma:
+        """Create a Chroma vectorstore from a list of embeddings.
+
+        If a persist_directory is specified, the collection will be persisted there.
+        Otherwise, the data will be ephemeral in-memory.
+
+        Args:
+            text_embeddings (List[Tuple[str, List[float]]]): List of tuples with texts and embeddings (list of floats).
+            metadatas (Optional[List[dict]]): List of metadatas. Defaults to None.
+            collection_name (str): Name of the collection to create.
+            persist_directory (Optional[str]): Directory to persist the collection.
+            ids (Optional[List[str]]): List of document IDs. Defaults to None.
+            embedding (Optional[Embeddings]): Embedding function. Defaults to None.
+            client_settings (Optional[chromadb.config.Settings]): Chroma client settings
+
+        Returns:
+            Chroma: Chroma vectorstore.
+        """
+        chroma_collection = cls(
+            collection_name=collection_name,
+            embedding_function=embedding,
+            persist_directory=persist_directory,
+            client_settings=client_settings,
+            client=client,
+        )
+        # split the text_embeddings into text and embeddings
+        texts = [item[0] for item in text_embeddings]
+        embeddings = [item[1] for item in text_embeddings]
+        chroma_collection.add_texts(
+            texts=texts, embeddings=embeddings, metadatas=metadatas, ids=ids
+        )
+        return chroma_collection
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
         """Delete by vector IDs.

--- a/tests/integration_tests/vectorstores/test_chroma.py
+++ b/tests/integration_tests/vectorstores/test_chroma.py
@@ -19,6 +19,22 @@ def test_chroma() -> None:
     assert output == [Document(page_content="foo")]
 
 
+def test_chroma_from_embeddings() -> None:
+    """Test end to end construction with embeddings and search."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    text_embeddings = ConsistentFakeEmbeddings().embed_documents(texts)
+    text_embedding_pairs = list(zip(texts, text_embeddings))
+    docsearch = Chroma.from_embeddings(
+        text_embeddings=text_embedding_pairs,
+        embedding=ConsistentFakeEmbeddings(),
+        metadatas=metadatas,
+    )
+
+    output = docsearch.similarity_search("foo", k=1)
+    assert output == [Document(page_content="foo", metadata={"page": "0"})]
+
+
 @pytest.mark.asyncio
 async def test_chroma_async() -> None:
     """Test end to end construction and search."""


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->

# Description
This PR adds a ``from_embeddings`` class method to the ``Chroma`` vectorstore. This can be handy, if one wants to replace vectorstores that have that method (e.g. ``FAISS``) with ``Chroma``. Additionally, this is useful if one already has pre-computed embeddings and does not want to re-compute them.

The implementation is very simple and just gets the Chroma collection, splits the ``text_embeddings`` into ``texts`` and ``embeddings`` and then calls the ``add_texts`` method. Within ``add_texts`` we need to add a check that only if ``embeddings is None`` we embed the documents to avoid re-embedding.

@rlancemartin and @eyurtsev would be happy to get some feedback!

## Usecase
To use the self-query feature from langchain for my [scholarGPT](https://twitter.com/L_Salewski/status/1673084085474820096) academic chatbot I moved from ``FAISS`` to ``Chroma`` and I wanted a drop-in replacement. 

## Notes
- This feature does not introduce any new dependencies.
- My Twitter handle is [@L_Salewski](https://twitter.com/L_Salewski)





