### PR TITLE
fix faiss vectorstore Delete by ID method

### DIFF
--- a/libs/langchain/langchain/vectorstores/faiss.py
+++ b/libs/langchain/langchain/vectorstores/faiss.py
@@ -491,8 +491,10 @@ class FAISS(VectorStore):
 
         # Removing ids from index.
         self.index.remove_ids(np.array(index_to_delete, dtype=np.int64))
+        # Reconstruct index_to_docstore_id because FAISS shift the index after removing
         for _id in index_to_delete:
             del self.index_to_docstore_id[_id]
+        self.index_to_docstore_id = dict(enumerate(self.index_to_docstore_id.values()))
 
         # Remove items from docstore.
         self.docstore.delete(ids)


### PR DESCRIPTION
Description: FAISS shift the index after removing ids when IndexFlatL2 or IndexFlatIP is used, so `index_to_docstore_id` need to update.