### PR TITLE
Update cube_semantic.py to add new type

### DIFF
--- a/libs/langchain/langchain/document_loaders/cube_semantic.py
+++ b/libs/langchain/langchain/document_loaders/cube_semantic.py
@@ -126,7 +126,7 @@ class CubeSemanticLoader(BaseLoader):
         docs = []
 
         for cube in cubes:
-            if cube.get("type") != "view":
+            if cube.get("type") != "view" and cube.get("type") != "cube":
                 continue
 
             cube_name = cube.get("name")


### PR DESCRIPTION
the cube_semantic example jupyter notebook didn't work, if I use curl, it has following json with type=cube, so I add this type in the code to make it work:
(langchain) ➜  langchain git:(master) ✗ curl \       
  -H "Authorization:.xxx" \
  -G \
  --data-urlencode 'query={"measures":["LineItems.count"]}' \
  https://xxx.cubecloudapp.dev/cubejs-api/v1/meta
{"cubes":[{"public":true,"name":"LineItems","type":"cube","title":"Line Items","measures":[{"name":"LineItems.count","title":"Line Items Count","shortTitle":"Count","cumulativeTotal":false,"cumulative":false,"type":"number","aggType":"count","drillMembers":[],"drillMembersGrouped":{"measures":[],"dimensions":[]},"isVisible":true},{"name":"LineItems.price","title":"Line Items Price","shortTitle":"Price","cumulativeTotal":fals



<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: Update cube_semantic.py to add new type "cube", 
  - Issue: the cube_semantic example jupyter notebook didn't work,
  - Dependencies: NA,
  - Tag maintainer: NA
  - Twitter handle: NA

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
