### PR TITLE
fix typo: Entity Summary Memory documentation

### DIFF
--- a/docs/snippets/modules/memory/how_to/entity_summary_memory.mdx
+++ b/docs/snippets/modules/memory/how_to/entity_summary_memory.mdx
@@ -261,7 +261,7 @@ conversation.predict(input="What do you know about Deven & Sam?")
 </CodeOutputBlock>
 
 ## Inspecting the memory store
-We can also inspect the memory store directly. In the following examaples, we look at it directly, and then go through some examples of adding information and watch how it changes.
+We can also inspect the memory store directly. In the following examples, we look at it directly, and then go through some examples of adding information and watch how it changes.
 
 
 ```python


### PR DESCRIPTION
Fixed a small typo I came across in the Memory documentation. 