### PR TITLE
#8786 Fixed: Callback handler disconnect in between

### DIFF
--- a/libs/langchain/langchain/chains/question_answering/__init__.py
+++ b/libs/langchain/langchain/chains/question_answering/__init__.py
@@ -83,6 +83,7 @@ def _load_stuff_chain(
         document_variable_name=document_variable_name,
         verbose=verbose,
         callback_manager=callback_manager,
+        callbacks=callbacks,
         **kwargs,
     )
 
@@ -209,6 +210,7 @@ def _load_refine_chain(
         initial_response_name=initial_response_name,
         verbose=verbose,
         callback_manager=callback_manager,
+        callbacks=callbacks,
         **kwargs,
     )
 


### PR DESCRIPTION
Fixes for  #8786 @agola11 

  - Description: The flow of callback is breaking till the last chain, as callbacks are missed in between chain along nested path. This will help get full trace and correlate parent child relationship in all nested chains.

  - Issue: the issue #8786 
  - Dependencies: NA
  - Tag maintainer: @agola11 
  - Twitter handle: Agarwal_Ankur