### PR TITLE
adding argument support for SupabaseVectorStore's postgres functions.

### DIFF
--- a/libs/langchain/langchain/vectorstores/supabase.py
+++ b/libs/langchain/langchain/vectorstores/supabase.py
@@ -197,17 +197,16 @@ class SupabaseVectorStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Dict[str, Any]] = None,
-        postgrest_filter: Optional[str] = None,
-        sql_fn_args: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         query_vector = self._embedding.embed_query(query)
+        sql_fn_args: Optional[Dict[str, Any]] = kwargs.get("sql_fn_args")
         if filter:
             if not sql_fn_args:
                 sql_fn_args = {}
-            sql_fn_args["filter"] = filter
+            sql_fn_args = sql_fn_args.update(filter)
         return self.similarity_search_by_vector_with_relevance_scores(
-            query_vector, k, postgrest_filter, sql_fn_args
+            query_vector, k, kwargs.get("postgrest_filter"), sql_fn_args
         )
 
     def match_args(

--- a/libs/langchain/langchain/vectorstores/supabase.py
+++ b/libs/langchain/langchain/vectorstores/supabase.py
@@ -183,9 +183,9 @@ class SupabaseVectorStore(VectorStore):
             sql_fn_args = {}
             for filter_key, filter_value in filter.items():
                 sql_fn_args[filter_key] = filter_value
-        postgrest_filter: Optional[str] = kwargs.get("postgrest_filter")
+        postgres_filter: Optional[str] = kwargs.get("postgres_filter")
         result = self.similarity_search_by_vector_with_relevance_scores(
-            embedding, k, postgrest_filter, sql_fn_args
+            embedding, k, postgres_filter, sql_fn_args
         )
 
         documents = [doc for doc, _ in result]
@@ -206,7 +206,7 @@ class SupabaseVectorStore(VectorStore):
                 sql_fn_args = {}
             sql_fn_args = sql_fn_args.update(filter)
         return self.similarity_search_by_vector_with_relevance_scores(
-            query_vector, k, kwargs.get("postgrest_filter"), sql_fn_args
+            query_vector, k, kwargs.get("postgres_filter"), sql_fn_args
         )
 
     def match_args(
@@ -222,15 +222,15 @@ class SupabaseVectorStore(VectorStore):
         self,
         query: List[float],
         k: int,
-        postgrest_filter: Optional[str] = None,
+        postgres_filter: Optional[str] = None,
         sql_fn_args: Optional[Dict[str, Any]] = None,
     ) -> List[Tuple[Document, float]]:
         match_documents_params = self.match_args(query, sql_fn_args)
         query_builder = self._client.rpc(self.query_name, match_documents_params)
 
-        if postgrest_filter:
+        if postgres_filter:
             query_builder.params = query_builder.params.set(
-                "and", f"({postgrest_filter})"
+                "and", f"({postgres_filter})"
             )
 
         query_builder.params = query_builder.params.set("limit", k)
@@ -255,15 +255,15 @@ class SupabaseVectorStore(VectorStore):
         self,
         query: List[float],
         k: int,
-        postgrest_filter: Optional[str] = None,
+        postgres_filter: Optional[str] = None,
         sql_fn_args: Optional[Dict[str, Any]] = None,
     ) -> List[Tuple[Document, float, np.ndarray[np.float32, Any]]]:
         match_documents_params = self.match_args(query, sql_fn_args)
         query_builder = self._client.rpc(self.query_name, match_documents_params)
 
-        if postgrest_filter:
+        if postgres_filter:
             query_builder.params = query_builder.params.set(
-                "and", f"({postgrest_filter})"
+                "and", f"({postgres_filter})"
             )
 
         query_builder.params = query_builder.params.set("limit", k)
@@ -365,17 +365,17 @@ class SupabaseVectorStore(VectorStore):
                         of diversity among the results with 0 corresponding
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
-            postgrest_filter: Postgrest filter to apply to the query results.
+            postgres_filter: Postgrest filter to apply to the query results.
                             fetch_k is already in the filter as f"limit={fetch_k}"
             sql_fn_args: Other arguments to pass to the sql function than
                         "query_embedding" (which should be a function's parameter).
         Returns:
             List of Documents selected by maximal marginal relevance.
         """
-        postgrest_filter: Optional[str] = kwargs.get("postgrest_filter")
+        postgres_filter: Optional[str] = kwargs.get("postgres_filter")
         sql_fn_args: Optional[Dict[str, Any]] = kwargs.get("sql_fn_args")
         result = self.similarity_search_by_vector_returning_embeddings(
-            embedding, fetch_k, postgrest_filter, sql_fn_args
+            embedding, fetch_k, postgres_filter, sql_fn_args
         )
 
         matched_documents = [doc_tuple[0] for doc_tuple in result]
@@ -453,7 +453,7 @@ class SupabaseVectorStore(VectorStore):
             k,
             fetch_k,
             lambda_mult,
-            postgrest_filter=kwargs.get("postgrest_filter"),
+            postgres_filter=kwargs.get("postgres_filter"),
             sql_fn_args=kwargs.get("sql_fn_args"),
         )
         return docs

--- a/libs/langchain/langchain/vectorstores/supabase.py
+++ b/libs/langchain/langchain/vectorstores/supabase.py
@@ -365,7 +365,7 @@ class SupabaseVectorStore(VectorStore):
                         of diversity among the results with 0 corresponding
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
-            postgres_filter: Postgrest filter to apply to the query results.
+            postgres_filter: Filter to apply to the query results.
                             fetch_k is already in the filter as f"limit={fetch_k}"
             sql_fn_args: Other arguments to pass to the sql function than
                         "query_embedding" (which should be a function's parameter).

--- a/libs/langchain/langchain/vectorstores/supabase.py
+++ b/libs/langchain/langchain/vectorstores/supabase.py
@@ -205,8 +205,9 @@ class SupabaseVectorStore(VectorStore):
             if not sql_fn_args:
                 sql_fn_args = {}
             sql_fn_args = sql_fn_args.update(filter)
+        postgres_filter: Optional[str] = kwargs.get("postgres_filter")
         return self.similarity_search_by_vector_with_relevance_scores(
-            query_vector, k, kwargs.get("postgres_filter"), sql_fn_args
+            query_vector, k, postgres_filter, sql_fn_args
         )
 
     def match_args(


### PR DESCRIPTION
  - **Description:** `SupabaseVectorStore` has some limitations using postgres functions since is limited to a function with only one parameter `query_embedding`, this PR intends to add as many arguments as you need, hence allowing to create functions with other parameters than `query_embedding`,  this PR also allows the use of `postgres_filter` from `SupabaseVectorStore`.
Usage
```python
vector_store = SupabaseVectorStoreMixin(embedding=embeddings, client=supabase, table_name="document", query_name="match_documents_mmr")
matched_docs = vector_store.max_marginal_relevance_search(query, k=2, fetch_k=5, sql_fn_args={
    "stack": "python", # stack is a parameter in the supabase postgres' function.
})
```
  - **Issue:** #10994 ,
  - **Dependencies:** None,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** AHardReset
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** `SupabaseVectorStore` has some limitations using postgres functions since is limited to a function with only one parameter `query_embedding`, this PR intends to add as many arguments as you need, hence allowing to create functions with other parameters than `query_embedding`,  this PR also allows the use of `postgres_filter` from `SupabaseVectorStore`.
Usage
```python
vector_store = SupabaseVectorStoreMixin(embedding=embeddings, client=supabase, table_name="document", query_name="match_documents_mmr")
matched_docs = vector_store.max_marginal_relevance_search(query, k=2, fetch_k=5, sql_fn_args={
    "stack": "python", # stack is a parameter in the supabase postgres's function.
})
```
  - **Issue:** #10994 ,
  - **Dependencies:** None,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** AHardReset

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
