### PR TITLE
Move from test to supported claude-instant-1 model

### DIFF
--- a/libs/langchain/tests/integration_tests/llms/test_anthropic.py
+++ b/libs/langchain/tests/integration_tests/llms/test_anthropic.py
@@ -11,14 +11,14 @@ from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 def test_anthropic_call() -> None:
     """Test valid call to anthropic."""
-    llm = Anthropic(model="test")
+    llm = Anthropic(model="claude-instant-1")
     output = llm("Say foo:")
     assert isinstance(output, str)
 
 
 def test_anthropic_streaming() -> None:
     """Test streaming tokens from anthropic."""
-    llm = Anthropic(model="test")
+    llm = Anthropic(model="claude-instant-1")
     generator = llm.stream("I'm Pickle Rick")
 
     assert isinstance(generator, Generator)


### PR DESCRIPTION
Moves from "test" model to "claude-instant-1" model which is supported and has actual capacity
