### PR TITLE
removed namespace title

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -40,11 +40,7 @@ API Reference
         functions = _members["functions"]
         if not (classes or functions):
             continue
-
-        module_title = module.replace("_", " ").title()
-        if module_title == "Llms":
-            module_title = "LLMs"
-        section = f":mod:`langchain.{module}`: {module_title}"
+        section = f":mod:`langchain.{module}`"
         full_doc += f"""\
 {section}
 {'=' * (len(section) + 1)}


### PR DESCRIPTION
Controversial!
This change compacts the left-side Navbar (ToC) of the [API Reference](https://api.python.langchain.com/en/latest/api_reference.html). 
Now almost each namespace item is split into two lines. For example `langchain.chat_models: Chat Models`
We remove the `Chat Models` and leave one the `langchain.chat_models`. 
This effectively compacts the navbar and increases the main page's usability. On my screen, it reduces # of lines in Toc from 28 t to 18, which is huge.

Removing the namespace "title" (like `Chat Models`) does not remove any information because the title is composed directly from the namespace.
API Reference users are developers. Usability for them is very important. We see less text => we find faster.

@baskaryan @hwchase17

