### PR TITLE
Allow specifying arbitrary keyword arguments in `langchain.llms.VLLM`

### DIFF
--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -62,6 +62,9 @@ class VLLM(BaseLLM):
     dtype: str = "auto"
     """The data type for the model weights and activations."""
 
+    vllm_kwargs: dict = {}
+    """Arbitrary keyword arguments for vllm.LLM."""
+
     client: Any  #: :meta private:
 
     @root_validator()
@@ -81,6 +84,7 @@ class VLLM(BaseLLM):
             tensor_parallel_size=values["tensor_parallel_size"],
             trust_remote_code=values["trust_remote_code"],
             dtype=values["dtype"],
+            **values['vllm_kwargs']
         )
 
         return values

--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import BaseLLM
 from langchain.llms.openai import BaseOpenAI
-from langchain.pydantic_v1 import root_validator
+from langchain.pydantic_v1 import Field, root_validator
 from langchain.schema.output import Generation, LLMResult
 
 
@@ -62,8 +62,8 @@ class VLLM(BaseLLM):
     dtype: str = "auto"
     """The data type for the model weights and activations."""
 
-    vllm_kwargs: dict = {}
-    """Arbitrary keyword arguments for vllm.LLM."""
+    vllm_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    """Holds any model parameters valid for `vllm.LLM` call not explicitly specified."""
 
     client: Any  #: :meta private:
 
@@ -84,7 +84,7 @@ class VLLM(BaseLLM):
             tensor_parallel_size=values["tensor_parallel_size"],
             trust_remote_code=values["trust_remote_code"],
             dtype=values["dtype"],
-            **values['vllm_kwargs']
+            **values["vllm_kwargs"],
         )
 
         return values


### PR DESCRIPTION
Description: add arbitrary keyword arguments for VLLM
Issue: https://github.com/langchain-ai/langchain/issues/9682
Dependencies: none
Tag maintainer: @hwchase17, @baskaryan