### PR TITLE
Improve structured chat output parser regex

### DIFF
--- a/libs/langchain/langchain/agents/structured_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/structured_chat/output_parser.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class StructuredChatOutputParser(AgentOutputParser):
     """Output parser for the structured chat agent."""
 
-    pattern = re.compile(r"```(?:json)?\n(.*?)```", re.DOTALL)
+    pattern = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
 
     def get_format_instructions(self) -> str:
         return FORMAT_INSTRUCTIONS


### PR DESCRIPTION
- **Description:** This PR improves the regex in the output parser for the `StructuredChatAgent`. Previously, it failed to match valid json if there was a space after `json` and before the new line, i.e., the follow string won't be matched by the previous regex:
````
```json 
{
  "action": "Tool",
  "action_input": "Tool input."
}
```
````


- **Issue:** N/A,
- **Dependencies:** N/A,
- **Tag maintainer:** don't know,
- **Twitter handle:** solitarypenman