### PR TITLE
Removing score threshold parameter of faiss _similarity_search_with_r…

### DIFF
--- a/libs/langchain/langchain/vectorstores/faiss.py
+++ b/libs/langchain/langchain/vectorstores/faiss.py
@@ -705,7 +705,6 @@ class FAISS(VectorStore):
         """Return docs and their similarity scores on a scale from 0 to 1."""
         # Pop score threshold so that only relevancy scores, not raw scores, are
         # filtered.
-        score_threshold = kwargs.pop("score_threshold", None)
         relevance_score_fn = self._select_relevance_score_fn()
         if relevance_score_fn is None:
             raise ValueError(
@@ -722,10 +721,4 @@ class FAISS(VectorStore):
         docs_and_rel_scores = [
             (doc, relevance_score_fn(score)) for doc, score in docs_and_scores
         ]
-        if score_threshold is not None:
-            docs_and_rel_scores = [
-                (doc, similarity)
-                for doc, similarity in docs_and_rel_scores
-                if similarity >= score_threshold
-            ]
         return docs_and_rel_scores


### PR DESCRIPTION
Removing score threshold parameter of faiss _similarity_search_with_relevance_scores as the thresholding part is implemented in similarity_search_with_relevance_scores method which calls this method. 

As this method is supposed to be a private method of faiss.py this will never receive the score threshold parameter as it is popped  in the super method similarity_search_with_relevance_scores.

@baskaryan @hwchase17 