### PR TITLE
docs: `google-drive-tool` example fix

### DIFF
--- a/docs/extras/integrations/tools/google_drive.ipynb
+++ b/docs/extras/integrations/tools/google_drive.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Google Drive tool\n",
+    "# Google Drive\n",
     "\n",
-    "This notebook walks through connecting a LangChain to the Google Drive API.\n",
+    "This notebook walks through connecting a LangChain to the `Google Drive API`.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
@@ -207,7 +207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This notebook was mistakenly placed in the `toolkits` folder and appears within `Agents & Toolkits` menu. But it should be in `Tools`.
Moved example into `tools/`; updated title to consistent format.