### PR TITLE
fixed regex to match sources for all cases, also includes source

### DIFF
--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -121,7 +121,9 @@ class BaseQAWithSourcesChain(Chain, ABC):
     def _split_sources(self, answer: str) -> Tuple[str, str]:
         """Split sources from answer."""
         if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
-            answer, sources = re.split(r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE)[:2]
+            answer, sources = re.split(
+                r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE
+            )[:2]
             sources = re.split(r"\n", sources)[0].strip()
         else:
             sources = ""

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -120,8 +120,8 @@ class BaseQAWithSourcesChain(Chain, ABC):
 
     def _split_sources(self, answer: str) -> Tuple[str, str]:
         """Split sources from answer."""
-        if re.search(r"SOURCES:\s", answer):
-            answer, sources = re.split(r"SOURCES:\s|QUESTION:\s", answer)[:2]
+        if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
+            answer, sources = re.split(r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE)[:2]
             sources = re.split(r"\n", sources)[0]
         else:
             sources = ""

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -122,7 +122,7 @@ class BaseQAWithSourcesChain(Chain, ABC):
         """Split sources from answer."""
         if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
             answer, sources = re.split(r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE)[:2]
-            sources = re.split(r"\n", sources)[0]
+            sources = re.split(r"\n", sources)[0].strip()
         else:
             sources = ""
         return answer, sources

--- a/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
+++ b/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
@@ -13,6 +13,21 @@ from tests.unit_tests.llms.fake_llm import FakeLLM
             "28-pl",
         ),
         (
+            "This Agreement is governed by English law.\nSources: 28-pl",
+            "This Agreement is governed by English law.\n",
+            "28-pl",
+        ),
+        (
+            "This Agreement is governed by English law.\nsource: 28-pl",
+            "This Agreement is governed by English law.\n",
+            "28-pl",
+        ),
+        (
+            "This Agreement is governed by English law.\nSource: 28-pl",
+            "This Agreement is governed by English law.\n",
+            "28-pl",
+        ),
+        (
             "This Agreement is governed by English law.\n"
             "SOURCES: 28-pl\n\n"
             "QUESTION: Which state/country's law governs the interpretation of the "


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: Updated the regex to handle all the different cases for string matching (SOURCES, sources, Sources), 
  - Issue: https://github.com/langchain-ai/langchain/issues/9774
  - Dependencies: N/A
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
