### PR TITLE
Add BasePromptTemplate.formatters which act on input variables before  they are passed to template string

### DIFF
--- a/libs/langchain/langchain/agents/schema.py
+++ b/libs/langchain/langchain/agents/schema.py
@@ -22,7 +22,7 @@ class AgentScratchPadChatPromptTemplate(ChatPromptTemplate):
             f"you return as final answer):\n{thoughts}"
         )
 
-    def _merge_partial_and_user_variables(self, **kwargs: Any) -> Dict[str, Any]:
+    def _prepare_variables(self, **kwargs: Any) -> Dict[str, Any]:
         intermediate_steps = kwargs.pop("intermediate_steps")
         kwargs["agent_scratchpad"] = self._construct_agent_scratchpad(
             intermediate_steps

--- a/libs/langchain/langchain/load/dump.py
+++ b/libs/langchain/langchain/load/dump.py
@@ -15,10 +15,16 @@ def default(obj: Any) -> Any:
 
 def dumps(obj: Any, *, pretty: bool = False) -> str:
     """Return a json string representation of an object."""
-    if pretty:
-        return json.dumps(obj, default=default, indent=2)
-    else:
-        return json.dumps(obj, default=default)
+    try:
+        if pretty:
+            return json.dumps(obj, default=default, indent=2)
+        else:
+            return json.dumps(obj, default=default)
+    except TypeError:
+        if pretty:
+            return json.dumps(to_json_not_implemented(obj), indent=2)
+        else:
+            return json.dumps(to_json_not_implemented(obj))
 
 
 def dumpd(obj: Any) -> Dict[str, Any]:

--- a/libs/langchain/langchain/prompts/chat.py
+++ b/libs/langchain/langchain/prompts/chat.py
@@ -533,7 +533,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate, ABC):
         Returns:
             list of formatted messages
         """
-        kwargs = self._merge_partial_and_user_variables(**kwargs)
+        kwargs = self._prepare_variables(**kwargs)
         result = []
         for message_template in self.messages:
             if isinstance(message_template, BaseMessage):

--- a/libs/langchain/langchain/prompts/few_shot.py
+++ b/libs/langchain/langchain/prompts/few_shot.py
@@ -134,7 +134,7 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
 
             prompt.format(variable1="foo")
         """
-        kwargs = self._merge_partial_and_user_variables(**kwargs)
+        kwargs = self._prepare_variables(**kwargs)
         # Get the examples to use.
         examples = self._get_examples(**kwargs)
         examples = [

--- a/libs/langchain/langchain/prompts/few_shot_with_templates.py
+++ b/libs/langchain/langchain/prompts/few_shot_with_templates.py
@@ -103,7 +103,7 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
 
             prompt.format(variable1="foo")
         """
-        kwargs = self._merge_partial_and_user_variables(**kwargs)
+        kwargs = self._prepare_variables(**kwargs)
         # Get the examples to use.
         examples = self._get_examples(**kwargs)
         # Format the examples.

--- a/libs/langchain/langchain/prompts/prompt.py
+++ b/libs/langchain/langchain/prompts/prompt.py
@@ -112,7 +112,7 @@ class PromptTemplate(StringPromptTemplate):
 
                 prompt.format(variable1="foo")
         """
-        kwargs = self._merge_partial_and_user_variables(**kwargs)
+        kwargs = self._prepare_variables(**kwargs)
         return DEFAULT_FORMATTER_MAPPING[self.template_format](self.template, **kwargs)
 
     @root_validator()

--- a/libs/langchain/langchain/schema/prompt_template.py
+++ b/libs/langchain/langchain/schema/prompt_template.py
@@ -76,7 +76,8 @@ class BasePromptTemplate(Serializable, Runnable[Dict, PromptValue], ABC):
     
     By default, the following types are supported:
     - `Document`: the `page_content` attribute of the document will be used.
-    - `list`: the list will be joined with newlines."""
+    - `list`: each element of the list will be formatted.
+    - `dict`: each value of the dict will be formatted."""
     input_variables: List[str]
     """A list of the names of the variables the prompt template expects."""
     output_parser: Optional[BaseOutputParser] = None

--- a/libs/langchain/langchain/schema/prompt_template.py
+++ b/libs/langchain/langchain/schema/prompt_template.py
@@ -6,10 +6,11 @@ from abc import ABC, abstractmethod
 from functools import partial
 from operator import attrgetter
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, TypeAlias, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union, cast
 
 import yaml
 from pydantic import Field, root_validator
+from typing_extensions import TypeAlias
 
 from langchain.load.serializable import Serializable
 from langchain.schema.document import Document

--- a/libs/langchain/langchain/schema/prompt_template.py
+++ b/libs/langchain/langchain/schema/prompt_template.py
@@ -68,7 +68,7 @@ def _format_value(formatters: FormattersType, value: Any) -> Any:
 class BasePromptTemplate(Serializable, Runnable[Dict, PromptValue], ABC):
     """Base class for all prompt templates, returning a prompt."""
 
-    formatters: FormattersType = PROMPT_DEFAULT_FORMATTERS
+    formatters: Optional[FormattersType] = None
     """A mapping of types to functions that format them into a string.
     The functions should take a single argument, the value to format, and
     return a string. If the function takes two arguments, the second argument
@@ -147,7 +147,12 @@ class BasePromptTemplate(Serializable, Runnable[Dict, PromptValue], ABC):
             for k, v in self.partial_variables.items()
         }
         all_variables = {**partial_kwargs, **kwargs}
-        return {k: _format_value(self.formatters, v) for k, v in all_variables.items()}
+        formatters = (
+            self.formatters
+            if self.formatters is not None
+            else PROMPT_DEFAULT_FORMATTERS
+        )
+        return {k: _format_value(formatters, v) for k, v in all_variables.items()}
 
     @abstractmethod
     def format(self, **kwargs: Any) -> str:
@@ -174,7 +179,6 @@ class BasePromptTemplate(Serializable, Runnable[Dict, PromptValue], ABC):
     def dict(self, **kwargs: Any) -> Dict:
         """Return dictionary representation of prompt."""
         prompt_dict = super().dict(**kwargs)
-        del prompt_dict["formatters"]
         prompt_dict["_type"] = self._prompt_type
         return prompt_dict
 

--- a/libs/langchain/tests/unit_tests/prompts/__snapshots__/test_prompt.ambr
+++ b/libs/langchain/tests/unit_tests/prompts/__snapshots__/test_prompt.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_default_formatters
+  '''
+  {
+    "lc": 1,
+    "type": "constructor",
+    "id": [
+      "langchain",
+      "prompts",
+      "prompt",
+      "PromptTemplate"
+    ],
+    "kwargs": {
+      "input_variables": [
+        "foo"
+      ],
+      "template": "This is a {foo} test.",
+      "template_format": "f-string",
+      "partial_variables": {}
+    }
+  }
+  '''
+# ---
+# name: test_default_formatters.1
+  '''
+  {
+    "lc": 1,
+    "type": "constructor",
+    "id": [
+      "langchain",
+      "prompts",
+      "prompt",
+      "PromptTemplate"
+    ],
+    "kwargs": {
+      "input_variables": [
+        "foo"
+      ],
+      "template": "This is a {foo} test.",
+      "template_format": "f-string",
+      "partial_variables": {},
+      "formatters": {}
+    }
+  }
+  '''
+# ---
+# name: test_default_formatters.2
+  '''
+  {
+    "lc": 1,
+    "type": "not_implemented",
+    "id": [
+      "langchain",
+      "prompts",
+      "prompt",
+      "PromptTemplate"
+    ]
+  }
+  '''
+# ---

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -1,4 +1,5 @@
 """Test functionality related to prompts."""
+from langchain.schema.document import Document
 import pytest
 
 from langchain.prompts.prompt import PromptTemplate
@@ -120,6 +121,23 @@ def test_partial_init_string() -> None:
     assert prompt.input_variables == []
     result = prompt.format()
     assert result == "This is a 1 test."
+
+
+def test_default_formatters() -> None:
+    """Test prompt can be initialized with partial variables."""
+    template = "This is a {foo} test."
+    prompt = PromptTemplate.from_template(template)
+    assert prompt.template == template
+    assert prompt.input_variables == ["foo"]
+
+    foo = [Document(page_content="Hello there", metadata={"some": "key"})]
+    assert prompt.format(foo=foo) == "This is a ['Hello there'] test."
+
+    prompt_no_formatters = PromptTemplate.from_template(template, formatters={})
+    assert (
+        prompt_no_formatters.format(foo=foo)
+        == "This is a [Document(page_content='Hello there', metadata={'some': 'key'})] test."
+    )
 
 
 def test_partial_init_func() -> None:

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -1,8 +1,8 @@
 """Test functionality related to prompts."""
-from langchain.schema.document import Document
 import pytest
 
 from langchain.prompts.prompt import PromptTemplate
+from langchain.schema.document import Document
 
 
 def test_prompt_valid() -> None:
@@ -136,7 +136,7 @@ def test_default_formatters() -> None:
     prompt_no_formatters = PromptTemplate.from_template(template, formatters={})
     assert (
         prompt_no_formatters.format(foo=foo)
-        == "This is a [Document(page_content='Hello there', metadata={'some': 'key'})] test."
+        == "This is a [Document(page_content='Hello there', metadata={'some': 'key'})] test."  # noqa: E501
     )
 
 

--- a/libs/langchain/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_prompt.py
@@ -1,9 +1,8 @@
 """Test functionality related to prompts."""
-from langchain.load.dump import dumps
 import pytest
-
 from syrupy import SnapshotAssertion
 
+from langchain.load.dump import dumps
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema.document import Document
 

--- a/libs/langchain/tests/unit_tests/schema/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/test_runnable.py
@@ -560,7 +560,7 @@ Question:
             SystemMessage(content="You are a nice assistant."),
             HumanMessage(
                 content="""Context:
-[Document(page_content='foo', metadata={}), Document(page_content='bar', metadata={})]
+['foo', 'bar']
 
 Question:
 What is your name?"""


### PR DESCRIPTION


Default formatters for list, dict and Document

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
