### PR TITLE
Add post-processing to Web Base url loader

### DIFF
--- a/docs/extras/modules/data_connection/document_loaders/integrations/web_base.ipynb
+++ b/docs/extras/modules/data_connection/document_loaders/integrations/web_base.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "id": "00b6de21",
    "metadata": {},
    "outputs": [],
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "id": "0231df35",
    "metadata": {},
    "outputs": [],
@@ -68,6 +68,72 @@
     }
    ],
    "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "452bbaad",
+   "metadata": {},
+   "source": [
+    "## Post-processing output test\n",
+    "\n",
+    "We can post-process the output. \n",
+    "\n",
+    "To compress the repeated newlines to a single newline, simply pass `compress_newlines=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c61bb4d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Document(page_content=\"\\nESPN - Serving Sports Fans. Anytime. Anywhere.\\n        Skip to main content\\n    \\n        Skip to navigation\\n    \\n<\\n>\\nMenuESPN\\nSearch\\nscores\\nNFLNBANHLMLBSoccerTennis…NCAAFNCAAMNCAAWSports BettingBoxingCFLNCAACricketF1GolfHorseMMANASCARNBA G LeagueOlympic SportsPLLRacingRN BBRN FBRugbyWNBAWWEX GamesXFLMore ESPNFantasyListenWatchESPN+\\n  \\nSUBSCRIBE NOW\\nThe Ultimate Fighter: Season 31\\n30 For 30\\nUFC 291: Poirier vs. Gaethje 2 (Jul. 29, ESPN+ PPV)\\nThe NFL's Best Quarterbacks\\nQuick Links\\nWomen's World Cup\\nNBA Summer League\\nNBA Free Agency Buzz\\nNBA Trade Machine\\nNHL Free Agency\\nHow To Watch PGA TOUR\\nFantasy Hockey: Sign Up\\nFavorites\\n      Manage Favorites\\n      \\nCustomize ESPNSign UpLog InESPN Sites\\nESPN Deportes\\nAndscape\\nespnW\\nESPNFC\\nX Games\\nSEC Network\\nESPN Apps\\nESPN\\nESPN Fantasy\\nFollow ESPN\\nFacebook\\nTwitter\\nInstagram\\nSnapchat\\nYouTube\\nThe ESPN Daily Podcast\\nWho are the 10 best quarterbacks in the NFL? We asked execs, coaches and scoutsHow do Patrick Mahomes, Josh Allen, Joe Burrow and Justin Herbert stack up? Evaluators around the league ranked their top 10 QBs in our annual summer series.3hJeremy FowlerIllustration by ESPNRanking the best players at every position: Execs make their picksFor the fourth straight year, we asked execs, coaches, scouts and players to name their top 10 at all positions.9hJeremy FowlerTOP HEADLINESEx-Northwestern players hire civil rights attorneyExit process? Embiid eyes title in or out of PhillyBench apologizes for antisemitic jab at ex-GMSources: Pollard unlikely to get deal by deadline'Rivalry' renewed: UT-OU clash revives old name'Titan up!': Hopkins defends choice of new teamOpen champ Smith optimistic about LIV's futureBlackhawks ink top pick Bedard on 18th birthdayHow will Messi perform in MLS?WOMEN'S WORLD CUPSTARTS THURSDAYPick your USWNT starting lineup for the World CupThe Women's World Cup kicks off this week. Think you can guide the USWNT to glory? Make your choices for the starting XI and let's find out.11hESPNRankings: The top 25 players at the Women's World CupESPN's expert panel selected the top 25 players to keep an eye on, from Sophia Smith to Sam Kerr and more.3dESPNMeet all 23 USWNT players going to World CupIf USWNT can't three-peat, is Vlatko's job safe?Women's World Cup 2023: Schedule, teams, venues, moreTHE OPEN 2023LAST MAJOR OF THE YEARWho can and cannot win The Open at Royal LiverpoolRory McIlroy is looking to win his first major since 2014 against a tough field. We assess the favorites, contenders and long shots to win it all.8hMark SchlabachJane Barlow/PA Images via Getty ImagesRory finishes birdie-birdie in high winds for come-from-behind win at Scottish Open1d1:47FASTEST TO THE SHOWMLB DRAFTThe 2023 MLB draft pick who will make the majors first for all 30 teamsPaul Skenes, Dylan Crews and ... which recent draft picks will we see in The Show soon?7hDavid SchoenfieldSteven Branscombe-USA TODAY SportsNBA SUMMER LEAGUECHAMPIONSHIP GAME: 9 P.M. ET ON ESPNBiggest surprises and disappointments in Las VegasOur insiders break down the biggest storylines in Las Vegas, including Victor Wembanyama's needed adjustments and Chet Holmgren's return from injury.3hNBA insidersAP Photo/John LocherSEC FOOTBALL MEDIA DAYSTHROUGH THURSDAY ON SEC+ NETWORKPreviewing SEC media days: Georgia turmoil, new coordinators and transfer QBsThe SEC is the next conference up in the media days slate. Here are the biggest topics heading into the three-day event in Nashville.7hChris Low and Alex ScarboroughRD MooreIs Nick Saban's legacy on the line this season?3h1:57Watch full coverage of media days on SEC NetworkMADDEN RATINGSMadden NFL 24 ratings and rankings: Top 10 wide receivers, led by Justin JeffersonMadden NFL 24 ratings are out, and we're revealing the top 10 wide receivers, including Justin Jefferson and Tyreek Hill.1mMichael RothsteinCourtesy EA Madden NFLNFL EXPECTATIONSIs it NFC championship or bust for Dak and the Cowboys?4h1:11Woody: Patriots not signing DeAndre Hopkins 'a big miss'5h1:02WIMBLEDONMEN'S SINGLES FINALAlcaraz tops Djokovic in 5-set thriller to win Wimbledon14h2:26Carlos Alcaraz and the best of the rest at WimbledonAlcaraz wasn't the only player who impressed. Here are seven others whose success bodes well.1dD'Arcy Maine\\nAlcaraz: Wimbledon win is 'a dream come true for me'14h3:20\\nDjokovic tears up when thanking family after defeat14h0:53\\nDjokovic destroys his racket in frustration during 5th set12h0:33\\nDjokovic breaks Alcaraz's serve, blows sarcastic kiss to crowd14h0:22\\n Top HeadlinesEx-Northwestern players hire civil rights attorneyExit process? Embiid eyes title in or out of PhillyBench apologizes for antisemitic jab at ex-GMSources: Pollard unlikely to get deal by deadline'Rivalry' renewed: UT-OU clash revives old name'Titan up!': Hopkins defends choice of new teamOpen champ Smith optimistic about LIV's futureBlackhawks ink top pick Bedard on 18th birthdayHow will Messi perform in MLS?Favorites FantasyManage FavoritesFantasy HomeCustomize ESPNSign UpLog InBest of ESPN+Illustration by ESPNRanking the NFL's best players at every position for 2023: Execs, coaches, scouts pick their top 10 at every positionBest corners in the NFL? Edge rushers? Tight ends? For the fourth straight year, we asked execs, coaches, scouts and players to name their top 10.AP Photo/Matt SlocumNBA free agency 2023: The 13 teams that could still shake up the summerMost of the big names are off the board, but there's still work to be done. Here's an updated guide to what you need to know.Illustration by ESPN2024 NFL mock draft: Jordan Reid's early first-round predictionsThree QBs in the top 10? A run on offensive linemen? Impact defenders galore? Here are Jordan Reid's early projections for next year's 32 first-round picks. Trending NowBettmann/Getty ImagesInside the worst team in NBA history, the 1972-73 SixersThe Philadelphia 76ers started the 1972-73 season by losing 21 of 23 games. They'd finish with the worst record in NBA history, 9-73. This is the story of what the team learned about themselves through turmoil.Ron Chenoy-USA TODAY SportsCups of coffee: Seven former NFL players remember their one and only gameTheir NFL careers lasted a single game. Seven members of a unique professional club discuss their journeys.Illustration by MASAThe FC 100 for 2023: Haaland, Mbappe lead our list of best men's soccer playersAfter a brief hiatus thanks to the winter World Cup in Qatar, ESPN presents its seventh annual ranking of the best men's players and coaches in world soccer! Welcome to FC 100. How to Watch on ESPN+(AP Photo/Koji Sasahara, File)How to watch the PGA Tour, Masters, PGA Championship and FedEx Cup playoffs on ESPN, ESPN+Here's everything you need to know about how to watch the PGA Tour, Masters, PGA Championship and FedEx Cup playoffs on ESPN and ESPN+. Sign up to play the #1 Fantasy game!Create A LeagueJoin Public LeagueReactivateMock Draft NowSign up for FREE!Create A LeagueJoin a Public LeagueReactivate a LeaguePractice With a Mock DraftSign up for FREE!Create A LeagueJoin a Public LeagueReactivate a LeaguePractice with a Mock Draft\\nESPN+\\nThe Ultimate Fighter: Season 31\\n30 For 30\\nUFC 291: Poirier vs. Gaethje 2 (Jul. 29, ESPN+ PPV)\\nThe NFL's Best Quarterbacks\\nQuick Links\\nWomen's World Cup\\nNBA Summer League\\nNBA Free Agency Buzz\\nNBA Trade Machine\\nNHL Free Agency\\nHow To Watch PGA TOUR\\nFantasy Hockey: Sign Up\\nESPN Sites\\nESPN Deportes\\nAndscape\\nespnW\\nESPNFC\\nX Games\\nSEC Network\\nESPN Apps\\nESPN\\nESPN Fantasy\\nFollow ESPN\\nFacebook\\nTwitter\\nInstagram\\nSnapchat\\nYouTube\\nThe ESPN Daily Podcast\\nTerms of UsePrivacy PolicyYour US State Privacy RightsChildren's Online Privacy PolicyInterest-Based AdsAbout Nielsen MeasurementDo Not Sell or Share My Personal InformationContact UsDisney Ad Sales SiteWork for ESPNCopyright: © ESPN Enterprises, Inc. All rights reserved.\\n\", metadata={'source': 'https://www.espn.com/', 'title': 'ESPN - Serving Sports Fans. Anytime. Anywhere.', 'description': 'Visit ESPN for live scores, highlights and sports news. Stream exclusive games on ESPN+ and play fantasy sports.', 'language': 'en'})]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loader = WebBaseLoader(\"https://www.espn.com/\", compress_newlines=True)\n",
+    "data = loader.load()\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "952fd96a",
+   "metadata": {},
+   "source": [
+    "To apply any find-replace (using `re.sub`) we can specify the expression and replacement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "32f59eed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Document(page_content=\"\\nESPN - Serving Sports Fans. Anytime. Anywhere.\\n        Skip to main content\\n            Skip to navigation\\n    <>MenuESPN\\nSearchscoresNFLNBANHLMLBSoccerTennis…NCAAFNCAAMNCAAWSports BettingBoxingCFLNCAACricketF1GolfHorseMMANASCARNBA G LeagueOlympic SportsPLLRacingRN BBRN FBRugbyWNBAWWEX GamesXFLMore ESPNFantasyListenWatchESPN+  SUBSCRIBE NOWThe Ultimate Fighter: Season 3130 For 30UFC 291: Poirier vs. Gaethje 2 (Jul. 29, ESPN+ PPV)The NFL's Best Quarterbacks\\nQuick Links\\nWomen's World CupNBA Summer LeagueNBA Free Agency BuzzNBA Trade MachineNHL Free AgencyHow To Watch PGA TOURFantasy Hockey: Sign Up\\nFavorites\\n      Manage Favorites\\n      Customize ESPNSign UpLog InESPN Sites\\nESPN DeportesAndscapeespnWESPNFCX GamesSEC Network\\nESPN Apps\\nESPNESPN Fantasy\\nFollow ESPN\\nFacebookTwitterInstagramSnapchatYouTubeThe ESPN Daily Podcast\\nWho are the 10 best quarterbacks in the NFL? We asked execs, coaches and scoutsHow do Patrick Mahomes, Josh Allen, Joe Burrow and Justin Herbert stack up? Evaluators around the league ranked their top 10 QBs in our annual summer series.3hJeremy FowlerIllustration by ESPNRanking the best players at every position: Execs make their picksFor the fourth straight year, we asked execs, coaches, scouts and players to name their top 10 at all positions.9hJeremy FowlerTOP HEADLINESEx-Northwestern players hire civil rights attorneyExit process? Embiid eyes title in or out of PhillyBench apologizes for antisemitic jab at ex-GMSources: Pollard unlikely to get deal by deadline'Rivalry' renewed: UT-OU clash revives old name'Titan up!': Hopkins defends choice of new teamOpen champ Smith optimistic about LIV's futureBlackhawks ink top pick Bedard on 18th birthdayHow will Messi perform in MLS?WOMEN'S WORLD CUPSTARTS THURSDAYPick your USWNT starting lineup for the World CupThe Women's World Cup kicks off this week. Think you can guide the USWNT to glory? Make your choices for the starting XI and let's find out.11hESPNRankings: The top 25 players at the Women's World CupESPN's expert panel selected the top 25 players to keep an eye on, from Sophia Smith to Sam Kerr and more.3dESPNMeet all 23 USWNT players going to World CupIf USWNT can't three-peat, is Vlatko's job safe?Women's World Cup 2023: Schedule, teams, venues, moreTHE OPEN 2023LAST MAJOR OF THE YEARWho can and cannot win The Open at Royal LiverpoolRory McIlroy is looking to win his first major since 2014 against a tough field. We assess the favorites, contenders and long shots to win it all.8hMark SchlabachJane Barlow/PA Images via Getty ImagesRory finishes birdie-birdie in high winds for come-from-behind win at Scottish Open1d1:47FASTEST TO THE SHOWMLB DRAFTThe 2023 MLB draft pick who will make the majors first for all 30 teamsPaul Skenes, Dylan Crews and ... which recent draft picks will we see in The Show soon?7hDavid SchoenfieldSteven Branscombe-USA TODAY SportsNBA SUMMER LEAGUECHAMPIONSHIP GAME: 9 P.M. ET ON ESPNBiggest surprises and disappointments in Las VegasOur insiders break down the biggest storylines in Las Vegas, including Victor Wembanyama's needed adjustments and Chet Holmgren's return from injury.3hNBA insidersAP Photo/John LocherSEC FOOTBALL MEDIA DAYSTHROUGH THURSDAY ON SEC+ NETWORKPreviewing SEC media days: Georgia turmoil, new coordinators and transfer QBsThe SEC is the next conference up in the media days slate. Here are the biggest topics heading into the three-day event in Nashville.7hChris Low and Alex ScarboroughRD MooreIs Nick Saban's legacy on the line this season?3h1:57Watch full coverage of media days on SEC NetworkMADDEN RATINGSMadden NFL 24 ratings and rankings: Top 10 wide receivers, led by Justin JeffersonMadden NFL 24 ratings are out, and we're revealing the top 10 wide receivers, including Justin Jefferson and Tyreek Hill.1mMichael RothsteinCourtesy EA Madden NFLNFL EXPECTATIONSIs it NFC championship or bust for Dak and the Cowboys?4h1:11Woody: Patriots not signing DeAndre Hopkins 'a big miss'5h1:02WIMBLEDONMEN'S SINGLES FINALAlcaraz tops Djokovic in 5-set thriller to win Wimbledon14h2:26Carlos Alcaraz and the best of the rest at WimbledonAlcaraz wasn't the only player who impressed. Here are seven others whose success bodes well.1dD'Arcy MaineAlcaraz: Wimbledon win is 'a dream come true for me'14h3:20\\nDjokovic tears up when thanking family after defeat14h0:53\\nDjokovic destroys his racket in frustration during 5th set12h0:33\\nDjokovic breaks Alcaraz's serve, blows sarcastic kiss to crowd14h0:22 Top HeadlinesEx-Northwestern players hire civil rights attorneyExit process? Embiid eyes title in or out of PhillyBench apologizes for antisemitic jab at ex-GMSources: Pollard unlikely to get deal by deadline'Rivalry' renewed: UT-OU clash revives old name'Titan up!': Hopkins defends choice of new teamOpen champ Smith optimistic about LIV's futureBlackhawks ink top pick Bedard on 18th birthdayHow will Messi perform in MLS?Favorites FantasyManage FavoritesFantasy HomeCustomize ESPNSign UpLog InBest of ESPN+Illustration by ESPNRanking the NFL's best players at every position for 2023: Execs, coaches, scouts pick their top 10 at every positionBest corners in the NFL? Edge rushers? Tight ends? For the fourth straight year, we asked execs, coaches, scouts and players to name their top 10.AP Photo/Matt SlocumNBA free agency 2023: The 13 teams that could still shake up the summerMost of the big names are off the board, but there's still work to be done. Here's an updated guide to what you need to know.Illustration by ESPN2024 NFL mock draft: Jordan Reid's early first-round predictionsThree QBs in the top 10? A run on offensive linemen? Impact defenders galore? Here are Jordan Reid's early projections for next year's 32 first-round picks. Trending NowBettmann/Getty ImagesInside the worst team in NBA history, the 1972-73 SixersThe Philadelphia 76ers started the 1972-73 season by losing 21 of 23 games. They'd finish with the worst record in NBA history, 9-73. This is the story of what the team learned about themselves through turmoil.Ron Chenoy-USA TODAY SportsCups of coffee: Seven former NFL players remember their one and only gameTheir NFL careers lasted a single game. Seven members of a unique professional club discuss their journeys.Illustration by MASAThe FC 100 for 2023: Haaland, Mbappe lead our list of best men's soccer playersAfter a brief hiatus thanks to the winter World Cup in Qatar, ESPN presents its seventh annual ranking of the best men's players and coaches in world soccer! Welcome to FC 100. How to Watch on ESPN+(AP Photo/Koji Sasahara, File)How to watch the PGA Tour, Masters, PGA Championship and FedEx Cup playoffs on ESPN, ESPN+Here's everything you need to know about how to watch the PGA Tour, Masters, PGA Championship and FedEx Cup playoffs on ESPN and ESPN+. Sign up to play the #1 Fantasy game!Create A LeagueJoin Public LeagueReactivateMock Draft NowSign up for FREE!Create A LeagueJoin a Public LeagueReactivate a LeaguePractice With a Mock DraftSign up for FREE!Create A LeagueJoin a Public LeagueReactivate a LeaguePractice with a Mock DraftESPN+\\nWatch NowThe Ultimate Fighter: Season 3130 For 30UFC 291: Poirier vs. Gaethje 2 (Jul. 29, ESPN+ PPV)The NFL's Best Quarterbacks\\nQuick Links\\nWomen's World CupNBA Summer LeagueNBA Free Agency BuzzNBA Trade MachineNHL Free AgencyHow To Watch PGA TOURFantasy Hockey: Sign Up\\nESPN Sites\\nESPN DeportesAndscapeespnWESPNFCX GamesSEC Network\\nESPN Apps\\nESPNESPN Fantasy\\nFollow ESPN\\nFacebookTwitterInstagramSnapchatYouTubeThe ESPN Daily Podcast\\nTerms of UsePrivacy PolicyYour US State Privacy RightsChildren's Online Privacy PolicyInterest-Based AdsAbout Nielsen MeasurementDo Not Sell or Share My Personal InformationContact UsDisney Ad Sales SiteWork for ESPNCopyright: © ESPN Enterprises, Inc. All rights reserved.\\n\", metadata={'source': 'https://www.espn.com/', 'title': 'ESPN - Serving Sports Fans. Anytime. Anywhere.', 'description': 'Visit ESPN for live scores, highlights and sports news. Stream exclusive games on ESPN+ and play fantasy sports.', 'language': 'en'})]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "loader = WebBaseLoader(\"https://www.espn.com/\", regex=\"\\n\", replacement=\"\")\n",
+    "data = loader.load()\n",
     "data"
    ]
   },
@@ -226,19 +292,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "672264ad",
+   "metadata": {},
    "source": [
     "## Using proxies\n",
     "\n",
     "Sometimes you might need to use proxies to get around IP blocks. You can pass in a dictionary of proxies to the loader (and `requests` underneath) to use them."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "672264ad"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9caf0310",
+   "metadata": {},
    "outputs": [],
    "source": [
     "loader = WebBaseLoader(\n",
@@ -249,11 +315,7 @@
     "    },\n",
     ")\n",
     "docs = loader.load()"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "9caf0310"
+   ]
   }
  ],
  "metadata": {
@@ -272,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/langchain/document_loaders/web_base.py
+++ b/langchain/document_loaders/web_base.py
@@ -65,7 +65,7 @@ class WebBaseLoader(BaseLoader):
         proxies: Optional[dict] = None,
         compress_newlines: Optional[bool] = False,
         regex: Optional[str] = None,
-        replacement: Optional[str] = "",
+        replacement: str = "",
     ):
         """Initialize with webpage path."""
 


### PR DESCRIPTION
Text loaded from urls can have low quality formatting (e.g., repeated newlines) that we want to post-process.

We add regex substitution and newline compression to WebBaseLoader.