### PR TITLE
Modifying generations.append to solve problem with OpenLLM

### DIFF
--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -1001,7 +1001,7 @@ class LLM(BaseLLM):
                 if new_arg_supported
                 else self._call(prompt, stop=stop, **kwargs)
             )
-            generations.append([Generation(text=text)])
+            generations.append([Generation(text=text['text'], generation_info=text)])
         return LLMResult(generations=generations)
 
     async def _agenerate(


### PR DESCRIPTION
# Description

Added the generation_info=text in the generations.append on the _generate function, to fix generation with OpenLLM model deployment.

# Issue

Fix: https://github.com/langchain-ai/langchain/issues/9923

# Twitter

@vitinleao1
