### PR TITLE
Fixes to SelfQueryRetriever and LLMRouterChain deprecation warning

### DIFF
--- a/libs/langchain/langchain/chains/router/llm_router.py
+++ b/libs/langchain/langchain/chains/router/llm_router.py
@@ -55,8 +55,10 @@ class LLMRouterChain(RouterChain):
         callbacks = _run_manager.get_child()
         output = cast(
             Dict[str, Any],
-            self.llm_chain.predict_and_parse(callbacks=callbacks, **inputs),
+            self.llm_chain.predict(callbacks=callbacks, **inputs),
         )
+        if self.llm_chain.prompt.output_parser is not None:
+            output = self.llm_chain.prompt.output_parser.parse(output)
         return output
 
     async def _acall(
@@ -68,8 +70,10 @@ class LLMRouterChain(RouterChain):
         callbacks = _run_manager.get_child()
         output = cast(
             Dict[str, Any],
-            await self.llm_chain.apredict_and_parse(callbacks=callbacks, **inputs),
+            await self.llm_chain.apredict(callbacks=callbacks, **inputs),
         )
+        if self.llm_chain.prompt.output_parser is not None:
+            output = self.llm_chain.prompt.output_parser.parse(output)
         return output
 
     @classmethod

--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -116,10 +116,12 @@ class SelfQueryRetriever(BaseRetriever, BaseModel):
         inputs = self.llm_chain.prep_inputs({"query": query})
         structured_query = cast(
             StructuredQuery,
-            self.llm_chain.predict_and_parse(
-                callbacks=run_manager.get_child(), **inputs
-            ),
+            self.llm_chain.predict(callbacks=run_manager.get_child(), **inputs),
         )
+        if self.llm_chain.prompt.output_parser is not None:
+            structured_query = self.llm_chain.prompt.output_parser.parse(
+                structured_query
+            )
         if self.verbose:
             print(structured_query)
         new_query, new_kwargs = self.structured_query_translator.visit_structured_query(


### PR DESCRIPTION
  - **Description:** Changed the `_get_relevant_documents` function inside `SelfQueryRetriever` and `_call` function inside `LLMRouterChain` to avoid using the deprecated `predict_and_parse` function inside `LLMChain`, and not getting the (annoying) warning message.
  - **Issue:** #10606 and #10462 for `SelfQueryRetriever`, and #6819 for `LLMRouterChain` 
  - **Dependencies:** None,
  - **Tag maintainer:** @baskaryan,
  - **Twitter handle:** @schnell_dj

**PS :** This is my first PR ever, and I am far from being a pro Dev. So your feedback, comments and guidance are more than welcome!