### PR TITLE
implement async exec for base.py

### DIFF
--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -94,7 +94,8 @@ class ToTChain(Chain):
         self, 
         thought: Thought, 
         level: int, 
-        run_manager: Optional[AsyncCallbackManagerForChainRun] = None):
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None
+    ) -> None:
         if run_manager:
             colors = {
                 ThoughtValidity.VALID_FINAL: "green",

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -103,6 +103,7 @@ class ToTChain(Chain):
                 ThoughtValidity.INVALID: "red",
             }
             text = indent(f"Thought: {thought.text}\n", prefix="    " * level)
+            # type: ignore
             run_manager.on_text(
                 text=text, color=colors[thought.validity], verbose=self.verbose
             )
@@ -110,7 +111,7 @@ class ToTChain(Chain):
     def _call(
         self,
         inputs: Dict[str, Any],
-        run_manager: Optional[CallbackManagerForChainRun] = None,
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
     ) -> Dict[str, str]:
         _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
         if run_manager:
@@ -168,8 +169,9 @@ class ToTChain(Chain):
                 checker_inputs["thoughts"] = thoughts_path + (thought_text,)
 
                 # type: ignore
-                result = self.checker.acall(checker_inputs, callbacks=_run_manager.get_child())
-
+                result = await self.checker.acall(
+                    checker_inputs, callbacks=_run_manager.get_child()
+                )
                 thought_validity = result["validity"]
                 thought = Thought(text=thought_text, validity=thought_validity)
                 if thought.validity == ThoughtValidity.VALID_FINAL:

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -91,11 +91,10 @@ class ToTChain(Chain):
         return [self.output_key]
 
     def log_thought(
-        self,
-        thought: Thought,
-        level: int,
-        run_manager: Optional[CallbackManagerForChainRun] = None,
-    ) -> None:
+        self, 
+        thought: Thought, 
+        level: int, 
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None):
         if run_manager:
             colors = {
                 ThoughtValidity.VALID_FINAL: "green",
@@ -166,9 +165,11 @@ class ToTChain(Chain):
                     problem_description, thoughts_path, callbacks=_run_manager.get_child()
                 )
                 checker_inputs["thoughts"] = thoughts_path + (thought_text,)
-                thought_validity = await self.checker.acall(
+                result = await self.checker.acall(
                     checker_inputs, callbacks=_run_manager.get_child()
-                )["validity"]
+                )
+                
+                thought_validity = result["validity"]
                 thought = Thought(text=thought_text, validity=thought_validity)
                 if thought.validity == ThoughtValidity.VALID_FINAL:
                     self.log_thought(thought, level, run_manager)

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -110,9 +110,9 @@ class ToTChain(Chain):
     def _call(
         self,
         inputs: Dict[str, Any],
-        run_manager: Optional[CallbackManagerForChainRun] = None,
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
     ) -> Dict[str, str]:
-        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
         if run_manager:
             run_manager.on_text(text="Starting the ToT solve procedure.\n")
 

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -94,7 +94,7 @@ class ToTChain(Chain):
         self, 
         thought: Thought, 
         level: int, 
-        run_manager: Optional[AsyncCallbackManagerForChainRun] = None
+        run_manager: Optional[CallbackManagerForChainRun] = None
     ) -> None:
         if run_manager:
             colors = {
@@ -111,9 +111,9 @@ class ToTChain(Chain):
     def _call(
         self,
         inputs: Dict[str, Any],
-        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+        run_manager: Optional[CallbackManagerForChainRun] = None,
     ) -> Dict[str, str]:
-        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
+        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
         if run_manager:
             run_manager.on_text(text="Starting the ToT solve procedure.\n")
 
@@ -144,44 +144,51 @@ class ToTChain(Chain):
 
         return {self.output_key: "No solution found"}
 
-    async def _acall(
-            self,
-            inputs: Dict[str, Any],
-            run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
-        ) -> Dict[str, str]:
-            _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
-            if run_manager:
-                await run_manager.on_text(text="Starting the ToT solve procedure.\n")
-    
-            problem_description = inputs["problem_description"]
-            checker_inputs = {"problem_description": problem_description}
-            thoughts_path: tuple[str, ...] = ()
-            thought_generator = self.tot_strategy_class(
-                llm=self.llm, c=self.c, verbose=self.verbose_llm
-            )
-    
-            level = 0
-            for _ in range(self.k):
-                level = self.tot_memory.level
-                thought_text = thought_generator.next_thought(
-                    problem_description, thoughts_path, callbacks=_run_manager.get_child()
-                )
-                checker_inputs["thoughts"] = thoughts_path + (thought_text,)
+            async def _async_acall_helper(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: AsyncCallbackManagerForChainRun,
+    ) -> Dict[str, str]:
+        problem_description = inputs["problem_description"]
+        checker_inputs = {"problem_description": problem_description}
+        thoughts_path: tuple[str, ...] = ()
+        thought_generator = self.tot_strategy_class(
+            llm=self.llm, c=self.c, verbose=self.verbose_llm
+        )
 
-                # type: ignore
-                result = await self.checker.acall(
-                    checker_inputs, callbacks=_run_manager.get_child()
-                )
-                thought_validity = result["validity"]
-                thought = Thought(text=thought_text, validity=thought_validity)
-                if thought.validity == ThoughtValidity.VALID_FINAL:
-                    self.log_thought(thought, level, run_manager)
-                    return {self.output_key: thought.text}
-                self.tot_memory.store(thought)
+        level = 0
+        for _ in range(self.k):
+            level = self.tot_memory.level
+            thought_text = thought_generator.next_thought(
+                problem_description, thoughts_path, callbacks=run_manager.get_child()
+            )
+            checker_inputs["thoughts"] = thoughts_path + (thought_text,)
+            thought_validity = self.checker(
+                checker_inputs, callbacks=run_manager.get_child()
+            )["validity"]
+            thought = Thought(text=thought_text, validity=thought_validity)
+            if thought.validity == ThoughtValidity.VALID_FINAL:
                 self.log_thought(thought, level, run_manager)
-                thoughts_path = self.tot_controller(self.tot_memory)
-    
-            return {self.output_key: "No solution found"}
+                return {self.output_key: thought.text}
+            self.tot_memory.store(thought)
+            self.log_thought(thought, level, run_manager)
+            thoughts_path = self.tot_controller(self.tot_memory)
+
+        return {self.output_key: "No solution found"}
+
+    async def _acall(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, str]:
+        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
+        if run_manager:
+            await run_manager.on_text(text="Starting the ToT solve procedure.\n")
+
+        # Call the asynchronous helper method
+        result = await self._async_acall_helper(inputs, _run_manager)
+
+        return result
 
     @property
     def _chain_type(self) -> str:

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -110,7 +110,7 @@ class ToTChain(Chain):
     def _call(
         self,
         inputs: Dict[str, Any],
-        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+        run_manager: Optional[CallbackManagerForChainRun] = None,
     ) -> Dict[str, str]:
         _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
         if run_manager:
@@ -166,10 +166,10 @@ class ToTChain(Chain):
                     problem_description, thoughts_path, callbacks=_run_manager.get_child()
                 )
                 checker_inputs["thoughts"] = thoughts_path + (thought_text,)
-                result = await self.checker.acall(
-                    checker_inputs, callbacks=_run_manager.get_child()
-                )
-                
+
+                # type: ignore
+                result = self.checker.acall(checker_inputs, callbacks=_run_manager.get_child())
+
                 thought_validity = result["validity"]
                 thought = Thought(text=thought_text, validity=thought_validity)
                 if thought.validity == ThoughtValidity.VALID_FINAL:


### PR DESCRIPTION
Can we such a method for async? The return type is specified as `asyncio.Task[Dict[str, str]]` to represent the dictionary return type wrapped in an `asyncio.Task`. `Since _acall()` is an asynchronous method, any coroutine calls within it should be awaited. So, we use await when calling `run_manager.on_text()` to properly await the completion of the asynchronous operation.

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
