### PR TITLE
fix: Lemon AI Analytics broken link

### DIFF
--- a/docs/extras/integrations/tools/lemonai.ipynb
+++ b/docs/extras/integrations/tools/lemonai.ipynb
@@ -193,7 +193,7 @@
     "2023-06-26T11:58:43.988788+0100 - 5efe603c-9898-4143-b99a-55b50007ed9d - airtable-append-data\n",
     "```\n",
     "\n",
-    "By using the [Lemon AI Analytics Tool](https://github.com/felixbrock/lemonai-analytics) you can easily gain a better understanding of how frequently and in which order tools are used. As a result, you can identify weak spots in your agent’s decision-making capabilities and move to a more deterministic behavior by defining Lemon AI functions."
+    "By using the [Lemon AI Analytics](https://github.com/felixbrock/lemon-agent/blob/main/apps/analytics/README.md) you can easily gain a better understanding of how frequently and in which order tools are used. As a result, you can identify weak spots in your agent’s decision-making capabilities and move to a more deterministic behavior by defining Lemon AI functions."
    ]
   }
  ],


### PR DESCRIPTION
**Description**

The [current redirect link](https://github.com/felixbrock/lemonai-analytics) gives 404 error replace it with the  [correct link](https://github.com/felixbrock/lemon-agent/blob/main/apps/analytics/README.md)

Resource: https://python.langchain.com/docs/integrations/tools/lemonai
