### PR TITLE
One Line Fix: missing text output with huggingface TGI LLM

### DIFF
--- a/langchain/llms/huggingface_text_gen_inference.py
+++ b/langchain/llms/huggingface_text_gen_inference.py
@@ -257,4 +257,5 @@ class HuggingFaceTextGenInference(LLM):
                 if not token.special:
                     if text_callback:
                         await text_callback(token.text)
+                    text += token.text
         return text


### PR DESCRIPTION
Small bug fix. The async _call method was missing a line to return the generated text.

@baskaryan 