### PR TITLE
Rely less on positional arg order in subclasses of vector store when calling async methods

### DIFF
--- a/libs/langchain/langchain/vectorstores/base.py
+++ b/libs/langchain/langchain/vectorstores/base.py
@@ -280,7 +280,9 @@ class VectorStore(ABC):
         # This is a temporary workaround to make the similarity search
         # asynchronous. The proper solution is to make the similarity search
         # asynchronous in the vector store implementations.
-        func = partial(self.similarity_search_with_relevance_scores, query, k, **kwargs)
+        func = partial(
+            self.similarity_search_with_relevance_scores, query, k=k, **kwargs
+        )
         return await asyncio.get_event_loop().run_in_executor(None, func)
 
     async def asimilarity_search(
@@ -291,7 +293,7 @@ class VectorStore(ABC):
         # This is a temporary workaround to make the similarity search
         # asynchronous. The proper solution is to make the similarity search
         # asynchronous in the vector store implementations.
-        func = partial(self.similarity_search, query, k, **kwargs)
+        func = partial(self.similarity_search, query, k=k, **kwargs)
         return await asyncio.get_event_loop().run_in_executor(None, func)
 
     def similarity_search_by_vector(
@@ -316,7 +318,7 @@ class VectorStore(ABC):
         # This is a temporary workaround to make the similarity search
         # asynchronous. The proper solution is to make the similarity search
         # asynchronous in the vector store implementations.
-        func = partial(self.similarity_search_by_vector, embedding, k, **kwargs)
+        func = partial(self.similarity_search_by_vector, embedding, k=k, **kwargs)
         return await asyncio.get_event_loop().run_in_executor(None, func)
 
     def max_marginal_relevance_search(
@@ -359,7 +361,12 @@ class VectorStore(ABC):
         # asynchronous. The proper solution is to make the similarity search
         # asynchronous in the vector store implementations.
         func = partial(
-            self.max_marginal_relevance_search, query, k, fetch_k, lambda_mult, **kwargs
+            self.max_marginal_relevance_search,
+            query,
+            k=k,
+            fetch_k=fetch_k,
+            lambda_mult=lambda_mult,
+            **kwargs,
         )
         return await asyncio.get_event_loop().run_in_executor(None, func)
 


### PR DESCRIPTION


<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
