### PR TITLE
Reduce cache timeouts to ensure faster builds on timeout.

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -41,7 +41,7 @@ runs:
       id: cache-pip
       name: Cache Pip ${{ inputs.python-version }}
       env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: "4"
       with:
         path: |
           ~/.cache/pip
@@ -69,7 +69,7 @@ runs:
     - uses: actions/cache@v3
       id: cache-poetry
       env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: "4"
         WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
       with:
         path: |

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -84,7 +84,7 @@ jobs:
         id: cache-pip
         name: Cache langchain editable pip install - ${{ matrix.python-version }}
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "4"
         with:
           path: |
             ~/.cache/pip
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "4"
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
@@ -115,7 +115,7 @@ jobs:
         uses: actions/cache@v3
         env:
           CACHE_BASE: black-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/poetry.lock', env.WORKDIR)) }}
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "1"
         with:
           path: |
             ${{ env.WORKDIR }}/.black_cache
@@ -127,7 +127,7 @@ jobs:
       - name: Get .mypy_cache to speed up mypy
         uses: actions/cache@v3
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "2"
         with:
           path: |
             ${{ env.WORKDIR }}/.mypy_cache


### PR DESCRIPTION
The current timeouts are too long, and mean that if the GitHub cache decides to act up, jobs get bogged down for 15min at a time. This has happened 2-3 times already this week -- a tiny fraction of our total workflows but really annoying when it happens to you. We can do better.

Installing deps on cache miss takes about ~4min, so it's not worth waiting more than 4min for the deps cache. The black and mypy caches save 1 and 2min, respectively, so wait only up to that long to download them.
