### PR TITLE
Fix of issue:

### DIFF
--- a/libs/langchain/langchain/memory/token_buffer.py
+++ b/libs/langchain/langchain/memory/token_buffer.py
@@ -55,5 +55,4 @@ class ConversationTokenBufferMemory(BaseChatMemory):
             pruned_memory = []
             while curr_buffer_length > self.max_token_limit:
                 pruned_memory.append(buffer.pop(0))
-                curr_buffer_length = self.llm.get_num_tokens_from_messages(
-                    buffer)
+                curr_buffer_length = self.llm.get_num_tokens_from_messages(buffer)

--- a/libs/langchain/langchain/memory/token_buffer.py
+++ b/libs/langchain/langchain/memory/token_buffer.py
@@ -21,7 +21,7 @@ class ConversationTokenBufferMemory(BaseChatMemory):
 
     @property
     def buffer_as_str(self) -> str:
-        """Exposes the buffer as a string in case return_messages is True."""
+        """Exposes the buffer as a string in case return_messages is False."""
         return get_buffer_string(
             self.chat_memory.messages,
             human_prefix=self.human_prefix,
@@ -30,7 +30,7 @@ class ConversationTokenBufferMemory(BaseChatMemory):
 
     @property
     def buffer_as_messages(self) -> List[BaseMessage]:
-        """Exposes the buffer as a list of messages in case return_messages is False."""
+        """Exposes the buffer as a list of messages in case return_messages is True."""
         return self.chat_memory.messages
 
     @property
@@ -55,4 +55,5 @@ class ConversationTokenBufferMemory(BaseChatMemory):
             pruned_memory = []
             while curr_buffer_length > self.max_token_limit:
                 pruned_memory.append(buffer.pop(0))
-                curr_buffer_length = self.llm.get_num_tokens_from_messages(buffer)
+                curr_buffer_length = self.llm.get_num_tokens_from_messages(
+                    buffer)


### PR DESCRIPTION
DOC: Inversion of 'True' and 'False' in ConversationTokenBufferMemory Property Comments #10420

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: Swap the True and False word in ConverstaionTokenBufferMemory buffer_as_str and buffer_as_messages methods, 
  - Issue: the issue #10420,
  - Dependencies: None
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
