### PR TITLE
Add additional_kwargs to BasePromptTemplate, allow use in ChatPromptTemplate

### DIFF
--- a/libs/langchain/langchain/prompts/chat.py
+++ b/libs/langchain/langchain/prompts/chat.py
@@ -489,6 +489,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
     def from_messages(
         cls,
         messages: Sequence[MessageLikeRepresentation],
+        **kwargs: Any,
     ) -> ChatPromptTemplate:
         """Create a chat prompt template from a variety of message formats.
 
@@ -534,7 +535,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
             ):
                 input_vars.update(_message.input_variables)
 
-        return cls(input_variables=sorted(input_vars), messages=_messages)
+        return cls(input_variables=sorted(input_vars), messages=_messages, **kwargs)
 
     def format(self, **kwargs: Any) -> str:
         """Format the chat template into a string.

--- a/libs/langchain/langchain/schema/prompt_template.py
+++ b/libs/langchain/langchain/schema/prompt_template.py
@@ -25,6 +25,8 @@ class BasePromptTemplate(Serializable, Runnable[Dict, PromptValue], ABC):
     partial_variables: Mapping[str, Union[str, Callable[[], str]]] = Field(
         default_factory=dict
     )
+    additional_kwargs: dict = Field(default_factory=dict)
+    """Additional keyword arguments to pass to the prompt template."""
 
     @property
     def lc_serializable(self) -> bool:


### PR DESCRIPTION
It can be useful to annotate templates with 3rd party metadata using `additional_kwargs` - this already works for `BaseStringMessagePromptTemplate` and `BaseMessage` but this wasn't yet wired up to `BasePromptTemplate`

I added this field and also allowed `ChatPromptTemplate.from_messages()` (derived from `BasePromptTemplate`) to pass on `**kwargs` so that you could use it in that way, also consistent with other classmethods in that file.

Tagging @hwchase17 and @eyurtsev for template/prompt stuff

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
