### PR TITLE
Add missing test for retrievers self_query

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/qdrant.py
+++ b/libs/langchain/langchain/retrievers/self_query/qdrant.py
@@ -31,7 +31,13 @@ class QdrantTranslator(Visitor):
         self.metadata_key = metadata_key
 
     def visit_operation(self, operation: Operation) -> rest.Filter:
-        from qdrant_client.http import models as rest
+        try:
+            from qdrant_client.http import models as rest
+        except ImportError as e:
+            raise ImportError(
+                "Cannot import qdrant_client. Please install with `pip install "
+                "qdrant-client`."
+            ) from e
 
         args = [arg.accept(self) for arg in operation.arguments]
         operator = {
@@ -42,7 +48,13 @@ class QdrantTranslator(Visitor):
         return rest.Filter(**{operator: args})
 
     def visit_comparison(self, comparison: Comparison) -> rest.FieldCondition:
-        from qdrant_client.http import models as rest
+        try:
+            from qdrant_client.http import models as rest
+        except ImportError as e:
+            raise ImportError(
+                "Cannot import qdrant_client. Please install with `pip install "
+                "qdrant-client`."
+            ) from e
 
         self._validate_func(comparison.comparator)
         attribute = self.metadata_key + "." + comparison.attribute

--- a/libs/langchain/tests/unit_tests/retrievers/self_query/test_myscale.py
+++ b/libs/langchain/tests/unit_tests/retrievers/self_query/test_myscale.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from typing import Any, Dict, Tuple
 
 import pytest
 
@@ -7,6 +7,7 @@ from langchain.chains.query_constructor.ir import (
     Comparison,
     Operation,
     Operator,
+    StructuredQuery,
 )
 from langchain.retrievers.self_query.myscale import MyScaleTranslator
 
@@ -41,4 +42,45 @@ def test_visit_operation() -> None:
     )
     expected = "metadata.foo < 2 AND metadata.bar = 'baz'"
     actual = DEFAULT_TRANSLATOR.visit_operation(op)
+    assert expected == actual
+
+
+def test_visit_structured_query() -> None:
+    query = "What is the capital of France?"
+    structured_query = StructuredQuery(
+        query=query,
+        filter=None,
+    )
+    expected: Tuple[str, Dict] = (query, {})
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+    comp = Comparison(comparator=Comparator.LT, attribute="foo", value=["1", "2"])
+    structured_query = StructuredQuery(
+        query=query,
+        filter=comp,
+    )
+    expected = (
+        query,
+        {"where_str": "metadata.foo < ['1', '2']"},
+    )
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+    op = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.LT, attribute="foo", value=2),
+            Comparison(comparator=Comparator.EQ, attribute="bar", value="baz"),
+        ],
+    )
+    structured_query = StructuredQuery(
+        query=query,
+        filter=op,
+    )
+    expected = (
+        query,
+        {"where_str": "metadata.foo < 2 AND metadata.bar = 'baz'"},
+    )
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
     assert expected == actual

--- a/libs/langchain/tests/unit_tests/retrievers/self_query/test_pinecone.py
+++ b/libs/langchain/tests/unit_tests/retrievers/self_query/test_pinecone.py
@@ -1,8 +1,11 @@
+from typing import Dict, Tuple
+
 from langchain.chains.query_constructor.ir import (
     Comparator,
     Comparison,
     Operation,
     Operator,
+    StructuredQuery,
 )
 from langchain.retrievers.self_query.pinecone import PineconeTranslator
 
@@ -26,4 +29,46 @@ def test_visit_operation() -> None:
     )
     expected = {"$and": [{"foo": {"$lt": 2}}, {"bar": {"$eq": "baz"}}]}
     actual = DEFAULT_TRANSLATOR.visit_operation(op)
+    assert expected == actual
+
+
+def test_visit_structured_query() -> None:
+    query = "What is the capital of France?"
+
+    structured_query = StructuredQuery(
+        query=query,
+        filter=None,
+    )
+    expected: Tuple[str, Dict] = (query, {})
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+    comp = Comparison(comparator=Comparator.LT, attribute="foo", value=["1", "2"])
+    structured_query = StructuredQuery(
+        query=query,
+        filter=comp,
+    )
+    expected = (
+        query,
+        {"filter": {"foo": {"$lt": ["1", "2"]}}},
+    )
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+    op = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.LT, attribute="foo", value=2),
+            Comparison(comparator=Comparator.EQ, attribute="bar", value="baz"),
+        ],
+    )
+    structured_query = StructuredQuery(
+        query=query,
+        filter=op,
+    )
+    expected = (
+        query,
+        {"filter": {"$and": [{"foo": {"$lt": 2}}, {"bar": {"$eq": "baz"}}]}},
+    )
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
     assert expected == actual


### PR DESCRIPTION
# What
- Add missing test for retrievers self_query
- Add missing import validation

<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: Add missing test for retrievers self_query
  - Issue: None
  - Dependencies: None
  - Tag maintainer: @rlancemartin, @eyurtsev
  - Twitter handle: @MlopsJ
  
Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
