### PR TITLE
fix: apply unstructured preprocess functions

### DIFF
--- a/docs/extras/integrations/document_loaders/unstructured_file.ipynb
+++ b/docs/extras/integrations/document_loaders/unstructured_file.ipynb
@@ -299,7 +299,7 @@
    "id": "1cf27fc8",
    "metadata": {},
    "source": [
-    "If you need to post process the `unstructured` elements after extraction, you can pass in a list of `Element` -> `Element` functions to the `post_processors` kwarg when you instantiate the `UnstructuredFileLoader`. This applies to other Unstructured loaders as well. Below is an example. Post processors are only applied if you run the loader in `\"elements\"` mode."
+    "If you need to post process the `unstructured` elements after extraction, you can pass in a list of `str` -> `str` functions to the `post_processors` kwarg when you instantiate the `UnstructuredFileLoader`. This applies to other Unstructured loaders as well. Below is an example."
    ]
   },
   {
@@ -495,7 +495,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/libs/langchain/langchain/document_loaders/unstructured.py
+++ b/libs/langchain/langchain/document_loaders/unstructured.py
@@ -74,7 +74,7 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
 
     def _post_process_elements(self, elements: list) -> list:
         """Applies post processing functions to extracted unstructured elements.
-        Post processing functions are Element -> Element callables are passed
+        Post processing functions are str -> str callables are passed
         in using the post_processors kwarg when the loader is instantiated."""
         for element in elements:
             for post_processor in self.post_processors:
@@ -84,6 +84,7 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
     def load(self) -> List[Document]:
         """Load file."""
         elements = self._get_elements()
+        self._post_process_elements(elements)
         if self.mode == "elements":
             docs: List[Document] = list()
             for element in elements:

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -373,7 +373,7 @@ build-backend = "poetry.core.masonry.api"
 #
 # https://github.com/tophat/syrupy
 # --snapshot-warn-unused    Prints a warning on unused snapshots rather than fail the test suite.
-addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused"
+addopts = "--strict-markers --strict-config --durations=5" # --snapshot-warn-unused"
 # Registering custom markers.
 # https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers
 markers = [

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -373,7 +373,7 @@ build-backend = "poetry.core.masonry.api"
 #
 # https://github.com/tophat/syrupy
 # --snapshot-warn-unused    Prints a warning on unused snapshots rather than fail the test suite.
-addopts = "--strict-markers --strict-config --durations=5" # --snapshot-warn-unused"
+addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused"
 # Registering custom markers.
 # https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers
 markers = [

--- a/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
@@ -12,18 +12,19 @@ EXAMPLE_DOCS_DIRECTORY = str(Path(__file__).parent.parent / "examples/")
 
 
 def test_unstructured_loader_with_post_processor() -> None:
-    from unstructured.cleaners.core import clean_extra_whitespace
+    add_the_end = lambda text: text + "THE END!"
 
     file_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf")
     loader = UnstructuredFileLoader(
         file_path=file_path,
-        pos_processors=[clean_extra_whitespace],
+        post_processors=[add_the_end],
         strategy="fast",
         mode="elements",
     )
     docs = loader.load()
 
     assert len(docs) > 1
+    assert docs[0].page_content.endswith("THE END!")
 
 
 def test_unstructured_api_file_loader() -> None:

--- a/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
@@ -12,7 +12,8 @@ EXAMPLE_DOCS_DIRECTORY = str(Path(__file__).parent.parent / "examples/")
 
 
 def test_unstructured_loader_with_post_processor() -> None:
-    add_the_end = lambda text: text + "THE END!"
+    def add_the_end(text: str):
+        return text + "THE END!"
 
     file_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf")
     loader = UnstructuredFileLoader(

--- a/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
@@ -12,7 +12,7 @@ EXAMPLE_DOCS_DIRECTORY = str(Path(__file__).parent.parent / "examples/")
 
 
 def test_unstructured_loader_with_post_processor() -> None:
-    def add_the_end(text: str):
+    def add_the_end(text: str) -> None:
         return text + "THE END!"
 
     file_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf")

--- a/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_unstructured.py
@@ -12,7 +12,7 @@ EXAMPLE_DOCS_DIRECTORY = str(Path(__file__).parent.parent / "examples/")
 
 
 def test_unstructured_loader_with_post_processor() -> None:
-    def add_the_end(text: str) -> None:
+    def add_the_end(text: str) -> str:
         return text + "THE END!"
 
     file_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper.pdf")


### PR DESCRIPTION
### Summary

Fixes a bug from #7850 where post processing functions in Unstructured loaders were not apply. Adds a assertion to the test to verify the post processing function was applied and also updates the explanation in the example notebook.