### PR TITLE
Fixed Typo in Fallbacks.ipynb

### DIFF
--- a/docs/extras/guides/fallbacks.ipynb
+++ b/docs/extras/guides/fallbacks.ipynb
@@ -84,7 +84,7 @@
     "# Let's use just the OpenAI LLm first, to show that we run into an error\n",
     "with patch('openai.ChatCompletion.create', side_effect=RateLimitError()):\n",
     "    try:\n",
-    "         print(openai_llm.invoke(\"Why did the the chicken cross the road?\"))\n",
+    "         print(openai_llm.invoke(\"Why did the chicken cross the road?\"))\n",
     "    except:\n",
     "        print(\"Hit error\")"
    ]


### PR DESCRIPTION
Removed extra "the" in the sentence about the chicken crossing the road in fallbacks.ipynb. The sentence now reads correctly: "Why did the chicken cross the road?" This resolves the grammatical error and improves the overall quality of the content.

@baskaryan , @hinthornw , @hwchase17 