### PR TITLE
add 3 property types in metadata for notiondb loader

### DIFF
--- a/libs/langchain/langchain/document_loaders/notiondb.py
+++ b/libs/langchain/langchain/document_loaders/notiondb.py
@@ -122,6 +122,12 @@ class NotionDBLoader(BaseLoader):
                     if prop_data["people"]
                     else []
                 )
+            elif prop_type == "date":
+                value = prop_data["date"]
+            elif prop_type == "created_time":
+                value = prop_data["created_time"]
+            elif prop_type == "last_edited_time":
+                value = prop_data["last_edited_time"]
             else:
                 value = None
 


### PR DESCRIPTION
### Description: 
NotionDB supports a number of common property types. I have found three common types that are not included in notiondb loader. When programs loaded them with notiondb, which will cause some metadata information not to be passed to langchain. Therefore, I added three common types: 
- date
- created_time
- last_edit_time.

### Issue: 
no
### Dependencies: 
No dependencies added :)
### Tag maintainer: 
@rlancemartin, @eyurtsev
### Twitter handle: 
@BJTUTC
