### PR TITLE
fix wrong import line in cassandra doc page for vector store

### DIFF
--- a/docs/extras/integrations/providers/cassandra.mdx
+++ b/docs/extras/integrations/providers/cassandra.mdx
@@ -21,7 +21,7 @@ pip install cassio
 See a [usage example](/docs/integrations/vectorstores/cassandra).
 
 ```python
-from langchain.memory import CassandraChatMessageHistory
+from langchain.vectorstores import Cassandra
 ```
 
 


### PR DESCRIPTION
This fixes the exampe import line in the general "cassandra" doc page mdx file. (it was erroneously a copy of the chat message history import statement found below).