### PR TITLE
doc: make install from source more clearer

### DIFF
--- a/docs/snippets/get_started/installation.mdx
+++ b/docs/snippets/get_started/installation.mdx
@@ -40,7 +40,7 @@ pip install 'langchain[all]'
 
 ## From source
 
-If you want to install from source, you can do so by cloning the repo and running:
+If you want to install from source, you can do so by cloning the repo and be sure that the directory is `PATH/TO/REPO/langchain/libs/langchain` running:
 
 ```bash
 pip install -e .


### PR DESCRIPTION
Description: if just `pip install -e .` it will not install anything, we have to find the right directory to do `pip install -e .`