### PR TITLE
Remove broken documentation links

### DIFF
--- a/docs/docs_skeleton/docs/modules/chains/index.mdx
+++ b/docs/docs_skeleton/docs/modules/chains/index.mdx
@@ -19,8 +19,6 @@ For more specifics check out:
 - [How-to](/docs/modules/chains/how_to/) for walkthroughs of different chain features
 - [Foundational](/docs/modules/chains/foundational/) to get acquainted with core building block chains
 - [Document](/docs/modules/chains/document/) to learn how to incorporate documents into chains
-- [Popular](/docs/modules/chains/popular/) chains for the most common use cases
-- [Additional](/docs/modules/chains/additional/) to see some of the more advanced chains and integrations that you can use out of the box
 
 ## Why do we need chains?
 


### PR DESCRIPTION
Description: Removed some broken links for popular chains and additional/advanced chains.
Issue: None
Dependencies: None
Tag maintainer: none yet
Twitter handle: ferrants 

Alternatively, these pages could be created, there are snippets for the popular pages, but no popular page itself.

![Screenshot from 2023-09-10 14-53-01](https://github.com/langchain-ai/langchain/assets/882183/7b79ab37-f6ca-4c41-a9dd-251b9bd8c214)

![Screenshot from 2023-09-10 15-00-26](https://github.com/langchain-ai/langchain/assets/882183/86c5ec64-aee1-4e44-b409-108b92a75da9)
