### PR TITLE
Add upsert support for pgvector

### DIFF
--- a/libs/langchain/langchain/vectorstores/_pgvector_data_models.py
+++ b/libs/langchain/langchain/vectorstores/_pgvector_data_models.py
@@ -64,4 +64,4 @@ class EmbeddingStore(BaseModel):
     cmetadata = sqlalchemy.Column(JSON, nullable=True)
 
     # custom_id : any user defined id
-    custom_id = sqlalchemy.Column(sqlalchemy.String, nullable=True)
+    custom_id = sqlalchemy.Column(sqlalchemy.String, nullable=True, unique=True)


### PR DESCRIPTION
## Description
Currently, there is no support for updates or upserts to PGVector through langchain.
This PR adds that support by leveraging `on_conflict_do_upsert`

This fixes https://github.com/langchain-ai/langchain/issues/6866

Maintainers: @rlancemartin, @eyurtsev

Twitter handle: [@lokeshdevnani](https://twitter.com/lokeshdevnani)