### PR TITLE
Fix for code snippet in documentation

### DIFF
--- a/docs/extras/use_cases/question_answering/index.mdx
+++ b/docs/extras/use_cases/question_answering/index.mdx
@@ -189,7 +189,7 @@ All retrievers implement some common methods, such as `get_relevant_documents()`
 from langchain.retrievers import SVMRetriever
 svm_retriever = SVMRetriever.from_documents(all_splits,OpenAIEmbeddings())
 docs_svm=svm_retriever.get_relevant_documents(question)
-len(docs)
+len(docs_svm)
 ```
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
- Description: I fixed an issue in the code snippet related to the variable name and the evaluation of its length. The original code used the variable "docs," but the correct variable name is "docs_svm" after using the SVMRetriever.
- maintainer: @baskaryan
- Twitter handle: @iamreechi_