### PR TITLE
RFC: remove things from init

### DIFF
--- a/libs/langchain/langchain/__init__.py
+++ b/libs/langchain/langchain/__init__.py
@@ -1,57 +1,7 @@
 """Main entrypoint into package."""
 
 from importlib import metadata
-from typing import Optional
-
-from langchain.agents import MRKLChain, ReActChain, SelfAskWithSearchChain
-from langchain.cache import BaseCache
-from langchain.chains import (
-    ConversationChain,
-    LLMBashChain,
-    LLMChain,
-    LLMCheckerChain,
-    LLMMathChain,
-    QAWithSourcesChain,
-    VectorDBQA,
-    VectorDBQAWithSourcesChain,
-)
-from langchain.docstore import InMemoryDocstore, Wikipedia
-from langchain.llms import (
-    Anthropic,
-    Banana,
-    CerebriumAI,
-    Cohere,
-    ForefrontAI,
-    GooseAI,
-    HuggingFaceHub,
-    HuggingFaceTextGenInference,
-    LlamaCpp,
-    Modal,
-    OpenAI,
-    Petals,
-    PipelineAI,
-    SagemakerEndpoint,
-    StochasticAI,
-    Writer,
-)
-from langchain.llms.huggingface_pipeline import HuggingFacePipeline
-from langchain.prompts import (
-    FewShotPromptTemplate,
-    Prompt,
-    PromptTemplate,
-)
-from langchain.schema.prompt_template import BasePromptTemplate
-from langchain.utilities.arxiv import ArxivAPIWrapper
-from langchain.utilities.golden_query import GoldenQueryAPIWrapper
-from langchain.utilities.google_search import GoogleSearchAPIWrapper
-from langchain.utilities.google_serper import GoogleSerperAPIWrapper
-from langchain.utilities.powerbi import PowerBIDataset
-from langchain.utilities.searx_search import SearxSearchWrapper
-from langchain.utilities.serpapi import SerpAPIWrapper
-from langchain.utilities.sql_database import SQLDatabase
-from langchain.utilities.wikipedia import WikipediaAPIWrapper
-from langchain.utilities.wolfram_alpha import WolframAlphaAPIWrapper
-from langchain.vectorstores import FAISS, ElasticVectorSearch
+from typing import Any, Optional
 
 try:
     __version__ = metadata.version(__package__)
@@ -62,57 +12,5 @@ del metadata  # optional, avoids polluting the results of dir(__package__)
 
 verbose: bool = False
 debug: bool = False
-llm_cache: Optional[BaseCache] = None
-
-# For backwards compatibility
-SerpAPIChain = SerpAPIWrapper
-
-__all__ = [
-    "LLMChain",
-    "LLMBashChain",
-    "LLMCheckerChain",
-    "LLMMathChain",
-    "ArxivAPIWrapper",
-    "GoldenQueryAPIWrapper",
-    "SelfAskWithSearchChain",
-    "SerpAPIWrapper",
-    "SerpAPIChain",
-    "SearxSearchWrapper",
-    "GoogleSearchAPIWrapper",
-    "GoogleSerperAPIWrapper",
-    "WolframAlphaAPIWrapper",
-    "WikipediaAPIWrapper",
-    "Anthropic",
-    "Banana",
-    "CerebriumAI",
-    "Cohere",
-    "ForefrontAI",
-    "GooseAI",
-    "Modal",
-    "OpenAI",
-    "Petals",
-    "PipelineAI",
-    "StochasticAI",
-    "Writer",
-    "BasePromptTemplate",
-    "Prompt",
-    "FewShotPromptTemplate",
-    "PromptTemplate",
-    "ReActChain",
-    "Wikipedia",
-    "HuggingFaceHub",
-    "SagemakerEndpoint",
-    "HuggingFacePipeline",
-    "SQLDatabase",
-    "PowerBIDataset",
-    "FAISS",
-    "MRKLChain",
-    "VectorDBQA",
-    "ElasticVectorSearch",
-    "InMemoryDocstore",
-    "ConversationChain",
-    "VectorDBQAWithSourcesChain",
-    "QAWithSourcesChain",
-    "LlamaCpp",
-    "HuggingFaceTextGenInference",
-]
+# Type as `Any` to avoid importing Cache
+llm_cache: Optional[Any] = None

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -13,10 +13,10 @@ from langchain.callbacks.manager import (
     AsyncCallbackManagerForChainRun,
     CallbackManagerForChainRun,
 )
-from langchain.chains import ReduceDocumentsChain
 from langchain.chains.base import Chain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
+from langchain.chains.combine_documents.reduce import ReduceDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
 from langchain.chains.llm import LLMChain
 from langchain.chains.qa_with_sources.loading import load_qa_with_sources_chain

--- a/libs/langchain/langchain/chains/question_answering/__init__.py
+++ b/libs/langchain/langchain/chains/question_answering/__init__.py
@@ -3,10 +3,10 @@ from typing import Any, Mapping, Optional, Protocol
 
 from langchain.callbacks.base import BaseCallbackManager
 from langchain.callbacks.manager import Callbacks
-from langchain.chains import ReduceDocumentsChain
 from langchain.chains.combine_documents.base import BaseCombineDocumentsChain
 from langchain.chains.combine_documents.map_reduce import MapReduceDocumentsChain
 from langchain.chains.combine_documents.map_rerank import MapRerankDocumentsChain
+from langchain.chains.combine_documents.reduce import ReduceDocumentsChain
 from langchain.chains.combine_documents.refine import RefineDocumentsChain
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
 from langchain.chains.llm import LLMChain

--- a/libs/langchain/langchain/output_parsers/__init__.py
+++ b/libs/langchain/langchain/output_parsers/__init__.py
@@ -16,6 +16,7 @@ from langchain.output_parsers.boolean import BooleanOutputParser
 from langchain.output_parsers.combining import CombiningOutputParser
 from langchain.output_parsers.datetime import DatetimeOutputParser
 from langchain.output_parsers.enum import EnumOutputParser
+from langchain.output_parsers.fix import OutputFixingParser
 from langchain.output_parsers.list import (
     CommaSeparatedListOutputParser,
     ListOutputParser,
@@ -24,6 +25,7 @@ from langchain.output_parsers.pydantic import PydanticOutputParser
 from langchain.output_parsers.rail_parser import GuardrailsOutputParser
 from langchain.output_parsers.regex import RegexParser
 from langchain.output_parsers.regex_dict import RegexDictParser
+from langchain.output_parsers.retry import RetryOutputParser, RetryWithErrorOutputParser
 from langchain.output_parsers.structured import ResponseSchema, StructuredOutputParser
 
 __all__ = [
@@ -34,9 +36,12 @@ __all__ = [
     "EnumOutputParser",
     "GuardrailsOutputParser",
     "ListOutputParser",
+    "OutputFixingParser",
     "PydanticOutputParser",
     "RegexDictParser",
     "RegexParser",
     "ResponseSchema",
+    "RetryOutputParser",
+    "RetryWithErrorOutputParser",
     "StructuredOutputParser",
 ]

--- a/libs/langchain/langchain/output_parsers/__init__.py
+++ b/libs/langchain/langchain/output_parsers/__init__.py
@@ -16,7 +16,6 @@ from langchain.output_parsers.boolean import BooleanOutputParser
 from langchain.output_parsers.combining import CombiningOutputParser
 from langchain.output_parsers.datetime import DatetimeOutputParser
 from langchain.output_parsers.enum import EnumOutputParser
-from langchain.output_parsers.fix import OutputFixingParser
 from langchain.output_parsers.list import (
     CommaSeparatedListOutputParser,
     ListOutputParser,
@@ -25,7 +24,6 @@ from langchain.output_parsers.pydantic import PydanticOutputParser
 from langchain.output_parsers.rail_parser import GuardrailsOutputParser
 from langchain.output_parsers.regex import RegexParser
 from langchain.output_parsers.regex_dict import RegexDictParser
-from langchain.output_parsers.retry import RetryOutputParser, RetryWithErrorOutputParser
 from langchain.output_parsers.structured import ResponseSchema, StructuredOutputParser
 
 __all__ = [
@@ -36,12 +34,9 @@ __all__ = [
     "EnumOutputParser",
     "GuardrailsOutputParser",
     "ListOutputParser",
-    "OutputFixingParser",
     "PydanticOutputParser",
     "RegexDictParser",
     "RegexParser",
     "ResponseSchema",
-    "RetryOutputParser",
-    "RetryWithErrorOutputParser",
     "StructuredOutputParser",
 ]

--- a/libs/langchain/langchain/prompts/loading.py
+++ b/libs/langchain/langchain/prompts/loading.py
@@ -6,7 +6,6 @@ from typing import Union
 
 import yaml
 
-from langchain.output_parsers.regex import RegexParser
 from langchain.prompts.few_shot import FewShotPromptTemplate
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import BaseLLMOutputParser, BasePromptTemplate, StrOutputParser
@@ -77,6 +76,9 @@ def _load_output_parser(config: dict) -> dict:
         _config = config.pop("output_parser")
         output_parser_type = _config.pop("_type")
         if output_parser_type == "regex_parser":
+            # Import here to avoid circular dependencies
+            from langchain.output_parsers.regex import RegexParser
+
             output_parser: BaseLLMOutputParser = RegexParser(**_config)
         elif output_parser_type == "default":
             output_parser = StrOutputParser(**_config)

--- a/libs/langchain/langchain/tools/vectorstore/tool.py
+++ b/libs/langchain/langchain/tools/vectorstore/tool.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
 
 from langchain.callbacks.manager import CallbackManagerForToolRun
-from langchain.chains import RetrievalQA, RetrievalQAWithSourcesChain
+from langchain.chains.qa_with_sources.retrieval import RetrievalQAWithSourcesChain
+from langchain.chains.retrieval_qa.base import RetrievalQA
 from langchain.llms.openai import OpenAI
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool


### PR DESCRIPTION
will speed up imports, cause less weird transient import errors, and set us up to split up the package