### PR TITLE
Update reduce_openapi_spec in spec.py to handle NULL value for 'docs'

### DIFF
--- a/libs/langchain/langchain/agents/agent_toolkits/openapi/spec.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/openapi/spec.py
@@ -73,7 +73,7 @@ def reduce_openapi_spec(spec: dict, dereference: bool = True) -> ReducedOpenAPIS
         (f"{operation_name.upper()} {route}", docs.get("description"), docs)
         for route, operation in spec["paths"].items()
         for operation_name, docs in operation.items()
-        if operation_name in ["get", "post", "patch", "delete"]
+        if operation_name in ["get", "post", "patch", "delete"] and docs
     ]
 
     # 2. Replace any refs so that complete docs are retrieved.


### PR DESCRIPTION
@hinthornw 

**Description**

When iterating through an openapi spec, if the value of `docs`  is NULL within a get/post/patch or delete endpoint, then the code throws an error - docs not have attribute "get".

**Example** 

An openapi compliant json spec where this is material fix - https://github.com/SpaceTradersAPI/api-docs/blob/main/reference/SpaceTraders.json

Code blob to load the file and check
```
from langchain.tools import OpenAPISpec
from langchain.agents.agent_toolkits.openapi.spec import reduce_openapi_spec

raw_spacetraders_spec = OpenAPISpec.from_file('Path/to/SpaceTraders.json') # load referenced JSON openapi spec
converted_spacetraders_spec = json.loads(raw_spacetraders_spec.json())
reduced_spacetraders_spec = reduce_openapi_spec(converted_spacetraders_spec) 
# The above line throws an Attribute error because a null type doesn't have attribute 'get' 

```

**Suggested Fix**

We can additionally check for docs being NULL as a part of the if statement. Thus, only if an endpoint is get/post/patch/delete AND the route is not null, do we store the tuple

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
