### PR TITLE
Ensure that no 'id' property is pushed to weaviate

### DIFF
--- a/libs/langchain/langchain/vectorstores/weaviate.py
+++ b/libs/langchain/langchain/vectorstores/weaviate.py
@@ -150,6 +150,8 @@ class Weaviate(VectorStore):
                 data_properties = {self._text_key: text}
                 if metadatas is not None:
                     for key, val in metadatas[i].items():
+                        # Check if an id property is provided and rename it to 'textid'
+                        key = "textid" if key == "id" else key
                         data_properties[key] = _json_serializable(val)
 
                 # Allow for ids (consistent w/ other methods)

--- a/libs/langchain/langchain/vectorstores/weaviate.py
+++ b/libs/langchain/langchain/vectorstores/weaviate.py
@@ -1,6 +1,6 @@
 """Wrapper around weaviate vector database."""
 from __future__ import annotations
-
+from warnings import warn
 import datetime
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 from uuid import uuid4
@@ -151,7 +151,9 @@ class Weaviate(VectorStore):
                 if metadatas is not None:
                     for key, val in metadatas[i].items():
                         # Check if an id property is provided and rename it to 'textid'
-                        key = "textid" if key == "id" else key
+                        if key == "id":
+                            warn('An import with the restricted "id" key was attempted. Renaming it to "textid"...', UserWarning)
+                            key = "textid"
                         data_properties[key] = _json_serializable(val)
 
                 # Allow for ids (consistent w/ other methods)


### PR DESCRIPTION
  - Description: The 'id' property in Weaviate is reserved, and any imports containing it will be rejected. This change introduces a simple check to ensure that if any import includes an 'id' key in the metadata, it will be renamed to 'textid'. This issue was detected when using the confluenceloader to import into Weaviate.
  - Issue: the 7803,
  - Dependencies: None,
  - Tag maintainer: @rlancemartin, @eyurtsev,
  - Twitter handle: ElabbarWanis