### PR TITLE
fix (Html2TextTransformer): allow configuration of html2text

### DIFF
--- a/libs/langchain/langchain/document_transformers/html2text.py
+++ b/libs/langchain/langchain/document_transformers/html2text.py
@@ -5,6 +5,11 @@ from langchain.schema import BaseDocumentTransformer, Document
 
 class Html2TextTransformer(BaseDocumentTransformer):
     """Replace occurrences of a particular search pattern with a replacement string
+
+    Arguments:
+        ignore_links: Whether links should be ignored; defaults to True.
+        ignore_images: Whether images should be ignored; defaults to True.
+
     Example:
         .. code-block:: python
             from langchain.document_transformers import Html2TextTransformer
@@ -12,11 +17,7 @@ class Html2TextTransformer(BaseDocumentTransformer):
             docs_transform=html2text.transform_documents(docs)
     """
 
-    def transform_documents(
-        self,
-        documents: Sequence[Document],
-        **kwargs: Any,
-    ) -> Sequence[Document]:
+    def __init__(self, ignore_links: bool = True, ignore_images: bool = True) -> None:
         try:
             import html2text
         except ImportError:
@@ -25,12 +26,20 @@ class Html2TextTransformer(BaseDocumentTransformer):
                 install it with `pip install html2text`"""
             )
 
-        # Create an html2text.HTML2Text object and override some properties
+        # Create a html2text.HTML2Text object and override some properties
         h = html2text.HTML2Text()
-        h.ignore_links = True
-        h.ignore_images = True
+        h.ignore_links = ignore_links
+        h.ignore_images = ignore_images
+
+        self.html2text = h
+
+    def transform_documents(
+        self,
+        documents: Sequence[Document],
+        **kwargs: Any,
+    ) -> Sequence[Document]:
         for d in documents:
-            d.page_content = h.handle(d.page_content)
+            d.page_content = self.html2text.handle(d.page_content)
         return documents
 
     async def atransform_documents(

--- a/libs/langchain/langchain/document_transformers/html2text.py
+++ b/libs/langchain/langchain/document_transformers/html2text.py
@@ -13,11 +13,19 @@ class Html2TextTransformer(BaseDocumentTransformer):
     Example:
         .. code-block:: python
             from langchain.document_transformers import Html2TextTransformer
-            html2text=Html2TextTransformer()
-            docs_transform=html2text.transform_documents(docs)
+            html2text = Html2TextTransformer()
+            docs_transform = html2text.transform_documents(docs)
     """
 
     def __init__(self, ignore_links: bool = True, ignore_images: bool = True) -> None:
+        self.ignore_links = ignore_links
+        self.ignore_images = ignore_images
+
+    def transform_documents(
+        self,
+        documents: Sequence[Document],
+        **kwargs: Any,
+    ) -> Sequence[Document]:
         try:
             import html2text
         except ImportError:
@@ -28,18 +36,11 @@ class Html2TextTransformer(BaseDocumentTransformer):
 
         # Create a html2text.HTML2Text object and override some properties
         h = html2text.HTML2Text()
-        h.ignore_links = ignore_links
-        h.ignore_images = ignore_images
+        h.ignore_links = self.ignore_links
+        h.ignore_images = self.ignore_images
 
-        self.html2text = h
-
-    def transform_documents(
-        self,
-        documents: Sequence[Document],
-        **kwargs: Any,
-    ) -> Sequence[Document]:
         for d in documents:
-            d.page_content = self.html2text.handle(d.page_content)
+            d.page_content = h.handle(d.page_content)
         return documents
 
     async def atransform_documents(


### PR DESCRIPTION
Hi, this PR enables configuring the html2text package, instead of being bound to use the hardcoded values. While simply passing `ignore_links` and `ignore_images` to the `transform_documents` method was possible, I preferred passing them to the `__init__` method for 2 reasons:

1. It is more efficient in case of subsequent calls to `transform_documents`.
2. It allows to move the "complexity" to the instantiation, keeping the actual execution simple and general enough. IMO the transformers should all follow this pattern, allowing something like this:
```python
# Instantiate transformers
transformers = [
    TransformerA(foo='bar'),
    TransformerB(bar='foo'),
    # others
]

# During execution, call them sequentially
documents = ...
for tr in transformers:
    documents = tr.transform_documents(documents)
```

Thanks for the reviews!

