### PR TITLE
Fix handling of ServerDisconnectedError in AsyncHtmlLoader that crash…

### DIFF
--- a/libs/langchain/langchain/document_loaders/async_html.py
+++ b/libs/langchain/langchain/document_loaders/async_html.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 import warnings
 from typing import Any, Dict, Iterator, List, Optional, Union
-from aiohttp import ServerDisconnectedError
 
 import aiohttp
 import requests
+from aiohttp import ServerDisconnectedError
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader

--- a/libs/langchain/langchain/retrievers/web_research.py
+++ b/libs/langchain/langchain/retrievers/web_research.py
@@ -202,10 +202,11 @@ class WebResearchRetriever(BaseRetriever):
             html2text = Html2TextTransformer()
             logger.info("Indexing new urls...")
             docs = loader.load()
-            docs = list(html2text.transform_documents(docs))
-            docs = self.text_splitter.split_documents(docs)
-            self.vectorstore.add_documents(docs)
-            self.url_database.extend(new_urls)
+            if len(docs) > 0:
+                docs = list(html2text.transform_documents(docs))
+                docs = self.text_splitter.split_documents(docs)
+                self.vectorstore.add_documents(docs)
+                self.url_database.extend(new_urls)
 
         # Search for relevant splits
         # TODO: make this async


### PR DESCRIPTION
I've updated the WebResearchRetriever to address a bug where it would crash if unable to retrieve content from a URL. I've implemented error handling and added checks to prevent this issue.

 @rlancemartin, @eyurtsev, @agola11