### PR TITLE
fix-typo

### DIFF
--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -446,7 +446,7 @@ class ChatOpenAI(BaseChatModel):
             **super()._get_invocation_params(stop=stop, **kwargs),
             **self._default_params,
             "model": self.model_name,
-            "function": kwargs.get("functions"),
+            "functions": kwargs.get("functions"),
         }
 
     @property


### PR DESCRIPTION
more general questions about this function:

```
        return {
            **super()._get_invocation_params(stop=stop, **kwargs),
            **self._default_params,
            "model": self.model_name,
            "functions": kwargs.get("functions"),
        }
```

1. `**super()._get_invocation_params(stop=stop, **kwargs)` returns everything in kwargs, including functions (if present). do we do `"functions": kwargs.get("functions"),` because we explicitly need to pass functions through even when not present? (im assuming this is not needed (because its been broken and we havent noticed) so can we just remove
2. This ordering of 

```
**super()._get_invocation_params(stop=stop, **kwargs),
            **self._default_params,
```

means that if an arbitrary param is passed in through `kwargs` that is same as one in `**self._default_params,`, the one in defuaut params gets logged. imo we want to give preference to everything in kwargs right? why is this ordering the same?