### PR TITLE
fix broken link in docugami loader docs

### DIFF
--- a/docs/extras/integrations/document_loaders/docugami.ipynb
+++ b/docs/extras/integrations/document_loaders/docugami.ipynb
@@ -36,7 +36,7 @@
     "3. Create an access token via the Developer Playground for your workspace. [Detailed instructions](https://help.docugami.com/home/docugami-api)\n",
     "4. Explore the [Docugami API](https://api-docs.docugami.com) to get a list of your processed docset IDs, or just the document IDs for a particular docset. \n",
     "6. Use the DocugamiLoader as detailed below, to get rich semantic chunks for your documents.\n",
-    "7. Optionally, build and publish one or more [reports or abstracts](https://help.docugami.com/home/reports). This helps Docugami improve the semantic XML with better tags based on your preferences, which are then added to the DocugamiLoader output as metadata. Use techniques like [self-querying retriever](/docs/modules/data_connection/retrievers/how_to/self_query_retriever/) to do high accuracy Document QA.\n",
+    "7. Optionally, build and publish one or more [reports or abstracts](https://help.docugami.com/home/reports). This helps Docugami improve the semantic XML with better tags based on your preferences, which are then added to the DocugamiLoader output as metadata. Use techniques like [self-querying retriever](/docs/modules/data_connection/retrievers/self_query/) to do high accuracy Document QA.\n",
     "\n",
     "## Advantages vs Other Chunking Techniques\n",
     "\n",


### PR DESCRIPTION
Just fixing the link to the self query retriever in docugami loader docs