### PR TITLE
ArcGISLoader: Limit number of results in query

### DIFF
--- a/libs/langchain/langchain/document_loaders/arcgis_loader.py
+++ b/libs/langchain/langchain/document_loaders/arcgis_loader.py
@@ -72,14 +72,15 @@ class ArcGISLoader(BaseLoader):
         self.result_record_count = result_record_count
         self.return_all_records = not isinstance(result_record_count, int)
 
-        self.query_params = dict(
+        query_params = dict(
             where=self.where,
             out_fields=self.out_fields,
             return_geometry=self.return_geometry,
             return_all_records=self.return_all_records,
             result_record_count=self.result_record_count,
-            **kwargs,
         )
+        query_params.update(kwargs)
+        self.query_params = query_params
 
     def _get_layer_properties(self, lyr_desc: Optional[str] = None) -> dict:
         """Get the layer properties from the FeatureLayer."""

--- a/libs/langchain/langchain/document_loaders/arcgis_loader.py
+++ b/libs/langchain/langchain/document_loaders/arcgis_loader.py
@@ -27,7 +27,7 @@ class ArcGISLoader(BaseLoader):
         where: str = "1=1",
         out_fields: Optional[Union[List[str], str]] = None,
         return_geometry: bool = False,
-        return_all_records: bool = True,
+        result_record_count: Optional[int] = None,
         lyr_desc: Optional[str] = None,
         **kwargs: Any,
     ):
@@ -68,7 +68,10 @@ class ArcGISLoader(BaseLoader):
             self.out_fields = ",".join(out_fields)
 
         self.return_geometry = return_geometry
-        self.return_all_records = return_all_records
+
+        self.result_record_count = result_record_count
+        self.return_all_records = not isinstance(result_record_count, int)
+
         self.kwargs = kwargs
 
     def _get_layer_properties(self, lyr_desc: Optional[str] = None) -> dict:

--- a/libs/langchain/langchain/document_loaders/arcgis_loader.py
+++ b/libs/langchain/langchain/document_loaders/arcgis_loader.py
@@ -78,9 +78,8 @@ class ArcGISLoader(BaseLoader):
             return_geometry=self.return_geometry,
             return_all_records=self.return_all_records,
             result_record_count=self.result_record_count,
-            **kwargs
+            **kwargs,
         )
-
 
     def _get_layer_properties(self, lyr_desc: Optional[str] = None) -> dict:
         """Get the layer properties from the FeatureLayer."""


### PR DESCRIPTION
Description: this PR changes the `ArcGISLoader` to set `return_all_records` to `False` when `result_record_count` is provided as a keyword argument. Previously, `return_all_records` was `True` by default and this made the API ignore `result_record_count`.

Issue: `ArcGISLoader` would ignore `result_record_count` unless user also passed `return_all_records=False`. 