### PR TITLE
Fix intermediate steps example in docs : replaced json.dumps with Langchain's dumps()

### DIFF
--- a/docs/extras/modules/agents/how_to/intermediate_steps.ipynb
+++ b/docs/extras/modules/agents/how_to/intermediate_steps.ipynb
@@ -166,9 +166,9 @@
     }
    ],
    "source": [
-    "import json\n",
+    "from langchain.load.dump import dumps\n",
     "\n",
-    "print(json.dumps(response[\"intermediate_steps\"], indent=2))"
+    "print(dumps(response[\"intermediate_steps\"], pretty=True))"
    ]
   },
   {


### PR DESCRIPTION
The intermediate steps example in docs has an example on how to retrieve and display the intermediate steps.
But the intermediate steps object is of type AgentAction which cannot be passed to json.dumps (it raises an error).
I replaced it with Langchain's dumps function (from langchain.load.dump import dumps) which is the preferred way to do so.
