### PR TITLE
Fixes error with providers that don't have model_id

### DIFF
--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -68,7 +68,7 @@ def use_simple_prompt(llm: BaseLanguageModel) -> bool:
         return True
 
     # Bedrock anthropic
-    if llm.model_id and "anthropic" in llm.model_id:  # type: ignore
+    if hasattr(llm, "model_id") and "anthropic" in llm.model_id:  # type: ignore
         return True
 
     return False


### PR DESCRIPTION
## Description
Fixes error with using the chain for providers that don't have `model_id` field.

![image](https://github.com/langchain-ai/langchain/assets/289369/a86074cf-6c99-4390-a135-b3af7a4f0827)
