### PR TITLE
Adding a Verbose Hook

### DIFF
--- a/libs/langchain/langchain/callbacks/stdout.py
+++ b/libs/langchain/langchain/callbacks/stdout.py
@@ -95,6 +95,8 @@ class StdOutCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """Run when agent ends."""
         print_text(text, color=color or self.color, end=end)
+        if "hook" in kwargs and kwargs["hook"] is not None:
+            kwargs["hook"](text, event="on_text") 
 
     def on_agent_finish(
         self, finish: AgentFinish, color: Optional[str] = None, **kwargs: Any

--- a/libs/langchain/langchain/chains/base.py
+++ b/libs/langchain/langchain/chains/base.py
@@ -112,6 +112,9 @@ class Chain(Serializable, Runnable[Dict[str, Any], Dict[str, Any]], ABC):
     verbose: bool = Field(default_factory=_get_verbosity)
     """Whether or not run in verbose mode. In verbose mode, some intermediate logs
     will be printed to the console. Defaults to `langchain.verbose` value."""
+    verbose_hook: Optional[Any] = None
+    """Function hook to be used in verbose mode, send verbose output to hook so it wont just be printed to the console.
+    Defaults to None."""
     tags: Optional[List[str]] = None
     """Optional list of tags associated with the chain. Defaults to None.
     These tags will be associated with each call to this chain,

--- a/libs/langchain/langchain/chains/llm.py
+++ b/libs/langchain/langchain/chains/llm.py
@@ -137,7 +137,7 @@ class LLMChain(Chain):
             _colored_text = get_colored_text(prompt.to_string(), "green")
             _text = "Prompt after formatting:\n" + _colored_text
             if run_manager:
-                run_manager.on_text(_text, end="\n", verbose=self.verbose)
+                run_manager.on_text(_text, end="\n", verbose=self.verbose, verbose_hook = self.verbose_hook if self.verbose_hook else None)
             if "stop" in inputs and inputs["stop"] != stop:
                 raise ValueError(
                     "If `stop` is present in any inputs, should be present in all."
@@ -163,7 +163,7 @@ class LLMChain(Chain):
             _colored_text = get_colored_text(prompt.to_string(), "green")
             _text = "Prompt after formatting:\n" + _colored_text
             if run_manager:
-                await run_manager.on_text(_text, end="\n", verbose=self.verbose)
+                await run_manager.on_text(_text, end="\n", verbose=self.verbose, verbose_hook = self.verbose_hook if self.verbose_hook else None)
             if "stop" in inputs and inputs["stop"] != stop:
                 raise ValueError(
                     "If `stop` is present in any inputs, should be present in all."


### PR DESCRIPTION
Adding a Verbose Hook, so verbose output wont only be printed, but also handled if chosen to

solution to #5448 (Issue: Get Verbose messages from chain)

Usage:
```python
def handle_verbose(verbose_output, *args, **kwargs):
    print("$$$$$$$ HANDLEING VERBOSE OUTPUT $$$$$$")
    print(verbose_output) # Handle verbose here
    print("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$", args, kwargs)

worker = LLMChain(prompt=prompt,llm=llm, verbose=verbose, verbose_hook=handle_verbose)
# Verbose messages will be sent to hook
```
Usefull when you want to include verbose output, for example in a custom debugger gui, logger, or for any other usage.
( I've only changed the on_text event, which includes the final (green) prompt before it is sent to the llm, if you like it you can extend to use in other places. )

Hope you find it useful as I do
Have a good one and all the best!

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
