### PR TITLE
Random compatibility issues

### DIFF
--- a/libs/langchain/tests/unit_tests/tools/test_custom_tools_pydantic_2.py
+++ b/libs/langchain/tests/unit_tests/tools/test_custom_tools_pydantic_2.py
@@ -1,0 +1,22 @@
+"""Testing that declaring custom tools using pydantic v2 works."""
+
+from langchain import _PYDANTIC_MAJOR_VERSION
+from langchain.tools.base import tool
+import pytest
+
+if _PYDANTIC_MAJOR_VERSION != 2:
+    pytest.skip(
+        "Unit tests for testing compatibility with pydantic major version 2",
+        allow_module_level=True,
+    )
+
+
+def test_custom_tool_pydantic_v2() -> None:
+    """Test that custom tools can be declared using pydantic v2."""
+
+    @tool()
+    def speak(what: str) -> str:
+        """Return what was said backwards."""
+        return what[::-1]
+
+    assert speak("hello") == "olleh"


### PR DESCRIPTION
A fix for random issues like this:

```
from pydantic import BaseModel, Field # <-- may be v2 namespace


class CalculatorInput(BaseModel):
    question: str = Field()

Tool.from_function( # <-- tool uses v1 namespace
    func=lambda question: 'hello',
    name="Calculator",
    description="useful for when you need to answer questions about math",
    args_schema=CalculatorInput
)

```