### PR TITLE
Fix Recursive URL Loader

### DIFF
--- a/libs/langchain/langchain/document_loaders/recursive_url_loader.py
+++ b/libs/langchain/langchain/document_loaders/recursive_url_loader.py
@@ -1,5 +1,5 @@
 from typing import Iterator, List, Optional, Set
-from urllib.parse import urljoin, urlparse, urldefrag
+from urllib.parse import urldefrag, urljoin, urlparse
 
 import requests
 

--- a/libs/langchain/langchain/document_loaders/recursive_url_loader.py
+++ b/libs/langchain/langchain/document_loaders/recursive_url_loader.py
@@ -95,10 +95,8 @@ class RecursiveUrlLoader(BaseLoader):
                     and link.startswith(current_root)
                 ):
                     child_links.add(link)
-        # import pdb; pdb.set_trace()
         # Get absolute path for all root relative links listed
         absolute_paths = [urljoin(base_url, link) for link in child_links]
-
         # Store the visited links and recursively visit the children
         for link in absolute_paths:
             # Check all unvisited links


### PR DESCRIPTION
Previously we wouldn't follow paths like
```
relative/to/current
```
or
```
https://www.samedomain.com/i/am/relative/path
```