### PR TITLE
Fixing _InactiveRpcError in MatchingEngine vectorstore

### DIFF
--- a/libs/langchain/langchain/vectorstores/matching_engine.py
+++ b/libs/langchain/langchain/vectorstores/matching_engine.py
@@ -174,11 +174,19 @@ class MatchingEngine(VectorStore):
         logger.debug(f"Embedding query {query}.")
         embedding_query = self.embedding.embed_documents([query])
 
-        response = self.endpoint.match(
-            deployed_index_id=self._get_index_id(),
-            queries=embedding_query,
-            num_neighbors=k,
-        )
+        # If the endpoint is public we use the find_neighbors function.
+        if self.endpoint._public_match_client:
+            response = self.endpoint.find_neighbors(
+                deployed_index_id=self._get_index_id(),
+                queries=embedding_query,
+                num_neighbors=k,
+            )
+        else:
+            response = self.endpoint.match(
+                deployed_index_id=self._get_index_id(),
+                queries=embedding_query,
+                num_neighbors=k,
+            )
 
         if len(response) == 0:
             return []


### PR DESCRIPTION
  - Description: There was an issue with the MatchingEngine VectorStore, preventing from using it with a public endpoint. In the Google Cloud library there are two similar methods for private or public endpoints : `match()` and `find_neighbors()`.
  - Issue: Fixes #8378 
  - This uses the `google.cloud.aiplatform` library : https://github.com/googleapis/python-aiplatform/blob/main/google/cloud/aiplatform/matching_engine/matching_engine_index_endpoint.py

