### PR TITLE
Fixing spelling mistakes in  fallbacks.ipynb

### DIFF
--- a/docs/extras/guides/fallbacks.ipynb
+++ b/docs/extras/guides/fallbacks.ipynb
@@ -19,9 +19,9 @@
    "source": [
     "## Handling LLM API Errors\n",
     "\n",
-    "This is maybe the most common use case for fallbacks. A request to an LLM API can fail for a variety of reasons - the API could be down, you could have hit rate limits, any number of things. Therefor, using fallbacks can help protect against these types of things.\n",
+    "This is maybe the most common use case for fallbacks. A request to an LLM API can fail for a variety of reasons - the API could be down, you could have hit rate limits, any number of things. Therefore, using fallbacks can help protect against these types of things.\n",
     "\n",
-    "IMPORTANT: By default, a lot of the LLM wrappers catch errors and retry. You will most likely want to turn those off when working with fallbacks. Otherwise the first wrapper will keep on retying and not failing."
+    "IMPORTANT: By default, a lot of the LLM wrappers catch errors and retry. You will most likely want to turn those off when working with fallbacks. Otherwise the first wrapper will keep on retrying and not failing."
    ]
   },
   {


### PR DESCRIPTION
Fix spelling errors in the text: 'Therefore' and 'Retrying

I want to stress that your feedback is invaluable to us and is genuinely cherished.
With gratitude,
@baskaryan  @hwchase17 