### PR TITLE
Bedrock embeddings async methods

### DIFF
--- a/docs/extras/integrations/llms/bedrock.ipynb
+++ b/docs/extras/integrations/llms/bedrock.ipynb
@@ -31,12 +31,11 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.llms.bedrock import Bedrock\n",
+    "from langchain.llms import Bedrock\n",
     "\n",
     "llm = Bedrock(\n",
     "    credentials_profile_name=\"bedrock-admin\",\n",
-    "    model_id=\"amazon.titan-tg1-large\",\n",
-    "    endpoint_url=\"custom_endpoint_url\",\n",
+    "    model_id=\"amazon.titan-tg1-large\"\n",
     ")"
    ]
   },

--- a/docs/extras/integrations/text_embedding/bedrock.ipynb
+++ b/docs/extras/integrations/text_embedding/bedrock.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "282239c8-e03a-4abc-86c1-ca6120231a20",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
     "from langchain.embeddings import BedrockEmbeddings\n",
     "\n",
     "embeddings = BedrockEmbeddings(\n",
-    "    credentials_profile_name=\"bedrock-admin\", endpoint_url=\"custom_endpoint_url\"\n",
+    "    credentials_profile_name=\"bedrock-admin\", region_name=\"us-east-1\"\n",
     ")"
    ]
   },
@@ -49,7 +49,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings.embed_documents([\"This is a content of the document\"])"
+    "embeddings.embed_documents([\"This is a content of the document\", \"This is another document\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6b364d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# async embed query\n",
+    "await embeddings.aembed_query(\"This is a content of the document\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9240a5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# async embed documents\n",
+    "await embeddings.aembed_documents([\"This is a content of the document\", \"This is another document\"])"
    ]
   }
  ],
@@ -69,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/libs/langchain/langchain/embeddings/bedrock.py
+++ b/libs/langchain/langchain/embeddings/bedrock.py
@@ -130,17 +130,11 @@ class BedrockEmbeddings(BaseModel, Embeddings):
         except Exception as e:
             raise ValueError(f"Error raised by inference endpoint: {e}")
 
-    def embed_documents(
-        self, texts: List[str], chunk_size: int = 1
-    ) -> List[List[float]]:
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a Bedrock model.
 
         Args:
-            texts: The list of texts to embed.
-            chunk_size: Bedrock currently only allows single string
-                inputs, so chunk size is always 1. This input is here
-                only for compatibility with the embeddings interface.
-
+            texts: The list of texts to embed
 
         Returns:
             List of embeddings, one for each text.
@@ -176,24 +170,16 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             None, partial(self.embed_query, text)
         )
 
-    async def aembed_documents(
-        self, texts: List[str], chunk_size: int = 1
-    ) -> List[List[float]]:
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         """Asynchronous compute doc embeddings using a Bedrock model.
 
         Args:
-            texts: The list of texts to embed.
-            chunk_size: Bedrock currently only allows single string
-                inputs, so chunk size is always 1. This input is here
-                only for compatibility with the embeddings interface.
+            texts: The list of texts to embed
 
         Returns:
             List of embeddings, one for each text.
         """
 
-        results = []
-        for text in texts:
-            result = await self.aembed_query(text)
-            results.append(result)
+        result = await asyncio.gather(*[self.aembed_query(text) for text in texts])
 
-        return results
+        return list(result)

--- a/libs/langchain/langchain/embeddings/bedrock.py
+++ b/libs/langchain/langchain/embeddings/bedrock.py
@@ -1,7 +1,7 @@
 import asyncio
-from functools import partial
 import json
 import os
+from functools import partial
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Extra, root_validator
@@ -161,10 +161,10 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             Embeddings for the text.
         """
         return self._embedding_func(text)
-    
+
     async def aembed_query(self, text: str) -> List[float]:
-        """Asynchronous Compute query embeddings using a Bedrock model.
-        
+        """Asynchronous compute query embeddings using a Bedrock model.
+
         Args:
             text: The text to embed.
 
@@ -175,14 +175,25 @@ class BedrockEmbeddings(BaseModel, Embeddings):
         return await asyncio.get_running_loop().run_in_executor(
             None, partial(self.embed_query, text)
         )
-    
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
-        """Asynchronous Embed search docs."""
-        
+
+    async def aembed_documents(
+        self, texts: List[str], chunk_size: int = 1
+    ) -> List[List[float]]:
+        """Asynchronous compute doc embeddings using a Bedrock model.
+
+        Args:
+            texts: The list of texts to embed.
+            chunk_size: Bedrock currently only allows single string
+                inputs, so chunk size is always 1. This input is here
+                only for compatibility with the embeddings interface.
+
+        Returns:
+            List of embeddings, one for each text.
+        """
+
         results = []
         for text in texts:
             result = await self.aembed_query(text)
             results.append(result)
 
         return results
-        

--- a/libs/langchain/langchain/embeddings/bedrock.py
+++ b/libs/langchain/langchain/embeddings/bedrock.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import partial
 import json
 import os
 from typing import Any, Dict, List, Optional
@@ -159,3 +161,28 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             Embeddings for the text.
         """
         return self._embedding_func(text)
+    
+    async def aembed_query(self, text: str) -> List[float]:
+        """Asynchronous Compute query embeddings using a Bedrock model.
+        
+        Args:
+            text: The text to embed.
+
+        Returns:
+            Embeddings for the text.
+        """
+
+        return await asyncio.get_running_loop().run_in_executor(
+            None, partial(self.embed_query, text)
+        )
+    
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Asynchronous Embed search docs."""
+        
+        results = []
+        for text in texts:
+            result = await self.aembed_query(text)
+            results.append(result)
+
+        return results
+        


### PR DESCRIPTION
## Description
This PR adds the `aembed_query` and `aembed_documents` async methods for improving the embeddings generation for large documents. The implementation uses asyncio tasks and gather to achieve concurrency as there is no bedrock async API in boto3.

### Maintainers
@agola11 
@aarora79  

### Open questions
To avoid throttling from the Bedrock API, should there be an option to limit the concurrency of the calls?

