### PR TITLE
Bugfix for async requests made through plugins failing making calls through agent.

### DIFF
--- a/libs/langchain/langchain/utilities/requests.py
+++ b/libs/langchain/langchain/utilities/requests.py
@@ -58,12 +58,12 @@ class Requests(BaseModel):
         if not self.aiosession:
             async with aiohttp.ClientSession() as session:
                 async with session.request(
-                    method, url, headers=self.headers, auth=self.auth, **kwargs
+                    method, url, headers=self.headers, **kwargs
                 ) as response:
                     yield response
         else:
             async with self.aiosession.request(
-                method, url, headers=self.headers, auth=self.auth, **kwargs
+                method, url, headers=self.headers, **kwargs
             ) as response:
                 yield response
 


### PR DESCRIPTION
This auth parameter being passed to the method results in a duplicate keyword argument since auth doesn't exist on the parameters.

This is an issue fix for https://github.com/langchain-ai/langchain/issues/7953

It was introduced as part of this change.
https://github.com/langchain-ai/langchain/commit/663b0933e488383e6a9bc2a04b4b1cf866a8ea94

@agola11  @baskaryan 
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
