### PR TITLE
Fix SingleStoreDB

### DIFF
--- a/libs/langchain/langchain/vectorstores/singlestoredb.py
+++ b/libs/langchain/langchain/vectorstores/singlestoredb.py
@@ -374,7 +374,7 @@ class SingleStoreDB(VectorStore):
                     FROM {} {} ORDER BY __score {} LIMIT %s""".format(
                         self.content_field,
                         self.metadata_field,
-                        self.distance_strategy,
+                        self.distance_strategy.name if isinstance(self.distance_strategy, DistanceStrategy) else self.distance_strategy,
                         self.vector_field,
                         self.table_name,
                         where_clause,

--- a/libs/langchain/langchain/vectorstores/singlestoredb.py
+++ b/libs/langchain/langchain/vectorstores/singlestoredb.py
@@ -374,7 +374,9 @@ class SingleStoreDB(VectorStore):
                     FROM {} {} ORDER BY __score {} LIMIT %s""".format(
                         self.content_field,
                         self.metadata_field,
-                        self.distance_strategy.name if isinstance(self.distance_strategy, DistanceStrategy) else self.distance_strategy,
+                        self.distance_strategy.name
+                        if isinstance(self.distance_strategy, DistanceStrategy)
+                        else self.distance_strategy,
                         self.vector_field,
                         self.table_name,
                         where_clause,


### PR DESCRIPTION
After the refactoring #6570, the DistanceStrategy class was moved to another module and this introduced a bug into the SingleStoreDB vector store, as the `DistanceStrategy.EUCLEDIAN_DISTANCE` started to convert into the 'DistanceStrategy.EUCLEDIAN_DISTANCE' string, instead of just 'EUCLEDIAN_DISTANCE' (same for 'DOT_PRODUCT'). 

In this change, I check the type of the parameter and use `.name` attribute to get the correct object's name. 
