### PR TITLE
fix: SQLDatabaseChain not return sql query even if return_direct=True

### DIFF
--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -158,7 +158,7 @@ class SQLDatabaseChain(Chain):
             # the result of the sql query result, otherwise try to get a human readable
             # final answer
             if self.return_direct:
-                final_result = result
+                final_result = sql_cmd
             else:
                 _run_manager.on_text("\nAnswer:", verbose=self.verbose)
                 input_text += f"{sql_cmd}\nSQLResult: {result}\nAnswer:"


### PR DESCRIPTION
**Description:** SQLDatabaseChain not return sql query even if return_direct=True

**Issue:**
for SQLDatabaseChain, although its parameter set to return_direct=True, it still returns results (e.g., USB wire 98, Laptop 90, Desktop 86, ....) instead of sql query (e.g., SELECT name AS "Product Category" FROM category ORDER BY category_id LIMIT 10;)

I found that it's because final_result variable is wrongly set to result variable instead of sql_cmd if self.return_direct = True, which is different from the documentation: python.langchain.com/docs/modules/chains/popular/sqlite

**How to replicate the issue**:
```import os
from langchain import OpenAI, SQLDatabase, SQLDatabaseChain
from langchain.chat_models import ChatOpenAI

os.environ["OPENAI_API_KEY"] = "<your openai api key>"

db = SQLDatabase.from_uri("<path to your database>")
llm = ChatOpenAI(temperature=0, verbose=True, model_name="gpt-3.5-turbo")

question = "What are the top 10 product categories"
raw_sql = db_chain(question)
raw_sql # you will see the output will not be sql query before this bug fix

````

**Tag mantainer:** @hinthornw

**Dependencies:** No change, as it's just a simple fix by replacing a variable

**Supporting Evidence:** 

![image](https://github.com/hwchase17/langchain/assets/64836390/d26098eb-7879-4cce-b4b5-eb2ea90017a4)


