### PR TITLE
In MergerRetriever async call all retrievers in parallel

### DIFF
--- a/libs/langchain/langchain/retrievers/merger_retriever.py
+++ b/libs/langchain/langchain/retrievers/merger_retriever.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List
 
 from langchain.callbacks.manager import (
@@ -100,12 +101,14 @@ class MergerRetriever(BaseRetriever):
         """
 
         # Get the results of all retrievers.
-        retriever_docs = [
-            await retriever.aget_relevant_documents(
-                query, callbacks=run_manager.get_child("retriever_{}".format(i + 1))
+        retriever_docs = await asyncio.gather(
+            *(
+                retriever.aget_relevant_documents(
+                    query, callbacks=run_manager.get_child("retriever_{}".format(i + 1))
+                )
+                for i, retriever in enumerate(self.retrievers)
             )
-            for i, retriever in enumerate(self.retrievers)
-        ]
+        )
 
         # Merge the results of the retrievers.
         merged_documents = []


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
