### PR TITLE
Bug-fix CSV Agent - Parsing Tool Inputs

### DIFF
--- a/libs/langchain/langchain/agents/openai_functions_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_agent/base.py
@@ -109,7 +109,9 @@ def _parse_ai_message(message: BaseMessage) -> Union[AgentAction, AgentFinish]:
     if function_call:
         function_name = function_call["name"]
         try:
-            _tool_input = json.loads(function_call["arguments"])
+            # escape special characters
+            _tool_input = json.dumps(function_call["arguments"])
+            _tool_input = json.loads(_tool_input)
         except JSONDecodeError:
             raise OutputParserException(
                 f"Could not parse tool input: {function_call} because "

--- a/libs/langchain/langchain/tools/python/tool.py
+++ b/libs/langchain/langchain/tools/python/tool.py
@@ -44,11 +44,6 @@ def sanitize_input(query: str) -> str:
     return query
 
 
-class AstArgSchema(BaseModel):
-    """A schema for the ast argument."""
-    query: str = Field(description="A string formatted plain python script with imports and variables to execute.")
-
-
 class PythonREPLTool(BaseTool):
     """A tool for running python code in a REPL."""
 
@@ -61,7 +56,6 @@ class PythonREPLTool(BaseTool):
     )
     python_repl: PythonREPL = Field(default_factory=_get_default_python_repl)
     sanitize_input: bool = True
-    args_schema: Type[BaseModel] = AstArgSchema
 
     def _run(
         self,
@@ -89,7 +83,7 @@ class PythonREPLTool(BaseTool):
 
 
 class PythonInputs(BaseModel):
-    query: str = Field(description="code snippet to run")
+    query: str = Field(description="A string formatted plain python script with imports and variables to execute.")
 
 
 class PythonAstREPLTool(BaseTool):

--- a/libs/langchain/langchain/tools/python/tool.py
+++ b/libs/langchain/langchain/tools/python/tool.py
@@ -31,12 +31,22 @@ def sanitize_input(query: str) -> str:
     Returns:
         str: The sanitized query
     """
+    # Extract the value inside '{"query": "..."}'
+    match = re.search(r'{\s*"query":\s?"(.*?)".*}', query, re.DOTALL)
+    if match:
+        query = match.group(1)
+        query = ast.literal_eval(f'"{query}"')
 
     # Removes `, whitespace & python from start
     query = re.sub(r"^(\s|`)*(?i:python)?\s*", "", query)
     # Removes whitespace & ` from end
     query = re.sub(r"(\s|`)*$", "", query)
     return query
+
+
+class AstArgSchema(BaseModel):
+    """A schema for the ast argument."""
+    query: str = Field(description="A string formatted plain python script with imports and variables to execute.")
 
 
 class PythonREPLTool(BaseTool):
@@ -51,6 +61,7 @@ class PythonREPLTool(BaseTool):
     )
     python_repl: PythonREPL = Field(default_factory=_get_default_python_repl)
     sanitize_input: bool = True
+    args_schema: Type[BaseModel] = AstArgSchema
 
     def _run(
         self,


### PR DESCRIPTION
Issue & Description:
Suggested changes are due to encountering constant constant errors when using the Pandas DataFrame Agent due to parsing the python code that comes in the responses from the LLMs.
To address the issue I propose json serialization of the arguments of the function call at the OpenAIFunctionsAgent, as well as a more detailed ArgSchema for the PythonAstREPLTool, and finally an addition to the input query sanitize function, since i've noticed that more often than not, OpenAI's GPT-3.5-turbo make function calls but instead of sending the "query" param as a plan python code string, it tries to serialize it into some sort of "{'query': 'python code snippet'}" string, which is just not what we want.