### PR TITLE
Add logprobs to SamplingParameters in vllm

### DIFF
--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -54,6 +54,9 @@ class VLLM(BaseLLM):
     max_new_tokens: int = 512
     """Maximum number of tokens to generate per output sequence."""
 
+    logprobs: Optional[int] = None
+    """Number of log probabilities to return per output token."""
+
     client: Any  #: :meta private:
 
     @root_validator()
@@ -91,6 +94,7 @@ class VLLM(BaseLLM):
             "stop": self.stop,
             "ignore_eos": self.ignore_eos,
             "use_beam_search": self.use_beam_search,
+            "logprobs": self.logprobs,
         }
 
     def _generate(


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->

This PR aims at amending #8806 , that I opened a few days ago, adding the extra `logprobs` parameter that I accidentally forgot 