### PR TITLE
fix the Loader 'BiliBiliLoader' 

### DIFF
--- a/docs/extras/integrations/document_loaders/bilibili.ipynb
+++ b/docs/extras/integrations/document_loaders/bilibili.ipynb
@@ -27,6 +27,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bd7e98b7",
+   "metadata": {},
+   "source": [
+    "## Without credential\n",
+    "Due to Bilibili's API rules, it is currently not possible to obtain subtitles without using credentials.  \n",
+    "Now, if you don't provide credentials, the loader will return the video's title and description."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "9ec8a3b3",
@@ -63,6 +73,53 @@
     },
     "pycharm": {
      "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d1dd676",
+   "metadata": {},
+   "source": [
+    "## With credential\n",
+    "How to obtain credentials, please refer to [get-credential](https://nemo2011.github.io/bilibili-api/#/get-credential)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5255c5af",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.document_loaders import BiliBiliLoader\n",
+    "from bilibili_api import Credential"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "282e7764",
+   "metadata": {},
+   "source": [
+    "credential = Credential(sessdata=sessdata, bili_jct=bili_jct, ac_time_value=ac_time_value)\n",
+    "loader = BiliBiliLoader([\"https://www.bilibili.com/video/BV1xt411o7Xu/\"], credential=credential)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17688faa",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
     }
    },
    "outputs": [],

--- a/libs/langchain/langchain/document_loaders/bilibili.py
+++ b/libs/langchain/langchain/document_loaders/bilibili.py
@@ -8,17 +8,27 @@ import requests
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
+try:
+    from bilibili_api import Credential, sync, video
+except ImportError:
+    raise ImportError(
+        "requests package not found, please install it with "
+        "`pip install bilibili-api-python`"
+    )
+
 
 class BiliBiliLoader(BaseLoader):
     """Load `BiliBili` video transcripts."""
 
-    def __init__(self, video_urls: List[str]):
+    def __init__(self, video_urls: List[str], credential: Credential = None):
         """Initialize with bilibili url.
 
         Args:
             video_urls: List of bilibili urls.
+            credential: The credential to access bilibili api.
         """
         self.video_urls = video_urls
+        self.credential = credential
 
     def load(self) -> List[Document]:
         """Load Documents from bilibili url."""
@@ -31,22 +41,16 @@ class BiliBiliLoader(BaseLoader):
         return results
 
     def _get_bilibili_subs_and_info(self, url: str) -> Tuple[str, dict]:
-        try:
-            from bilibili_api import sync, video
-        except ImportError:
-            raise ImportError(
-                "requests package not found, please install it with "
-                "`pip install bilibili-api-python`"
-            )
-
         bvid = re.search(r"BV\w+", url)
         if bvid is not None:
-            v = video.Video(bvid=bvid.group())
+            v = video.Video(bvid=bvid.group(), credential=self.credential)
         else:
             aid = re.search(r"av[0-9]+", url)
             if aid is not None:
                 try:
-                    v = video.Video(aid=int(aid.group()[2:]))
+                    v = video.Video(
+                        aid=int(aid.group()[2:]), credential=self.credential
+                    )
                 except AttributeError:
                     raise ValueError(f"{url} is not bilibili url.")
             else:
@@ -54,10 +58,19 @@ class BiliBiliLoader(BaseLoader):
 
         video_info = sync(v.get_info())
         video_info.update({"url": url})
-        sub = sync(v.get_subtitle(video_info["cid"]))
 
-        # Get subtitle url
-        sub_list = sub["subtitles"]
+        if (
+            self.credential and len(video_info["subtitle"]["list"]) > 0
+        ):  # video has subtitle
+            if not sync(self.credential.check_valid()):  # check credential is valid
+                raise ValueError("credential is invalid.")
+
+            sub = sync(v.get_subtitle(video_info["cid"]))
+            # Get subtitle url
+            sub_list = sub["subtitles"]
+        else:
+            sub_list = []
+
         if sub_list:
             sub_url = sub_list[0]["subtitle_url"]
             if not sub_url.startswith("http"):
@@ -73,11 +86,14 @@ class BiliBiliLoader(BaseLoader):
             )
             return raw_transcript_with_meta_info, video_info
         else:
-            raw_transcript = ""
             warnings.warn(
                 f"""
                 No subtitles found for video: {url}.
                 Return Empty transcript.
                 """
             )
-            return raw_transcript, video_info
+            raw_transcript_with_meta_info = (
+                f"Video Title: {video_info['title']},"
+                f"description: {video_info['desc']}\n\n"
+            )
+            return raw_transcript_with_meta_info, video_info


### PR DESCRIPTION
  - **Description:** fix the Loader 'BiliBiliLoader' and it's doc
  - **Issue:** Due to recent modifications in Bilibili's API regulations, it is now imperative to include credentials when making a request to obtain subtitles.
Furthermore, it is important to note that not all videos will necessarily have associated subtitles.
As a result, I have revised the logic for acquiring subtitles. Presently, in the absence of credentials, the response will include the video's title and description, with subtitles only retrieved if valid credentials are provided.
And I also changed the doc,adding how to get and provide the credential.
  - **Dependencies:** Nope