### PR TITLE
fix: bump min_unstructured_version for UnstructuredAPIFileLoader

### DIFF
--- a/libs/langchain/langchain/document_loaders/unstructured.py
+++ b/libs/langchain/langchain/document_loaders/unstructured.py
@@ -253,10 +253,7 @@ class UnstructuredAPIFileLoader(UnstructuredFileLoader):
     ):
         """Initialize with file path."""
 
-        if isinstance(file_path, str):
-            validate_unstructured_version(min_unstructured_version="0.6.2")
-        else:
-            validate_unstructured_version(min_unstructured_version="0.6.3")
+        validate_unstructured_version(min_unstructured_version="0.10.15")
 
         self.url = url
         self.api_key = api_key


### PR DESCRIPTION
**Description:** New metadata fields were added to `unstructured==0.10.15`, and our hosted api has been updated to reflect this. When users call `partition_via_api` with an older version of the library, they'll hit a parsing error related to the new fields.