### PR TITLE
`Brave Search` and `DataDog Logs` retrievers

### DIFF
--- a/docs/extras/integrations/document_loaders/datadog_logs.ipynb
+++ b/docs/extras/integrations/document_loaders/datadog_logs.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -10,15 +9,6 @@
     ">[Datadog](https://www.datadoghq.com/) is a monitoring and analytics platform for cloud-scale applications.\n",
     "\n",
     "This loader fetches the logs from your applications in Datadog using the `datadog_api_client` Python package. You must initialize the loader with your `Datadog API key` and `APP key`, and you need to pass in the query to extract the desired logs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain.document_loaders import DatadogLogsLoader"
    ]
   },
   {
@@ -36,11 +26,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from langchain.document_loaders import DatadogLogsLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "query = \"service:agent status:error\"\n",
     "\n",
     "loader = DatadogLogsLoader(\n",
     "    query=query,\n",
-    "    api_key=DD_API_KEY,\n",
     "    app_key=DD_APP_KEY,\n",
     "    from_time=1688732708951,  # Optional, timestamp in milliseconds\n",
     "    to_time=1688736308951,  # Optional, timestamp in milliseconds\n",
@@ -73,7 +71,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -87,10 +85,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11"
-  },
-  "orig_nbformat": 4
+   "version": "3.10.12"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/extras/integrations/providers/arxiv.mdx
+++ b/docs/extras/integrations/providers/arxiv.mdx
@@ -31,6 +31,8 @@ from langchain.document_loaders import ArxivLoader
 
 See a [usage example](/docs/integrations/retrievers/arxiv).
 
+`ArxivLoader` derives from the `BaseLoaderAsRetriever` class, so it can be used as a Retriever.
+
 ```python
-from langchain.retrievers import ArxivRetriever
+from langchain.document_loaders import ArxivLoader
 ```

--- a/docs/extras/integrations/providers/brave_search.mdx
+++ b/docs/extras/integrations/providers/brave_search.mdx
@@ -27,6 +27,17 @@ See a [usage example](/docs/integrations/document_loaders/brave_search).
 from langchain.document_loaders import BraveSearchLoader
 ```
 
+
+## Retriever
+
+`BraveSearchLoader` derives from the `BaseLoaderAsRetriever` class, so it can be used as a Retriever.
+
+See a [usage example](/docs/integrations/retrievers/brave_search).
+
+```python
+from langchain.document_loaders import BraveSearchLoader
+```
+
 ## Tool
 
 See a [usage example](/docs/integrations/tools/brave_search).

--- a/docs/extras/integrations/providers/datadog_logs.mdx
+++ b/docs/extras/integrations/providers/datadog_logs.mdx
@@ -8,11 +8,21 @@
 pip install datadog_api_client
 ```
 
-We must initialize the loader with the Datadog API key and APP key, and we need to set up the query to extract the desired logs.
+We must set up the `Datadog API key` and `APP key`, and we need to set up the query to extract the desired logs.
 
 ## Document Loader
 
 See a [usage example](/docs/integrations/document_loaders/datadog_logs).
+
+```python
+from langchain.document_loaders import DatadogLogsLoader
+```
+
+## Retriever
+
+`DatadogLogsLoader` derives from the `BaseLoaderAsRetriever` class, so it can be used as a Retriever.
+
+See a [usage example](/docs/integrations/retrievers/datadog_logs).
 
 ```python
 from langchain.document_loaders import DatadogLogsLoader

--- a/docs/extras/integrations/retrievers/arxiv.ipynb
+++ b/docs/extras/integrations/retrievers/arxiv.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1a737220",
    "metadata": {
     "tags": []
@@ -45,7 +45,9 @@
    "id": "6c15470b-a16b-4e0d-bc6a-6998bafbb5a4",
    "metadata": {},
    "source": [
-    "`ArxivRetriever` has these arguments:\n",
+    "`ArxivLoader` derives from the `BaseLoaderAsRetriever` class, so it exposes all Retriver functionality.\n",
+    "\n",
+    "`ArxivLoader` has these arguments:\n",
     "- optional `load_max_docs`: default=100. Use it to limit number of downloaded documents. It takes time to download all 100 documents, so use a small number for experiments. There is a hard limit of 300 for now.\n",
     "- optional `load_all_available_meta`: default=False. By default only the most important fields downloaded: `Published` (date when document was published/last updated), `Title`, `Authors`, `Summary`. If True, other fields also downloaded.\n",
     "\n",
@@ -77,7 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.retrievers import ArxivRetriever"
+    "from langchain.retrievers import ArxivLoader"
    ]
   },
   {
@@ -87,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retriever = ArxivRetriever(load_max_docs=2)"
+    "retriever = ArxivLoader(load_max_docs=2)"
    ]
   },
   {

--- a/docs/extras/integrations/retrievers/brave_search.ipynb
+++ b/docs/extras/integrations/retrievers/brave_search.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 30,
    "id": "d7d7be09-58bd-47d7-bf1b-33964564f777",
    "metadata": {},
    "outputs": [],
@@ -56,13 +56,27 @@
    "id": "7f483caf-58ef-4138-975a-5b783559dc1b",
    "metadata": {},
    "source": [
-    "## Example"
+    "## Example\n",
+    "\n",
+    "`BraveSearchLoader` derives from the `BaseLoaderAsRetriever` class, so it can be used as a Retriever."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 26,
    "id": "766634cf-3bc7-4656-939a-cafa218807a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = BraveSearchLoader(\n",
+    "    query=\"\", api_key=api_key, search_kwargs={\"count\": 3}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "00f70b96-096a-43b7-a38c-26a87736143e",
    "metadata": {},
    "outputs": [
     {
@@ -71,22 +85,19 @@
        "3"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "loader = BraveSearchLoader(\n",
-    "    query=\"obama middle name\", api_key=api_key, search_kwargs={\"count\": 3}\n",
-    ")\n",
-    "docs = loader.load()\n",
+    "docs = retriever.get_relevant_documents(query=\"Obama middle name\")\n",
     "len(docs)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 28,
    "id": "f1fcc9f1-cbdc-46b3-89d3-80311d557dc6",
    "metadata": {},
    "outputs": [
@@ -97,11 +108,11 @@
        "  'link': 'https://www.cair.com/cair_in_the_news/obamas-middle-name-my-last-name-is-hussein-so/'},\n",
        " {'title': \"What's up with Obama's middle name? - Quora\",\n",
        "  'link': 'https://www.quora.com/Whats-up-with-Obamas-middle-name'},\n",
-       " {'title': 'Barack Obama | Biography, Parents, Education, Presidency, Books, ...',\n",
-       "  'link': 'https://www.britannica.com/biography/Barack-Obama'}]"
+       " {'title': \"The Influence of President Obama's Middle Name on ...\",\n",
+       "  'link': 'https://papers.ssrn.com/sol3/Delivery.cfm/SSRN_ID1652545_code1512485.pdf?abstractid=1644161'}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -112,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 29,
    "id": "601bfd77-03d3-468e-843f-2523d5e215bd",
    "metadata": {},
    "outputs": [
@@ -121,10 +132,10 @@
       "text/plain": [
        "['I wasn’t sure whether to laugh or cry a few days back listening to radio talk show host Bill Cunningham repeatedly scream Barack <strong>Obama</strong>’<strong>s</strong> <strong>middle</strong> <strong>name</strong> — my last <strong>name</strong> — as if he had anti-Muslim Tourette’s. “Hussein,” Cunningham hissed like he was beckoning Satan when shouting the ...',\n",
        " 'Answer (1 of 15): A better question would be, “What’s up with <strong>Obama</strong>’s first <strong>name</strong>?” President Barack Hussein <strong>Obama</strong>’s father’s <strong>name</strong> was Barack Hussein <strong>Obama</strong>. He was <strong>named</strong> after his father. Hussein, <strong>Obama</strong>’<strong>s</strong> <strong>middle</strong> <strong>name</strong>, is a very common Arabic <strong>name</strong>, meaning &quot;good,&quot; &quot;handsome,&quot; or ...',\n",
-       " 'Barack <strong>Obama</strong>, in full Barack Hussein <strong>Obama</strong> II, (born August 4, 1961, Honolulu, Hawaii, U.S.), 44th president of the United States (2009–17) and the first African American to hold the office. Before winning the presidency, <strong>Obama</strong> represented Illinois in the U.S.']"
+       " 'In a series of cross-cultural experiments, we explore whether mentioning President <strong>Obama</strong>’<strong>s</strong> <strong>middle</strong> <strong>name</strong> facilitates or impedes his delicate position as a peace b']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/extras/integrations/retrievers/datadog_logs.ipynb
+++ b/docs/extras/integrations/retrievers/datadog_logs.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "055b12cd-8acb-4599-abeb-e328f0288ea8",
+   "metadata": {},
+   "source": [
+    "# Datadog Logs\n",
+    "\n",
+    ">[Datadog](https://www.datadoghq.com/) is a monitoring and analytics platform for cloud-scale applications.\n",
+    "\n",
+    "This retriever fetches the logs from your applications in Datadog using the `datadog_api_client` Python package. You must initialize the loader with your `Datadog API key` and `APP key`, and you need to pass in the query to extract the desired logs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c1d7cd2-3000-4d5b-890e-1ead0bc82cfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install datadog-api-client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e16221de-b611-43a2-9ec6-536012fde5f7",
+   "metadata": {},
+   "source": [
+    "The `DatadogLogsLoader` derived from the `BaseLoaderAsRetriever` class so it can be used as a Retriever.\n",
+    "It is possible because the `DatadogLogsLoader` has the `query` semantics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27140b43-b125-4176-a2cc-37ca709b7bc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders import DatadogLogsLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca796edf-d948-4efa-9afe-f5f674b8f74f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = DatadogLogsLoader(\n",
+    "    query=None,  # we use the query argument of the get_relevant_documents() now\n",
+    "    app_key=DD_APP_KEY,\n",
+    "    from_time=1688732708951,  # Optional, timestamp in milliseconds\n",
+    "    to_time=1688736308951,  # Optional, timestamp in milliseconds\n",
+    "    limit=100,  # Optional, default is 100\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f31d26a-de34-4ba5-8c29-dfe0b0857137",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs = retriever.get_relevant_documents(query=\"vice:agent status:error\")\n",
+    "docs"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "276bba05-f107-490e-b7d5-ece35679e743",
+   "metadata": {},
+   "source": [
+    "[Document(page_content='message: grep: /etc/datadog-agent/system-probe.yaml: No such file or directory', metadata={'id': 'AgAAAYkwpLImvkjRpQAAAAAAAAAYAAAAAEFZa3dwTUFsQUFEWmZfLU5QdElnM3dBWQAAACQAAAAAMDE4OTMwYTQtYzk3OS00MmJjLTlhNDAtOTY4N2EwY2I5ZDdk', 'status': 'error', 'service': 'agent', 'tags': ['accessible-from-goog-gke-node', 'allow-external-ingress-high-ports', 'allow-external-ingress-http', 'allow-external-ingress-https', 'container_id:c7d8ecd27b5b3cfdf3b0df04b8965af6f233f56b7c3c2ffabfab5e3b6ccbd6a5', 'container_name:lab_datadog_1', 'datadog.pipelines:false', 'datadog.submission_auth:private_api_key', 'docker_image:datadog/agent:7.41.1', 'env:dd101-dev', 'hostname:lab-host', 'image_name:datadog/agent', 'image_tag:7.41.1', 'instance-id:7497601202021312403', 'instance-type:custom-1-4096', 'instruqt_aws_accounts:', 'instruqt_azure_subscriptions:', 'instruqt_gcp_projects:', 'internal-hostname:lab-host.d4rjybavkary.svc.cluster.local', 'numeric_project_id:3390740675', 'p-d4rjybavkary', 'project:instruqt-prod', 'service:agent', 'short_image:agent', 'source:agent', 'zone:europe-west1-b'], 'timestamp': datetime.datetime(2023, 7, 7, 13, 57, 27, 206000, tzinfo=tzutc())}),\n",
+    " Document(page_content='message: grep: /etc/datadog-agent/system-probe.yaml: No such file or directory', metadata={'id': 'AgAAAYkwpLImvkjRpgAAAAAAAAAYAAAAAEFZa3dwTUFsQUFEWmZfLU5QdElnM3dBWgAAACQAAAAAMDE4OTMwYTQtYzk3OS00MmJjLTlhNDAtOTY4N2EwY2I5ZDdk', 'status': 'error', 'service': 'agent', 'tags': ['accessible-from-goog-gke-node', 'allow-external-ingress-high-ports', 'allow-external-ingress-http', 'allow-external-ingress-https', 'container_id:c7d8ecd27b5b3cfdf3b0df04b8965af6f233f56b7c3c2ffabfab5e3b6ccbd6a5', 'container_name:lab_datadog_1', 'datadog.pipelines:false', 'datadog.submission_auth:private_api_key', 'docker_image:datadog/agent:7.41.1', 'env:dd101-dev', 'hostname:lab-host', 'image_name:datadog/agent', 'image_tag:7.41.1', 'instance-id:7497601202021312403', 'instance-type:custom-1-4096', 'instruqt_aws_accounts:', 'instruqt_azure_subscriptions:', 'instruqt_gcp_projects:', 'internal-hostname:lab-host.d4rjybavkary.svc.cluster.local', 'numeric_project_id:3390740675', 'p-d4rjybavkary', 'project:instruqt-prod', 'service:agent', 'short_image:agent', 'source:agent', 'zone:europe-west1-b'], 'timestamp': datetime.datetime(2023, 7, 7, 13, 57, 27, 206000, tzinfo=tzutc())})]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/extras/modules/data_connection/retrievers/document_loaders_as_retrievers.ipynb
+++ b/docs/extras/modules/data_connection/retrievers/document_loaders_as_retrievers.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "63e8e6be-f949-4e14-8be9-19036a77cb70",
+   "metadata": {},
+   "source": [
+    "# Document loaders as retrievers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dbfd014-ea54-445b-ab20-ba4950e60860",
+   "metadata": {},
+   "source": [
+    "## Concept"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "408282d2-7e32-43a3-8080-a4bef163e7b7",
+   "metadata": {},
+   "source": [
+    "Retriever is very similar to the Document Loader.\n",
+    "\n",
+    "Usually, Document Loaders are used for downloading many documents in a single run but retrievers are used for downloading small amount of documents. That is the biggest difference.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9ab107d-d6ff-4e87-aede-d1202cb778c9",
+   "metadata": {},
+   "source": [
+    "## Any Document loader works as a Retriever"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b2dd742-c5c6-48f1-9301-6fb6b094e900",
+   "metadata": {},
+   "source": [
+    "If we are going to add a new integration to the LangChain, we don't have to implement the `get_relevant_documents` function for a new Document Loader. We just have to inherit our new <name>Loader from `BaseLoaderAsRetriever` not from `BaseLoader`.\n",
+    "`BaseLoaderAsRetriever` adds a `query` parameter to the `BaseLoader` interface.\n",
+    "\n",
+    "Any Document Loader derived from the `BaseLoaderAsRetriever` can be used as a retriever. But make sure that `get_relevant_documents` returns a small number of documents!\n",
+    "\n",
+    "**Note:** Please, make sure that the Document Loader is implementing the **query** semantics and that your Loader class is realy using the `query` parameter. \n",
+    "Otherwise, the `query` argument in the `get_relevant_documents` is just a placeholder and does not change the downloaded dataset.\n",
+    "\n",
+    "Retrievers use `query` in every retrieve run. Document Loaders use `query` only optionally because they want to download a big amoung of documents.\n",
+    "\n",
+    "That's why Document Loader defines a `query` also as an attribute, not as a function argument. A `query` as the function argument in `get_relevant_documents` has a priotiy to the `query` class attribute if both are declared."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67e76b8b-a7d2-4aac-b6fd-961f33ae5d47",
+   "metadata": {},
+   "source": [
+    "## Example\n",
+    "\n",
+    "The `ArxivLoader` inherits from the `BaseLoaderAsRetrive`. So it can be used as a Retriever."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "dcbb24f3-c452-4cbc-8b89-01fedf9036e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders import ArxivLoader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53d53251-dd4e-4868-927e-81fcfb444b1d",
+   "metadata": {},
+   "source": [
+    "Let's use our `ArxivLoader` directly as the Document loader. \n",
+    "\n",
+    "**Note:** The `ArxivLoader` is using the `query` parameter for downloading documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "7e262086-0795-4781-b9df-03129270832b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = ArxivLoader(query=\"1605.08386\", load_max_docs=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "c58b2f41-2f93-4a8e-9ca6-72dfcf854734",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs = loader.load()\n",
+    "len(docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ce1e7e5f-c4f1-4105-a107-ada63935ab1e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Published': '2016-05-26',\n",
+       " 'Title': 'Heat-bath random walks with Markov bases',\n",
+       " 'Authors': 'Caprice Stanley, Tobias Windisch',\n",
+       " 'Summary': 'Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs[0].metadata  # meta-information of the Document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "1120e6b9-dadd-4e68-ad42-c6a1cff1d7ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'arXiv:1605.08386v1  [math.CO]  26 May 2016\\nHEAT-BATH RANDOM WALKS WITH MARKOV BASES\\nCAPRICE STANLEY AND TOBIAS WINDISCH\\nAbstract. Graphs on lattice points are studied whose edges come from a ﬁnite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on ﬁbers of a\\nﬁxed integer matrix can be bounded from above by a constant. We then study the mixing\\nbehaviour of heat-b'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs[0].page_content[:400]  # the Document content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eadf341f-f2c5-4a68-8ee8-28888e45b100",
+   "metadata": {},
+   "source": [
+    "But we also can use the `ArxivLoader` as a retriever. \n",
+    "\n",
+    "For that, we have to use the `query` parameter for every call of the `get_relevant_documents` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "7e1e4cc2-e775-4e93-8065-9b68aa60e8da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "retrieved_docs = loader.get_relevant_documents(query='Caprice Stanley')\n",
+    "len(retrieved_docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "44d730ce-c91b-4610-ad9d-d0966affcd17",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Published': '2017-10-10',\n",
+       " 'Title': 'On Mixing Behavior of a Family of Random Walks Determined by a Linear Recurrence',\n",
+       " 'Authors': 'Caprice Stanley, Seth Sullivant',\n",
+       " 'Summary': 'We study random walks on the integers mod $G_n$ that are determined by an\\ninteger sequence $\\\\{ G_n \\\\}_{n \\\\geq 1}$ generated by a linear recurrence\\nrelation. Fourier analysis provides explicit formulas to compute the\\neigenvalues of the transition matrices and we use this to bound the mixing time\\nof the random walks.'}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "retrieved_docs[0].metadata  # meta-information of the Document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "0c21bb77-d89f-4f56-938b-b84ed346fd46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Published': '2016-05-26',\n",
+       " 'Title': 'Heat-bath random walks with Markov bases',\n",
+       " 'Authors': 'Caprice Stanley, Tobias Windisch',\n",
+       " 'Summary': 'Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.'}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "retrieved_docs[1].metadata  # meta-information of the Document"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/langchain/langchain/document_loaders/arxiv.py
+++ b/libs/langchain/langchain/document_loaders/arxiv.py
@@ -1,11 +1,11 @@
 from typing import List, Optional
 
 from langchain.docstore.document import Document
-from langchain.document_loaders.base import BaseLoader
+from langchain.document_loaders.base import BaseLoaderAsRetriever
 from langchain.utilities.arxiv import ArxivAPIWrapper
 
 
-class ArxivLoader(BaseLoader):
+class ArxivLoader(BaseLoaderAsRetriever):
     """Load a query result from `Arxiv`.
 
     The loader converts the original PDF format into the text.
@@ -13,7 +13,7 @@ class ArxivLoader(BaseLoader):
 
     def __init__(
         self,
-        query: str,
+        query: Optional[str] = None,
         load_max_docs: Optional[int] = 100,
         load_all_available_meta: Optional[bool] = False,
     ):

--- a/libs/langchain/langchain/document_loaders/base.py
+++ b/libs/langchain/langchain/document_loaders/base.py
@@ -93,3 +93,43 @@ class BaseBlobParser(ABC):
             List of documents
         """
         return list(self.lazy_parse(blob))
+
+
+class QueryMixin(ABC):
+    """Abstract interface for query mixin."""
+
+    query: Optional[str] = None
+    """"Optional query string."""
+
+
+class BaseLoaderAsRetriever(BaseLoader, QueryMixin):
+    """Interface for using a Document Loader as a Retriever.
+
+    It used for Loaders that can use a query.
+    It can be used as a Loader with a query or
+    directly as a Retriever with get_relevant_documents().
+    """
+
+    def get_relevant_documents(self, query: str) -> List[Document]:
+        """Get documents relevant for a query.
+        Args:
+            query: string to find relevant documents.
+        Returns:
+            List of relevant documents.
+        """
+        # function query doesn't replace the class query.
+        cls_query, self.query = self.query, query
+        ret = self.load()
+        self.query = cls_query
+        return ret
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        """Asynchronously get documents relevant for a query.
+        Args:
+            query: string to find relevant documents.
+        Returns:
+            List of relevant documents
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement aget_relevant_documents()"
+        )

--- a/libs/langchain/langchain/document_loaders/brave_search.py
+++ b/libs/langchain/langchain/document_loaders/brave_search.py
@@ -1,11 +1,11 @@
 from typing import Iterator, List, Optional
 
 from langchain.docstore.document import Document
-from langchain.document_loaders.base import BaseLoader
+from langchain.document_loaders.base import BaseLoaderAsRetriever
 from langchain.utilities.brave_search import BraveSearchWrapper
 
 
-class BraveSearchLoader(BaseLoader):
+class BraveSearchLoader(BaseLoaderAsRetriever):
     """Load with `Brave Search` engine."""
 
     def __init__(self, query: str, api_key: str, search_kwargs: Optional[dict] = None):
@@ -16,7 +16,7 @@ class BraveSearchLoader(BaseLoader):
             api_key: The API key to use.
             search_kwargs: The search kwargs to use.
         """
-        self.query = query
+        self.query: str = query
         self.api_key = api_key
         self.search_kwargs = search_kwargs or {}
 

--- a/libs/langchain/langchain/document_loaders/datadog_logs.py
+++ b/libs/langchain/langchain/document_loaders/datadog_logs.py
@@ -2,10 +2,10 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 from langchain.docstore.document import Document
-from langchain.document_loaders.base import BaseLoader
+from langchain.document_loaders.base import BaseLoaderAsRetriever
 
 
-class DatadogLogsLoader(BaseLoader):
+class DatadogLogsLoader(BaseLoaderAsRetriever):
     """Load `Datadog` logs.
 
     Logs are written into the `page_content` and into the `metadata`.
@@ -23,21 +23,22 @@ class DatadogLogsLoader(BaseLoader):
         """Initialize Datadog document loader.
 
         Requirements:
-            - Must have datadog_api_client installed. Install with `pip install datadog_api_client`.
+            - Must have datadog_api_client installed.
+              Install with `pip install datadog_api_client`.
 
         Args:
             query: The query to run in Datadog.
             api_key: The Datadog API key.
             app_key: The Datadog APP key.
             from_time: Optional. The start of the time range to query.
-                Supports date math and regular timestamps (milliseconds) like '1688732708951'
-                Defaults to 20 minutes ago.
+                Supports date math and regular timestamps (milliseconds)
+                like '1688732708951'. Defaults to 20 minutes ago.
             to_time: Optional. The end of the time range to query.
-                Supports date math and regular timestamps (milliseconds) like '1688732708951'
-                Defaults to now.
+                Supports date math and regular timestamps (milliseconds)
+                like '1688732708951'. Defaults to now.
             limit: The maximum number of logs to return.
                 Defaults to 100.
-        """  # noqa: E501
+        """
         try:
             from datadog_api_client import Configuration
         except ImportError as ex:

--- a/libs/langchain/langchain/retrievers/__init__.py
+++ b/libs/langchain/langchain/retrievers/__init__.py
@@ -18,7 +18,6 @@ the backbone of a retriever, but there are other types of retrievers as well.
     CallbackManagerForRetrieverRun, AsyncCallbackManagerForRetrieverRun
 """
 
-from langchain.retrievers.arxiv import ArxivRetriever
 from langchain.retrievers.azure_cognitive_search import AzureCognitiveSearchRetriever
 from langchain.retrievers.bm25 import BM25Retriever
 from langchain.retrievers.chaindesk import ChaindeskRetriever
@@ -60,7 +59,6 @@ from langchain.retrievers.zilliz import ZillizRetriever
 
 __all__ = [
     "AmazonKendraRetriever",
-    "ArxivRetriever",
     "AzureCognitiveSearchRetriever",
     "ChatGPTPluginRetriever",
     "ContextualCompressionRetriever",

--- a/libs/langchain/langchain/retrievers/arxiv.py
+++ b/libs/langchain/langchain/retrievers/arxiv.py
@@ -6,7 +6,8 @@ from langchain.utilities.arxiv import ArxivAPIWrapper
 
 
 class ArxivRetriever(BaseRetriever, ArxivAPIWrapper):
-    """`Arxiv` retriever.
+    """
+    Retriever for Arxiv.
 
     It wraps load() to get_relevant_documents().
     It uses all ArxivAPIWrapper arguments without any change.

--- a/libs/langchain/langchain/utilities/arxiv.py
+++ b/libs/langchain/langchain/utilities/arxiv.py
@@ -105,7 +105,7 @@ class ArxivAPIWrapper(BaseModel):
         else:
             return "No good Arxiv Result was found"
 
-    def load(self, query: str) -> List[Document]:
+    def load(self, query: Optional[str] = "") -> List[Document]:
         """
         Run Arxiv search and get the article texts plus the article meta information.
         See https://lukasschwab.me/arxiv.py/index.html#Search
@@ -125,6 +125,10 @@ class ArxivAPIWrapper(BaseModel):
                 "PyMuPDF package not found, please install it with "
                 "`pip install pymupdf`"
             )
+
+        if not query:
+            logger.debug("Query is empty, please define it.")
+            return []
 
         try:
             # Remove the ":" and "-" from the query, as they can cause search problems

--- a/libs/langchain/tests/integration_tests/document_loaders/test_arxiv.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_arxiv.py
@@ -1,3 +1,4 @@
+"""tests for Arxiv Loader."""
 from typing import List
 
 import pytest

--- a/libs/langchain/tests/integration_tests/retrievers/test_arxiv.py
+++ b/libs/langchain/tests/integration_tests/retrievers/test_arxiv.py
@@ -1,15 +1,17 @@
-"""Integration test for Arxiv API Wrapper."""
+"""Integration test for Arxiv retriever."""
 from typing import List
 
 import pytest
 
-from langchain.retrievers import ArxivRetriever
+from langchain.document_loaders import ArxivLoader
 from langchain.schema import Document
 
 
 @pytest.fixture
-def retriever() -> ArxivRetriever:
-    return ArxivRetriever()
+def retriever() -> ArxivLoader:
+    """We use ArxivLoader as a Retriever for the test.
+    We test the BaseLoaderAsRetriever interface."""
+    return ArxivLoader()
 
 
 def assert_docs(docs: List[Document], all_meta: bool = False) -> None:
@@ -24,13 +26,13 @@ def assert_docs(docs: List[Document], all_meta: bool = False) -> None:
             assert len(set(doc.metadata)) == len(main_meta)
 
 
-def test_load_success(retriever: ArxivRetriever) -> None:
+def test_load_success(retriever: ArxivLoader) -> None:
     docs = retriever.get_relevant_documents(query="1605.08386")
     assert len(docs) == 1
     assert_docs(docs, all_meta=False)
 
 
-def test_load_success_all_meta(retriever: ArxivRetriever) -> None:
+def test_load_success_all_meta(retriever: ArxivLoader) -> None:
     retriever.load_all_available_meta = True
     retriever.load_max_docs = 2
     docs = retriever.get_relevant_documents(query="ChatGPT")
@@ -39,12 +41,12 @@ def test_load_success_all_meta(retriever: ArxivRetriever) -> None:
 
 
 def test_load_success_init_args() -> None:
-    retriever = ArxivRetriever(load_max_docs=1, load_all_available_meta=True)
+    retriever = ArxivLoader(load_max_docs=1, load_all_available_meta=True)
     docs = retriever.get_relevant_documents(query="ChatGPT")
     assert len(docs) == 1
     assert_docs(docs, all_meta=True)
 
 
-def test_load_no_result(retriever: ArxivRetriever) -> None:
+def test_load_no_result(retriever: ArxivLoader) -> None:
     docs = retriever.get_relevant_documents("1605.08386WWW")
     assert not docs


### PR DESCRIPTION
- Created two new retrievers: `Brave Search` and `DataDog Logs` based on `BaseLoaderAsRetriever`
- Created `BaseLoaderAsRetriever` with `QueryMixin`. This class is used to treat DocumentLoaders as Retrievers where DocumentLoader has query semantics.
- added retriever examples
- used `Arxiv` as a testbed:
  - derived `ArxivLoader` from  `BaseLoaderAsRetriever`. This eliminates the necessity of a separate `ArxivRetriever`.
  - removed `ArxivRetriever` and tested `ArxivLoader` in place of `ArxivRetriever`
  - changed `Arxiv` examples to address the above changes.
  - 
 @rlancemartin, @eyurtsev

