### PR TITLE
Docs: Fix Rockset links

### DIFF
--- a/docs/extras/integrations/providers/rockset.mdx
+++ b/docs/extras/integrations/providers/rockset.mdx
@@ -12,7 +12,7 @@ pip install rockset
 
 ## Vector Store
 
-See a [usage example](/docs/modules/data_connection/vectorstores/integrations/rockset.html).
+See a [usage example](/docs/integrations/vectorstores/rockset).
 
 ```python
 from langchain.vectorstores import RocksetDB
@@ -20,7 +20,7 @@ from langchain.vectorstores import RocksetDB
 
 ## Document Loader
 
-See a [usage example](docs/modules/data_connection/document_loaders/integrations/rockset).
+See a [usage example](/docs/integrations/document_loaders/rockset).
 ```python
 from langchain.document_loaders import RocksetLoader
 ```


### PR DESCRIPTION
Fix broken Rockset links.

Right now links at https://python.langchain.com/docs/integrations/providers/rockset are broken.

@rlancemartin, @eyurtsev

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
