### PR TITLE
bugfix: ArangoDB Empty Schema Case 

### DIFF
--- a/libs/langchain/langchain/graphs/arangodb_graph.py
+++ b/libs/langchain/langchain/graphs/arangodb_graph.py
@@ -66,6 +66,10 @@ class ArangoGraph:
             col_type: str = collection["type"]
             col_size: int = self.db.collection(col_name).count()
 
+            # Skip collection if empty
+            if col_size == 0:
+                continue
+
             # Set number of ArangoDB documents/edges to retrieve
             limit_amount = ceil(sample_ratio * col_size) or 1
 

--- a/libs/langchain/tests/integration_tests/chains/test_graph_database_arangodb.py
+++ b/libs/langchain/tests/integration_tests/chains/test_graph_database_arangodb.py
@@ -54,6 +54,7 @@ def test_connect_arangodb() -> None:
     sample_aql_result = graph.query("RETURN 'hello world'")
     assert ["hello_world"] == sample_aql_result
 
+
 def test_empty_schema_on_no_data() -> None:
     """Test that the schema is empty for an empty ArangoDB Database"""
     db = get_arangodb_client()

--- a/libs/langchain/tests/integration_tests/chains/test_graph_database_arangodb.py
+++ b/libs/langchain/tests/integration_tests/chains/test_graph_database_arangodb.py
@@ -65,8 +65,9 @@ def test_empty_schema_on_no_data() -> None:
 
     assert graph.schema == {
         "Graph Schema": [],
-        "Collection Schema": []
+        "Collection Schema": [],
     }
+
 
 def test_aql_generation() -> None:
     """Test that AQL statement is correctly generated and executed."""

--- a/libs/langchain/tests/integration_tests/chains/test_graph_database_arangodb.py
+++ b/libs/langchain/tests/integration_tests/chains/test_graph_database_arangodb.py
@@ -54,6 +54,19 @@ def test_connect_arangodb() -> None:
     sample_aql_result = graph.query("RETURN 'hello world'")
     assert ["hello_world"] == sample_aql_result
 
+def test_empty_schema_on_no_data() -> None:
+    """Test that the schema is empty for an empty ArangoDB Database"""
+    db = get_arangodb_client()
+    db.delete_graph("GameOfThrones", drop_collections=True, ignore_missing=True)
+    db.delete_collection("empty_collection", ignore_missing=True)
+    db.create_collection("empty_collection")
+
+    graph = ArangoGraph(db)
+
+    assert graph.schema == {
+        "Graph Schema": [],
+        "Collection Schema": []
+    }
 
 def test_aql_generation() -> None:
     """Test that AQL statement is correctly generated and executed."""


### PR DESCRIPTION
- Introduces a conditional in `ArangoGraph.generate_schema()` to exclude empty ArangoDB Collections from the schema
- Add empty collection test case

Issue: N/A
Dependencies: None