### PR TITLE
Make json output parser handle newlines inside markdown code blocks

### DIFF
--- a/libs/langchain/langchain/output_parsers/json.py
+++ b/libs/langchain/langchain/output_parsers/json.py
@@ -8,20 +8,17 @@ from typing import Any, List
 from langchain.schema import BaseOutputParser, OutputParserException
 
 
-def replace_new_line(matched_string):
-    if matched_string:
-        value = matched_string.group(2)
-        value = re.sub(r"\n", r"\\n", value)
-        value = re.sub(r"\r", r"\\r", value)
-        value = re.sub(r"\t", r"\\t", value)
-        value = re.sub('"', r"\"", value)
+def replace_new_line(match: re.Match[str]) -> str:
+    value = match.group(2)
+    value = re.sub(r"\n", r"\\n", value)
+    value = re.sub(r"\r", r"\\r", value)
+    value = re.sub(r"\t", r"\\t", value)
+    value = re.sub('"', r"\"", value)
 
-        return matched_string.group(1) + value + matched_string.group(3)
-    else:
-        return matched_string
+    return match.group(1) + value + match.group(3)
 
 
-def custom_parser(multiline_string):
+def custom_parser(multiline_string: str) -> str:
     if isinstance(multiline_string, (bytes, bytearray)):
         multiline_string = multiline_string.decode()
 
@@ -58,7 +55,7 @@ def parse_json_markdown(json_string: str) -> dict:
     # Strip whitespace and newlines from the start and end
     json_str = json_str.strip()
 
-    # handle newlines and other special characters that might be inside the returned value
+    # handle newlines and other special characters inside the returned value
     json_str = custom_parser(json_str)
 
     # Parse the JSON string into a Python dictionary

--- a/libs/langchain/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/langchain/tests/unit_tests/output_parsers/test_json.py
@@ -60,6 +60,13 @@ JSON_WITH_MARKDOWN_CODE_BLOCK = """```json
 }
 ```"""
 
+JSON_WITH_MARKDOWN_CODE_BLOCK_AND_NEWLINES = """```json
+{
+    "action": "Final Answer",
+    "action_input": "```bar\n<div id="1" class=\"value\">\n\ttext\n</div>```"
+}
+```"""
+
 NO_TICKS = """{
     "foo": "bar"
 }"""
@@ -114,6 +121,13 @@ def test_parse_json(json_string: str) -> None:
     assert parsed == {"foo": "bar"}
 
 
-def test_parse_json_with_code_block() -> None:
+def test_parse_json_with_code_blocks() -> None:
     parsed = parse_json_markdown(JSON_WITH_MARKDOWN_CODE_BLOCK)
     assert parsed == {"foo": "```bar```"}
+
+    parsed = parse_json_markdown(JSON_WITH_MARKDOWN_CODE_BLOCK_AND_NEWLINES)
+
+    assert parsed == {
+        "action": "Final Answer",
+        "action_input": '```bar\n<div id="1" class="value">\n\ttext\n</div>```',
+    }


### PR DESCRIPTION
Update to #8528

Newlines and other special characters within markdown code blocks returned as `action_input` should be handled correctly (in particular, unescaped `"` => `\"` and `\n` => `\\n`) so they don't break JSON parsing.

@baskaryan 