### PR TITLE
Ensure the in-project venv gets cached in CI tests.

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -62,6 +62,19 @@ runs:
       run: |
         poetry lock --check
 
+    - name: Set proper Poetry.lock file
+      shell: bash
+      env:
+        WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
+      run: |
+        if [ -f "$WORKDIR/poetry.lock" ]; then
+          echo 'Using working directory poetry.lock in cache key'
+          cp "$WORKDIR/poetry.lock" poetry-lock.cache-key
+        else
+          echo 'Using the top-level poetry.lock in cache key'
+          cp poetry.lock poetry-lock.cache-key
+        fi
+
     - uses: actions/cache@v3
       id: cache-poetry
       env:
@@ -71,7 +84,8 @@ runs:
           ~/.cache/pypoetry/virtualenvs
           ~/.cache/pypoetry/cache
           ~/.cache/pypoetry/artifacts
-        key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}-${{ inputs.cache-key }}-${{ hashFiles('poetry.lock') }}
+          ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}/.venv
+        key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}-${{ inputs.cache-key }}-${{ hashFiles('poetry-lock.cache-key') }}
 
     - run: ${{ inputs.install-command }}
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
The previous caching configuration was attempting to cache poetry venvs created in the default shared virtualenvs directory. However, all langchain packages use `in-project = true` for their poetry virtualenv setup, which moves the venv inside the package itself instead. This meant that poetry venvs were not being cached at all.

This PR ensures that the venv gets cached by adding the in-project venv directory to the cached directories list.

It also makes sure that the cache key *only* includes the lockfile being installed, as opposed to *all lockfiles* (unnecessary cache misses) or just the *top-level lockfile* (cache hits when it shouldn't).