### PR TITLE
Add AliCloudPaiEAS type in langchain.llms to access alicloud pai-eas service.

### DIFF
--- a/docs/extras/integrations/llms/alicloud_api_eas.ipynb
+++ b/docs/extras/integrations/llms/alicloud_api_eas.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AliCloud PAI EAS\n",
+    "Machine Learning Platform for AI of Alibaba Cloud is a machine learning or deep learning engineering platform intended for enterprises and developers. It provides easy-to-use, cost-effective, high-performance, and easy-to-scale plug-ins that can be applied to various industry scenarios. With over 140 built-in optimization algorithms, Machine Learning Platform for AI provides whole-process AI engineering capabilities including data labeling (PAI-iTAG), model building (PAI-Designer and PAI-DSW), model training (PAI-DLC), compilation optimization, and inference deployment (PAI-EAS). PAI-EAS supports different types of hardware resources, including CPUs and GPUs, and features high throughput and low latency. It allows you to deploy large-scale complex models with a few clicks and perform elastic scale-ins and scale-outs in real time. It also provides a comprehensive O&M and monitoring system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.llms.alicloud_pai_eas import AliCloudPaiEAS\n",
+    "from langchain import PromptTemplate, LLMChain\n",
+    "\n",
+    "template = \"\"\"Question: {question}\n",
+    "\n",
+    "Answer: Let's think step by step.\"\"\"\n",
+    "\n",
+    "prompt = PromptTemplate(template=template, input_variables=[\"question\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One who want to use eas llms must set up eas service first. When the eas service is launched, eas_service_rul and eas_service token can be got. Users can refer to https://www.alibabacloud.com/help/en/pai/user-guide/service-deployment/ for more information,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"EAS_SERVICE_URL\"] = \"Your_EAS_Service_URL\"\n",
+    "os.environ[\"EAS_SERVICE_TOKEN\"] = \"Your_EAS_Service_Token\"\n",
+    "llm = AliCloudPaiEAS(eas_service_url=os.environ[\"EAS_SERVICE_URL\"], eas_service_token=os.environ[\"EAS_SERVICE_TOKEN\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'  Thank you for asking! However, I must respectfully point out that the question contains an error. Justin Bieber was born in 1994, and the Super Bowl was first played in 1967. Therefore, it is not possible for any NFL team to have won the Super Bowl in the year Justin Bieber was born.\\n\\nI hope this clarifies things! If you have any other questions, please feel free to ask.'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
+    "\n",
+    "question = \"What NFL team won the Super Bowl in the year Justin Beiber was born?\"\n",
+    "llm_chain.run(question)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -21,6 +21,7 @@ from typing import Dict, Type
 
 from langchain.llms.ai21 import AI21
 from langchain.llms.aleph_alpha import AlephAlpha
+from langchain.llms.alicloud_pai_eas import AliCloudPaiEAS
 from langchain.llms.amazon_api_gateway import AmazonAPIGateway
 from langchain.llms.anthropic import Anthropic
 from langchain.llms.anyscale import Anyscale
@@ -89,6 +90,7 @@ from langchain.llms.xinference import Xinference
 __all__ = [
     "AI21",
     "AlephAlpha",
+    "AliCloudPaiEAS",
     "AmazonAPIGateway",
     "Anthropic",
     "Anyscale",
@@ -162,6 +164,7 @@ __all__ = [
 type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
     "ai21": AI21,
     "aleph_alpha": AlephAlpha,
+    "alicloud_pai_eas": AliCloudPaiEAS,
     "amazon_api_gateway": AmazonAPIGateway,
     "amazon_bedrock": Bedrock,
     "anthropic": Anthropic,

--- a/libs/langchain/langchain/llms/alicloud_pai_eas.py
+++ b/libs/langchain/langchain/llms/alicloud_pai_eas.py
@@ -1,26 +1,26 @@
-import logging
 import json
-import requests
+import logging
 from typing import Any, Dict, List, Mapping, Optional
 
+import requests
 
+from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
+from langchain.llms.utils import enforce_stop_tokens
 from langchain.pydantic_v1 import root_validator
 from langchain.utils import get_from_dict_or_env
-from langchain.llms.utils import enforce_stop_tokens
-from langchain.callbacks.manager import CallbackManagerForLLMRun
-
 
 logger = logging.getLogger(__name__)
 
 
 class AliCloudPaiEAS(LLM):
     """PAI-EAS Service URL"""
+
     eas_service_url: str
-    
+
     """PAI-EAS Service TOKEN"""
-    eas_service_token: str = None
-    
+    eas_service_token: str
+
     """PAI-EAS Service Infer Params"""
     max_new_tokens: Optional[int] = 512
     temperature: Optional[float] = 0.95
@@ -35,14 +35,10 @@ class AliCloudPaiEAS(LLM):
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         values["eas_service_url"] = get_from_dict_or_env(
-            values,
-            "eas_service_url",
-            "EAS_SERVICE_URL"
+            values, "eas_service_url", "EAS_SERVICE_URL"
         )
         values["eas_service_token"] = get_from_dict_or_env(
-            values,
-            "eas_service_token",
-            "EAS_SERVICE_TOKEN"
+            values, "eas_service_token", "EAS_SERVICE_TOKEN"
         )
 
         return values
@@ -59,7 +55,7 @@ class AliCloudPaiEAS(LLM):
             "max_new_tokens": self.max_new_tokens,
             "temperature": self.temperature,
             "top_k": self.top_k,
-            "top_p": self.top_p
+            "top_p": self.top_p,
         }
 
     @property
@@ -117,7 +113,7 @@ class AliCloudPaiEAS(LLM):
         }
 
         body = {
-            "input_ids":  f"{prompt}",
+            "input_ids": f"{prompt}",
         }
 
         # add params to body
@@ -125,8 +121,7 @@ class AliCloudPaiEAS(LLM):
             body[key] = value
 
         # make request
-        response = requests.post(self.eas_service_url, headers=headers,
-                                 json=body)
+        response = requests.post(self.eas_service_url, headers=headers, json=body)
 
         if response.status_code != 200:
             raise Exception(
@@ -135,4 +130,3 @@ class AliCloudPaiEAS(LLM):
             )
 
         return json.loads(response.text)
-    

--- a/libs/langchain/langchain/llms/alicloud_pai_eas.py
+++ b/libs/langchain/langchain/llms/alicloud_pai_eas.py
@@ -1,0 +1,138 @@
+import logging
+import json
+import requests
+from typing import Any, Dict, List, Mapping, Optional
+
+
+from langchain.llms.base import LLM
+from langchain.pydantic_v1 import root_validator
+from langchain.utils import get_from_dict_or_env
+from langchain.llms.utils import enforce_stop_tokens
+from langchain.callbacks.manager import CallbackManagerForLLMRun
+
+
+logger = logging.getLogger(__name__)
+
+
+class AliCloudPaiEAS(LLM):
+    """PAI-EAS Service URL"""
+    eas_service_url: str
+    
+    """PAI-EAS Service TOKEN"""
+    eas_service_token: str = None
+    
+    """PAI-EAS Service Infer Params"""
+    max_new_tokens: Optional[int] = 512
+    temperature: Optional[float] = 0.95
+    top_p: Optional[float] = 0.1
+    top_k: Optional[int] = 0
+    stop_sequences: Optional[List[str]] = None
+
+    """Key/value arguments to pass to the model. Reserved for future use"""
+    model_kwargs: Optional[dict] = None
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        """Validate that api key and python package exists in environment."""
+        values["eas_service_url"] = get_from_dict_or_env(
+            values,
+            "eas_service_url",
+            "EAS_SERVICE_URL"
+        )
+        values["eas_service_token"] = get_from_dict_or_env(
+            values,
+            "eas_service_token",
+            "EAS_SERVICE_TOKEN"
+        )
+
+        return values
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "alicloud_pai_eas"
+
+    @property
+    def _default_params(self) -> Dict[str, Any]:
+        """Get the default parameters for calling Cohere API."""
+        return {
+            "max_new_tokens": self.max_new_tokens,
+            "temperature": self.temperature,
+            "top_k": self.top_k,
+            "top_p": self.top_p
+        }
+
+    @property
+    def _identifying_params(self) -> Mapping[str, Any]:
+        """Get the identifying parameters."""
+        _model_kwargs = self.model_kwargs or {}
+        return {
+            "eas_service_url": self.eas_service_url,
+            "eas_service_token": self.eas_service_token,
+            **{"model_kwargs": _model_kwargs},
+        }
+
+    def _invocation_params(
+        self, stop_sequences: Optional[List[str]], **kwargs: Any
+    ) -> dict:
+        params = self._default_params
+        if self.stop_sequences is not None and stop_sequences is not None:
+            raise ValueError("`stop` found in both the input and default params.")
+        elif self.stop_sequences is not None:
+            params["stop_sequences"] = self.stop_sequences
+        else:
+            params["stop_sequences"] = stop_sequences
+        return {**params, **kwargs}
+
+    @staticmethod
+    def _process_response(response: Any, stop: Optional[List[str]]) -> str:
+        text = response["response"]
+        if stop:
+            text = enforce_stop_tokens(text, stop)
+        return "".join(text)
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        params = self._invocation_params(stop, **kwargs)
+        prompt = prompt.strip()
+        response = None
+        try:
+            response = self._call_eas_service(prompt, params)
+        except Exception as error:
+            raise ValueError(f"Error raised by the service: {error}")
+
+        _stop = params.get("stop_sequences")
+        return self._process_response(response, _stop)
+
+    def _call_eas_service(self, prompt: str = "", params: Dict = {}) -> Any:
+        """Generate text from the eas service."""
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"{self.eas_service_token}",
+        }
+
+        body = {
+            "input_ids":  f"{prompt}",
+        }
+
+        # add params to body
+        for key, value in params.items():
+            body[key] = value
+
+        # make request
+        response = requests.post(self.eas_service_url, headers=headers,
+                                 json=body)
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Request failed with status code {response.status_code}"
+                f" and message {response.text}"
+            )
+
+        return json.loads(response.text)
+    

--- a/libs/langchain/tests/integration_tests/llms/test_alicloud_eas.py
+++ b/libs/langchain/tests/integration_tests/llms/test_alicloud_eas.py
@@ -6,7 +6,9 @@ from langchain.llms.alicloud_pai_eas import AliCloudPaiEAS
 
 def test_eas_call() -> None:
     """Test valid call to PAI-EAS Service."""
-    llm = AliCloudPaiEAS(eas_service_url=os.getenv("EAS_SERVICE_URL"),
-                         eas_service_token=os.getenv("EAS_SERVICE_TOKEN"))
+    llm = AliCloudPaiEAS(
+        eas_service_url=os.getenv("EAS_SERVICE_URL"),
+        eas_service_token=os.getenv("EAS_SERVICE_TOKEN"),
+    )
     output = llm("Say foo:")
     assert isinstance(output, str)

--- a/libs/langchain/tests/integration_tests/llms/test_alicloud_eas.py
+++ b/libs/langchain/tests/integration_tests/llms/test_alicloud_eas.py
@@ -1,0 +1,12 @@
+"""Test AliCloudPaiEAS API wrapper."""
+import os
+
+from langchain.llms.alicloud_pai_eas import AliCloudPaiEAS
+
+
+def test_eas_call() -> None:
+    """Test valid call to PAI-EAS Service."""
+    llm = AliCloudPaiEAS(eas_service_url=os.getenv("EAS_SERVICE_URL"),
+                         eas_service_token=os.getenv("EAS_SERVICE_TOKEN"))
+    output = llm("Say foo:")
+    assert isinstance(output, str)


### PR DESCRIPTION
### Description
  This PR aims at adding new llm type  AliCloudPaiEAS to support service accessing for alicloud product named pai-eas service. PAI-EAS can help users to deploy llm models on alicloud.  

### Usage
The user needs to start an eas service on alicloud and then set the service's access url and token as a params for AliCloudPaiEAS. Then AliCloudPaiEAS  object as a llm object is passed to the Chain to run an output. 
The usage is like:
`llm = AliCloudPaiEAS(eas_service_url="your_access_url",eas_service_token="your_access_token"`
`llm_chain = LLMChain(prompt=prompt, llm=llm)
`
`llm_chain.run("Hello there.")`

### Test and example
The integration test case is located at libs/langchain/tests/integration_tests/llms/test_alicloud_eas.py
The example notebook is located at docs/extras/integrations/lls/alicloud_api_eas.ipynb