### PR TITLE
Allow extra variables when invoking prompt templates

### DIFF
--- a/libs/langchain/langchain/schema/prompt_template.py
+++ b/libs/langchain/langchain/schema/prompt_template.py
@@ -37,7 +37,9 @@ class BasePromptTemplate(Serializable, Runnable[Dict, PromptValue], ABC):
 
     def invoke(self, input: Dict, config: RunnableConfig | None = None) -> PromptValue:
         return self._call_with_config(
-            lambda inner_input: self.format_prompt(**inner_input),
+            lambda inner_input: self.format_prompt(
+                **{key: inner_input[key] for key in self.input_variables}
+            ),
             input,
             config,
             run_type="prompt",

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -369,7 +369,7 @@ async def test_prompt() -> None:
     ] == [expected]
 
 
-def test_extra_prompt_template_params() -> None:
+def test_prompt_template_params() -> None:
     prompt = ChatPromptTemplate.from_template(
         "Respond to the following question: {question}"
     )
@@ -382,6 +382,9 @@ def test_extra_prompt_template_params() -> None:
     assert result == ChatPromptValue(
         messages=[HumanMessage(content="Respond to the following question: test")]
     )
+
+    with pytest.raises(KeyError):
+        prompt.invoke({})
 
 
 @pytest.mark.asyncio

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -370,7 +370,7 @@ async def test_prompt() -> None:
 
 
 def test_extra_prompt_template_params() -> None:
-    prompt = PromptTemplate.from_template(
+    prompt = ChatPromptTemplate.from_template(
         "Respond to the following question: {question}"
     )
     result = prompt.invoke(
@@ -379,7 +379,9 @@ def test_extra_prompt_template_params() -> None:
             "topic": "test",
         }
     )
-    assert result == "Respond to the following question: test"
+    assert result == ChatPromptValue(
+        messages=[HumanMessage(content="Respond to the following question: test")]
+    )
 
 
 @pytest.mark.asyncio

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -369,6 +369,19 @@ async def test_prompt() -> None:
     ] == [expected]
 
 
+def test_extra_prompt_template_params() -> None:
+    prompt = PromptTemplate.from_template(
+        "Respond to the following question: {question}"
+    )
+    result = prompt.invoke(
+        {
+            "question": "test",
+            "topic": "test",
+        }
+    )
+    assert result == "Respond to the following question: test"
+
+
 @pytest.mark.asyncio
 @freeze_time("2023-01-01")
 async def test_prompt_with_chat_model(


### PR DESCRIPTION
Makes chaining easier as many maps have extra properties.

@baskaryan @hwchase17 