### PR TITLE
Landonsilla patch 1

### DIFF
--- a/libs/langchain/langchain/callbacks/base.py
+++ b/libs/langchain/langchain/callbacks/base.py
@@ -112,6 +112,13 @@ class ChainManagerMixin:
     ) -> Any:
         """Run on agent end."""
 
+    def on_retry(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run on agent retry."""
+
 
 class ToolManagerMixin:
     """Mixin for tool callbacks."""

--- a/libs/langchain/tests/unit_tests/callbacks/test_openai_info.py
+++ b/libs/langchain/tests/unit_tests/callbacks/test_openai_info.py
@@ -124,3 +124,10 @@ def test_on_llm_end_no_cost_invalid_model(
     )
     handler.on_llm_end(response)
     assert handler.total_cost == 0
+
+def test_on_retry_works(handler: OpenAICallbackHandler) -> None:
+    response = LLMResult(
+        generations=[],
+        llm_output={}
+    )
+    handler.on_retry(response)


### PR DESCRIPTION
  - Description: there is an on_retry event that gets called. however the common callback handlers don't implement an `on_retry` method. So i added a "do nothing" stub method that gets inherited for all these common callback handlers.
  - Issue: [the issue # it fixes (if applicable),](https://github.com/langchain-ai/langchain/issues/8542),
  - Dependencies: none,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!