### PR TITLE
Aleph ALpha Embeddings:Changing from None to the defaults because otherwise the Request to A…

### DIFF
--- a/libs/langchain/langchain/embeddings/aleph_alpha.py
+++ b/libs/langchain/langchain/embeddings/aleph_alpha.py
@@ -34,10 +34,10 @@ class AlephAlphaAsymmetricSemanticEmbedding(BaseModel, Embeddings):
     # Embedding params
     model: str = "luminous-base"
     """Model name to use."""
-    compress_to_size: Optional[int] = None
+    compress_to_size: Optional[int] = 128
     """Should the returned embeddings come back as an original 5120-dim vector, 
     or should it be compressed to 128-dim."""
-    normalize: Optional[bool] = None
+    normalize: Optional[bool] = True
     """Should returned embeddings be normalized"""
     contextual_control_threshold: Optional[int] = None
     """Attention control parameters only apply to those tokens that have 


### PR DESCRIPTION
Changing from None to the defaults because otherwise the Request to Aleph Alpha will fail due to None instead of boolean.


  - **Description:** Change of the parameters `compress to size` and `normalize` because if you do not define these in the AlephAlphaAsymmetricSemanticEmbedding explicit it fails with this error: ` ValueError: (400, '{"error":"Json deserialize error: invalid type: null, expected a boolean at line 1 column 2378","code":"PAYLOAD_ERROR"}')` This seems hard to figure out therefore i set the settings to the default ones.


  - **Dependencies:** None
  - **Tag maintainer:** @hwchase17.
  - **Twitter handle:** @mfmezger 

It may be a good idea to write a test for aleph alpha embeddings because i did not find one yet, the only question remains is if you have a token for aleph alpha in your ci that one can use?



