### PR TITLE
Corrected Typo in MultiPromptChain Example in router.ipynb

### DIFF
--- a/docs/extras/modules/chains/foundational/router.ipynb
+++ b/docs/extras/modules/chains/foundational/router.ipynb
@@ -15,7 +15,7 @@
     "- destination_chains: chains that the router chain can route to\n",
     "\n",
     "\n",
-    "In this notebook we will focus on the different types of routing chains. We will show these routing chains used in a `MultiPromptChain` to create a question-answering chain that selects the prompt which is most relevant for a given question, and then answers the question using that prompt."
+    "In this notebook, we will focus on the different types of routing chains. We will show these routing chains used in a `MultiPromptChain` to create a question-answering chain that selects the prompt which is most relevant for a given question, and then answers the question using that prompt."
    ]
   },
   {
@@ -231,7 +231,7 @@
     }
    ],
    "source": [
-    "print(chain.run(\"What is the name of the type of cloud that rins\"))"
+    "print(chain.run(\"What is the name of the type of cloud that rains?\"))"
    ]
   },
   {


### PR DESCRIPTION
Refined the example in router.ipynb by addressing a minor typographical error. The typo "rins" has been corrected to "rains" in the code snippet that demonstrates the usage of the MultiPromptChain. This change ensures accuracy and consistency in the provided code example.

This improvement enhances the readability and correctness of the notebook, making it easier for users to understand and follow the demonstration. The commit aims to maintain the quality and accuracy of the content within the repository.

Thank you for your attention to detail, and please review the change at your convenience.

@baskaryan , @hwchase17 