### PR TITLE
Fix bug in SPARQL intent selection

### DIFF
--- a/libs/langchain/langchain/chains/graph_qa/sparql.py
+++ b/libs/langchain/langchain/chains/graph_qa/sparql.py
@@ -90,7 +90,7 @@ class GraphSparqlQAChain(Chain):
                 "I am sorry, but this prompt seems to fit none of the currently "
                 "supported SPARQL query types, i.e., SELECT and UPDATE."
             )
-        elif intent.find("SELECT") < intent.find("UPDATE"):
+        elif intent.find("SELECT") != -1:
             sparql_generation_chain = self.sparql_generation_select_chain
             intent = "SELECT"
         else:

--- a/libs/langchain/langchain/chains/graph_qa/sparql.py
+++ b/libs/langchain/langchain/chains/graph_qa/sparql.py
@@ -85,17 +85,17 @@ class GraphSparqlQAChain(Chain):
         _intent = self.sparql_intent_chain.run({"prompt": prompt}, callbacks=callbacks)
         intent = _intent.strip()
 
-        if "SELECT" not in intent and "UPDATE" not in intent:
+        if "SELECT" in intent and "UPDATE" not in intent:
+            sparql_generation_chain = self.sparql_generation_select_chain
+            intent = "SELECT"
+        elif "UPDATE" in intent and "SELECT" not in intent:
+            sparql_generation_chain = self.sparql_generation_update_chain
+            intent = "UPDATE"
+        else:
             raise ValueError(
                 "I am sorry, but this prompt seems to fit none of the currently "
                 "supported SPARQL query types, i.e., SELECT and UPDATE."
             )
-        elif intent.find("SELECT") != -1:
-            sparql_generation_chain = self.sparql_generation_select_chain
-            intent = "SELECT"
-        else:
-            sparql_generation_chain = self.sparql_generation_update_chain
-            intent = "UPDATE"
 
         _run_manager.on_text("Identified intent:", end="\n", verbose=self.verbose)
         _run_manager.on_text(intent, color="green", end="\n", verbose=self.verbose)


### PR DESCRIPTION
- Description: Fix bug in SPARQL intent selection
- Issue: After the change in #7758 the intent is always set to "UPDATE". Indeed, if the answer to the prompt contains only "SELECT" the `find("SELECT")` operation returns a higher value w.r.t. `-1` returned by `find("UPDATE")`.
- Dependencies: None,
- Tag maintainer: @baskaryan @aditya-29 
- Twitter handle: @mario_scrock