### PR TITLE
Adding endpoint_url to embeddings/bedrock.py and updated docs 

### DIFF
--- a/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "from langchain.embeddings import BedrockEmbeddings\n",
     "\n",
-    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"https://custom_endpoint_url\")"
+    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_endpoint_url\")"
    ]
   },
   {

--- a/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
@@ -27,7 +27,9 @@
    "source": [
     "from langchain.embeddings import BedrockEmbeddings\n",
     "\n",
-    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_endpoint_url\")"
+    "embeddings = BedrockEmbeddings(\n",
+    "    credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_endpoint_url\"\n",
+    ")"
    ]
   },
   {

--- a/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "from langchain.embeddings import BedrockEmbeddings\n",
     "\n",
-    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_url\")"
+    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_endpoint_url\")"
    ]
   },
   {

--- a/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "from langchain.embeddings import BedrockEmbeddings\n",
     "\n",
-    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_endpoint_url\")"
+    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"https://custom_endpoint_url\")"
    ]
   },
   {

--- a/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/bedrock.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "from langchain.embeddings import BedrockEmbeddings\n",
     "\n",
-    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\")"
+    "embeddings = BedrockEmbeddings(credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_url\")"
    ]
   },
   {

--- a/docs/extras/modules/model_io/models/llms/integrations/bedrock.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/bedrock.ipynb
@@ -34,7 +34,7 @@
     "from langchain.llms.bedrock import Bedrock\n",
     "\n",
     "llm = Bedrock(\n",
-    "    credentials_profile_name=\"bedrock-admin\", model_id=\"amazon.titan-tg1-large\", endpoint_url=\"https://custom_endpoint_url\"\n",
+    "    credentials_profile_name=\"bedrock-admin\", model_id=\"amazon.titan-tg1-large\", endpoint_url=\"custom_endpoint_url\"\n",
     ")"
    ]
   },

--- a/docs/extras/modules/model_io/models/llms/integrations/bedrock.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/bedrock.ipynb
@@ -34,7 +34,9 @@
     "from langchain.llms.bedrock import Bedrock\n",
     "\n",
     "llm = Bedrock(\n",
-    "    credentials_profile_name=\"bedrock-admin\", model_id=\"amazon.titan-tg1-large\", endpoint_url=\"custom_endpoint_url\"\n",
+    "    credentials_profile_name=\"bedrock-admin\",\n",
+    "    model_id=\"amazon.titan-tg1-large\",\n",
+    "    endpoint_url=\"custom_endpoint_url\",\n",
     ")"
    ]
   },

--- a/docs/extras/modules/model_io/models/llms/integrations/bedrock.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/bedrock.ipynb
@@ -34,7 +34,7 @@
     "from langchain.llms.bedrock import Bedrock\n",
     "\n",
     "llm = Bedrock(\n",
-    "    credentials_profile_name=\"bedrock-admin\", model_id=\"amazon.titan-tg1-large\"\n",
+    "    credentials_profile_name=\"bedrock-admin\", model_id=\"amazon.titan-tg1-large\", endpoint_url=\"https://custom_endpoint_url\"\n",
     ")"
    ]
   },

--- a/langchain/embeddings/bedrock.py
+++ b/langchain/embeddings/bedrock.py
@@ -87,7 +87,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             client_params = {}
             if values["region_name"]:
                 client_params["region_name"] = values["region_name"]
-            
+
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
 

--- a/langchain/embeddings/bedrock.py
+++ b/langchain/embeddings/bedrock.py
@@ -60,6 +60,9 @@ class BedrockEmbeddings(BaseModel, Embeddings):
     model_kwargs: Optional[Dict] = None
     """Key word arguments to pass to the model."""
 
+    endpoint_url: Optional[str] = None
+    """Needed if you don't want to default to us-east-1 endpoint"""
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -84,6 +87,9 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             client_params = {}
             if values["region_name"]:
                 client_params["region_name"] = values["region_name"]
+            
+            if values["endpoint_url"]:
+                client_params["endpoint_url"] = values["endpoint_url"]
 
             values["client"] = session.client("bedrock", **client_params)
 


### PR DESCRIPTION
 BedrockEmbeddings does not have endpoint_url so that switching to custom endpoint is not possible. I have access to Bedrock custom endpoint and cannot use BedrockEmbeddings