### PR TITLE
Added misssing model name to GPT4AllEmbeddings.

### DIFF
--- a/libs/langchain/langchain/embeddings/gpt4all.py
+++ b/libs/langchain/langchain/embeddings/gpt4all.py
@@ -18,6 +18,7 @@ class GPT4AllEmbeddings(BaseModel, Embeddings):
     """
 
     client: Any  #: :meta private:
+    model: str = 'ggml-all-MiniLM-L6-v2-f16'
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:


### PR DESCRIPTION
  - Description:  Added model name to `GPT4AllEmbeddings`. Apparently, when we use `CacheBackedEmbeddings`, we must provide a namespace so our doc embeddings with different model ids remain distinct. This change makes it easy to add name from the model.  
https://python.langchain.com/docs/modules/data_connection/caching_embeddings
  - Dependencies: None
  - Tag maintainer: @baskaryan
