### PR TITLE
Fix issue #10985 - Skip model.to(device) if it is instantiated with bitsandbytes config

### DIFF
--- a/libs/langchain/langchain/llms/huggingface_pipeline.py
+++ b/libs/langchain/langchain/llms/huggingface_pipeline.py
@@ -63,7 +63,7 @@ class HuggingFacePipeline(LLM):
         cls,
         model_id: str,
         task: str,
-        device: int = -1,
+        device: Optional[int] = -1,
         model_kwargs: Optional[dict] = None,
         pipeline_kwargs: Optional[dict] = None,
         **kwargs: Any,
@@ -101,7 +101,20 @@ class HuggingFacePipeline(LLM):
                 f"Could not load the {task} model due to missing dependencies."
             ) from e
 
-        if importlib.util.find_spec("torch") is not None:
+        if (
+            model.is_quantized
+            or model.model.is_loaded_in_4bit
+            or model.model.is_loaded_in_8bit
+        ) and device is not None:
+            logger.warning(
+                f"Setting the `device` argument to None from {device} to avoid "
+                "the error caused by attempting to move the model that was already "
+                "loaded on the GPU using the Accelerate module to the same or "
+                "another device."
+            )
+            device = None
+
+        if device is not None and importlib.util.find_spec("torch") is not None:
             import torch
 
             cuda_device_count = torch.cuda.device_count()


### PR DESCRIPTION
Preventing error caused by attempting to move the model that was already loaded on the GPU using the Accelerate module to the same or another device. It is not possible to load model with Accelerate/PEFT to CPU for now

Addresses: [#10985](https://github.com/langchain-ai/langchain/issues/10985)