### PR TITLE
Fix mypy error in openai.py for client

### DIFF
--- a/libs/langchain/langchain/embeddings/openai.py
+++ b/libs/langchain/langchain/embeddings/openai.py
@@ -159,7 +159,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
 
     """
 
-    client: Any  #: :meta private:
+    client: Any = None  #: :meta private:
     model: str = "text-embedding-ada-002"
     deployment: str = model  # to support Azure OpenAI Service custom deployment names
     openai_api_version: Optional[str] = None


### PR DESCRIPTION
We use your library and we have a mypy error because you have not defined a default value for the optional class property.

Please fix this issue to make it compatible with the mypy. Thank you.