### PR TITLE
doc(prompts): Add redirect to fix broken link on Prompts Page

### DIFF
--- a/docs/docs_skeleton/vercel.json
+++ b/docs/docs_skeleton/vercel.json
@@ -3450,7 +3450,7 @@
     },
     {
       "source": "/en/latest/modules/prompts.html",
-      "destination": "/docs/modules/model_io/prompts.html"
+      "destination": "/docs/modules/model_io/prompts"
     },
     {
       "source": "/en/latest/modules/prompts/output_parsers.html",

--- a/docs/docs_skeleton/vercel.json
+++ b/docs/docs_skeleton/vercel.json
@@ -3449,6 +3449,10 @@
       "destination": "/docs/integrations/llms/writer"
     },
     {
+      "source": "/en/latest/modules/prompts.html",
+      "destination": "/docs/modules/model_io/prompts.html"
+    },
+    {
       "source": "/en/latest/modules/prompts/output_parsers.html",
       "destination": "/docs/modules/model_io/output_parsers/"
     },


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with: -->
  - Description: Fixes a broken link in https://docs.langchain.com/docs/components/prompts/ with a redirect
  - Issue: #8105
  - Dependencies: none
  - Tag maintainer: @baskaryan
  - Twitter handle: [@BharatR123](https://twitter.com/BharatR123)

<!--
Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
