### PR TITLE
Support `ensure_trailing_slash` and `headers` options in RecursiveUrlLoader

### DIFF
--- a/libs/langchain/langchain/document_loaders/recursive_url_loader.py
+++ b/libs/langchain/langchain/document_loaders/recursive_url_loader.py
@@ -35,7 +35,8 @@ class RecursiveUrlLoader(BaseLoader):
             when extract function returns empty string, the document will be ignored.
             max_depth: The max depth of the recursive loading.
             timeout: The timeout for the requests, in the unit of seconds.
-            ensure_trailing_slash: Ensure a trailing slash when requesting to the given url or a child link.
+            ensure_trailing_slash: Ensure a trailing slash
+                                   when requesting to the given url or a child link.
             headers: Headers when requesting to the url.
         """
 

--- a/libs/langchain/langchain/document_loaders/recursive_url_loader.py
+++ b/libs/langchain/langchain/document_loaders/recursive_url_loader.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from typing import Callable, Iterator, List, Optional, Set, Union, Dict
+from typing import Callable, Dict, Iterator, List, Optional, Set, Union
 from urllib.parse import urljoin, urlparse
 
 import requests


### PR DESCRIPTION
This commit adds the following support:

- `ensure_trailing_slash` ... Ensure a trailing slash when requesting to the given url or a child link.
  - This option is necessary when the site doesn't support trailing slash e.g. `https://wiki.supercombo.gg/w/Street_Fighter_6` works but `https://wiki.supercombo.gg/w/Street_Fighter_6/` doesn't work.
- `headers` ... Headers when requesting to the url. 
  - This option is necessary when the site requires specific header to respond e.g. `https://www.streetfighter.com/6/character` requires `user-agent` header.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
