### PR TITLE
Update mongodb_atlas.py docstrings

### DIFF
--- a/langchain/vectorstores/mongodb_atlas.py
+++ b/langchain/vectorstores/mongodb_atlas.py
@@ -69,6 +69,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
                 document.
             embedding_key: MongoDB field that will contain the embedding for
                 each document.
+            index_name: Name of the Atlas Search index.
         """
         self._collection = collection
         self._embedding = embedding


### PR DESCRIPTION
Hi all, I just added the "index_name" parameter to the docstrings for mongodb_atlas.py (it is missing in the [public doc page](https://api.python.langchain.com/en/latest/vectorstores/langchain.vectorstores.mongodb_atlas.MongoDBAtlasVectorSearch.html#langchain-vectorstores-mongodb-atlas-mongodbatlasvectorsearch).

@rlancemartin 

Thanks