### PR TITLE
fix multipart email body retrieval

### DIFF
--- a/libs/langchain/langchain/tools/gmail/get_message.py
+++ b/libs/langchain/langchain/tools/gmail/get_message.py
@@ -46,7 +46,17 @@ class GmailGetMessage(GmailBaseTool):
         subject = email_msg["Subject"]
         sender = email_msg["From"]
 
-        message_body = email_msg.get_payload()
+        if email_msg.is_multipart():
+            for part in email_msg.walk():
+                ctype = part.get_content_type()
+                cdispo = str(part.get("Content-Disposition"))
+                if ctype == "text/plain" and "attachment" not in cdispo:
+                    message_body = part.get_payload(decode=True)
+                    break
+        else:
+            message_body = email_msg.get_payload(decode=True)
+
+        message_body = message_body.decode("utf-8")
 
         body = clean_email_body(message_body)
 

--- a/libs/langchain/langchain/tools/gmail/get_message.py
+++ b/libs/langchain/langchain/tools/gmail/get_message.py
@@ -46,17 +46,16 @@ class GmailGetMessage(GmailBaseTool):
         subject = email_msg["Subject"]
         sender = email_msg["From"]
 
+        message_body = ""
         if email_msg.is_multipart():
             for part in email_msg.walk():
                 ctype = part.get_content_type()
                 cdispo = str(part.get("Content-Disposition"))
                 if ctype == "text/plain" and "attachment" not in cdispo:
-                    message_body = part.get_payload(decode=True)
+                    message_body = part.get_payload(decode=True).decode("utf-8")
                     break
         else:
-            message_body = email_msg.get_payload(decode=True)
-
-        message_body = message_body.decode("utf-8")
+            message_body = email_msg.get_payload(decode=True).decode("utf-8")
 
         body = clean_email_body(message_body)
 

--- a/libs/langchain/langchain/tools/gmail/search.py
+++ b/libs/langchain/langchain/tools/gmail/search.py
@@ -91,17 +91,16 @@ class GmailSearch(GmailBaseTool):
             subject = email_msg["Subject"]
             sender = email_msg["From"]
 
+            message_body = ""
             if email_msg.is_multipart():
                 for part in email_msg.walk():
                     ctype = part.get_content_type()
                     cdispo = str(part.get("Content-Disposition"))
                     if ctype == "text/plain" and "attachment" not in cdispo:
-                        message_body = part.get_payload(decode=True)
+                        message_body = part.get_payload(decode=True).decode("utf-8")
                         break
             else:
-                message_body = email_msg.get_payload(decode=True)
-
-            message_body = message_body.decode("utf-8")
+                message_body = email_msg.get_payload(decode=True).decode("utf-8")
 
             body = clean_email_body(message_body)
 

--- a/libs/langchain/langchain/tools/gmail/search.py
+++ b/libs/langchain/langchain/tools/gmail/search.py
@@ -91,7 +91,17 @@ class GmailSearch(GmailBaseTool):
             subject = email_msg["Subject"]
             sender = email_msg["From"]
 
-            message_body = email_msg.get_payload()
+            if email_msg.is_multipart():
+                for part in email_msg.walk():
+                    ctype = part.get_content_type()
+                    cdispo = str(part.get("Content-Disposition"))
+                    if ctype == "text/plain" and "attachment" not in cdispo:
+                        message_body = part.get_payload(decode=True)
+                        break
+            else:
+                message_body = email_msg.get_payload(decode=True)
+
+            message_body = message_body.decode("utf-8")
 
             body = clean_email_body(message_body)
 


### PR DESCRIPTION
Description: 
Gmail message retrieval in GmailGetMessage and GmailSearch returned an empty string when encountering multipart emails. This change correctly extracts the email body for multipart emails.

Dependencies: None

@hwchase17 @vowelparrot 
