### PR TITLE
docs: update LlamaCpp max_tokens args

### DIFF
--- a/docs/extras/integrations/llms/llamacpp.ipynb
+++ b/docs/extras/integrations/llms/llamacpp.ipynb
@@ -242,7 +242,7 @@
     "llm = LlamaCpp(\n",
     "    model_path=\"/Users/rlm/Desktop/Code/llama/llama-2-7b-ggml/llama-2-7b-chat.ggmlv3.q4_0.bin\",\n",
     "    temperature=0.75,\n",
-    "    max_length=2000,\n",
+    "    max_tokens=2000,\n",
     "    top_p=1,\n",
     "    callback_manager=callback_manager,\n",
     "    verbose=True,\n",


### PR DESCRIPTION
This PR updates documentations only, `max_length` should be `max_tokens` according to latest LlamaCpp API doc: https://api.python.langchain.com/en/latest/llms/langchain.llms.llamacpp.LlamaCpp.html

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
