### PR TITLE
Fix ChatMessageHistory

### DIFF
--- a/libs/langchain/langchain/memory/chat_message_histories/in_memory.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/in_memory.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from langchain.pydantic_v1 import BaseModel
+from langchain.pydantic_v1 import BaseModel, Field
 from langchain.schema import (
     BaseChatMessageHistory,
 )
@@ -13,7 +13,7 @@ class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
     Stores messages in an in memory list.
     """
 
-    messages: List[BaseMessage] = []
+    messages: List[BaseMessage] = Field(default_factory=list)
 
     def add_message(self, message: BaseMessage) -> None:
         """Add a self-created message to the store"""


### PR DESCRIPTION
The initialization of the array of ChatMessageHistory is buggy.
The list is shared with all instances.