### PR TITLE
use logger instead of logging

### DIFF
--- a/libs/langchain/langchain/callbacks/tracers/langchain_v1.py
+++ b/libs/langchain/langchain/callbacks/tracers/langchain_v1.py
@@ -19,6 +19,8 @@ from langchain.callbacks.tracers.schemas import (
 from langchain.schema.messages import get_buffer_string
 from langchain.utils import raise_for_status_with_text
 
+logger = logging.getLogger(__name__)
+
 
 def get_headers() -> Dict[str, Any]:
     """Get the headers for the LangChain API."""
@@ -137,7 +139,7 @@ class LangChainTracerV1(BaseTracer):
             )
             raise_for_status_with_text(response)
         except Exception as e:
-            logging.warning(f"Failed to persist run: {e}")
+            logger.warning(f"Failed to persist run: {e}")
 
     def _persist_session(
         self, session_create: TracerSessionV1Base
@@ -151,7 +153,7 @@ class LangChainTracerV1(BaseTracer):
             )
             session = TracerSessionV1(id=r.json()["id"], **session_create.dict())
         except Exception as e:
-            logging.warning(f"Failed to create session, using default session: {e}")
+            logger.warning(f"Failed to create session, using default session: {e}")
             session = TracerSessionV1(id=1, **session_create.dict())
         return session
 
@@ -166,7 +168,7 @@ class LangChainTracerV1(BaseTracer):
             tracer_session = TracerSessionV1(**r.json()[0])
         except Exception as e:
             session_type = "default" if not session_name else session_name
-            logging.warning(
+            logger.warning(
                 f"Failed to load {session_type} session, using empty session: {e}"
             )
             tracer_session = TracerSessionV1(id=1)

--- a/libs/langchain/langchain/document_loaders/evernote.py
+++ b/libs/langchain/langchain/document_loaders/evernote.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, Iterator, List, Optional
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
+logger = logging.getLogger(__name__)
+
 
 class EverNoteLoader(BaseLoader):
     """EverNote Loader.
@@ -72,7 +74,7 @@ class EverNoteLoader(BaseLoader):
 
             return html2text.html2text(content).strip()
         except ImportError as e:
-            logging.error(
+            logger.error(
                 "Could not import `html2text`. Although it is not a required package "
                 "to use Langchain, using the EverNote loader requires `html2text`. "
                 "Please install `html2text` via `pip install html2text` and try again."
@@ -133,7 +135,7 @@ class EverNoteLoader(BaseLoader):
         try:
             from lxml import etree
         except ImportError as e:
-            logging.error(
+            logger.error(
                 "Could not import `lxml`. Although it is not a required package to use "
                 "Langchain, using the EverNote loader requires `lxml`. Please install "
                 "`lxml` via `pip install lxml` and try again."

--- a/libs/langchain/langchain/document_loaders/onedrive.py
+++ b/libs/langchain/langchain/document_loaders/onedrive.py
@@ -203,7 +203,7 @@ class OneDriveLoader(BaseLoader, BaseModel):
             for object_id in self.object_ids if self.object_ids else [""]:
                 file = drive.get_item(object_id)
                 if not file:
-                    logging.warning(
+                    logger.warning(
                         "There isn't a file with "
                         f"object_id {object_id} in drive {drive}."
                     )

--- a/libs/langchain/langchain/vectorstores/redis.py
+++ b/libs/langchain/langchain/vectorstores/redis.py
@@ -66,7 +66,7 @@ def _check_redis_module_exist(client: RedisType, required_modules: List[dict]) -
         "Please head to https://redis.io/docs/stack/search/quick_start/"
         "to know more about installing the RediSearch module within Redis Stack."
     )
-    logging.error(error_message)
+    logger.error(error_message)
     raise ValueError(error_message)
 
 

--- a/libs/langchain/langchain/vectorstores/vectara.py
+++ b/libs/langchain/langchain/vectorstores/vectara.py
@@ -14,6 +14,8 @@ from langchain.embeddings.base import Embeddings
 from langchain.schema import Document
 from langchain.vectorstores.base import VectorStore, VectorStoreRetriever
 
+logger = logging.getLogger(__name__)
+
 
 class Vectara(VectorStore):
     """Implementation of Vector Store using Vectara.
@@ -51,12 +53,12 @@ class Vectara(VectorStore):
             or self._vectara_corpus_id is None
             or self._vectara_api_key is None
         ):
-            logging.warning(
+            logger.warning(
                 "Can't find Vectara credentials, customer_id or corpus_id in "
                 "environment."
             )
         else:
-            logging.debug(f"Using corpus id {self._vectara_corpus_id}")
+            logger.debug(f"Using corpus id {self._vectara_corpus_id}")
         self._session = requests.Session()  # to reuse connections
         adapter = requests.adapters.HTTPAdapter(max_retries=3)
         self._session.mount("http://", adapter)
@@ -96,7 +98,7 @@ class Vectara(VectorStore):
             headers=self._get_post_headers(),
         )
         if response.status_code != 200:
-            logging.error(
+            logger.error(
                 f"Delete request failed for doc_id = {doc_id} with status code "
                 f"{response.status_code}, reason {response.reason}, text "
                 f"{response.text}"
@@ -152,7 +154,7 @@ class Vectara(VectorStore):
         doc_ids = []
         for inx, file in enumerate(files_list):
             if not os.path.exists(file):
-                logging.error(f"File {file} does not exist, skipping")
+                logger.error(f"File {file} does not exist, skipping")
                 continue
             md = metadatas[inx] if metadatas else {}
             files: dict = {
@@ -170,14 +172,14 @@ class Vectara(VectorStore):
 
             if response.status_code == 409:
                 doc_id = response.json()["document"]["documentId"]
-                logging.info(
+                logger.info(
                     f"File {file} already exists on Vectara (doc_id={doc_id}), skipping"
                 )
             elif response.status_code == 200:
                 doc_id = response.json()["document"]["documentId"]
                 doc_ids.append(doc_id)
             else:
-                logging.info(f"Error indexing file {file}: {response.json()}")
+                logger.info(f"Error indexing file {file}: {response.json()}")
 
         return doc_ids
 
@@ -290,7 +292,7 @@ class Vectara(VectorStore):
         )
 
         if response.status_code != 200:
-            logging.error(
+            logger.error(
                 "Query failed %s",
                 f"(code {response.status_code}, reason {response.reason}, details "
                 f"{response.text})",


### PR DESCRIPTION
# What
- Use `logger` instead of using logging directly.

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: Use `logger` instead of using logging directly.
  - Issue: None
  - Dependencies: None
  - Tag maintainer: @baskaryan
  - Twitter handle: @MlopsJ

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
