### PR TITLE
HuggingGPT string inplace

### DIFF
--- a/libs/experimental/langchain_experimental/autonomous_agents/hugginggpt/task_executor.py
+++ b/libs/experimental/langchain_experimental/autonomous_agents/hugginggpt/task_executor.py
@@ -111,7 +111,7 @@ class TaskExecutor:
             dep_task = self.id_task_map[dep_id]
             for k, v in task.args.items():
                 if f"<resource-{dep_id}>" in v:
-                    task.args[k].replace(f"<resource-{dep_id}>", dep_task.result)
+                    task.args[k] = task.args[k].replace(f"<resource-{dep_id}>", dep_task.result)
 
     def run(self) -> str:
         for task in self.tasks:


### PR DESCRIPTION
Description: This bug is found when using HuggingGPT in LangChain. I found that if there are dependencies between tasks, the execution results will become very bad. I debugged the code and found that it is because the filename of the generated file is not updated to the args of the following task, mainly due to the "replace()" function in string operation (it is not an in-place operation). You should assign the replace result with the string to save the change.

Issue: N/A

Dependencies: N/A