### PR TITLE
Fix imports in awslambda docs

### DIFF
--- a/docs/extras/integrations/tools/awslambda.ipynb
+++ b/docs/extras/integrations/tools/awslambda.ipynb
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "from langchain import OpenAI\n",
-    "from langchain.agents import load_tools, AgentType\n",
+    "from langchain.agents import load_tools, initialize_agent, AgentType\n",
     "\n",
     "llm = OpenAI(temperature=0)\n",
     "\n",


### PR DESCRIPTION
Minor doc fix to awslambda tool notebook. 

Add missing import for initialize_agent to awslambda agent example
