### PR TITLE
Deny creating files as a result of test runs.

### DIFF
--- a/.github/workflows/_pydantic_compatibility.yml
+++ b/.github/workflows/_pydantic_compatibility.yml
@@ -79,3 +79,15 @@ jobs:
       - name: Run pydantic compatibility tests
         shell: bash
         run: make test
+
+      - name: Ensure the tests did not create any additional files
+        shell: bash
+        run: |
+          set -eu
+
+          STATUS="$(git status)"
+          echo "$STATUS"
+
+          # grep will exit non-zero if the target message isn't found,
+          # and `set -e` above will cause the step to fail.
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -43,3 +43,15 @@ jobs:
       - name: Run core tests
         shell: bash
         run: make test
+
+      - name: Ensure the tests did not create any additional files
+        shell: bash
+        run: |
+          set -eu
+
+          STATUS="$(git status)"
+          echo "$STATUS"
+
+          # grep will exit non-zero if the target message isn't found,
+          # and `set -e` above will cause the step to fail.
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'

--- a/.github/workflows/langchain_ci.yml
+++ b/.github/workflows/langchain_ci.yml
@@ -83,3 +83,15 @@ jobs:
 
       - name: Run extended tests
         run: make extended_tests
+
+      - name: Ensure the tests did not create any additional files
+        shell: bash
+        run: |
+          set -eu
+
+          STATUS="$(git status)"
+          echo "$STATUS"
+
+          # grep will exit non-zero if the target message isn't found,
+          # and `set -e` above will cause the step to fail.
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'

--- a/.github/workflows/langchain_experimental_ci.yml
+++ b/.github/workflows/langchain_experimental_ci.yml
@@ -115,3 +115,15 @@ jobs:
 
       - name: Run extended tests
         run: make extended_tests
+
+      - name: Ensure the tests did not create any additional files
+        shell: bash
+        run: |
+          set -eu
+
+          STATUS="$(git status)"
+          echo "$STATUS"
+
+          # grep will exit non-zero if the target message isn't found,
+          # and `set -e` above will cause the step to fail.
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -47,3 +47,15 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           make scheduled_tests
+
+      - name: Ensure the tests did not create any additional files
+        shell: bash
+        run: |
+          set -eu
+
+          STATUS="$(git status)"
+          echo "$STATUS"
+
+          # grep will exit non-zero if the target message isn't found,
+          # and `set -e` above will cause the step to fail.
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'

--- a/libs/langchain/langchain/chat_loaders/telegram.py
+++ b/libs/langchain/langchain/chat_loaders/telegram.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import tempfile
 import zipfile
 from pathlib import Path
 from typing import Iterator, List, Union
@@ -136,7 +137,8 @@ class TelegramChatLoader(chat_loaders.BaseChatLoader):
             with zipfile.ZipFile(path) as zip_file:
                 for file in zip_file.namelist():
                     if file.endswith((".html", ".json")):
-                        yield zip_file.extract(file)
+                        with tempfile.TemporaryDirectory() as temp_dir:
+                            yield zip_file.extract(file, path=temp_dir)
 
     def lazy_load(self) -> Iterator[chat_loaders.ChatSession]:
         """Lazy load the messages from the chat file and yield them


### PR DESCRIPTION
A test file was accidentally dropping a `results.json` file in the current working directory as a result of running `make test`.

This is undesirable, since we don't want to risk accidentally adding stray files into the repo if we run tests locally and then do `git add .` without inspecting the file list very closely.