### PR TITLE
Fix Typo : `openai_api_key` -> `serpapi_api_key`

### DIFF
--- a/docs/extras/modules/agents/agent_types/openai_multi_functions_agent.ipynb
+++ b/docs/extras/modules/agents/agent_types/openai_multi_functions_agent.ipynb
@@ -71,7 +71,7 @@
     "llm = ChatOpenAI(temperature=0, model=\"gpt-3.5-turbo-0613\")\n",
     "\n",
     "# Initialize the SerpAPIWrapper for search functionality\n",
-    "# Replace <your_api_key> in serpai_api_key=\"<your_api_key>\" with your actual SerpAPI key.\n",
+    "# Replace <your_api_key> in serpapi_api_key=\"<your_api_key>\" with your actual SerpAPI key.\n",
     "search = SerpAPIWrapper()\n",
     "\n",
     "# Define a list of tools offered by the agent\n",

--- a/docs/extras/modules/agents/agent_types/openai_multi_functions_agent.ipynb
+++ b/docs/extras/modules/agents/agent_types/openai_multi_functions_agent.ipynb
@@ -71,7 +71,7 @@
     "llm = ChatOpenAI(temperature=0, model=\"gpt-3.5-turbo-0613\")\n",
     "\n",
     "# Initialize the SerpAPIWrapper for search functionality\n",
-    "# Replace <your_api_key> in openai_api_key=\"<your_api_key>\" with your actual SerpAPI key.\n",
+    "# Replace <your_api_key> in serpai_api_key=\"<your_api_key>\" with your actual SerpAPI key.\n",
     "search = SerpAPIWrapper()\n",
     "\n",
     "# Define a list of tools offered by the agent\n",


### PR DESCRIPTION
Fixed typo in the comments Notebook. (which says `openai_api_key` for SerpAPI)
