### PR TITLE
fix: absolute URLs from links in `RecursiveUrlLoader`

### DIFF
--- a/langchain/document_loaders/recursive_url_loader.py
+++ b/langchain/document_loaders/recursive_url_loader.py
@@ -70,11 +70,18 @@ class RecursiveUrlLoader(BaseLoader):
         soup = BeautifulSoup(response.text, "html.parser")
         all_links = [link.get("href") for link in soup.find_all("a")]
 
+        # Make all links relative to the root of the website
+        all_links_relative = [
+            link.replace(base_url, "/")
+            for link in all_links
+            if link and link.startswith(base_url)
+        ]
+
         # Extract only the links that are children of the current URL
         child_links = list(
             {
                 link
-                for link in all_links
+                for link in all_links_relative
                 if link and link.startswith(current_path) and link != current_path
             }
         )

--- a/langchain/document_loaders/recursive_url_loader.py
+++ b/langchain/document_loaders/recursive_url_loader.py
@@ -72,9 +72,8 @@ class RecursiveUrlLoader(BaseLoader):
 
         # Make all links relative to the root of the website
         all_links_relative = [
-            link.replace(base_url, "/")
+            link.replace(base_url, "/") if link and link.startswith(base_url) else link
             for link in all_links
-            if link and link.startswith(base_url)
         ]
 
         # Extract only the links that are children of the current URL


### PR DESCRIPTION
## Description

This PR solves an absolute link problem in `RecursiveUrlLoader`. When the "href" of a link on the page contains an absolute URL, the link is ignored.
Example: `<a href="http://test.com/example"></a>` will be ignored when base_url is `http://test.com/`.

@rlancemartin @eyurtsev