### PR TITLE
Updating port and ssl use in sample notebook

### DIFF
--- a/docs/extras/use_cases/graph/neptune_cypher_qa.ipynb
+++ b/docs/extras/use_cases/graph/neptune_cypher_qa.ipynb
@@ -18,8 +18,8 @@
     "\n",
     "\n",
     "host = \"<neptune-host>\"\n",
-    "port = 80\n",
-    "use_https = False\n",
+    "port = 8182\n",
+    "use_https = True\n",
     "\n",
     "graph = NeptuneGraph(host=host, port=port, use_https=use_https)"
    ]


### PR DESCRIPTION
## Description
This PR updates the sample notebook to use the default port (8182) and the ssl for the Neptune database connection.