### PR TITLE
Use existing required args obj if specified

### DIFF
--- a/libs/langchain/langchain/tools/convert_to_openai.py
+++ b/libs/langchain/langchain/tools/convert_to_openai.py
@@ -19,7 +19,9 @@ def format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     if isinstance(tool, StructuredTool):
         schema_ = tool.args_schema.schema()
         # Bug with required missing for structured tools.
-        required = sorted(schema_["properties"])  # BUG WORKAROUND
+        required = schema_.get(
+            "required", sorted(schema_["properties"])  # Backup is a BUG WORKAROUND
+        )
         return {
             "name": tool.name,
             "description": tool.description,


### PR DESCRIPTION
We always overwrote the required args but we infer them by default. Doing it only the old way makes it so the llm guesses even if an arg is optional (e.g., for uuids)