### PR TITLE
edit prompt format method

### DIFF
--- a/libs/langchain/langchain/prompts/prompt.py
+++ b/libs/langchain/langchain/prompts/prompt.py
@@ -13,23 +13,25 @@ from langchain.prompts.base import (
     _get_jinja2_variables_from_template,
     check_valid_template,
 )
-
 from langchain.schema import Document
 
 doc_repr_default = Document.__repr__
 doc_format_default = Document.__format__
 
+
 def doc_repr_temp(self: Document) -> str:
     """Temporary __repr__ method for Document.
-        To prevent the meta data from being represented.
+    To prevent the meta data from being represented.
     """
     return f"'{self.page_content}'"
 
+
 def doc_format_temp(self: Document, format_spec: str) -> str:
     """Temporary __format__ method for Document.
-        To prevent the meta data from being formatted.
+    To prevent the meta data from being formatted.
     """
-    return doc_format_default( f"'{self.page_content}'", format_spec)
+    return doc_format_default(f"'{self.page_content}'", format_spec)
+
 
 class PromptTemplate(StringPromptTemplate):
     """Schema to represent a prompt for an LLM.
@@ -66,7 +68,7 @@ class PromptTemplate(StringPromptTemplate):
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with the inputs.
-            To prevent the meta data from being printed, 
+            To prevent the meta data from being printed,
             temporarily change the __repr__ and __format__ method of Document.
 
         Args:
@@ -82,13 +84,14 @@ class PromptTemplate(StringPromptTemplate):
             prompt.format(variable1="foo")
         """
         kwargs = self._merge_partial_and_user_variables(**kwargs)
-        setattr(Document, '__repr__', doc_repr_temp)
-        setattr(Document, '__format__', doc_format_temp)
-        result = DEFAULT_FORMATTER_MAPPING[self.template_format](self.template, **kwargs)
-        setattr(Document, '__repr__', doc_repr_default)
-        setattr(Document, '__format__', doc_format_default)
+        setattr(Document, "__repr__", doc_repr_temp)
+        setattr(Document, "__format__", doc_format_temp)
+        result = DEFAULT_FORMATTER_MAPPING[self.template_format](
+            self.template, **kwargs
+        )
+        setattr(Document, "__repr__", doc_repr_default)
+        setattr(Document, "__format__", doc_format_default)
         return result
-
 
     @root_validator()
     def template_is_valid(cls, values: Dict) -> Dict:

--- a/libs/langchain/langchain/prompts/prompt.py
+++ b/libs/langchain/langchain/prompts/prompt.py
@@ -14,6 +14,22 @@ from langchain.prompts.base import (
     check_valid_template,
 )
 
+from langchain.schema import Document
+
+doc_repr_default = Document.__repr__
+doc_format_default = Document.__format__
+
+def doc_repr_temp(self: Document) -> str:
+    """Temporary __repr__ method for Document.
+        To prevent the meta data from being represented.
+    """
+    return f"'{self.page_content}'"
+
+def doc_format_temp(self: Document, format_spec: str) -> str:
+    """Temporary __format__ method for Document.
+        To prevent the meta data from being formatted.
+    """
+    return doc_format_default( f"'{self.page_content}'", format_spec)
 
 class PromptTemplate(StringPromptTemplate):
     """Schema to represent a prompt for an LLM.
@@ -50,6 +66,8 @@ class PromptTemplate(StringPromptTemplate):
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with the inputs.
+            To prevent the meta data from being printed, 
+            temporarily change the __repr__ and __format__ method of Document.
 
         Args:
             kwargs: Any arguments to be passed to the prompt template.
@@ -64,7 +82,13 @@ class PromptTemplate(StringPromptTemplate):
             prompt.format(variable1="foo")
         """
         kwargs = self._merge_partial_and_user_variables(**kwargs)
-        return DEFAULT_FORMATTER_MAPPING[self.template_format](self.template, **kwargs)
+        setattr(Document, '__repr__', doc_repr_temp)
+        setattr(Document, '__format__', doc_format_temp)
+        result = DEFAULT_FORMATTER_MAPPING[self.template_format](self.template, **kwargs)
+        setattr(Document, '__repr__', doc_repr_default)
+        setattr(Document, '__format__', doc_format_default)
+        return result
+
 
     @root_validator()
     def template_is_valid(cls, values: Dict) -> Dict:

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -1,8 +1,8 @@
 """Test functionality related to prompts."""
 import pytest
 
-from langchain.prompts.prompt import PromptTemplate
-
+from langchain.prompts.prompt import PromptTemplate, doc_repr_temp, doc_format_temp
+from langchain.schema import Document
 
 def test_prompt_valid() -> None:
     """Test prompts can be constructed."""
@@ -146,6 +146,39 @@ def test_partial() -> None:
     result = prompt.format(foo="foo")
     assert result == "This is a foo test."
 
+
+def test_doc_repr_temp() -> None:
+    """Test temporary __repr__ method for Document."""
+    doc = Document(page_content="foo")
+    assert doc_repr_temp(doc) == "'foo'"
+    
+    doc = Document(page_content="foo", meta_data={"bar": "baz"})
+    assert doc_repr_temp(doc) == "'foo'"
+    
+def test_doc_format_temp() -> None:
+    """Test temporary __format__ method for Document."""
+    doc = Document(page_content="foo")
+    assert doc_format_temp(doc, "") == "'foo'"
+    
+    doc = Document(page_content="foo", meta_data={"bar": "baz"})
+    assert doc_format_temp(doc, "") == "'foo'"
+    
+def test_format() -> None:
+    """Test formatting works as expected."""
+    prompt = PromptTemplate.from_template("This is a {var} test.")
+    # if the variable is string
+    output = prompt.format(var="good")
+    assert output == "This is a good test."
+
+    # if the variable is Document without meta_data
+    doc = Document(page_content="good")
+    output = prompt.format(var=doc)
+    print(output)
+    assert output == "This is a 'good' test."
+
+    # if the variable is Document with meta_data
+    output = prompt.format(var=Document(page_content="good", meta_data={"bar": "baz"}))
+    assert output == "This is a 'good' test."
 
 @pytest.mark.requires("jinja2")
 def test_prompt_from_jinja2_template() -> None:

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -185,9 +185,10 @@ def test_format() -> None:
     assert output == "This is a 'good' test."
     
     # if the variable is Document and it is inside a list
-    doc = Document(page_content="good", meta_data={"bar": "baz"})
-    output = prompt.format(var=[doc])
-    assert output == "This is a ['good'] test."
+    doc1 = Document(page_content="good1", meta_data={"bar": "baz"})
+    doc2 = Document(page_content="good2", meta_data={"bar": "baz"})
+    output = prompt.format(var=[doc1, doc2])
+    assert output == "This is a ['good1', 'good2'] test."
 
 
 @pytest.mark.requires("jinja2")

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -173,7 +173,6 @@ def test_format() -> None:
     # if the variable is Document without meta_data
     doc = Document(page_content="good")
     output = prompt.format(var=doc)
-    print(output)
     assert output == "This is a 'good' test."
     # if the variable is Document with meta_data
     doc = Document(page_content="good", meta_data={"bar": "baz"})

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -180,8 +180,14 @@ def test_format() -> None:
     assert output == "This is a 'good' test."
 
     # if the variable is Document with meta_data
-    output = prompt.format(var=Document(page_content="good", meta_data={"bar": "baz"}))
+    doc = Document(page_content="good", meta_data={"bar": "baz"})
+    output = prompt.format(var=doc)
     assert output == "This is a 'good' test."
+    
+    # if the variable is Document and it is inside a list
+    doc = Document(page_content="good", meta_data={"bar": "baz"})
+    output = prompt.format(var=[doc])
+    assert output == "This is a ['good'] test."
 
 
 @pytest.mark.requires("jinja2")

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -152,7 +152,6 @@ def test_doc_repr_temp() -> None:
     """Test temporary __repr__ method for Document."""
     doc = Document(page_content="foo")
     assert doc_repr_temp(doc) == "'foo'"
-
     doc = Document(page_content="foo", meta_data={"bar": "baz"})
     assert doc_repr_temp(doc) == "'foo'"
 
@@ -161,7 +160,6 @@ def test_doc_format_temp() -> None:
     """Test temporary __format__ method for Document."""
     doc = Document(page_content="foo")
     assert doc_format_temp(doc, "") == "'foo'"
-
     doc = Document(page_content="foo", meta_data={"bar": "baz"})
     assert doc_format_temp(doc, "") == "'foo'"
 
@@ -172,7 +170,6 @@ def test_format() -> None:
     # if the variable is string
     output = prompt.format(var="good")
     assert output == "This is a good test."
-
     # if the variable is Document without meta_data
     doc = Document(page_content="good")
     output = prompt.format(var=doc)
@@ -183,7 +180,6 @@ def test_format() -> None:
     doc = Document(page_content="good", meta_data={"bar": "baz"})
     output = prompt.format(var=doc)
     assert output == "This is a 'good' test."
-    
     # if the variable is Document and it is inside a list
     doc1 = Document(page_content="good1", meta_data={"bar": "baz"})
     doc2 = Document(page_content="good2", meta_data={"bar": "baz"})

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -1,8 +1,9 @@
 """Test functionality related to prompts."""
 import pytest
 
-from langchain.prompts.prompt import PromptTemplate, doc_repr_temp, doc_format_temp
+from langchain.prompts.prompt import PromptTemplate, doc_format_temp, doc_repr_temp
 from langchain.schema import Document
+
 
 def test_prompt_valid() -> None:
     """Test prompts can be constructed."""
@@ -151,18 +152,20 @@ def test_doc_repr_temp() -> None:
     """Test temporary __repr__ method for Document."""
     doc = Document(page_content="foo")
     assert doc_repr_temp(doc) == "'foo'"
-    
+
     doc = Document(page_content="foo", meta_data={"bar": "baz"})
     assert doc_repr_temp(doc) == "'foo'"
-    
+
+
 def test_doc_format_temp() -> None:
     """Test temporary __format__ method for Document."""
     doc = Document(page_content="foo")
     assert doc_format_temp(doc, "") == "'foo'"
-    
+
     doc = Document(page_content="foo", meta_data={"bar": "baz"})
     assert doc_format_temp(doc, "") == "'foo'"
-    
+
+
 def test_format() -> None:
     """Test formatting works as expected."""
     prompt = PromptTemplate.from_template("This is a {var} test.")
@@ -179,6 +182,7 @@ def test_format() -> None:
     # if the variable is Document with meta_data
     output = prompt.format(var=Document(page_content="good", meta_data={"bar": "baz"}))
     assert output == "This is a 'good' test."
+
 
 @pytest.mark.requires("jinja2")
 def test_prompt_from_jinja2_template() -> None:

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -175,7 +175,6 @@ def test_format() -> None:
     output = prompt.format(var=doc)
     print(output)
     assert output == "This is a 'good' test."
-
     # if the variable is Document with meta_data
     doc = Document(page_content="good", meta_data={"bar": "baz"})
     output = prompt.format(var=doc)


### PR DESCRIPTION
  - Description:  Modify the `PromptTemplate`'s `format` method behavior by temporarily altering the `__repr__` and `__format__` methods of the `Document` class. This will result in only the `page_content` being added to the template when conduct formatting. Refer to the unit test case below for further clarification.
  - Issue: the issue #7967 it fixes
  - Dependencies: No
  - Tag maintainer: @baskaryan @rlancemartin
  - Twitter handle: dayuanjian21687

Below is the unit test cases.

```python
    prompt = PromptTemplate.from_template("This is a {var} test.")
    # if the variable is string
    output = prompt.format(var="good")
    assert output == "This is a good test."

    # if the variable is Document without meta_data
    doc = Document(page_content="good")
    output = prompt.format(var=doc)
    print(output)
    assert output == "This is a 'good' test."

    # if the variable is Document with meta_data
    doc = Document(page_content="good", meta_data={"bar": "baz"})
    output = prompt.format(var=doc)
    assert output == "This is a 'good' test."
    
    # if the variable is Document and it is inside a list
    doc1 = Document(page_content="good1", meta_data={"bar": "baz"})
    doc2 = Document(page_content="good2", meta_data={"bar": "baz"})
    output = prompt.format(var=[doc1, doc2])
    assert output == "This is a ['good1', 'good2'] test."
```

