### PR TITLE
Unbreak devcontainer

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -37,5 +37,8 @@ ARG PYTHON_VIRTUALENV_HOME
 # Copy only the dependency files for installation
 COPY pyproject.toml poetry.toml ./
 
+# Copy the langchain library for installation
+COPY libs/langchain/ libs/langchain/
+
 # Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)
 RUN poetry install --no-interaction --no-ansi --with dev,test,docs

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,5 @@
+[virtualenvs]
+in-project = true
+
+[installer]
+modern-installation = false


### PR DESCRIPTION
Codespaces and devcontainer was broken by the [repo restructure](https://github.com/langchain-ai/langchain/discussions/8043).



  - Description: Add libs/langchain to container so it can be built without error.
  - Issue: -
  - Dependencies: -
  - Tag maintainer: @hwchase17 @baskaryan 
  - Twitter handle: @finnless

The failed build log says:
```
#10 [langchain-dev-dependencies 2/2] RUN poetry install --no-interaction --no-ansi --with dev,test,docs
#10 sha256:e850ee99fc966158bfd2d85e82b7c57244f47ecbb1462e75bd83b981a56a1929
2023-07-23 23:30:33.692Z: #10 0.827 
#10 0.827 Directory libs/langchain does not exist
2023-07-23 23:30:33.738Z: #10 ERROR: executor failed running [/bin/sh -c poetry install --no-interaction --no-ansi --with dev,test,docs]: exit code: 1
```

The new pyproject.toml imports from libs/langchain:
https://github.com/langchain-ai/langchain/blob/77bf75c236351edf47d3a76a522bb45ccc90d299/pyproject.toml#L14-L16

But libs/langchain is never added to the dev.Dockerfile:

https://github.com/langchain-ai/langchain/blob/77bf75c236351edf47d3a76a522bb45ccc90d299/libs/langchain/dev.Dockerfile#L37-L39
