### PR TITLE
typo: funtions --> functions

### DIFF
--- a/docs/extras/use_cases/extraction.ipynb
+++ b/docs/extras/use_cases/extraction.ipynb
@@ -55,7 +55,7 @@
    "source": [
     "## Quickstart\n",
     "\n",
-    "OpenAI funtions are one way to get started with extraction.\n",
+    "OpenAI functions are one way to get started with extraction.\n",
     "\n",
     "Define a schema that specifies the properties we want to extract from the LLM output.\n",
     "\n",
@@ -122,7 +122,7 @@
    "id": "6f7eb826",
    "metadata": {},
    "source": [
-    "## Option 1: OpenAI funtions\n",
+    "## Option 1: OpenAI functions\n",
     "\n",
     "### Looking under the hood\n",
     "\n",


### PR DESCRIPTION
Minor typo in the extractions use-case