### PR TITLE
`ChatPromptTemplate` is not an `ABC`, it's instantiated directly.

### DIFF
--- a/libs/langchain/langchain/prompts/chat.py
+++ b/libs/langchain/langchain/prompts/chat.py
@@ -337,7 +337,7 @@ MessageLikeRepresentation = Union[
 ]
 
 
-class ChatPromptTemplate(BaseChatPromptTemplate, ABC):
+class ChatPromptTemplate(BaseChatPromptTemplate):
     """A prompt template for chat models.
 
     Use to create flexible templated prompts for chat models.


### PR DESCRIPTION
Its own `__add__` method constructs `ChatPromptTemplate` objects directly, it cannot be abstract.

Found while debugging something else with @nfcampos.