### PR TITLE
AzureSearch Vector Store: Moving the usage of additional_fields into context of it's definition (bug fix from python error)

### DIFF
--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -269,12 +269,6 @@ class AzureSearch(VectorStore):
             metadata = metadatas[i] if metadatas else {}
             # Add data to index
             # Additional metadata to fields mapping
-            if metadata:
-                additional_fields = {
-                    k: v
-                    for k, v in metadata.items()
-                    if k in [x.name for x in self.fields]
-                }
             doc = {
                 "@search.action": "upload",
                 FIELDS_ID: key,
@@ -284,7 +278,13 @@ class AzureSearch(VectorStore):
                 ).tolist(),
                 FIELDS_METADATA: json.dumps(metadata),
             }
-            doc.update(additional_fields)
+            if metadata:
+                additional_fields = {
+                    k: v
+                    for k, v in metadata.items()
+                    if k in [x.name for x in self.fields]
+                }
+                doc.update(additional_fields)
             data.append(doc)
             ids.append(key)
             # Upload data in batches


### PR DESCRIPTION
Description: Using Azure Cognitive Search as a VectorStore.    Calling the `add_texts` method throws an error if there is no metadata property specified.   The `additional_fields` field is set in an `if` statement and then is used later outside the if statement.  This PR just moves the declaration of `additional_fields` below and puts the usage of it in context.

Issue: https://github.com/langchain-ai/langchain/issues/8544

Tagging @rlancemartin, @eyurtsev as this is related to Vector stores.

`make format`, `make lint`, `make spellcheck`, and `make test` have been run