### PR TITLE
Corrected Sentence in .ipynb File

### DIFF
--- a/docs/extras/use_cases/apis.ipynb
+++ b/docs/extras/use_cases/apis.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "## Quickstart \n",
     "\n",
-    "Many APIs already are compatible with OpenAI function calling.\n",
+    "Many APIs are already compatible with OpenAI function calling.\n",
     "\n",
     "For example, [Klarna](https://www.klarna.com/international/press/klarna-brings-smoooth-shopping-to-chatgpt/) has a YAML file that describes its API and allows OpenAI to interact with it:\n",
     "\n",


### PR DESCRIPTION
Fixed grammatical errors in the sentence by repositioning the word "are" for improved clarity and readability.

 @baskaryan @hwchase17 @hinthornw 