### PR TITLE
Moved from InferenceApi to InferenceClient to avoid deprecation warning for huggingface_hub

### DIFF
--- a/libs/langchain/langchain/llms/huggingface_hub.py
+++ b/libs/langchain/langchain/llms/huggingface_hub.py
@@ -60,7 +60,7 @@ class HuggingFaceHub(LLM):
                 values["task"] = model_info.pipeline_tag
             if values["task"] not in VALID_TASKS:
                 raise ValueError(
-                    f"Got invalid task {values.get('task')}, "
+                    f"Got invalid task {values['task']}, "
                     f"currently only {VALID_TASKS} are supported"
                 )
             values["client"] = client


### PR DESCRIPTION
Updated huggingface_hub llm to use the new InferenceClient to avoid deprecation warning. 

Resolves the issue: #10483


@baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
