### PR TITLE
Cache .mypy_cache across lint runs.

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -13,9 +13,6 @@ env:
 
 jobs:
   build:
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,12 +45,25 @@ jobs:
           cache-dependency-path: |
             ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}/**/poetry.lock
       - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
         run: |
           poetry install
       - name: Install langchain editable
+        working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.working-directory != 'langchain' }}
         run: |
           pip install -e ../langchain
+      - name: Get .mypy_cache to speed up mypy
+        uses: actions/cache@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+          WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
+        with:
+          path: |
+            ${{ env.WORKDIR }}/.mypy_cache
+          key: mypy-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/poetry.lock', env.WORKDIR)) }}
+
       - name: Analysing the code with our lint
+        working-directory: ${{ inputs.working-directory }}
         run: |
           make lint


### PR DESCRIPTION
Preserve the `.mypy_cache` directory across lint runs, to avoid having to re-parse all dependencies and their type information.

Approximately a 1min perf win for CI.

Before:
![image](https://github.com/langchain-ai/langchain/assets/2348618/6524f2a9-efc0-4588-a94c-69914b98b382)

After:
![image](https://github.com/langchain-ai/langchain/assets/2348618/dd0af954-4dc9-43d3-8544-25846616d41d)