### PR TITLE
Fix: when only config custom evaluators, the keys(input_key,prediction_key,reference_key) config will be lost 

### DIFF
--- a/libs/langchain/langchain/smith/evaluation/runner_utils.py
+++ b/libs/langchain/langchain/smith/evaluation/runner_utils.py
@@ -539,7 +539,7 @@ def _load_run_evaluators(
     input_key, prediction_key, reference_key = None, None, None
     if config.evaluators or any(
         [isinstance(e, EvaluatorType) for e in config.evaluators]
-    ):
+    ) or config.custom_evaluators:
         input_key, prediction_key, reference_key = _get_keys(
             config, run_inputs, run_outputs, example_outputs
         )


### PR DESCRIPTION
* Description:  When only use  custom evaluators, Will meet ` Could not map run {which} with multiple keys {source} \n Please manually specify a {which}_key`  ERROR from `ChainStringRunMapper`.   Because  the configuration of the keys(input_key,prediction_key,reference_key) are initialized only when `config.evaluators` are configured. So `ChainStringRunMapper` can't get the keys configuration.
* Issue: None
* Dependencies: None
* Maintainer:  @hinthornw @baskaryan 
* Twitter handle: @_LiuHu
