### PR TITLE
add test to ensure values in time weighted retriever are updated

### DIFF
--- a/libs/langchain/tests/unit_tests/retrievers/test_time_weighted_retriever.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_time_weighted_retriever.py
@@ -1,6 +1,6 @@
 """Tests for the time-weighted retriever class."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Iterable, List, Optional, Tuple, Type
 
 import pytest
@@ -139,7 +139,11 @@ def test_get_salient_docs(
 ) -> None:
     query = "Test query"
     docs_and_scores = time_weighted_retriever.get_salient_docs(query)
+    want = [(doc, 0.5) for doc in _get_example_memories()]
     assert isinstance(docs_and_scores, dict)
+    assert len(docs_and_scores) == len(want)
+    for k, doc in docs_and_scores.items():
+        assert doc in want
 
 
 def test_get_relevant_documents(
@@ -147,7 +151,17 @@ def test_get_relevant_documents(
 ) -> None:
     query = "Test query"
     relevant_documents = time_weighted_retriever.get_relevant_documents(query)
+    want = [(doc, 0.5) for doc in _get_example_memories()]
     assert isinstance(relevant_documents, list)
+    assert len(relevant_documents) == len(want)
+    now = datetime.now()
+    for doc in relevant_documents:
+        # assert that the last_accessed_at is close to now.
+        assert now - timedelta(hours=1) < doc.metadata["last_accessed_at"] <= now
+
+    # assert that the last_accessed_at in the memory stream is updated.
+    for d in time_weighted_retriever.memory_stream:
+        assert now - timedelta(hours=1) < d.metadata["last_accessed_at"] <= now
 
 
 def test_add_documents(


### PR DESCRIPTION
# What
- add test to ensure values in time weighted retriever are updated

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: add test to ensure values in time weighted retriever are updated
  - Issue: None
  - Dependencies: None
  - Tag maintainer: @rlancemartin, @eyurtsev
  - Twitter handle: @MlopsJ


Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
