### PR TITLE
docs: Fix the syntax error, replace "dotenv.load_env()" with "dotenv.…

### DIFF
--- a/docs/extras/use_cases/apis.ipynb
+++ b/docs/extras/use_cases/apis.ipynb
@@ -62,7 +62,7 @@
     "\n",
     "# Set env var OPENAI_API_KEY or load from a .env file:\n",
     "# import dotenv\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/chatbots.ipynb
+++ b/docs/extras/use_cases/chatbots.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "# Set env var OPENAI_API_KEY or load from a .env file:\n",
     "# import dotenv\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/code_understanding.ipynb
+++ b/docs/extras/use_cases/code_understanding.ipynb
@@ -42,7 +42,7 @@
     "# Set env var OPENAI_API_KEY or load from a .env file\n",
     "# import dotenv\n",
     "\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/extraction.ipynb
+++ b/docs/extras/use_cases/extraction.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "# Set env var OPENAI_API_KEY or load from a .env file:\n",
     "# import dotenv\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/more/agents/agents.ipynb
+++ b/docs/extras/use_cases/more/agents/agents.ipynb
@@ -70,7 +70,7 @@
     "# Set env var OPENAI_API_KEY and SERPAPI_API_KEY or load from a .env file\n",
     "# import dotenv\n",
     "\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/question_answering/question_answering.ipynb
+++ b/docs/extras/use_cases/question_answering/question_answering.ipynb
@@ -47,7 +47,7 @@
     "# Set env var OPENAI_API_KEY or load from a .env file\n",
     "# import dotenv\n",
     "\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/sql.ipynb
+++ b/docs/extras/use_cases/sql.ipynb
@@ -50,7 +50,7 @@
     "# Set env var OPENAI_API_KEY or load from a .env file\n",
     "# import dotenv\n",
     "\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/summarization.ipynb
+++ b/docs/extras/use_cases/summarization.ipynb
@@ -76,7 +76,7 @@
     "# Set env var OPENAI_API_KEY or load from a .env file\n",
     "# import dotenv\n",
     "\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/tagging.ipynb
+++ b/docs/extras/use_cases/tagging.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "# Set env var OPENAI_API_KEY or load from a .env file:\n",
     "# import dotenv\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {

--- a/docs/extras/use_cases/web_scraping.ipynb
+++ b/docs/extras/use_cases/web_scraping.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "# Set env var OPENAI_API_KEY or load from a .env file:\n",
     "# import dotenv\n",
-    "# dotenv.load_env()"
+    "# dotenv.load_dotenv()"
    ]
   },
   {


### PR DESCRIPTION
Description:  The documents incorrectly mentions "dotenv.load_env()", but it should actually be "dotenv.load_dotenv()". You can see the screenshot below for reference:

python-dotenv: 1.0.0

![image](https://github.com/langchain-ai/langchain/assets/2959046/94dc4b51-cc2f-412d-92e9-16b8ff0d513e)


