### PR TITLE
Xata chat memory FIX

### DIFF
--- a/libs/langchain/langchain/memory/chat_message_histories/xata.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/xata.py
@@ -56,7 +56,7 @@ class XataChatMessageHistory(BaseChatMessageHistory):
                     {"name": "role", "type": "string"},
                     {"name": "content", "type": "text"},
                     {"name": "name", "type": "string"},
-                    {"name": "additionalKwargs", "type": "text"},
+                    {"name": "additionalKwargs", "type": "json"},
                 ]
             },
         )
@@ -101,7 +101,7 @@ class XataChatMessageHistory(BaseChatMessageHistory):
                         "content": m["content"],
                         "role": m.get("role"),
                         "name": m.get("name"),
-                        "additionalKwargs": json.loads(m["additionalKwargs"]),
+                        "additional_kwargs": json.loads(m["additionalKwargs"]),
                     },
                 }
                 for m in r["records"]


### PR DESCRIPTION
  - **Description:** Changed data type from `text` to `json` in xata for improved performance. Also corrected the `additionalKwargs` key in the `messages()` function to `additional_kwargs` to adhere to `BaseMessage` requirements.
  - **Issue:** The Chathisroty.messages() will return {} of `additional_kwargs`, as the name is wrong for `additionalKwargs` .
  - **Dependencies:**  N/A
  - **Tag maintainer:** N/A
  - **Twitter handle:** N/A

My PR is passing linting and testing before submitting.