### PR TITLE
import tqdm.auto instead of tqdm tqdm for OpenAIEmbeddings

### DIFF
--- a/libs/langchain/langchain/embeddings/openai.py
+++ b/libs/langchain/langchain/embeddings/openai.py
@@ -352,9 +352,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
 
         if self.show_progress_bar:
             try:
-                import tqdm
+                from tqdm.auto import tqdm
 
-                _iter = tqdm.tqdm(range(0, len(tokens), _chunk_size))
+                _iter = tqdm(range(0, len(tokens), _chunk_size))
             except ImportError:
                 _iter = range(0, len(tokens), _chunk_size)
         else:


### PR DESCRIPTION
  - Description: current code does not work very well on jupyter notebook, so I changed the code so that it imports `tqdm.auto` instead.
  - Issue: #9582 
  - Dependencies: N/A
  - Tag maintainer: @hwchase17, @baskaryan
  - Twitter handle: N/A