### PR TITLE
Patch to pass attribute_filter to kendra query call with get_relevant_documents kendra retriever method

### DIFF
--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -375,13 +375,21 @@ class AmazonKendraRetriever(BaseRetriever):
                 "profile name are valid."
             ) from e
 
-    def _kendra_query(self, query: str) -> Sequence[ResultItem]:
+    def _kendra_query(
+        self, 
+        query: str,
+        attribute_filter: Optional[Dict] = None,
+    ) -> Sequence[ResultItem]:
         kendra_kwargs = {
             "IndexId": self.index_id,
             "QueryText": query.strip(),
             "PageSize": self.top_k,
         }
-        if self.attribute_filter is not None:
+        #attribute_filter provided in _get_relevant_documents supersedes that defined at retriever instance
+        if attribute_filter is not None:
+            kendra_kwargs["AttributeFilter"] = attribute_filter
+        #otherwise attribute_filter falls back to retriever instance attribute
+        elif self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
         if self.user_context is not None:
             kendra_kwargs["UserContext"] = self.user_context
@@ -406,6 +414,7 @@ class AmazonKendraRetriever(BaseRetriever):
     def _get_relevant_documents(
         self,
         query: str,
+        attribute_filter: Optional[Dict] = None,
         *,
         run_manager: CallbackManagerForRetrieverRun,
     ) -> List[Document]:
@@ -417,6 +426,6 @@ class AmazonKendraRetriever(BaseRetriever):
             docs = retriever.get_relevant_documents('This is my query')
 
         """
-        result_items = self._kendra_query(query)
+        result_items = self._kendra_query(query,attribute_filter)
         top_k_docs = self._get_top_k_docs(result_items)
         return top_k_docs

--- a/libs/langchain/langchain/retrievers/kendra.py
+++ b/libs/langchain/langchain/retrievers/kendra.py
@@ -376,7 +376,7 @@ class AmazonKendraRetriever(BaseRetriever):
             ) from e
 
     def _kendra_query(
-        self, 
+        self,
         query: str,
         attribute_filter: Optional[Dict] = None,
     ) -> Sequence[ResultItem]:
@@ -385,10 +385,10 @@ class AmazonKendraRetriever(BaseRetriever):
             "QueryText": query.strip(),
             "PageSize": self.top_k,
         }
-        #attribute_filter provided in _get_relevant_documents supersedes that defined at retriever instance
+        # attribute_filter provided in _get_relevant_documents supersedes that defined at retriever instance
         if attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = attribute_filter
-        #otherwise attribute_filter falls back to retriever instance attribute
+        # otherwise attribute_filter falls back to retriever instance attribute
         elif self.attribute_filter is not None:
             kendra_kwargs["AttributeFilter"] = self.attribute_filter
         if self.user_context is not None:
@@ -426,6 +426,6 @@ class AmazonKendraRetriever(BaseRetriever):
             docs = retriever.get_relevant_documents('This is my query')
 
         """
-        result_items = self._kendra_query(query,attribute_filter)
+        result_items = self._kendra_query(query, attribute_filter)
         top_k_docs = self._get_top_k_docs(result_items)
         return top_k_docs


### PR DESCRIPTION
**Description:** 

- Add attribute_filter as an optional input argument to get_relevant_documents method of kendra retriever class. Currently it is only possible to define an attribute_filter, used to filter kendra searched docs by metadata attributes (such as s3 prefix), when creating a Kendra retriever instance. 

- This patch to add attribute_filter as an optional argument to get_relevant_documents would enable programmatic changes in query filters to more easily support map reduce design patterns. 

- This change simply passes the optional attribute_filter dict as an optional argument to the _kendra_query method. 
- It does not store the attribute_filter as a class attribute as is the case for an attribute_filter defined when creating Kendra retriever class instance. 

- If a class attribute_filter instance exists, the attribute_filter provided during get_relevant_documents supersedes it.


**Tests:**

- This is a very minor, small change. Nonetheless I still ran `make docker_tests`.
- The only kendra relevant output was below and it does not pertain to the changes made:
- `langchain/retrievers/kendra.py:24
   /app/langchain/retrievers/kendra.py:24: DeprecationWarning: invalid escape sequence '\s'
     res = re.sub("\s+", " ", excerpt).replace("...", "")`
