### PR TITLE
Pre-release Xata version no longer required

### DIFF
--- a/docs/extras/integrations/memory/xata_chat_message_history.ipynb
+++ b/docs/extras/integrations/memory/xata_chat_message_history.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install xata==1.0.0rc0 openai langchain"
+    "!pip install xata openai langchain"
    ]
   },
   {

--- a/docs/extras/integrations/vectorstores/xata.ipynb
+++ b/docs/extras/integrations/vectorstores/xata.ipynb
@@ -52,7 +52,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install xata==1.0.0a7 openai tiktoken langchain"
+    "!pip install xata openai tiktoken langchain"
    ]
   },
   {


### PR DESCRIPTION
Tiny PR: Since we've released version 1.0.0 of the python SDK, we no longer need to specify the pre-release version when pip installing.