### PR TITLE
Pass HuggingFacePipeline kwargs on inference

### DIFF
--- a/libs/langchain/langchain/llms/huggingface_pipeline.py
+++ b/libs/langchain/langchain/llms/huggingface_pipeline.py
@@ -164,7 +164,7 @@ class HuggingFacePipeline(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
-        response = self.pipeline(prompt)
+        response = self.pipeline(prompt, self.pipeline_kwargs)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.
             text = response[0]["generated_text"][len(prompt) :]

--- a/libs/langchain/langchain/llms/huggingface_pipeline.py
+++ b/libs/langchain/langchain/llms/huggingface_pipeline.py
@@ -164,7 +164,7 @@ class HuggingFacePipeline(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
-        response = self.pipeline(prompt, self.pipeline_kwargs)
+        response = self.pipeline(prompt, **self.pipeline_kwargs)
         if self.pipeline.task == "text-generation":
             # Text generation return includes the starter text.
             text = response[0]["generated_text"][len(prompt) :]


### PR DESCRIPTION
**Description:**

Pass HuggingFacePipeline kwargs at inference, not just when it's instantiated, so that changing the arguments of the pipeline would actually affect the result, e.g.
```python
from langchain import HuggingFacePipeline

pipe = HuggingFacePipeline.from_model_id(
    task="text-generation",
    device=1,
    model_id="meta-llama/Llama-2-7b-chat-hf",
    pipeline_kwargs={
        'max_length': 100,
        'temperature': 0.1
    },
)

pipe('hello, how are you?')  # this can return up to 100 tokens w temperature 0.1

pipe.pipeline_kwargs['temperature'] = 0.9
pipe.pipeline_kwargs['max_length'] = 50
pipe('hello, how are you?')  # this can return up to 50 tokens w temperature 0.9
```
**Issue:**
None
**Dependencies:**
None 
**Tag maintainer:**
None
**Twitter handle:**
None 