### PR TITLE
Remove operator overloading for BaseMessage

### DIFF
--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, List, Sequence
+from typing import List, Sequence
 
 from pydantic import Field
 
 from langchain.load.serializable import Serializable
-
-if TYPE_CHECKING:
-    from langchain.prompts.chat import ChatPromptTemplate
 
 
 def get_buffer_string(

--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -80,12 +80,6 @@ class BaseMessage(Serializable):
         """Whether this class is LangChain serializable."""
         return True
 
-    def __add__(self, other: Any) -> ChatPromptTemplate:
-        from langchain.prompts.chat import ChatPromptTemplate
-
-        prompt = ChatPromptTemplate(messages=[self])
-        return prompt + other
-
 
 class HumanMessage(BaseMessage):
     """A Message from a human."""


### PR DESCRIPTION
This PR removes operator overloading for base message.

Removing the `+` operating from base message will help make sure that:

1) There's no need to re-define `+` for message chunks
2) That there's no unexpected behavior in terms of types changing (adding two messages yields a ChatPromptTemplate which is not a message)