### PR TITLE
Release on push to `master` instead of on closed PRs targeting it.

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -13,9 +13,8 @@ env:
 
 jobs:
   if_release:
-    if: |
-        github.event.pull_request.merged == true
-        && contains(github.event.pull_request.labels.*.name, 'release')
+    # Disallow publishing from branches that aren't `master`.
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/langchain_experimental_release.yml
+++ b/.github/workflows/langchain_experimental_release.yml
@@ -2,9 +2,7 @@
 name: libs/experimental Release
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
     paths:

--- a/.github/workflows/langchain_release.yml
+++ b/.github/workflows/langchain_release.yml
@@ -2,9 +2,7 @@
 name: libs/langchain Release
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
     paths:


### PR DESCRIPTION
This is safer than the prior approach, since it's safe by default: the release workflows never get triggered for non-merged PRs, so there's no possibility of a buggy conditional accidentally letting a workflow proceed when it shouldn't have.

The only loss is that publishing no longer requires a `release` label on the merged PR that bumps the version. We can add a separate CI step that enforces that part as a condition for merging into `master`, if desirable.
