### PR TITLE
fix: catch pydantic validation errors

### DIFF
--- a/langchain/agents/agent.py
+++ b/langchain/agents/agent.py
@@ -958,8 +958,8 @@ s
                     except ValidationError as ve:
                         observation = (
                             'Please review the "arguments" to correctly execute '
-                            f"{agent_action.tool}. The execution ended with the following "
-                            f"error: {str(ve)}"
+                            f"{agent_action.tool}. The execution ended with the "
+                            f"following error: {str(ve)}"
                         )
             else:
                 tool_run_kwargs = self.agent.tool_run_logging_kwargs()


### PR DESCRIPTION
This PR proposes a fix to catch `pydantic` `ValidationErrors` and request a fix of the arguments to the LLM, instead of the error stopping the execution. 

The change is implemented within the `_take_next_step` and `_atake_next_step` methods of the `AgentExecutor`, where the `tool.run` is now within a `try` block. If during the execution of `tool.run` a `ValidationError` is raised, an except block now catches said error and turns the observation into a request for the LLM to fix the arguments for the requested action.

This proposed fix improves the reliability of the `AgentExecutor`.

 - Maintainer: @hinthornw 
 - Twitter handle: @aledelunap 