### PR TITLE
Fix region sagemaker

### DIFF
--- a/libs/langchain/langchain/llms/sagemaker_endpoint.py
+++ b/libs/langchain/langchain/llms/sagemaker_endpoint.py
@@ -171,6 +171,12 @@ class SagemakerEndpoint(LLM):
                     # use default credentials
                     session = boto3.Session()
 
+                if values["region_name"] is None:
+                    raise ValueError(
+                        "region_name parameter is missing. "
+                        "Please add the region_name parameter in order to connect to client"
+                                     )
+
                 values["client"] = session.client(
                     "sagemaker-runtime", region_name=values["region_name"]
                 )

--- a/libs/langchain/langchain/llms/sagemaker_endpoint.py
+++ b/libs/langchain/langchain/llms/sagemaker_endpoint.py
@@ -175,7 +175,7 @@ class SagemakerEndpoint(LLM):
                     raise ValueError(
                         "region_name parameter is missing. "
                         "Please add the region_name parameter in order to connect to client"
-                                     )
+                    )
 
                 values["client"] = session.client(
                     "sagemaker-runtime", region_name=values["region_name"]
@@ -210,11 +210,11 @@ class SagemakerEndpoint(LLM):
         return "sagemaker_endpoint"
 
     def _call(
-        self,
-        prompt: str,
-        stop: Optional[List[str]] = None,
-        run_manager: Optional[CallbackManagerForLLMRun] = None,
-        **kwargs: Any,
+            self,
+            prompt: str,
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
     ) -> str:
         """Call out to Sagemaker inference endpoint.
 


### PR DESCRIPTION
I encountered an issue while working with the Sagemaker endpoint module and attempting to establish a connection to the client. 
The error message `"Failed to load credentials for AWS client authentication`" was being raised, despite passing the **`profile_name`** parameter. 

Upon reviewing the code, I realized that the error was caused by the omission of the **`region_name`** parameter. To address this, I introduced a validation step to ensure that the **`region_name`** parameter is provided, and I implemented an error-raising mechanism in case the parameter is found to be `None`. 

This adjustment effectively resolved the issue.

Thanks!