### PR TITLE
Add  `pip install langsmith` for Quick Install part of README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please fill out [this form](https://forms.gle/57d8AmXBYp8PP8tZA) and we'll set u
 
 `pip install langchain`
 or
-`conda install langchain -c conda-forge`
+`pip install langsmith && conda install langchain -c conda-forge`
 
 ## 🤔 What is this?
 


### PR DESCRIPTION
**Issue**
When I use conda to install langchain, a dependency error throwed - "ModuleNotFoundError: No module named 'langsmith'"

**Updated**
Run `pip install langsmith` when install langchain with conda
