### PR TITLE
Issue #2241 Support nested code blocks in agent response JSON.

### DIFF
--- a/libs/langchain/langchain/agents/conversational_chat/prompt.py
+++ b/libs/langchain/langchain/agents/conversational_chat/prompt.py
@@ -16,22 +16,22 @@ When responding to me, please output a response in one of two formats:
 Use this if you want the human to use a tool.
 Markdown code snippet formatted in the following schema:
 
-```json
+````json
 {{{{
     "action": string, \\ The action to take. Must be one of {tool_names}
     "action_input": string \\ The input to the action
 }}}}
-```
+````
 
 **Option #2:**
 Use this if you want to respond directly to the human. Markdown code snippet formatted in the following schema:
 
-```json
+````json
 {{{{
     "action": "Final Answer",
     "action_input": string \\ You should put what you want to return to use here
 }}}}
-```"""
+````"""
 
 SUFFIX = """TOOLS
 ------


### PR DESCRIPTION
Resolves https://github.com/langchain-ai/langchain/issues/2241.

ConversationalChatAgent prompt contains JSON examples nested in triple-ticked codeblocks.

When response contains a triple-ticked codeblock, this breaks the response.

PR updates prompt to use quadruple-ticked code blocks, enabling responses to include code examples in markdown.

cc: @hwchase17 @agola11