### PR TITLE
Run CI when CI infra itself has changed.

### DIFF
--- a/.github/workflows/langchain_ci.yml
+++ b/.github/workflows/langchain_ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [ master ]
   pull_request:
     paths:
+      - '.github/actions/poetry_setup/action.yml'
+      - '.github/tools/**'
       - '.github/workflows/_lint.yml'
       - '.github/workflows/_test.yml'
       - '.github/workflows/_pydantic_compatibility.yml'

--- a/.github/workflows/langchain_experimental_ci.yml
+++ b/.github/workflows/langchain_experimental_ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [ master ]
   pull_request:
     paths:
+      - '.github/actions/poetry_setup/action.yml'
+      - '.github/tools/**'
       - '.github/workflows/_lint.yml'
       - '.github/workflows/_test.yml'
       - '.github/workflows/langchain_experimental_ci.yml'


### PR DESCRIPTION
Make sure that changes to CI infrastructure get tested on CI before being merged.

Without this PR, changes to the poetry setup action don't trigger a CI run and in principle could break `master` when merged.
