### PR TITLE
Update to use non-pydantic run schema

### DIFF
--- a/libs/langchain/langchain/callbacks/tracers/schemas.py
+++ b/libs/langchain/langchain/callbacks/tracers/schemas.py
@@ -6,7 +6,7 @@ import warnings
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from langsmith.schemas import RunBase as BaseRunV2
+from langsmith.schemas import RunBase as Run
 from langsmith.schemas import RunTypeEnum as RunTypeEnumDep
 from pydantic import BaseModel, Field, root_validator
 
@@ -94,28 +94,6 @@ class ToolRun(BaseRun):
     child_llm_runs: List[LLMRun] = Field(default_factory=list)
     child_chain_runs: List[ChainRun] = Field(default_factory=list)
     child_tool_runs: List[ToolRun] = Field(default_factory=list)
-
-
-# Begin V2 API Schemas
-
-
-class Run(BaseRunV2):
-    """Run schema for the V2 API in the Tracer."""
-
-    execution_order: int
-    child_execution_order: int
-    child_runs: List[Run] = Field(default_factory=list)
-    tags: Optional[List[str]] = Field(default_factory=list)
-
-    @root_validator(pre=True)
-    def assign_name(cls, values: dict) -> dict:
-        """Assign name to the run."""
-        if values.get("name") is None:
-            if "name" in values["serialized"]:
-                values["name"] = values["serialized"]["name"]
-            elif "id" in values["serialized"]:
-                values["name"] = values["serialized"]["id"][-1]
-        return values
 
 
 ChainRun.update_forward_refs()

--- a/libs/langchain/langchain/smith/evaluation/string_run_evaluator.py
+++ b/libs/langchain/langchain/smith/evaluation/string_run_evaluator.py
@@ -261,9 +261,9 @@ class StringRunEvaluatorChain(Chain, RunEvaluator):
         return evaluate_strings_inputs
 
     def _prepare_output(self, output: Dict[str, Any]) -> Dict[str, Any]:
-        evaluation_result = EvaluationResult(
-            key=self.name, comment=output.get("reasoning"), **output
-        )
+        if "key" not in output:
+            output["key"] = self.name
+        evaluation_result = EvaluationResult.from_dict(output)
         if RUN_KEY in output:
             # TODO: Not currently surfaced. Update
             evaluation_result.evaluator_info[RUN_KEY] = output[RUN_KEY]

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -120,7 +120,7 @@ cassio = {version = "^0.0.7", optional = true}
 rdflib = {version = "^6.3.2", optional = true}
 sympy = {version = "^1.12", optional = true}
 rapidfuzz = {version = "^3.1.1", optional = true}
-langsmith = "~0.0.11"
+langsmith = "~0.1.0"
 rank-bm25 = {version = "^0.2.2", optional = true}
 amadeus = {version = ">=8.1.0", optional = true}
 geopandas = {version = "^0.13.1", optional = true}


### PR DESCRIPTION
Slowly trying to remove inhibitions on letting users upgrade to pydantic v2.

Depends on https://github.com/langchain-ai/langsmith-sdk/pull/127 or something similar being landed and an actual 0.1.0 to be cut before this can land / pass CI