### PR TITLE
docs: `memory` menu

### DIFF
--- a/docs/extras/modules/memory/adding_memory.ipynb
+++ b/docs/extras/modules/memory/adding_memory.ipynb
@@ -7,9 +7,11 @@
     "tags": []
    },
    "source": [
-    "# How to add Memory to an LLMChain\n",
+    "# Memory in LLMChain\n",
     "\n",
-    "This notebook goes over how to use the Memory class with an LLMChain. For the purposes of this walkthrough, we will add  the [ConversationBufferMemory](https://api.python.langchain.com/en/latest/memory/langchain.memory.buffer.ConversationBufferMemory.html#langchain.memory.buffer.ConversationBufferMemory) class, although this can be any memory class."
+    "This notebook goes over how to use the Memory class with an LLMChain. \n",
+    "\n",
+    "We will add  the [ConversationBufferMemory](https://api.python.langchain.com/en/latest/memory/langchain.memory.buffer.ConversationBufferMemory.html#langchain.memory.buffer.ConversationBufferMemory) class, although this can be any memory class."
    ]
   },
   {
@@ -321,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/memory/adding_memory_chain_multiple_inputs.ipynb
+++ b/docs/extras/modules/memory/adding_memory_chain_multiple_inputs.ipynb
@@ -5,9 +5,9 @@
    "id": "e42733c5",
    "metadata": {},
    "source": [
-    "# How to add memory to a Multi-Input Chain\n",
+    "# Memory in the Multi-Input Chain\n",
     "\n",
-    "Most memory objects assume a single input. In this notebook, we go over how to add memory to a chain that has multiple inputs. As an example of such a chain, we will add memory to a question/answering chain. This chain takes as inputs both related documents and a user question."
+    "Most memory objects assume a single input. In this notebook, we go over how to add memory to a chain that has multiple inputs. We will add memory to a question/answering chain. This chain takes as inputs both related documents and a user question."
    ]
   },
   {
@@ -178,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/memory/agent_with_memory.ipynb
+++ b/docs/extras/modules/memory/agent_with_memory.ipynb
@@ -5,11 +5,11 @@
    "id": "fa6802ac",
    "metadata": {},
    "source": [
-    "# How to add Memory to an Agent\n",
+    "# Memory in Agent\n",
     "\n",
     "This notebook goes over adding memory to an Agent. Before going through this notebook, please walkthrough the following notebooks, as this will build on top of both of them:\n",
     "\n",
-    "- [Adding memory to an LLM Chain](/docs/modules/memory/how_to/adding_memory.html)\n",
+    "- [Memory in LLMChain](/docs/modules/memory/how_to/adding_memory.html)\n",
     "- [Custom Agents](/docs/modules/agents/how_to/custom_agent.html)\n",
     "\n",
     "In order to add a memory to an agent we are going to the the following steps:\n",
@@ -317,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/memory/agent_with_memory_in_db.ipynb
+++ b/docs/extras/modules/memory/agent_with_memory_in_db.ipynb
@@ -5,13 +5,13 @@
    "id": "fa6802ac",
    "metadata": {},
    "source": [
-    "# Adding Message Memory backed by a database to an Agent\n",
+    "# Message Memory in Agent backed by a database\n",
     "\n",
     "This notebook goes over adding memory to an Agent where the memory uses an external message store. Before going through this notebook, please walkthrough the following notebooks, as this will build on top of both of them:\n",
     "\n",
-    "- [Adding memory to an LLM Chain](/docs/modules/memory/how_to/adding_memory.html)\n",
+    "- [Memory in LLMChain](/docs/modules/memory/how_to/adding_memory.html)\n",
     "- [Custom Agents](/docs/modules/agents/how_to/custom_agent.html)\n",
-    "- [Agent with Memory](/docs/modules/memory/how_to/agent_with_memory.html)\n",
+    "- [Memory in Agent](/docs/modules/memory/how_to/agent_with_memory.html)\n",
     "\n",
     "In order to add a memory with an external message store to an agent we are going to do the following steps:\n",
     "\n",
@@ -348,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/memory/conversational_customization.ipynb
+++ b/docs/extras/modules/memory/conversational_customization.ipynb
@@ -5,7 +5,7 @@
    "id": "69e35d6f",
    "metadata": {},
    "source": [
-    "# How to customize conversational memory\n",
+    "# Customizing Conversational Memory\n",
     "\n",
     "This notebook walks through a few ways to customize conversational memory."
    ]
@@ -373,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/memory/custom_memory.ipynb
+++ b/docs/extras/modules/memory/custom_memory.ipynb
@@ -5,7 +5,8 @@
    "id": "94e33ebe",
    "metadata": {},
    "source": [
-    "# How to create a custom Memory class\n",
+    "# Custom Memory\n",
+    "\n",
     "Although there are a few predefined types of memory in LangChain, it is highly possible you will want to add your own type of memory that is optimal for your application. This notebook covers how to do that."
    ]
   },
@@ -295,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/extras/modules/memory/multiple_memory.ipynb
+++ b/docs/extras/modules/memory/multiple_memory.ipynb
@@ -5,8 +5,9 @@
    "id": "d9fec22e",
    "metadata": {},
    "source": [
-    "# How to use multiple memory classes in the same chain\n",
-    "It is also possible to use multiple memory classes in the same chain. To combine multiple memory classes, we can initialize the `CombinedMemory` class, and then use that."
+    "# Multiple Memory classes\n",
+    "\n",
+    "We can use multiple memory classes in the same chain. To combine multiple memory classes, we initialize and use the `CombinedMemory` class."
    ]
   },
   {
@@ -158,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The [Memory](https://python.langchain.com/docs/modules/memory/) menu is clogged with unnecessary wording.
I've made it more concise by simplifying titles of the example notebooks. 
As results, menu is shorter and better for comprehend.
