### PR TITLE
Fix same issue #7524 in FileCallbackHandler

### DIFF
--- a/langchain/callbacks/file.py
+++ b/langchain/callbacks/file.py
@@ -24,7 +24,7 @@ class FileCallbackHandler(BaseCallbackHandler):
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
         """Print out that we are entering a chain."""
-        class_name = serialized.get("id", [""])[-1]
+        class_name = serialized.get("name", serialized.get("id", ["<unknown>"])[-1])
         print_text(
             f"\n\n\033[1m> Entering new {class_name} chain...\033[0m",
             end="\n",

--- a/langchain/callbacks/file.py
+++ b/langchain/callbacks/file.py
@@ -24,7 +24,7 @@ class FileCallbackHandler(BaseCallbackHandler):
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> None:
         """Print out that we are entering a chain."""
-        class_name = serialized["name"]
+        class_name = serialized.get("id", [""])[-1]
         print_text(
             f"\n\n\033[1m> Entering new {class_name} chain...\033[0m",
             end="\n",


### PR DESCRIPTION
Fix for Serializable class to include name, used in FileCallbackHandler as same issue #7524 

Description: Fixes the Serializable class to include 'name' attribute (class_name) in the dict created,
This is used in Callbacks, specifically the StdOutCallbackHandler, FileCallbackHandler.
Issue: As described in issue #7524
Dependencies: None
Tag maintainer: SInce this is related to the callback module, tagging @agola11 @idoru 
Comments:

Glad to see issue #7524 fixed in pull #6124, but you forget to change the same place in FileCallbackHandler