### PR TITLE
Python: Add iterator support to chat history base class

### DIFF
--- a/libs/langchain/langchain/schema/chat_history.py
+++ b/libs/langchain/langchain/schema/chat_history.py
@@ -65,3 +65,7 @@ class BaseChatMessageHistory(ABC):
     @abstractmethod
     def clear(self) -> None:
         """Remove all messages from the store"""
+
+    def __iter__(self) -> Iterator[BaseMessage]:
+        for message in self.messages:
+            yield message

--- a/libs/langchain/tests/unit_tests/memory/chat_message_histories/test_file.py
+++ b/libs/langchain/tests/unit_tests/memory/chat_message_histories/test_file.py
@@ -69,3 +69,20 @@ def test_multiple_sessions(file_chat_message_history: FileChatMessageHistory) ->
     assert messages[2].content == "Tell me a joke."
     expected_content = "Why did the chicken cross the road? To get to the other side!"
     assert messages[3].content == expected_content
+
+
+def test_history_iterator(file_chat_message_history: FileChatMessageHistory) -> None:
+    file_chat_message_history.add_user_message("Hello!")
+    file_chat_message_history.add_ai_message("Hi there!")
+
+    index = 0
+    for message in file_chat_message_history:
+        if index == 0:
+            assert isinstance(message, HumanMessage)
+            assert message.content == "Hello!"
+        elif index == 1:
+            assert isinstance(message, AIMessage)
+            assert message.content == "Hi there!"
+        else:
+            pytest.fail("Message history should not contain more than 2 messages.")
+        index += 1


### PR DESCRIPTION
  - **Description:** Add Python iterator support for chat messages in `BaseChatMessageHistory`.  This makes any chat history class iterable on its message list.  Here is my use-case that triggered this change.  
  
  I have a `ConversationBufferMemory` that is backed by a `FileChatMessageHistory`:
```python
vectorstore = get_vectorstore()
chat_history = FileChatMessageHistory("chat_memory_path/session.json")
memory = ConversationBufferMemory(memory_key="chat_history", chat_memory=chat_history, return_messages=True)
qa = ConversationalRetrievalChain.from_llm(
    get_chat_model(),
    vectorstore.as_retriever(),
    return_source_documents=True,
    memory=memory,
)
```
where `get_chat_model()` returns a LLM and `vectorstore` is your favorite Vector store.  

A problem occurs when `BaseConversationalRetrievalChain._get_chat_history()` is called.  In my setup, `chat_history` is an instance of `FileChatMessageHistory` and `_get_chat_history()` tries to create an iterator from it (see this [line](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/chains/conversational_retrieval/base.py#L37)).  I could supply my own callable version when building the chain, but it kind of made sense to me that a chat history would be iterable.

I'm looking for input on how to make this pass in `mypy` since it complains with the following:
```
langchain/memory/chat_message_histories/in_memory.py:10: error: Definition of "__iter__" in base class "BaseChatMessageHistory" is incompatible with definition in base class "BaseModel"  [misc]
```