### PR TITLE
Update prompts to only return SQL command

### DIFF
--- a/libs/langchain/langchain/chains/sql_database/prompt.py
+++ b/libs/langchain/langchain/chains/sql_database/prompt.py
@@ -8,19 +8,11 @@ PROMPT_SUFFIX = """Only use the following tables:
 
 Question: {input}"""
 
-_DEFAULT_TEMPLATE = """Given an input question, first create a syntactically correct {dialect} query to run, then look at the results of the query and return the answer. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results. You can order the results by a relevant column to return the most interesting examples in the database.
+_DEFAULT_TEMPLATE = """Given an input question, create a syntactically correct {dialect} query to run. Unless the user specifies in his question a specific number of examples he wishes to obtain, always limit your query to at most {top_k} results. You can order the results by a relevant column to return the most interesting examples in the database.
 
 Never query for all the columns from a specific table, only ask for a the few relevant columns given the question.
 
 Pay attention to use only the column names that you can see in the schema description. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
 """
 
 PROMPT = PromptTemplate(
@@ -42,19 +34,11 @@ DECIDER_PROMPT = PromptTemplate(
     output_parser=CommaSeparatedListOutputParser(),
 )
 
-_duckdb_prompt = """You are a DuckDB expert. Given an input question, first create a syntactically correct DuckDB query to run, then look at the results of the query and return the answer to the input question.
+_duckdb_prompt = """You are a DuckDB expert. Given an input question, create a syntactically correct DuckDB query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per DuckDB. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use today() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
 """
 
 DUCKDB_PROMPT = PromptTemplate(
@@ -62,19 +46,11 @@ DUCKDB_PROMPT = PromptTemplate(
     template=_duckdb_prompt + PROMPT_SUFFIX,
 )
 
-_googlesql_prompt = """You are a GoogleSQL expert. Given an input question, first create a syntactically correct GoogleSQL query to run, then look at the results of the query and return the answer to the input question.
+_googlesql_prompt = """You are a GoogleSQL expert. Given an input question, create a syntactically correct GoogleSQL query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per GoogleSQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use CURRENT_DATE() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
 """
 
 GOOGLESQL_PROMPT = PromptTemplate(
@@ -83,19 +59,11 @@ GOOGLESQL_PROMPT = PromptTemplate(
 )
 
 
-_mssql_prompt = """You are an MS SQL expert. Given an input question, first create a syntactically correct MS SQL query to run, then look at the results of the query and return the answer to the input question.
+_mssql_prompt = """You are an MS SQL expert. Given an input question, create a syntactically correct MS SQL query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the TOP clause as per MS SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in square brackets ([]) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use CAST(GETDATE() as date) function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
-
 """
 
 MSSQL_PROMPT = PromptTemplate(
@@ -104,18 +72,11 @@ MSSQL_PROMPT = PromptTemplate(
 )
 
 
-_mysql_prompt = """You are a MySQL expert. Given an input question, first create a syntactically correct MySQL query to run, then look at the results of the query and return the answer to the input question.
+_mysql_prompt = """You are a MySQL expert. Given an input question, create a syntactically correct MySQL query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MySQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use CURDATE() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
 
 """
 
@@ -125,18 +86,11 @@ MYSQL_PROMPT = PromptTemplate(
 )
 
 
-_mariadb_prompt = """You are a MariaDB expert. Given an input question, first create a syntactically correct MariaDB query to run, then look at the results of the query and return the answer to the input question.
+_mariadb_prompt = """You are a MariaDB expert. Given an input question, create a syntactically correct MariaDB query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per MariaDB. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in backticks (`) to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use CURDATE() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
 
 """
 
@@ -146,18 +100,11 @@ MARIADB_PROMPT = PromptTemplate(
 )
 
 
-_oracle_prompt = """You are an Oracle SQL expert. Given an input question, first create a syntactically correct Oracle SQL query to run, then look at the results of the query and return the answer to the input question.
+_oracle_prompt = """You are an Oracle SQL expert. Given an input question, create a syntactically correct Oracle SQL query to ru.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the FETCH FIRST n ROWS ONLY clause as per Oracle SQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use TRUNC(SYSDATE) function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
 
 """
 
@@ -167,18 +114,11 @@ ORACLE_PROMPT = PromptTemplate(
 )
 
 
-_postgres_prompt = """You are a PostgreSQL expert. Given an input question, first create a syntactically correct PostgreSQL query to run, then look at the results of the query and return the answer to the input question.
+_postgres_prompt = """You are a PostgreSQL expert. Given an input question, create a syntactically correct PostgreSQL query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PostgreSQL. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use CURRENT_DATE function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
 
 """
 
@@ -188,18 +128,11 @@ POSTGRES_PROMPT = PromptTemplate(
 )
 
 
-_sqlite_prompt = """You are a SQLite expert. Given an input question, first create a syntactically correct SQLite query to run, then look at the results of the query and return the answer to the input question.
+_sqlite_prompt = """You are a SQLite expert. Given an input question, create a syntactically correct SQLite query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per SQLite. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use date('now') function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: Question here
-SQLQuery: SQL Query to run
-SQLResult: Result of the SQLQuery
-Answer: Final answer here
 
 """
 
@@ -208,18 +141,11 @@ SQLITE_PROMPT = PromptTemplate(
     template=_sqlite_prompt + PROMPT_SUFFIX,
 )
 
-_clickhouse_prompt = """You are a ClickHouse expert. Given an input question, first create a syntactically correct Clic query to run, then look at the results of the query and return the answer to the input question.
+_clickhouse_prompt = """You are a ClickHouse expert. Given an input question, create a syntactically correct Clic query to run.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per ClickHouse. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use today() function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
 
 """
 
@@ -228,18 +154,11 @@ CLICKHOUSE_PROMPT = PromptTemplate(
     template=_clickhouse_prompt + PROMPT_SUFFIX,
 )
 
-_prestodb_prompt = """You are a PrestoDB expert. Given an input question, first create a syntactically correct PrestoDB query to run, then look at the results of the query and return the answer to the input question.
+_prestodb_prompt = """You are a PrestoDB expert. Given an input question, create a syntactically correct PrestoDB query to ru.
 Unless the user specifies in the question a specific number of examples to obtain, query for at most {top_k} results using the LIMIT clause as per PrestoDB. You can order the results to return the most informative data in the database.
 Never query for all columns from a table. You must query only the columns that are needed to answer the question. Wrap each column name in double quotes (") to denote them as delimited identifiers.
 Pay attention to use only the column names you can see in the tables below. Be careful to not query for columns that do not exist. Also, pay attention to which column is in which table.
 Pay attention to use current_date function to get the current date, if the question involves "today".
-
-Use the following format:
-
-Question: "Question here"
-SQLQuery: "SQL Query to run"
-SQLResult: "Result of the SQLQuery"
-Answer: "Final answer here"
 
 """
 


### PR DESCRIPTION
v0.0.248 included new documentation for the sql integration (#8442). I had been struggling already to get sql integration working right, so as soon as I saw that I followed it. Using the `create_sql_query_chain` function resulted in the following error (it's marked as a warning, but sqlite still doesn't do anything with it:

> Warning: You can only execute one statement at a time.

I figured out this is because the prompt is still telling the LLM to try executing the sql to get an answer. In my case (on a local LLM and using OpenAI). So using the code:

```python
chain = create_sql_query_chain(llm, db, prompt=pipeline_prompt, k=10)
response = chain.invoke({"question": "How many records are in the service_logs table?"})
print(f"==={response}===") # Using === to show it's all one string
```

I got:

> ===SELECT COUNT(*) FROM "service_logs";
>
> SQLResult: 
> Answer: 3===

I was able to fix this by removing the instruction to execute the query from the response, as well as the template that shows the query, answer, etc.

Note: I am only able to test this on sqlite. I don't have access to the other databases.

Tag: @hwchase17 @baskaryan 
