### PR TITLE
📖 docs: compact api reference

### DIFF
--- a/docs/docs_skeleton/src/theme/CodeBlock/index.js
+++ b/docs/docs_skeleton/src/theme/CodeBlock/index.js
@@ -23,7 +23,7 @@ function Imports({ imports }) {
         {imports.map(({ imported, source, docs }) => (
           <li key={imported}>
             <a href={docs}>
-              <span>{imported}{"."}{source}</span>
+              <span>{imported}</span>
             </a>
           </li>
         ))}

--- a/docs/docs_skeleton/src/theme/CodeBlock/index.js
+++ b/docs/docs_skeleton/src/theme/CodeBlock/index.js
@@ -23,9 +23,8 @@ function Imports({ imports }) {
         {imports.map(({ imported, source, docs }) => (
           <li key={imported}>
             <a href={docs}>
-              <span>{imported}</span>
-            </a>{" "}
-            from <code>{source}</code>
+              <span>{imported}{"."}{source}</span>
+            </a>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
Updated design of the "API Reference" text
Here is an example of the current format:
![image](https://github.com/langchain-ai/langchain/assets/2256422/8727f2ba-1b69-497f-aa07-07f939b6da3b)

It changed to
`langchain.retrievers.ElasticSearchBM25Retriever` format. The same format as it is in the API Reference Toc.

It also resembles code: 
`from langchain.retrievers import ElasticSearchBM25Retriever` (namespace THEN class_name)

Current format is
`ElasticSearchBM25Retriever from langchain.retrievers` (class_name THEN namespace) 

This change is in line with other formats and improves readability.

 @baskaryan

