### PR TITLE
skip over empty google spreadsheets

### DIFF
--- a/libs/langchain/langchain/document_loaders/googledrive.py
+++ b/libs/langchain/langchain/document_loaders/googledrive.py
@@ -169,6 +169,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 .execute()
             )
             values = result.get("values", [])
+            if not values:
+                continue  # empty sheet
 
             header = values[0]
             for i, row in enumerate(values[1:], start=1):


### PR DESCRIPTION
  - Description: Allow GoogleDriveLoader to handle empty spreadsheets  
  - Issue: Currently GoogleDriveLoader will crash if it tries to load a spreadsheet with an empty sheet
  - Dependencies: n/a
  - Tag maintainer: @rlancemartin, @eyurtsev 