### PR TITLE
Add firestore_client param to FirestoreChatMessageHistory if caller already has one; also lets them specify GCP project, etc.

### DIFF
--- a/libs/langchain/langchain/memory/chat_message_histories/firestore.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/firestore.py
@@ -23,7 +23,7 @@ class FirestoreChatMessageHistory(BaseChatMessageHistory):
         collection_name: str,
         session_id: str,
         user_id: str,
-        firestore_client: Client,
+        firestore_client: Optional[Client] = None,
     ):
         """
         Initialize a new instance of the FirestoreChatMessageHistory class.


### PR DESCRIPTION
Existing implementation requires that you install `firebase-admin` package, and prevents you from using an existing Firestore client instance if available.

This adds optional `firestore_client` param to `FirestoreChatMessageHistory`, so users can just use their existing client/settings. If not passed, existing logic executes to initialize a `firestore_client`.