### PR TITLE
Add tensor_split support to LlamaCpp

### DIFF
--- a/libs/langchain/langchain/llms/llamacpp.py
+++ b/libs/langchain/langchain/llms/llamacpp.py
@@ -67,6 +67,9 @@ class LlamaCpp(LLM):
     n_gpu_layers: Optional[int] = Field(None, alias="n_gpu_layers")
     """Number of layers to be loaded into gpu memory. Default None."""
 
+    tensor_split: Optional[List[float]] = Field(None, alias="tensor_split")
+    """Split tensors across multiple GPUs by a list of proportions. Default None."""
+
     suffix: Optional[str] = Field(None)
     """A suffix to append to the generated text. If None, no suffix is appended."""
 
@@ -136,8 +139,10 @@ class LlamaCpp(LLM):
         ]
         model_params = {k: values[k] for k in model_param_names}
         # For backwards compatibility, only include if non-null.
-        if values["n_gpu_layers"] is not None:
-            model_params["n_gpu_layers"] = values["n_gpu_layers"]
+        keys = ["n_gpu_layers", "tensor_split"]
+        for key in keys:
+            if values[key] is not None:
+                model_params[key] = values[key]
 
         try:
             from llama_cpp import Llama


### PR DESCRIPTION
Adds the option `tensor_split` to the `LlamaCpp` binding, for specifying how to split the model memory onto multiple GPUs.

Example running airoboros 33b on 4x Nvidia RTX 2080Ti, (11 GB each)

```python
os.environ["CUDA_VISIBLE_DEVICES"]="0,1,2,3"
LlamaCpp(
            model_path="airoboros-33b-gpt4-2.0.ggmlv3.q8_0.bin",
            n_gpu_layers=63,
            tensor_split=[0.1, 0.3, 0.3, 0.3],
            ...
```

This leaves space on GPU0 for the tokenizer etc.

More info about the option in the [llama-cpp-python documentation](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.llama.Llama.__init__).