### PR TITLE
Fix json parsing error of MULTI_PROMPT_ROUTER_TEMPLATE

### DIFF
--- a/libs/langchain/langchain/chains/router/multi_prompt_prompt.py
+++ b/libs/langchain/langchain/chains/router/multi_prompt_prompt.py
@@ -28,4 +28,5 @@ modifications are needed.
 {{input}}
 
 << OUTPUT (must include ```json at the start of the response) >>
+<< OUTPUT (must end with ```) >>
 """


### PR DESCRIPTION
The output at times lacks the closing markdown code block. The prompt is changed to explicitly request the closing backticks.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
