### PR TITLE
Fix SelfAskOutputParser (from langchain.agents.self_ask_with_search.output_parser)

### DIFF
--- a/libs/langchain/langchain/agents/self_ask_with_search/output_parser.py
+++ b/libs/langchain/langchain/agents/self_ask_with_search/output_parser.py
@@ -1,3 +1,4 @@
+import re
 from typing import Sequence, Union
 
 from langchain.agents.agent import AgentOutputParser
@@ -8,17 +9,21 @@ class SelfAskOutputParser(AgentOutputParser):
     """Output parser for the self-ask agent."""
 
     followups: Sequence[str] = ("Follow up:", "Followup:")
-    finish_string: str = "So the final answer is: "
+    finish_string: str = "So the final answer is:"
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        last_line = text.split("\n")[-1]
-        if not any([follow in last_line for follow in self.followups]):
-            if self.finish_string not in last_line:
-                raise OutputParserException(f"Could not parse output: {text}")
-            return AgentFinish({"output": last_line[len(self.finish_string) :]}, text)
+        followup_pattern = "|".join(map(lambda followup: f"{followup}", self.followups))
+        followup = re.findall(rf"({followup_pattern})(?ms:(.*))", text)
+        end = re.findall(rf"({self.finish_string})(?ms:(.*))$", text)
 
-        after_colon = text.split(":")[-1].strip()
-        return AgentAction("Intermediate Answer", after_colon, text)
+        # if follow up
+        if len(followup) > 0 and followup[-1][0] in self.followups:
+            return AgentAction("Intermediate Answer", followup[-1][1].strip(), text)
+        # if final output
+        if len(end) > 0 and end[-1][0] == self.finish_string:
+            return AgentFinish({"output": end[-1][1].strip()}, text)
+
+        raise OutputParserException(f"Could not parse output: {text}")
 
     @property
     def _type(self) -> str:


### PR DESCRIPTION
# Description of the change

By replacing hard coded position of "follow up" and "final output" pattern with regex pattern matching using "re" I reduce failed outputs like markdown list or any multiline outputs

Example of the issue:
```
from langchain import OpenAI, SerpAPIWrapper
from langchain.agents import initialize_agent, Tool
from langchain.agents import AgentType

llm = OpenAI(temperature=0)
search = SerpAPIWrapper()
tools = [
    Tool(
        name="Intermediate Answer",
        func=search.run,
        description="useful for when you need to ask with search",
    )
]

self_ask_with_search = initialize_agent(
    tools, llm, agent=AgentType.SELF_ASK_WITH_SEARCH, verbose=True
)
out = self_ask_with_search.run(
    "List men and women Rolland Garros winners between 2020 and 2023?"
)
-------------------------
> Entering new AgentExecutor chain...
 Yes.
Follow up: Who won the men's Rolland Garros in 2020?
Intermediate answer: Three-time defending champion Rafael Nadal defeated Novak Djokovic in the final, 6–0, 6–2, 7–5 to win the men's singles tennis title at the 2020 French Open.

Follow up: Who won the women's Rolland Garros in 2020?
Intermediate answer: Iga Świątek defeated Sofia Kenin in the final, 6–4, 6–1 to win the women's singles tennis title at the 2020 French Open.

Follow up: Who won the men's Rolland Garros in 2021?
Intermediate answer: Novak Djokovic defeated Stefanos Tsitsipas in the final, 6–7(6–8), 2–6, 6–3, 6–2, 6–4 to win the men's singles tennis title at the 2021 French Open.

Follow up: Who won the women's Rolland Garros in 2021?
Intermediate answer: Barbora Krejčíková defeated Anastasia Pavlyuchenkova in the final, 6–1, 2–6, 6–4 to win the women's singles tennis title at the 2021 French Open.

Follow up: Who won the men's Rolland Garros in 2022?
Intermediate answer: Rafael Nadal defeated Casper Ruud in the final, 6–3, 6–3, 6–0 to win the men's singles tennis title at the 2022 French Open. It was his record-extending ...

Follow up: Who won the women's Rolland Garros in 2022?
Intermediate answer: Iga Świątek defeated Coco Gauff in the final, 6–1, 6–3 to win the women's singles tennis title at the 2022 French Open. It was her second French Open title, ...

Follow up: Who won the men's Rolland Garros in 2023?
Intermediate answer: Novak Djokovic defeated Casper Ruud in the final, 7–6(7–1), 6–3, 7–5 to win the men's singles tennis title at the 2023 French Open. It was his third French ...

Follow up: Who won the women's Rolland Garros in 2023?
Intermediate answer: World number one Iga Swiatek clinched her third French Open and fourth Grand Slam title of her career on Saturday with an epic three-set ...
---------------------------------------------------------------------------
OutputParserException                     Traceback (most recent call last)
...
File /usr/local/Caskroom/miniconda/base/envs/py_3_10/lib/python3.10/site-packages/langchain/agents/self_ask_with_search/output_parser.py:17, in SelfAskOutputParser.parse(self, text)
     15 if not any([follow in last_line for follow in self.followups]):
     16     if self.finish_string not in last_line:
---> 17         raise OutputParserException(f"Could not parse output: {text}")
     18     return AgentFinish({"output": last_line[len(self.finish_string) :]}, text)
     20 after_colon = text.split(":")[-1].strip()

OutputParserException: Could not parse output: So the final answer is: 
2020: Men's - Rafael Nadal, Women's - Iga Świątek 
2021: Men's - Novak Djokovic, Women's - Barbora Krejčíková 
2022: Men's - Rafael Nadal, Women's - Iga Świątek 
2023: Men's - Novak Djokovic, Women's - Iga Świątek
```


Using regex matching now we obtain a correct answer:

```
> Entering new AgentExecutor chain...
 Yes.
Follow up: Who won the men's singles at the 2020 French Open?
Intermediate answer: Rafael Nadal
Follow up: Who won the women's singles at the 2020 French Open?
Intermediate answer: Iga Swiatek
Follow up: Who won the men's singles at the 2021 French Open?
Intermediate answer: Novak Djokovic
Follow up: Who won the women's singles at the 2021 French Open?
Intermediate answer: Barbora Krejčíková
Follow up: Who won the men's singles at the 2022 French Open?
Intermediate answer: Rafael Nadal
Follow up: Who won the women's singles at the 2022 French Open?
Intermediate answer: Iga Swiatek
Follow up: Who won the men's singles at the 2023 French Open?
Intermediate answer: Novak Djokovic
Follow up: Who won the women's singles at the 2023 French Open?
Intermediate answer: Iga Swiatek
So the final answer is: 
2020: Rafael Nadal (men's singles) and Iga Swiatek (women's singles)
2021: Novak Djokovic (men's singles) and Barbora Krejčíková (women's singles)
2022: Rafael Nadal (men's singles) and Iga Swiatek (women's singles)
2023: Novak Djokovic (men's singles) and Iga Swiatek (women's singles)

> Finished chain.
```

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->


<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
