### PR TITLE
addition of cosine distance function for faiss

### DIFF
--- a/libs/langchain/langchain/vectorstores/faiss.py
+++ b/libs/langchain/langchain/vectorstores/faiss.py
@@ -736,6 +736,8 @@ class FAISS(VectorStore):
         elif self.distance_strategy == DistanceStrategy.EUCLIDEAN_DISTANCE:
             # Default behavior is to use euclidean distance relevancy
             return self._euclidean_relevance_score_fn
+        elif self.distance_strategy == DistanceStrategy.COSINE:
+            return self._cosine_relevance_score_fn
         else:
             raise ValueError(
                 "Unknown distance strategy, must be cosine, max_inner_product,"


### PR DESCRIPTION
  - Description: added the _cosine_relevance_score_fn to _select_relevance_score_fn of faiss.py to enable the use of cosine distance for similarity for this vector store and to comply with the Error Message, that implies, that cosine should be a valid distance strategy
  - Issue: no relevant Issue found, but needed this function myself and tested it in a private repo
  - Dependencies: none


