### PR TITLE
Feature/partial clearance buffer memory

### DIFF
--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -40,3 +40,7 @@ class BaseChatMemory(BaseMemory, ABC):
     def clear(self) -> None:
         """Clear memory contents."""
         self.chat_memory.clear()
+
+    def partial_clear(self, delete_ratio: float = 0.5) -> None:
+        """Clear a portion of the history."""
+        self.chat_memory.partial_clear(delete_ratio=delete_ratio)

--- a/libs/langchain/langchain/memory/chat_message_histories/in_memory.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/in_memory.py
@@ -24,5 +24,5 @@ class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
         self.messages = []
 
     def partial_clear(self, delete_ratio: float = 0.5) -> None:
-        """Clear a portion of the history."""
-        self.messages = self.messages[-1 * int(len(self.messages) * delete_ratio) :]
+        """Clear a portion of the history. Removes the oldest messages."""
+        self.messages = self.messages[int(len(self.messages) * delete_ratio) :]

--- a/libs/langchain/langchain/memory/chat_message_histories/in_memory.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/in_memory.py
@@ -22,3 +22,7 @@ class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
 
     def clear(self) -> None:
         self.messages = []
+
+    def partial_clear(self, delete_ratio: float = 0.5) -> None:
+        """Clear a portion of the history."""
+        self.messages = self.messages[-1 * int(len(self.messages) * delete_ratio) :]


### PR DESCRIPTION

  - Description: I ran into a problem several times that Conversation buffer memory gets full as soon as it reaches 4097 tokens. And we wouldn't want to completely clear the history as then the complete context would be lost. So I have added a method in **ChatMessageHistory** named **partial_clear** which takes an argument **delete_ratio**. If you pass 0.5 as delete_ratio it will remove 50% of the oldest messages in the memory. **BaseChatMemory** also inherits this method.
  - Issue: NA,
  - Dependencies: NA,
  - Tag maintainer: @hwchase17,
