### PR TITLE
(issue #5163) Append reminder to nest multi-prompt router prompt output in JSON markdown code block, resolving JSON parsing error.

### DIFF
--- a/libs/langchain/langchain/chains/router/multi_prompt_prompt.py
+++ b/libs/langchain/langchain/chains/router/multi_prompt_prompt.py
@@ -27,5 +27,5 @@ modifications are needed.
 << INPUT >>
 {{input}}
 
-<< OUTPUT >>
+<< OUTPUT (must include ```json at the start of the response) >>
 """


### PR DESCRIPTION
Resolves occasional JSON parsing error when some predictions are passed through a `MultiPromptChain`.

Makes [this modification](https://github.com/langchain-ai/langchain/issues/5163#issuecomment-1652220401) to `multi_prompt_prompt.py`, which is much cleaner than appending an entire example object, which is another community-reported solution.

@hwchase17, @baskaryan

cc: @SimasJan