### PR TITLE
Fix for missing class apis in docs

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -19,7 +19,7 @@ def load_members(dir: Path) -> dict:
             members[top_level] = {"classes": [], "functions": []}
         with open(py, "r") as f:
             for line in f.readlines():
-                cls = re.findall(r"^class ([^_].*)\(", line)
+                cls = re.findall(r"^class ([^_].*)[\(\:]", line)
                 members[top_level]["classes"].extend([module + "." + c for c in cls])
                 func = re.findall(r"^def ([^_].*)\(", line)
                 afunc = re.findall(r"^async def ([^_].*)\(", line)


### PR DESCRIPTION
## Description
Current `api_docs_build` is not capturing all classes, particularly the ones without any base class. The problem seems to be with the regex used for capturing the class names. This is causing broken links in the docs in several places, due to missing api docs. Here are some examples of missing api docs.

https://api.python.langchain.com/en/latest/graphs/langchain.graphs.neptune_graph.NeptuneGraph.html
https://api.python.langchain.com/en/latest/graphs/langchain.graphs.nebula_graph.NebulaGraph.html

This PR fixes the regex, so the build captures all classes.

## Maintainers
@baskaryan 

