### PR TITLE
Update SQLDatabaseChain for intermediate SQLResults

### DIFF
--- a/libs/experimental/langchain_experimental/sql/base.py
+++ b/libs/experimental/langchain_experimental/sql/base.py
@@ -136,8 +136,8 @@ class SQLDatabaseChain(Chain):
                 intermediate_steps.append(
                     sql_cmd
                 )  # output: sql generation (no checker)
-                intermediate_steps.append({"sql_cmd": sql_cmd})  # input: sql exec
                 result = self.database.run(sql_cmd)
+                intermediate_steps.append({"sql_cmd": checked_sql_command, "sql_result": str(result)}) # input: sql exec
                 intermediate_steps.append(str(result))  # output: sql exec
             else:
                 query_checker_prompt = self.query_checker_prompt or PromptTemplate(
@@ -159,10 +159,9 @@ class SQLDatabaseChain(Chain):
                 _run_manager.on_text(
                     checked_sql_command, color="green", verbose=self.verbose
                 )
-                intermediate_steps.append(
-                    {"sql_cmd": checked_sql_command}
-                )  # input: sql exec
+                 
                 result = self.database.run(checked_sql_command)
+                intermediate_steps.append({"sql_cmd": checked_sql_command, "sql_result": str(result)}) # input: sql exec
                 intermediate_steps.append(str(result))  # output: sql exec
                 sql_cmd = checked_sql_command
 


### PR DESCRIPTION
Description: 
In the call method within the SQLDatabaseChain class:
Amend the intermediate steps dictionary to include a new key, say sql_result, where the SQL results at different stages would be saved.
During the SQL execution step, save the SQL result into the sql_result key in the intermediate steps dictionary, similar to how sql_cmd is being saved currently.

Issue: #10500 
Tag maintainer: zzfab


