### PR TITLE
Adding code to allow pandas to show all columns instead of truncating…

### DIFF
--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -118,7 +118,7 @@ def _get_prompt_and_tools(
 ) -> Tuple[BasePromptTemplate, List[PythonAstREPLTool]]:
     try:
         import pandas as pd
-        pd.set_option('display.max_rows', None)
+        pd.set_option('display.max_columns', None)
     except ImportError:
         raise ValueError(
             "pandas package not found, please install with `pip install pandas`"
@@ -228,7 +228,7 @@ def _get_functions_prompt_and_tools(
 ) -> Tuple[BasePromptTemplate, List[PythonAstREPLTool]]:
     try:
         import pandas as pd
-        pd.set_option('display.max_rows', None)
+        pd.set_option('display.max_columns', None)
     except ImportError:
         raise ValueError(
             "pandas package not found, please install with `pip install pandas`"

--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -118,7 +118,8 @@ def _get_prompt_and_tools(
 ) -> Tuple[BasePromptTemplate, List[PythonAstREPLTool]]:
     try:
         import pandas as pd
-        pd.set_option('display.max_columns', None)
+
+        pd.set_option("display.max_columns", None)
     except ImportError:
         raise ValueError(
             "pandas package not found, please install with `pip install pandas`"
@@ -228,7 +229,8 @@ def _get_functions_prompt_and_tools(
 ) -> Tuple[BasePromptTemplate, List[PythonAstREPLTool]]:
     try:
         import pandas as pd
-        pd.set_option('display.max_columns', None)
+
+        pd.set_option("display.max_columns", None)
     except ImportError:
         raise ValueError(
             "pandas package not found, please install with `pip install pandas`"

--- a/langchain/agents/agent_toolkits/pandas/base.py
+++ b/langchain/agents/agent_toolkits/pandas/base.py
@@ -118,6 +118,7 @@ def _get_prompt_and_tools(
 ) -> Tuple[BasePromptTemplate, List[PythonAstREPLTool]]:
     try:
         import pandas as pd
+        pd.set_option('display.max_rows', None)
     except ImportError:
         raise ValueError(
             "pandas package not found, please install with `pip install pandas`"
@@ -227,6 +228,7 @@ def _get_functions_prompt_and_tools(
 ) -> Tuple[BasePromptTemplate, List[PythonAstREPLTool]]:
     try:
         import pandas as pd
+        pd.set_option('display.max_rows', None)
     except ImportError:
         raise ValueError(
             "pandas package not found, please install with `pip install pandas`"


### PR DESCRIPTION
  - Description: Adding code to set pandas dataframe to display all the columns.  Otherwise, some data get truncated (it puts a "..." in the middle and just shows the first 4 and last 4 columns) and the LLM doesn't realize it isn't getting the full data.  Default value is 8, so this helps Dataframes larger than that.
  - Issue: none
  - Dependencies: none
  - Tag maintainer: @hinthornw 
  - Twitter handle: none