### PR TITLE
Anthropic: Allow the use of kwargs consistent with ChatOpenAI.

### DIFF
--- a/libs/langchain/langchain/chat_models/anthropic.py
+++ b/libs/langchain/langchain/chat_models/anthropic.py
@@ -36,6 +36,12 @@ class ChatAnthropic(BaseChatModel, _AnthropicCommon):
             model = ChatAnthropic(model="<model_name>", anthropic_api_key="my-api-key")
     """
 
+    class Config:
+        """Configuration for this pydantic object."""
+
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+
     @property
     def lc_secrets(self) -> Dict[str, str]:
         return {"anthropic_api_key": "ANTHROPIC_API_KEY"}

--- a/libs/langchain/langchain/llms/anthropic.py
+++ b/libs/langchain/langchain/llms/anthropic.py
@@ -59,14 +59,15 @@ class _AnthropicCommon(BaseLanguageModel):
     def consistent_kwargs(cls, values: Dict) -> Dict:
         """Allow the use of kwargs consistent with ChatOpenAI."""
 
-        def patch_alias(original_name: str, alias_name: str):
+        def patch_alias(_values: Dict, original_name: str, alias_name: str) -> Dict:
             if alias_name in values.keys():
-                values[original_name] = values[alias_name]
+                _values[original_name] = _values[alias_name]
             else:
-                values[alias_name] = values[original_name]
+                _values[alias_name] = _values[original_name]
+            return _values
 
-        patch_alias("model", "model_name")
-        patch_alias("max_tokens_to_sample", "max_tokens")
+        values = patch_alias(values, "model", "model_name")
+        values = patch_alias(values, "max_tokens_to_sample", "max_tokens")
         return values
 
     @root_validator(pre=True)

--- a/libs/langchain/langchain/llms/anthropic.py
+++ b/libs/langchain/langchain/llms/anthropic.py
@@ -23,9 +23,13 @@ class _AnthropicCommon(BaseLanguageModel):
     async_client: Any = None  #: :meta private:
     model: str = "claude-2"
     """Model name to use."""
+    model_name: str = "claude-2"
+    """Model name to use (alias)."""
 
     max_tokens_to_sample: int = 256
     """Denotes the number of tokens to predict per generation."""
+    max_tokens: int = 256
+    """Denotes the number of tokens to predict per generation (alias)."""
 
     temperature: Optional[float] = None
     """A non-negative float that tunes the degree of randomness in generation."""
@@ -54,10 +58,15 @@ class _AnthropicCommon(BaseLanguageModel):
     @root_validator(pre=True)
     def consistent_kwargs(cls, values: Dict) -> Dict:
         """Allow the use of kwargs consistent with ChatOpenAI."""
-        if "model_name" in values.keys():
-            values["model"] = values["model_name"]
-        if "max_tokens" in values.keys():
-            values["max_tokens_to_sample"] = values["max_tokens"]
+
+        def patch_alias(original_name: str, alias_name: str):
+            if alias_name in values.keys():
+                values[original_name] = values[alias_name]
+            else:
+                values[alias_name] = values[original_name]
+
+        patch_alias("model", "model_name")
+        patch_alias("max_tokens_to_sample", "max_tokens")
         return values
 
     @root_validator(pre=True)

--- a/libs/langchain/langchain/llms/anthropic.py
+++ b/libs/langchain/langchain/llms/anthropic.py
@@ -52,6 +52,15 @@ class _AnthropicCommon(BaseLanguageModel):
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
 
     @root_validator(pre=True)
+    def consistent_kwargs(cls, values: Dict) -> Dict:
+        """Allow the use of kwargs consistent with ChatOpenAI."""
+        if "model_name" in values.keys():
+            values["model"] = values["model_name"]
+        if "max_tokens" in values.keys():
+            values["max_tokens_to_sample"] = values["max_tokens"]
+        return values
+
+    @root_validator(pre=True)
     def build_extra(cls, values: Dict) -> Dict:
         extra = values.get("model_kwargs", {})
         all_required_field_names = get_pydantic_field_names(cls)

--- a/libs/langchain/langchain/llms/anthropic.py
+++ b/libs/langchain/langchain/llms/anthropic.py
@@ -21,15 +21,11 @@ from langchain.utils.utils import build_extra_kwargs
 class _AnthropicCommon(BaseLanguageModel):
     client: Any = None  #: :meta private:
     async_client: Any = None  #: :meta private:
-    model: str = "claude-2"
+    model: str = Field(default="claude-2", alias="model_name")
     """Model name to use."""
-    model_name: str = "claude-2"
-    """Model name to use (alias)."""
 
-    max_tokens_to_sample: int = 256
+    max_tokens_to_sample: int = Field(default=256, alias="max_tokens")
     """Denotes the number of tokens to predict per generation."""
-    max_tokens: int = 256
-    """Denotes the number of tokens to predict per generation (alias)."""
 
     temperature: Optional[float] = None
     """A non-negative float that tunes the degree of randomness in generation."""
@@ -54,21 +50,6 @@ class _AnthropicCommon(BaseLanguageModel):
     AI_PROMPT: Optional[str] = None
     count_tokens: Optional[Callable[[str], int]] = None
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
-
-    @root_validator(pre=True)
-    def consistent_kwargs(cls, values: Dict) -> Dict:
-        """Allow the use of kwargs consistent with ChatOpenAI."""
-
-        def patch_alias(_values: Dict, original_name: str, alias_name: str) -> Dict:
-            if alias_name in values.keys():
-                _values[original_name] = _values[alias_name]
-            else:
-                _values[alias_name] = _values[original_name]
-            return _values
-
-        values = patch_alias(values, "model", "model_name")
-        values = patch_alias(values, "max_tokens_to_sample", "max_tokens")
-        return values
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict) -> Dict:

--- a/libs/langchain/langchain/llms/anthropic.py
+++ b/libs/langchain/langchain/llms/anthropic.py
@@ -144,6 +144,7 @@ class Anthropic(LLM, _AnthropicCommon):
 
             import anthropic
             from langchain.llms import Anthropic
+
             model = Anthropic(model="<model_name>", anthropic_api_key="my-api-key")
 
             # Simplest invocation, automatically wrapped with HUMAN_PROMPT
@@ -156,6 +157,12 @@ class Anthropic(LLM, _AnthropicCommon):
             prompt = f"{anthropic.HUMAN_PROMPT} {prompt}{anthropic.AI_PROMPT}"
             response = model(prompt)
     """
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
 
     @root_validator()
     def raise_warning(cls, values: Dict) -> Dict:

--- a/libs/langchain/tests/integration_tests/chat_models/test_anthropic_2.py
+++ b/libs/langchain/tests/integration_tests/chat_models/test_anthropic_2.py
@@ -9,6 +9,18 @@ os.environ["ANTHROPIC_API_KEY"] = "foo"
 
 
 @pytest.mark.requires("anthropic")
+def test_anthropic_model_name_param() -> None:
+    llm = ChatAnthropic(model_name="foo")
+    assert llm.model == "foo"
+
+
+@pytest.mark.requires("anthropic")
+def test_anthropic_model_param() -> None:
+    llm = ChatAnthropic(model="foo")
+    assert llm.model == "foo"
+
+
+@pytest.mark.requires("anthropic")
 def test_anthropic_model_kwargs() -> None:
     llm = ChatAnthropic(model_kwargs={"foo": "bar"})
     assert llm.model_kwargs == {"foo": "bar"}

--- a/libs/langchain/tests/integration_tests/llms/test_anthropic.py
+++ b/libs/langchain/tests/integration_tests/llms/test_anthropic.py
@@ -9,6 +9,18 @@ from langchain.schema import LLMResult
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
 
+@pytest.mark.requires("anthropic")
+def test_anthropic_model_name_param() -> None:
+    llm = Anthropic(model_name="foo")
+    assert llm.model == "foo"
+
+
+@pytest.mark.requires("anthropic")
+def test_anthropic_model_param() -> None:
+    llm = Anthropic(model="foo")
+    assert llm.model == "foo"
+
+
 def test_anthropic_call() -> None:
     """Test valid call to anthropic."""
     llm = Anthropic(model="claude-instant-1")
@@ -24,7 +36,7 @@ def test_anthropic_streaming() -> None:
     assert isinstance(generator, Generator)
 
     for token in generator:
-        assert isinstance(token["completion"], str)
+        assert isinstance(token, str)
 
 
 def test_anthropic_streaming_callback() -> None:

--- a/libs/langchain/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_openai.py
@@ -6,15 +6,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from langchain.adapters.openai import convert_dict_to_message
-from langchain.chat_models.openai import (
-    ChatOpenAI,
-)
+from langchain.chat_models.openai import ChatOpenAI
 from langchain.schema.messages import (
     AIMessage,
     FunctionMessage,
     HumanMessage,
     SystemMessage,
 )
+
+
+@pytest.mark.requires("openai")
+def test_openai_model_param() -> None:
+    llm = ChatOpenAI(model="foo")
+    assert llm.model_name == "foo"
+    llm = ChatOpenAI(model_name="foo")
+    assert llm.model_name == "foo"
 
 
 def test_function_message_dict_to_function_message() -> None:


### PR DESCRIPTION
  - Description: ~~Creates a new root_validator in `_AnthropicCommon` that allows the use of `model_name` and `max_tokens` keyword arguments.~~ Adds pydantic field aliases to support `model_name` and `max_tokens` as keyword arguments. Ultimately, this makes `ChatAnthropic` more consistent with `ChatOpenAI`, making the two classes more interchangeable for the developer.
  - Issue: https://github.com/langchain-ai/langchain/issues/9510