### PR TITLE
Add integration to collect feedback on documentation

### DIFF
--- a/docs/docs_skeleton/package-lock.json
+++ b/docs/docs_skeleton/package-lock.json
@@ -8,7 +8,7 @@
       "name": "docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docsly/react": "^1.8.6",
+        "@docsly/react": "^1.9.0",
         "@docusaurus/core": "2.4.0",
         "@docusaurus/preset-classic": "2.4.0",
         "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",
@@ -2043,9 +2043,9 @@
       }
     },
     "node_modules/@docsly/react": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@docsly/react/-/react-1.8.6.tgz",
-      "integrity": "sha512-FwcVeTYsZnOMIFYgW0R9/0xaWKWfzvW4eKA9QjJApXKbfGFHgzm0tWEmVf9TyZgsA3qoI+0qaUuJ3JlQrdONXg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@docsly/react/-/react-1.9.1.tgz",
+      "integrity": "sha512-MzInFvAXoAC2KlouOJgdKw7TLHShKwqDCv8JbmbISnUG/h1iEqGVTnfxwPJIPBfMGnkyqB6+7Ja+khV5Gir6hg==",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "clsx": "^1.2.1",

--- a/docs/docs_skeleton/package-lock.json
+++ b/docs/docs_skeleton/package-lock.json
@@ -8,6 +8,7 @@
       "name": "docs",
       "version": "0.0.0",
       "dependencies": {
+        "@docsly/react": "^1.8.6",
         "@docusaurus/core": "2.4.0",
         "@docusaurus/preset-classic": "2.4.0",
         "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",
@@ -2041,6 +2042,23 @@
         }
       }
     },
+    "node_modules/@docsly/react": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@docsly/react/-/react-1.8.6.tgz",
+      "integrity": "sha512-FwcVeTYsZnOMIFYgW0R9/0xaWKWfzvW4eKA9QjJApXKbfGFHgzm0tWEmVf9TyZgsA3qoI+0qaUuJ3JlQrdONXg==",
+      "dependencies": {
+        "@heroicons/react": "^2.0.18",
+        "clsx": "^1.2.1",
+        "dayjs": "^1.11.7",
+        "react-error-boundary": "^3.1.4",
+        "react-hot-toast": "^2.4.0",
+        "swr": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/@docusaurus/core": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
@@ -2898,6 +2916,14 @@
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
+      "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5925,6 +5951,11 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "node_modules/dayjs": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -7975,6 +8006,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -11683,6 +11722,21 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -11707,6 +11761,21 @@
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {
@@ -13266,6 +13335,17 @@
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
+      "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/tapable": {

--- a/docs/docs_skeleton/package.json
+++ b/docs/docs_skeleton/package.json
@@ -19,7 +19,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,md,mdx}\""
   },
   "dependencies": {
-    "@docsly/react": "^1.8.6",
+    "@docsly/react": "^1.9.1",
     "@docusaurus/core": "2.4.0",
     "@docusaurus/preset-classic": "2.4.0",
     "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",

--- a/docs/docs_skeleton/package.json
+++ b/docs/docs_skeleton/package.json
@@ -19,6 +19,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,md,mdx}\""
   },
   "dependencies": {
+    "@docsly/react": "^1.8.6",
     "@docusaurus/core": "2.4.0",
     "@docusaurus/preset-classic": "2.4.0",
     "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",

--- a/docs/docs_skeleton/src/theme/Footer/index.js
+++ b/docs/docs_skeleton/src/theme/Footer/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+import Footer from "@theme-original/Footer";
+import Docsly from "@docsly/react";
+import "@docsly/react/styles.css";
+import { useLocation } from "@docusaurus/router";
+ 
+export default function FooterWrapper(props) {
+  const { pathname } = useLocation();
+  return (
+    <>
+      <Footer {...props} />
+      <Docsly publicId="public_FpkRFtHG3zlOAQ1PwmZ84zpg4bEt3od1jh6B648GpXJ4JrXvSEH8j5yazVwG07KQ" pathname={pathname} />
+    </>
+  );
+}


### PR DESCRIPTION
## Background

LangChain has become widely popular and adopted by developers. The documentation of any developer product plays a crucial role in the developer experience. Collecting feedback on the LangChain documentation will further improve the developer experience and help the community.

## Description

[Docsly](https://docsly.dev) is a feedback tool crafted for developer documentation. It lets the readers leave contextual feedback  (comments) on the documentation website and helps the maintainer by showing the feedback exactly where the user left it.

The feedback feature (like/dislike) gives a general sense of whether users are finding a particular page helpful.

  - Dependencies: Installed `@docsly/react` in the Docusaurus project
  - Tag maintainer: @baskaryan
  - Twitter handle: [sun_anshuman](https://twitter.com/sun_anshuman)

### Example project for preview

[Clerk](https://clerk.com/docs), [Tigris](https://www.tigrisdata.com/docs/), and [Dyte](https://docs.dyte.io) are using docsly in production already.

### Todo

- [ ] Sign up on [docsly.dev ](https://docsly.dev/dashboard)for a fresh account for maintainers

### Cost implications

[Docsly](https://docsly.dev) is free to use for open-source projects. 
