### PR TITLE
Fix: RecursiveUrlLoader is not working (#8367)

### DIFF
--- a/libs/langchain/langchain/document_loaders/recursive_url_loader.py
+++ b/libs/langchain/langchain/document_loaders/recursive_url_loader.py
@@ -67,7 +67,7 @@ class RecursiveUrlLoader(BaseLoader):
         all_links = [urljoin(url, link.get("href")) for link in soup.find_all("a")]
         # Filter children url of current url
         child_links = [link for link in set(all_links) if link.startswith(url)]
-        # Remove framents to avoid repititions
+        # Remove fragments to avoid repetitions
         defraged_child_links = [urldefrag(link).url for link in child_links]
 
         # Store the visited links and recursively visit the children


### PR DESCRIPTION
Fixes #8367 

Before this fix: 
```python
from langchain.document_loaders import RecursiveUrlLoader
docs = RecursiveUrlLoader(url="https://docs.python.org/3/").load()
print(len(docs))
```
It returns 0 docs

After this fix:
```python
from langchain.document_loaders import RecursiveUrlLoader
docs = RecursiveUrlLoader(url="https://docs.python.org/3/").load()
print(len(docs))
```
It returns 23 docs now.



<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
