### PR TITLE
fix 'Thought:' prefix for structured chat agent

### DIFF
--- a/docs/docs/modules/agents/tools/custom_tools.ipynb
+++ b/docs/docs/modules/agents/tools/custom_tools.ipynb
@@ -29,7 +29,8 @@
    "outputs": [],
    "source": [
     "# Import things that are needed generically\n",
-    "from langchain.chains import LLMMathChain\nfrom langchain.utilities import SerpAPIWrapper\n",
+    "from langchain.chains import LLMMathChain\n",
+    "from langchain.utilities import SerpAPIWrapper\n",
     "from langchain.agents import AgentType, initialize_agent\n",
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.tools import BaseTool, StructuredTool, Tool, tool"
@@ -367,7 +368,7 @@
    "id": "824eaf74",
    "metadata": {},
    "source": [
-    "## Using the `tool` decorator\n",
+    "### Using the decorator\n",
     "\n",
     "To make it easier to define custom tools, a `@tool` decorator is provided. This decorator can be used to quickly create a `Tool` from a simple function. The decorator uses the function name as the tool name by default, but this can be overridden by passing a string as the first argument. Additionally, the decorator will use the function's docstring as the tool's description."
    ]
@@ -531,7 +532,7 @@
    "id": "fb0a38eb",
    "metadata": {},
    "source": [
-    "## Subclassing the BaseTool\n",
+    "### Subclassing the BaseTool\n",
     "\n",
     "The BaseTool automatically infers the schema from the `_run` method's signature."
    ]
@@ -624,7 +625,7 @@
    "id": "7d68b0ac",
    "metadata": {},
    "source": [
-    "## Using the decorator\n",
+    "### Using the decorator\n",
     "\n",
     "The `tool` decorator creates a structured tool automatically if the signature has multiple arguments."
    ]
@@ -774,7 +775,8 @@
     "from langchain.agents import initialize_agent, Tool\n",
     "from langchain.agents import AgentType\n",
     "from langchain.llms import OpenAI\n",
-    "from langchain.chains import LLMMathChain\nfrom langchain.utilities import SerpAPIWrapper\n",
+    "from langchain.chains import LLMMathChain\n",
+    "from langchain.utilities import SerpAPIWrapper\n",
     "\n",
     "search = SerpAPIWrapper()\n",
     "tools = [\n",


### PR DESCRIPTION
The current implementation of the `StructuredChatAgent` includes a system prompt that is less than ideal for the following reasons:

- The first "Thought:" prefix is added to the system prompt before the human message.
- Subsequent "Thought:" prefixes are added everytime the `agent_scratchpad` is created.

As a result, the input format presented to the LLMs in the first round appears as follows:

```
You are an agent ...
...
Begin!
Thought:

Human: {input}

```

In the subsequent rounds, the input format is as follows:

```
You are an agent ...
...
Begin!
Thought:

Human: {input}

This was your previous work (but I haven\'t seen any of it! I only see what you return as final answer):
Action: ...
Observation: ...
Thought:
```

The issue here is that the first "Thought:" prefix precedes the human input, which can be misleading to the LLM, causing it to sometimes skip generating any thoughts in the first round.

This misplaced "Thought:" also disrupts the intended format instruction, which is designed to guide the LLM to follow the routing sequence of Question -> Thought -> Action -> Observation -> ... -> Final Answer.

This PR fixes this issue by removing the "Thought:" prefix in the system prompt, and add it back in the `agent_scratchpad`