### PR TITLE
Fix the RedisVectorStoreRetriever import

### DIFF
--- a/libs/langchain/langchain/vectorstores/redis/__init__.py
+++ b/libs/langchain/langchain/vectorstores/redis/__init__.py
@@ -1,4 +1,4 @@
-from .base import Redis
+from .base import Redis, RedisVectorStoreRetriever
 from .filters import (
     RedisFilter,
     RedisNum,
@@ -6,4 +6,11 @@ from .filters import (
     RedisText,
 )
 
-__all__ = ["Redis", "RedisFilter", "RedisTag", "RedisText", "RedisNum"]
+__all__ = [
+    "Redis",
+    "RedisFilter",
+    "RedisTag",
+    "RedisText",
+    "RedisNum",
+    "RedisVectorStoreRetriever",
+]


### PR DESCRIPTION
As the title suggests.

Replace this entire comment with:
  - Description: Add a syntactic sugar import fix for #10186 
  - Issue: #10186 
  - Tag maintainer: @baskaryan 
  - Twitter handle: @Spartee 
