### PR TITLE
LRU cache for import to avoid repetetive calls to huggingface

### DIFF
--- a/libs/langchain/langchain/schema/language_model.py
+++ b/libs/langchain/langchain/schema/language_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -18,7 +19,6 @@ from langchain.schema.output import LLMResult
 from langchain.schema.prompt import PromptValue
 from langchain.schema.runnable import Runnable
 from langchain.utils import get_pydantic_field_names
-from functools import lru_cache
 
 if TYPE_CHECKING:
     from langchain.callbacks.manager import Callbacks
@@ -37,6 +37,7 @@ def get_tokenizer():
     # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 
+
 def _get_token_ids_default_method(text: str) -> List[int]:
     """Encode the text into token IDs."""
     # get the cached tokenizer
@@ -44,6 +45,7 @@ def _get_token_ids_default_method(text: str) -> List[int]:
 
     # tokenize the text using the GPT-2 tokenizer
     return tokenizer.encode(text)
+
 
 LanguageModelInput = Union[PromptValue, str, List[BaseMessage]]
 LanguageModelOutput = TypeVar("LanguageModelOutput")


### PR DESCRIPTION
# Description
Performance improvement to avoid repeated calls to huggingface when calling `RetrievalQAWithSourcesChain.from_chain_type`. By caching the call to the underlying transformers library, we avoid re-importing the library, instantiating the object and pulling data from huggingface. This significantly speeds up the chain (in our situation from 9 seconds to 3 seconds)

We noticed that our chain was spending a significant time pulling files from huggingface _on every LLM call_
![Screenshot 2023-08-28 at 18 53 50](https://github.com/langchain-ai/langchain/assets/2284951/1f850740-b9aa-4ac2-8880-e85e04870e0e)
![Screenshot 2023-08-28 at 18 54 00](https://github.com/langchain-ai/langchain/assets/2284951/a7024616-01ce-4d54-bfaf-162f2736a0aa)


Twitter: @PascalBrokmeier


<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
