### PR TITLE
fix: unify generation outputs on newer openllm release

### DIFF
--- a/libs/langchain/langchain/llms/openllm.py
+++ b/libs/langchain/langchain/llms/openllm.py
@@ -266,12 +266,14 @@ class OpenLLM(LLM):
         )
         if self._client:
             o = self._client.query(prompt, **config.model_dump(flatten=True))
-            if isinstance(o, dict) and 'text' in o: return o['text']
+            if isinstance(o, dict) and "text" in o:
+                return o["text"]
             return o
         else:
             assert self._runner is not None
             o = self._runner(prompt, **config.model_dump(flatten=True))
-            if isinstance(o, dict) and 'text' in o: return o['text']
+            if isinstance(o, dict) and "text" in o:
+                return o["text"]
             return o
 
     async def _acall(
@@ -298,7 +300,8 @@ class OpenLLM(LLM):
             o = await self._client.acall(
                 "generate", prompt, **config.model_dump(flatten=True)
             )
-            if isinstance(o, dict) and 'text' in o: return o['text']
+            if isinstance(o, dict) and "text" in o:
+                return o["text"]
             return o
         else:
             assert self._runner is not None
@@ -313,5 +316,6 @@ class OpenLLM(LLM):
             o = self._runner.llm.postprocess_generate(
                 prompt, generated_result, **postprocess_kwargs
             )
-            if isinstance(o, dict) and 'text' in o: return o['text']
+            if isinstance(o, dict) and "text" in o:
+                return o["text"]
             return o

--- a/libs/langchain/langchain/llms/openllm.py
+++ b/libs/langchain/langchain/llms/openllm.py
@@ -265,10 +265,14 @@ class OpenLLM(LLM):
             self._identifying_params["model_name"], **copied
         )
         if self._client:
-            return self._client.query(prompt, **config.model_dump(flatten=True))
+            o = self._client.query(prompt, **config.model_dump(flatten=True))
+            if isinstance(o, dict) and 'text' in o: return o['text']
+            return o
         else:
             assert self._runner is not None
-            return self._runner(prompt, **config.model_dump(flatten=True))
+            o = self._runner(prompt, **config.model_dump(flatten=True))
+            if isinstance(o, dict) and 'text' in o: return o['text']
+            return o
 
     async def _acall(
         self,
@@ -291,9 +295,11 @@ class OpenLLM(LLM):
             self._identifying_params["model_name"], **copied
         )
         if self._client:
-            return await self._client.acall(
+            o = await self._client.acall(
                 "generate", prompt, **config.model_dump(flatten=True)
             )
+            if isinstance(o, dict) and 'text' in o: return o['text']
+            return o
         else:
             assert self._runner is not None
             (
@@ -304,6 +310,8 @@ class OpenLLM(LLM):
             generated_result = await self._runner.generate.async_run(
                 prompt, **generate_kwargs
             )
-            return self._runner.llm.postprocess_generate(
+            o = self._runner.llm.postprocess_generate(
                 prompt, generated_result, **postprocess_kwargs
             )
+            if isinstance(o, dict) and 'text' in o: return o['text']
+            return o


### PR DESCRIPTION
update newer generation format from OpenLLm where it returns a dictionary for one shot generation

cc @baskaryan 

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. These live is docs/extras directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17, @rlancemartin.
 -->
