### PR TITLE
Cube semantic loader: allow cubes processing

### DIFF
--- a/docs/extras/integrations/document_loaders/cube_semantic.ipynb
+++ b/docs/extras/integrations/document_loaders/cube_semantic.ipynb
@@ -106,15 +106,39 @@
     "  - `column_data_type`\n",
     "  - `column_title`\n",
     "  - `column_description`\n",
-    "  - `column_values`"
+    "  - `column_values`\n",
+    "  - `cube_data_obj_type`"
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "> page_content='Users View City, None' metadata={'table_name': 'users_view', 'column_name': 'users_view.city', 'column_data_type': 'string', 'column_title': 'Users View City', 'column_description': 'None', 'column_member_type': 'dimension', 'column_values': ['Austin', 'Chicago', 'Los Angeles', 'Mountain View', 'New York', 'Palo Alto', 'San Francisco', 'Seattle']}"
+    "# Given string containing page content\n",
+    "page_content = 'Users View City, None'\n",
+    "\n",
+    "# Given dictionary containing metadata\n",
+    "metadata = {\n",
+    "    'table_name': 'users_view',\n",
+    "    'column_name': 'users_view.city',\n",
+    "    'column_data_type': 'string',\n",
+    "    'column_title': 'Users View City',\n",
+    "    'column_description': 'None',\n",
+    "    'column_member_type': 'dimension',\n",
+    "    'column_values': [\n",
+    "        'Austin',\n",
+    "        'Chicago',\n",
+    "        'Los Angeles',\n",
+    "        'Mountain View',\n",
+    "        'New York',\n",
+    "        'Palo Alto',\n",
+    "        'San Francisco',\n",
+    "        'Seattle'\n",
+    "    ],\n",
+    "    'cube_data_obj_type': 'view'\n",
+    "}"
    ]
   }
  ],

--- a/libs/langchain/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -35,7 +35,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
                 {
                     "name": "test_cube",
                     "type": "view",
-                    "isVisible": True,
+                    "public": True,
                     "measures": [],
                     "dimensions": [
                         {

--- a/libs/langchain/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -35,6 +35,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
                 {
                     "name": "test_cube",
                     "type": "view",
+                    "isVisible": True,
                     "measures": [],
                     "dimensions": [
                         {


### PR DESCRIPTION
We've started to receive feedback (after launch) that using only views is confusing.
We're considering this as a good practice, as a view serves as a "facade" for your data - however, we decided to let users decide this on their own.

Solves the questions from:
- https://github.com/cube-js/cube/issues/7028
- https://github.com/langchain-ai/langchain/pull/9690