### PR TITLE
Latest version of HazyResearch/manifest doesn't support accessing "client" directly

### DIFF
--- a/docs/extras/integrations/llms/manifest.ipynb
+++ b/docs/extras/integrations/llms/manifest.ipynb
@@ -57,7 +57,7 @@
     "manifest = Manifest(\n",
     "    client_name=\"huggingface\", client_connection=\"http://127.0.0.1:5000\"\n",
     ")\n",
-    "print(manifest.client.get_model_params())"
+    "print(manifest.client_pool.get_current_client().get_model_params())"
    ]
   },
   {

--- a/libs/langchain/langchain/llms/manifest.py
+++ b/libs/langchain/langchain/llms/manifest.py
@@ -34,7 +34,7 @@ class ManifestWrapper(LLM):
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
         kwargs = self.llm_kwargs or {}
-        return {**self.client.client.get_model_params(), **kwargs}
+        return {**self.client.client_pool.get_current_client().get_model_params(), **kwargs}
 
     @property
     def _llm_type(self) -> str:

--- a/libs/langchain/langchain/llms/manifest.py
+++ b/libs/langchain/langchain/llms/manifest.py
@@ -34,7 +34,10 @@ class ManifestWrapper(LLM):
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
         kwargs = self.llm_kwargs or {}
-        return {**self.client.client_pool.get_current_client().get_model_params(), **kwargs}
+        return {
+            **self.client.client_pool.get_current_client().get_model_params(),
+            **kwargs,
+        }
 
     @property
     def _llm_type(self) -> str:


### PR DESCRIPTION
**Description:** 
The latest version of HazyResearch/manifest doesn't support accessing the "client" directly. The latest version supports connection pools and a client has to be requested from the client pool. 
**Issue:**
No matching issue was found
**Dependencies:** 
The manifest.ipynb file in docs/extras/integrations/llms need to be updated
**Tag maintainer:** 
**Twitter handle:** 
@hrk_cbe