### PR TITLE
fix missing _identifying_params() in _VertexAICommon

### DIFF
--- a/libs/langchain/langchain/llms/vertexai.py
+++ b/libs/langchain/langchain/llms/vertexai.py
@@ -123,6 +123,11 @@ class _VertexAICommon(BaseModel):
         return text
 
     @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        """Get the identifying parameters."""
+        return {**{"model_name": self.model_name}, **self._default_params}
+
+    @property
     def _llm_type(self) -> str:
         return "vertexai"
 


### PR DESCRIPTION
Full set of params are missing from Vertex* LLMs when `dict()` method is called.

```
>>> from langchain.chat_models.vertexai import ChatVertexAI
>>> from langchain.llms.vertexai import VertexAI
>>> chat_llm = ChatVertexAI()
l>>> llm = VertexAI()
>>> chat_llm.dict()
{'_type': 'vertexai'}
>>> llm.dict()
{'_type': 'vertexai'}
```

This PR just uses the same mechanism used elsewhere to expose the full params.

Since `_identifying_params()` is on the `_VertexAICommon` class, it should cover the chat and non-chat cases.