### PR TITLE
add missing RemoteLangChainRetriever _get_relevant_documents test

### DIFF
--- a/libs/langchain/tests/unit_tests/retrievers/test_remote_retriever.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_remote_retriever.py
@@ -1,0 +1,71 @@
+import uuid
+from typing import Dict
+
+import pytest
+from pytest_mock import MockerFixture
+
+from langchain.callbacks.manager import CallbackManagerForRetrieverRun
+from langchain.retrievers import RemoteLangChainRetriever
+from langchain.schema import Document
+
+
+class MockResponse:
+    def __init__(self, json_data: Dict, status_code: int):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self) -> Dict:
+        return self.json_data
+
+
+def mocked_requests_post() -> MockResponse:
+    return MockResponse(
+        json_data={
+            "message": [
+                {
+                    "page_content": "I like apples",
+                    "metadata": {
+                        "test": 0,
+                    },
+                },
+                {
+                    "page_content": "I like pineapples",
+                    "metadata": {
+                        "test": 1,
+                    },
+                },
+            ]
+        },
+        status_code=200,
+    )
+
+
+@pytest.fixture
+def test_RemoteLangChainRetriever__get_relevant_documents(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("requests.post", side_effect=mocked_requests_post)
+
+    remote_langchain_retriever = RemoteLangChainRetriever(
+        url="http://localhost:8000",
+    )
+    response = remote_langchain_retriever._get_relevant_documents(
+        query="I like apples",
+        run_manager=CallbackManagerForRetrieverRun(
+            run_id=uuid.uuid4(),
+            handlers=[],
+            inheritable_handlers=[],
+        ),
+    )
+    want = [
+        Document(page_content="I like apples", metadata={"test": 0}),
+        Document(page_content="I like pineapples", metadata={"test": 1}),
+    ]
+
+    assert len(response) == len(want)
+    for r, w in zip(response, want):
+        assert r.page_content == w.page_content
+        assert r.metadata == w.metadata
+
+
+# TODO: _aget_relevant_documents test

--- a/libs/langchain/tests/unit_tests/retrievers/test_remote_retriever.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_remote_retriever.py
@@ -1,10 +1,7 @@
-import uuid
-from typing import Dict
+from typing import Any, Dict
 
-import pytest
 from pytest_mock import MockerFixture
 
-from langchain.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain.retrievers import RemoteLangChainRetriever
 from langchain.schema import Document
 
@@ -18,10 +15,10 @@ class MockResponse:
         return self.json_data
 
 
-def mocked_requests_post() -> MockResponse:
+def mocked_requests_post(*args: Any, **kwargs: Any) -> MockResponse:
     return MockResponse(
         json_data={
-            "message": [
+            "response": [
                 {
                     "page_content": "I like apples",
                     "metadata": {
@@ -40,8 +37,7 @@ def mocked_requests_post() -> MockResponse:
     )
 
 
-@pytest.fixture
-def test_RemoteLangChainRetriever__get_relevant_documents(
+def test_RemoteLangChainRetriever_get_relevant_documents(
     mocker: MockerFixture,
 ) -> None:
     mocker.patch("requests.post", side_effect=mocked_requests_post)
@@ -49,14 +45,7 @@ def test_RemoteLangChainRetriever__get_relevant_documents(
     remote_langchain_retriever = RemoteLangChainRetriever(
         url="http://localhost:8000",
     )
-    response = remote_langchain_retriever._get_relevant_documents(
-        query="I like apples",
-        run_manager=CallbackManagerForRetrieverRun(
-            run_id=uuid.uuid4(),
-            handlers=[],
-            inheritable_handlers=[],
-        ),
-    )
+    response = remote_langchain_retriever.get_relevant_documents("I like apples")
     want = [
         Document(page_content="I like apples", metadata={"test": 0}),
         Document(page_content="I like pineapples", metadata={"test": 1}),


### PR DESCRIPTION
# What
- Add missing RemoteLangChainRetriever _get_relevant_documents test

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: Add missing RemoteLangChainRetriever _get_relevant_documents test
  - Issue: None
  - Dependencies: None
  - Tag maintainer: @rlancemartin, @eyurtsev
  - Twitter handle: @MLOpsj

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
