### PR TITLE
add support AsyncIteratorCallbackHandler with buffer

### DIFF
--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -76,7 +76,7 @@ class ChunkAsyncIteratorCallbackHandler(AsyncIteratorCallbackHandler):
     """Callback handler that returns an async iterator."""
     def __init__(self, chunk_size=10) -> None:
         super().__init__()
-        self.chunk = []
+        self.chunk :List[str] = []
         self.chunk_size = chunk_size
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         if token is not None and token != "":

--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -71,3 +71,17 @@ class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
 
             # Otherwise, the extracted value is a token, which we yield
             yield token_or_done
+
+class ChunkAsyncIteratorCallbackHandler(AsyncIteratorCallbackHandler):
+    """Callback handler that returns an async iterator."""
+    def __init__(self, chunk_size=10) -> None:
+        super().__init__()
+        self.chunk = []
+        self.chunk_size = chunk_size
+    async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        if token is not None and token != "":
+            if len(self.chunk) < self.chunk_size:
+                self.chunk.append(token)
+            else:
+                self.queue.put_nowait("".join(self.chunk))
+                self.chunk = [token]


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description:Add new class [ChunkAsyncIteratorCallbackHandler], like AsyncIteratorCallbackHandler with buffer (chunk)
  - Issue: the issue None
  - Dependencies: None
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
