### PR TITLE
feat(streaming_aiter.py): add support for multiple LLM runs in a AsyncIteratorCallbackHandler

### DIFF
--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, Dict, List, Literal, Union, cast, Optional
+from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Union, cast
 
 from langchain.callbacks.base import AsyncCallbackHandler
 from langchain.schema.output import LLMResult

--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -1,41 +1,59 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, Dict, List, Literal, Union, cast
+from typing import Any, AsyncIterator, Dict, List, Literal, Union, cast, Optional
 
 from langchain.callbacks.base import AsyncCallbackHandler
 from langchain.schema.output import LLMResult
 
-# TODO If used by two LLM runs in parallel this won't work as expected
+
+class Run:
+    def __init__(self):
+        self.queue = asyncio.Queue()
+        self.done = asyncio.Event()
 
 
 class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
     """Callback handler that returns an async iterator."""
 
-    queue: asyncio.Queue[str]
-
-    done: asyncio.Event
+    runs_queue: asyncio.Queue[Run]
+    current_run: Optional[Run] = None
+    all_done: asyncio.Event
+    pending_runs: int
 
     @property
     def always_verbose(self) -> bool:
         return True
 
     def __init__(self) -> None:
-        self.queue = asyncio.Queue()
-        self.done = asyncio.Event()
+        self.runs_queue = asyncio.Queue()
+        self.all_done = asyncio.Event()
+        self.pending_runs = 0
 
     async def on_llm_start(
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> None:
         # If two calls are made in a row, this resets the state
-        self.done.clear()
+        self.current_run = Run()
+        self.runs_queue.put_nowait(self.current_run)
+        self.pending_runs += 1
 
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         if token is not None and token != "":
-            self.queue.put_nowait(token)
+            self.current_run.queue.put_nowait(token)
 
     async def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        self.done.set()
+        self.current_run.done.set()
+        # When a Run object ends, decrement pending_runs
+        self.pending_runs -= 1
+        # If there are no running Run objects
+        # wait for a while for new Run objects to have a chance to start
+        # and if there are still no running Run objects
+        # set the all_done event
+        if self.pending_runs == 0:
+            await asyncio.sleep(1)
+            if self.pending_runs == 0:
+                self.all_done.set()
 
     async def on_llm_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
@@ -45,29 +63,37 @@ class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
     # TODO implement the other methods
 
     async def aiter(self) -> AsyncIterator[str]:
-        while not self.queue.empty() or not self.done.is_set():
-            # Wait for the next token in the queue,
-            # but stop waiting if the done event is set
-            done, other = await asyncio.wait(
-                [
-                    # NOTE: If you add other tasks here, update the code below,
-                    # which assumes each set has exactly one task each
-                    asyncio.ensure_future(self.queue.get()),
-                    asyncio.ensure_future(self.done.wait()),
-                ],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+        while not self.all_done.is_set():
+            if self.current_run is None or self.current_run.done.is_set():
+                try:
+                    self.current_run = await self.runs_queue.get()
+                except asyncio.QueueEmpty:
+                    break
+            while (
+                not self.current_run.queue.empty() or not self.current_run.done.is_set()
+            ):
+                # Wait for the next token in the queue,
+                # but stop waiting if the done event is set
+                done, other = await asyncio.wait(
+                    [
+                        # NOTE: If you add other tasks here, update the code below,
+                        # which assumes each set has exactly one task each
+                        asyncio.ensure_future(self.current_run.queue.get()),
+                        asyncio.ensure_future(self.current_run.done.wait()),
+                    ],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
 
-            # Cancel the other task
-            if other:
-                other.pop().cancel()
+                # Cancel the other task
+                if other:
+                    other.pop().cancel()
 
-            # Extract the value of the first completed task
-            token_or_done = cast(Union[str, Literal[True]], done.pop().result())
+                # Extract the value of the first completed task
+                token_or_done = cast(Union[str, Literal[True]], done.pop().result())
 
-            # If the extracted value is the boolean True, the done event was set
-            if token_or_done is True:
-                break
+                # If the extracted value is the boolean True, the done event was set
+                if token_or_done is True:
+                    break
 
-            # Otherwise, the extracted value is a token, which we yield
-            yield token_or_done
+                # Otherwise, the extracted value is a token, which we yield
+                yield token_or_done

--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -35,6 +35,9 @@ class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
             self.queue.put_nowait(token)
 
     async def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        # Keeps the asynchronous iterator (aiter) running if text is not generated.
+        # This ensures that aiter does not terminate at the first occurrence of
+        # on_llm_end when using function calling.
         if (
             response.generations[0][0].text is not None
             and response.generations[0][0].text != ""

--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -1,59 +1,45 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Union, cast
+from typing import Any, AsyncIterator, Dict, List, Literal, Union, cast
 
 from langchain.callbacks.base import AsyncCallbackHandler
 from langchain.schema.output import LLMResult
 
-
-class Run:
-    def __init__(self):
-        self.queue = asyncio.Queue()
-        self.done = asyncio.Event()
+# TODO If used by two LLM runs in parallel this won't work as expected
 
 
 class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
     """Callback handler that returns an async iterator."""
 
-    runs_queue: asyncio.Queue[Run]
-    current_run: Optional[Run] = None
-    all_done: asyncio.Event
-    pending_runs: int
+    queue: asyncio.Queue[str]
+
+    done: asyncio.Event
 
     @property
     def always_verbose(self) -> bool:
         return True
 
     def __init__(self) -> None:
-        self.runs_queue = asyncio.Queue()
-        self.all_done = asyncio.Event()
-        self.pending_runs = 0
+        self.queue = asyncio.Queue()
+        self.done = asyncio.Event()
 
     async def on_llm_start(
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> None:
         # If two calls are made in a row, this resets the state
-        self.current_run = Run()
-        self.runs_queue.put_nowait(self.current_run)
-        self.pending_runs += 1
+        self.done.clear()
 
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         if token is not None and token != "":
-            self.current_run.queue.put_nowait(token)
+            self.queue.put_nowait(token)
 
     async def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        self.current_run.done.set()
-        # When a Run object ends, decrement pending_runs
-        self.pending_runs -= 1
-        # If there are no running Run objects
-        # wait for a while for new Run objects to have a chance to start
-        # and if there are still no running Run objects
-        # set the all_done event
-        if self.pending_runs == 0:
-            await asyncio.sleep(1)
-            if self.pending_runs == 0:
-                self.all_done.set()
+        if (
+            response.generations[0][0].text is not None
+            and response.generations[0][0].text != ""
+        ):
+            self.done.set()
 
     async def on_llm_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
@@ -63,37 +49,29 @@ class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
     # TODO implement the other methods
 
     async def aiter(self) -> AsyncIterator[str]:
-        while not self.all_done.is_set():
-            if self.current_run is None or self.current_run.done.is_set():
-                try:
-                    self.current_run = await self.runs_queue.get()
-                except asyncio.QueueEmpty:
-                    break
-            while (
-                not self.current_run.queue.empty() or not self.current_run.done.is_set()
-            ):
-                # Wait for the next token in the queue,
-                # but stop waiting if the done event is set
-                done, other = await asyncio.wait(
-                    [
-                        # NOTE: If you add other tasks here, update the code below,
-                        # which assumes each set has exactly one task each
-                        asyncio.ensure_future(self.current_run.queue.get()),
-                        asyncio.ensure_future(self.current_run.done.wait()),
-                    ],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
+        while not self.queue.empty() or not self.done.is_set():
+            # Wait for the next token in the queue,
+            # but stop waiting if the done event is set
+            done, other = await asyncio.wait(
+                [
+                    # NOTE: If you add other tasks here, update the code below,
+                    # which assumes each set has exactly one task each
+                    asyncio.ensure_future(self.queue.get()),
+                    asyncio.ensure_future(self.done.wait()),
+                ],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
 
-                # Cancel the other task
-                if other:
-                    other.pop().cancel()
+            # Cancel the other task
+            if other:
+                other.pop().cancel()
 
-                # Extract the value of the first completed task
-                token_or_done = cast(Union[str, Literal[True]], done.pop().result())
+            # Extract the value of the first completed task
+            token_or_done = cast(Union[str, Literal[True]], done.pop().result())
 
-                # If the extracted value is the boolean True, the done event was set
-                if token_or_done is True:
-                    break
+            # If the extracted value is the boolean True, the done event was set
+            if token_or_done is True:
+                break
 
-                # Otherwise, the extracted value is a token, which we yield
-                yield token_or_done
+            # Otherwise, the extracted value is a token, which we yield
+            yield token_or_done


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->

- Description: When I want to integrate LangChain into my Poe-API Project, which aims to provide multiple OpenAI functions for users, I write code based on https://github.com/langchain-ai/langchain-template-poe-fastapi/blob/main/langchain_template_poe_fastapi/handler.py
  ```py
  class EchoBot(PoeBot):
    async def get_response(self, query):
        callback_handler = AsyncIteratorCallbackHandler()

        mode = ChatOpenAI(
            temperature=0,
            model="gpt-3.5-turbo",
            streaming=True,
            callbacks=[callback_handler],
        )

        memory = convert_poe_messages(query.query)

        agent = initialize_agent(
            tools,
            llm=mode,
            agent=AgentType.OPENAI_FUNCTIONS,
            verbose=True,
            agent_kwargs={
                "extra_prompt_messages": [MessagesPlaceholder(variable_name="memory")],
            },
            memory=memory,
        )

        logging.info(query.query)

        last_message = query.query[-1].content
        run = asyncio.create_task(agent.arun(last_message))

        # Yield the tokens as they come in
        async for token in callback_handler.aiter():
            yield self.text_event(token)
        # Await the chain run
        await run
  ```
  However, I have noticed that it is not functioning properly. Example of each run process: `__init__ -> aiter -> on_llm_start -> on_llm_end -> on_llm_start ->on_llm_end`, `aiter` will end at the first `on_llm_end`. 
  The purpose of this PR is to ensure that `aiter` does not terminate at the first occurrence of `on_llm_end` when `LLMResult` has no any output message.

- Issue: https://github.com/langchain-ai/langchain/issues/9374

- Dependencies: None
