### PR TITLE
Cache linting venv on CI.

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
+          cache-dependency-path: |
+            ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}/**/poetry.lock
       - name: Install dependencies
         run: |
           poetry install

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -26,11 +26,22 @@ jobs:
           - "3.11"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: cache-pip
+        name: Cache langchain editable pip install - ${{ matrix.python-version }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+        with:
+          path: |
+            ~/.cache/pip
+          key: pip-editable-langchain-deps-${{ runner.os }}-${{ runner.arch }}-py-${{ matrix.python-version }}
       - name: Install poetry
         run: |
           pipx install poetry==$POETRY_VERSION
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry


### PR DESCRIPTION
Ensure that we cache the linting virtualenv as well as the pip cache for the `pip install -e langchain` step.

This is a win of about 60-90s overall.

Before:
![image](https://github.com/langchain-ai/langchain/assets/2348618/f55f8398-2c3a-4112-bad3-2c646d186183)

After:
![image](https://github.com/langchain-ai/langchain/assets/2348618/984a9529-2431-41b4-97e5-7f5dd7742651)
