### PR TITLE
Added Proper Documentation for `faiss-gpu` Installation

### DIFF
--- a/docs/extras/integrations/vectorstores/faiss.ipynb
+++ b/docs/extras/integrations/vectorstores/faiss.ipynb
@@ -23,9 +23,9 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install faiss\n",
+    "!pip install faiss-gpu # For CUDA 7.5+ Supported GPU's.\n",
     "# OR\n",
-    "!pip install faiss-cpu"
+    "!pip install faiss-cpu # For CPU Installation"
    ]
   },
   {

--- a/libs/langchain/langchain/vectorstores/faiss.py
+++ b/libs/langchain/langchain/vectorstores/faiss.py
@@ -40,7 +40,7 @@ def dependable_faiss_import(no_avx2: Optional[bool] = None) -> Any:
     except ImportError:
         raise ImportError(
             "Could not import faiss python package. "
-            "Please install it with `pip install faiss` "
+            "Please install it with `pip install faiss-gpu` (for CUDA supported GPU) "
             "or `pip install faiss-cpu` (depending on Python version)."
         )
     return faiss


### PR DESCRIPTION
### Description
 In the LangChain Documentation and Comments, I've Noticed that `pip install faiss` was mentioned, instead of `pip install faiss-gpu`, since installing `pip install faiss` results in an error. I've gone ahead and updated the Documentation, and `faiss.ipynb`. This Change will ensure ease of use for the end user, trying to install `faiss-gpu`.

### Issue: 
Documentation / Comments Related.

### Dependencies:
No Dependencies we're changed only updated the files with the wrong reference.

### Tag maintainer:
 @rlancemartin, @eyurtsev (Thank You for your contributions :smile: )
 


