### PR TITLE
Impl chat message prompt type/dict (#10033)

### DIFF
--- a/libs/langchain/langchain/prompts/chat.py
+++ b/libs/langchain/langchain/prompts/chat.py
@@ -40,6 +40,23 @@ class BaseMessagePromptTemplate(Serializable, ABC):
     """Base class for message prompt templates."""
 
     @property
+    def _prompt_type(self) -> str:
+        """Return the prompt type key."""
+        return "message"
+
+    @property
+    def _msg_type(self) -> str:
+        """Return the msg type key."""
+        raise NotImplementedError
+
+    def dict(self, **kwargs: Any) -> Dict:
+        """Return dictionary representation of prompt."""
+        prompt = super().dict(**kwargs)
+        prompt["_type"] = self._prompt_type
+        prompt["_msg_type"] = self._msg_type
+        return prompt
+
+    @property
     def lc_serializable(self) -> bool:
         """Whether this object should be serialized.
 
@@ -86,6 +103,11 @@ class MessagesPlaceholder(BaseMessagePromptTemplate):
 
     variable_name: str
     """Name of variable to use as messages."""
+
+    @property
+    def _msg_type(self) -> str:
+        """Return the msg type key."""
+        return "placeholder"
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format messages from kwargs.
@@ -213,6 +235,11 @@ class ChatMessagePromptTemplate(BaseStringMessagePromptTemplate):
     role: str
     """Role of the message."""
 
+    @property
+    def _msg_type(self) -> str:
+        """Return the msg type key."""
+        return "chat"
+
     def format(self, **kwargs: Any) -> BaseMessage:
         """Format the prompt template.
 
@@ -231,6 +258,11 @@ class ChatMessagePromptTemplate(BaseStringMessagePromptTemplate):
 class HumanMessagePromptTemplate(BaseStringMessagePromptTemplate):
     """Human message prompt template. This is a message that is sent to the user."""
 
+    @property
+    def _msg_type(self) -> str:
+        """Return the msg type key."""
+        return "human"
+
     def format(self, **kwargs: Any) -> BaseMessage:
         """Format the prompt template.
 
@@ -246,6 +278,11 @@ class HumanMessagePromptTemplate(BaseStringMessagePromptTemplate):
 
 class AIMessagePromptTemplate(BaseStringMessagePromptTemplate):
     """AI message prompt template. This is a message that is not sent to the user."""
+
+    @property
+    def _msg_type(self) -> str:
+        """Return the msg type key."""
+        return "ai"
 
     def format(self, **kwargs: Any) -> BaseMessage:
         """Format the prompt template.
@@ -264,6 +301,11 @@ class SystemMessagePromptTemplate(BaseStringMessagePromptTemplate):
     """System message prompt template.
     This is a message that is not sent to the user.
     """
+
+    @property
+    def _msg_type(self) -> str:
+        """Return the msg type key."""
+        return "system"
 
     def format(self, **kwargs: Any) -> BaseMessage:
         """Format the prompt template.

--- a/libs/langchain/langchain/prompts/loading.py
+++ b/libs/langchain/langchain/prompts/loading.py
@@ -7,6 +7,14 @@ from typing import Callable, Dict, Union
 import yaml
 
 from langchain.output_parsers.regex import RegexParser
+from langchain.prompts.chat import (
+    AIMessagePromptTemplate,
+    BaseMessagePromptTemplate,
+    ChatMessagePromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    SystemMessagePromptTemplate,
+)
 from langchain.prompts.few_shot import FewShotPromptTemplate
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import BaseLLMOutputParser, BasePromptTemplate, StrOutputParser
@@ -113,6 +121,35 @@ def _load_prompt(config: dict) -> PromptTemplate:
     config = _load_template("template", config)
     config = _load_output_parser(config)
     return PromptTemplate(**config)
+
+
+def load_message_prompt(config: dict) -> BaseMessagePromptTemplate:
+    msg_type = config["_msg_type"]
+    if msg_type == "ai":
+        return AIMessagePromptTemplate(
+            prompt=load_prompt_from_config(config["prompt"]),
+            additional_kwargs=config.get("additional_kwargs", {}),
+        )
+    elif msg_type == "system":
+        return SystemMessagePromptTemplate(
+            prompt=load_prompt_from_config(config["prompt"]),
+            additional_kwargs=config.get("additional_kwargs", {}),
+        )
+    elif msg_type == "human":
+        return HumanMessagePromptTemplate(
+            prompt=load_prompt_from_config(config["prompt"]),
+            additional_kwargs=config.get("additional_kwargs", {}),
+        )
+    elif msg_type == "chat":
+        return ChatMessagePromptTemplate(
+            role=config["role"],
+            prompt=load_prompt_from_config(config["prompt"]),
+            additional_kwargs=config.get("additional_kwargs", {}),
+        )
+    elif msg_type == "placeholder":
+        return MessagesPlaceholder(**config)
+    else:
+        raise ValueError(f"Unsupported msg type: {msg_type}")
 
 
 def load_prompt(path: Union[str, Path]) -> BasePromptTemplate:

--- a/libs/langchain/tests/unit_tests/prompts/test_chat.py
+++ b/libs/langchain/tests/unit_tests/prompts/test_chat.py
@@ -12,6 +12,7 @@ from langchain.prompts.chat import (
     ChatPromptTemplate,
     ChatPromptValue,
     HumanMessagePromptTemplate,
+    MessagesPlaceholder,
     SystemMessagePromptTemplate,
     _convert_to_message,
 )
@@ -349,3 +350,52 @@ def test_chat_message_partial() -> None:
     ]
     assert res == expected
     assert template2.format(input="hello") == get_buffer_string(expected)
+
+
+def test_base_message_template_to_dict() -> None:
+    # system message
+    system_msg = SystemMessagePromptTemplate(
+        prompt=PromptTemplate(
+            template="Here's some context: {context}",
+            input_variables=["context"],
+        ),
+        additional_kwargs={"foo": "bar"},
+    )
+    system_msg_dict = system_msg.dict()
+    assert system_msg_dict["_msg_type"] == "system"
+
+    # human message
+    human_msg = HumanMessagePromptTemplate(
+        prompt=PromptTemplate(
+            template="Hello {foo}, I'm {bar}. Thanks for the {context}",
+            input_variables=["foo", "bar", "context"],
+        )
+    )
+    human_msg_dict = human_msg.dict()
+    assert human_msg_dict["_msg_type"] == "human"
+
+    # ai message
+    ai_msg = AIMessagePromptTemplate(
+        prompt=PromptTemplate(
+            template="I'm an AI. I'm {foo}. I'm {bar}.",
+            input_variables=["foo", "bar"],
+        )
+    )
+    ai_msg_dict = ai_msg.dict()
+    assert ai_msg_dict["_msg_type"] == "ai"
+
+    # chat message
+    chat_msg = ChatMessagePromptTemplate(
+        role="test",
+        prompt=PromptTemplate(
+            template="I'm a generic message. I'm {foo}. I'm {bar}.",
+            input_variables=["foo", "bar"],
+        ),
+    )
+    chat_msg_dict = chat_msg.dict()
+    assert chat_msg_dict["_msg_type"] == "chat"
+
+    # placeholder
+    placeholder_msg = MessagesPlaceholder(variable_name="foo")
+    placeholder_msg_dict = placeholder_msg.dict()
+    assert placeholder_msg_dict["_msg_type"] == "placeholder"


### PR DESCRIPTION
## Description
Dumping BaseMessagePromptTemplate to json and loading to original Template is difficult, as retrieving exact type of message type from json is not possible.
Therefore, I suggest adding _msg_type / _type property on BaseMessagePromptTemplate and utilized it on _dict and added load_message_prompt,
like In [BasePromptTemplate dict method](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/schema/prompt_template.py#L108-L116).

## Issue
#10033 

## Dependencies
None

