### PR TITLE
Getting SQL cmd directly from SQLDatabase Chain.

### DIFF
--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -41,6 +41,8 @@ class SQLDatabaseChain(Chain):
     """Number of results to return from the query"""
     input_key: str = "query"  #: :meta private:
     output_key: str = "result"  #: :meta private:
+    return_sql: bool = False
+    """Will return sql-command directly without executing it"""
     return_intermediate_steps: bool = False
     """Whether or not to return the intermediate steps along with the final answer."""
     return_direct: bool = False
@@ -117,6 +119,9 @@ class SQLDatabaseChain(Chain):
                 callbacks=_run_manager.get_child(),
                 **llm_inputs,
             ).strip()
+            if self.return_sql:
+                chain_result: Dict[str, Any] = {self.output_key: sql_cmd}
+                return chain_result
             if not self.use_query_checker:
                 _run_manager.on_text(sql_cmd, color="green", verbose=self.verbose)
                 intermediate_steps.append(

--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -120,8 +120,7 @@ class SQLDatabaseChain(Chain):
                 **llm_inputs,
             ).strip()
             if self.return_sql:
-                chain_result: Dict[str, Any] = {self.output_key: sql_cmd}
-                return chain_result
+                return {self.output_key: sql_cmd}
             if not self.use_query_checker:
                 _run_manager.on_text(sql_cmd, color="green", verbose=self.verbose)
                 intermediate_steps.append(


### PR DESCRIPTION

- Description: Get SQL Cmd directly generated by SQL-Database Chain without executing it in the DB engine.
- Issue: #4853 
- Tag maintainer: @hinthornw,@baskaryan
