### PR TITLE
Fixed exports for NeptuneOpenCypherQAChain

### DIFF
--- a/docs/extras/use_cases/graph/neptune_cypher_qa.ipynb
+++ b/docs/extras/use_cases/graph/neptune_cypher_qa.ipynb
@@ -10,11 +10,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.graphs.neptune_graph import NeptuneGraph\n",
+    "from langchain.graphs import NeptuneGraph\n",
     "\n",
     "\n",
     "host = \"<neptune-host>\"\n",
@@ -26,12 +26,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The Austin airport has 98 outgoing routes.'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from langchain.chat_models import ChatOpenAI\n",
-    "from langchain.chains.graph_qa.neptune_cypher import NeptuneOpenCypherQAChain\n",
+    "from langchain.chains import NeptuneOpenCypherQAChain\n",
     "\n",
     "llm = ChatOpenAI(temperature=0, model=\"gpt-4\")\n",
     "\n",
@@ -42,8 +53,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "orig_nbformat": 4
  },

--- a/libs/langchain/langchain/chains/__init__.py
+++ b/libs/langchain/langchain/chains/__init__.py
@@ -34,6 +34,7 @@ from langchain.chains.graph_qa.cypher import GraphCypherQAChain
 from langchain.chains.graph_qa.hugegraph import HugeGraphQAChain
 from langchain.chains.graph_qa.kuzu import KuzuQAChain
 from langchain.chains.graph_qa.nebulagraph import NebulaGraphQAChain
+from langchain.chains.graph_qa.neptune_cypher import NeptuneOpenCypherQAChain
 from langchain.chains.graph_qa.sparql import GraphSparqlQAChain
 from langchain.chains.hyde.base import HypotheticalDocumentEmbedder
 from langchain.chains.llm import LLMChain
@@ -101,6 +102,7 @@ __all__ = [
     "MultiRouteChain",
     "NatBotChain",
     "NebulaGraphQAChain",
+    "NeptuneOpenCypherQAChain",
     "OpenAIModerationChain",
     "OpenAPIEndpointChain",
     "QAGenerationChain",

--- a/libs/langchain/tests/unit_tests/chains/test_neptune_cypher_qa.py
+++ b/libs/langchain/tests/unit_tests/chains/test_neptune_cypher_qa.py
@@ -1,0 +1,2 @@
+def test_import() -> None:
+    from langchain.chains import NeptuneOpenCypherQAChain  # noqa: F401

--- a/libs/langchain/tests/unit_tests/graphs/test_neptune_graph.py
+++ b/libs/langchain/tests/unit_tests/graphs/test_neptune_graph.py
@@ -1,0 +1,2 @@
+def test_import() -> None:
+    from langchain.graphs import NeptuneGraph  # noqa: F401


### PR DESCRIPTION
## Description
The imports for `NeptuneOpenCypherQAChain` are failing. This PR adds the chain class to the `__init__.py` file to fix this issue.

## Maintainers
@dev2049 
@krlawrence