### PR TITLE
Airbyte loaders: Fix last_state getter

### DIFF
--- a/libs/langchain/langchain/document_loaders/airbyte.py
+++ b/libs/langchain/langchain/document_loaders/airbyte.py
@@ -61,7 +61,7 @@ class AirbyteCDKLoader(BaseLoader):
         )
 
     @property
-    def last_state(self):
+    def last_state(self) -> Any:
         return self._integration.last_state
 
 

--- a/libs/langchain/langchain/document_loaders/airbyte.py
+++ b/libs/langchain/langchain/document_loaders/airbyte.py
@@ -60,6 +60,10 @@ class AirbyteCDKLoader(BaseLoader):
             stream_name=self._stream_name, state=self._state
         )
 
+    @property
+    def last_state(self):
+        return self._integration.last_state
+
 
 class AirbyteHubspotLoader(AirbyteCDKLoader):
     """Load from `Hubspot` using an `Airbyte` source connector."""


### PR DESCRIPTION
This PR fixes the Airbyte loaders when doing incremental syncs. The notebooks are calling out to access `loader.last_state` to get the current state of incremental syncs, but this didn't work due to a refactoring of how the loaders are structured internally in the original PR.

This PR fixes the issue by adding a `last_state` property that forwards the state correctly from the CDK adapter.