### PR TITLE
typo in locall llms fixed

### DIFF
--- a/docs/extras/guides/local_llms.ipynb
+++ b/docs/extras/guides/local_llms.ipynb
@@ -146,7 +146,7 @@
    "source": [
     "## Environment\n",
     "\n",
-    "Inference speed is a chllenge when running models locally (see above).\n",
+    "Inference speed is a challenge when running models locally (see above).\n",
     "\n",
     "To minimize latency, it is desiable to run models locally on GPU, which ships with many consumer laptops [e.g., Apple devices](https://www.apple.com/newsroom/2022/06/apple-unveils-m2-with-breakthrough-performance-and-capabilities/).\n",
     "\n",


### PR DESCRIPTION
Hi, 

I noticed a typo in the local_llms.ipynb file and fixed it. The word challenge is without 'a' in the original file. 
@baskaryan , @eyurtsev

Thanks.