### PR TITLE
Add notebook example to use sqlite-vss as a vector store.

### DIFF
--- a/docs/extras/integrations/vectorstores/sqlitevss.ipynb
+++ b/docs/extras/integrations/vectorstores/sqlitevss.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# sqlite-vss\n",
+    "\n",
+    ">[sqlite-vss](https://alexgarcia.xyz/sqlite-vss/) is an SQLite extension designed for vector search, emphasizing local-first operations and easy integration into applications without external servers. Leveraging the Faiss library, it offers efficient similarity search and clustering capabilities.\n",
+    "\n",
+    "This notebook shows how to use the `SQLiteVSS` vector database."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# You need to install sqlite-vss as a dependency.\n",
+    "%pip install sqlite-vss"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Quickstart"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \\n\\nTonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \\n\\nOne of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court. \\n\\nAnd I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.'"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.embeddings.sentence_transformer import SentenceTransformerEmbeddings\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.vectorstores import SQLiteVSS\n",
+    "from langchain.document_loaders import TextLoader\n",
+    "\n",
+    "# load the document and split it into chunks\n",
+    "loader = TextLoader(\"../../../state_of_the_union.txt\")\n",
+    "documents = loader.load()\n",
+    "\n",
+    "# split it into chunks\n",
+    "text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
+    "docs = text_splitter.split_documents(documents)\n",
+    "texts = [doc.page_content for doc in docs]\n",
+    "\n",
+    "\n",
+    "# create the open-source embedding function\n",
+    "embedding_function = SentenceTransformerEmbeddings(model_name=\"all-MiniLM-L6-v2\")\n",
+    "\n",
+    "\n",
+    "# load it in sqlite-vss in a table named state_union.\n",
+    "# the db_file parameter is the name of the file you want\n",
+    "# as your sqlite database.\n",
+    "db = SQLiteVSS.from_texts(\n",
+    "    texts=texts,\n",
+    "    embedding=embedding_function,\n",
+    "    table=\"state_union\",\n",
+    "    db_file=\"/tmp/vss.db\"\n",
+    ")\n",
+    "\n",
+    "# query it\n",
+    "query = \"What did the president say about Ketanji Brown Jackson\"\n",
+    "data = db.similarity_search(query)\n",
+    "\n",
+    "# print results\n",
+    "data[0].page_content"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-06T14:55:55.370351Z",
+     "start_time": "2023-09-06T14:55:53.547755Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Using existing sqlite connection"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'Ketanji Brown Jackson is awesome'"
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.embeddings.sentence_transformer import SentenceTransformerEmbeddings\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.vectorstores import SQLiteVSS\n",
+    "from langchain.document_loaders import TextLoader\n",
+    "\n",
+    "# load the document and split it into chunks\n",
+    "loader = TextLoader(\"../../../state_of_the_union.txt\")\n",
+    "documents = loader.load()\n",
+    "\n",
+    "# split it into chunks\n",
+    "text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
+    "docs = text_splitter.split_documents(documents)\n",
+    "texts = [doc.page_content for doc in docs]\n",
+    "\n",
+    "\n",
+    "# create the open-source embedding function\n",
+    "embedding_function = SentenceTransformerEmbeddings(model_name=\"all-MiniLM-L6-v2\")\n",
+    "connection = SQLiteVSS.create_connection(db_file=\"/tmp/vss.db\")\n",
+    "\n",
+    "db1 = SQLiteVSS(\n",
+    "    table=\"state_union\",\n",
+    "    embedding=embedding_function,\n",
+    "    connection=connection\n",
+    ")\n",
+    "\n",
+    "db1.add_texts([\"Ketanji Brown Jackson is awesome\"])\n",
+    "# query it again\n",
+    "query = \"What did the president say about Ketanji Brown Jackson\"\n",
+    "data = db1.similarity_search(query)\n",
+    "\n",
+    "# print results\n",
+    "data[0].page_content"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-06T14:59:22.086252Z",
+     "start_time": "2023-09-06T14:59:21.693237Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [],
+   "source": [
+    "# Cleaning up\n",
+    "import os\n",
+    "os.remove(\"/tmp/vss.db\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-06T15:01:15.550318Z",
+     "start_time": "2023-09-06T15:01:15.546428Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Follow-up PR for https://github.com/langchain-ai/langchain/pull/10047, simply adding a notebook quickstart example for the vector store with SQLite, using the class SQLiteVSS. 

Maintainer tag @baskaryan 