### PR TITLE
Support multiple filters for ElasticVectorStore

### DIFF
--- a/langchain/vectorstores/elastic_vector_search.py
+++ b/langchain/vectorstores/elastic_vector_search.py
@@ -35,8 +35,16 @@ def _default_text_mapping(dim: int) -> Dict:
 
 def _default_script_query(query_vector: List[float], filter: Optional[dict]) -> Dict:
     if filter:
-        ((key, value),) = filter.items()
-        filter = {"match": {f"metadata.{key}.keyword": f"{value}"}}
+        filter = {
+            "bool": {
+                "filter": [
+                    {
+                        "match": {f"metadata.{key}.keyword": f"{value}"}
+                        for key, value in filter.items()
+                    }
+                ]
+            }
+        }
     else:
         filter = {"match_all": {}}
     return {

--- a/langchain/vectorstores/elastic_vector_search.py
+++ b/langchain/vectorstores/elastic_vector_search.py
@@ -33,8 +33,10 @@ def _default_text_mapping(dim: int) -> Dict:
     }
 
 
-def _default_script_query(query_vector: List[float], filter: Optional[dict]) -> Dict:
-    if filter:
+def _default_script_query(
+    query_vector: List[float], filter: Optional[dict], filter_is_es_query: bool = False
+) -> Dict:
+    if not filter_is_es_query and filter:
         filter = {
             "bool": {
                 "filter": [


### PR DESCRIPTION
This PR will
- Enable the ElasticVectorStore to support multiple filters (combine all the filters using `AND` operator)
- Put the query in a filter context ensuring that the scores of the retrieved documents are not affected by the number of filters.  (For reference on the difference between query context and filter context see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#filter-context)
- add support for arbitrary elasticsearch query as filter using the `filter_is_es_query` toggle

 
@rlancemartin, @eyurtsev

