### PR TITLE
Provide option to use folder_id instead of folder_path

### DIFF
--- a/docs/extras/integrations/document_loaders/microsoft_sharepoint.ipynb
+++ b/docs/extras/integrations/document_loaders/microsoft_sharepoint.ipynb
@@ -21,7 +21,7 @@
     "7. To find your `Tenant Name` follow the instructions at this [document](https://learn.microsoft.com/en-us/azure/active-directory-b2c/tenant-management-read-tenant-name). Once you got this, just remove `.onmicrosoft.com` from the value and hold the rest as your `Tenant Name`.\n",
     "8. To obtain your `Collection ID` and `Subsite ID`, you will need your **SharePoint** `site-name`. Your `SharePoint` site URL has the following format `https://<tenant-name>.sharepoint.com/sites/<site-name>`. The last part of this URL is the `site-name`.\n",
     "9. To Get the Site `Collection ID`, hit this URL in the browser: `https://<tenant>.sharepoint.com/sites/<site-name>/_api/site/id` and copy the value of the `Edm.Guid` property.\n",
-    "10. To get the `Subsite ID` (or web ID) use: `https://<tenant>.sharepoint.com/<site-name>/_api/web/id` and copy the value of the `Edm.Guid` property.\n",
+    "10. To get the `Subsite ID` (or web ID) use: `https://<tenant>.sharepoint.com/sites/<site-name>/_api/web/id` and copy the value of the `Edm.Guid` property.\n",
     "11. The `SharePoint site ID` has the following format: `<tenant-name>.sharepoint.com,<Collection ID>,<subsite ID>`. You can hold that value to use in the next step.\n",
     "12. Visit the [Graph Explorer Playground](https://developer.microsoft.com/en-us/graph/graph-explorer) to obtain your `Document Library ID`. The first step is to ensure you are logged in with the account associated with your **SharePoint** site. Then you need to make a request to `https://graph.microsoft.com/v1.0/sites/<SharePoint site ID>/drive` and the response will return a payload with a field `id` that holds the ID of your `Document Library ID`.\n",
     "\n",
@@ -65,6 +65,15 @@
     "documents = loader.load()\n",
     "```\n",
     "\n",
+    "If you are receiving the error `Resource not found for the segment`, try using the `folder_id` instead of the folder path, which can be obtained from the [Microsoft Graph API](https://developer.microsoft.com/en-us/graph/graph-explorer)\n",
+    "\n",
+    "```python\n",
+    "from langchain.document_loaders.sharepoint import SharePointLoader\n",
+    "\n",
+    "loader = SharePointLoader(document_library_id=\"YOUR DOCUMENT LIBRARY ID\", folder_id=\"<folder-id>\", auth_with_token=True)\n",
+    "documents = loader.load()\n",
+    "```\n",
+    "\n",
     "#### 📑 Loading documents from a list of Documents IDs\n",
     "\n",
     "Another possibility is to provide a list of `object_id` for each document you want to load. For that, you will need to query the [Microsoft Graph API](https://developer.microsoft.com/en-us/graph/graph-explorer) to find all the documents ID that you are interested in. This [link](https://learn.microsoft.com/en-us/graph/api/resources/onedrive?view=graph-rest-1.0#commonly-accessed-resources) provides a list of endpoints that will be helpful to retrieve the documents ID.\n",
@@ -78,6 +87,11 @@
     "documents = loader.load()\n",
     "```\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/libs/langchain/langchain/document_loaders/sharepoint.py
+++ b/libs/langchain/langchain/document_loaders/sharepoint.py
@@ -21,6 +21,8 @@ class SharePointLoader(O365BaseLoader):
     """ The path to the folder to load data from."""
     object_ids: Optional[List[str]] = None
     """ The IDs of the objects to load data from."""
+    folder_id: Optional[List[str]] = None
+    """ The ID of the folder to load data from."""
 
     @property
     def _file_types(self) -> Sequence[_FileType]:
@@ -52,6 +54,12 @@ class SharePointLoader(O365BaseLoader):
                 yield from blob_parser.lazy_parse(blob)
         if self.object_ids:
             for blob in self._load_from_object_ids(drive, self.object_ids):
+                yield from blob_parser.lazy_parse(blob)
+        if self.folder_id:
+            target_folder = drive.get_item(self.folder_path)
+            if not isinstance(target_folder, Folder):
+                raise ValueError(f"There isn't a folder with path {self.folder_path}.")
+            for blob in self._load_from_folder(target_folder):
                 yield from blob_parser.lazy_parse(blob)
 
     def load(self) -> List[Document]:


### PR DESCRIPTION
  - **Description:** Provides user with the option to use folder ID to get the SharePoint folder. Updated notebook to show use of this optional feature. Also fixed a typo in the url to get Subsite ID in the notebook (url was missing 'sites/' before <site-name>), 
  - **Issue:** GraphAPI will often return "No Resource Found" error when using the folder path. This is as far as I can tell a bug on the GraphAPI and not user related. This can be circumvented by using the folder ID and get_item() method instead of the folder path and get_item_by_path() method,
  - **Dependencies:** None,
  - **Tag maintainer:** @baskaryan,
  - **Twitter handle:** @WRhetoric
