### PR TITLE
update(llms/TGI): Allow None as temperature value

### DIFF
--- a/libs/langchain/langchain/llms/huggingface_text_gen_inference.py
+++ b/libs/langchain/langchain/llms/huggingface_text_gen_inference.py
@@ -65,7 +65,7 @@ class HuggingFaceTextGenInference(LLM):
     typical_p: Optional[float] = 0.95
     """Typical Decoding mass. See [Typical Decoding for Natural Language
     Generation](https://arxiv.org/abs/2202.00666) for more information."""
-    temperature: float = 0.8
+    temperature: Optional[float] = 0.8
     """The value used to module the logits distribution."""
     repetition_penalty: Optional[float] = None
     """The parameter for repetition penalty. 1.0 means no penalty.


### PR DESCRIPTION
Text Generation Inference's client permits the use of a None temperature as seen [here](https://github.com/huggingface/text-generation-inference/blob/033230ae667101d2d8d8bcd4952442fa348ef951/clients/python/text_generation/client.py#L71C9-L71C20). While I haved dived into TGI's server code and don't know about the implications of using None as a temperature setting, I think we should grant users the option to pass None as a temperature parameter to TGI.


<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
