### PR TITLE
add kwargs support for Baseten models

### DIFF
--- a/libs/langchain/langchain/llms/baseten.py
+++ b/libs/langchain/langchain/llms/baseten.py
@@ -67,8 +67,8 @@ class Baseten(LLM):
         # get the model and version
         try:
             model = baseten.deployed_model_version_id(self.model)
-            response = model.predict({"prompt": prompt})
+            response = model.predict({"prompt": prompt, **kwargs})
         except baseten.common.core.ApiError:
             model = baseten.deployed_model_id(self.model)
-            response = model.predict({"prompt": prompt})
+            response = model.predict({"prompt": prompt, **kwargs})
         return "".join(response)


### PR DESCRIPTION
This bugfix PR adds kwargs support to Baseten model invocations so that e.g. the following script works properly:

```python
chatgpt_chain = LLMChain(
    llm=Baseten(model="MODEL_ID"),
    prompt=prompt,
    verbose=False,
    memory=ConversationBufferWindowMemory(k=2),
    llm_kwargs={"max_length": 4096}
)
```