### PR TITLE
langchain[minor]: Fix typing in WebResearchRetriver

### DIFF
--- a/libs/langchain/langchain/retrievers/web_research.py
+++ b/libs/langchain/langchain/retrievers/web_research.py
@@ -16,7 +16,7 @@ from langchain.output_parsers.pydantic import PydanticOutputParser
 from langchain.prompts import BasePromptTemplate, PromptTemplate
 from langchain.pydantic_v1 import BaseModel, Field
 from langchain.schema import BaseRetriever, Document
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.text_splitter import RecursiveCharacterTextSplitter, TextSplitter
 from langchain.utilities import GoogleSearchAPIWrapper
 from langchain.vectorstores.base import VectorStore
 
@@ -75,7 +75,7 @@ class WebResearchRetriever(BaseRetriever):
     llm_chain: LLMChain
     search: GoogleSearchAPIWrapper = Field(..., description="Google Search API Wrapper")
     num_search_results: int = Field(1, description="Number of pages per Google search")
-    text_splitter: RecursiveCharacterTextSplitter = Field(
+    text_splitter: TextSplitter = Field(
         RecursiveCharacterTextSplitter(chunk_size=1500, chunk_overlap=50),
         description="Text splitter for splitting web pages into chunks",
     )


### PR DESCRIPTION
Hello @hwchase17 

**Issue**:
The class WebResearchRetriever accept only RecursiveCharacterTextSplitter, but never uses a specification of this class. I propose to change the type to TextSplitter. Then, the lint can accept all subtypes.

