### PR TITLE
Add Language Detection

### DIFF
--- a/docs/extras/use_cases/lang_detection.ipynb
+++ b/docs/extras/use_cases/lang_detection.ipynb
@@ -1,0 +1,385 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d7889bc6-30c9-426b-80a8-9bc8d56354ea",
+   "metadata": {},
+   "source": [
+    "# Language Detection with langdetect package\n",
+    "[![Open In Collab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/extras/use_cases/lang_detection.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a778a1d-e9f8-483d-a475-f79369990b63",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "Implemented model detects language of a text using naive Bayesian filter. Achieves 99% over precision for 53 languages.\n",
+    "\n",
+    "Language detector allows you to use 2 following methods:\n",
+    "1. detect_single_language - returns the language with the highest score obtained with the detection model,\n",
+    "2. detect_many_languages - returns list of pairs consisting of language and corresponding score obtained by the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a6a233c-5b0c-469d-8b4a-fd6ef762c018",
+   "metadata": {},
+   "source": [
+    "## Quickstart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c44f8459-ee49-4868-a98e-fac836489a85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install necessary packages\n",
+    "# ! pip install langdetect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "448d85ba-a6f5-4c2d-98b0-1f8870257c69",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'en'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain_experimental.language_detector import LangDetector\n",
+    "\n",
+    "single_lang_text = \"Hello world, my name is John Doe\"\n",
+    "\n",
+    "lang_detector = LangDetector()\n",
+    "lang_detector.detect_single_language(single_lang_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b38d3323-a5dd-422a-b6ee-16d36ca44755",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('en', 0.999996206585063)]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lang_detector.detect_many_languages(single_lang_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cc9268cc-10d1-4d86-93db-f25b51754350",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'en'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "many_langs_text = \"Hello world! Me lammo Sofía, soy Madrileña. Auf Wiedersehen!\"\n",
+    "lang_detector.detect_single_language(many_langs_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ec38c689-2104-4740-88b3-7e67fec48fc0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('en', 0.5714275935995099), ('de', 0.42857059444347717)]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lang_detector.detect_many_languages(many_langs_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43ca9050-1c5b-4fab-aa18-dc7120a97dae",
+   "metadata": {},
+   "source": [
+    "## Usage in chain\n",
+    "Language detection is particulary useful with the components that require selection of a language, e.g. text-to-speech or data anonymizer. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4618c101-2269-42bd-9655-1e491051bd58",
+   "metadata": {},
+   "source": [
+    "### Usage with data anonymizer\n",
+    "Let's investigate how to join the functionalities of both modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "e219c166-50ea-47db-9c29-17b968e9f46b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install other required packages\n",
+    "# ! pip install presidio-analyzer presidio-anonymizer faker\n",
+    "# ! python -m spacy download en_core_web_lg\n",
+    "# ! python -m spacy download es_core_news_md"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "2c6b70fa-bad8-472e-a52e-861d7d71e37f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.chains import TransformChain\n",
+    "from langchain_experimental.data_anonymizer import PresidioReversibleAnonymizer\n",
+    "\n",
+    "languages_config = {\n",
+    "    \"nlp_engine_name\": \"spacy\",\n",
+    "    \"models\": [\n",
+    "        {\"lang_code\": \"en\", \"model_name\": \"en_core_web_lg\"},\n",
+    "        {\"lang_code\": \"es\", \"model_name\": \"es_core_news_sm\"},\n",
+    "    ],\n",
+    "}\n",
+    "anonymizer = PresidioReversibleAnonymizer(languages_config=languages_config)\n",
+    "llm = ChatOpenAI(temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "2d5ccf64-737f-49f4-883c-01836d52538f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def lang_transform_func(inputs: dict) -> dict:\n",
+    "    text = inputs[\"text\"]\n",
+    "    language = lang_detector.detect_single_language(text)\n",
+    "    return {\"text\": text, \"language\": language}\n",
+    "\n",
+    "lang_transform_chain = TransformChain(input_variables=[\"text\"], output_variables=[\"text\", \"language\"], transform=lang_transform_func)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "696366b0-955d-4c55-9c8a-45dd5b9337ba",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello world, my name is John Doe\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content='Hello Emily Woods! How can I assist you today?', additional_kwargs={}, example=False)"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(single_lang_text)\n",
+    "chain = lang_transform_chain | (lambda x: anonymizer.anonymize(x[\"text\"], language=x[\"language\"])) | llm\n",
+    "chain.invoke(single_lang_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c903663f-e76e-4a79-b6c1-0e963cf42b4b",
+   "metadata": {},
+   "source": [
+    "As it was expected the entity called \"John Doe\" was anonymized. \n",
+    "\n",
+    "However, english language is the default one. Let's see how the anonimyzation works for spanish."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "3bfc0326-f84d-4c8b-99e5-850e53af7fc0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hola el mundo, Yo soy Sofia Lopez\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content='¡Hola Daisy Dudley! ¿Cómo puedo ayudarte hoy?', additional_kwargs={}, example=False)"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "es_lang_text = \"Hola el mundo, Yo soy Sofia Lopez\"\n",
+    "print(es_lang_text)\n",
+    "chain.invoke(es_lang_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df4d2016-ae8d-476e-8db0-fe780d0ad070",
+   "metadata": {},
+   "source": [
+    "We can see that \"Sofia Lopez\" was anonymized as a single entity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "dd6a7412-53df-48da-9f3b-82549c5c6d45",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'PERSON': {'Emily Woods': 'John Doe', 'Daisy Dudley': 'Sofia Lopez'}}"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "anonymizer._deanonymizer_mapping.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54123f29-dc6d-4028-8f5b-aa2f90a4bcc5",
+   "metadata": {},
+   "source": [
+    "Let's compare it with the anonymizer set to the default english language."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "ebd409f8-ca64-4a3e-9102-722c1f247d53",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content='¡Hola Crystal y Monica! ¿Cómo están? ¿En qué puedo ayudarles hoy?', additional_kwargs={}, example=False)"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bare_anonymizer = PresidioReversibleAnonymizer(languages_config=languages_config)\n",
+    "bare_chain = bare_anonymizer.anonymize | llm\n",
+    "bare_chain.invoke(es_lang_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b56b06db-da02-44ff-a94f-db662ccb5a9c",
+   "metadata": {},
+   "source": [
+    "This time, both \"Yo soy\" and \"Sofia Lopez\" were recognized as PERSON entities and got anonymized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "b4b90610-c865-4075-b9d9-2ac9a2286d61",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'PERSON': {'Crystal Dawson': 'Yo soy', 'Monica Black': 'Sofia Lopez'}}"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bare_anonymizer._deanonymizer_mapping.data"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/experimental/langchain_experimental/language_detector/__init__.py
+++ b/libs/experimental/langchain_experimental/language_detector/__init__.py
@@ -1,0 +1,4 @@
+"""Language detector package."""
+from langchain_experimental.language_detector.lang_detect import LangDetector
+
+__all__ = ["LangDetector"]

--- a/libs/experimental/langchain_experimental/language_detector/base.py
+++ b/libs/experimental/langchain_experimental/language_detector/base.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import List, Tuple
+
+class LanguageDetectorBase(ABC):
+    """
+    Base abstract class for language detectors.
+    """
+    
+    def detect_single_language(self, text: str) -> str:
+        """Detect language of a single text"""
+        return self._detect_single(text)
+    
+    @abstractmethod
+    def _detect_single(self, text: str) -> str:
+        """Abstract method to detect language of a single text"""
+
+    def detect_many_languages(self, text: str) -> List[Tuple[str, float]]:
+        """Detect languages of a single text"""
+        return self._detect_many(text)
+    
+    @abstractmethod
+    def _detect_many(self, text: str) -> List[Tuple[str, float]]:
+        """Abstract method to detect languages of a single text"""

--- a/libs/experimental/langchain_experimental/language_detector/base.py
+++ b/libs/experimental/langchain_experimental/language_detector/base.py
@@ -1,15 +1,16 @@
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 
+
 class LanguageDetectorBase(ABC):
     """
     Base abstract class for language detectors.
     """
-    
+
     def detect_single_language(self, text: str) -> str:
         """Detect language of a single text"""
         return self._detect_single(text)
-    
+
     @abstractmethod
     def _detect_single(self, text: str) -> str:
         """Abstract method to detect language of a single text"""
@@ -17,7 +18,7 @@ class LanguageDetectorBase(ABC):
     def detect_many_languages(self, text: str) -> List[Tuple[str, float]]:
         """Detect languages of a single text"""
         return self._detect_many(text)
-    
+
     @abstractmethod
     def _detect_many(self, text: str) -> List[Tuple[str, float]]:
         """Abstract method to detect languages of a single text"""

--- a/libs/experimental/langchain_experimental/language_detector/lang_detect.py
+++ b/libs/experimental/langchain_experimental/language_detector/lang_detect.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Tuple
+from typing import List, Tuple
 
 from langchain_experimental.language_detector.base import LanguageDetectorBase
 
@@ -8,10 +8,6 @@ except ImportError:
     raise ImportError(
         "Could not import langdetect, please install with " "`pip install langdetect`."
     )
-
-
-if TYPE_CHECKING:
-    import langdetect
 
 
 class LangDetector(LanguageDetectorBase):

--- a/libs/experimental/langchain_experimental/language_detector/lang_detect.py
+++ b/libs/experimental/langchain_experimental/language_detector/lang_detect.py
@@ -1,0 +1,35 @@
+from typing import TYPE_CHECKING, List, Tuple
+
+from langchain_experimental.language_detector.base import LanguageDetectorBase
+
+try:
+    import langdetect
+except ImportError:
+    raise ImportError("Could not import langdetect, please install with "
+        "`pip install langdetect`."
+    )
+
+
+if TYPE_CHECKING:
+    import langdetect
+    
+
+class LangDetector(LanguageDetectorBase):
+    """
+    Language detector based on langdetect package.
+    Warning: Results are not deterministic!
+    It supports 55 languages out of the box.
+    """
+    def __init__(self, threshold: float = 0.1):
+        self.threshold = threshold  # Minimum probability to consider a language as detected.
+    
+    def _detect_single(self, text: str) -> str:
+        """Detects the most probable language of a single text."""
+        return langdetect.detect(text)
+    
+    def _detect_many(self, text: str) -> List[Tuple[str, float]]:
+        """Detects all languages of a single text with a score bigger than threshold.
+        Returns them sorted on score in descending order.
+        """
+        predictions = langdetect.detect_langs(text)
+        return [(x.lang, x.prob) for x in predictions if x.prob > self.threshold]

--- a/libs/experimental/langchain_experimental/language_detector/lang_detect.py
+++ b/libs/experimental/langchain_experimental/language_detector/lang_detect.py
@@ -5,14 +5,14 @@ from langchain_experimental.language_detector.base import LanguageDetectorBase
 try:
     import langdetect
 except ImportError:
-    raise ImportError("Could not import langdetect, please install with "
-        "`pip install langdetect`."
+    raise ImportError(
+        "Could not import langdetect, please install with " "`pip install langdetect`."
     )
 
 
 if TYPE_CHECKING:
     import langdetect
-    
+
 
 class LangDetector(LanguageDetectorBase):
     """
@@ -20,13 +20,16 @@ class LangDetector(LanguageDetectorBase):
     Warning: Results are not deterministic!
     It supports 55 languages out of the box.
     """
+
     def __init__(self, threshold: float = 0.1):
-        self.threshold = threshold  # Minimum probability to consider a language as detected.
-    
+        self.threshold = (
+            threshold  # Minimum probability to consider a language as detected.
+        )
+
     def _detect_single(self, text: str) -> str:
         """Detects the most probable language of a single text."""
         return langdetect.detect(text)
-    
+
     def _detect_many(self, text: str) -> List[Tuple[str, float]]:
         """Detects all languages of a single text with a score bigger than threshold.
         Returns them sorted on score in descending order.

--- a/libs/experimental/tests/unit_tests/test_language_detector.py
+++ b/libs/experimental/tests/unit_tests/test_language_detector.py
@@ -11,7 +11,7 @@ import pytest
         ("Hallo, mein Name ist John Doe.", "de"),
     ],
 )
-def test_detect_single_language(text: str, language: str) -> str:
+def test_detect_single_language(text: str, language: str) -> None:
     """Test detecting most probable language of a text"""
     from langchain_experimental.language_detector import LangDetector
 
@@ -25,10 +25,13 @@ def test_detect_single_language(text: str, language: str) -> str:
     "text,languages",
     [
         ("Hello, my name is John Doe.", ["en"]),
-        ("Hello, my name is John Doe. I live in London. Auf Wiedersehen.", ["de", "en"]),
+        (
+            "Hello, my name is John Doe. I live in London. Auf Wiedersehen.",
+            ["de", "en"],
+        ),
     ],
 )
-def test_detect_many_languages(text: str, languages: List[str]) -> str:
+def test_detect_many_languages(text: str, languages: List[str]) -> None:
     """Test detecting most probable languages of a text"""
     from langchain_experimental.language_detector import LangDetector
 

--- a/libs/experimental/tests/unit_tests/test_language_detector.py
+++ b/libs/experimental/tests/unit_tests/test_language_detector.py
@@ -1,0 +1,39 @@
+from typing import List
+
+import pytest
+
+
+@pytest.mark.requires("langdetect")
+@pytest.mark.parametrize(
+    "text,language", 
+    [
+        ("Hello, my name is John Doe.", "en"), 
+        ("Hallo, mein Name ist John Doe.", "de"),
+        ("Hello, my name is John Doe. Auf Wiedersehen.", "en"),
+        ("xfgb 21s xaaa", "unknown")
+    ]
+)
+def test_detect_single_language(text: str, language: str) -> str:
+    """Test detecting most probable language of a text"""
+    from langchain_experimental.language_detector import LangDetector
+    
+    lang_detector = LangDetector()
+    predicted = lang_detector.detect_single_language(text)
+    assert predicted == language
+    
+    
+@pytest.mark.requires("langdetect")
+@pytest.mark.parametrize(
+    "text,languages", 
+    [
+        ("Hello, my name is John Doe.", ["en"]), 
+        ("Hello, my name is John Doe. Auf Wiedersehen.", ["en", "de"]),
+    ]
+)
+def test_detect_single_language(text: str, languages: List[str]) -> str:
+    """Test detecting most probable languages of a text"""
+    from langchain_experimental.language_detector import LangDetector
+    
+    lang_detector = LangDetector()
+    predicted = lang_detector.detect_many_languages(text)
+    assert [x[0] for x in predicted] == languages

--- a/libs/experimental/tests/unit_tests/test_language_detector.py
+++ b/libs/experimental/tests/unit_tests/test_language_detector.py
@@ -5,35 +5,33 @@ import pytest
 
 @pytest.mark.requires("langdetect")
 @pytest.mark.parametrize(
-    "text,language", 
+    "text,language",
     [
-        ("Hello, my name is John Doe.", "en"), 
+        ("Hello, my name is John Doe.", "en"),
         ("Hallo, mein Name ist John Doe.", "de"),
-        ("Hello, my name is John Doe. Auf Wiedersehen.", "en"),
-        ("xfgb 21s xaaa", "unknown")
-    ]
+    ],
 )
 def test_detect_single_language(text: str, language: str) -> str:
     """Test detecting most probable language of a text"""
     from langchain_experimental.language_detector import LangDetector
-    
+
     lang_detector = LangDetector()
     predicted = lang_detector.detect_single_language(text)
     assert predicted == language
-    
-    
+
+
 @pytest.mark.requires("langdetect")
 @pytest.mark.parametrize(
-    "text,languages", 
+    "text,languages",
     [
-        ("Hello, my name is John Doe.", ["en"]), 
-        ("Hello, my name is John Doe. Auf Wiedersehen.", ["en", "de"]),
-    ]
+        ("Hello, my name is John Doe.", ["en"]),
+        ("Hello, my name is John Doe. I live in London. Auf Wiedersehen.", ["de", "en"]),
+    ],
 )
-def test_detect_single_language(text: str, languages: List[str]) -> str:
+def test_detect_many_languages(text: str, languages: List[str]) -> str:
     """Test detecting most probable languages of a text"""
     from langchain_experimental.language_detector import LangDetector
-    
+
     lang_detector = LangDetector()
     predicted = lang_detector.detect_many_languages(text)
     assert [x[0] for x in predicted] == languages


### PR DESCRIPTION
**!! Should wait for https://github.com/langchain-ai/langchain/pull/10181 to be merged, so that the example with TTS component is added !!**

### Description

Adds language detection component based on [langdetect](https://github.com/Mimino666/langdetect/tree/master/langdetect) library. It implements naive Bayesian filter and is able to recognize >50 languages. This module can be especially useful together with components that require selection of the language (e.g. text-2-speech or data-anonymizer)

### Twitter handle

@deepsense_ai, @matt_wosinski