### PR TITLE
fix setting --only-extended or --only-core flags to False if not prov…

### DIFF
--- a/libs/langchain/tests/unit_tests/conftest.py
+++ b/libs/langchain/tests/unit_tests/conftest.py
@@ -40,8 +40,8 @@ def pytest_collection_modifyitems(config: Config, items: Sequence[Function]) -> 
     # Used to avoid repeated calls to `util.find_spec`
     required_pkgs_info: Dict[str, bool] = {}
 
-    only_extended = config.getoption("--only-extended") or False
-    only_core = config.getoption("--only-core") or False
+    only_extended = config.getoption("--only-extended", default=False)
+    only_core = config.getoption("--only-core", default=False)
 
     if only_extended and only_core:
         raise ValueError("Cannot specify both `--only-extended` and `--only-core`.")


### PR DESCRIPTION
Description:
`--only-extended` and `--only-core` flags are not set correctly to `False`, if not provided

Issue:
When trying to run `make coverage` I got the following issue:
```
INTERNALERROR> ValueError: no option named 'only_extended'
```
It turned out that `config.getoption("--only-extended")` in `pytest_collection_modifyitems` function was unable to get the `--only-extended` value 