### PR TITLE
Don't throw JSON decode error in OpenAIFunctionsAgent

### DIFF
--- a/langchain/agents/openai_functions_agent/base.py
+++ b/langchain/agents/openai_functions_agent/base.py
@@ -52,12 +52,16 @@ def _convert_agent_action_to_messages(
         AIMessage that corresponds to the original tool invocation.
     """
     if isinstance(agent_action, _FunctionsAgentAction):
-        return agent_action.message_log + [_create_function_message(agent_action, observation)]
+        return agent_action.message_log + [
+            _create_function_message(agent_action, observation)
+        ]
     else:
         return [AIMessage(content=agent_action.log)]
 
 
-def _create_function_message(agent_action: AgentAction, observation: str) -> FunctionMessage:
+def _create_function_message(
+    agent_action: AgentAction, observation: str
+) -> FunctionMessage:
     """Convert agent action and observation into a function message.
     Args:
         agent_action: the tool invocation request from the agent
@@ -108,6 +112,7 @@ def _parse_ai_message(message: BaseMessage) -> Union[AgentAction, AgentFinish]:
         try:
             _tool_input = json.loads(function_call["arguments"])
         except JSONDecodeError:
+            # Sometimes the agent just passes a string as an argument
             _tool_input = {"__arg1": function_call["arguments"]}
 
         # HACK HACK HACK:
@@ -258,11 +263,15 @@ class OpenAIFunctionsAgent(BaseSingleActionAgent):
             )
         elif early_stopping_method == "generate":
             # Generate does one final forward pass
-            agent_decision = self.plan(intermediate_steps, with_functions=False, **kwargs)
+            agent_decision = self.plan(
+                intermediate_steps, with_functions=False, **kwargs
+            )
             if type(agent_decision) == AgentFinish:
                 return agent_decision
             else:
-                raise ValueError(f"got AgentAction with no functions provided: {agent_decision}")
+                raise ValueError(
+                    f"got AgentAction with no functions provided: {agent_decision}"
+                )
         else:
             raise ValueError(
                 "early_stopping_method should be one of `force` or `generate`, "

--- a/langchain/agents/openai_functions_agent/base.py
+++ b/langchain/agents/openai_functions_agent/base.py
@@ -52,16 +52,12 @@ def _convert_agent_action_to_messages(
         AIMessage that corresponds to the original tool invocation.
     """
     if isinstance(agent_action, _FunctionsAgentAction):
-        return agent_action.message_log + [
-            _create_function_message(agent_action, observation)
-        ]
+        return agent_action.message_log + [_create_function_message(agent_action, observation)]
     else:
         return [AIMessage(content=agent_action.log)]
 
 
-def _create_function_message(
-    agent_action: AgentAction, observation: str
-) -> FunctionMessage:
+def _create_function_message(agent_action: AgentAction, observation: str) -> FunctionMessage:
     """Convert agent action and observation into a function message.
     Args:
         agent_action: the tool invocation request from the agent
@@ -112,10 +108,7 @@ def _parse_ai_message(message: BaseMessage) -> Union[AgentAction, AgentFinish]:
         try:
             _tool_input = json.loads(function_call["arguments"])
         except JSONDecodeError:
-            raise OutputParserException(
-                f"Could not parse tool input: {function_call} because "
-                f"the `arguments` is not valid JSON."
-            )
+            _tool_input = {"__arg1": function_call["arguments"]}
 
         # HACK HACK HACK:
         # The code that encodes tool input into Open AI uses a special variable
@@ -265,15 +258,11 @@ class OpenAIFunctionsAgent(BaseSingleActionAgent):
             )
         elif early_stopping_method == "generate":
             # Generate does one final forward pass
-            agent_decision = self.plan(
-                intermediate_steps, with_functions=False, **kwargs
-            )
+            agent_decision = self.plan(intermediate_steps, with_functions=False, **kwargs)
             if type(agent_decision) == AgentFinish:
                 return agent_decision
             else:
-                raise ValueError(
-                    f"got AgentAction with no functions provided: {agent_decision}"
-                )
+                raise ValueError(f"got AgentAction with no functions provided: {agent_decision}")
         else:
             raise ValueError(
                 "early_stopping_method should be one of `force` or `generate`, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.0.238.1"
+version = "0.0.238"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.0.238"
+version = "0.0.238.1"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"


### PR DESCRIPTION
related to https://github.com/appfolio/af_reactor/issues/1438

### Expected behavior

For a `BaseTool` the OpenAIFunctionCallingAgent reliably outputs a response of the form
```json
{"name": "<tool_name>", "arguments": {"__arg1": "<tool_input>"}}
```

### Actual behavior

For some inputs it formats the response as
```json
{"name": "<tool_name>", "arguments": "<tool_input>"}
```
which leads to a `JSONDecodeError`. The agent doesn't seem to follow the "hacky" format very reliably, even when explicitly encouraged in the system prompt.

@hinthornw


<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
