### PR TITLE
feat: moving azure OpenAI API version to the latest 2023-05-15

### DIFF
--- a/docs/extras/ecosystem/integrations/azure_openai.mdx
+++ b/docs/extras/ecosystem/integrations/azure_openai.mdx
@@ -22,7 +22,7 @@ import os
 os.environ["OPENAI_API_TYPE"] = "azure"
 os.environ["OPENAI_API_BASE"] = "https://<your-endpoint.openai.azure.com/"
 os.environ["OPENAI_API_KEY"] = "your AzureOpenAI key"
-os.environ["OPENAI_API_VERSION"] = "2023-03-15-preview"
+os.environ["OPENAI_API_VERSION"] = "2023-05-15"
 ```
 
 ## LLM

--- a/docs/extras/modules/data_connection/text_embedding/integrations/azureopenai.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/azureopenai.ipynb
@@ -23,7 +23,7 @@
     "os.environ[\"OPENAI_API_TYPE\"] = \"azure\"\n",
     "os.environ[\"OPENAI_API_BASE\"] = \"https://<your-endpoint.openai.azure.com/\"\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"your AzureOpenAI key\"\n",
-    "os.environ[\"OPENAI_API_VERSION\"] = \"2023-03-15-preview\""
+    "os.environ[\"OPENAI_API_VERSION\"] = \"2023-05-15\""
    ]
   },
   {

--- a/docs/extras/modules/model_io/models/chat/integrations/azure_chat_openai.ipynb
+++ b/docs/extras/modules/model_io/models/chat/integrations/azure_chat_openai.ipynb
@@ -33,7 +33,7 @@
     "DEPLOYMENT_NAME = \"chat\"\n",
     "model = AzureChatOpenAI(\n",
     "    openai_api_base=BASE_URL,\n",
-    "    openai_api_version=\"2023-03-15-preview\",\n",
+    "    openai_api_version=\"2023-05-15\",\n",
     "    deployment_name=DEPLOYMENT_NAME,\n",
     "    openai_api_key=API_KEY,\n",
     "    openai_api_type=\"azure\",\n",

--- a/docs/extras/modules/model_io/models/llms/integrations/azure_openai_example.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/azure_openai_example.ipynb
@@ -17,8 +17,8 @@
     "```bash\n",
     "# Set this to `azure`\n",
     "export OPENAI_API_TYPE=azure\n",
-    "# The API version you want to use: set this to `2023-03-15-preview` for the released version.\n",
-    "export OPENAI_API_VERSION=2023-03-15-preview\n",
+    "# The API version you want to use: set this to `2023-05-15` for the released version.\n",
+    "export OPENAI_API_VERSION=2023-05-15\n",
     "# The base URL for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource.\n",
     "export OPENAI_API_BASE=https://your-resource-name.openai.azure.com\n",
     "# The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource.\n",
@@ -71,7 +71,7 @@
     "import os\n",
     "\n",
     "os.environ[\"OPENAI_API_TYPE\"] = \"azure\"\n",
-    "os.environ[\"OPENAI_API_VERSION\"] = \"2023-03-15-preview\"\n",
+    "os.environ[\"OPENAI_API_VERSION\"] = \"2023-05-15\"\n",
     "os.environ[\"OPENAI_API_BASE\"] = \"...\"\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"...\""
    ]

--- a/langchain/chat_models/azure_openai.py
+++ b/langchain/chat_models/azure_openai.py
@@ -33,7 +33,7 @@ class AzureChatOpenAI(ChatOpenAI):
 
         AzureChatOpenAI(
             deployment_name="35-turbo-dev",
-            openai_api_version="2023-03-15-preview",
+            openai_api_version="2023-05-15",
         )
 
     Be aware the API version may change.

--- a/langchain/embeddings/openai.py
+++ b/langchain/embeddings/openai.py
@@ -144,7 +144,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             os.environ["OPENAI_API_TYPE"] = "azure"
             os.environ["OPENAI_API_BASE"] = "https://<your-endpoint.openai.azure.com/"
             os.environ["OPENAI_API_KEY"] = "your AzureOpenAI key"
-            os.environ["OPENAI_API_VERSION"] = "2023-03-15-preview"
+            os.environ["OPENAI_API_VERSION"] = "2023-05-15"
             os.environ["OPENAI_PROXY"] = "http://your-corporate-proxy:8080"
 
             from langchain.embeddings.openai import OpenAIEmbeddings


### PR DESCRIPTION
Moving to the latest non-preview Azure OpenAI API version=2023-05-15. The previous 2023-03-15-preview doesn't have support, SLA etc. For instance, OpenAI SDK has moved to this version https://github.com/openai/openai-python/releases/tag/v0.27.7

@baskaryan 