### PR TITLE
docs: Improve ApifyDatasetLoader docstring

### DIFF
--- a/langchain/document_loaders/apify_dataset.py
+++ b/langchain/document_loaders/apify_dataset.py
@@ -7,7 +7,24 @@ from langchain.document_loaders.base import BaseLoader
 
 
 class ApifyDatasetLoader(BaseLoader, BaseModel):
-    """Loading Documents from Apify datasets."""
+    """Loads datasets from Apify-a web scraping, crawling, and data extraction platform.
+    For details, see https://docs.apify.com/platform/integrations/langchain
+
+    Example:
+    ```python
+    from langchain.document_loaders import ApifyDatasetLoader
+    from langchain.document_loaders.base import Document
+
+    loader = ApifyDatasetLoader(
+        dataset_id="YOUR-DATASET-ID",
+        dataset_mapping_function=lambda dataset_item: Document(
+            page_content=dataset_item["text"], metadata={"source": dataset_item["url"]}
+        ),
+    )
+    documents = loader.load()
+    ```
+
+    """
 
     apify_client: Any
     """An instance of the ApifyClient class from the apify-client Python package."""


### PR DESCRIPTION
I noticed the `ApifyDatasetLoader` is lacking a code example in the docstring. I'm adding it along with a link to Apify's docs about langchain integration to improve developer experience.

PS: I'd be happy to update the search in https://integrations.langchain.com/ to also consider the description, not just the title. But AFAIK the source code for the page is not public, right?