### PR TITLE
Refactored `env`

### DIFF
--- a/libs/langchain/langchain/env.py
+++ b/libs/langchain/langchain/env.py
@@ -1,17 +1,4 @@
-import platform
-from functools import lru_cache
+"""Keep here for backwards compatibility."""
+from langchain.utils.env import get_runtime_environment
 
-
-@lru_cache(maxsize=1)
-def get_runtime_environment() -> dict:
-    """Get information about the environment."""
-    # Lazy import to avoid circular imports
-    from langchain import __version__
-
-    return {
-        "library_version": __version__,
-        "library": "langchain",
-        "platform": platform.platform(),
-        "runtime": "python",
-        "runtime_version": platform.python_version(),
-    }
+__all__ = ["get_runtime_environment"]

--- a/libs/langchain/langchain/env.py
+++ b/libs/langchain/langchain/env.py
@@ -1,4 +1,4 @@
-"""Keep here for backwards compatibility."""
+"""DEPRECATED: Kept for backwards compatibility."""
 from langchain.utils.env import get_runtime_environment
 
 __all__ = ["get_runtime_environment"]

--- a/libs/langchain/langchain/sql_database.py
+++ b/libs/langchain/langchain/sql_database.py
@@ -1,4 +1,4 @@
-"""Keep here for backwards compatibility."""
+"""DEPRECATED: Kept for backwards compatibility."""
 from langchain.utilities.sql_database import SQLDatabase
 
 __all__ = ["SQLDatabase"]

--- a/libs/langchain/langchain/utils/__init__.py
+++ b/libs/langchain/langchain/utils/__init__.py
@@ -4,7 +4,11 @@ Utility functions for langchain.
 These functions do not depend on any other langchain modules.
 """
 
-from langchain.utils.env import get_from_dict_or_env, get_from_env
+from langchain.utils.env import (
+    get_from_dict_or_env,
+    get_from_env,
+    get_runtime_environment,
+)
 from langchain.utils.formatting import StrictFormatter, formatter
 from langchain.utils.input import (
     get_bolded_text,
@@ -36,6 +40,7 @@ __all__ = [
     "get_from_dict_or_env",
     "get_from_env",
     "get_pydantic_field_names",
+    "get_runtime_environment",
     "guard_import",
     "mock_now",
     "print_text",

--- a/libs/langchain/langchain/utils/env.py
+++ b/libs/langchain/langchain/utils/env.py
@@ -1,4 +1,6 @@
 import os
+import platform
+from functools import lru_cache
 from typing import Any, Dict, Optional
 
 
@@ -24,3 +26,18 @@ def get_from_env(key: str, env_key: str, default: Optional[str] = None) -> str:
             f" `{env_key}` which contains it, or pass"
             f"  `{key}` as a named parameter."
         )
+
+
+@lru_cache(maxsize=1)
+def get_runtime_environment() -> dict:
+    """Get information about the environment."""
+    # Lazy import to avoid circular imports
+    from langchain import __version__
+
+    return {
+        "library_version": __version__,
+        "library": "langchain",
+        "platform": platform.platform(),
+        "runtime": "python",
+        "runtime_version": platform.python_version(),
+    }


### PR DESCRIPTION
Refactored `env.py`. The same as #7961 
`env.py` is in the root code folder. This creates the `langchain.env: Env ` group on the API Reference navigation ToC, on the same level as `Chains` and `Agents` which is not correct.

Refactoring:
- moved env.py content into utils/env.py
- added the backwards compatibility ref in the original `env.py`

@hwchase17
