### PR TITLE
fix: Imports for the ConfluenceLoader:process_page

### DIFF
--- a/libs/langchain/langchain/document_loaders/confluence.py
+++ b/libs/langchain/langchain/document_loaders/confluence.py
@@ -431,24 +431,7 @@ class ConfluenceLoader(BaseLoader):
         ocr_languages: Optional[str] = None,
         keep_markdown_format: Optional[bool] = False,
     ) -> Document:
-        if include_comments and keep_markdown_format:
-            try:
-                from bs4 import BeautifulSoup  # type: ignore
-                from markdownify import markdownify
-            except ImportError:
-                raise ImportError(
-                    "`beautifulsoup4` and  `markdownify` packages not found, please run "
-                    "`pip install beautifulsoup4 markdownify`"
-                )
-        elif include_comments or not keep_markdown_format:
-            try:
-                from bs4 import BeautifulSoup  # type: ignore
-            except ImportError:
-                raise ImportError(
-                    "`beautifulsoup4` package not found, please run "
-                    "`pip install beautifulsoup4`"
-                )
-        else:
+        if keep_markdown_format:
             try:
                 from markdownify import markdownify
             except ImportError:
@@ -456,7 +439,14 @@ class ConfluenceLoader(BaseLoader):
                     "`markdownify` package not found, please run "
                     "`pip install markdownify`"
                 )
-
+        if include_comments or not keep_markdown_format:
+            try:
+                from bs4 import BeautifulSoup  # type: ignore
+            except ImportError:
+                raise ImportError(
+                    "`beautifulsoup4` package not found, please run "
+                    "`pip install beautifulsoup4`"
+                )
         if include_attachments:
             attachment_texts = self.process_attachment(page["id"], ocr_languages)
         else:

--- a/libs/langchain/langchain/document_loaders/confluence.py
+++ b/libs/langchain/langchain/document_loaders/confluence.py
@@ -431,21 +431,30 @@ class ConfluenceLoader(BaseLoader):
         ocr_languages: Optional[str] = None,
         keep_markdown_format: Optional[bool] = False,
     ) -> Document:
-        if keep_markdown_format:
+        if include_comments and keep_markdown_format:
             try:
+                from bs4 import BeautifulSoup  # type: ignore
                 from markdownify import markdownify
             except ImportError:
                 raise ImportError(
-                    "`markdownify` package not found, please run "
-                    "`pip install markdownify`"
+                    "`beautifulsoup4` and  `markdownify` packages not found, please run "
+                    "`pip install beautifulsoup4 markdownify`"
                 )
-        else:
+        elif include_comments or not keep_markdown_format:
             try:
                 from bs4 import BeautifulSoup  # type: ignore
             except ImportError:
                 raise ImportError(
                     "`beautifulsoup4` package not found, please run "
                     "`pip install beautifulsoup4`"
+                )
+        else:
+            try:
+                from markdownify import markdownify
+            except ImportError:
+                raise ImportError(
+                    "`markdownify` package not found, please run "
+                    "`pip install markdownify`"
                 )
 
         if include_attachments:


### PR DESCRIPTION
### Description
When we're loading documents using `ConfluenceLoader`:`load` function and, if both `include_comments=True` and `keep_markdown_format=True`, we're getting an error saying `NameError: free variable 'BeautifulSoup' referenced before assignment in enclosing scope`.
    
    loader = ConfluenceLoader(url="URI", token="TOKEN")
    documents = loader.load(
        space_key="SPACE", 
        include_comments=True, 
        keep_markdown_format=True, 
    )

This happens because previous imports only consider the `keep_markdown_format` parameter, however to include the comments, it's using `BeautifulSoup`

Now it's fixed to handle all four scenarios considering both `include_comments` and `keep_markdown_format`.

### Twitter
`@SathinduGA`