### PR TITLE
Change type annotations from LLMChain to Chain in MultiPromptChain

### DIFF
--- a/libs/langchain/langchain/chains/router/multi_prompt.py
+++ b/libs/langchain/langchain/chains/router/multi_prompt.py
@@ -1,12 +1,12 @@
 """Use a single chain to route an input to one of multiple llm chains."""
 from __future__ import annotations
 
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 
 from langchain.chains import ConversationChain
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
-from langchain.chains.router.base import MultiRouteChain, RouterChain
+from langchain.chains.router.base import MultiRouteChain
 from langchain.chains.router.llm_router import LLMRouterChain, RouterOutputParser
 from langchain.chains.router.multi_prompt_prompt import MULTI_PROMPT_ROUTER_TEMPLATE
 from langchain.prompts import PromptTemplate
@@ -15,13 +15,6 @@ from langchain.schema.language_model import BaseLanguageModel
 
 class MultiPromptChain(MultiRouteChain):
     """A multi-route chain that uses an LLM router chain to choose amongst prompts."""
-
-    router_chain: RouterChain
-    """Chain for deciding a destination chain and the input to it."""
-    destination_chains: Mapping[str, Chain]
-    """Map of name to candidate chains that inputs can be routed to."""
-    default_chain: Chain
-    """Default chain to use when router doesn't map input to one of the destinations."""
 
     @property
     def output_keys(self) -> List[str]:

--- a/libs/langchain/langchain/chains/router/multi_prompt.py
+++ b/libs/langchain/langchain/chains/router/multi_prompt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Mapping, Optional
 
 from langchain.chains import ConversationChain
+from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
 from langchain.chains.router.base import MultiRouteChain, RouterChain
 from langchain.chains.router.llm_router import LLMRouterChain, RouterOutputParser
@@ -17,9 +18,9 @@ class MultiPromptChain(MultiRouteChain):
 
     router_chain: RouterChain
     """Chain for deciding a destination chain and the input to it."""
-    destination_chains: Mapping[str, LLMChain]
+    destination_chains: Mapping[str, Chain]
     """Map of name to candidate chains that inputs can be routed to."""
-    default_chain: LLMChain
+    default_chain: Chain
     """Default chain to use when router doesn't map input to one of the destinations."""
 
     @property
@@ -31,7 +32,7 @@ class MultiPromptChain(MultiRouteChain):
         cls,
         llm: BaseLanguageModel,
         prompt_infos: List[Dict[str, str]],
-        default_chain: Optional[LLMChain] = None,
+        default_chain: Optional[Chain] = None,
         **kwargs: Any,
     ) -> MultiPromptChain:
         """Convenience constructor for instantiating from destination prompts."""


### PR DESCRIPTION
- **Description:** The types of 'destination_chains' and 'default_chain' in 'MultiPromptChain' were changed from 'LLMChain' to 'Chain'. and removed variables declared overlapping with the parent class
- **Issue:** When a class that inherits only Chain and not LLMChain, such as 'SequentialChain' or 'RetrievalQA', is entered in 'destination_chains' and 'default_chain', a pydantic validation error is raised.
-  -  codes
```
retrieval_chain = ConversationalRetrievalChain(
        retriever=doc_retriever,
        combine_docs_chain=combine_docs_chain,
        question_generator=question_gen_chain,
    )
    
    destination_chains = {
        'retrieval': retrieval_chain,
    }
    
    main_chain = MultiPromptChain(
        router_chain=router_chain,
        destination_chains=destination_chains,
        default_chain=default_chain,
        verbose=True,
    )
```
-  -  error log
```
  File "/Users/aimmo-aip-0170/Library/Caches/pypoetry/virtualenvs/aimmo-slack-chatbot-XJShztsB-py3.9/lib/python3.9/site-packages/langchain/load/serializable.py", line 75, in __init__
    super().__init__(**kwargs)
  File "/Users/aimmo-aip-0170/Library/Caches/pypoetry/virtualenvs/aimmo-slack-chatbot-XJShztsB-py3.9/lib/python3.9/site-packages/pydantic/v1/main.py", line 341, in __init__
    raise validation_error
pydantic.v1.error_wrappers.ValidationError: 10 validation errors for MultiPromptChain
destination_chains -> retrieval -> prompt
  field required (type=value_error.missing)
destination_chains -> retrieval -> llm
  field required (type=value_error.missing)
destination_chains -> retrieval -> combine_docs_chain
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> get_chat_history
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> max_tokens_limit
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> question_generator
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> rephrase_question
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> retriever
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> return_generated_question
  extra fields not permitted (type=value_error.extra)
destination_chains -> retrieval -> return_source_documents
  extra fields not permitted (type=value_error.extra)
```
  - **Tag maintainer:** @hwchase17 


✅ `make format`, `make lint` and `make test`
