### PR TITLE
Fix ChromaDB integration -> docker container instructions

### DIFF
--- a/docs/extras/integrations/vectorstores/chroma.ipynb
+++ b/docs/extras/integrations/vectorstores/chroma.ipynb
@@ -215,10 +215,23 @@
     "Chroma has the ability to handle multiple `Collections` of documents, but the LangChain interface expects one, so we need to specify the collection name. The default collection name used by LangChain is \"langchain\".\n",
     "\n",
     "Here is how to clone, build, and run the Docker Image:\n",
-    "```\n",
+    "```sh\n",
     "git clone git@github.com:chroma-core/chroma.git\n",
-    "docker-compose up -d --build\n",
-    "```"
+    "```\n",
+    "\n",
+    "Edit the `docker-compose.yml` file and add `ALLOW_RESET=TRUE` under `environment`\n",
+    "```yaml\n",
+    "    ...\n",
+    "    command: uvicorn chromadb.app:app --reload --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml\n",
+    "    environment:\n",
+    "      - IS_PERSISTENT=TRUE\n",
+    "      - ALLOW_RESET=TRUE\n",
+    "    ports:\n",
+    "      - 8000:8000\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "Then run `docker-compose up -d --build`"
    ]
   },
   {


### PR DESCRIPTION
## Description
This PR handles modifying the Chroma DB integration's documentation.
It modifies the **Docker container** example to fix the instructions mentioned in the documentation.
In the current documentation, the below `client.reset()` line causes a runtime error:

```py
...
client = chromadb.HttpClient(settings=Settings(allow_reset=True))
client.reset()  # resets the database
collection = client.create_collection("my_collection")
...
```

`Exception: {"error":"ValueError('Resetting is not allowed by this configuration')"}`

This is due to the Chroma DB server needing to have the `allow_reset` flag set to `true` there as well.
This is fixed by adding the `ALLOW_RESET=TRUE` to the `docker-compose` file environment variable to the docker container before spinning it

## Issue
This fixes the runtime error that occurs when running the docker container example code

## Tag Maintainer
@rlancemartin, @eyurtsev