### PR TITLE
Test experimental package with `langchain` on `master` branch.

### DIFF
--- a/.github/workflows/langchain_experimental_ci.yml
+++ b/.github/workflows/langchain_experimental_ci.yml
@@ -13,6 +13,10 @@ on:
       - 'libs/experimental/**'
   workflow_dispatch:  # Allows to trigger the workflow manually in GitHub UI
 
+env:
+  POETRY_VERSION: "1.5.1"
+  WORKDIR: "libs/experimental"
+
 jobs:
   lint:
     uses:
@@ -20,9 +24,45 @@ jobs:
     with:
       working-directory: libs/experimental
     secrets: inherit
+
   test:
     uses:
       ./.github/workflows/_test.yml
     with:
       working-directory: libs/experimental
     secrets: inherit
+
+  # It's possible that langchain-experimental works fine with the latest *published* langchain,
+  # but is broken with the langchain on `master`.
+  #
+  # We want to catch situations like that *before* releasing a new langchain, hence this test.
+  test-with-latest-langchain:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.WORKDIR }}
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+    name: test with unpublished langchain - Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: "./.github/actions/poetry_setup"
+        with:
+          python-version: ${{ matrix.python-version }}
+          working-directory: ${{ env.WORKDIR }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          cache-key: unpublished-langchain
+          install-command: |
+            echo "Running tests with unpublished langchain, installing dependencies with poetry..."
+            poetry install
+
+            echo "Editably installing langchain outside of poetry, to avoid messing up lockfile..."
+            poetry run pip install -e ../langchain
+      - name: Run tests
+        run: make test

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -528,9 +528,13 @@ class BaseLLM(BaseLanguageModel[str], ABC):
                 f" argument of type {type(prompts)}."
             )
         # Create callback managers
-        if isinstance(callbacks, list) and (
-            isinstance(callbacks[0], (list, BaseCallbackManager))
-            or callbacks[0] is None
+        if (
+            isinstance(callbacks, list)
+            and callbacks
+            and (
+                isinstance(callbacks[0], (list, BaseCallbackManager))
+                or callbacks[0] is None
+            )
         ):
             # We've received a list of callbacks args to apply to each input
             assert len(callbacks) == len(prompts)


### PR DESCRIPTION
It's possible that langchain-experimental works fine with the latest *published* langchain, but is broken with the langchain on `master`. Unfortunately, you can see this is currently the case — this is why this PR also includes a minor fix for the `langchain` package itself.

We want to catch situations like that *before* releasing a new langchain, hence this test.
