### PR TITLE
vertex default model_name changed to the stable version

### DIFF
--- a/libs/langchain/langchain/llms/vertexai.py
+++ b/libs/langchain/langchain/llms/vertexai.py
@@ -157,7 +157,7 @@ class _VertexAICommon(_VertexAIBase):
 class VertexAI(_VertexAICommon, LLM):
     """Google Vertex AI large language models."""
 
-    model_name: str = "text-bison"
+    model_name: str = "text-bison@001"
     "The name of the Vertex AI large language model."
     tuned_model_name: Optional[str] = None
     "The name of a tuned model. If provided, model_name is ignored."


### PR DESCRIPTION


<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:**  the default model_name for VertexAI llm is "text-bison", this model points to text-bison@latest, which is NOT the stable version of text-bison., 
  - **Issue:** llm results when no model_name are not stable, as it is pointing to the latest/experimental model and not to the stable version ,
  - **Dependencies:** no,
  - **Tag maintainer:** 
  - **Twitter handle:**

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->
