### PR TITLE
Use new Python setup approach for scheduled tests.

### DIFF
--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -25,18 +25,25 @@ jobs:
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: "./.github/actions/poetry_setup"
         with:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ env.POETRY_VERSION }}
           working-directory: libs/langchain
-          install-command: |
-            echo "Running scheduled tests, installing dependencies with poetry..."
-            poetry install --with=test_integration
+          cache-key: scheduled
+
+      - name: Install dependencies
+        working-directory: libs/langchain
+        shell: bash
+        run: |
+          echo "Running scheduled tests, installing dependencies with poetry..."
+          poetry install --with=test_integration
+
       - name: Run tests
+        shell: bash
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           make scheduled_tests
-        shell: bash


### PR DESCRIPTION
Using the same new unified Python setup as the regular tests and the lint job, as set up in #9625.