### PR TITLE
Update markdown links for tracing

### DIFF
--- a/docs/extras/guides/evaluation/agent_benchmarking.ipynb
+++ b/docs/extras/guides/evaluation/agent_benchmarking.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Here we go over how to benchmark performance of an agent on tasks where it has access to a calculator and a search tool.\n",
     "\n",
-    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/docs/guides/tracing/) for an explanation of what tracing is and how to set it up."
+    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/docs/modules/callbacks/how_to/tracing) for an explanation of what tracing is and how to set it up."
    ]
   },
   {

--- a/docs/extras/guides/evaluation/agent_vectordb_sota_pg.ipynb
+++ b/docs/extras/guides/evaluation/agent_vectordb_sota_pg.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Here we go over how to benchmark performance on a question answering task using an agent to route between multiple vectordatabases.\n",
     "\n",
-    "It is highly recommended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/guides/tracing/) for an explanation of what tracing is and how to set it up."
+    "It is highly recommended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/docs/modules/callbacks/how_to/tracing) for an explanation of what tracing is and how to set it up."
    ]
   },
   {

--- a/docs/extras/guides/evaluation/benchmarking_template.ipynb
+++ b/docs/extras/guides/evaluation/benchmarking_template.ipynb
@@ -15,7 +15,7 @@
    "id": "984169ca",
    "metadata": {},
    "source": [
-    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://langchain.readthedocs.io/en/latest/tracing.html) for an explanation of what tracing is and how to set it up."
+    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/docs/modules/callbacks/how_to/tracing) for an explanation of what tracing is and how to set it up."
    ]
   },
   {

--- a/docs/extras/guides/evaluation/qa_benchmarking_sota.ipynb
+++ b/docs/extras/guides/evaluation/qa_benchmarking_sota.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Here we go over how to benchmark performance on a question answering task over a state of the union address.\n",
     "\n",
-    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://langchain.readthedocs.io/en/latest/tracing.html) for an explanation of what tracing is and how to set it up."
+    "It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](https://python.langchain.com/docs/modules/callbacks/how_to/tracing) for an explanation of what tracing is and how to set it up."
    ]
   },
   {


### PR DESCRIPTION
Updated all old `It is highly reccomended that you do any evaluation/benchmarking with tracing enabled. See [here](...)` link to -> https://python.langchain.com/docs/modules/callbacks/how_to/tracing