### PR TITLE
Fix broken `make` targets `format_diff` and `lint_diff`

### DIFF
--- a/libs/experimental/Makefile
+++ b/libs/experimental/Makefile
@@ -23,7 +23,7 @@ test_watch:
 # Define a variable for Python and notebook files.
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/experimental --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 
 lint lint_diff:
 	poetry run mypy $(PYTHON_FILES)

--- a/libs/langchain/Makefile
+++ b/libs/langchain/Makefile
@@ -70,7 +70,7 @@ docker_tests:
 # Define a variable for Python and notebook files.
 PYTHON_FILES=.
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 
 lint lint_diff:
 	poetry run mypy $(PYTHON_FILES)


### PR DESCRIPTION
Since the refactoring into sub-projects `libs/langchain` and `libs/experimental`, the `make` targets `format_diff` and `lint_diff` do not work anymore when running `make` from these subdirectories. Reason is that 

```
PYTHON_FILES=$(shell git diff --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
```

generates paths from the project's root directory instead of the corresponding subdirectories. This PR fixes this by adding a `--relative` command line option.

- Tag maintainer: @baskaryan
