### PR TITLE
Fix chat_history message order

### DIFF
--- a/libs/langchain/langchain/memory/chat_message_histories/sql.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/sql.py
@@ -109,9 +109,13 @@ class SQLChatMessageHistory(BaseChatMessageHistory):
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve all messages from db"""
         with self.Session() as session:
-            result = session.query(self.sql_model_class).where(
-                getattr(self.sql_model_class, self.session_id_field_name)
-                == self.session_id
+            result = (
+                session.query(self.sql_model_class)
+                .where(
+                    getattr(self.sql_model_class, self.session_id_field_name)
+                    == self.session_id
+                )
+                .order_by(self.sql_model_class.id.asc())
             )
             messages = []
             for record in result:


### PR DESCRIPTION
Not all databases uses id as default order, so add it explicitly

sqlite uses rawid as default order in select statement: [https://www.sqlite.org/lang_createtable.html#rowid](https://www.sqlite.org/lang_createtable.html#rowid), but some other databases like postgresql not behaves like this. since this class supports multiple db engine. we should have an order.