### PR TITLE
Final poetry action fix: manually recreate softlinks broken by caching.

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -39,9 +39,34 @@ runs:
       with:
         path: |
           /opt/pipx/venvs/poetry
-          /opt/pipx_bin/poetry
         # This step caches the poetry installation, so make sure it's keyed on the poetry version as well.
         key: bin-poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ inputs.python-version }}-${{ inputs.poetry-version }}
+
+    - name: Refresh shell hashtable and fixup softlinks
+      if: steps.cache-bin-poetry.outputs.cache-hit == 'true'
+      shell: bash
+      env:
+        POETRY_VERSION: ${{ inputs.poetry-version }}
+        PYTHON_VERSION: ${{ inputs.python-version }}
+      run: |
+        set -eux
+
+        # Refresh the shell hashtable, to ensure correct `which` output.
+        hash -r
+
+        # `actions/cache@v3` doesn't always seem able to correctly unpack softlinks.
+        # Delete and recreate the softlinks pipx expects to have.
+        rm /opt/pipx/venvs/poetry/bin/python
+        cd /opt/pipx/venvs/poetry/bin
+        ln -s "$(which "python$PYTHON_VERSION")" python
+        chmod +x python
+        cd /opt/pipx_bin/
+        ln -s /opt/pipx/venvs/poetry/bin/poetry poetry
+        chmod +x poetry
+
+        # Ensure everything got set up correctly.
+        /opt/pipx/venvs/poetry/bin/python --version
+        /opt/pipx_bin/poetry --version
 
     - name: Install poetry
       if: steps.cache-bin-poetry.outputs.cache-hit != 'true'
@@ -50,16 +75,6 @@ runs:
         POETRY_VERSION: ${{ inputs.poetry-version }}
         PYTHON_VERSION: ${{ inputs.python-version }}
       run: pipx install "poetry==$POETRY_VERSION" --python "python$PYTHON_VERSION" --verbose
-
-    - name: Refresh shell hashtable and show python/poetry binaries and versions
-      shell: bash
-      run: |
-        set -eux
-        hash -r
-        ls -alh /opt/pipx_bin/poetry
-        ls -alh /opt/pipx/venvs/poetry/bin/python
-        /opt/pipx/venvs/poetry/bin/python --version
-        /opt/pipx_bin/poetry --version
 
     - name: Restore pip and poetry cached dependencies
       uses: actions/cache@v3


### PR DESCRIPTION
It seems the caching action was not always correctly recreating softlinks. At first glance, the softlinks it created seemed fine, but they didn't always work. Possibly hitting some kind of underlying bug, but not particularly worth debugging in depth -- we can manually create the soft links we need.
