### PR TITLE
Fixes #8310 Fix maximum recursion depth exceeded error

### DIFF
--- a/libs/langchain/langchain/vectorstores/elastic_vector_search.py
+++ b/libs/langchain/langchain/vectorstores/elastic_vector_search.py
@@ -155,7 +155,7 @@ class ElasticVectorSearch(VectorStore, ABC):
 
     @property
     def embeddings(self) -> Embeddings:
-        return self.embeddings
+        return self.embedding
 
     def add_texts(
         self,


### PR DESCRIPTION
ElasticsearchVectorStore.as_retriever() method is returning RecursionError: maximum recursion depth exceeded because of incorrect field reference in
 embeddings() method

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: Fix RecursionError 
  - Issue: the issue #8310 
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: @eyurtsev
  - Twitter handle: bpatel

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
