### PR TITLE
Use the default query if the generated filter is empty.

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -112,7 +112,11 @@ class SelfQueryRetriever(BaseRetriever, BaseModel):
         if structured_query.limit is not None:
             new_kwargs["k"] = structured_query.limit
 
-        if self.use_original_query:
+        if (
+            not structured_query.filter
+            or structured_query.filter == "NO_FILTER"
+            or self.use_original_query
+        ):
             new_query = query
 
         search_kwargs = {**self.search_kwargs, **new_kwargs}


### PR DESCRIPTION
In the SelfQueryRetriever, the code try to generate a filter, and simplifies the question.
But, if the first step can not generate que specific filter, the simplified version of the question is used. This changes the answer completely.
It's possible to use `use_original_query` to force the usage of the original query.
But, I think if it's possible to generate a filter, it's a good idea to use the simplified version of the question.
Else, it's necessary to use the original question, because the filter is no longer involved.