### PR TITLE
Fix bash test regex for Linux under WSL2.

### DIFF
--- a/libs/langchain/tests/unit_tests/test_bash.py
+++ b/libs/langchain/tests/unit_tests/test_bash.py
@@ -56,7 +56,9 @@ def test_incorrect_command_return_err_output() -> None:
     """Test optional returning of shell output on incorrect command."""
     session = BashProcess(return_err_output=True)
     output = session.run(["invalid_command"])
-    assert re.match(r"^/bin/sh:.*invalid_command.*not found.*$", output)
+    assert re.match(
+        r"^/bin/sh:.*invalid_command.*(?:not found|Permission denied).*$", output
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
It fails with `Permission denied` and not `not found`. Both seem reasonable.
