### PR TITLE
Fix stop key of TextGen.

### DIFF
--- a/libs/langchain/langchain/llms/textgen.py
+++ b/libs/langchain/langchain/llms/textgen.py
@@ -175,7 +175,7 @@ class TextGen(LLM):
             params = {"preset": self.preset}
 
         # then sets it as configured, or default to an empty list:
-        params["stop"] = self.stopping_strings or stop or []
+        params["stopping_strings"] = self.stopping_strings or stop or []
 
         return params
 


### PR DESCRIPTION
The key of stopping strings used in text-generation-webui api is [`stopping_strings`](https://github.com/oobabooga/text-generation-webui/blob/main/api-examples/api-example.py#L51), not `stop`.