### PR TITLE
Bug fix: feature/issue-7804-chroma-client_settings-bug follow-up on PR #8267 is_persistent also needs to be set to True

### DIFF
--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -94,9 +94,9 @@ class Chroma(VectorStore):
             if client_settings:
                 # If client_settings is provided with persist_directory specified,
                 # then it is "in-memory and persisting to disk" mode.
-                client_settings.persist_directory = (
-                    persist_directory or client_settings.persist_directory
-                )
+                if persist_directory:
+                    client_settings.persist_directory = persist_directory
+                    client_settings.is_persistent = True
                 if client_settings.persist_directory is not None:
                     # Maintain backwards compatibility with chromadb < 0.4.0
                     major, minor, _ = chromadb.__version__.split(".")


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

  - Description: is_persistent also needs to be set to True when persist_directory exists
  - Issue: PR #8267 fixed issue-7804 but introduced another issue where is_persistent is not set to True (defaulted to False). This causes ChromaDB not persisting data to disk.
  - Dependencies: N/A
  - Tag maintainer: N/A
  - Twitter handle: peidaqi
  
Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
