### PR TITLE
Added Hugging face inference api to embed documents without locally d…

### DIFF
--- a/docs/extras/integrations/text_embedding/huggingfacehub.ipynb
+++ b/docs/extras/integrations/text_embedding/huggingfacehub.ipynb
@@ -5,13 +5,23 @@
    "id": "ed47bb62",
    "metadata": {},
    "source": [
-    "# Hugging Face Hub\n",
+    "# Hugging Face\n",
     "Let's load the Hugging Face Embedding class."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "id": "16b20335-da1d-46ba-aa23-fbf3e2c6fe60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install langchain sentence_transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "861521a9",
    "metadata": {},
    "outputs": [],
@@ -21,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "id": "ff9be586",
    "metadata": {},
    "outputs": [],
@@ -31,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "id": "d0a98ae9",
    "metadata": {},
    "outputs": [],
@@ -41,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "5d6c682b",
    "metadata": {},
    "outputs": [],
@@ -51,7 +61,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
+   "id": "b57b8ce9-ef7d-4e63-979e-aa8763d1f9a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[-0.04895168915390968, -0.03986193612217903, -0.021562768146395683]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query_result[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "bb5e74c0",
    "metadata": {},
    "outputs": [],
@@ -60,19 +91,71 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aaad49f8",
+   "cell_type": "markdown",
+   "id": "92019ef1-5d30-4985-b4e6-c0d98bdfe265",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Hugging Face Inference API\n",
+    "We can also access embedding models via the Hugging Face Inference API, which does not require us to install ``sentence_transformers`` and download models locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "66f5c6ba-1446-43e1-b012-800d17cef300",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter your HF Inference API Key:\n",
+      "\n",
+      " ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "inference_api_key = getpass.getpass(\"Enter your HF Inference API Key:\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d0623c1f-cd82-4862-9bce-3655cb9b66ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[-0.038338541984558105, 0.1234646737575531, -0.028642963618040085]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.embeddings import HuggingFaceInferenceAPIEmbeddings\n",
+    "\n",
+    "embeddings = HuggingFaceInferenceAPIEmbeddings(\n",
+    "    api_key=inference_api_key,\n",
+    "    model_name=\"sentence-transformers/all-MiniLM-l6-v2\"\n",
+    ")\n",
+    "\n",
+    "query_result = embeddings.embed_query(text)\n",
+    "query_result[:3]"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "poetry-venv",
    "language": "python",
-   "name": "python3"
+   "name": "poetry-venv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/libs/langchain/langchain/embeddings/__init__.py
+++ b/libs/langchain/langchain/embeddings/__init__.py
@@ -35,6 +35,7 @@ from langchain.embeddings.gpt4all import GPT4AllEmbeddings
 from langchain.embeddings.huggingface import (
     HuggingFaceBgeEmbeddings,
     HuggingFaceEmbeddings,
+    HuggingFaceInferenceAPIEmbeddings,
     HuggingFaceInstructEmbeddings,
 )
 from langchain.embeddings.huggingface_hub import HuggingFaceHubEmbeddings
@@ -69,6 +70,7 @@ __all__ = [
     "CohereEmbeddings",
     "ElasticsearchEmbeddings",
     "HuggingFaceEmbeddings",
+    "HuggingFaceInferenceAPIEmbeddings",
     "JinaEmbeddings",
     "LlamaCppEmbeddings",
     "HuggingFaceHubEmbeddings",

--- a/libs/langchain/langchain/embeddings/huggingface.py
+++ b/libs/langchain/langchain/embeddings/huggingface.py
@@ -266,3 +266,62 @@ class HuggingFaceBgeEmbeddings(BaseModel, Embeddings):
             self.query_instruction + text, **self.encode_kwargs
         )
         return embedding.tolist()
+
+
+class  HuggingFaceInferenceAPI(BaseModel, Embeddings):
+    """
+    This class is used to get embeddings for a list of texts using the HuggingFace API.
+    It requires an API key and a model name. The default model name is "sentence-transformers/all-MiniLM-L6-v2".
+    """
+
+    def __init__(
+        self, api_key: str, model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
+    ):
+        """
+        Initialize the HuggingFaceEmbeddingFunction.
+
+        Args:
+            api_key (str): Your API key for the HuggingFace API.
+            model_name (str, optional): The name of the model to use for text embeddings. Defaults to "sentence-transformers/all-MiniLM-L6-v2".
+        """
+        try:
+            import requests
+        except ImportError:
+            raise ValueError(
+                "The requests python package is not installed. Please install it with `pip install requests`"
+            )
+        self._api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_name}"
+        self._session = requests.Session()
+        self._session.headers.update({"Authorization": f"Bearer {api_key}"})
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """
+        Get the embeddings for a list of texts.
+
+        Args:
+            texts (Documents): A list of texts to get embeddings for.
+
+        Returns:
+            List[List[float]]
+
+        Example:
+            >>> hugging_face = HuggingFaceEmbeddingFunction(api_key="your_api_key")
+            >>> texts = ["Hello, world!", "How are you?"]
+            >>> embeddings = hugging_face(texts)
+        """
+        # Call HuggingFace Embedding API for each document
+        return self._session.post(  # type: ignore
+            self._api_url, json={"inputs": texts, "options": {"wait_for_model": True, "use_cache": True}}
+        ).json()
+    
+    def embed_query(self, text: str) -> List[float]:
+        """Compute query embeddings using a HuggingFace transformer model.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            Embeddings for the text.
+        """
+        return self.embed_documents([text])[0]
+        


### PR DESCRIPTION
…ownloading the model

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: Added Hugging Face Inference API support for embedding small documents without downloading the model locally , 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: There are no external dependencies as it depends on embedding model of langchain as requested by @hwchase17 ,
  

>
