### PR TITLE
add from_existing_graph to neo4j vector

### DIFF
--- a/docs/extras/integrations/vectorstores/neo4jvector.ipynb
+++ b/docs/extras/integrations/vectorstores/neo4jvector.ipynb
@@ -107,7 +107,7 @@
     "password = \"pleaseletmein\"\n",
     "\n",
     "# You can also use environment variables instead of directly passing named parameters\n",
-    "#os.environ[\"NEO4J_URL\"] = \"bolt://localhost:7687\"\n",
+    "#os.environ[\"NEO4J_URI\"] = \"bolt://localhost:7687\"\n",
     "#os.environ[\"NEO4J_USERNAME\"] = \"neo4j\"\n",
     "#os.environ[\"NEO4J_PASSWORD\"] = \"pleaseletmein\""
    ]
@@ -123,7 +123,16 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/tomaz/neo4j/langchain/libs/langchain/langchain/vectorstores/neo4j_vector.py:165: ExperimentalWarning: The configuration may change in the future.\n",
+      "  self._driver.verify_connectivity()\n"
+     ]
+    }
+   ],
    "source": [
     "# The Neo4jVector Module will connect to Neo4j and create a vector index if needed.\n",
     "\n",
@@ -139,7 +148,7 @@
    "outputs": [],
    "source": [
     "query = \"What did the president say about Ketanji Brown Jackson\"\n",
-    "docs_with_score = db.similarity_search_with_score(query)"
+    "docs_with_score = db.similarity_search_with_score(query, k=2)"
    ]
   },
   {
@@ -152,7 +161,7 @@
      "output_type": "stream",
      "text": [
       "--------------------------------------------------------------------------------\n",
-      "Score:  0.9077161550521851\n",
+      "Score:  0.9099836349487305\n",
       "Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \n",
       "\n",
       "Tonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \n",
@@ -162,50 +171,14 @@
       "And I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.\n",
       "--------------------------------------------------------------------------------\n",
       "--------------------------------------------------------------------------------\n",
-      "Score:  0.891287088394165\n",
-      "A former top litigator in private practice. A former federal public defender. And from a family of public school educators and police officers. A consensus builder. Since she’s been nominated, she’s received a broad range of support—from the Fraternal Order of Police to former judges appointed by Democrats and Republicans. \n",
+      "Score:  0.9099686145782471\n",
+      "Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \n",
       "\n",
-      "And if we are to advance liberty and justice, we need to secure the Border and fix the immigration system. \n",
+      "Tonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \n",
       "\n",
-      "We can do both. At our border, we’ve installed new technology like cutting-edge scanners to better detect drug smuggling.  \n",
+      "One of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court. \n",
       "\n",
-      "We’ve set up joint patrols with Mexico and Guatemala to catch more human traffickers.  \n",
-      "\n",
-      "We’re putting in place dedicated immigration judges so families fleeing persecution and violence can have their cases heard faster. \n",
-      "\n",
-      "We’re securing commitments and supporting partners in South and Central America to host more refugees and secure their own borders.\n",
-      "--------------------------------------------------------------------------------\n",
-      "--------------------------------------------------------------------------------\n",
-      "Score:  0.8867912292480469\n",
-      "And for our LGBTQ+ Americans, let’s finally get the bipartisan Equality Act to my desk. The onslaught of state laws targeting transgender Americans and their families is wrong. \n",
-      "\n",
-      "As I said last year, especially to our younger transgender Americans, I will always have your back as your President, so you can be yourself and reach your God-given potential. \n",
-      "\n",
-      "While it often appears that we never agree, that isn’t true. I signed 80 bipartisan bills into law last year. From preventing government shutdowns to protecting Asian-Americans from still-too-common hate crimes to reforming military justice. \n",
-      "\n",
-      "And soon, we’ll strengthen the Violence Against Women Act that I first wrote three decades ago. It is important for us to show the nation that we can come together and do big things. \n",
-      "\n",
-      "So tonight I’m offering a Unity Agenda for the Nation. Four big things we can do together.  \n",
-      "\n",
-      "First, beat the opioid epidemic.\n",
-      "--------------------------------------------------------------------------------\n",
-      "--------------------------------------------------------------------------------\n",
-      "Score:  0.8866499662399292\n",
-      "Tonight, I’m announcing a crackdown on these companies overcharging American businesses and consumers. \n",
-      "\n",
-      "And as Wall Street firms take over more nursing homes, quality in those homes has gone down and costs have gone up.  \n",
-      "\n",
-      "That ends on my watch. \n",
-      "\n",
-      "Medicare is going to set higher standards for nursing homes and make sure your loved ones get the care they deserve and expect. \n",
-      "\n",
-      "We’ll also cut costs and keep the economy going strong by giving workers a fair shot, provide more training and apprenticeships, hire them based on their skills not degrees. \n",
-      "\n",
-      "Let’s pass the Paycheck Fairness Act and paid leave.  \n",
-      "\n",
-      "Raise the minimum wage to $15 an hour and extend the Child Tax Credit, so no one has to raise a family in poverty. \n",
-      "\n",
-      "Let’s increase Pell Grants and increase our historic support of HBCUs, and invest in what Jill—our First Lady who teaches full-time—calls America’s best-kept secret: community colleges.\n",
+      "And I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.\n",
       "--------------------------------------------------------------------------------\n"
      ]
     }
@@ -232,7 +205,16 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/tomaz/neo4j/langchain/libs/langchain/langchain/vectorstores/neo4j_vector.py:165: ExperimentalWarning: The configuration may change in the future.\n",
+      "  self._driver.verify_connectivity()\n"
+     ]
+    }
+   ],
    "source": [
     "index_name = \"vector\"  # default index name\n",
     "\n",
@@ -249,8 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Add documents\n",
-    "We can add documents to the existing vectorstore."
+    "We can also initialize a vectorstore from existing graph using the `from_existing_graph` method. This method pulls relevant text information from the database, and calculates and stores the text embeddings back to the database."
    ]
   },
   {
@@ -261,10 +242,90 @@
     {
      "data": {
       "text/plain": [
-       "['064c7032-5093-11ee-8041-3b350f274873']"
+       "[]"
       ]
      },
      "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# First we create sample data in graph\n",
+    "store.query(\n",
+    "    \"CREATE (p:Person {name: 'Tomaz', location:'Slovenia', hobby:'Bicycle'})\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/tomaz/neo4j/langchain/libs/langchain/langchain/vectorstores/neo4j_vector.py:165: ExperimentalWarning: The configuration may change in the future.\n",
+      "  self._driver.verify_connectivity()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Now we initialize from existing graph\n",
+    "existing_graph = Neo4jVector.from_existing_graph(\n",
+    "        embedding=OpenAIEmbeddings(),\n",
+    "        url=url,\n",
+    "        username=username,\n",
+    "        password=password,\n",
+    "        index_name=\"person_index\",\n",
+    "        node_label=\"Person\",\n",
+    "        text_node_properties=[\"name\", \"location\"],\n",
+    "        embedding_node_property=\"embedding\",\n",
+    "    )\n",
+    "result = existing_graph.similarity_search(\"Slovenia\", k = 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Document(page_content='\\nname: Tomaz\\nlocation: Slovenia', metadata={'hobby': 'Bicycle'})"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add documents\n",
+    "We can add documents to the existing vectorstore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['187fc53a-5dde-11ee-ad78-1f6b05bf8513']"
+      ]
+     },
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -275,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {
     "scrolled": true
    },
@@ -295,7 +356,7 @@
        "(Document(page_content='foo', metadata={}), 1.0)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,9 +376,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/tomaz/neo4j/langchain/libs/langchain/langchain/vectorstores/neo4j_vector.py:165: ExperimentalWarning: The configuration may change in the future.\n",
+      "  self._driver.verify_connectivity()\n"
+     ]
+    }
+   ],
    "source": [
     "# The Neo4jVector Module will connect to Neo4j and create a vector and keyword indices if needed.\n",
     "hybrid_db = Neo4jVector.from_documents(\n",
@@ -339,9 +409,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/tomaz/neo4j/langchain/libs/langchain/langchain/vectorstores/neo4j_vector.py:165: ExperimentalWarning: The configuration may change in the future.\n",
+      "  self._driver.verify_connectivity()\n"
+     ]
+    }
+   ],
    "source": [
     "index_name = \"vector\"  # default index name\n",
     "keyword_index_name = \"keyword\" #default keyword index name\n",
@@ -368,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -377,7 +456,7 @@
        "Document(page_content='Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \\n\\nTonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \\n\\nOne of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court. \\n\\nAnd I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.', metadata={'source': '../../modules/state_of_the_union.txt'})"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -398,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,17 +498,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'answer': \"The president honored Justice Stephen Breyer, who is retiring from the United States Supreme Court, and thanked him for his service. The president also mentioned that he nominated Circuit Court of Appeals Judge Ketanji Brown Jackson to continue Justice Breyer's legacy of excellence. \\n\",\n",
+       "{'answer': \"The president honored Justice Stephen Breyer, who is retiring from the United States Supreme Court. He thanked him for his service and mentioned that he nominated Circuit Court of Appeals Judge Ketanji Brown Jackson to continue Justice Breyer's legacy of excellence. \\n\",\n",
        " 'sources': '../../modules/state_of_the_union.txt'}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/libs/langchain/langchain/vectorstores/neo4j_vector.py
+++ b/libs/langchain/langchain/vectorstores/neo4j_vector.py
@@ -885,8 +885,8 @@ class Neo4jVector(VectorStore):
                 f"MATCH (n:`{node_label}`) "
                 f"WHERE n.{embedding_node_property} IS null "
                 "AND any(k in $props WHERE n[k] IS NOT null) "
-                f"RETURN elementId(n) AS id, reduce("
-                "str='', k IN $props | str + '\\n' + k + ':' + coalesce(n[k])) AS text "
+                f"RETURN elementId(n) AS id, reduce(str='',"
+                "k IN $props | str + '\\n' + k + ':' + coalesce(n[k], '')) AS text "
                 "LIMIT 1000"
             )
             data = store.query(fetch_query, params={"props": text_node_properties})

--- a/libs/langchain/langchain/vectorstores/neo4j_vector.py
+++ b/libs/langchain/langchain/vectorstores/neo4j_vector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import os
 import uuid
 from typing import (
     Any,
@@ -148,7 +149,10 @@ class Neo4jVector(VectorStore):
             )
 
         # Handle if the credentials are environment variables
-        url = get_from_env("url", "NEO4J_URL", url)
+
+        # Support URL for backwards compatibility
+        url = os.environ.get("NEO4J_URL", url)
+        url = get_from_env("url", "NEO4J_URI", url)
         username = get_from_env("username", "NEO4J_USERNAME", username)
         password = get_from_env("password", "NEO4J_PASSWORD", password)
         database = get_from_env("database", "NEO4J_DATABASE", database)
@@ -299,7 +303,9 @@ class Neo4jVector(VectorStore):
         except IndexError:
             return None
 
-    def retrieve_existing_fts_index(self) -> Optional[str]:
+    def retrieve_existing_fts_index(
+        self, text_node_properties: List[str] = []
+    ) -> Optional[str]:
         """
         Check if the fulltext index exists in the Neo4j database
 
@@ -314,12 +320,12 @@ class Neo4jVector(VectorStore):
             "SHOW INDEXES YIELD name, type, labelsOrTypes, properties, options "
             "WHERE type = 'FULLTEXT' AND (name = $keyword_index_name "
             "OR (labelsOrTypes = [$node_label] AND "
-            "properties = [$text_node_property])) "
+            "properties = $text_node_property)) "
             "RETURN name, labelsOrTypes, properties, options ",
             params={
                 "keyword_index_name": self.keyword_index_name,
                 "node_label": self.node_label,
-                "text_node_property": self.text_node_property,
+                "text_node_property": text_node_properties or [self.text_node_property],
             },
         )
         # sort by index_name
@@ -355,17 +361,17 @@ class Neo4jVector(VectorStore):
         }
         self.query(index_query, params=parameters)
 
-    def create_new_keyword_index(self) -> None:
+    def create_new_keyword_index(self, text_node_properties: List[str] = []) -> None:
         """
         This method constructs a Cypher query and executes it
         to create a new full text index in Neo4j.
         """
+        node_props = text_node_properties or [self.text_node_property]
         fts_index_query = (
             f"CREATE FULLTEXT INDEX {self.keyword_index_name} "
             f"FOR (n:`{self.node_label}`) ON EACH "
-            f"[n.`{self.text_node_property}`]"
+            f"[{', '.join(['n.`' + el + '`' for el in node_props])}]"
         )
-
         self.query(fts_index_query)
 
     @property
@@ -781,6 +787,108 @@ class Neo4jVector(VectorStore):
             ids=ids,
             **kwargs,
         )
+
+    @classmethod
+    def from_existing_graph(
+        cls: Type[Neo4jVector],
+        embedding: Embeddings,
+        node_label: str,
+        embedding_node_property: str,
+        text_node_properties: List[str],
+        *,
+        keyword_index_name: Optional[str] = "keyword",
+        index_name: str = "vector",
+        search_type: SearchType = DEFAULT_SEARCH_TYPE,
+        retrieval_query: str = "",
+        **kwargs: Any,
+    ) -> Neo4jVector:
+        """
+        Return Neo4jVector initialized from existing graph.
+        Neo4j credentials are required in the form of `url`, `username`,
+        and `password` and optional `database` parameters.
+        """
+
+        # Prefer retrieval query from params, otherwise construct it
+        if not retrieval_query:
+            retrieval_query = (
+                f"RETURN reduce(str='', k IN {text_node_properties} |"
+                " str + '\\n' + k + ':' + coalesce(node[k], '')) AS text, "
+                "node {.*, `"
+                + embedding_node_property
+                + "`: Null, id: Null, "
+                + ", ".join([f"`{prop}`: Null" for prop in text_node_properties])
+                + "} AS metadata, score"
+            )
+        store = cls(
+            embedding=embedding,
+            index_name=index_name,
+            keyword_index_name=keyword_index_name,
+            search_type=search_type,
+            retrieval_query=retrieval_query,
+            node_label=node_label,
+            embedding_node_property=embedding_node_property,
+            **kwargs,
+        )
+
+        # Check if the vector index already exists
+        embedding_dimension = store.retrieve_existing_index()
+
+        # If the vector index doesn't exist yet
+        if not embedding_dimension:
+            store.create_new_index()
+        # If the index already exists, check if embedding dimensions match
+        elif not store.embedding_dimension == embedding_dimension:
+            raise ValueError(
+                f"Index with name {store.index_name} already exists."
+                "The provided embedding function and vector index "
+                "dimensions do not match.\n"
+                f"Embedding function dimension: {store.embedding_dimension}\n"
+                f"Vector index dimension: {embedding_dimension}"
+            )
+        # FTS index for Hybrid search
+        if search_type == SearchType.HYBRID:
+            fts_node_label = store.retrieve_existing_fts_index(text_node_properties)
+            # If the FTS index doesn't exist yet
+            if not fts_node_label:
+                store.create_new_keyword_index(text_node_properties)
+            else:  # Validate that FTS and Vector index use the same information
+                if not fts_node_label == store.node_label:
+                    raise ValueError(
+                        "Vector and keyword index don't index the same node label"
+                    )
+
+        # Populate embeddings
+        while True:
+            fetch_query = (
+                f"MATCH (n:{node_label}) "
+                f"WHERE n.{embedding_node_property} IS null "
+                "AND any(k in $props WHERE n[k] IS NOT null) "
+                f"RETURN id(n) AS id, reduce("
+                "str='', k IN $props | str + '\\n' + k + ':' + n[k]) AS text "
+                "LIMIT 1000"
+            )
+            data = store.query(fetch_query, params={"props": text_node_properties})
+            text_embeddings = embedding.embed_documents([el["text"] for el in data])
+
+            params = {
+                "data": [
+                    {"id": el["id"], "embedding": embedding}
+                    for el, embedding in zip(data, text_embeddings)
+                ]
+            }
+
+            store.query(
+                "UNWIND $data AS row "
+                f"MATCH (n:{node_label}) "
+                f"CALL db.create.setVectorProperty(n, "
+                f"'{embedding_node_property}', row.embedding) "
+                "YIELD node RETURN distinct 'done'",
+                params=params,
+            )
+
+            if len(data) < 1000:
+                break
+        return store
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         """

--- a/libs/langchain/langchain/vectorstores/neo4j_vector.py
+++ b/libs/langchain/langchain/vectorstores/neo4j_vector.py
@@ -803,9 +803,27 @@ class Neo4jVector(VectorStore):
         **kwargs: Any,
     ) -> Neo4jVector:
         """
-        Return Neo4jVector initialized from existing graph.
-        Neo4j credentials are required in the form of `url`, `username`,
-        and `password` and optional `database` parameters.
+        Initialize and return a Neo4jVector instance from an existing graph.
+
+        This method initializes a Neo4jVector instance using the provided
+        parameters and the existing graph. It validates the existence of
+        the indices and creates new ones if they don't exist.
+
+        Returns:
+        Neo4jVector: An instance of Neo4jVector initialized with the provided parameters
+                    and existing graph.
+
+        Example:
+        >>> neo4j_vector = Neo4jVector.from_existing_graph(
+        ...     embedding=my_embedding,
+        ...     node_label="Document",
+        ...     embedding_node_property="embedding",
+        ...     text_node_properties=["title", "content"]
+        ... )
+
+        Note:
+        Neo4j credentials are required in the form of `url`, `username`, and `password`,
+        and optional `database` parameters passed as additional keyword arguments.
         """
         # Validate the list is not empty
         if not text_node_properties:

--- a/libs/langchain/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -470,3 +470,147 @@ def test_neo4jvector_hybrid_from_existing() -> None:
     assert output == [Document(page_content="foo")]
 
     drop_vector_indexes(existing)
+
+
+def test_neo4jvector_from_existing_graph() -> None:
+    """Test from_existing_graph with a single property."""
+    graph = Neo4jVector.from_texts(
+        texts=["test"],
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="foo",
+        node_label="Foo",
+        embedding_node_property="vector",
+        text_node_property="info",
+        pre_delete_collection=True,
+    )
+
+    graph.query("MATCH (n) DETACH DELETE n")
+
+    graph.query("CREATE (:Test {name:'Foo'})," "(:Test {name:'Bar'})")
+
+    existing = Neo4jVector.from_existing_graph(
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="vector",
+        node_label="Test",
+        text_node_properties=["name"],
+        embedding_node_property="embedding",
+    )
+
+    output = existing.similarity_search("foo", k=1)
+    assert output == [Document(page_content="\nname: Foo")]
+
+    drop_vector_indexes(existing)
+
+
+def test_neo4jvector_from_existing_graph_hybrid() -> None:
+    """Test from_existing_graph hybrid with a single property."""
+    graph = Neo4jVector.from_texts(
+        texts=["test"],
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="foo",
+        node_label="Foo",
+        embedding_node_property="vector",
+        text_node_property="info",
+        pre_delete_collection=True,
+    )
+
+    graph.query("MATCH (n) DETACH DELETE n")
+
+    graph.query("CREATE (:Test {name:'foo'})," "(:Test {name:'Bar'})")
+
+    existing = Neo4jVector.from_existing_graph(
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="vector",
+        node_label="Test",
+        text_node_properties=["name"],
+        embedding_node_property="embedding",
+        search_type=SearchType.HYBRID,
+    )
+
+    output = existing.similarity_search("foo", k=1)
+    assert output == [Document(page_content="\nname: foo")]
+
+    drop_vector_indexes(existing)
+
+
+def test_neo4jvector_from_existing_graph_multiple_properties() -> None:
+    """Test from_existing_graph with a two property."""
+    graph = Neo4jVector.from_texts(
+        texts=["test"],
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="foo",
+        node_label="Foo",
+        embedding_node_property="vector",
+        text_node_property="info",
+        pre_delete_collection=True,
+    )
+    graph.query("MATCH (n) DETACH DELETE n")
+
+    graph.query("CREATE (:Test {name:'Foo', name2: 'Fooz'})," "(:Test {name:'Bar'})")
+
+    existing = Neo4jVector.from_existing_graph(
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="vector",
+        node_label="Test",
+        text_node_properties=["name", "name2"],
+        embedding_node_property="embedding",
+    )
+
+    output = existing.similarity_search("foo", k=1)
+    assert output == [Document(page_content="\nname: Foo\nname2: Fooz")]
+
+    drop_vector_indexes(existing)
+
+
+def test_neo4jvector_from_existing_graph_multiple_properties_hybrid() -> None:
+    """Test from_existing_graph with a two property."""
+    graph = Neo4jVector.from_texts(
+        texts=["test"],
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="foo",
+        node_label="Foo",
+        embedding_node_property="vector",
+        text_node_property="info",
+        pre_delete_collection=True,
+    )
+    graph.query("MATCH (n) DETACH DELETE n")
+
+    graph.query("CREATE (:Test {name:'Foo', name2: 'Fooz'})," "(:Test {name:'Bar'})")
+
+    existing = Neo4jVector.from_existing_graph(
+        embedding=FakeEmbeddingsWithOsDimension(),
+        url=url,
+        username=username,
+        password=password,
+        index_name="vector",
+        node_label="Test",
+        text_node_properties=["name", "name2"],
+        embedding_node_property="embedding",
+        search_type=SearchType.HYBRID,
+    )
+
+    output = existing.similarity_search("foo", k=1)
+    assert output == [Document(page_content="\nname: Foo\nname2: Fooz")]
+
+    drop_vector_indexes(existing)


### PR DESCRIPTION
This PR adds the option to create a Neo4jvector instance from existing graph, which embeds existing text in the database and creates relevant indices.

Todo:

* [x] Docs
* [x] Tests