### PR TITLE
Modified chain datatype to Chain to support for ConversationalRetrievalChain, etc

### DIFF
--- a/libs/langchain/langchain/chains/constitutional_ai/base.py
+++ b/libs/langchain/langchain/chains/constitutional_ai/base.py
@@ -44,7 +44,7 @@ class ConstitutionalChain(Chain):
             constitutional_chain.run(question="What is the meaning of life?")
     """
 
-    chain: LLMChain
+    chain: Chain
     constitutional_principles: List[ConstitutionalPrinciple]
     critique_chain: LLMChain
     revision_chain: LLMChain
@@ -63,7 +63,7 @@ class ConstitutionalChain(Chain):
     def from_llm(
         cls,
         llm: BaseLanguageModel,
-        chain: LLMChain,
+        chain: Chain,
         critique_prompt: BasePromptTemplate = CRITIQUE_PROMPT,
         revision_prompt: BasePromptTemplate = REVISION_PROMPT,
         **kwargs: Any,


### PR DESCRIPTION
 **Description:**
In the class ConstitutionalChain currently supports LLMChain when using from_llm.
When we try to use it with other type of chains such as ConversationalRetrievalChain whose superclass isn't LLMChain it gives a type error.
As both the class's superclass was Chain, when replaced with it, it worked as supposed to.

**Issue:**
Found it to be relevant to
[https://github.com/langchain-ai/langchain/issues/5881](https://github.com/langchain-ai/langchain/issues/5881)
[https://github.com/langchain-ai/langchain/issues/1904](https://github.com/langchain-ai/langchain/issues/1904)

**Dependencies:**
None

**Tag maintainer:**
@wnmurphy
@hwchase17 

**Twitter handle:**
Linkdin: www.linkedin.com/in/prar

**How I used it**
```
 qa_chain = ConversationalRetrievalChain.from_llm(llm, db.as_retriever(), 
                        memory=memory, condense_question_prompt=qa_prompt)

constitutional_chain = ConstitutionalChain.from_llm(
            llm=llm,
            chain=qa_chain,
            constitutional_principles=list(principles),
        )

```
