### PR TITLE
Fix issue with Metaphor Search Tool throwing error on missing keys in API response

### DIFF
--- a/libs/langchain/langchain/utilities/metaphor_search.py
+++ b/libs/langchain/langchain/utilities/metaphor_search.py
@@ -163,10 +163,10 @@ class MetaphorSearchAPIWrapper(BaseModel):
         for result in raw_search_results:
             cleaned_results.append(
                 {
-                    "title": result["title"],
-                    "url": result["url"],
-                    "author": result["author"],
-                    "published_date": result["publishedDate"],
+                    "title": result.get("title", "Unknown Title"),
+                    "url": result.get("url", "Unknown URL"),
+                    "author": result.get("author", "Unknown Author"),
+                    "published_date": result.get("publishedDate", "Unknown Date"),
                 }
             )
         return cleaned_results


### PR DESCRIPTION
  - Description: Fixes an issue with Metaphor Search Tool throwing when missing keys in API response. 
  - Issue: #9048 
  - Tag maintainer: @hinthornw @hwchase17 
  - Twitter handle: @pelaseyed
