### PR TITLE
fix(DynamoDBChatMessageHistory): correct delete_item method call

### DIFF
--- a/libs/langchain/langchain/memory/chat_message_histories/dynamodb.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/dynamodb.py
@@ -121,6 +121,6 @@ class DynamoDBChatMessageHistory(BaseChatMessageHistory):
             ) from e
 
         try:
-            self.table.delete_item(self.key)
+            self.table.delete_item(Key=self.key)
         except ClientError as err:
             logger.error(err)


### PR DESCRIPTION
**Description**: 
Fixed a bug introduced in version 0.0.281 in `DynamoDBChatMessageHistory` where `self.table.delete_item(self.key)` produced a TypeError: `TypeError: delete_item() only accepts keyword arguments`. Updated the method call to `self.table.delete_item(Key=self.key)` to resolve this issue.

Please see also [the official AWS documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/table/delete_item.html#) on this **delete_item** method - only `**kwargs` are accepted.

See also the PR, which introduced this bug: https://github.com/langchain-ai/langchain/pull/9896#discussion_r1317899073

Please merge this, I rely on this delete dynamodb item functionality (because of GDPR considerations).

**Dependencies**: 
None

**Tag maintainer**: 
@hwchase17 @joshualwhite 

**Twitter handle**: 
[@BenjaminLinnik](https://twitter.com/BenjaminLinnik)

- [x] Linting (`make lint`)
- [x] Formatting (`make format`)
- [x] Tests (`make test`)
