### PR TITLE
support for arbitrary kwargs for llamacpp

### DIFF
--- a/libs/langchain/tests/integration_tests/llms/test_llamacpp.py
+++ b/libs/langchain/tests/integration_tests/llms/test_llamacpp.py
@@ -4,6 +4,8 @@ import os
 from typing import Generator
 from urllib.request import urlretrieve
 
+import pytest
+
 from langchain.llms import LlamaCpp
 
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
@@ -68,3 +70,19 @@ def test_llamacpp_streaming_callback() -> None:
     )
     llm("Q: Can you count to 10? A:'1, ")
     assert callback_handler.llm_streams <= MAX_TOKENS + OFF_BY_ONE
+
+
+def test_llamacpp_model_kwargs() -> None:
+    llm = LlamaCpp(model_path=get_model(), model_kwargs={"n_gqa": None})
+    assert llm.model_kwargs == {"n_gqa": None}
+
+
+def test_llamacpp_invalid_model_kwargs() -> None:
+    with pytest.raises(ValueError):
+        LlamaCpp(model_path=get_model(), model_kwargs={"n_ctx": 1024})
+
+
+def test_llamacpp_incorrect_field() -> None:
+    with pytest.warns(match="not default parameter"):
+        llm = LlamaCpp(model_path=get_model(), n_gqa=None)
+    llm.model_kwargs == {"n_gqa": None}

--- a/libs/langchain/tests/unit_tests/llms/test_openai.py
+++ b/libs/langchain/tests/unit_tests/llms/test_openai.py
@@ -18,6 +18,12 @@ def test_openai_model_param() -> None:
 
 
 @pytest.mark.requires("openai")
+def test_openai_model_kwargs() -> None:
+    llm = OpenAI(model_kwargs={"foo": "bar"})
+    assert llm.model_kwargs == {"foo": "bar"}
+
+
+@pytest.mark.requires("openai")
 def test_openai_invalid_model_kwargs() -> None:
     with pytest.raises(ValueError):
         OpenAI(model_kwargs={"model_name": "foo"})


### PR DESCRIPTION
llamacpp params (per their own code) are unstable, so instead of adding/deleting them constantly adding a model_kwargs parameter that allows for arbitrary additional kwargs

cc @jsjolund and @zacps re #8599 and #8704