### PR TITLE
Fixed regex bug in RetrievalQAWithSources in previous update

### DIFF
--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -121,10 +121,8 @@ class BaseQAWithSourcesChain(Chain, ABC):
     def _split_sources(self, answer: str) -> Tuple[str, str]:
         """Split sources from answer."""
         if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
-            answer, sources = re.split(
-                r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE
-            )[:2]
-            sources = re.split(r"\n", sources)[0]
+            answer, sources = re.split(r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE)[:2]
+            sources = re.split(r"\n", sources)[0].strip()
         else:
             sources = ""
         return answer, sources

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -122,7 +122,7 @@ class BaseQAWithSourcesChain(Chain, ABC):
         """Split sources from answer."""
         if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
             answer, sources = re.split(
-                r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE
+                r"SOURCES?[:]|QUESTION:\s", answer, flags=re.IGNORECASE
             )[:2]
             sources = re.split(r"\n", sources)[0].strip()
         else:

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -121,7 +121,9 @@ class BaseQAWithSourcesChain(Chain, ABC):
     def _split_sources(self, answer: str) -> Tuple[str, str]:
         """Split sources from answer."""
         if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
-            answer, sources = re.split(r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE)[:2]
+            answer, sources = re.split(
+                r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE
+            )[:2]
             sources = re.split(r"\n", sources)[0].strip()
         else:
             sources = ""

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -120,9 +120,9 @@ class BaseQAWithSourcesChain(Chain, ABC):
 
     def _split_sources(self, answer: str) -> Tuple[str, str]:
         """Split sources from answer."""
-        if re.search(r"SOURCES?[:\s]", answer, re.IGNORECASE):
+        if re.search(r"SOURCES?[:]\s", answer, re.IGNORECASE):
             answer, sources = re.split(
-                r"SOURCES?[:]|QUESTION:\s", answer, flags=re.IGNORECASE
+                r"SOURCES?[:]\s|QUESTION:\s", answer, flags=re.IGNORECASE
             )[:2]
             sources = re.split(r"\n", sources)[0].strip()
         else:

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -120,9 +120,9 @@ class BaseQAWithSourcesChain(Chain, ABC):
 
     def _split_sources(self, answer: str) -> Tuple[str, str]:
         """Split sources from answer."""
-        if re.search(r"SOURCES?[:]\s", answer, re.IGNORECASE):
+        if re.search(r"SOURCES?:", answer, re.IGNORECASE):
             answer, sources = re.split(
-                r"SOURCES?[:]\s|QUESTION:\s", answer, flags=re.IGNORECASE
+                r"SOURCES?:|QUESTION:\s", answer, flags=re.IGNORECASE
             )[:2]
             sources = re.split(r"\n", sources)[0].strip()
         else:

--- a/libs/langchain/langchain/chains/qa_with_sources/base.py
+++ b/libs/langchain/langchain/chains/qa_with_sources/base.py
@@ -124,7 +124,7 @@ class BaseQAWithSourcesChain(Chain, ABC):
             answer, sources = re.split(
                 r"SOURCES?[:\s]|QUESTION:\s", answer, flags=re.IGNORECASE
             )[:2]
-            sources = re.split(r"\n", sources)[0].strip()
+            sources = re.split(r"\n", sources)[0]
         else:
             sources = ""
         return answer, sources

--- a/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
+++ b/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
@@ -28,7 +28,8 @@ from tests.unit_tests.llms.fake_llm import FakeLLM
             "28-pl",
         ),
         (
-            "According to the sources, the agreement is governed by English law.\nSource: 28-pl",
+            "According to the sources, the agreement is governed by English law.\n"
+            "Source: 28-pl",
             "According to the sources, the agreement is governed by English law.\n",
             "28-pl",
         ),

--- a/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
+++ b/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
@@ -28,9 +28,9 @@ from tests.unit_tests.llms.fake_llm import FakeLLM
             "28-pl",
         ),
         (
-            "According to the sources, the agreement is governed by English law.\n"
+            "According to the sources the agreement is governed by English law.\n"
             "Source: 28-pl",
-            "According to the sources, the agreement is governed by English law.\n",
+            "According to the sources the agreement is governed by English law.\n",
             "28-pl",
         ),
         (

--- a/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
+++ b/libs/langchain/tests/unit_tests/chains/test_qa_with_sources.py
@@ -28,6 +28,11 @@ from tests.unit_tests.llms.fake_llm import FakeLLM
             "28-pl",
         ),
         (
+            "According to the sources, the agreement is governed by English law.\nSource: 28-pl",
+            "According to the sources, the agreement is governed by English law.\n",
+            "28-pl",
+        ),
+        (
             "This Agreement is governed by English law.\n"
             "SOURCES: 28-pl\n\n"
             "QUESTION: Which state/country's law governs the interpretation of the "


### PR DESCRIPTION
  - Description: In my previous PR, I had modified the code to catch all kinds of [SOURCES, sources, Source, Sources]. However, this change included checking for a colon or a white space which should actually have been only checking for a colon.
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: @baskaryan 
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.
