### PR TITLE
📖 docs: Integration Cards

### DIFF
--- a/docs/extras/integrations/providers/index.mdx
+++ b/docs/extras/integrations/providers/index.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Grouped by provider
+# Integration Cards
 
 import DocCardList from "@theme/DocCardList";
 


### PR DESCRIPTION
- applied the `Integration Card` term to the `integration summary` pages. In the same manner, as HuggingFace uses a `Model Card` and `Dataset Card`, the `Integration Card` is used as a root to access all related info for this integration.

 @baskaryan
