### PR TITLE
fix: make error message clear when input_key arg is required

### DIFF
--- a/langchain/experimental/autonomous_agents/autogpt/memory.py
+++ b/langchain/experimental/autonomous_agents/autogpt/memory.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 from pydantic import Field
 
-from langchain.memory.chat_memory import BaseChatMemory, get_prompt_input_key
+from langchain.memory.chat_memory import BaseChatMemory
 from langchain.vectorstores.base import VectorStoreRetriever
 
 
@@ -14,14 +14,8 @@ class AutoGPTMemory(BaseChatMemory):
     def memory_variables(self) -> List[str]:
         return ["chat_history", "relevant_context"]
 
-    def _get_prompt_input_key(self, inputs: Dict[str, Any]) -> str:
-        """Get the input key for the prompt."""
-        if self.input_key is None:
-            return get_prompt_input_key(inputs, self.memory_variables)
-        return self.input_key
-
     def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        input_key = self._get_prompt_input_key(inputs)
+        input_key = self.get_prompt_input_key(inputs)
         query = inputs[input_key]
         docs = self.retriever.get_relevant_documents(query)
         return {

--- a/langchain/memory/buffer.py
+++ b/langchain/memory/buffer.py
@@ -78,7 +78,7 @@ class ConversationStringBufferMemory(BaseMemory):
             prompt_input_key = self.input_key
         if self.output_key is None:
             if len(outputs) != 1:
-                raise ValueError(f"One output key expected, got {outputs.keys()}")
+                raise ValueError(f"Missing output_key arg with multiple prompt output variables: {outputs.keys()}")
             output_key = list(outputs.keys())[0]
         else:
             output_key = self.output_key

--- a/langchain/memory/chat_memory.py
+++ b/langchain/memory/chat_memory.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional, Tuple
 from pydantic import Field
 
 from langchain.memory.chat_message_histories.in_memory import ChatMessageHistory
-from langchain.memory.utils import get_prompt_input_key
 from langchain.schema import BaseChatMessageHistory, BaseMemory
 
 
@@ -17,16 +16,8 @@ class BaseChatMemory(BaseMemory, ABC):
     def _get_input_output(
         self, inputs: Dict[str, Any], outputs: Dict[str, str]
     ) -> Tuple[str, str]:
-        if self.input_key is None:
-            prompt_input_key = get_prompt_input_key(inputs, self.memory_variables)
-        else:
-            prompt_input_key = self.input_key
-        if self.output_key is None:
-            if len(outputs) != 1:
-                raise ValueError(f"One output key expected, got {outputs.keys()}")
-            output_key = list(outputs.keys())[0]
-        else:
-            output_key = self.output_key
+        prompt_input_key = self.get_prompt_input_key(inputs)
+        output_key = self.get_prompt_output_key(outputs)
         return inputs[prompt_input_key], outputs[output_key]
 
     def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
@@ -38,3 +29,40 @@ class BaseChatMemory(BaseMemory, ABC):
     def clear(self) -> None:
         """Clear memory contents."""
         self.chat_memory.clear()
+
+    def get_prompt_input_key(self, inputs: Dict[str, Any]) -> str:
+        """
+        Get the prompt input key.
+
+        Args:
+            inputs: Dict[str, Any]
+
+        Returns:
+            A prompt input key.
+        """
+        if self.input_key is not None:
+            return self.input_key
+
+        # "stop" is a special key that can be passed as input but is not used to
+        # format the prompt.
+        prompt_input_variables = list(set(inputs).difference(self.memory_variables + ["stop"]))
+        if len(prompt_input_variables) != 1:
+            raise ValueError(f"Missing input_key arg with multiple prompt input variables: {prompt_input_variables}")
+        return prompt_input_variables[0]
+
+    def get_prompt_output_key(self, outputs: Dict[str, str]) -> str:
+        """
+        Get the prompt output key.
+
+        Args:
+            outputs: Dict[str, Any]
+
+        Returns:
+            A prompt output key.
+        """
+        if self.output_key is not None:
+            return self.output_key
+
+        if len(outputs) != 1:
+            raise ValueError(f"Missing output_key arg with multiple prompt output variables: {outputs.keys()}")
+        return list(outputs.keys())[0]

--- a/langchain/memory/entity.py
+++ b/langchain/memory/entity.py
@@ -11,7 +11,6 @@ from langchain.memory.prompt import (
     ENTITY_EXTRACTION_PROMPT,
     ENTITY_SUMMARIZATION_PROMPT,
 )
-from langchain.memory.utils import get_prompt_input_key
 from langchain.schema import BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.schema.messages import BaseMessage, get_buffer_string
@@ -292,11 +291,7 @@ class ConversationEntityMemory(BaseChatMemory):
 
         # Create an LLMChain for predicting entity names from the recent chat history:
         chain = LLMChain(llm=self.llm, prompt=self.entity_extraction_prompt)
-
-        if self.input_key is None:
-            prompt_input_key = get_prompt_input_key(inputs, self.memory_variables)
-        else:
-            prompt_input_key = self.input_key
+        prompt_input_key = self.get_prompt_input_key(inputs)
 
         # Extract an arbitrary window of the last message pairs from
         # the chat history, where the hyperparameter k is the
@@ -354,11 +349,7 @@ class ConversationEntityMemory(BaseChatMemory):
         """
 
         super().save_context(inputs, outputs)
-
-        if self.input_key is None:
-            prompt_input_key = get_prompt_input_key(inputs, self.memory_variables)
-        else:
-            prompt_input_key = self.input_key
+        prompt_input_key = self.get_prompt_input_key(inputs)
 
         # Extract an arbitrary window of the last message pairs from
         # the chat history, where the hyperparameter k is the

--- a/langchain/memory/utils.py
+++ b/langchain/memory/utils.py
@@ -18,5 +18,5 @@ def get_prompt_input_key(inputs: Dict[str, Any], memory_variables: List[str]) ->
     # format the prompt.
     prompt_input_keys = list(set(inputs).difference(memory_variables + ["stop"]))
     if len(prompt_input_keys) != 1:
-        raise ValueError(f"One input key expected got {prompt_input_keys}")
+        raise ValueError(f"Missing input_key with multiple prompt input variables: {prompt_input_keys}")
     return prompt_input_keys[0]

--- a/tests/unit_tests/chains/test_memory.py
+++ b/tests/unit_tests/chains/test_memory.py
@@ -5,10 +5,59 @@ from langchain.chains.conversation.memory import (
     ConversationBufferWindowMemory,
     ConversationSummaryMemory,
 )
+from langchain.chains import LLMChain
 from langchain.memory import ReadOnlySharedMemory, SimpleMemory
 from langchain.schema import BaseMemory
+from langchain.prompts import PromptTemplate
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
+
+def test_chain_with_memory_and_multiple_prompt_params() -> None:
+    template = """
+    {resource}
+
+    {history}
+    Human: {human_input}
+    AI: 
+    """
+
+    prompt = PromptTemplate(input_variables=["resource", "history", "human_input"], template=template)
+    memory = ConversationBufferMemory(memory_key="history")
+    llm_chain = LLMChain(llm=FakeLLM(), prompt=prompt, verbose=True, memory=memory)
+    resource="lorem ipsum"
+    print(llm_chain.predict(human_input="Bar?", resource=resource) + "\n")
+    print(llm_chain.predict(human_input="Bazz?", resource=resource) + "\n")
+
+def test_chain_with_memory_and_multiple_prompt_params_and_input_key() -> None:
+    template = """
+    {resource}
+
+    {history}
+    Human: {human_input}
+    AI: 
+    """
+
+    prompt = PromptTemplate(input_variables=["resource", "history", "human_input"], template=template)
+    memory = ConversationBufferMemory(memory_key="history", input_key="human_input")
+    llm_chain = LLMChain(llm=FakeLLM(), prompt=prompt, verbose=True, memory=memory)
+    resource="lorem ipsum"
+    print(llm_chain.predict(human_input="Bar?", resource=resource) + "\n")
+    print(llm_chain.predict(human_input="Bazz?", resource=resource) + "\n")
+
+
+def test_chain_with_multiple_prompt_params() -> None:
+    template = """
+    {resource}
+
+    Human: {human_input}
+    AI: 
+    """
+
+    prompt = PromptTemplate(input_variables=["resource", "human_input"], template=template)
+    llm_chain = LLMChain(llm=FakeLLM(), prompt=prompt, verbose=True)
+    resource="lorem ipsum"
+    print(llm_chain.predict(human_input="Bar?", resource=resource) + "\n")
+    print(llm_chain.predict(human_input="Bazz?", resource=resource) + "\n")
 
 def test_simple_memory() -> None:
     """Test SimpleMemory."""

--- a/tests/unit_tests/chains/test_memory.py
+++ b/tests/unit_tests/chains/test_memory.py
@@ -24,9 +24,9 @@ def test_chain_with_memory_and_multiple_prompt_params() -> None:
     prompt = PromptTemplate(input_variables=["resource", "history", "human_input"], template=template)
     memory = ConversationBufferMemory(memory_key="history")
     llm_chain = LLMChain(llm=FakeLLM(), prompt=prompt, verbose=True, memory=memory)
-    resource="lorem ipsum"
-    print(llm_chain.predict(human_input="Bar?", resource=resource) + "\n")
-    print(llm_chain.predict(human_input="Bazz?", resource=resource) + "\n")
+    with pytest.raises(ValueError):
+        llm_chain.predict(human_input="Bar?", resource="lorem ipsum")
+
 
 def test_chain_with_memory_and_multiple_prompt_params_and_input_key() -> None:
     template = """
@@ -40,9 +40,8 @@ def test_chain_with_memory_and_multiple_prompt_params_and_input_key() -> None:
     prompt = PromptTemplate(input_variables=["resource", "history", "human_input"], template=template)
     memory = ConversationBufferMemory(memory_key="history", input_key="human_input")
     llm_chain = LLMChain(llm=FakeLLM(), prompt=prompt, verbose=True, memory=memory)
-    resource="lorem ipsum"
-    print(llm_chain.predict(human_input="Bar?", resource=resource) + "\n")
-    print(llm_chain.predict(human_input="Bazz?", resource=resource) + "\n")
+    output = llm_chain.predict(human_input="Bar?", resource="lorem ipsum")
+    assert output == "foo"
 
 
 def test_chain_with_multiple_prompt_params() -> None:
@@ -55,9 +54,9 @@ def test_chain_with_multiple_prompt_params() -> None:
 
     prompt = PromptTemplate(input_variables=["resource", "human_input"], template=template)
     llm_chain = LLMChain(llm=FakeLLM(), prompt=prompt, verbose=True)
-    resource="lorem ipsum"
-    print(llm_chain.predict(human_input="Bar?", resource=resource) + "\n")
-    print(llm_chain.predict(human_input="Bazz?", resource=resource) + "\n")
+    output = llm_chain.predict(human_input="Bar?", resource="lorem ipsum")
+    assert output == "foo"
+
 
 def test_simple_memory() -> None:
     """Test SimpleMemory."""


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: Makes it more clear that input_key argument is required when there are multiple input variables in a prompt, 
  - Issue: #2013,
  - Tag maintainer: @hwchase17,

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
 
 - Description: Makes it more clear that input_key argument is required with multiple input variables in a prompt, 
 - Issue: #2013,
 - Tag maintainer: @hwchase17,
