### PR TITLE
LlamaCpp, add n_gqa flag to support Llama2

### DIFF
--- a/libs/langchain/langchain/llms/llamacpp.py
+++ b/libs/langchain/langchain/llms/llamacpp.py
@@ -41,6 +41,9 @@ class LlamaCpp(LLM):
     """Number of parts to split the model into.
     If -1, the number of parts is automatically determined."""
 
+    n_gqa: Optional[int] = None
+    """Grouped query attention. Must be 8 for Llama 2 70B"""
+
     seed: int = Field(-1, alias="seed")
     """Seed. If -1, a random seed is used."""
 
@@ -123,6 +126,7 @@ class LlamaCpp(LLM):
             "lora_base",
             "n_ctx",
             "n_parts",
+            "n_gqa",
             "seed",
             "f16_kv",
             "logits_all",


### PR DESCRIPTION
To load and run llama 2 70b models `n_gqa` must be set to 8. For other models it can be unset (and defaults to 1). Tested with both llama 2 70b (set) and llama 2 13b (unset) and both work.

Maintainer guess @hwchase17 

Fixes https://github.com/langchain-ai/langchain/issues/8486