### PR TITLE
Fixing regex to support all valid JSON formats

### DIFF
--- a/libs/langchain/langchain/output_parsers/pydantic.py
+++ b/libs/langchain/langchain/output_parsers/pydantic.py
@@ -19,7 +19,9 @@ class PydanticOutputParser(BaseOutputParser[T]):
         try:
             # Greedy search for 1st json candidate.
             match = re.search(
-                r"\{.*\}", text.strip(), re.MULTILINE | re.IGNORECASE | re.DOTALL
+                r"\{[^{}]*\}|\[[^\[\]]*\]",
+                text.strip(),
+                re.MULTILINE | re.IGNORECASE | re.DOTALL,
             )
             json_str = ""
             if match:

--- a/libs/langchain/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/langchain/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -41,6 +41,11 @@ DEF_RESULT_FAIL = """{
     "additional_fields": null
 }"""
 
+JSON_AS_LIST_INPUT = """[
+"Some value"
+]
+"""
+
 DEF_EXPECTED_RESULT = TestModel(
     action=Actions.UPDATE,
     action_input="The PydanticOutputParser class is powerful",
@@ -70,6 +75,22 @@ def test_pydantic_output_parser_fail() -> None:
 
     try:
         pydantic_parser.parse(DEF_RESULT_FAIL)
+    except OutputParserException as e:
+        print("parse_result:", e)
+        assert "Failed to parse TestModel from completion" in str(e)
+    else:
+        assert False, "Expected OutputParserException"
+
+
+def test_pydantic_parser_json_as_list() -> None:
+    """Test PydanticOutputParser where JSON input is a list."""
+
+    pydantic_parser: PydanticOutputParser[TestModel] = PydanticOutputParser(
+        pydantic_object=TestModel
+    )
+
+    try:
+        pydantic_parser.parse(JSON_AS_LIST_INPUT)
     except OutputParserException as e:
         print("parse_result:", e)
         assert "Failed to parse TestModel from completion" in str(e)


### PR DESCRIPTION
**Description:**
The regex used to match JSONs was only to match curly braces, regex now has changed to support square braces
e.g `'["This is valid!"]'`

added test to verify list is also supported as valid JSON

closes [#10057](https://github.com/langchain-ai/langchain/issues/10057)
