### PR TITLE
make auto-setting the encodings optional, alow explicitly setting it

### DIFF
--- a/libs/langchain/langchain/document_loaders/web_base.py
+++ b/libs/langchain/langchain/document_loaders/web_base.py
@@ -63,6 +63,7 @@ class WebBaseLoader(BaseLoader):
         verify_ssl: Optional[bool] = True,
         proxies: Optional[dict] = None,
         continue_on_failure: Optional[bool] = False,
+        autoset_encoding: Optional[bool] = True,
     ):
         """Initialize with webpage path."""
 
@@ -98,7 +99,7 @@ class WebBaseLoader(BaseLoader):
         self.session.headers = dict(headers)
         self.session.verify = verify_ssl
         self.continue_on_failure = continue_on_failure
-
+        self.autoset_encoding = autoset_encoding
         if proxies:
             self.session.proxies.update(proxies)
 
@@ -208,7 +209,9 @@ class WebBaseLoader(BaseLoader):
         html_doc = self.session.get(url, **self.requests_kwargs)
         if self.raise_for_status:
             html_doc.raise_for_status()
-        html_doc.encoding = html_doc.apparent_encoding
+
+        if self.autoset_encoding:
+            html_doc.encoding = html_doc.apparent_encoding
         return BeautifulSoup(html_doc.text, parser)
 
     def scrape(self, parser: Union[str, None] = None) -> Any:

--- a/libs/langchain/langchain/document_loaders/web_base.py
+++ b/libs/langchain/langchain/document_loaders/web_base.py
@@ -64,6 +64,7 @@ class WebBaseLoader(BaseLoader):
         proxies: Optional[dict] = None,
         continue_on_failure: Optional[bool] = False,
         autoset_encoding: Optional[bool] = True,
+        encoding: Optional[str] = None,
     ):
         """Initialize with webpage path."""
 
@@ -100,6 +101,7 @@ class WebBaseLoader(BaseLoader):
         self.session.verify = verify_ssl
         self.continue_on_failure = continue_on_failure
         self.autoset_encoding = autoset_encoding
+        self.encoding = encoding
         if proxies:
             self.session.proxies.update(proxies)
 
@@ -210,7 +212,9 @@ class WebBaseLoader(BaseLoader):
         if self.raise_for_status:
             html_doc.raise_for_status()
 
-        if self.autoset_encoding:
+        if self.encoding is not None:
+            html_doc.encoding = self.encoding
+        elif self.autoset_encoding:
             html_doc.encoding = html_doc.apparent_encoding
         return BeautifulSoup(html_doc.text, parser)
 


### PR DESCRIPTION
I was trying to use web loaders on some spanish documentation (e.g. [this site](https://www.fromdoppler.com/es/mailing-tendencias/), but the auto-encoding introduced in https://github.com/langchain-ai/langchain/pull/3602 was detected as "MacRoman" instead of the (correct)  "UTF-8".

To address this, I've added the ability to disable the auto-encoding, as well as the ability to explicitly tell the loader what encoding to use.

  - **Description:** Makes auto-setting the encoding optional in `WebBaseLoader`, and introduces an `encoding` option to explicitly set it.
  - **Dependencies:** N/A
  - **Tag maintainer:** @hwchase17 
  - **Twitter handle:** @czue
