### PR TITLE
Changed the NIBittensorLLM API URL to the correct one

### DIFF
--- a/docs/extras/integrations/llms/bittensor.ipynb
+++ b/docs/extras/integrations/llms/bittensor.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "This LLM showcases true potential of decentralized AI by giving you the best response(s) from the Bittensor protocol, which consist of various AI models such as OpenAI, LLaMA2 etc.\n",
     "\n",
-    "Users can view their logs, requests, and API keys on the [Validator Endpoint Frontend](https://api.neuralinterent.ai/). However, changes to the configuration are currently prohibited; otherwise, the user's queries will be blocked.\n",
+    "Users can view their logs, requests, and API keys on the [Validator Endpoint Frontend](https://api.neuralinternet.ai/). However, changes to the configuration are currently prohibited; otherwise, the user's queries will be blocked.\n",
     "\n",
     "If you encounter any difficulties or have any questions, please feel free to reach out to our developer on [GitHub](https://github.com/Kunj-2206), [Discord](https://discordapp.com/users/683542109248159777) or join our discord server for latest update and queries [Neural Internet](https://discord.gg/neuralinternet).\n"
    ]


### PR DESCRIPTION
Changed https://api.neuralinterent.ai/ to https://api.neuralinternet.ai/ which is the valid URL for the API of NIBittensorLLM.