### PR TITLE
Updated Neptune graph to use boto

### DIFF
--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -60,7 +60,7 @@ def extract_cypher(text: str) -> str:
 
 def use_simple_prompt(llm: BaseLanguageModel) -> bool:
     """Decides whether to use the simple prompt"""
-    return llm._llm_type and "anthropic" in llm._llm_type  # type: noqa
+    return llm._llm_type and "anthropic" in llm._llm_type  # type: ignore
 
 
 PROMPT_SELECTOR = ConditionalPromptSelector(

--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -60,11 +60,11 @@ def extract_cypher(text: str) -> str:
 
 def use_simple_prompt(llm: BaseLanguageModel) -> bool:
     """Decides whether to use the simple prompt"""
-    if llm._llm_type and "anthropic" in llm._llm_type: # type: ignore
+    if llm._llm_type and "anthropic" in llm._llm_type:  # type: ignore
         return True
-    
+
     # Bedrock anthropic
-    if llm.model_id and "anthropic" in llm.model_id: # type: ignore
+    if llm.model_id and "anthropic" in llm.model_id:  # type: ignore
         return True
 
     return False

--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -18,6 +18,30 @@ from langchain.pydantic_v1 import Field
 INTERMEDIATE_STEPS_KEY = "intermediate_steps"
 
 
+def trim_query(query: str) -> str:
+    keywords = (
+        "MATCH",
+        "CREATE",
+        "MERGE",
+        "WITH",
+        "UNWIND",
+        "RETURN",
+        "DELETE",
+        "OPTIONAL",
+        "CALL",
+        "//",
+    )
+
+    lines = query.split("\n")
+    new_query = ""
+
+    for line in lines:
+        if line.strip().upper().startswith(keywords):
+            new_query += line + "\n"
+
+    return new_query
+
+
 def extract_cypher(text: str) -> str:
     """Extract Cypher code from text using Regex."""
     # The pattern to find Cypher code enclosed in triple backticks
@@ -108,6 +132,7 @@ class NeptuneOpenCypherQAChain(Chain):
 
         # Extract Cypher code if it is wrapped in backticks
         generated_cypher = extract_cypher(generated_cypher)
+        generated_cypher = trim_query(generated_cypher)
 
         _run_manager.on_text("Generated Cypher:", end="\n", verbose=self.verbose)
         _run_manager.on_text(

--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -22,18 +22,22 @@ INTERMEDIATE_STEPS_KEY = "intermediate_steps"
 
 def trim_query(query: str) -> str:
     keywords = (
-        "MATCH",
-        "CREATE",
-        "MERGE",
-        "WITH",
-        "UNWIND",
-        "RETURN",
-        "DELETE",
-        "OPTIONAL",
-        "WHERE",
-        "LIMIT",
-        "ORDER",
         "CALL",
+        "CREATE",
+        "DELETE",
+        "DETACH",
+        "LIMIT",
+        "MATCH",
+        "MERGE",
+        "OPTIONAL",
+        "ORDER",
+        "REMOVE",
+        "RETURN",
+        "SET",
+        "SKIP",
+        "UNWIND",
+        "WITH",
+        "WHERE",
         "//",
     )
 

--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -60,7 +60,14 @@ def extract_cypher(text: str) -> str:
 
 def use_simple_prompt(llm: BaseLanguageModel) -> bool:
     """Decides whether to use the simple prompt"""
-    return llm._llm_type and "anthropic" in llm._llm_type  # type: ignore
+    if llm._llm_type and "anthropic" in llm._llm_type: # type: ignore
+        return True
+    
+    # Bedrock anthropic
+    if llm.model_id and "anthropic" in llm.model_id: # type: ignore
+        return True
+
+    return False
 
 
 PROMPT_SELECTOR = ConditionalPromptSelector(

--- a/libs/langchain/langchain/chains/graph_qa/prompts.py
+++ b/libs/langchain/langchain/chains/graph_qa/prompts.py
@@ -331,3 +331,15 @@ NEPTUNE_OPENCYPHER_GENERATION_PROMPT = PromptTemplate(
     input_variables=["schema", "question"],
     template=NEPTUNE_OPENCYPHER_GENERATION_TEMPLATE,
 )
+
+NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE = """
+Write an openCypher query to answer the following question. Do not explain the answer. Only return the query. 
+Question:  "{question}". 
+Here is the property graph schema: 
+{schema}
+\n"""
+
+NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_PROMPT = PromptTemplate(
+    input_variables=["schema", "question"],
+    template=NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE,
+)

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -146,13 +146,13 @@ class NeptuneGraph:
 
     def _get_triples(self, e_labels: List[str]) -> List[str]:
         triple_query = """
-        MATCH (a)-[e:{e_label}]->(b)
+        MATCH (a)-[e:`{e_label}`]->(b)
         WITH a,e,b LIMIT 3000
         RETURN DISTINCT labels(a) AS from, type(e) AS edge, labels(b) AS to
         LIMIT 10
         """
 
-        triple_template = "(:{a})-[:{e}]->(:{b})"
+        triple_template = "(:`{a}`)-[:`{e}`]->(:`{b}`)"
         triple_schema = []
         for label in e_labels:
             q = triple_query.format(e_label=label)
@@ -167,7 +167,7 @@ class NeptuneGraph:
 
     def _get_node_properties(self, n_labels: List[str], types: Dict) -> List:
         node_properties_query = """
-        MATCH (a:{n_label})
+        MATCH (a:`{n_label}`)
         RETURN properties(a) AS props
         LIMIT 100
         """
@@ -190,7 +190,7 @@ class NeptuneGraph:
 
     def _get_edge_properties(self, e_labels: List[str], types: Dict[str, Any]) -> List:
         edge_properties_query = """
-        MATCH ()-[e:{e_label}]->()
+        MATCH ()-[e:`{e_label}`]->()
         RETURN properties(e) AS props
         LIMIT 100
         """
@@ -222,6 +222,7 @@ class NeptuneGraph:
             "int": "INTEGER",
             "list": "LIST",
             "dict": "MAP",
+            "bool": "BOOLEAN",
         }
         n_labels, e_labels = self._get_labels()
         triple_schema = self._get_triples(e_labels)

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -39,6 +39,7 @@ class NeptuneGraph:
         client: Any = None,
         credentials_profile_name: Optional[str] = None,
         region_name: Optional[str] = None,
+        service: str = 'neptune-db',
     ) -> None:
         """Create a new Neptune graph wrapper instance."""
 
@@ -62,7 +63,7 @@ class NeptuneGraph:
 
                 client_params["endpoint_url"] = f"{protocol}://{host}:{port}"
 
-                self.client = session.client("neptune-db", **client_params)
+                self.client = session.client(service, **client_params)
 
         except ImportError:
             raise ModuleNotFoundError(

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -22,6 +22,15 @@ class NeptuneQueryException(Exception):
 class NeptuneGraph:
     """Neptune wrapper for graph operations.
 
+    Args:
+        host: endpoint for the database instance
+        port: port number for the database instance, default is 8182
+        use_https: whether to use secure connection, default is True
+        client: optional boto3 Neptune client
+        credentials_profile_name: optional AWS profile name
+        region_name: optional AWS region, e.g., us-west-2 
+        service: optional service name, default is neptunedata
+
     Example:
         .. code-block:: python
 
@@ -39,7 +48,7 @@ class NeptuneGraph:
         client: Any = None,
         credentials_profile_name: Optional[str] = None,
         region_name: Optional[str] = None,
-        service: str = "neptune-db",
+        service: str = "neptunedata",
     ) -> None:
         """Create a new Neptune graph wrapper instance."""
 
@@ -70,13 +79,18 @@ class NeptuneGraph:
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
-
         except Exception as e:
-            raise ValueError(
-                "Could not load credentials to authenticate with AWS client. "
-                "Please check that credentials in the specified "
-                "profile name are valid."
-            ) from e
+            if type(e).__name__ == 'UnknownServiceError':
+                raise ModuleNotFoundError(
+                    "NeptuneGraph requires a boto3 version 1.28.38 or greater."
+                    "Please install it with `pip install -U boto3`."
+                ) from e
+            else:
+                raise ValueError(
+                    "Could not load credentials to authenticate with AWS client. "
+                    "Please check that credentials in the specified "
+                    "profile name are valid."
+                ) from e
 
         try:
             self._refresh_schema()

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -28,7 +28,7 @@ class NeptuneGraph:
         use_https: whether to use secure connection, default is True
         client: optional boto3 Neptune client
         credentials_profile_name: optional AWS profile name
-        region_name: optional AWS region, e.g., us-west-2 
+        region_name: optional AWS region, e.g., us-west-2
         service: optional service name, default is neptunedata
 
     Example:
@@ -80,7 +80,7 @@ class NeptuneGraph:
                 "Please install it with `pip install boto3`."
             )
         except Exception as e:
-            if type(e).__name__ == 'UnknownServiceError':
+            if type(e).__name__ == "UnknownServiceError":
                 raise ModuleNotFoundError(
                     "NeptuneGraph requires a boto3 version 1.28.38 or greater."
                     "Please install it with `pip install -U boto3`."
@@ -121,7 +121,7 @@ class NeptuneGraph:
                         "Summary API is not available for this instance of Neptune,"
                         "ensure the engine version is >=1.2.1.0"
                     ),
-                    "details": e.message,
+                    "details": str(e),
                 }
             )
 

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -113,7 +113,6 @@ class NeptuneGraph:
     def _get_labels(self) -> Tuple[List[str], List[str]]:
         """Get node and edge labels from the Neptune statistics summary"""
         summary = self._get_summary()
-        print(summary)
         n_labels = summary["nodeLabels"]
         e_labels = summary["edgeLabels"]
         return n_labels, e_labels

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -39,7 +39,7 @@ class NeptuneGraph:
         client: Any = None,
         credentials_profile_name: Optional[str] = None,
         region_name: Optional[str] = None,
-        service: str = 'neptune-db',
+        service: str = "neptune-db",
     ) -> None:
         """Create a new Neptune graph wrapper instance."""
 
@@ -98,7 +98,19 @@ class NeptuneGraph:
         return self.client.execute_open_cypher_query(openCypherQuery=query)
 
     def _get_summary(self) -> Dict:
-        response = self.client.get_propertygraph_summary()
+        try:
+            response = self.client.get_propertygraph_summary()
+        except Exception as e:
+            raise NeptuneQueryException(
+                {
+                    "message": (
+                        "Summary API is not available for this instance of Neptune,"
+                        "ensure the engine version is >=1.2.1.0"
+                    ),
+                    "details": e.message,
+                }
+            )
+
         try:
             summary = response["payload"]["graphSummary"]
         except Exception:


### PR DESCRIPTION
## Description
This PR updates the `NeptuneGraph` class to start using the boto API for connecting to the Neptune service. With boto integration, the graph class now supports authenticating requests using Sigv4; this is encapsulated with the boto API, and users only have to ensure they have the correct AWS credentials setup in their workspace to work with the graph class.

This PR also introduces a conditional prompt that uses a simpler prompt when using the `Anthropic` model provider. A simpler prompt have seemed to work better for generating cypher queries in our testing.

**Note**: This version will require boto3 version 1.28.38 or greater to work.


