### PR TITLE
Fix docs for AssemblyAIAudioTranscriptLoader (shorter import path)

### DIFF
--- a/docs/extras/integrations/document_loaders/assemblyai.ipynb
+++ b/docs/extras/integrations/document_loaders/assemblyai.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.document_loaders.assemblyai import AssemblyAIAudioTranscriptLoader\n",
+    "from langchain.document_loaders import AssemblyAIAudioTranscriptLoader\n",
     "\n",
     "audio_file = \"https://storage.googleapis.com/aai-docs-samples/nbc.mp3\"\n",
     "# or a local file path: audio_file = \"./nbc.mp3\"\n",
@@ -148,10 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.document_loaders.assemblyai import (\n",
-    "    AssemblyAIAudioTranscriptLoader,\n",
-    "    TranscriptFormat,\n",
-    ")\n",
+    "from langchain.document_loaders.assemblyai import TranscriptFormat\n",
     "\n",
     "loader = AssemblyAIAudioTranscriptLoader(\n",
     "    file_path=\"./your_file.mp3\",\n",

--- a/libs/langchain/tests/unit_tests/document_loaders/test_assemblyai.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_assemblyai.py
@@ -1,10 +1,8 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from langchain.document_loaders.assemblyai import (
-    AssemblyAIAudioTranscriptLoader,
-    TranscriptFormat,
-)
+from langchain.document_loaders import AssemblyAIAudioTranscriptLoader
+from langchain.document_loaders.assemblyai import TranscriptFormat
 
 
 @pytest.mark.requires("assemblyai")


### PR DESCRIPTION
Uses the shorter import path

`from langchain.document_loaders import` instead of the full path
`from langchain.document_loaders.assemblyai`

Applies those changes to the docs and the unit test.

See #9667 that adds this new loader.

