### PR TITLE
runnable.bind().bind() should combine kwargs, instead of nesting wrappers

### DIFF
--- a/libs/langchain/langchain/schema/runnable.py
+++ b/libs/langchain/langchain/schema/runnable.py
@@ -714,6 +714,9 @@ class RunnableBinding(Serializable, Runnable[Input, Output]):
     def lc_serializable(self) -> bool:
         return True
 
+    def bind(self, **kwargs: Any) -> Runnable[Input, Output]:
+        return self.__class__(bound=self.bound, kwargs={**self.kwargs, **kwargs})
+
     def invoke(self, input: Input, config: Optional[RunnableConfig] = None) -> Output:
         return self.bound.invoke(input, config, **self.kwargs)
 

--- a/libs/langchain/tests/unit_tests/schema/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/test_runnable.py
@@ -11,7 +11,7 @@ from langchain.callbacks.tracers.base import BaseTracer
 from langchain.callbacks.tracers.schemas import Run
 from langchain.chat_models.fake import FakeListChatModel
 from langchain.llms.fake import FakeListLLM
-from langchain.load.dump import dumps
+from langchain.load.dump import dumpd, dumps
 from langchain.output_parsers.list import CommaSeparatedListOutputParser
 from langchain.prompts.chat import (
     ChatPromptTemplate,
@@ -609,3 +609,13 @@ def test_seq_prompt_map(
         ]
     )
     assert tracer.runs == snapshot
+
+
+def test_bind_bind():
+    llm = FakeListLLM(responses=["i'm a textbot"])
+
+    assert dumpd(
+        llm.bind(stop=["Thought:"], one="two").bind(
+            stop=["Observation:"], hello="world"
+        )
+    ) == dumpd(llm.bind(stop=["Observation:"], one="two", hello="world"))

--- a/libs/langchain/tests/unit_tests/schema/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/test_runnable.py
@@ -611,7 +611,7 @@ def test_seq_prompt_map(
     assert tracer.runs == snapshot
 
 
-def test_bind_bind():
+def test_bind_bind() -> None:
     llm = FakeListLLM(responses=["i'm a textbot"])
 
     assert dumpd(


### PR DESCRIPTION


<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
