### PR TITLE
[ OpenSearch ] : Add AOSS Support to OpenSearch

### DIFF
--- a/docs/extras/integrations/vectorstores/opensearch.ipynb
+++ b/docs/extras/integrations/vectorstores/opensearch.ipynb
@@ -315,6 +315,101 @@
     "    metadata_field=\"message_metadata\",\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Using AOSS (Amazon OpenSearch Service Serverless)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# This is just an example to show how to use AOSS with faiss engine and efficient_filter, you need to set proper values.\n",
+    "\n",
+    "service = 'aoss' # must set the service as 'aoss'\n",
+    "region = 'us-east-2'\n",
+    "credentials = boto3.Session(aws_access_key_id='xxxxxx',aws_secret_access_key='xxxxx').get_credentials()\n",
+    "awsauth = AWS4Auth('xxxxx', 'xxxxxx', region,service, session_token=credentials.token)\n",
+    "\n",
+    "docsearch = OpenSearchVectorSearch.from_documents(\n",
+    "    docs,\n",
+    "    embeddings,\n",
+    "    opensearch_url=\"host url\",\n",
+    "    http_auth=awsauth,\n",
+    "    timeout = 300,\n",
+    "    use_ssl = True,\n",
+    "    verify_certs = True,\n",
+    "    connection_class = RequestsHttpConnection,\n",
+    "    index_name=\"test-index-using-aoss\",\n",
+    "    engine=\"faiss\",\n",
+    ")\n",
+    "\n",
+    "docs = docsearch.similarity_search(\n",
+    "    \"What is feature selection\",\n",
+    "     efficient_filter=filter,\n",
+    "     k=200,\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Using AOS (Amazon OpenSearch Service)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# This is just an example to show how to use AOS , you need to set proper values.\n",
+    "\n",
+    "service = 'es' # must set the service as 'es'\n",
+    "region = 'us-east-2'\n",
+    "credentials = boto3.Session(aws_access_key_id='xxxxxx',aws_secret_access_key='xxxxx').get_credentials()\n",
+    "awsauth = AWS4Auth('xxxxx', 'xxxxxx', region,service, session_token=credentials.token)\n",
+    "\n",
+    "docsearch = OpenSearchVectorSearch.from_documents(\n",
+    "    docs,\n",
+    "    embeddings,\n",
+    "    opensearch_url=\"host url\",\n",
+    "    http_auth=awsauth,\n",
+    "    timeout = 300,\n",
+    "    use_ssl = True,\n",
+    "    verify_certs = True,\n",
+    "    connection_class = RequestsHttpConnection,\n",
+    "    index_name=\"test-index\",\n",
+    ")\n",
+    "\n",
+    "docs = docsearch.similarity_search(\n",
+    "    \"What is feature selection\",\n",
+    "     k=200,\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Description

This PR includes the following changes:

- Adds AOSS (Amazon OpenSearch Service Serverless) support to OpenSearch. Please refer to the documentation on how to use it.
- While creating an index, AOSS only supports Approximate Search with `nmslib` and `faiss` engines. During Search, only Approximate Search and Script Scoring (on doc values) are supported.
- This PR also adds support to `efficient_filter` which can be used with `faiss` and `lucene` engines.
- The `lucene_filter` is deprecated. Instead please use the `efficient_filter` for the lucene engine.

### Maintainers
@rlancemartin, @eyurtsev, @navneet1v
