### PR TITLE
Fix typo in huggingface_textgen_inference.ipynb

### DIFF
--- a/docs/extras/integrations/llms/huggingface_textgen_inference.ipynb
+++ b/docs/extras/integrations/llms/huggingface_textgen_inference.ipynb
@@ -74,7 +74,7 @@
     "    typical_p=0.95,\n",
     "    temperature=0.01,\n",
     "    repetition_penalty=1.03,\n",
-    "    stream=True\n",
+    "    streaming=True\n",
     ")\n",
     "llm(\"What did foo say about bar?\", callbacks=[StreamingStdOutCallbackHandler()])"
    ]


### PR DESCRIPTION
Replaced incorrect `stream` parameter by `streaming` on Integrations docs.