### PR TITLE
PydanticOutputParser doc nb: use langchain.pydantic_v1; remove unused imports

### DIFF
--- a/docs/extras/modules/model_io/output_parsers/pydantic.ipynb
+++ b/docs/extras/modules/model_io/output_parsers/pydantic.ipynb
@@ -15,30 +15,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "b322c447",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain.prompts import (\n",
-    "    PromptTemplate,\n",
-    "    ChatPromptTemplate,\n",
-    "    HumanMessagePromptTemplate,\n",
-    ")\n",
-    "from langchain.llms import OpenAI\n",
-    "from langchain.chat_models import ChatOpenAI"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "id": "cba6d8e3",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from typing import List\n",
+    "\n",
+    "from langchain.llms import OpenAI\n",
     "from langchain.output_parsers import PydanticOutputParser\n",
-    "from pydantic import BaseModel, Field, validator\n",
-    "from typing import List"
+    "from langchain.prompts import PromptTemplate\n",
+    "from langchain.pydantic_v1 import BaseModel, Field, validator"
    ]
   },
   {


### PR DESCRIPTION
Description: This PR changes the import section of the `PydanticOutputParser` notebook.
* Import from `langchain.pydantic_v1` instead of `pydantic`
* Remove unused imports

Issue: running the notebook as written, when pydantic v2 is installed, results in the following:
```python
PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.3/migration/
```
[...]
```python
PydanticUserError: The `field` and `config` parameters are not available in Pydantic V2, please use the `info` parameter instead.

For further information visit https://errors.pydantic.dev/2.3/u/validator-field-config-info
```