### PR TITLE
change error "pyspark is not installed. Please install it with `pip i…

### DIFF
--- a/libs/langchain/langchain/utilities/spark_sql.py
+++ b/libs/langchain/langchain/utilities/spark_sql.py
@@ -185,4 +185,3 @@ class SparkSQL:
         except Exception as e:
             """Format the error message"""
             return f"Error: {e}"
-

--- a/libs/langchain/langchain/utilities/spark_sql.py
+++ b/libs/langchain/langchain/utilities/spark_sql.py
@@ -179,18 +179,10 @@ class SparkSQL:
 
         If the statement throws an error, the error message is returned.
         """
-        use_pyspark_exception = True
-
-        try:
-            from pyspark.errors import PySparkException
-        except ImportError:
-            use_pyspark_exception = False
 
         try:
             return self.run(command, fetch)
         except Exception as e:
-            if use_pyspark_exception and isinstance(e, PySparkException):
-                """Format the error message"""
-                return f"Error: {e}"
-            else:
-                return f"An error occurred: {e}"
+            """Format the error message"""
+            return f"Error: {e}"
+

--- a/libs/langchain/langchain/utilities/spark_sql.py
+++ b/libs/langchain/langchain/utilities/spark_sql.py
@@ -179,14 +179,18 @@ class SparkSQL:
 
         If the statement throws an error, the error message is returned.
         """
+        use_pyspark_exception = True
+
         try:
             from pyspark.errors import PySparkException
         except ImportError:
-            raise ValueError(
-                "pyspark is not installed. Please install it with `pip install pyspark`"
-            )
+            use_pyspark_exception = False
+
         try:
             return self.run(command, fetch)
-        except PySparkException as e:
-            """Format the error message"""
-            return f"Error: {e}"
+        except Exception as e:
+            if use_pyspark_exception and isinstance(e, PySparkException):
+                """Format the error message"""
+                return f"Error: {e}"
+            else:
+                return f"An error occurred: {e}"


### PR DESCRIPTION
Description: The issue is you can not run spark_sql with a version below 3.4, because pyspark.errors is added in 3.4.
And if you are below you get 3.4  "pyspark is not installed. Please install it with `pip nstall pyspark`" which is not helpful. Also if you not have pyspark installed you get already the error in __init__. I would return all errors. But if you have a different idea feel free to comment.

Issue: None
Dependencies: None
Maintainer: 