### PR TITLE
added ContentFormatter escape special characters for message content

### DIFF
--- a/libs/langchain/langchain/chat_models/azureml_endpoint.py
+++ b/libs/langchain/langchain/chat_models/azureml_endpoint.py
@@ -17,23 +17,24 @@ from langchain.utils import get_from_dict_or_env
 
 class LlamaContentFormatter(ContentFormatterBase):
     """Content formatter for `LLaMA`."""
+    
 
     SUPPORTED_ROLES: List[str] = ["user", "assistant", "system"]
 
     @staticmethod
     def _convert_message_to_dict(message: BaseMessage) -> Dict:
         """Converts message to a dict according to role"""
-        if isinstance(message, HumanMessage):
-            return {"role": "user", "content": message.content}
+        if isinstance(message, HumanMessage): 
+            return {"role": "user", "content": ContentFormatterBase.escape_special_characters(message.content)}
         elif isinstance(message, AIMessage):
-            return {"role": "assistant", "content": message.content}
+            return {"role": "assistant", "content": ContentFormatterBase.escape_special_characters(message.content)}
         elif isinstance(message, SystemMessage):
-            return {"role": "system", "content": message.content}
+            return {"role": "system", "content": ContentFormatterBase.escape_special_characters(message.content)}
         elif (
             isinstance(message, ChatMessage)
             and message.role in LlamaContentFormatter.SUPPORTED_ROLES
         ):
-            return {"role": message.role, "content": message.content}
+            return {"role": message.role, "content": ContentFormatterBase.escape_special_characters(message.content)}
         else:
             supported = ",".join(
                 [role for role in LlamaContentFormatter.SUPPORTED_ROLES]
@@ -46,7 +47,7 @@ class LlamaContentFormatter(ContentFormatterBase):
     def _format_request_payload(
         self, messages: List[BaseMessage], model_kwargs: Dict
     ) -> bytes:
-        chat_messages = [
+        chat_messages = [ 
             LlamaContentFormatter._convert_message_to_dict(message)
             for message in messages
         ]

--- a/libs/langchain/langchain/chat_models/azureml_endpoint.py
+++ b/libs/langchain/langchain/chat_models/azureml_endpoint.py
@@ -17,28 +17,43 @@ from langchain.utils import get_from_dict_or_env
 
 class LlamaContentFormatter(ContentFormatterBase):
     """Content formatter for `LLaMA`."""
-    
 
     SUPPORTED_ROLES: List[str] = ["user", "assistant", "system"]
 
     @staticmethod
     def _convert_message_to_dict(message: BaseMessage) -> Dict:
         """Converts message to a dict according to role"""
-        if isinstance(message, HumanMessage): 
-            return {"role": "user", 
-            "content": ContentFormatterBase.escape_special_characters(message.content)}
+        if isinstance(message, HumanMessage):
+            return {
+                "role": "user",
+                "content": ContentFormatterBase.escape_special_characters(
+                    message.content
+                ),
+            }
         elif isinstance(message, AIMessage):
-            return {"role": "assistant", 
-            "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {
+                "role": "assistant",
+                "content": ContentFormatterBase.escape_special_characters(
+                    message.content
+                ),
+            }
         elif isinstance(message, SystemMessage):
-            return {"role": "system", 
-            "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {
+                "role": "system",
+                "content": ContentFormatterBase.escape_special_characters(
+                    message.content
+                ),
+            }
         elif (
             isinstance(message, ChatMessage)
             and message.role in LlamaContentFormatter.SUPPORTED_ROLES
         ):
-            return {"role": message.role, 
-            "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {
+                "role": message.role,
+                "content": ContentFormatterBase.escape_special_characters(
+                    message.content
+                ),
+            }
         else:
             supported = ",".join(
                 [role for role in LlamaContentFormatter.SUPPORTED_ROLES]
@@ -51,7 +66,7 @@ class LlamaContentFormatter(ContentFormatterBase):
     def _format_request_payload(
         self, messages: List[BaseMessage], model_kwargs: Dict
     ) -> bytes:
-        chat_messages = [ 
+        chat_messages = [
             LlamaContentFormatter._convert_message_to_dict(message)
             for message in messages
         ]

--- a/libs/langchain/langchain/chat_models/azureml_endpoint.py
+++ b/libs/langchain/langchain/chat_models/azureml_endpoint.py
@@ -25,16 +25,20 @@ class LlamaContentFormatter(ContentFormatterBase):
     def _convert_message_to_dict(message: BaseMessage) -> Dict:
         """Converts message to a dict according to role"""
         if isinstance(message, HumanMessage): 
-            return {"role": "user", "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {"role": "user", 
+            "content": ContentFormatterBase.escape_special_characters(message.content)}
         elif isinstance(message, AIMessage):
-            return {"role": "assistant", "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {"role": "assistant", 
+            "content": ContentFormatterBase.escape_special_characters(message.content)}
         elif isinstance(message, SystemMessage):
-            return {"role": "system", "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {"role": "system", 
+            "content": ContentFormatterBase.escape_special_characters(message.content)}
         elif (
             isinstance(message, ChatMessage)
             and message.role in LlamaContentFormatter.SUPPORTED_ROLES
         ):
-            return {"role": message.role, "content": ContentFormatterBase.escape_special_characters(message.content)}
+            return {"role": message.role, 
+            "content": ContentFormatterBase.escape_special_characters(message.content)}
         else:
             supported = ",".join(
                 [role for role in LlamaContentFormatter.SUPPORTED_ROLES]


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: for azure ml chat endpoint added support for ContentFormatter escape special characters for message content, 
  - Issue: escape special character for message content,
  - Dependencies: not required any
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
