### PR TITLE
Issue 9401 - SequentialChain runs the same callbacks over and over in async mode

### DIFF
--- a/libs/langchain/langchain/chains/sequential.py
+++ b/libs/langchain/langchain/chains/sequential.py
@@ -191,11 +191,10 @@ class SimpleSequentialChain(Chain):
         run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
     ) -> Dict[str, Any]:
         _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
-        callbacks = _run_manager.get_child()
         _input = inputs[self.input_key]
         color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])
         for i, chain in enumerate(self.chains):
-            _input = await chain.arun(_input, callbacks=callbacks)
+            _input = await chain.arun(_input, callbacks=_run_manager.get_child(f"step_{i+1}"))
             if self.strip_outputs:
                 _input = _input.strip()
             await _run_manager.on_text(

--- a/libs/langchain/langchain/chains/sequential.py
+++ b/libs/langchain/langchain/chains/sequential.py
@@ -194,7 +194,9 @@ class SimpleSequentialChain(Chain):
         _input = inputs[self.input_key]
         color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])
         for i, chain in enumerate(self.chains):
-            _input = await chain.arun(_input, callbacks=_run_manager.get_child(f"step_{i+1}"))
+            _input = await chain.arun(
+                _input, callbacks=_run_manager.get_child(f"step_{i+1}")
+            )
             if self.strip_outputs:
                 _input = _input.strip()
             await _run_manager.on_text(

--- a/libs/langchain/tests/unit_tests/chains/test_sequential.py
+++ b/libs/langchain/tests/unit_tests/chains/test_sequential.py
@@ -3,11 +3,12 @@ from typing import Dict, List, Optional
 
 import pytest
 
-from langchain.callbacks.manager import CallbackManagerForChainRun
+from langchain.callbacks.manager import CallbackManagerForChainRun, AsyncCallbackManagerForChainRun
 from langchain.chains.base import Chain
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 from langchain.memory import ConversationBufferMemory
 from langchain.memory.simple import SimpleMemory
+from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 
 class FakeChain(Chain):
@@ -36,6 +37,13 @@ class FakeChain(Chain):
             variables = [inputs[k] for k in self.input_variables]
             outputs[var] = f"{' '.join(variables)}foo"
         return outputs
+
+    async def _acall(
+        self,
+        inputs: Dict[str, str],
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, str]:
+        return self._call(inputs, run_manager)
 
 
 def test_sequential_usage_single_inputs() -> None:
@@ -163,6 +171,29 @@ def test_simple_sequential_functionality() -> None:
     output = chain({"input": "123"})
     expected_output = {"output": "123foofoo", "input": "123"}
     assert output == expected_output
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("isAsync", [False, True])
+async def test_simple_sequential_functionality_with_callbacks(isAsync: bool) -> None:
+    """Test simple sequential functionality."""
+    handler_1 = FakeCallbackHandler()
+    handler_2 = FakeCallbackHandler()
+    handler_3 = FakeCallbackHandler()
+    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"], callbacks=[handler_1])
+    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"], callbacks=[handler_2])
+    chain_3 = FakeChain(input_variables=["jack"], output_variables=["baf"], callbacks=[handler_3])
+    chain = SimpleSequentialChain(chains=[chain_1, chain_2, chain_3])
+    if isAsync:
+        output = await chain.ainvoke({"input": "123"})
+    else:
+        output = chain({"input": "123"})
+    expected_output = {"output": "123foofoofoo", "input": "123"}
+    assert output == expected_output
+    # Check that each of the callbacks were invoked once per the entire run
+    for handler in [handler_1, handler_2, handler_3]:
+        assert handler.starts == 1
+        assert handler.ends == 1
+        assert handler.errors == 0
 
 
 def test_multi_input_errors() -> None:

--- a/libs/langchain/tests/unit_tests/chains/test_sequential.py
+++ b/libs/langchain/tests/unit_tests/chains/test_sequential.py
@@ -3,11 +3,15 @@ from typing import Dict, List, Optional
 
 import pytest
 
-from langchain.callbacks.manager import CallbackManagerForChainRun, AsyncCallbackManagerForChainRun
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
 from langchain.chains.base import Chain
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 from langchain.memory import ConversationBufferMemory
 from langchain.memory.simple import SimpleMemory
+
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 
@@ -176,6 +180,7 @@ def test_simple_sequential_functionality() -> None:
     expected_output = {"output": "123foofoo", "input": "123"}
     assert output == expected_output
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("isAsync", [False, True])
 async def test_simple_sequential_functionality_with_callbacks(isAsync: bool) -> None:
@@ -183,9 +188,15 @@ async def test_simple_sequential_functionality_with_callbacks(isAsync: bool) -> 
     handler_1 = FakeCallbackHandler()
     handler_2 = FakeCallbackHandler()
     handler_3 = FakeCallbackHandler()
-    chain_1 = FakeChain(input_variables=["foo"], output_variables=["bar"], callbacks=[handler_1])
-    chain_2 = FakeChain(input_variables=["bar"], output_variables=["baz"], callbacks=[handler_2])
-    chain_3 = FakeChain(input_variables=["jack"], output_variables=["baf"], callbacks=[handler_3])
+    chain_1 = FakeChain(
+        input_variables=["foo"], output_variables=["bar"], callbacks=[handler_1]
+    )
+    chain_2 = FakeChain(
+        input_variables=["bar"], output_variables=["baz"], callbacks=[handler_2]
+    )
+    chain_3 = FakeChain(
+        input_variables=["jack"], output_variables=["baf"], callbacks=[handler_3]
+    )
     chain = SimpleSequentialChain(chains=[chain_1, chain_2, chain_3])
     if isAsync:
         output = await chain.ainvoke({"input": "123"})

--- a/libs/langchain/tests/unit_tests/chains/test_sequential.py
+++ b/libs/langchain/tests/unit_tests/chains/test_sequential.py
@@ -43,7 +43,11 @@ class FakeChain(Chain):
         inputs: Dict[str, str],
         run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
     ) -> Dict[str, str]:
-        return self._call(inputs, run_manager)
+        outputs = {}
+        for var in self.output_variables:
+            variables = [inputs[k] for k in self.input_variables]
+            outputs[var] = f"{' '.join(variables)}foo"
+        return outputs
 
 
 def test_sequential_usage_single_inputs() -> None:

--- a/libs/langchain/tests/unit_tests/chains/test_sequential.py
+++ b/libs/langchain/tests/unit_tests/chains/test_sequential.py
@@ -11,7 +11,6 @@ from langchain.chains.base import Chain
 from langchain.chains.sequential import SequentialChain, SimpleSequentialChain
 from langchain.memory import ConversationBufferMemory
 from langchain.memory.simple import SimpleMemory
-
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 


### PR DESCRIPTION
Issue: https://github.com/langchain-ai/langchain/issues/9401

In the Async mode, SequentialChain implementation seems to run the same callbacks over and over since it is re-using the same callbacks object.

Langchain version: 0.0.264, master

The implementation of this aysnc route differs from the sync route and sync approach follows the right pattern of generating a new callbacks object instead of re-using the old one and thus avoiding the cascading run of callbacks at each step.

Async mode:
```
        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
        callbacks = _run_manager.get_child()
        ...
        for i, chain in enumerate(self.chains):
            _input = await chain.arun(_input, callbacks=callbacks)
            ...
```

Regular mode:
```
        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
        for i, chain in enumerate(self.chains):
            _input = chain.run(_input, callbacks=_run_manager.get_child(f"step_{i+1}"))
            ...
```

Notice how we are reusing the callbacks object in the Async code which will have a cascading effect as we run through the chain. It runs the same callbacks over and over resulting in issues.

Solution:
Define the async function in the same pattern as the regular one and added tests.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
