### PR TITLE
Updating service name for bedrock

### DIFF
--- a/libs/langchain/langchain/llms/bedrock.py
+++ b/libs/langchain/langchain/llms/bedrock.py
@@ -136,7 +136,7 @@ class BedrockBase(BaseModel, ABC):
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
 
-            values["client"] = session.client("bedrock", **client_params)
+            values["client"] = session.client("bedrock-runtime", **client_params)
 
         except ImportError:
             raise ModuleNotFoundError(


### PR DESCRIPTION
## Description
With the Bedrock GA release scheduled soon, the service name has been updated to `bedrock-runtime` instead of `bedrock` for `invoke_model` and `invoke_model_with_response_stream` APIs.

