### PR TITLE
fix(openapi): openapi chain will work without/empty description/summa…

### DIFF
--- a/libs/langchain/langchain/tools/openapi/utils/api_models.py
+++ b/libs/langchain/langchain/tools/openapi/utils/api_models.py
@@ -480,7 +480,7 @@ class APIOperation(BaseModel):
             description = spec.paths[path].description or spec.paths[path].summary
         return cls(
             operation_id=operation_id,
-            description=description,
+            description=description or '',
             base_url=spec.base_url,
             path=path,
             method=method,

--- a/libs/langchain/langchain/tools/openapi/utils/api_models.py
+++ b/libs/langchain/langchain/tools/openapi/utils/api_models.py
@@ -480,7 +480,7 @@ class APIOperation(BaseModel):
             description = spec.paths[path].description or spec.paths[path].summary
         return cls(
             operation_id=operation_id,
-            description=description or '',
+            description=description or "",
             base_url=spec.base_url,
             path=path,
             method=method,


### PR DESCRIPTION
Description: 

This PR will enable the Open API chain to work with valid Open API specifications missing `description` and `summary` properties for path and operation nodes in open api specs.

Since both `description` and `summary` property are declared optional we cannot be sure they are defined. This PR resolves this problem by providing an empty (`''`) description as fallback. 

The previous behavior of the Open API chain was that the underlying LLM (OpenAI) throw ed an exception since `None` is not of type string: 

```
openai.error.InvalidRequestError: None is not of type 'string' - 'functions.0.description'
```

Using this PR the Open API chain will succeed also using Open API specs lacking `description` and `summary` properties for path and operation nodes.

Thanks for your amazing work !

Tag maintainer: @baskaryan

