### PR TITLE
Add ne comparator

### DIFF
--- a/libs/langchain/langchain/chains/query_constructor/ir.py
+++ b/libs/langchain/langchain/chains/query_constructor/ir.py
@@ -81,6 +81,7 @@ class Comparator(str, Enum):
     """Enumerator of the comparison operators."""
 
     EQ = "eq"
+    NE = "ne"
     GT = "gt"
     GTE = "gte"
     LT = "lt"

--- a/libs/langchain/langchain/retrievers/self_query/chroma.py
+++ b/libs/langchain/langchain/retrievers/self_query/chroma.py
@@ -17,6 +17,7 @@ class ChromaTranslator(Visitor):
     """Subset of allowed logical operators."""
     allowed_comparators = [
         Comparator.EQ,
+        Comparator.NE,
         Comparator.GT,
         Comparator.GTE,
         Comparator.LT,

--- a/libs/langchain/langchain/retrievers/self_query/deeplake.py
+++ b/libs/langchain/langchain/retrievers/self_query/deeplake.py
@@ -22,6 +22,7 @@ COMPARATOR_TO_TQL = {
 OPERATOR_TO_TQL = {
     Operator.AND: "and",
     Operator.OR: "or",
+    Operator.NOT: "NOT",
 }
 
 
@@ -37,7 +38,7 @@ def can_cast_to_float(string: str) -> bool:
 class DeepLakeTranslator(Visitor):
     """Translate `DeepLake` internal query language elements to valid filters."""
 
-    allowed_operators = [Operator.AND, Operator.OR]
+    allowed_operators = [Operator.AND, Operator.OR, Operator.NOT]
     """Subset of allowed logical operators."""
     allowed_comparators = [
         Comparator.EQ,

--- a/libs/langchain/langchain/retrievers/self_query/pinecone.py
+++ b/libs/langchain/langchain/retrievers/self_query/pinecone.py
@@ -21,7 +21,7 @@ class PineconeTranslator(Visitor):
         Comparator.GTE,
     )
     """Subset of allowed logical comparators."""
-    allowed_operators = (Operator.AND, Operator.OR)
+    allowed_operators = (Operator.AND, Operator.OR, Operator.NOT)
     """Subset of allowed logical operators."""
 
     def _format_func(self, func: Union[Operator, Comparator]) -> str:

--- a/libs/langchain/langchain/retrievers/self_query/pinecone.py
+++ b/libs/langchain/langchain/retrievers/self_query/pinecone.py
@@ -15,13 +15,14 @@ class PineconeTranslator(Visitor):
 
     allowed_comparators = (
         Comparator.EQ,
+        Comparator.NE,
         Comparator.LT,
         Comparator.LTE,
         Comparator.GT,
         Comparator.GTE,
     )
     """Subset of allowed logical comparators."""
-    allowed_operators = (Operator.AND, Operator.OR, Operator.NOT)
+    allowed_operators = (Operator.AND, Operator.OR)
     """Subset of allowed logical operators."""
 
     def _format_func(self, func: Union[Operator, Comparator]) -> str:


### PR DESCRIPTION
Description: Adds the not comparator and operator to pinecone, chroma and deeplake.
Issue: Not a registered issue but when using a selfqueryretriever with pinecone I got this error + stacktrace when I entered a query that asked to not include specific data: 
 
>  raised following `error:`
> Received unrecognized function ne. Valid functions are [<Operator.AND: 'and'>, <Operator.OR: 'or'>, <Operator.NOT: 'not'>, <Comparator.EQ: 'eq'>, <Comparator.GT: 'gt'>, <Comparator.GTE: 'gte'>, <Comparator.LT: 'lt'>, <Comparator.LTE: 'lte'>]

I noticed that chroma and deeplake also support not equals/not filtering so I added it there as well


[pinecone](https://docs.pinecone.io/docs/metadata-filtering#metadata-query-language)
[chroma](https://docs.trychroma.com/usage-guide#filtering-by-metadata)
[deeplake](https://docs.activeloop.ai/enterprise-features/compute-engine/querying-datasets/query-syntax#and-or-not)