### PR TITLE
docs(zilliz): connection_args add token description for serverless cl…

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/zilliz.ipynb
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/zilliz.ipynb
@@ -65,7 +65,8 @@
     "# replace\n",
     "ZILLIZ_CLOUD_URI = \"\"  # example: \"https://in01-17f69c292d4a5sa.aws-us-west-2.vectordb.zillizcloud.com:19536\"\n",
     "ZILLIZ_CLOUD_USERNAME = \"\"  # example: \"username\"\n",
-    "ZILLIZ_CLOUD_PASSWORD = \"\"  # example: \"*********\""
+    "ZILLIZ_CLOUD_PASSWORD = \"\"  # example: \"*********\"\n",
+    "ZILLIZ_CLOUD_API_KEY = \"\"  # example: \"*********\" (for serverless clusters which can be used as replacements for user and password)"
    ]
   },
   {
@@ -112,6 +113,7 @@
     "        \"uri\": ZILLIZ_CLOUD_URI,\n",
     "        \"user\": ZILLIZ_CLOUD_USERNAME,\n",
     "        \"password\": ZILLIZ_CLOUD_PASSWORD,\n",
+    "        \"token\": ZILLIZ_CLOUD_API_KEY,  # API key, for serverless clusters which can be used as replacements for user and password\n",
     "        \"secure\": True,\n",
     "    },\n",
     ")"

--- a/docs/extras/modules/data_connection/vectorstores/integrations/zilliz.ipynb
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/zilliz.ipynb
@@ -113,7 +113,7 @@
     "        \"uri\": ZILLIZ_CLOUD_URI,\n",
     "        \"user\": ZILLIZ_CLOUD_USERNAME,\n",
     "        \"password\": ZILLIZ_CLOUD_PASSWORD,\n",
-    "        \"token\": ZILLIZ_CLOUD_API_KEY,  # API key, for serverless clusters which can be used as replacements for user and password\n",
+    "        # \"token\": ZILLIZ_CLOUD_API_KEY,  # API key, for serverless clusters which can be used as replacements for user and password\n",
     "        \"secure\": True,\n",
     "    },\n",
     ")"
@@ -176,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/langchain/vectorstores/zilliz.py
+++ b/langchain/vectorstores/zilliz.py
@@ -50,6 +50,8 @@ class Zilliz(Milvus):
             password are provided, we will add related header in every RPC call.
         password (str): Required when user is provided. The password
             corresponding to the user.
+        token (str): API key, for serverless clusters which can be used as
+            replacements for user and password.
         secure (bool): Default is false. If set to true, tls will be enabled.
         client_key_path (str): If use tls two-way authentication, need to
             write the client.key path.
@@ -76,6 +78,7 @@ class Zilliz(Milvus):
                 "uri": "https://in03-ba4234asae.api.gcp-us-west1.zillizcloud.com",
                 "user": "temp",
                 "password": "temp",
+                "token": "temp", # API key, for serverless clusters which can be used as replacements for user and password
                 "secure": True
             }
             drop_old: True,

--- a/langchain/vectorstores/zilliz.py
+++ b/langchain/vectorstores/zilliz.py
@@ -78,7 +78,7 @@ class Zilliz(Milvus):
                 "uri": "https://in03-ba4234asae.api.gcp-us-west1.zillizcloud.com",
                 "user": "temp",
                 "password": "temp",
-                "token": "temp", # API key, for serverless clusters which can be used as replacements for user and password
+                "token": "temp", # API key as replacements for user and password
                 "secure": True
             }
             drop_old: True,


### PR DESCRIPTION
Description:

Currently, Zilliz only support dedicated clusters using a pair of username and password for connection. Regarding serverless clusters, they can connect to them by using API keys( [ see official note detail](https://docs.zilliz.com/docs/manage-cluster-credentials)), so I add API key(token) description in Zilliz docs to make it more obvious and convenient for this group of users to better utilize Zilliz. No changes done to code.

Maintainer:
@baskaryan 

