### PR TITLE
Added runtime argument to Deep Lake Vector Store initialization

### DIFF
--- a/libs/langchain/langchain/vectorstores/deeplake.py
+++ b/libs/langchain/langchain/vectorstores/deeplake.py
@@ -62,6 +62,7 @@ class DeepLake(VectorStore):
         num_workers: int = 0,
         verbose: bool = True,
         exec_option: Optional[str] = None,
+        runtime: Optional[Dict] = None,
         **kwargs: Any,
     ) -> None:
         """Creates an empty DeepLakeVectorStore or loads an existing one.
@@ -77,7 +78,7 @@ class DeepLake(VectorStore):
             >>> # Create a vector store in the Deep Lake Managed Tensor Database
             >>> data = DeepLake(
             ...        path = "hub://org_id/dataset_name",
-            ...        exec_option = "tensor_db",
+            ...        runtime = {"tensor_db": True},
             ... )
 
         Args:
@@ -114,6 +115,10 @@ class DeepLake(VectorStore):
                     responsible for storage and query execution. Only for data stored in
                     the Deep Lake Managed Database. Use runtime = {"db_engine": True}
                     during dataset creation.
+            runtime (Dict, optional): Parameters for creating the Vector Store in 
+                Deep Lake's Managed Tensor Database. Not applicable when loading an 
+                existing Vector Store. To create a Vector Store in the Managed Tensor 
+                Database, set `runtime = {"tensor_db": True}`.
             **kwargs: Other optional keyword arguments.
 
         Raises:
@@ -131,11 +136,11 @@ class DeepLake(VectorStore):
             )
 
         if (
-            kwargs.get("runtime") == {"tensor_db": True}
+            runtime == {"tensor_db": True}
             and version_compare(deeplake.__version__, "3.6.7") == -1
         ):
             raise ImportError(
-                "To use tensor_db option you need to update deeplake to `3.6.7`. "
+                "To use tensor_db option you need to update deeplake to `3.6.7` or higher. "
                 f"Currently installed deeplake version is {deeplake.__version__}. "
             )
 
@@ -154,6 +159,7 @@ class DeepLake(VectorStore):
             token=token,
             exec_option=exec_option,
             verbose=verbose,
+            runtime=runtime,
             **kwargs,
         )
 


### PR DESCRIPTION
In this PR I am adding optional runtime argument that is responsible for transferring data to Deep Lake's Managed Service, and also change docs accordingly so that users know how to use that argument.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
