### PR TITLE
Change text tracking for aim callback "on_chain_start", "on_chain_end"

### DIFF
--- a/libs/langchain/langchain/callbacks/aim_callback.py
+++ b/libs/langchain/langchain/callbacks/aim_callback.py
@@ -275,10 +275,19 @@ class AimCallbackHandler(BaseMetadataCallbackHandler, BaseCallbackHandler):
         resp.update(self.get_custom_callback_meta())
 
         inputs_res = deepcopy(inputs)
-
-        self._run.track(
-            aim.Text(inputs_res["input"]), name="on_chain_start", context=resp
-        )
+        for key, value in inputs_res.items():
+            if key == "input_documents":
+                self._run.track(
+                    {key: [aim.Text(document.page_content) for document in value]},
+                    step=resp["step"],
+                    context=resp,
+                )
+            else:
+                self._run.track(
+                    {key: aim.Text(value)},
+                    step=resp["step"],
+                    context=resp,
+                )
 
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
@@ -293,7 +302,9 @@ class AimCallbackHandler(BaseMetadataCallbackHandler, BaseCallbackHandler):
         outputs_res = deepcopy(outputs)
 
         self._run.track(
-            aim.Text(outputs_res["output"]), name="on_chain_end", context=resp
+            {"outputs": [aim.Text(document) for document in outputs_res["outputs"]]},
+            context=resp,
+            step=resp["step"],
         )
 
     def on_chain_error(


### PR DESCRIPTION
**Description:** 
 The previous behaviour was causing an error, because the keys input resp. output did not exist in the passed parameters inputs resp. outputs.

Now, all keys are tracked in aim as texts and from the input_documents, the page content is tracked.

Additionally the structure of the tracking is more useful for getting an overview of the run.

**Issue:** new version of pull request 6161
**Dependencies:** aim
**Tag maintainer:** @leo-gan 
**Twitter handle:** no
