### PR TITLE
SQLDatabase: adding security disclamer

### DIFF
--- a/docs/extras/modules/agents/toolkits/sql_database.ipynb
+++ b/docs/extras/modules/agents/toolkits/sql_database.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0e499e90-7a6d-4fab-8aab-31a4df417601",
    "metadata": {},
@@ -15,6 +16,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ec927ac6-9b2a-4e8a-9a6e-3e429191875c",
    "metadata": {
@@ -54,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f74d1792",
    "metadata": {},
@@ -81,6 +84,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "971cc455",
    "metadata": {},
@@ -106,6 +110,44 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "54c01168",
+   "metadata": {},
+   "source": [
+    "## Disclamer ⚠️\n",
+    "\n",
+    "The query chain may generate insert/update/delete queries. When this is not expected, use a custom prompt or create a SQL users without write permissions.\n",
+    "\n",
+    "The final user might overload your SQL database by asking a simple question such as \"run the biggest query possible\". The generated query might look like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "949772b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SELECT * FROM \"public\".\"users\"\n",
+    "    JOIN \"public\".\"user_permissions\" ON \"public\".\"users\".id = \"public\".\"user_permissions\".user_id\n",
+    "    JOIN \"public\".\"projects\" ON \"public\".\"users\".id = \"public\".\"projects\".user_id\n",
+    "    JOIN \"public\".\"events\" ON \"public\".\"projects\".id = \"public\".\"events\".project_id;"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5a4a9455",
+   "metadata": {},
+   "source": [
+    "For a transactional SQL database, if one of the table above contains millions of rows, the query might cause trouble to other applications using the same database.\n",
+    "\n",
+    "Most datawarehouse oriented databases support user-level quota, for limiting resource usage."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "36ae48c7-cb08-4fef-977e-c7d4b96a464b",
    "metadata": {},
@@ -195,6 +237,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9abcfe8e-1868-42a4-8345-ad2d9b44c681",
    "metadata": {},
@@ -269,6 +312,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6fbc26af-97e4-4a21-82aa-48bdc992da26",
    "metadata": {},
@@ -451,6 +495,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7c7503b5-d9d9-4faa-b064-29fcdb5ff213",
    "metadata": {},


### PR DESCRIPTION
It might be obvious to most engineers, but I think everybody should be cautious when using such a chain.

![image](https://github.com/hwchase17/langchain/assets/2951285/a1df6567-9d56-4c12-98ea-767401ae2ac8)
