### PR TITLE
Remove summarization from VALID TASKS tuple

### DIFF
--- a/libs/langchain/langchain/llms/huggingface_endpoint.py
+++ b/libs/langchain/langchain/llms/huggingface_endpoint.py
@@ -8,7 +8,7 @@ from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
 from langchain.utils import get_from_dict_or_env
 
-VALID_TASKS = ("text2text-generation", "text-generation", "summarization")
+VALID_TASKS = ("text2text-generation", "text-generation")
 
 
 class HuggingFaceEndpoint(LLM):


### PR DESCRIPTION
In llms.huggingface_endpoint.py, remove summarization from VALID_TASKS because docstring says that summarization is not supported. Also, when trying summarization task, we get an error `KeyError: 'summary_text'` from huggingface endpoint.


resolves #9286


  - Twitter handle: @Zorns_Lemma

@baskaryan  
 
 
