### PR TITLE
Update output_parser.py

### DIFF
--- a/libs/langchain/tests/unit_tests/agents/test_mrkl_output_parser.py
+++ b/libs/langchain/tests/unit_tests/agents/test_mrkl_output_parser.py
@@ -52,11 +52,25 @@ def test_missing_action_input() -> None:
     )
 
 
-def test_final_answer_and_parsable_action() -> None:
-    llm_output = """Final Answer: The best pizza to eat is margaritta 
-        I can use the `foo` tool to achieve the goal.
+def test_final_answer_before_parsable_action() -> None:
+    llm_output = """Final Answer: The best pizza to eat is margaritta
+
         Action: foo
         Action Input: bar
+        """
+    agent_finish: AgentFinish = mrkl_output_parser.parse(llm_output)  # type: ignore
+    assert (
+        agent_finish.return_values.get("output")
+        == "The best pizza to eat is margaritta"
+    )
+
+
+def test_final_answer_after_parsable_action() -> None:
+    llm_output = """
+        Observation: I can use the `foo` tool to achieve the goal.
+        Action: foo
+        Action Input: bar
+        Final Answer: The best pizza to eat is margaritta 
         """
     with pytest.raises(OutputParserException) as exception_info:
         mrkl_output_parser.parse(llm_output)


### PR DESCRIPTION
- Description: Updated output parser for mrkl to remove any hallucination actions after the final answer; this was encountered when using Anthropic claude v2 for planning; reopening PR with updated unit tests
- Issue: #10278 
- Dependencies: N/A
- Twitter handle: @johnreynolds