### PR TITLE
Fixed qa_citations.ipynb documentation error

### DIFF
--- a/docs/extras/use_cases/question_answering/how_to/qa_citations.ipynb
+++ b/docs/extras/use_cases/question_answering/how_to/qa_citations.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = chain.run(question=question, context=context)"
+    "result = chain.run({\"question\":question, \"context\":context})"
    ]
   },
   {


### PR DESCRIPTION
Issue: #8593 
Description: Documentation error fixed. create_citation_fuzzy_match_chain expects dictionary with a specific key-value pair, not just any dictionary like the documentation showed.
Dependencies: None
Twitter handle: @ayushzenith
Tag maintainer: @hwchase17 