### PR TITLE
Update chroma.py

### DIFF
--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -40,7 +40,9 @@ def _results_to_docs_and_scores(results: Any) -> List[Tuple[Document, float]]:
         # TODO: Chroma can do batch querying,
         # we shouldn't hard code to the 1st result
         # minor fix :metadata may contain distances dict by merge two dicts
-        (Document(page_content=result[0], metadata={**result[1],**{"distances":result[2]} } or {}), result[2])
+        (Document(page_content=result[0], 
+         metadata={**result[1],**{"distances":result[2]} } or {}), 
+         result[2])
         for result in zip(
             results["documents"][0],
             results["metadatas"][0],

--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -39,7 +39,8 @@ def _results_to_docs_and_scores(results: Any) -> List[Tuple[Document, float]]:
     return [
         # TODO: Chroma can do batch querying,
         # we shouldn't hard code to the 1st result
-        (Document(page_content=result[0], metadata=result[1] or {}), result[2])
+        # minor fix :metadata may contain distances dict by merge two dicts
+        (Document(page_content=result[0], metadata={**result[1],**{"distances":result[2]} } or {}), result[2])
         for result in zip(
             results["documents"][0],
             results["metadatas"][0],


### PR DESCRIPTION
- Description: add minor fix codes in  langchain.vectorstors.chroma  to return distances value .
  so 
    qa=RetrievalQA.from_chain_type(
        llm=llm,
        chain_type="stuff",
        retriever=retriever, #a chroma db 
        return_source_documents=True,
        chain_type_kwargs={"prompt": prompt, "memory": memory},
    )
  res = qa(query)
  Now res can return distances value in the metadata dict. 
 
  answer, docs = res["result"], res["source_documents"]
  for document in docs:
       print("\n> [source file path]: " + document.metadata["source"] )
       print("> [cosine  similarity]:" + str(1.0-document.metadata["distances"]) )   # Add This  and it will print 1-distance_value
       print(">[text slice]:" + document.page_content)

    It is a very minor change.  I tested on the [https://github.com/PromtEngineer/localGPT/blob/main/run_localGPT.py#L237]
  
- Issue: the issue #4710 #5416 Maybe this fix is not directly with the issues , but I guess the intuition is alike.
- Dependencies: same as the main branch
- Tag maintainer: @baskaryan, @eyurtsev, @hwchase17, @rlancemartin
 
