### PR TITLE
Fixed inaccurate import in integrations:providers:bedrock documentation

### DIFF
--- a/docs/extras/integrations/providers/bedrock.mdx
+++ b/docs/extras/integrations/providers/bedrock.mdx
@@ -13,7 +13,7 @@ pip install boto3
 See a [usage example](/docs/integrations/llms/bedrock).
 
 ```python
-from langchain import Bedrock
+from langchain.llms.bedrock import Bedrock
 ```
 
 ## Text Embedding Models


### PR DESCRIPTION
Description:
Fixed inaccurate import in integrations:providers:bedrock documentation

In the current version of the bedrock documentation, page https://python.langchain.com/docs/integrations/providers/bedrock it states that the import is from langchain import Bedrock

This has been changed to from langchain.llms.bedrock import Bedrock as stated in https://python.langchain.com/docs/integrations/llms/bedrock

Issue:
Not applicable

Dependencies
No dependencies required

Tag maintainer
@baskaryan

Twitter handle:
Not applicable
