### PR TITLE
get rid of google-api-python-client as it is has a huge filesystem footprint

### DIFF
--- a/libs/langchain/langchain/utilities/google_search.py
+++ b/libs/langchain/langchain/utilities/google_search.py
@@ -65,7 +65,7 @@ class GoogleSearchAPIWrapper(BaseModel):
         }
 
         if self.siterestrict:
-            params["siterestrict"] = True
+            params["siterestrict"] = "true"
 
         import requests
 

--- a/libs/langchain/langchain/utilities/google_search.py
+++ b/libs/langchain/langchain/utilities/google_search.py
@@ -61,20 +61,23 @@ class GoogleSearchAPIWrapper(BaseModel):
             "q": search_term,
             "cx": self.google_cse_id,
             "key": self.google_api_key,
-            **kwargs
+            **kwargs,
         }
 
         if self.siterestrict:
             params["siterestrict"] = True
 
         import requests
+
         res = requests.get(self.base_url, params=params)
         return res.json().get("items", [])
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and CSE ID exists in environment."""
-        google_api_key = get_from_dict_or_env(values, "google_api_key", "GOOGLE_API_KEY")
+        google_api_key = get_from_dict_or_env(
+            values, "google_api_key", "GOOGLE_API_KEY"
+        )
         values["google_api_key"] = google_api_key
 
         google_cse_id = get_from_dict_or_env(values, "google_cse_id", "GOOGLE_CSE_ID")

--- a/libs/langchain/langchain/utilities/google_search.py
+++ b/libs/langchain/langchain/utilities/google_search.py
@@ -84,7 +84,7 @@ class GoogleSearchAPIWrapper(BaseModel):
         values["google_cse_id"] = google_cse_id
 
         try:
-            import requests
+            import requests  # noqa: F401
 
         except ImportError:
             raise ImportError(

--- a/libs/langchain/langchain/utilities/google_search.py
+++ b/libs/langchain/langchain/utilities/google_search.py
@@ -45,7 +45,7 @@ class GoogleSearchAPIWrapper(BaseModel):
     .com
     """
 
-    base_url = "https://www.googleapis.com/customsearch/v1"
+    base_url: str = "https://www.googleapis.com/customsearch/v1"
     google_api_key: Optional[str] = None
     google_cse_id: Optional[str] = None
     k: int = 10


### PR DESCRIPTION
**Description:** 
Refactored the `GoogleSearchAPIWrapper` to utilize the `requests` library for direct interactions with the Google Custom Search API. This eliminates the dependency on the `google-api-python-client` library, significantly reducing the filesystem footprint.

**Reasoning:** 
Upon closer inspection, I discovered that the `googleapiclient` has a filesystem footprint of 84.8 MiB. This is particularly heavy for applications, especially when the primary use-case is just a single call to Google Search. I use langchain in a AWS lambda environment and getting rid of `google-api-python-client` greatly helped me to be able to run my agent serverless. Further reasoning:

1. **Microservice Architecture:** In a microservices ecosystem, each service ideally should be lightweight and singular in function. Including bulky libraries for minimal features increases the overhead without proportionate benefits.

2. **AWS Lambdas:** AWS Lambda has packaging size limits. For languages like Python, the deployment package size (zipped) should be under 50 MB for direct upload and under 250 MB when uploaded from S3. Reducing unnecessary bulk is crucial for efficient AWS Lambda deployments.

3. **Optimized Docker Images:** Large libraries increase the size of Docker images, which subsequently affects deployment times, scaling efficiency, and even costs (especially in serverless environments where you pay per execution time).

4. **Faster Start Times:** In cloud functions or similar serverless architectures, a lighter package means faster cold starts.

Making this change is a step towards optimized, efficient, and cost-effective deployments, especially in serverless and microservice environments. 

**Dependencies:** 
- `requests`

**Tag maintainer:** 
@hinthornw

Please help me to test this, I hope some GitHub actions will test this PR, the change is rather small and inside a private function, so I hope all tests will pass.