### PR TITLE
OpenAI function calling docstring and notebook imports

### DIFF
--- a/docs/extras/modules/chains/how_to/openai_functions.ipynb
+++ b/docs/extras/modules/chains/how_to/openai_functions.ipynb
@@ -26,8 +26,7 @@
     "    create_structured_output_chain,\n",
     ")\n",
     "from langchain.chat_models import ChatOpenAI\n",
-    "from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate\n",
-    "from langchain.schema import HumanMessage, SystemMessage"
+    "from langchain.prompts import ChatPromptTemplate"
    ]
   },
   {
@@ -57,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pydantic import BaseModel, Field\n",
+    "from langchain.pydantic_v1 import BaseModel, Field\n",
     "\n",
     "\n",
     "class Person(BaseModel):\n",
@@ -80,13 +79,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mSystem: You are a world class algorithm for extracting information in structured formats.\n",
+      "\u001B[32;1m\u001B[1;3mSystem: You are a world class algorithm for extracting information in structured formats.\n",
       "Human: Use the given format to extract information from the following input: Sally is 13\n",
-      "Human: Tip: Make sure to answer in the correct format\u001b[0m\n",
+      "Human: Tip: Make sure to answer in the correct format\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {
@@ -135,13 +134,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mSystem: You are a world class algorithm for extracting information in structured formats.\n",
+      "\u001B[32;1m\u001B[1;3mSystem: You are a world class algorithm for extracting information in structured formats.\n",
       "Human: Use the given format to extract information from the following input: Sally is 13, Joey just turned 12 and loves spinach. Caroline is 10 years older than Sally.\n",
-      "Human: Tip: Make sure to answer in the correct format\u001b[0m\n",
+      "Human: Tip: Make sure to answer in the correct format\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {
@@ -217,13 +216,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mSystem: You are a world class algorithm for extracting information in structured formats.\n",
+      "\u001B[32;1m\u001B[1;3mSystem: You are a world class algorithm for extracting information in structured formats.\n",
       "Human: Use the given format to extract information from the following input: Sally is 13\n",
-      "Human: Tip: Make sure to answer in the correct format\u001b[0m\n",
+      "Human: Tip: Make sure to answer in the correct format\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {
@@ -301,13 +300,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mSystem: You are a world class algorithm for recording entities.\n",
+      "\u001B[32;1m\u001B[1;3mSystem: You are a world class algorithm for recording entities.\n",
       "Human: Make calls to the relevant function to record the entities in the following input: Harry was a chubby brown beagle who loved chicken\n",
-      "Human: Tip: Make sure to answer in the correct format\u001b[0m\n",
+      "Human: Tip: Make sure to answer in the correct format\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {
@@ -357,13 +356,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mSystem: You are a world class algorithm for recording entities.\n",
+      "\u001B[32;1m\u001B[1;3mSystem: You are a world class algorithm for recording entities.\n",
       "Human: Make calls to the relevant function to record the entities in the following input: The most important thing to remember about Tommy, my 12 year old, is that he'll do anything for apple pie.\n",
-      "Human: Tip: Make sure to answer in the correct format\u001b[0m\n",
+      "Human: Tip: Make sure to answer in the correct format\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {
@@ -427,13 +426,13 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mSystem: You are a world class algorithm for recording entities.\n",
+      "\u001B[32;1m\u001B[1;3mSystem: You are a world class algorithm for recording entities.\n",
       "Human: Make calls to the relevant function to record the entities in the following input: I can't find my dog Henry anywhere, he's a small brown beagle. Could you send a message about him?\n",
-      "Human: Tip: Make sure to answer in the correct format\u001b[0m\n",
+      "Human: Tip: Make sure to answer in the correct format\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {

--- a/libs/langchain/langchain/chains/openai_functions/base.py
+++ b/libs/langchain/langchain/chains/openai_functions/base.py
@@ -220,11 +220,13 @@ def create_openai_fn_chain(
     Example:
         .. code-block:: python
 
+                from typing import Optional
+
                 from langchain.chains.openai_functions import create_openai_fn_chain
                 from langchain.chat_models import ChatOpenAI
                 from langchain.prompts import ChatPromptTemplate
 
-                from pydantic_v1 import BaseModel, Field
+                from langchain.pydantic_v1 import BaseModel, Field
 
 
                 class RecordPerson(BaseModel):
@@ -306,11 +308,13 @@ def create_structured_output_chain(
     Example:
         .. code-block:: python
 
+                from typing import Optional
+
                 from langchain.chains.openai_functions import create_structured_output_chain
                 from langchain.chat_models import ChatOpenAI
                 from langchain.prompts import ChatPromptTemplate
 
-                from pydantic_v1 import BaseModel, Field
+                from langchain.pydantic_v1 import BaseModel, Field
 
                 class Dog(BaseModel):
                     \"\"\"Identifying information about a dog.\"\"\"


### PR DESCRIPTION
This PR is a documentation fix.

Description:
* fixes imports in the code samples in the docstrings of `create_openai_fn_chain` and `create_structured_output_chain`
* fixes imports in `docs/extras/modules/chains/how_to/openai_functions.ipynb`
* removes unused imports from the notebook

Issues:
* the docstrings use `from pydantic_v1 import BaseModel, Field` which this PR changes to `from langchain.pydantic_v1 import BaseModel, Field`
* importing `pydantic` instead of `langchain.pydantic_v1` leads to errors later in the notebook