### PR TITLE
Substring support for similarity_search_with_score

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgembedding.py
+++ b/libs/langchain/langchain/vectorstores/pgembedding.py
@@ -360,6 +360,10 @@ class PGEmbedding(VectorStore):
                             value_case_insensitive[IN]
                         )
                         filter_clauses.append(filter_by_metadata)
+                    elif isinstance(value, dict) and "substring" in map(str.lower, value):
+                        filter_by_metadata = EmbeddingStore.cmetadata[key].astext.ilike(
+                            f"%{value['substring']}%")
+                        filter_clauses.append(filter_by_metadata)
                     else:
                         filter_by_metadata = EmbeddingStore.cmetadata[
                             key

--- a/libs/langchain/langchain/vectorstores/pgembedding.py
+++ b/libs/langchain/langchain/vectorstores/pgembedding.py
@@ -360,9 +360,12 @@ class PGEmbedding(VectorStore):
                             value_case_insensitive[IN]
                         )
                         filter_clauses.append(filter_by_metadata)
-                    elif isinstance(value, dict) and "substring" in map(str.lower, value):
+                    elif isinstance(value, dict) and "substring" in map(
+                        str.lower, value
+                    ):
                         filter_by_metadata = EmbeddingStore.cmetadata[key].astext.ilike(
-                            f"%{value['substring']}%")
+                            f"%{value['substring']}%"
+                        )
                         filter_clauses.append(filter_by_metadata)
                     else:
                         filter_by_metadata = EmbeddingStore.cmetadata[


### PR DESCRIPTION
  **Description:** Possible to filter with substrings in similarity_search_with_score, for example: filter={'user_id': {'substring': 'user'}}

