### PR TITLE
giving path to the copy command for *.toml files

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -35,7 +35,7 @@ FROM langchain-dev-base AS langchain-dev-dependencies
 ARG PYTHON_VIRTUALENV_HOME
 
 # Copy only the dependency files for installation
-COPY pyproject.toml poetry.toml ./
+COPY libs/langchain/pyproject.toml libs/langchain/poetry.toml ./
 
 # Copy the langchain library for installation
 COPY libs/langchain/ libs/langchain/


### PR DESCRIPTION
Description: in the .devcontainer, docker-compose build is currently failing due to the src paths in the COPY command. This change adds the full path to the pyproject.toml and poetry.toml to allow the build to run.
Issue: 

You can see the issue if you try to build the dev docker image with:
```
cd .devcontainer
docker-compose build
```

Dependencies: none
Twitter handle: byronsalty