### PR TITLE
Support weight only quantization with intel-extension-for-transformers

### DIFF
--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -662,6 +662,7 @@ __all__ = [
     "HuggingFacePipeline",
     "HuggingFaceTextGenInference",
     "HumanInputLLM",
+    "ITREXWrightOnlyQuantPipeline",
     "KoboldApiLLM",
     "LlamaCpp",
     "TextGen",

--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -662,7 +662,7 @@ __all__ = [
     "HuggingFacePipeline",
     "HuggingFaceTextGenInference",
     "HumanInputLLM",
-    "ITREXWrightOnlyQuantPipeline",
+    "WrightOnlyQuantPipeline",
     "KoboldApiLLM",
     "LlamaCpp",
     "TextGen",

--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -662,7 +662,7 @@ __all__ = [
     "HuggingFacePipeline",
     "HuggingFaceTextGenInference",
     "HumanInputLLM",
-    "WrightOnlyQuantPipeline",
+    "WeightOnlyQuantPipeline",
     "KoboldApiLLM",
     "LlamaCpp",
     "TextGen",

--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -220,6 +220,12 @@ def _import_huggingface_pipeline() -> Any:
     return HuggingFacePipeline
 
 
+def _import_weight_only_pipeline() -> Any:
+    from langchain.llms.weight_only_quantization import WeightOnlyQuantPipeline
+
+    return WeightOnlyQuantPipeline
+
+
 def _import_huggingface_text_gen_inference() -> Any:
     from langchain.llms.huggingface_text_gen_inference import (
         HuggingFaceTextGenInference,
@@ -615,6 +621,8 @@ def __getattr__(name: str) -> Any:
         return _import_vllm_openai()
     elif name == "Writer":
         return _import_writer()
+    elif name == "WeightOnlyQuantPipeline":
+        return _import_weight_only_pipeline()
     elif name == "Xinference":
         return _import_xinference()
     elif name == "type_to_cls_dict":
@@ -773,6 +781,7 @@ def get_type_to_cls_dict() -> Dict[str, Callable[[], Type[BaseLLM]]]:
         "vllm": _import_vllm,
         "vllm_openai": _import_vllm_openai,
         "writer": _import_writer,
+        "weight_only_quantization": _import_weight_only_pipeline,
         "xinference": _import_xinference,
         "javelin-ai-gateway": _import_javelin_ai_gateway,
         "qianfan_endpoint": _import_baidu_qianfan_endpoint,

--- a/libs/langchain/langchain/llms/itrex_weight_only_quantization.py
+++ b/libs/langchain/langchain/llms/itrex_weight_only_quantization.py
@@ -1,0 +1,194 @@
+import logging
+from typing import Any, List, Mapping, Optional
+
+from langchain.callbacks.manager import CallbackManagerForLLMRun
+from langchain.llms.base import LLM
+from langchain.llms.utils import enforce_stop_tokens
+
+
+DEFAULT_MODEL_ID = "gpt2"
+DEFAULT_TASK = "text-generation"
+VALID_TASKS = ("text2text-generation", "text-generation", "summarization")
+
+
+class ITREXWrightOnlyQuantPipeline(LLM):
+    """Weight only quantized model.
+
+    To use, you should have the `intel-extension-for-transformers` packabge and `transformers` package installed.
+    intel-extension-for-transformers: https://github.com/intel/intel-extension-for-transformers
+
+    Example using from_model_id:
+        .. code-block:: python
+
+            from langchain.llms import ITREXWrightOnlyQuant
+            from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
+            config = WeightOnlyQuantConfig
+            hf = ITREXWrightOnlyQuant.from_model_id(
+                model_id="google/flan-t5-large",
+                task="text2text-generation"
+                pipeline_kwargs={"max_new_tokens": 10},
+                quantization_config=config,
+            )
+    Example passing pipeline in directly:
+        .. code-block:: python
+
+            from langchain.llms import ITREXWrightOnlyQuant
+            from intel_extension_for_transformers.transformers import AutoModelForSeq2SeqLM
+            from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
+            from transformers import AutoTokenizer, pipeline
+
+            model_id = "google/flan-t5-large"
+            tokenizer = AutoTokenizer.from_pretrained(model_id)
+            config = WeightOnlyQuantConfig
+            model = AutoModelForSeq2SeqLM.from_pretrained(model_id, quantization_config=config)
+            pipe = pipeline(
+                "text-generation", model=model, tokenizer=tokenizer, max_new_tokens=10
+            )
+            hf = ITREXWrightOnlyQuant(pipeline=pipe)
+    """
+
+    client: Any  #: :meta private:
+    model_id: str
+    """Model name or local path to use."""
+
+    model_kwargs: Optional[dict] = None
+    """Key word arguments passed to the model."""
+
+    pipeline_kwargs: Optional[dict] = None
+    """Key word arguments passed to the pipeline."""
+
+    @classmethod
+    def from_model_id(
+        cls,
+        model_id: str,
+        task: str,
+        device: int = -1,
+        model_kwargs: Optional[dict] = None,
+        pipeline_kwargs: Optional[dict] = None,
+        load_in_4bit: Optional[bool] = False,
+        load_in_8bit: Optional[bool] = False,
+        quantization_config=None,
+        **kwargs: Any,
+    ) -> LLM:
+        """Construct the pipeline object from model_id and task."""
+        try:
+            from intel_extension_for_transformers.transformers import (
+                AutoModelForCausalLM,
+                AutoModelForSeq2SeqLM,
+            )
+            from transformers import AutoTokenizer, pipeline as hf_pipeline
+        except ImportError:
+            raise ValueError(
+                "Could not import transformers python package. "
+                "Please install it with `pip install transformers` "
+                "and `pip install intel-extension-for-transformers`."
+            )
+
+        _model_kwargs = model_kwargs or {}
+        tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
+
+        try:
+            if task == "text-generation":
+                model = AutoModelForCausalLM.from_pretrained(model_id,
+                                                             load_in_4bit=load_in_4bit,
+                                                             load_in_8bit=load_in_8bit,
+                                                             quantization_config=quantization_config,
+                                                             **_model_kwargs)
+            elif task in ("text2text-generation", "summarization"):
+                model = AutoModelForSeq2SeqLM.from_pretrained(model_id,
+                                                              load_in_4bit=load_in_4bit,
+                                                              load_in_8bit=load_in_8bit,
+                                                              quantization_config=quantization_config,
+                                                              **_model_kwargs)
+            else:
+                raise ValueError(
+                    f"Got invalid task {task}, "
+                    f"currently only {VALID_TASKS} are supported"
+                )
+        except ImportError as e:
+            raise ValueError(
+                f"Could not load the {task} model due to missing dependencies."
+            ) from e
+
+        if "trust_remote_code" in _model_kwargs:
+            _model_kwargs = {
+                k: v for k, v in _model_kwargs.items() if k != "trust_remote_code"
+            }
+        _pipeline_kwargs = pipeline_kwargs or {}
+        pipeline = hf_pipeline(
+            task=task,
+            model=model,
+            tokenizer=tokenizer,
+            device=device,
+            model_kwargs=_model_kwargs,
+            **_pipeline_kwargs,
+        )
+        if pipeline.task not in VALID_TASKS:
+            raise ValueError(
+                f"Got invalid task {pipeline.task}, "
+                f"currently only {VALID_TASKS} are supported"
+            )
+        return cls(
+            pipeline=pipeline,
+            model_id=model_id,
+            model_kwargs=_model_kwargs,
+            pipeline_kwargs=_pipeline_kwargs,
+            **kwargs,
+        )
+
+    @property
+    def _identifying_params(self) -> Mapping[str, Any]:
+        """Get the identifying parameters."""
+        return {
+            "model_id": self.model_id,
+            "model_kwargs": self.model_kwargs,
+            "pipeline_kwargs": self.pipeline_kwargs,
+        }
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "itrex_weight_only_quantization"
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Call the HuggingFace model and return the output.
+
+        Args:
+            prompt: The prompt to use for generation.
+            stop: A list of strings to stop generation when encountered.
+
+        Returns:
+            The generated text.
+
+        Example:
+            .. code-block:: python
+
+                from langchain.llms import ITREXWrightOnlyQuant
+                llm = ITREXWrightOnlyQuant.from_model_id(model_id="google/flan-t5-large",
+                                                         task="text2text-generation")
+                llm("This is a prompt.")
+        """
+        response = self.pipeline(prompt)
+        if self.pipeline.task == "text-generation":
+            # Text generation return includes the starter text.
+            text = response[0]["generated_text"][len(prompt) :]
+        elif self.pipeline.task == "text2text-generation":
+            text = response[0]["generated_text"]
+        elif self.pipeline.task == "summarization":
+            text = response[0]["summary_text"]
+        else:
+            raise ValueError(
+                f"Got invalid task {self.pipeline.task}, "
+                f"currently only {VALID_TASKS} are supported"
+            )
+        if stop:
+            # This is a bit hacky, but I can't figure out a better way to enforce
+            # stop tokens when making calls to huggingface_hub.
+            text = enforce_stop_tokens(text, stop)
+        return text

--- a/libs/langchain/langchain/llms/weight_only_quantization.py
+++ b/libs/langchain/langchain/llms/weight_only_quantization.py
@@ -11,7 +11,7 @@ DEFAULT_TASK = "text2text-generation"
 VALID_TASKS = ("text2text-generation", "text-generation", "summarization")
 
 
-class WrightOnlyQuantPipeline(LLM):
+class WeightOnlyQuantPipeline(LLM):
     """Weight only quantized model.
 
     To use, you should have the `intel-extension-for-transformers` packabge and `transformers` package installed.
@@ -20,10 +20,10 @@ class WrightOnlyQuantPipeline(LLM):
     Example using from_model_id:
         .. code-block:: python
 
-            from langchain.llms import WrightOnlyQuantPipeline
+            from langchain.llms import WeightOnlyQuantPipeline
             from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
             config = WeightOnlyQuantConfig
-            hf = WrightOnlyQuantPipeline.from_model_id(
+            hf = WeightOnlyQuantPipeline.from_model_id(
                 model_id="google/flan-t5-large",
                 task="text2text-generation"
                 pipeline_kwargs={"max_new_tokens": 10},
@@ -32,7 +32,7 @@ class WrightOnlyQuantPipeline(LLM):
     Example passing pipeline in directly:
         .. code-block:: python
 
-            from langchain.llms import WrightOnlyQuantPipeline
+            from langchain.llms import WeightOnlyQuantPipeline
             from intel_extension_for_transformers.transformers import AutoModelForSeq2SeqLM
             from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
             from transformers import AutoTokenizer, pipeline
@@ -44,7 +44,7 @@ class WrightOnlyQuantPipeline(LLM):
             pipe = pipeline(
                 "text-generation", model=model, tokenizer=tokenizer, max_new_tokens=10
             )
-            hf = WrightOnlyQuantPipeline(pipeline=pipe)
+            hf = WeightOnlyQuantPipeline(pipeline=pipe)
     """
 
     pipeline: Any  #: :meta private:
@@ -98,12 +98,14 @@ class WrightOnlyQuantPipeline(LLM):
                                                              load_in_4bit=load_in_4bit,
                                                              load_in_8bit=load_in_8bit,
                                                              quantization_config=quantization_config,
+                                                             use_llm_runtime=False,
                                                              **_model_kwargs)
             elif task in ("text2text-generation", "summarization"):
                 model = AutoModelForSeq2SeqLM.from_pretrained(model_id,
                                                               load_in_4bit=load_in_4bit,
                                                               load_in_8bit=load_in_8bit,
                                                               quantization_config=quantization_config,
+                                                              use_llm_runtime=False,
                                                               **_model_kwargs)
             else:
                 raise ValueError(
@@ -174,8 +176,8 @@ class WrightOnlyQuantPipeline(LLM):
         Example:
             .. code-block:: python
 
-                from langchain.llms import WrightOnlyQuantPipeline
-                llm = WrightOnlyQuantPipeline.from_model_id(model_id="google/flan-t5-large",
+                from langchain.llms import WeightOnlyQuantPipeline
+                llm = WeightOnlyQuantPipeline.from_model_id(model_id="google/flan-t5-large",
                                                          task="text2text-generation")
                 llm("This is a prompt.")
         """

--- a/libs/langchain/langchain/llms/weight_only_quantization.py
+++ b/libs/langchain/langchain/llms/weight_only_quantization.py
@@ -1,17 +1,17 @@
-import logging
 from typing import Any, List, Mapping, Optional
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.pydantic_v1 import Extra
 
 
-DEFAULT_MODEL_ID = "gpt2"
-DEFAULT_TASK = "text-generation"
+DEFAULT_MODEL_ID = "google/flan-t5-large"
+DEFAULT_TASK = "text2text-generation"
 VALID_TASKS = ("text2text-generation", "text-generation", "summarization")
 
 
-class ITREXWrightOnlyQuantPipeline(LLM):
+class WrightOnlyQuantPipeline(LLM):
     """Weight only quantized model.
 
     To use, you should have the `intel-extension-for-transformers` packabge and `transformers` package installed.
@@ -20,10 +20,10 @@ class ITREXWrightOnlyQuantPipeline(LLM):
     Example using from_model_id:
         .. code-block:: python
 
-            from langchain.llms import ITREXWrightOnlyQuant
+            from langchain.llms import WrightOnlyQuantPipeline
             from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
             config = WeightOnlyQuantConfig
-            hf = ITREXWrightOnlyQuant.from_model_id(
+            hf = WrightOnlyQuantPipeline.from_model_id(
                 model_id="google/flan-t5-large",
                 task="text2text-generation"
                 pipeline_kwargs={"max_new_tokens": 10},
@@ -32,7 +32,7 @@ class ITREXWrightOnlyQuantPipeline(LLM):
     Example passing pipeline in directly:
         .. code-block:: python
 
-            from langchain.llms import ITREXWrightOnlyQuant
+            from langchain.llms import WrightOnlyQuantPipeline
             from intel_extension_for_transformers.transformers import AutoModelForSeq2SeqLM
             from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
             from transformers import AutoTokenizer, pipeline
@@ -44,11 +44,11 @@ class ITREXWrightOnlyQuantPipeline(LLM):
             pipe = pipeline(
                 "text-generation", model=model, tokenizer=tokenizer, max_new_tokens=10
             )
-            hf = ITREXWrightOnlyQuant(pipeline=pipe)
+            hf = WrightOnlyQuantPipeline(pipeline=pipe)
     """
 
-    client: Any  #: :meta private:
-    model_id: str
+    pipeline: Any  #: :meta private:
+    model_id: str = DEFAULT_MODEL_ID
     """Model name or local path to use."""
 
     model_kwargs: Optional[dict] = None
@@ -56,6 +56,11 @@ class ITREXWrightOnlyQuantPipeline(LLM):
 
     pipeline_kwargs: Optional[dict] = None
     """Key word arguments passed to the pipeline."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.allow
 
     @classmethod
     def from_model_id(
@@ -148,7 +153,7 @@ class ITREXWrightOnlyQuantPipeline(LLM):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "itrex_weight_only_quantization"
+        return "weight_only_quantization"
 
     def _call(
         self,
@@ -169,8 +174,8 @@ class ITREXWrightOnlyQuantPipeline(LLM):
         Example:
             .. code-block:: python
 
-                from langchain.llms import ITREXWrightOnlyQuant
-                llm = ITREXWrightOnlyQuant.from_model_id(model_id="google/flan-t5-large",
+                from langchain.llms import WrightOnlyQuantPipeline
+                llm = WrightOnlyQuantPipeline.from_model_id(model_id="google/flan-t5-large",
                                                          task="text2text-generation")
                 llm("This is a prompt.")
         """

--- a/libs/langchain/tests/integration_tests/llms/test_weight_only_quantization.py
+++ b/libs/langchain/tests/integration_tests/llms/test_weight_only_quantization.py
@@ -1,0 +1,68 @@
+"""Test HuggingFace Pipeline wrapper."""
+
+from pathlib import Path
+
+from langchain.llms.weight_only_quantization import WrightOnlyQuantPipeline
+from langchain.llms.loading import load_llm
+from tests.integration_tests.llms.utils import assert_llm_equality
+
+model_id = "google/flan-t5-large"
+
+
+def test_weight_only_quantization_with_config() -> None:
+    """Test valid call to HuggingFace text2text model."""
+    from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
+    conf = WeightOnlyQuantConfig(weight_dtype="nf4")
+    llm = WrightOnlyQuantPipeline.from_model_id(
+        model_id=model_id, task="text2text-generation",
+        quantization_config=conf
+    )
+    output = llm("Say foo:")
+    assert isinstance(output, str)
+
+
+def test_weight_only_quantization_4bit() -> None:
+    """Test valid call to HuggingFace text2text model."""
+    llm = WrightOnlyQuantPipeline.from_model_id(
+        model_id=model_id, task="text2text-generation",
+        load_in_4bit=True
+    )
+    output = llm("Say foo:")
+    assert isinstance(output, str)
+
+
+def test_weight_only_quantization_8bit() -> None:
+    """Test valid call to HuggingFace text2text model."""
+    llm = WrightOnlyQuantPipeline.from_model_id(
+        model_id=model_id, task="text2text-generation",
+        load_in_8bit=True
+    )
+    output = llm("Say foo:")
+    assert isinstance(output, str)
+
+
+def test_init_with_pipeline() -> None:
+    """Test initialization with a HF pipeline."""
+    from intel_extension_for_transformers.transformers import AutoModelForSeq2SeqLM
+    from transformers import AutoTokenizer, pipeline
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_id, load_in_4bit=True)
+    pipe = pipeline(
+        "text2text-generation", model=model, tokenizer=tokenizer
+    )
+    llm = WrightOnlyQuantPipeline(pipeline=pipe)
+    output = llm("Say foo:")
+    assert isinstance(output, str)
+
+
+def text_weight_only_pipeline_summarization() -> None:
+    """Test valid call to HuggingFace summarization model."""
+    from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
+    conf = WeightOnlyQuantConfig()
+    llm = WrightOnlyQuantPipeline.from_model_id(
+        model_id=model_id, task="summarization",
+        quantization_config=conf
+    )
+    output = llm("Say foo:")
+    assert isinstance(output, str)

--- a/libs/langchain/tests/integration_tests/llms/test_weight_only_quantization.py
+++ b/libs/langchain/tests/integration_tests/llms/test_weight_only_quantization.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from langchain.llms.weight_only_quantization import WrightOnlyQuantPipeline
+from langchain.llms.weight_only_quantization import WeightOnlyQuantPipeline
 from langchain.llms.loading import load_llm
 from tests.integration_tests.llms.utils import assert_llm_equality
 
@@ -13,7 +13,7 @@ def test_weight_only_quantization_with_config() -> None:
     """Test valid call to HuggingFace text2text model."""
     from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
     conf = WeightOnlyQuantConfig(weight_dtype="nf4")
-    llm = WrightOnlyQuantPipeline.from_model_id(
+    llm = WeightOnlyQuantPipeline.from_model_id(
         model_id=model_id, task="text2text-generation",
         quantization_config=conf
     )
@@ -23,7 +23,7 @@ def test_weight_only_quantization_with_config() -> None:
 
 def test_weight_only_quantization_4bit() -> None:
     """Test valid call to HuggingFace text2text model."""
-    llm = WrightOnlyQuantPipeline.from_model_id(
+    llm = WeightOnlyQuantPipeline.from_model_id(
         model_id=model_id, task="text2text-generation",
         load_in_4bit=True
     )
@@ -33,7 +33,7 @@ def test_weight_only_quantization_4bit() -> None:
 
 def test_weight_only_quantization_8bit() -> None:
     """Test valid call to HuggingFace text2text model."""
-    llm = WrightOnlyQuantPipeline.from_model_id(
+    llm = WeightOnlyQuantPipeline.from_model_id(
         model_id=model_id, task="text2text-generation",
         load_in_8bit=True
     )
@@ -51,7 +51,7 @@ def test_init_with_pipeline() -> None:
     pipe = pipeline(
         "text2text-generation", model=model, tokenizer=tokenizer
     )
-    llm = WrightOnlyQuantPipeline(pipeline=pipe)
+    llm = WeightOnlyQuantPipeline(pipeline=pipe)
     output = llm("Say foo:")
     assert isinstance(output, str)
 
@@ -60,7 +60,7 @@ def text_weight_only_pipeline_summarization() -> None:
     """Test valid call to HuggingFace summarization model."""
     from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
     conf = WeightOnlyQuantConfig()
-    llm = WrightOnlyQuantPipeline.from_model_id(
+    llm = WeightOnlyQuantPipeline.from_model_id(
         model_id=model_id, task="summarization",
         quantization_config=conf
     )


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
Support weight only quantization with intel-extension-for-transformers.
[Intel® Extension for Transformers](https://github.com/intel/intel-extension-for-transformers) is an innovative toolkit to accelerate Transformer-based models on Intel platforms, in particular effective on 4th Intel Xeon Scalable processor Sapphire Rapids (codenamed [Sapphire Rapids](https://www.intel.com/content/www/us/en/products/docs/processors/xeon-accelerated/4th-gen-xeon-scalable-processors.html)). The toolkit provides the below key features:
 * Seamless user experience of model compressions on Transformer-based models by extending [Hugging Face transformers](https://github.com/huggingface/transformers) APIs and leveraging [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
 * Advanced software optimizations and unique compression-aware runtime.
 * Optimized Transformer-based model packages.
 * [NeuralChat](https://github.com/intel/intel-extension-for-transformers/blob/main/intel_extension_for_transformers/neural_chat), a customizable chatbot framework to create your own chatbot within minutes by leveraging a rich set of plugins and SOTA optimizations.
 * [Inference](https://github.com/intel/intel-extension-for-transformers/blob/main/intel_extension_for_transformers/llm/runtime/graph) of Large Language Model (LLM) in pure C/C++ with weight-only quantization kernels.
 
This PR is an integration of weight only quantization feature with intel-extension-for-transformers.
 * Unit test is in lib/langchain/tests/integration_tests/llm/test_weight_only_quantization.py

