### PR TITLE
HuggingFaceTextGenInference bug fix: Multiple values for keyword argument

### DIFF
--- a/langchain/llms/huggingface_text_gen_inference.py
+++ b/langchain/llms/huggingface_text_gen_inference.py
@@ -144,8 +144,7 @@ class HuggingFaceTextGenInference(LLM):
         self, runtime_stop: Optional[List[str]], **kwargs: Any
     ) -> Dict[str, Any]:
         params = {**self._default_params, **kwargs}
-        runtime_stop = runtime_stop or []
-        params["stop_sequences"] += runtime_stop
+        params["stop_sequences"] = params["stop_sequences"] + (runtime_stop or [])
         return params
 
     def _call(

--- a/langchain/llms/huggingface_text_gen_inference.py
+++ b/langchain/llms/huggingface_text_gen_inference.py
@@ -151,13 +151,15 @@ class HuggingFaceTextGenInference(LLM):
             stop = self.stop_sequences
         else:
             stop += self.stop_sequences
-
+        generate_params = {
+            **self._default_params,
+            "stop_sequences": stop,
+            **kwargs,
+        }
         if not self.stream:
             res = self.client.generate(
                 prompt,
-                **self._default_params,
-                stop_sequences=stop,
-                **kwargs,
+                **generate_params
             )
             # remove stop sequences from the end of the generated text
             for stop_seq in stop:
@@ -172,13 +174,8 @@ class HuggingFaceTextGenInference(LLM):
                 text_callback = partial(
                     run_manager.on_llm_new_token, verbose=self.verbose
                 )
-            params = {
-                **self._default_params,
-                "stop_sequences": stop,
-                **kwargs,
-            }
             text = ""
-            for res in self.client.generate_stream(prompt, **params):
+            for res in self.client.generate_stream(prompt, **generate_params):
                 token = res.token
                 is_stop = False
                 for stop_seq in stop:
@@ -204,13 +201,15 @@ class HuggingFaceTextGenInference(LLM):
             stop = self.stop_sequences
         else:
             stop += self.stop_sequences
-
+        generate_params = {
+            **self._default_params,
+            "stop_sequences": stop,
+            **kwargs,
+        }
         if not self.stream:
             res = await self.async_client.generate(
                 prompt,
-                **self._default_params,
-                stop_sequences=stop,
-                **kwargs,
+                **generate_params,
             )
             # remove stop sequences from the end of the generated text
             for stop_seq in stop:
@@ -225,13 +224,8 @@ class HuggingFaceTextGenInference(LLM):
                 text_callback = partial(
                     run_manager.on_llm_new_token, verbose=self.verbose
                 )
-            params = {
-                **self._default_params,
-                "stop_sequences": stop,
-                **kwargs,
-            }
             text = ""
-            async for res in self.async_client.generate_stream(prompt, **params):
+            async for res in self.async_client.generate_stream(prompt, **generate_params):
                 token = res.token
                 is_stop = False
                 for stop_seq in stop:

--- a/langchain/llms/huggingface_text_gen_inference.py
+++ b/langchain/llms/huggingface_text_gen_inference.py
@@ -157,10 +157,7 @@ class HuggingFaceTextGenInference(LLM):
             **kwargs,
         }
         if not self.stream:
-            res = self.client.generate(
-                prompt,
-                **generate_params
-            )
+            res = self.client.generate(prompt, **generate_params)
             # remove stop sequences from the end of the generated text
             for stop_seq in stop:
                 if stop_seq in res.generated_text:
@@ -225,7 +222,9 @@ class HuggingFaceTextGenInference(LLM):
                     run_manager.on_llm_new_token, verbose=self.verbose
                 )
             text = ""
-            async for res in self.async_client.generate_stream(prompt, **generate_params):
+            async for res in self.async_client.generate_stream(
+                prompt, **generate_params
+            ):
                 token = res.token
                 is_stop = False
                 for stop_seq in stop:

--- a/tests/integration_tests/llms/test_huggingface_text_gen_inference.py
+++ b/tests/integration_tests/llms/test_huggingface_text_gen_inference.py
@@ -1,0 +1,19 @@
+from langchain import HuggingFaceTextGenInference
+
+
+def test_invocation_params_stop_sequences() -> None:
+    llm = HuggingFaceTextGenInference()
+    assert llm._default_params["stop_sequences"] == []
+
+    runtime_stop = None
+    assert llm._invocation_params(runtime_stop)["stop_sequences"] == []
+    assert llm._default_params["stop_sequences"] == []
+
+    runtime_stop = ["stop"]
+    assert llm._invocation_params(runtime_stop)["stop_sequences"] == ["stop"]
+    assert llm._default_params["stop_sequences"] == []
+
+    llm = HuggingFaceTextGenInference(stop_sequences=["."])
+    runtime_stop = ["stop"]
+    assert llm._invocation_params(runtime_stop)["stop_sequences"] == [".", "stop"]
+    assert llm._default_params["stop_sequences"] == ["."]


### PR DESCRIPTION
Fixed the bug causing: `TypeError: generate() got multiple values for keyword argument 'stop_sequences'`

```python
res = await self.async_client.generate(
                prompt,
                **self._default_params,
                stop_sequences=stop,
                **kwargs,
            )
```
The above throws an error because stop_sequences is in also in the self._default_params.

@baskaryan review please?