### PR TITLE
feat: Add with_history option for chatglm

### DIFF
--- a/docs/extras/modules/model_io/models/llms/integrations/chatglm.ipynb
+++ b/docs/extras/modules/model_io/models/llms/integrations/chatglm.ipynb
@@ -95,6 +95,22 @@
     "\n",
     "llm_chain.run(question)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By Default, ChatGLM is statful to keep track of the conversation history and send the accumulated context to the model. To enable stateless mode, we could set ChatGLM.with_history as `False` explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm.with_history = False"
+   ]
   }
  ],
  "metadata": {

--- a/langchain/llms/chatglm.py
+++ b/langchain/llms/chatglm.py
@@ -1,11 +1,13 @@
 from typing import Any, List, Mapping, Optional
 
+import logging
 import requests
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
 
+logger = logging.getLogger(__name__)
 
 class ChatGLM(LLM):
     """ChatGLM LLM service.
@@ -34,6 +36,8 @@ class ChatGLM(LLM):
     """History of the conversation"""
     top_p: float = 0.7
     """Top P for nucleus sampling from 0 to 1"""
+    with_history: bool = True
+    """Whether to use history or not"""
 
     @property
     def _llm_type(self) -> str:
@@ -85,7 +89,7 @@ class ChatGLM(LLM):
         payload.update(_model_kwargs)
         payload.update(kwargs)
 
-        # print("ChatGLM payload:", payload)
+        logger.debug(f"ChatGLM payload: {payload}")
 
         # call api
         try:
@@ -93,7 +97,7 @@ class ChatGLM(LLM):
         except requests.exceptions.RequestException as e:
             raise ValueError(f"Error raised by inference endpoint: {e}")
 
-        # print("ChatGLM resp:", response)
+        logger.debug(f"ChatGLM response: {response}")
 
         if response.status_code != 200:
             raise ValueError(f"Failed with response: {response}")
@@ -119,5 +123,6 @@ class ChatGLM(LLM):
 
         if stop is not None:
             text = enforce_stop_tokens(text, stop)
-        self.history = self.history + [[None, parsed_response["response"]]]
+        if self.with_history:
+            self.history = self.history + [[None, parsed_response["response"]]]
         return text

--- a/langchain/llms/chatglm.py
+++ b/langchain/llms/chatglm.py
@@ -9,6 +9,7 @@ from langchain.llms.utils import enforce_stop_tokens
 
 logger = logging.getLogger(__name__)
 
+
 class ChatGLM(LLM):
     """ChatGLM LLM service.
 

--- a/langchain/llms/chatglm.py
+++ b/langchain/llms/chatglm.py
@@ -1,6 +1,6 @@
+import logging
 from typing import Any, List, Mapping, Optional
 
-import logging
 import requests
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun


### PR DESCRIPTION
In certain 0-shot scenarios, the existing stateful language model can unintentionally send/accumulate the .history.

This commit adds the "with_history" option to chatglm, allowing users to control the behavior of .history and prevent unintended accumulation.

Possible reviewers @hwchase17 @baskaryan @mlot

Refer to discussion over this thread: https://twitter.com/wey_gu/status/1681996149543276545?s=20
