### PR TITLE
Allow returning message objects for fake chat LLM

### DIFF
--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -652,8 +652,10 @@ class SimpleChatModel(BaseChatModel):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> ChatResult:
-        output_str = self._call(messages, stop=stop, run_manager=run_manager, **kwargs)
-        message = AIMessage(content=output_str)
+        output = self._call(messages, stop=stop, run_manager=run_manager, **kwargs)
+        message = (
+            output if isinstance(output, BaseMessage) else AIMessage(content=output)
+        )
         generation = ChatGeneration(message=message)
         return ChatResult(generations=[generation])
 

--- a/libs/langchain/langchain/chat_models/fake.py
+++ b/libs/langchain/langchain/chat_models/fake.py
@@ -53,7 +53,8 @@ class FakeListChatModel(SimpleChatModel):
         for c in response:
             if self.sleep is not None:
                 time.sleep(self.sleep)
-            yield ChatGenerationChunk(message=AIMessageChunk(content=c))
+            message = c if isinstance(c, BaseMessage) else AIMessageChunk(content=c)
+            yield ChatGenerationChunk(message=message)
 
     async def _astream(
         self,


### PR DESCRIPTION
Checks if a returned response is already a message object.

If so, returns it directly, if not, build one.

Allows the fake chat LLM to return more robust fake responses, e.g. function calls

P.S. I'm not entirely sure this is the correct solution, if anyone has a better idea, lemme know.