### PR TITLE
Update milvus.py: avoid key error of insert_dict

### DIFF
--- a/libs/langchain/langchain/vectorstores/milvus.py
+++ b/libs/langchain/langchain/vectorstores/milvus.py
@@ -460,7 +460,7 @@ class Milvus(VectorStore):
             # Grab end index
             end = min(i + batch_size, total_count)
             # Convert dict to list of lists batch for insertion
-            insert_list = [insert_dict[x][i:end] for x in self.fields]
+            insert_list = [insert_dict.get(x, "")[i:end] for x in self.fields]
             # Insert into the collection.
             try:
                 res: Collection

--- a/libs/langchain/langchain/vectorstores/milvus.py
+++ b/libs/langchain/langchain/vectorstores/milvus.py
@@ -446,7 +446,7 @@ class Milvus(VectorStore):
         if metadatas is not None:
             for d in metadatas:
                 for key, value in d.items():
-                    if key in self.fields:
+                    if key in self.fields and key not in [self._text_field, self._vector_field]:
                         val = insert_dict.setdefault(key, [])
                         if isinstance(val, list):
                             val.append(value)

--- a/libs/langchain/langchain/vectorstores/milvus.py
+++ b/libs/langchain/langchain/vectorstores/milvus.py
@@ -447,7 +447,9 @@ class Milvus(VectorStore):
             for d in metadatas:
                 for key, value in d.items():
                     if key in self.fields:
-                        insert_dict.setdefault(key, []).append(value)
+                        val = insert_dict.setdefault(key, [])
+                        if isinstance(val, list):
+                            val.append(value)
 
         # Total insert count
         vectors: list = insert_dict[self._vector_field]


### PR DESCRIPTION
the Milvus.fields is union of all metadata.keys from different file types. but insert_dict is limited to specific file, `insert_dict[x]` will raise key error after Milvus.fields growed.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
