### PR TITLE
Add user_context to AmazonKendraRetriever

### DIFF
--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -297,7 +297,8 @@ class AmazonKendraRetriever(BaseRetriever):
 
         client: boto3 client for Kendra
 
-        jwt_token: JSON Web Token (JWT)
+        user_context: Provides information about the user context
+            See: https://docs.aws.amazon.com/kendra/latest/APIReference/API_UserContext.html
 
     Example:
         .. code-block:: python
@@ -315,7 +316,7 @@ class AmazonKendraRetriever(BaseRetriever):
     attribute_filter: Optional[Dict] = None
     page_content_formatter: Callable[[ResultItem], str] = combined_text
     client: Any
-    jwt_token: str = None
+    user_context: Optional[Dict] = None
 
     @validator("top_k")
     def validate_top_k(cls, value: int) -> int:
@@ -364,9 +365,9 @@ class AmazonKendraRetriever(BaseRetriever):
         }
         if self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
-        if self.jwt_token is not None: 
-            kendra_kwargs['UserContext'] = {"Token": self.jwt_token}
-            
+        if self.user_context is not None: 
+            kendra_kwargs['UserContext'] = self.user_context
+
         response = self.client.retrieve(**kendra_kwargs)
         r_result = RetrieveResult.parse_obj(response)
         if r_result.ResultItems:

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -297,7 +297,7 @@ class AmazonKendraRetriever(BaseRetriever):
 
         client: boto3 client for Kendra
 
-        jwt_token: JWT (JSON Web) Token 
+        jwt_token: JSON Web Token (JWT)
 
     Example:
         .. code-block:: python

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -363,7 +363,6 @@ class AmazonKendraRetriever(BaseRetriever):
             "QueryText": query.strip(),
             "PageSize": self.top_k,
         }
-        print('user context is : ', self.user_context)
         if self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
         if self.user_context is not None: 

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -298,7 +298,7 @@ class AmazonKendraRetriever(BaseRetriever):
         client: boto3 client for Kendra
 
         user_context: Provides information about the user context
-            See: https://docs.aws.amazon.com/kendra/latest/APIReference/API_UserContext.html
+            See: https://docs.aws.amazon.com/kendra/latest/APIReference
 
     Example:
         .. code-block:: python

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -365,8 +365,8 @@ class AmazonKendraRetriever(BaseRetriever):
         }
         if self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
-        if self.user_context is not None: 
-            kendra_kwargs['UserContext'] = self.user_context
+        if self.user_context is not None:
+            kendra_kwargs["UserContext"] = self.user_context
 
         response = self.client.retrieve(**kendra_kwargs)
         r_result = RetrieveResult.parse_obj(response)

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -297,6 +297,8 @@ class AmazonKendraRetriever(BaseRetriever):
 
         client: boto3 client for Kendra
 
+        jwt_token: JWT (JSON Web) Token 
+
     Example:
         .. code-block:: python
 
@@ -313,6 +315,7 @@ class AmazonKendraRetriever(BaseRetriever):
     attribute_filter: Optional[Dict] = None
     page_content_formatter: Callable[[ResultItem], str] = combined_text
     client: Any
+    jwt_token: str = None
 
     @validator("top_k")
     def validate_top_k(cls, value: int) -> int:
@@ -361,7 +364,9 @@ class AmazonKendraRetriever(BaseRetriever):
         }
         if self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
-
+        if self.jwt_token is not None: 
+            kendra_kwargs['UserContext'] = {"Token": self.jwt_token}
+            
         response = self.client.retrieve(**kendra_kwargs)
         r_result = RetrieveResult.parse_obj(response)
         if r_result.ResultItems:

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -363,6 +363,7 @@ class AmazonKendraRetriever(BaseRetriever):
             "QueryText": query.strip(),
             "PageSize": self.top_k,
         }
+        print('user context is : ', self.user_context)
         if self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
         if self.user_context is not None: 


### PR DESCRIPTION
### Description 

Now, we can pass information like a JWT token using user_context:  

```python
self.retriever = AmazonKendraRetriever(index_id=kendraIndexId, user_context={"Token": jwt_token})
```

- [x] `make lint`
- [x] `make format`
- [x] `make test`

Also tested by pip installing in my own project, and it allows access through the token. 

### Maintainers 

 @rlancemartin, @eyurtsev

### My twitter handle 

[girlknowstech](https://twitter.com/girlknowstech)

### Tests passed 

```
-------------------------------------------------------------------------------------------------------- snapshot report summary --------------------------------------------------------------------------------------------------------
22 snapshots passed.
========================================================================================================== slowest 5 durations ==========================================================================================================
4.01s call     tests/unit_tests/llms/test_openai.py::test_openai_async_retries
4.01s call     tests/unit_tests/llms/test_openai.py::test_openai_retries
0.76s call     tests/unit_tests/memory/chat_message_histories/test_sql.py::test_multiple_sessions[SQLite]
0.67s call     tests/unit_tests/document_loaders/parsers/test_pdf_parsers.py::test_pdfminer_parser
0.65s call     tests/unit_tests/memory/chat_message_histories/test_sql.py::test_clear_messages[SQLite]
============================================================================================ 1022 passed, 83 skipped, 47 warnings in 21.99s =============================================================================================
```
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
