### PR TITLE
Uncomment create_vector_extension in __post_init__ of PGVector class

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -118,7 +118,7 @@ class PGVector(VectorStore):
         Initialize the store.
         """
         self._conn = self.connect()
-        # self.create_vector_extension()
+        self.create_vector_extension()
         from langchain.vectorstores._pgvector_data_models import (
             CollectionStore,
             EmbeddingStore,


### PR DESCRIPTION
I have the 0-day experience with PGVector in mind. I can't use PGVector.create_vector_extension at all if the `vector` extension is not already created on postgres. If one initializes PGVector without the extension, it fails since __post_init__ tries to create tables and that fails without the extension.

Is there a reason why create_vector_extension is commented from __post_init__? If not then uncommenting it should fix this issue.

#9511 

twitter @skydowx