### PR TITLE
[Opensearch] : Fix the service validation in http_auth

### DIFF
--- a/libs/langchain/langchain/vectorstores/opensearch_vector_search.py
+++ b/libs/langchain/langchain/vectorstores/opensearch_vector_search.py
@@ -85,7 +85,7 @@ def _is_aoss_enabled(http_auth: Any) -> bool:
     """Check if the service is http_auth is set as `aoss`."""
     if (
         http_auth is not None
-        and http_auth.service is not None
+        and hasattr(http_auth, "service")
         and http_auth.service == "aoss"
     ):
         return True


### PR DESCRIPTION
### Description
OpenSearch supports validation using both Master Credentials (Username and password) and IAM. For Master Credentials users will not pass the argument `service` in `http_auth` and the existing code will break. To fix this, I have updated the condition to check if service attribute is present in http_auth before accessing it. 

### Maintainers
@baskaryan @navneet1v