### PR TITLE
Update ConversationTokenBufferMemory to Enforce Token Limit in load_memory_variables

### DIFF
--- a/libs/langchain/tests/unit_tests/memory/test_token_buffer.py
+++ b/libs/langchain/tests/unit_tests/memory/test_token_buffer.py
@@ -2,6 +2,7 @@
 from langchain.memory.token_buffer import ConversationTokenBufferMemory
 from tests.unit_tests.llms.fake_llm import FakeLLM
 
+
 def test_token_buffer_memory() -> None:
     """Test ConversationTokenBufferMemory with a max_token_limit of 6."""
     memory = ConversationTokenBufferMemory(
@@ -10,8 +11,8 @@ def test_token_buffer_memory() -> None:
     memory.save_context({"input": "bar"}, {"output": "foo"})
     output = memory.load_memory_variables({})
     # Check the initial conversation.
-    assert output == {'baz': 'Human: bar\nAI: foo'}
+    assert output == {"baz": "Human: bar\nAI: foo"}
     memory.save_context({"input": "bar1"}, {"output": "foo1"})
     # Check the pruned conversation after exceeding the token limit.
     output = memory.load_memory_variables({})
-    assert output == {'baz': 'AI: foo\nHuman: bar1\nAI: foo1'}
+    assert output == {"baz": "AI: foo\nHuman: bar1\nAI: foo1"}

--- a/libs/langchain/tests/unit_tests/memory/test_token_buffer.py
+++ b/libs/langchain/tests/unit_tests/memory/test_token_buffer.py
@@ -1,0 +1,17 @@
+"""Test TokenBufferMemory."""
+from langchain.memory.token_buffer import ConversationTokenBufferMemory
+from tests.unit_tests.llms.fake_llm import FakeLLM
+
+def test_token_buffer_memory() -> None:
+    """Test ConversationTokenBufferMemory with a max_token_limit of 6."""
+    memory = ConversationTokenBufferMemory(
+        llm=FakeLLM(), memory_key="baz", max_token_limit=6
+    )
+    memory.save_context({"input": "bar"}, {"output": "foo"})
+    output = memory.load_memory_variables({})
+    # Check the initial conversation.
+    assert output == {'baz': 'Human: bar\nAI: foo'}
+    memory.save_context({"input": "bar1"}, {"output": "foo1"})
+    # Check the pruned conversation after exceeding the token limit.
+    output = memory.load_memory_variables({})
+    assert output == {'baz': 'AI: foo\nHuman: bar1\nAI: foo1'}


### PR DESCRIPTION
## Description:
This pull request updates the ConversationTokenBufferMemory class to enforce the token limit within the load_memory_variables method. Previously, the token limit was enforced in the save_context method.

## Issue:
Fix #3922

## Dependencies:
No additional dependencies are required for this change.

## Maintainer:
@hwchase17 as this change pertains to Memory.

## Twitter handle:
https://twitter.com/yakigac


Please let me know if there's anything else you need.
