### PR TITLE
Add StreamlitChatMessageHistory

### DIFF
--- a/docs/extras/integrations/memory/streamlit_chat_message_history.ipynb
+++ b/docs/extras/integrations/memory/streamlit_chat_message_history.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "91c6a7ef",
+   "metadata": {},
+   "source": [
+    "# Streamlit Chat Message History\n",
+    "\n",
+    "This notebook goes over how to use Streamlit to store chat message history. Note, StreamlitChatMessageHistory only works when run in a Streamlit app. For more on Streamlit check out their\n",
+    "[getting started documentation](https://docs.streamlit.io/library/get-started)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d15e3302",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.memory import StreamlitChatMessageHistory\n",
+    "\n",
+    "history = StreamlitChatMessageHistory(\"foo\")\n",
+    "\n",
+    "history.add_user_message(\"hi!\")\n",
+    "history.add_ai_message(\"whats up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64fc465e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history.messages"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "poetry-venv",
+   "language": "python",
+   "name": "poetry-venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/langchain/langchain/memory/__init__.py
+++ b/libs/langchain/langchain/memory/__init__.py
@@ -42,6 +42,7 @@ from langchain.memory.chat_message_histories import (
     PostgresChatMessageHistory,
     RedisChatMessageHistory,
     SQLChatMessageHistory,
+    StreamlitChatMessageHistory,
     ZepChatMessageHistory,
 )
 from langchain.memory.combined import CombinedMemory
@@ -87,6 +88,7 @@ __all__ = [
     "SQLChatMessageHistory",
     "SQLiteEntityStore",
     "SimpleMemory",
+    "StreamlitChatMessageHistory",
     "VectorStoreRetrieverMemory",
     "ZepChatMessageHistory",
     "ZepMemory",

--- a/libs/langchain/langchain/memory/chat_message_histories/__init__.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/__init__.py
@@ -13,7 +13,9 @@ from langchain.memory.chat_message_histories.mongodb import MongoDBChatMessageHi
 from langchain.memory.chat_message_histories.postgres import PostgresChatMessageHistory
 from langchain.memory.chat_message_histories.redis import RedisChatMessageHistory
 from langchain.memory.chat_message_histories.sql import SQLChatMessageHistory
-from langchain.memory.chat_message_histories.streamlit import StreamlitChatMessageHistory
+from langchain.memory.chat_message_histories.streamlit import (
+    StreamlitChatMessageHistory,
+)
 from langchain.memory.chat_message_histories.zep import ZepChatMessageHistory
 
 __all__ = [

--- a/libs/langchain/langchain/memory/chat_message_histories/__init__.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/__init__.py
@@ -13,6 +13,7 @@ from langchain.memory.chat_message_histories.mongodb import MongoDBChatMessageHi
 from langchain.memory.chat_message_histories.postgres import PostgresChatMessageHistory
 from langchain.memory.chat_message_histories.redis import RedisChatMessageHistory
 from langchain.memory.chat_message_histories.sql import SQLChatMessageHistory
+from langchain.memory.chat_message_histories.streamlit import StreamlitChatMessageHistory
 from langchain.memory.chat_message_histories.zep import ZepChatMessageHistory
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "PostgresChatMessageHistory",
     "RedisChatMessageHistory",
     "SQLChatMessageHistory",
+    "StreamlitChatMessageHistory",
     "ZepChatMessageHistory",
 ]

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -11,16 +11,15 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
     Chat message history that stores messages in Streamlit session state.
 
     Args:
-        message_key: session state key to use for storing messages.
+        key: The key to use in Streamlit session state for storing messages.
     """
 
-    def __init__(self, message_key: str = "messages"):
+    def __init__(self, key: str = "messages"):
         import streamlit as st
 
-        if message_key not in st.session_state:
-            st.session_state[message_key] = []
-        self._message_key = message_key
-        self._messages = st.session_state[message_key]
+        if key not in st.session_state:
+            st.session_state[key] = []
+        self._messages = st.session_state[key]
 
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -20,17 +20,17 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
         if message_key not in st.session_state:
             st.session_state[message_key] = []
         self._message_key = message_key
-        self._state = st.session_state
+        self._messages = st.session_state[message_key]
 
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the current list of messages"""
-        return self._state[self._message_key]
+        return self._messages
 
     def add_message(self, message: BaseMessage) -> None:
         """Add a message to the session memory"""
-        self._state[self._message_key].append(message)
+        self._messages.append(message)
 
     def clear(self) -> None:
         """Clear session memory"""
-        self._state[self._message_key] = []
+        self._messages.clear()

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from langchain.schema import (
     BaseChatMessageHistory,
 )

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -15,7 +15,12 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
     """
 
     def __init__(self, key: str = "langchain_messages"):
-        import streamlit as st
+        try:
+            import streamlit as st
+        except ImportError as e:
+            raise ImportError(
+                "Unable to import streamlit, please run `pip install streamlit`."
+            ) from e
 
         if key not in st.session_state:
             st.session_state[key] = []

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -4,6 +4,7 @@ from langchain.schema import (
 )
 from langchain.schema.messages import BaseMessage
 
+
 class StreamlitChatMessageHistory(BaseChatMessageHistory):
     """
     Chat message history that stores messages in Streamlit session state.
@@ -12,7 +13,7 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
         message_key: session state key to use for storing messages.
     """
 
-    def __init__(self, message_key="messages"):
+    def __init__(self, message_key: str = "messages"):
         import streamlit as st
 
         if message_key not in st.session_state:
@@ -21,7 +22,7 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
         self._state = st.session_state
 
     @property
-    def messages(self) -> List[BaseMessage]:
+    def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the current list of messages"""
         return self._state[self._message_key]
 

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -1,0 +1,34 @@
+from typing import List
+from langchain.schema import (
+    BaseChatMessageHistory,
+)
+from langchain.schema.messages import BaseMessage
+
+class StreamlitChatMessageHistory(BaseChatMessageHistory):
+    """
+    Chat message history that stores messages in Streamlit session state.
+
+    Args:
+        message_key: session state key to use for storing messages.
+    """
+
+    def __init__(self, message_key="messages"):
+        import streamlit as st
+
+        if message_key not in st.session_state:
+            st.session_state[message_key] = []
+        self._message_key = message_key
+        self._state = st.session_state
+
+    @property
+    def messages(self) -> List[BaseMessage]:
+        """Retrieve the current list of messages"""
+        return self._state[self._message_key]
+
+    def add_message(self, message: BaseMessage) -> None:
+        """Add a message to the session memory"""
+        self._state[self._message_key].append(message)
+
+    def clear(self) -> None:
+        """Clear session memory"""
+        self._state[self._message_key] = []

--- a/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/streamlit.py
@@ -14,7 +14,7 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
         key: The key to use in Streamlit session state for storing messages.
     """
 
-    def __init__(self, key: str = "messages"):
+    def __init__(self, key: str = "langchain_messages"):
         import streamlit as st
 
         if key not in st.session_state:

--- a/libs/langchain/tests/integration_tests/memory/test_streamlit.py
+++ b/libs/langchain/tests/integration_tests/memory/test_streamlit.py
@@ -31,8 +31,9 @@ test_script = """
 
 
 @pytest.mark.requires("streamlit")
-def test_memory_with_message_store():
+def test_memory_with_message_store() -> None:
     from streamlit.testing.script_interactions import InteractiveScriptTests
+
     test_handler = InteractiveScriptTests()
     test_handler.setUp()
     sr = test_handler.script_from_string(test_script).run()

--- a/libs/langchain/tests/integration_tests/memory/test_streamlit.py
+++ b/libs/langchain/tests/integration_tests/memory/test_streamlit.py
@@ -8,6 +8,7 @@ from langchain.memory import ConversationBufferMemory
 from langchain.memory.chat_message_histories import StreamlitChatMessageHistory
 from langchain.schema.messages import _message_to_dict
 
+
 @pytest.mark.requires("streamlit")
 def test_memory_with_message_store() -> None:
     """Test the memory with a message store."""

--- a/libs/langchain/tests/integration_tests/memory/test_streamlit.py
+++ b/libs/langchain/tests/integration_tests/memory/test_streamlit.py
@@ -1,0 +1,31 @@
+"""Integration tests for StreamlitChatMessageHistory functionality."""
+
+
+import json
+import pytest
+
+from langchain.memory import ConversationBufferMemory
+from langchain.memory.chat_message_histories import StreamlitChatMessageHistory
+from langchain.schema.messages import _message_to_dict
+
+@pytest.mark.requires("streamlit")
+def test_memory_with_message_store() -> None:
+    """Test the memory with a message store."""
+    message_history = StreamlitChatMessageHistory()
+    memory = ConversationBufferMemory(chat_memory=message_history, return_messages=True)
+
+    # add some messages
+    memory.chat_memory.add_ai_message("This is me, the AI")
+    memory.chat_memory.add_user_message("This is me, the human")
+
+    # get the message history from the memory store and turn it into a json
+    messages = memory.chat_memory.messages
+    messages_json = json.dumps([_message_to_dict(msg) for msg in messages])
+
+    assert "This is me, the AI" in messages_json
+    assert "This is me, the human" in messages_json
+
+    # remove the record from Azure Cosmos DB, so the next test run won't pick it up
+    memory.chat_memory.clear()
+
+    assert memory.chat_memory.messages == []

--- a/libs/langchain/tests/integration_tests/memory/test_streamlit.py
+++ b/libs/langchain/tests/integration_tests/memory/test_streamlit.py
@@ -2,6 +2,7 @@
 
 
 import json
+
 import pytest
 
 from langchain.memory import ConversationBufferMemory

--- a/libs/langchain/tests/unit_tests/memory/chat_message_histories/test_streamlit.py
+++ b/libs/langchain/tests/unit_tests/memory/chat_message_histories/test_streamlit.py
@@ -1,4 +1,4 @@
-"""Integration tests for StreamlitChatMessageHistory functionality."""
+"""Unit tests for StreamlitChatMessageHistory functionality."""
 import pytest
 
 test_script = """
@@ -16,42 +16,49 @@ test_script = """
         memory.chat_memory.add_ai_message("This is me, the AI")
         memory.chat_memory.add_user_message("This is me, the human")
     else:
-        st.text("Skipped add")
+        st.markdown("Skipped add")
 
     # Clear messages if checked
     if st.checkbox("clear messages"):
-        st.text("Cleared!")
+        st.markdown("Cleared!")
         memory.chat_memory.clear()
 
     # Write the output to st.code as a json blob for inspection
     messages = memory.chat_memory.messages
     messages_json = json.dumps([_message_to_dict(msg) for msg in messages])
-    st.code(messages_json)
+    st.text(messages_json)
 """
 
 
 @pytest.mark.requires("streamlit")
 def test_memory_with_message_store() -> None:
-    from streamlit.testing.script_interactions import InteractiveScriptTests
+    try:
+        from streamlit.testing.script_interactions import InteractiveScriptTests
+    except ModuleNotFoundError:
+        pytest.skip("Incorrect version of Streamlit installed")
 
     test_handler = InteractiveScriptTests()
     test_handler.setUp()
-    sr = test_handler.script_from_string(test_script).run()
+    try:
+        sr = test_handler.script_from_string(test_script).run()
+    except TypeError:
+        # Earlier version expected 2 arguments
+        sr = test_handler.script_from_string("memory_test.py", test_script).run()
 
     # Initial run should write two messages
-    messages_json = sr.code[0].value
+    messages_json = sr.get("text")[-1].value
     assert "This is me, the AI" in messages_json
     assert "This is me, the human" in messages_json
 
     # Uncheck the initial write, they should persist in session_state
-    sr = sr.checkbox[0].uncheck().run()
-    assert sr.text[0].value == "Skipped add"
-    messages_json = sr.code[0].value
+    sr = sr.get("checkbox")[0].uncheck().run()
+    assert sr.get("markdown")[0].value == "Skipped add"
+    messages_json = sr.get("text")[-1].value
     assert "This is me, the AI" in messages_json
     assert "This is me, the human" in messages_json
 
     # Clear the message history
-    sr = sr.checkbox[1].check().run()
-    assert sr.text[1].value == "Cleared!"
-    messages_json = sr.code[0].value
-    assert sr.code[0].value == "[]"
+    sr = sr.get("checkbox")[1].check().run()
+    assert sr.get("markdown")[1].value == "Cleared!"
+    messages_json = sr.get("text")[-1].value
+    assert messages_json == "[]"


### PR DESCRIPTION
Add a StreamlitChatMessageHistory class that stores chat messages in [Streamlit's Session State](https://docs.streamlit.io/library/api-reference/session-state).

Note: The integration test uses a currently-experimental Streamlit testing framework to simulate the execution of a Streamlit app. Marking this PR as draft until I confirm with the Streamlit team that we're comfortable supporting it.
