### PR TITLE
refactor(document_loaders): abstract page evaluation logic in PlaywrightURLLoader

### DIFF
--- a/libs/langchain/langchain/document_loaders/url_playwright.py
+++ b/libs/langchain/langchain/document_loaders/url_playwright.py
@@ -48,7 +48,7 @@ class PlaywrightURLLoader(BaseLoader):
         self.headless = headless
         self.remove_selectors = remove_selectors
 
-    def sync_evaluate(self, page, browser, response):
+    def _sync_evaluate(self, page, browser, response):
         """Process a page and return the text content synchronously.
 
         Args:
@@ -72,7 +72,7 @@ class PlaywrightURLLoader(BaseLoader):
         text = "\n\n".join([str(el) for el in elements])
         return text
 
-    async def async_evaluate(self, page, browser, response):
+    async def _async_evaluate(self, page, browser, response):
         """Process a page and return the text content asynchronously.
 
         Args:
@@ -112,7 +112,7 @@ class PlaywrightURLLoader(BaseLoader):
                 try:
                     page = browser.new_page()
                     response = page.goto(url)
-                    text = self.sync_evaluate(page, browser, response)
+                    text = self._sync_evaluate(page, browser, response)
                     metadata = {"source": url}
                     docs.append(Document(page_content=text, metadata=metadata))
                 except Exception as e:
@@ -142,7 +142,7 @@ class PlaywrightURLLoader(BaseLoader):
                 try:
                     page = await browser.new_page()
                     response = await page.goto(url)
-                    text = await self.async_evaluate(page, browser, response)
+                    text = await self._async_evaluate(page, browser, response)
                     metadata = {"source": url}
                     docs.append(Document(page_content=text, metadata=metadata))
                 except Exception as e:

--- a/libs/langchain/langchain/document_loaders/url_playwright.py
+++ b/libs/langchain/langchain/document_loaders/url_playwright.py
@@ -49,8 +49,13 @@ class PlaywrightURLLoader(BaseLoader):
         self.remove_selectors = remove_selectors
 
     def sync_evaluate_page(self, page):
-        """Process a page and return the text content.
-        This method can be overridden to apply custom logic.
+        """Process a page and return the text content synchronously.
+
+        Args:
+            page: The page to process.
+
+        Returns:
+            text: The text content of the page.
         """
         for selector in self.remove_selectors or []:
             elements = page.locator(selector).all()
@@ -64,8 +69,13 @@ class PlaywrightURLLoader(BaseLoader):
         return text
 
     async def async_evaluate_page(self, page):
-        """Process a page asynchronously and return the text content.
-        This method can be overridden to apply custom logic.
+        """Process a page and return the text content asynchronously.
+
+        Args:
+            page: The page to process.
+
+        Returns:
+            text: The text content of the page.
         """
         for selector in self.remove_selectors or []:
             elements = await page.locator(selector).all()

--- a/libs/langchain/tests/integration_tests/document_loaders/test_url_playwright.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_url_playwright.py
@@ -1,16 +1,25 @@
 """Tests for the Playwright URL loader"""
+from typing import TYPE_CHECKING
+
 import pytest
 
 from langchain.document_loaders import PlaywrightURLLoader
+from langchain.document_loaders.url_playwright import PlaywrightEvaluator
+
+if TYPE_CHECKING:
+    from playwright.async_api import AsyncBrowser, AsyncPage, AsyncResponse
+    from playwright.sync_api import Browser, Page, Response
 
 
-class TestEvaluator(PageEvaluator):
+class TestEvaluator(PlaywrightEvaluator):
     """A simple evaluator for testing purposes."""
 
-    def evaluate(self, page, browser, response):
+    def evaluate(self, page: "Page", browser: "Browser", response: "Response") -> str:
         return "test"
 
-    async def evaluate_async(self, page, browser, response):
+    async def evaluate_async(
+        self, page: "AsyncPage", browser: "AsyncBrowser", response: "AsyncResponse"
+    ) -> str:
         return "test"
 
 
@@ -56,13 +65,13 @@ def test_playwright_url_loader_with_custom_evaluator() -> None:
     urls = ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]
     loader = PlaywrightURLLoader(
         urls=urls,
-        page_evaluator=TestEvaluator(),
+        evaluator=TestEvaluator(),
         continue_on_failure=False,
         headless=True,
     )
     docs = loader.load()
     assert len(docs) == 1
-    assert docs[0].page_content == "test-"
+    assert docs[0].page_content == "test"
 
 
 @pytest.mark.asyncio
@@ -71,10 +80,10 @@ async def test_playwright_async_url_loader_with_custom_evaluator() -> None:
     urls = ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]
     loader = PlaywrightURLLoader(
         urls=urls,
-        page_evaluator=TestEvaluator(),
+        evaluator=TestEvaluator(),
         continue_on_failure=False,
         headless=True,
     )
     docs = await loader.aload()
-    assert len(docs) == 2
+    assert len(docs) == 1
     assert docs[0].page_content == "test"

--- a/libs/langchain/tests/integration_tests/document_loaders/test_url_playwright.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_url_playwright.py
@@ -4,6 +4,16 @@ import pytest
 from langchain.document_loaders import PlaywrightURLLoader
 
 
+class TestEvaluator(PageEvaluator):
+    """A simple evaluator for testing purposes."""
+
+    def evaluate(self, page, browser, response):
+        return "test"
+
+    async def evaluate_async(self, page, browser, response):
+        return "test"
+
+
 def test_playwright_url_loader() -> None:
     """Test Playwright URL loader."""
     urls = [
@@ -39,3 +49,32 @@ async def test_playwright_async_url_loader() -> None:
     )
     docs = await loader.aload()
     assert len(docs) > 0
+
+
+def test_playwright_url_loader_with_custom_evaluator() -> None:
+    """Test Playwright URL loader with a custom evaluator."""
+    urls = ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]
+    loader = PlaywrightURLLoader(
+        urls=urls,
+        page_evaluator=TestEvaluator(),
+        continue_on_failure=False,
+        headless=True,
+    )
+    docs = loader.load()
+    assert len(docs) == 1
+    assert docs[0].page_content == "test-"
+
+
+@pytest.mark.asyncio
+async def test_playwright_async_url_loader_with_custom_evaluator() -> None:
+    """Test Playwright async URL loader with a custom evaluator."""
+    urls = ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]
+    loader = PlaywrightURLLoader(
+        urls=urls,
+        page_evaluator=TestEvaluator(),
+        continue_on_failure=False,
+        headless=True,
+    )
+    docs = await loader.aload()
+    assert len(docs) == 2
+    assert docs[0].page_content == "test"


### PR DESCRIPTION
This PR brings structural updates to `PlaywrightURLLoader`, aiming at making the code more readable and extensible through the abstraction of page evaluation logic. These changes also align this implementation with a similar structure used in LangChain.js. 

The key enhancements include:

1. Introduction of 'PlaywrightEvaluator', an abstract base class for all evaluators. 
2. Creation of 'UnstructuredHtmlEvaluator', a concrete class implementing 'PlaywrightEvaluator', which uses `unstructured` library for processing page's HTML content.
3. Extension of 'PlaywrightURLLoader' constructor to optionally accept an evaluator of the type 'PlaywrightEvaluator'. It defaults to 'UnstructuredHtmlEvaluator' if no evaluator is provided.
4. Refactoring of 'load' and 'aload' methods to use the 'evaluate' and 'evaluate_async' methods of the provided 'PageEvaluator' for page content handling.

This update brings flexibility to 'PlaywrightURLLoader' as it can now utilize different evaluators for page processing depending on the requirement. The abstraction also improves code maintainability and readability.

Please find the reference for LangChain.js implementation [here](https://github.com/hwchase17/langchainjs/blob/29f3ffdcb34acce1f1db78078f4e7d184eaec6b5/langchain/src/document_loaders/web/playwright.ts#L59).

Maintainers for review: @rlancemartin, @eyurtsev

Twitter: @ywkim