### PR TITLE
implement async exec for base.py

### DIFF
--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from textwrap import indent
 from typing import Any, Dict, List, Optional, Type, Awaitable
+import asyncio
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -106,7 +107,7 @@ class ToTChain(Chain):
             run_manager.on_text(
                 text=text, color=colors[thought.validity], verbose=self.verbose
             )
-
+        return None
     def _call(
         self,
         inputs: Dict[str, Any],
@@ -143,6 +144,7 @@ class ToTChain(Chain):
 
         return {self.output_key: "No solution found"}
 
+
     async def _acall(
         self,
         inputs: Dict[str, Any],
@@ -167,6 +169,7 @@ class ToTChain(Chain):
             # Ensure that thought_text is awaitable (if it's not already)
             if not isinstance(thought_text, Awaitable):
                 thought_text = asyncio.ensure_future(thought_text)
+    
             checker_inputs["thoughts"] = thoughts_path + (thought_text,)
             thought_validity = (await self.checker(checker_inputs, callbacks=_run_manager.get_child()))[
                 "validity"
@@ -175,6 +178,7 @@ class ToTChain(Chain):
             if thought.validity == ThoughtValidity.VALID_FINAL:
                 await self.log_thought(thought, level, run_manager)
                 return {self.output_key: thought.text}
+    
             await self.tot_memory.store(thought)
             await self.log_thought(thought, level, run_manager)
             thoughts_path = await self.tot_controller(self.tot_memory)

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -106,6 +106,7 @@ class ToTChain(Chain):
             run_manager.on_text(
                 text=text, color=colors[thought.validity], verbose=self.verbose
             )
+        return
 
     def _call(
         self,

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -162,7 +162,6 @@ class ToTChain(Chain):
     
         level = 0
         while level < self.k:
-            _run_manager.update_level(level)
             thought_text = await thought_generator.next_thought(
                 problem_description, thoughts_path, callbacks=_run_manager.get_child()
             )

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -12,7 +12,7 @@ possible solutions to a problem.
 from __future__ import annotations
 
 from textwrap import indent
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Awaitable
 
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import (
@@ -106,7 +106,6 @@ class ToTChain(Chain):
             run_manager.on_text(
                 text=text, color=colors[thought.validity], verbose=self.verbose
             )
-        return
 
     def _call(
         self,
@@ -165,6 +164,9 @@ class ToTChain(Chain):
             thought_text = await thought_generator.next_thought(
                 problem_description, thoughts_path, callbacks=_run_manager.get_child()
             )
+            # Ensure that thought_text is awaitable (if it's not already)
+            if not isinstance(thought_text, Awaitable):
+                thought_text = asyncio.ensure_future(thought_text)
             checker_inputs["thoughts"] = thoughts_path + (thought_text,)
             thought_validity = (await self.checker(checker_inputs, callbacks=_run_manager.get_child()))[
                 "validity"

--- a/libs/experimental/langchain_experimental/tot/base.py
+++ b/libs/experimental/langchain_experimental/tot/base.py
@@ -103,10 +103,11 @@ class ToTChain(Chain):
                 ThoughtValidity.VALID_INTERMEDIATE: "yellow",
                 ThoughtValidity.INVALID: "red",
             }
-            text = indent(f"Thought: {thought.text}\n", prefix="    " * level)
+            text = indent(f"Thought: {thought.text}\n", prefix="  " * level)
             run_manager.on_text(
                 text=text, color=colors[thought.validity], verbose=self.verbose
             )
+        return None
 
     def _call(
         self,
@@ -144,8 +145,14 @@ class ToTChain(Chain):
 
         return {self.output_key: "No solution found"}
 
+    def store(
+        self,
+        thought: Thought,
+    ) -> None:
+        self.thought_memory.append(thought)
+        return None
 
-
+    
     async def _acall(
         self,
         inputs: Dict[str, Any],
@@ -176,18 +183,15 @@ class ToTChain(Chain):
                 "validity"
             ]
             thought = Thought(text=thought_text, validity=thought_validity)
-    
             if thought.validity == ThoughtValidity.VALID_FINAL:
                 break
     
-            await asyncio.ensure_future(self.tot_memory.store(thought))
+            await self.tot_memory.store(thought)
             await self.log_thought(thought, level, run_manager)
             thoughts_path = await asyncio.ensure_future(self.tot_controller(self.tot_memory))
             level += 1
     
         return {self.output_key: "No solution found"}
-
-
 
     @property
     def _chain_type(self) -> str:


### PR DESCRIPTION
This is my implementation of async exec. This code is similar to the synchronous version, but it uses async and await to make it asynchronous. To use this asynchronous version of _acall, we can simply call it with the async keyword: `output = await chain.acall(inputs)`

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
