### PR TITLE
Update ContextCallbackHandler Docstring & metadata key

### DIFF
--- a/libs/langchain/langchain/callbacks/context_callback.py
+++ b/libs/langchain/langchain/callbacks/context_callback.py
@@ -33,7 +33,7 @@ def import_context() -> Any:
 class ContextCallbackHandler(BaseCallbackHandler):
     """Callback Handler that records transcripts to the Context service.
 
-     (https://getcontext.ai).
+     (https://context.ai).
 
     Keyword Args:
         token (optional): The token with which to authenticate requests to Context.

--- a/libs/langchain/langchain/callbacks/context_callback.py
+++ b/libs/langchain/langchain/callbacks/context_callback.py
@@ -122,7 +122,7 @@ class ContextCallbackHandler(BaseCallbackHandler):
         """Run when the chat model is started."""
         llm_model = kwargs.get("invocation_params", {}).get("model", None)
         if llm_model is not None:
-            self.metadata["llm_model"] = llm_model
+            self.metadata["model"] = llm_model
 
         if len(messages) == 0:
             return


### PR DESCRIPTION

  - **Description:** Updating URL in Context Callback Docstrings and update metadata key Context CallbackHandler uses to send model names.
  - **Issue:** The URL in ContextCallbackHandler is out of date. Model data being sent to Context should be under the "model" key and not "llm_model". This allows Context to do more sophisticated analysis.
  - **Dependencies:** None

Tagging @agamble.
