### PR TITLE
database -> db in from_llm

### DIFF
--- a/libs/experimental/langchain_experimental/sql/base.py
+++ b/libs/experimental/langchain_experimental/sql/base.py
@@ -242,15 +242,13 @@ class SQLDatabaseSequentialChain(Chain):
     def from_llm(
         cls,
         llm: BaseLanguageModel,
-        database: SQLDatabase,
+        db: SQLDatabase,
         query_prompt: BasePromptTemplate = PROMPT,
         decider_prompt: BasePromptTemplate = DECIDER_PROMPT,
         **kwargs: Any,
     ) -> SQLDatabaseSequentialChain:
         """Load the necessary chains."""
-        sql_chain = SQLDatabaseChain.from_llm(
-            llm, database, prompt=query_prompt, **kwargs
-        )
+        sql_chain = SQLDatabaseChain.from_llm(llm, db, prompt=query_prompt, **kwargs)
         decider_chain = LLMChain(
             llm=llm, prompt=decider_prompt, output_key="table_names"
         )


### PR DESCRIPTION
**Description:** Renamed argument `database` in `SQLDatabaseSequentialChain.from_llm()` to `db`, 

I realize it's tiny and a bit of a nitpick but for consistency with SQLDatabaseChain (and all the others actually) I thought it should be renamed.  Also got me while working and using it today.

:heavy_check_mark:  Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

