### PR TITLE
fix #7782: check title and excerpt separately for page_content

### DIFF
--- a/langchain/retrievers/kendra.py
+++ b/langchain/retrievers/kendra.py
@@ -38,9 +38,12 @@ def combined_text(title: str, excerpt: str) -> str:
         The combined text.
 
     """
-    if not title or not excerpt:
-        return ""
-    return f"Document Title: {title} \nDocument Excerpt: \n{excerpt}\n"
+    text = ""
+    if title:
+        text += f"Document Title: {title}\n"
+    if excerpt:
+        text += f"Document Excerpt: \n{excerpt}\n"
+    return text
 
 
 class Highlight(BaseModel, extra=Extra.allow):


### PR DESCRIPTION
  - Description: check title and excerpt separately for page_content so that if title is empty but excerpt is present, the page_content will only contain the excerpt
  - Issue: #7782 
  - Tag maintainer: @3coins @baskaryan 
  - Twitter handle: wilsonleao