### PR TITLE
Azure search extra fields

### DIFF
--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -63,7 +63,7 @@ def _get_search_client(
     index_name: str,
     embedding_function: Callable,
     semantic_configuration_name: Optional[str] = None,
-    metadata_fields:Optional[str] = [],
+    metadata_fields:Optional[str] = None,
 ) -> SearchClient:
     from azure.core.credentials import AzureKeyCredential
     from azure.core.exceptions import ResourceNotFoundError
@@ -117,14 +117,15 @@ def _get_search_client(
             ),
             SearchableField(
                 name=FIELDS_METADATA,
-                type=SearchFieldDataType.String,
+                type=SearchFieldDataType.String,metadata_fi
                 searchable=True,
                 retrievable=True,
             ),
         ]
-        for item in metadata_fields:
-            fields.append(SearchableField(name=item, type="Edm.String", searchable=True, retrievable=True, filterable=True))
-        # Vector search configuration
+        if metadata_fields:
+            for item in metadata_fields:
+                fields.append(SearchableField(name=item, type="Edm.String", searchable=True, retrievable=True, filterable=True))
+            # Vector search configuration
         vector_search = VectorSearch(
             algorithm_configurations=[
                 VectorSearchAlgorithmConfiguration(
@@ -191,7 +192,7 @@ class AzureSearch(VectorStore):
             index_name,
             embedding_function,
             semantic_configuration_name,
-            metadata_fields = kwargs.get('metadata_fields', []),
+            metadata_fields = kwargs.get('metadata_fields', None),
         )
         self.search_type = search_type
         self.semantic_configuration_name = semantic_configuration_name
@@ -213,7 +214,7 @@ class AzureSearch(VectorStore):
         ids = []
         # Write data to index
         data = []
-        metadata_fields = kwargs.get('metadata_fields', [])
+        metadata_fields = kwargs.get('metadata_fields', None)
         for i, text in enumerate(texts):
             # Use provided key otherwise use default key
             key = keys[i] if keys else str(uuid.uuid4())

--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -213,6 +213,7 @@ class AzureSearch(VectorStore):
         ids = []
         # Write data to index
         data = []
+        metadata_fields = kwargs.get('metadata_fields', [])
         for i, text in enumerate(texts):
             # Use provided key otherwise use default key
             key = keys[i] if keys else str(uuid.uuid4())
@@ -229,8 +230,9 @@ class AzureSearch(VectorStore):
                     ).tolist(),
                     FIELDS_METADATA: json.dumps(metadata),
                 }
-            for met_key, value in metadata.items():
-                    data_item[met_key] = value
+            if metadata_fields:
+                for met_key, value in metadata.items():
+                        data_item[met_key] = value
             data.append(data_item)
             ids.append(key)
             # Upload data in batches

--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -123,7 +123,7 @@ def _get_search_client(
             ),
         ]
         for item in metadata_fields:
-            fields.append(SearchableField(name=item), type="Edm.String", searchable=True, retrievable=True, filterable=True)
+            fields.append(SearchableField(name=item, type="Edm.String", searchable=True, retrievable=True, filterable=True))
         # Vector search configuration
         vector_search = VectorSearch(
             algorithm_configurations=[


### PR DESCRIPTION
  - Description: Added ability to make metadata filterable and retrievable,
  - Issue:  #6134 #7154 
  - Dependencies: None,
  - Tag maintainer:  @rlancemartin, @eyurtsev,,
  - Twitter handle: @AkhilSivanand

Example usage
```metadatas = [{'doc_id':'1', 'text_block_id':'23'}]
azure_search_endpoint=os.getenv("VECTOR_STORE_ADDRESS")
azure_search_key=os.getenv("VECTOR_STORE_PASSWORD")
metadata_fields = ['doc_id', 'text_block_id']
vector_store: AzureSearch = AzureSearch(
    azure_search_endpoint=azure_search_endpoint,
    azure_search_key=azure_search_key,
    index_name=index_name,
    embedding_function=embeddings.embed_query,
    search_type="similarity",
    metadata_fields=metadata_fields
)
result = vector_store.add_texts(texts = texts, metadatas=metadatas, metadata_fields=metadata_fields)
```



An additional field 'metadata_fields' is used to define if metadata should be made filterable and searchable. It is defined as **kwargs. So If we want to use it in the old format, we can just omit 'metadata_fields'during the function call.
If we are using the metadata_fields, the format of the index will be as shown below

![image](https://github.com/langchain-ai/langchain/assets/32809324/a180fccd-b653-4ba2-a01d-d99c32ddcba5)




