### PR TITLE
track langchain usage for Rockset

### DIFF
--- a/libs/langchain/langchain/document_loaders/rocksetdb.py
+++ b/libs/langchain/langchain/document_loaders/rocksetdb.py
@@ -94,7 +94,7 @@ class RocksetLoader(BaseLoader):
         self.request_model = QueryRequestSql
 
         try:
-            self.client.set_application('langchain')
+            self.client.set_application("langchain")
         except AttributeError:
             # ignore
             pass

--- a/libs/langchain/langchain/document_loaders/rocksetdb.py
+++ b/libs/langchain/langchain/document_loaders/rocksetdb.py
@@ -93,6 +93,12 @@ class RocksetLoader(BaseLoader):
         self.paginator = QueryPaginator
         self.request_model = QueryRequestSql
 
+        try:
+            self.client.set_application('langchain')
+        except AttributeError:
+            # ignore
+            pass
+
     def load(self) -> List[Document]:
         return list(self.lazy_load())
 

--- a/libs/langchain/langchain/memory/chat_message_histories/rocksetdb.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/rocksetdb.py
@@ -197,6 +197,13 @@ class RocksetChatMessageHistory(BaseChatMessageHistory):
         self.message_uuid_method = message_uuid_method
         self.sync = sync
 
+        try:
+            self.client.set_application('langchain')
+        except AttributeError:
+            # ignore
+            pass
+
+
         if not self._collection_exists():
             self._create_collection()
             self._wait_until_collection_created()

--- a/libs/langchain/langchain/memory/chat_message_histories/rocksetdb.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/rocksetdb.py
@@ -198,11 +198,10 @@ class RocksetChatMessageHistory(BaseChatMessageHistory):
         self.sync = sync
 
         try:
-            self.client.set_application('langchain')
+            self.client.set_application("langchain")
         except AttributeError:
             # ignore
             pass
-
 
         if not self._collection_exists():
             self._create_collection()

--- a/libs/langchain/langchain/vectorstores/rocksetdb.py
+++ b/libs/langchain/langchain/vectorstores/rocksetdb.py
@@ -84,6 +84,12 @@ class Rockset(VectorStore):
         self._embedding_key = embedding_key
         self._workspace = workspace
 
+        try:
+            self._client.set_application('langchain')
+        except AttributeError:
+            # ignore
+            pass
+
     @property
     def embeddings(self) -> Embeddings:
         return self._embeddings

--- a/libs/langchain/langchain/vectorstores/rocksetdb.py
+++ b/libs/langchain/langchain/vectorstores/rocksetdb.py
@@ -85,7 +85,7 @@ class Rockset(VectorStore):
         self._workspace = workspace
 
         try:
-            self._client.set_application('langchain')
+            self._client.set_application("langchain")
         except AttributeError:
             # ignore
             pass


### PR DESCRIPTION
Add ability to track langchain usage for Rockset. Rockset's new python client allows setting this. To prevent old clients from failing, it ignore if setting throws exception (we can't track old versions)

Tested locally with old and new Rockset python client

cc @baskaryan