### PR TITLE
Store and retrieve documents from remote instance

### DIFF
--- a/docs/extras/integrations/vectorstores/chroma.ipynb
+++ b/docs/extras/integrations/vectorstores/chroma.ipynb
@@ -408,6 +408,113 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e016dda0",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## Deploying Chroma on AWS and connecting it to Langchain\n",
+    "\n",
+    "You can also create a ChromaDB client on AWS and store the embeddings in a remote instance and retrieve the documents on demand.\n",
+    "\n",
+    "First create an instance using this command in terminal\n",
+    "\n",
+    "```sh\n",
+    "aws cloudformation create-stack --stack-name my-chroma-stack --template-url https://s3.amazonaws.com/public.trychroma.com/cloudformation/latest/chroma.cf.json\n",
+    "```\n",
+    "This will create an instance of ChromaDB is AWS. Next retrieve the public IP of the instance using this command in terminal\n",
+    "\n",
+    "```\n",
+    "aws cloudformation describe-stacks --stack-name my-chroma-stack --query 'Stacks[0].Outputs'\n",
+    "```\n",
+    "\n",
+    "This will return the puclic IP of the instance\n",
+    "\n",
+    "```\n",
+    "[\n",
+    "    {\n",
+    "        \"OutputKey\": \"ServerIp\",\n",
+    "        \"OutputValue\": \"3.101.XXX.XX\",\n",
+    "        \"Description\": \"IP address of the Chroma server\"\n",
+    "    }\n",
+    "]\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c43d4c4",
+   "metadata": {},
+   "source": [
+    "### Storing the Embeddings in AWS instance\n",
+    "\n",
+    "Using the above generated Public IP a client can be created"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86ca95ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import chromadb\n",
+    "chromadb_public_ip = \"3.101.XXX.XX\"\n",
+    "\n",
+    "client = chromadb.HttpClient(host=chromadb_public_ip, port=8000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa2b01e1",
+   "metadata": {},
+   "source": [
+    "Using the above client you can store the documents in a collection "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3addab22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdf_path = \"./test.pdf\"\n",
+    "loader = PyPDFium2Loader(pdf_path)\n",
+    "pages = loader.load_and_split()\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "vectordb = Chroma.from_documents(pages, embedding=embeddings, collection_name=\"testcollection\", client=client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61f7b811",
+   "metadata": {},
+   "source": [
+    "### Retrieve the embeddings from AWS\n",
+    "Later the collection can be loaded anytime and a chain can be used to query from"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a67e19a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embeddings = OpenAIEmbeddings()\n",
+    "vectordb = Chroma(client=client, collection_name=\"testcollection\", embedding_function=embeddings)\n",
+    "\n",
+    "qa_chain = RetrievalQA.from_chain_type(llm=ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0.4), \n",
+    "                                     chain_type=\"stuff\", \n",
+    "                                     retriever=vectordb.as_retriever(), \n",
+    "                                     return_source_documents=True)\n",
+    "                                     \n",
+    "question = \"What is the capital of France?\"                                     \n",
+    "answer = (qa_chain({\"query\": question}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6d9c28ad",
    "metadata": {},
    "source": [


### PR DESCRIPTION


Replace this entire comment with:
  - Description: I have added documentation on how to create a remote instance of chromadb on AWS, store the documents in it, retrieve the documents from it and then query them using chains, 
  - Issue: NA,
  - Dependencies: NA,
  - Tag maintainer: @eyurtsev,
  - Twitter handle: NA
