### PR TITLE
Add string example mapper

### DIFF
--- a/libs/langchain/langchain/smith/evaluation/string_run_evaluator.py
+++ b/libs/langchain/langchain/smith/evaluation/string_run_evaluator.py
@@ -375,7 +375,11 @@ class StringRunEvaluatorChain(Chain, RunEvaluator):
             )
 
         # Configure how example rows are fed as a reference string to the evaluator
-        if reference_key is not None or data_type in (DataType.llm, DataType.chat):
+        if (
+            reference_key is not None
+            or data_type in (DataType.llm, DataType.chat)
+            or evaluator.requires_reference
+        ):
             example_mapper = StringExampleMapper(reference_key=reference_key)
         elif evaluator.requires_reference:
             raise ValueError(


### PR DESCRIPTION
Now that we accept any runnable or arbitrary function to evaluate, we don't always look up the input keys. If an evaluator requires references, we should try to infer if there's one key present. We only have delayed validation here but it's better than nothing