### PR TITLE
Fix S3DirectoryLoader exception

### DIFF
--- a/libs/langchain/langchain/document_loaders/s3_directory.py
+++ b/libs/langchain/langchain/document_loaders/s3_directory.py
@@ -114,7 +114,7 @@ class S3DirectoryLoader(BaseLoader):
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,
-            boto_config=self.boto_config,
+            config=self.boto_config,
         )
         bucket = s3.Bucket(self.bucket)
         docs = []


### PR DESCRIPTION
#9304 introduced a critical bug. The S3DirectoryLoader fails completely because boto3 checks the naming of kw arguments and one of the args is badly named (very sorry for that)

cc @baskaryan