### PR TITLE
Fix `allowed_search_types` in `VectorStoreRetriever`

### DIFF
--- a/langchain/vectorstores/base.py
+++ b/langchain/vectorstores/base.py
@@ -465,7 +465,7 @@ class VectorStoreRetriever(BaseRetriever):
     search_kwargs: dict = Field(default_factory=dict)
     allowed_search_types: ClassVar[Collection[str]] = (
         "similarity",
-        "similarityatscore_threshold",
+        "similarity_score_threshold",
         "mmr",
     )
 


### PR DESCRIPTION


<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->

I guess `allowed_search_types` is unexpectedly changed in https://github.com/hwchase17/langchain/commit/6792a3557dc396804a12ba8892b36a322434c7c6, so that we cannot specify `similarity_score_threshold` here.

```python
class VectorStoreRetriever(BaseRetriever):
    ...
    allowed_search_types: ClassVar[Collection[str]] = (
        "similarity",
        "similarityatscore_threshold",
        "mmr",
    )

    @root_validator()
    def validate_search_type(cls, values: Dict) -> Dict:
        """Validate search type."""
        search_type = values["search_type"]
        if search_type not in cls.allowed_search_types:
            raise ValueError(...)
        if search_type == "similarity_score_threshold":
            ... # UNREACHABLE CODE
```

VectorStores Maintainers: @rlancemartin @eyurtsev