### PR TITLE
Qdrant Client: Expose instance for creating client

### DIFF
--- a/libs/langchain/langchain/vectorstores/qdrant.py
+++ b/libs/langchain/langchain/vectorstores/qdrant.py
@@ -1088,7 +1088,7 @@ class Qdrant(VectorStore):
                 embeddings = OpenAIEmbeddings()
                 qdrant = Qdrant.from_texts(texts, embeddings, "localhost")
         """
-        qdrant = cls._construct_instance(
+        qdrant = cls.construct_instance(
             texts,
             embedding,
             location,
@@ -1264,7 +1264,7 @@ class Qdrant(VectorStore):
                 embeddings = OpenAIEmbeddings()
                 qdrant = await Qdrant.afrom_texts(texts, embeddings, "localhost")
         """
-        qdrant = await cls._aconstruct_instance(
+        qdrant = await cls.aconstruct_instance(
             texts,
             embedding,
             location,
@@ -1300,7 +1300,7 @@ class Qdrant(VectorStore):
         return qdrant
 
     @classmethod
-    def _construct_instance(
+    def construct_instance(
         cls: Type[Qdrant],
         texts: List[str],
         embedding: Embeddings,
@@ -1466,7 +1466,7 @@ class Qdrant(VectorStore):
         return qdrant
 
     @classmethod
-    async def _aconstruct_instance(
+    async def aconstruct_instance(
         cls: Type[Qdrant],
         texts: List[str],
         embedding: Embeddings,


### PR DESCRIPTION
Expose classmethods to convenient initialize the vectostore.

The purpose of this PR is to make it easy for users to initialize an empty vectorstore that's properly pre-configured without having to index documents into it via `from_documents`.

This will make it easier for users to rely on the following indexing code: https://github.com/langchain-ai/langchain/pull/9614
to help manage data in the qdrant vectorstore.
