### PR TITLE
WIP: Weaviate MMR search to support fetch_k greater than amount of docs

### DIFF
--- a/tests/integration_tests/vectorstores/test_weaviate.py
+++ b/tests/integration_tests/vectorstores/test_weaviate.py
@@ -150,6 +150,13 @@ class TestWeaviate:
             Document(page_content="bar", metadata={"page": 1}),
         ]
 
+        # when using fetch_k>len(texts), the search shall not fail (with an ValidationError)
+        standard_ranking = docsearch.similarity_search("foo", k=2)
+        output = docsearch.max_marginal_relevance_search(
+            "foo", k=2, fetch_k=len(texts)+1, lambda_mult=1.0
+        )
+        assert output == standard_ranking
+
     @pytest.mark.vcr(ignore_localhost=True)
     def test_max_marginal_relevance_search_by_vector(
         self, weaviate_url: str, embedding_openai: OpenAIEmbeddings


### PR DESCRIPTION
  - Description: Currently, when searching the weaviate vector db with a fetch_k parameter greater than the amount of docs, an error is thrown, 
  - Issue: #7829 
  - Dependencies: -,
  - Tag maintainer: -,
  - Twitter handle: -

Maintainer(s):
  - VectorStores rlancemartin, eyurtsev