### PR TITLE
Update SeleniumURLLoader to use webdriver Service in favor of deprecated executable_path parameter

### DIFF
--- a/libs/langchain/langchain/document_loaders/url_selenium.py
+++ b/libs/langchain/langchain/document_loaders/url_selenium.py
@@ -74,6 +74,7 @@ class SeleniumURLLoader(BaseLoader):
         if self.browser.lower() == "chrome":
             from selenium.webdriver import Chrome
             from selenium.webdriver.chrome.options import Options as ChromeOptions
+            from selenium.webdriver.chrome.service import Service
 
             chrome_options = ChromeOptions()
 
@@ -87,10 +88,14 @@ class SeleniumURLLoader(BaseLoader):
                 chrome_options.binary_location = self.binary_location
             if self.executable_path is None:
                 return Chrome(options=chrome_options)
-            return Chrome(executable_path=self.executable_path, options=chrome_options)
+            return Chrome(
+                options=chrome_options,
+                service=Service(executable_path=self.executable_path),
+            )
         elif self.browser.lower() == "firefox":
             from selenium.webdriver import Firefox
             from selenium.webdriver.firefox.options import Options as FirefoxOptions
+            from selenium.webdriver.firefox.service import Service
 
             firefox_options = FirefoxOptions()
 
@@ -104,7 +109,8 @@ class SeleniumURLLoader(BaseLoader):
             if self.executable_path is None:
                 return Firefox(options=firefox_options)
             return Firefox(
-                executable_path=self.executable_path, options=firefox_options
+                options=firefox_options,
+                service=Service(executable_path=self.executable_path),
             )
         else:
             raise ValueError("Invalid browser specified. Use 'chrome' or 'firefox'.")


### PR DESCRIPTION
Description: This commit uses the new Service object in Selenium webdriver as executable_path has been [deprecated and removed in selenium version 4.11.2](https://github.com/SeleniumHQ/selenium/commit/9f5801c82fb3be3d5850707c46c3f8176e3ccd8e)
Issue: https://github.com/langchain-ai/langchain/issues/9808
Tag Maintainer: @eyurtsev

Note -
First attempt was to create a Service object and pass empty if executable_path not provided as such:
`def _get_driver(self) -> Union["Chrome", "Firefox"]:
"""Create and return a WebDriver instance based on the specified browser.

    Raises:
        ValueError: If an invalid browser is specified.

    Returns:
        Union[Chrome, Firefox]: A WebDriver instance for the specified browser.
    """
    if self.browser.lower() == "chrome":
        from selenium.webdriver import Chrome
        from selenium.webdriver.chrome.options import Options as ChromeOptions
        from selenium.webdriver.chrome.service import Service

        chrome_options = ChromeOptions()
        chrome_service = Service()

        for arg in self.arguments:
            chrome_options.add_argument(arg)

        if self.headless:
            chrome_options.add_argument("--headless")
            chrome_options.add_argument("--no-sandbox")
        if self.binary_location is not None:
            chrome_options.binary_location = self.binary_location
        if self.executable_path is None:
            chrome_service.path = self.executable_path
        return Chrome(options=chrome_options, service=chrome_service)
    elif self.browser.lower() == "firefox":
        from selenium.webdriver import Firefox
        from selenium.webdriver.firefox.options import Options as FirefoxOptions
        from selenium.webdriver.firefox.service import Service

        firefox_options = FirefoxOptions()
        firefox_service = Service()

        for arg in self.arguments:
            firefox_options.add_argument(arg)

        if self.headless:
            firefox_options.add_argument("--headless")
        if self.binary_location is not None:
            firefox_options.binary_location = self.binary_location
        if self.executable_path is None:
            firefox_service.path = self.executable_path
        return Firefox(options=firefox_options, service=firefox_service)
    else:
        raise ValueError("Invalid browser specified. Use 'chrome' or 'firefox'.")`
However in testing I found this crashes when executable_path is not passed in with the follow Exception: NoSuchDriverException(f"Unable to locate or obtain driver for {options.capabilities['browserName']}"). This updated pull request revises to only pass Service object when executable_path is provided