### PR TITLE
Change kwargs to the proper line

### DIFF
--- a/libs/langchain/langchain/vectorstores/milvus.py
+++ b/libs/langchain/langchain/vectorstores/milvus.py
@@ -822,7 +822,6 @@ class Milvus(VectorStore):
             index_params=index_params,
             search_params=search_params,
             drop_old=drop_old,
-            **kwargs,
         )
-        vector_db.add_texts(texts=texts, metadatas=metadatas)
+        vector_db.add_texts(texts=texts, metadatas=metadatas, **kwargs)
         return vector_db


### PR DESCRIPTION

   - **Description:**  modified the method a `from_texts` as the` **kwargs` was wrongly set to the self initialization. This produced errors when additional optional parameters were added. Also, they weren't passed to the subsequent add_text method which causes not being able to add optional parameters to reach `pymilvus`. Now you can add any additional parameters like `partition_name` which would make effective inserting in partitions. 
  - **Issue:**  [#10671](https://github.com/langchain-ai/langchain/issues/10671)
  - **Dependencies:** N/A
  - **Tag maintainer:** @hwchase17 
