### PR TITLE
Fix chroma vectorstore error message

### DIFF
--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -217,7 +217,7 @@ class Chroma(VectorStore):
                     if "Expected metadata value to be" in str(e):
                         msg = (
                             "Try filtering complex metadata from the document using "
-                            "langchain.vectorstore.utils.filter_complex_metadata."
+                            "langchain.vectorstores.utils.filter_complex_metadata."
                         )
                         raise ValueError(e.args[0] + "\n\n" + msg)
                     else:


### PR DESCRIPTION
- Description: Updated the error message in the Chroma vectorestore, that displayed a wrong import path for langchain.vectorstores.utils.filter_complex_metadata.
- Tag maintainer: @sbusso 
