### PR TITLE
Open file in UTF-8 encoding (#6919)

### DIFF
--- a/libs/langchain/langchain/callbacks/file.py
+++ b/libs/langchain/langchain/callbacks/file.py
@@ -13,7 +13,7 @@ class FileCallbackHandler(BaseCallbackHandler):
         self, filename: str, mode: str = "a", color: Optional[str] = None
     ) -> None:
         """Initialize callback handler."""
-        self.file = cast(TextIO, open(filename, mode))
+        self.file = cast(TextIO, open(filename, mode, encoding = "utf-8"))
         self.color = color
 
     def __del__(self) -> None:

--- a/libs/langchain/langchain/callbacks/file.py
+++ b/libs/langchain/langchain/callbacks/file.py
@@ -13,7 +13,7 @@ class FileCallbackHandler(BaseCallbackHandler):
         self, filename: str, mode: str = "a", color: Optional[str] = None
     ) -> None:
         """Initialize callback handler."""
-        self.file = cast(TextIO, open(filename, mode, encoding = "utf-8"))
+        self.file = cast(TextIO, open(filename, mode, encoding="utf-8"))
         self.color = color
 
     def __del__(self) -> None:


### PR DESCRIPTION
FileCallbackHandler cannot handle some language, for example: Chinese. 
Open file using UTF-8 encoding can fix it.
@agola11
  
**Issue**: #6919 
**Dependencies**: NO dependencies,