### PR TITLE
fix: create schema description from URIs and str w/out rdflib warnings

### DIFF
--- a/langchain/graphs/rdf_graph.py
+++ b/langchain/graphs/rdf_graph.py
@@ -225,7 +225,7 @@ class RdfGraph:
     def _res_to_str(self, res: rdflib.query.ResultRow, var: str) -> str:
         return (
             "<"
-            + res[var]
+            + str(res[var])
             + "> ("
             + self._get_local_name(res[var])
             + ", "


### PR DESCRIPTION
- Description: fix to avoid rdflib warnings when concatenating URIs and strings to create the text snippet for the knowledge graph's schema. @marioscrock pointed this out in a comment related to #7165
- Issue: None, but the problem was mentioned as a comment in #7165
- Dependencies: None
- Tag maintainer: Related to memory -> @hwchase17, maybe @baskaryan as it is a fix
