### PR TITLE
Fix bug in llm.py when the list of documents is empty

### DIFF
--- a/libs/langchain/langchain/chains/llm.py
+++ b/libs/langchain/langchain/chains/llm.py
@@ -127,7 +127,7 @@ class LLMChain(Chain):
     ) -> Tuple[List[PromptValue], Optional[List[str]]]:
         """Prepare prompts from inputs."""
         stop = None
-        if "stop" in input_list[0]:
+        if input_list and "stop" in input_list[0]:
             stop = input_list[0]["stop"]
         prompts = []
         for inputs in input_list:


### PR DESCRIPTION
llm.prep_prompts(input_list=[])

throw exception.

I fix this bug.