### PR TITLE
Update output_parser.py

### DIFF
--- a/libs/langchain/langchain/agents/mrkl/output_parser.py
+++ b/libs/langchain/langchain/agents/mrkl/output_parser.py
@@ -36,7 +36,7 @@ class MRKLOutputParser(AgentOutputParser):
                 )
             action = action_match.group(1).strip()
             action_input = action_match.group(2)
-            tool_input = action_input.strip(" ")
+            tool_input = action_input.strip(" '")
             # ensure if its a well formed SQL query we don't remove any trailing " chars
             if tool_input.startswith("SELECT ") is False:
                 tool_input = tool_input.strip('"')


### PR DESCRIPTION
I created a customLLM base on a llama2_70b online API service, used it for a text_to_sql mission.
I  used the "create_sql_agent", it didn't work well. A piece of the logfile looks like this:

Action: sql_db_schema
Action Input: 'customers'
Observation: Error: table_names {"'customers'"} not found in database

It seemed like the llama2_70b is more likely to use single quotes, probably some other llms too.
I find out that the output_parser  in "langchain\agents\mrkl\output_parser.py" strip the " " but not "'", strip them both should be a solution once for all. And it works for me.

