### PR TITLE
ChatPromptTemplate: minor fix in doc string

### DIFF
--- a/libs/langchain/langchain/prompts/chat.py
+++ b/libs/langchain/langchain/prompts/chat.py
@@ -274,7 +274,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate, ABC):
             template = ChatPromptTemplate.from_messages([
                 ("system", "You are a helpful AI bot. Your name is {name}."),
                 ("human", "Hello, how are you doing?"),
-                ("assistant", "I'm doing well, thanks!"),
+                ("ai", "I'm doing well, thanks!"),
                 ("human", "{user_input}"),
             ])
 


### PR DESCRIPTION
Minor fix in doc-string to use `ai` rather than `assistant`
