### PR TITLE
[Fix] Update litellm to use model instead of model_name

### DIFF
--- a/libs/langchain/langchain/chat_models/litellm.py
+++ b/libs/langchain/langchain/chat_models/litellm.py
@@ -205,6 +205,7 @@ class ChatLiteLLM(BaseChatModel):
 
     client: Any  #: :meta private:
     model: str = "gpt-3.5-turbo"
+    model_name: Optional[str] = None
     """Model name to use."""
     openai_api_key: Optional[str] = None
     azure_api_key: Optional[str] = None
@@ -237,8 +238,11 @@ class ChatLiteLLM(BaseChatModel):
     @property
     def _default_params(self) -> Dict[str, Any]:
         """Get the default parameters for calling OpenAI API."""
+        set_model_value = self.model
+        if self.model_name != None:
+            set_model_value = self.model_name
         return {
-            "model": self.model,
+            "model": set_model_value,
             "force_timeout": self.request_timeout,
             "max_tokens": self.max_tokens,
             "stream": self.streaming,
@@ -250,10 +254,13 @@ class ChatLiteLLM(BaseChatModel):
     @property
     def _client_params(self) -> Dict[str, Any]:
         """Get the parameters used for the openai client."""
+        set_model_value = self.model
+        if self.model_name != None:
+            set_model_value = self.model_name
         self.client.api_base = self.api_base
         self.client.organization = self.organization
         creds: Dict[str, Any] = {
-            "model": self.model,
+            "model": set_model_value,
             "force_timeout": self.request_timeout,
         }
         return {**self._default_params, **creds}
@@ -346,7 +353,10 @@ class ChatLiteLLM(BaseChatModel):
             )
             generations.append(gen)
         token_usage = response.get("usage", {})
-        llm_output = {"token_usage": token_usage, "model": self.model}
+        set_model_value = self.model
+        if self.model_name != None:
+            set_model_value = self.model_name
+        llm_output = {"token_usage": token_usage, "model": set_model_value}
         return ChatResult(generations=generations, llm_output=llm_output)
 
     def _create_message_dicts(
@@ -436,8 +446,11 @@ class ChatLiteLLM(BaseChatModel):
     @property
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
+        set_model_value = self.model
+        if self.model_name != None:
+            set_model_value = self.model_name
         return {
-            "model": self.model,
+            "model": set_model_value,
             "temperature": self.temperature,
             "top_p": self.top_p,
             "top_k": self.top_k,

--- a/libs/langchain/langchain/chat_models/litellm.py
+++ b/libs/langchain/langchain/chat_models/litellm.py
@@ -207,7 +207,7 @@ class ChatLiteLLM(BaseChatModel):
     """
 
     client: Any  #: :meta private:
-    model_name: str = "gpt-3.5-turbo"
+    model: str = "gpt-3.5-turbo"
     """Model name to use."""
     openai_api_key: Optional[str] = None
     azure_api_key: Optional[str] = None
@@ -240,7 +240,7 @@ class ChatLiteLLM(BaseChatModel):
     def _default_params(self) -> Dict[str, Any]:
         """Get the default parameters for calling OpenAI API."""
         return {
-            "model": self.model_name,
+            "model": self.model,
             "force_timeout": self.request_timeout,
             "max_tokens": self.max_tokens,
             "stream": self.streaming,
@@ -255,7 +255,7 @@ class ChatLiteLLM(BaseChatModel):
         self.client.api_base = self.api_base
         self.client.organization = self.organization
         creds: Dict[str, Any] = {
-            "model": self.model_name,
+            "model": self.model,
             "force_timeout": self.request_timeout,
         }
         return {**self._default_params, **creds}
@@ -348,7 +348,7 @@ class ChatLiteLLM(BaseChatModel):
             )
             generations.append(gen)
         token_usage = response.get("usage", {})
-        llm_output = {"token_usage": token_usage, "model_name": self.model_name}
+        llm_output = {"token_usage": token_usage, "model": self.model}
         return ChatResult(generations=generations, llm_output=llm_output)
 
     def _create_message_dicts(
@@ -439,7 +439,7 @@ class ChatLiteLLM(BaseChatModel):
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
         return {
-            "model_name": self.model_name,
+            "model": self.model,
             "temperature": self.temperature,
             "top_p": self.top_p,
             "top_k": self.top_k,

--- a/libs/langchain/langchain/chat_models/litellm.py
+++ b/libs/langchain/langchain/chat_models/litellm.py
@@ -191,9 +191,6 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
 class ChatLiteLLM(BaseChatModel):
     """`LiteLLM` Chat models API.
 
-    To use you must have the google.generativeai Python package installed and
-    either:
-
         1. The ``GOOGLE_API_KEY``` environment variable set with your API key, or
         2. Pass your API key using the google_api_key kwarg to the ChatGoogle
            constructor.
@@ -218,8 +215,9 @@ class ChatLiteLLM(BaseChatModel):
     streaming: bool = False
     api_base: Optional[str] = None
     organization: Optional[str] = None
+    custom_llm_provider: Optional[str] = None
     request_timeout: Optional[Union[float, Tuple[float, float]]] = None
-    temperature: Optional[float] = None
+    temperature: Optional[float] = 1
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Run inference with this temperature. Must by in the closed
        interval [0.0, 1.0]."""


### PR DESCRIPTION
When using liteLLM allow users to set `model` using `model` instead of `model_name`. liteLLM uses `model` so using the same naming convention 

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
