### PR TITLE
Update faiss.py    delete bug fixed

### DIFF
--- a/libs/langchain/langchain/vectorstores/faiss.py
+++ b/libs/langchain/langchain/vectorstores/faiss.py
@@ -489,11 +489,18 @@ class FAISS(VectorStore):
 
         index_to_delete = [_reversed_index[i] for i in ids]
 
-        # Removing ids from index.
+        # Removing ids from index.        
         self.index.remove_ids(np.array(index_to_delete, dtype=np.int64))
         for _id in index_to_delete:
             del self.index_to_docstore_id[_id]
 
+        # Modify the keys of 'index_to_docstore_id' to consecutive numbers
+        index_to_docstore_id_items = sorted(self.index_to_docstore_id.items())
+        for i in range(len(index_to_docstore_id_items)):
+            index_to_docstore_id_items[i] = (i, index_to_docstore_id_items[i][1])
+            self.index_to_docstore_id.clear()
+            self.index_to_docstore_id.update(index_to_docstore_id_items)
+            
         # Remove items from docstore.
         self.docstore.delete(ids)
         return True


### PR DESCRIPTION
# After invoking the 'remove_ids' function, the indices of vectors in the Faiss Index will remain consecutive. 

# To ensure consistency between the keys of 'index_to_docstore_id' and the indices of vectors in the Faiss Index, modify the keys of 'index_to_docstore_id' to consecutive numbers, like 0, 3, 4 - > 0, 1, 2.
