### PR TITLE
fix RecursiveUrlLoader

### DIFF
--- a/libs/langchain/langchain/document_loaders/recursive_url_loader.py
+++ b/libs/langchain/langchain/document_loaders/recursive_url_loader.py
@@ -92,9 +92,7 @@ class RecursiveUrlLoader(BaseLoader):
                     yield from loaded_link
                 else:
                     yield loaded_link
-                # If the link is a directory (w/ children) then visit it
-                if link.endswith("/"):
-                    yield from self.get_child_links_recursive(link, visited)
+                yield from self.get_child_links_recursive(link, visited)
 
         return visited
 


### PR DESCRIPTION
Description: the recursive url loader does not fully crawl for all urls under base url
Maintainer: @baskaryan