### PR TITLE
added lxml to the pip install example since it is required

### DIFF
--- a/docs/extras/integrations/document_loaders/trello.ipynb
+++ b/docs/extras/integrations/document_loaders/trello.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install py-trello beautifulsoup4"
+    "#!pip install py-trello beautifulsoup4 lxml"
    ]
   },
   {


### PR DESCRIPTION
  - Description: The trello dataloader example didn't work without an additional dependency installed - lxml
  - Issue: na
