### PR TITLE
Add support for load_chat_model

### DIFF
--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -24,6 +24,8 @@ from langchain.chains.qa_with_sources.base import QAWithSourcesChain
 from langchain.chains.qa_with_sources.vector_db import VectorDBQAWithSourcesChain
 from langchain.chains.retrieval_qa.base import RetrievalQA, VectorDBQA
 from langchain.chains.sql_database.base import SQLDatabaseChain
+from langchain.chat_models import type_to_cls_dict as chat_model_type_to_cls_dict
+from langchain.chat_models.loading import load_chat_model, load_chat_model_from_config
 from langchain.llms.loading import load_llm, load_llm_from_config
 from langchain.prompts.loading import (
     _load_output_parser,
@@ -39,9 +41,17 @@ def _load_llm_chain(config: dict, **kwargs: Any) -> LLMChain:
     """Load LLM chain from config dict."""
     if "llm" in config:
         llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config)
+        llm_type = llm_config.get("_type")
+        if llm_type in chat_model_type_to_cls_dict:
+            llm = load_chat_model_from_config(llm_config)
+        else:
+            llm = load_llm_from_config(llm_config)
     elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"))
+        llm_path = config.pop("llm_path")
+        if llm_type in chat_model_type_to_cls_dict:
+            llm = load_chat_model(llm_path)
+        else:
+            llm = load_llm(llm_path)
     else:
         raise ValueError("One of `llm` or `llm_path` must be present.")
 

--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -32,6 +32,7 @@ from langchain.prompts.loading import (
     load_prompt,
     load_prompt_from_config,
 )
+from langchain.schema.language_model import BaseLanguageModel
 from langchain.utilities.loading import try_load_from_hub
 
 URL_BASE = "https://raw.githubusercontent.com/hwchase17/langchain-hub/master/chains/"
@@ -39,6 +40,7 @@ URL_BASE = "https://raw.githubusercontent.com/hwchase17/langchain-hub/master/cha
 
 def _load_llm_chain(config: dict, **kwargs: Any) -> LLMChain:
     """Load LLM chain from config dict."""
+    llm: BaseLanguageModel = None
     if "llm" in config:
         llm_config = config.pop("llm")
         llm_type = llm_config.get("_type")

--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -40,7 +40,7 @@ URL_BASE = "https://raw.githubusercontent.com/hwchase17/langchain-hub/master/cha
 
 def _load_llm_chain(config: dict, **kwargs: Any) -> LLMChain:
     """Load LLM chain from config dict."""
-    llm: BaseLanguageModel = None
+    llm: BaseLanguageModel
     if "llm" in config:
         llm_config = config.pop("llm")
         llm_type = llm_config.get("_type")

--- a/libs/langchain/langchain/chat_models/__init__.py
+++ b/libs/langchain/langchain/chat_models/__init__.py
@@ -1,5 +1,8 @@
+from typing import Dict, Type
+
 from langchain.chat_models.anthropic import ChatAnthropic
 from langchain.chat_models.azure_openai import AzureChatOpenAI
+from langchain.chat_models.base import BaseChatModel
 from langchain.chat_models.fake import FakeListChatModel
 from langchain.chat_models.google_palm import ChatGooglePalm
 from langchain.chat_models.human import HumanInputChatModel
@@ -19,3 +22,8 @@ __all__ = [
     "JinaChat",
     "HumanInputChatModel",
 ]
+
+type_to_cls_dict: Dict[str, Type[BaseChatModel]] = {
+    "azure-openai-chat": AzureChatOpenAI,
+    "openai-chat": ChatOpenAI,
+}

--- a/libs/langchain/langchain/chat_models/azure_openai.py
+++ b/libs/langchain/langchain/chat_models/azure_openai.py
@@ -118,7 +118,10 @@ class AzureChatOpenAI(ChatOpenAI):
     @property
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
-        return {**self._default_params}
+        return {
+            "deployment_name": self.deployment_name,
+            **super()._identifying_params,
+        }
 
     @property
     def _client_params(self) -> Dict[str, Any]:

--- a/libs/langchain/langchain/chat_models/loading.py
+++ b/libs/langchain/langchain/chat_models/loading.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+from typing import Union
+
+import yaml
+
+from langchain.chat_models import type_to_cls_dict
+from langchain.chat_models.base import BaseChatModel
+
+
+def load_chat_model_from_config(config: dict) -> BaseChatModel:
+    """Load Chat Model from Config Dict."""
+    if "_type" not in config:
+        raise ValueError("Must specify a Chat Model Type in config")
+    config_type = config["_type"]
+
+    if config_type not in type_to_cls_dict:
+        raise ValueError(f"Loading {config_type} Chat Model not supported")
+
+    llm_cls = type_to_cls_dict[config_type]
+    del config["_type"]
+    return llm_cls(**config)
+
+
+def load_chat_model(file: Union[str, Path]) -> BaseChatModel:
+    """Load Chat Model from file."""
+    # Convert file to Path object.
+    if isinstance(file, str):
+        file_path = Path(file)
+    else:
+        file_path = file
+    # Load from either json or yaml.
+    if file_path.suffix == ".json":
+        with open(file_path) as f:
+            config = json.load(f)
+    elif file_path.suffix == ".yaml":
+        with open(file_path, "r") as f:
+            config = yaml.safe_load(f)
+    else:
+        raise ValueError("File type must be json or yaml")
+    # Load the Chat Model from the config now.
+    return load_chat_model_from_config(config)

--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -421,7 +421,15 @@ class ChatOpenAI(BaseChatModel):
     @property
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
-        return {**{"model_name": self.model_name}, **self._default_params}
+        return {
+            "model_name": self.model_name,
+            "request_timeout": self.request_timeout,
+            "max_tokens": self.max_tokens,
+            "streaming": self.streaming,
+            "n": self.n,
+            "temperature": self.temperature,
+            "model_kwargs": self.model_kwargs,
+        }
 
     @property
     def _client_params(self) -> Dict[str, Any]:


### PR DESCRIPTION
- Description:
  - Add `load_chat_model()` and `load_chat_model_from_config()` in `langchain.chat_model.loading` module
  - Update `_load_llm_chain()` to use the above functions in case of LLMs that are Chat Models
  - Fix warning while loading `AzureChatOpenAI` and `ChatOpenAI`: WARNING! engine is not default parameter.
  - **TODO**: I'll add/update unit tests once I get a go-ahead from maintainers for these new additions.
- Issue:
  - https://github.com/langchain-ai/langchain/issues/2627
  - Related PR that was closed: https://github.com/langchain-ai/langchain/pull/1715
- Dependencies: None
- Tag maintainer: @baskaryan
- Twitter handle: None
