### PR TITLE
Fix SQL search_path for Trino query engine

### DIFF
--- a/libs/langchain/langchain/utilities/sql_database.py
+++ b/libs/langchain/langchain/utilities/sql_database.py
@@ -384,6 +384,8 @@ class SQLDatabase:
                     connection.exec_driver_sql(f"SET @@dataset_id='{self._schema}'")
                 elif self.dialect == "mssql":
                     pass
+                elif self.dialect == "trino":
+                    connection.exec_driver_sql(f"USE {self._schema}")
                 else:  # postgresql and compatible dialects
                     connection.exec_driver_sql(f"SET search_path TO {self._schema}")
             cursor = connection.execute(text(command))


### PR DESCRIPTION
This PR replaces the generic `SET search_path TO` statement by `USE` for the Trino dialect since Trino does not support `SET search_path`.  Official Trino documentation can be found [here](https://trino.io/docs/current/sql/use.html).

With this fix, the `SQLdatabase` will now be able to set the current schema and execute queries using the Trino engine.  It will use the catalog set as default by the connection uri.
