### PR TITLE
Rely on `WORKDIR` env var to avoid ugly ternary operators in workflows.

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -62,30 +62,18 @@ runs:
       run: |
         poetry lock --check
 
-    - name: Set proper Poetry.lock file
-      shell: bash
-      env:
-        WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
-      run: |
-        if [ -f "$WORKDIR/poetry.lock" ]; then
-          echo 'Using working directory poetry.lock in cache key'
-          cp "$WORKDIR/poetry.lock" poetry-lock.cache-key
-        else
-          echo 'Using the top-level poetry.lock in cache key'
-          cp poetry.lock poetry-lock.cache-key
-        fi
-
     - uses: actions/cache@v3
       id: cache-poetry
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+        WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
       with:
         path: |
           ~/.cache/pypoetry/virtualenvs
           ~/.cache/pypoetry/cache
           ~/.cache/pypoetry/artifacts
-          ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}/.venv
-        key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}-${{ inputs.cache-key }}-${{ hashFiles('poetry-lock.cache-key') }}
+          ${{ env.WORKDIR }}/.venv
+        key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}-${{ inputs.cache-key }}-${{ hashFiles(format('{0}/poetry.lock', env.WORKDIR)) }}
 
     - run: ${{ inputs.install-command }}
       working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   POETRY_VERSION: "1.4.2"
+  WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
 
 jobs:
   build:
@@ -20,7 +21,6 @@ jobs:
       # and also as small as possible since increasing the number makes
       # the initial `git fetch` slower.
       FETCH_DEPTH: 50
-      WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
     strategy:
       matrix:
         # Only lint on the min and max supported Python versions.
@@ -47,8 +47,6 @@ jobs:
         # since the previous action step just created them.
         # This command resets the mtime to the last time the files were modified in git instead,
         # which is a high-quality and stable representation of the last modification date.
-        env:
-          WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
         run: |
           # Important considerations:
           # - These commands run at base of the repo, since we never `cd` to the `WORKDIR`.
@@ -102,7 +100,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
           cache-dependency-path: |
-            ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}/**/poetry.lock
+            ${{ env.WORKDIR }}/**/poetry.lock
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
         run: |


### PR DESCRIPTION
Ternary operators in GitHub Actions syntax are pretty ugly and hard to read: `inputs.working-directory == '' && '.' || inputs.working-directory` means "if the condition is true, use `'.'` and otherwise use the expression after the `||`".

This PR performs the ternary as few times as possible, assigning its outcome to an env var we can then reuse as needed.
