### PR TITLE
update_forward_refs for Run

### DIFF
--- a/libs/langchain/langchain/callbacks/tracers/schemas.py
+++ b/libs/langchain/langchain/callbacks/tracers/schemas.py
@@ -120,6 +120,7 @@ class Run(BaseRunV2):
 
 ChainRun.update_forward_refs()
 ToolRun.update_forward_refs()
+Run.update_forward_refs()
 
 __all__ = [
     "BaseRun",


### PR DESCRIPTION
Adds a call to Pydantic's `update_forward_refs` for the `Run` class (in addition to the `ChainRun` and `ToolRun` classes, for which that method is already called). Without it, the self-reference of child classes (type `List[Run]`) is problematic. For example:

```python
from langchain.callbacks import StdOutCallbackHandler
from langchain.chains import LLMChain
from langchain.llms import OpenAI
from langchain.prompts import PromptTemplate
from wandb.integration.langchain import WandbTracer

llm = OpenAI()
prompt = PromptTemplate.from_template("1 + {number} = ")

chain = LLMChain(llm=llm, prompt=prompt, callbacks=[StdOutCallbackHandler(), WandbTracer()])
print(chain.run(number=2))

```

results in the following output before the change

```
WARNING:root:Error in on_chain_start callback: field "child_runs" not yet prepared so type is still a ForwardRef, you might need to call Run.update_forward_refs().

> Entering new LLMChain chain...
Prompt after formatting:
1 + 2 = 
WARNING:root:Error in on_chain_end callback: No chain Run found to be traced

> Finished chain.

3
```

but afterwards the callback error messages are gone.