### PR TITLE
[ElasticsearchStore] Improve migration text to ElasticsearchStore

### DIFF
--- a/libs/langchain/langchain/vectorstores/elastic_vector_search.py
+++ b/libs/langchain/langchain/vectorstores/elastic_vector_search.py
@@ -1,4 +1,3 @@
-"""[DEPRECATED] Please use ElasticsearchStore instead."""
 from __future__ import annotations
 
 import uuid
@@ -51,9 +50,19 @@ def _default_script_query(query_vector: List[float], filter: Optional[dict]) -> 
     }
 
 
-@deprecated("0.0.265", alternative="ElasticsearchStore class.", pending=True)
 class ElasticVectorSearch(VectorStore):
-    """[DEPRECATED] `Elasticsearch` vector store.
+    """
+
+    ElasticVectorSearch uses the brute force method of searching on vectors.
+
+    Recommended to use ElasticsearchStore instead, which gives you the option
+    to uses the approx  HNSW algorithm which performs better on large datasets.
+
+    ElasticsearchStore also supports metadata filtering, customising the
+    query retriever and much more!
+
+    You can read more on ElasticsearchStore:
+    https://python.langchain.com/docs/integrations/vectorstores/elasticsearch
 
     To connect to an `Elasticsearch` instance that does not require
     login credentials, pass the Elasticsearch URL and index name along with the

--- a/libs/langchain/langchain/vectorstores/elastic_vector_search.py
+++ b/libs/langchain/langchain/vectorstores/elastic_vector_search.py
@@ -348,9 +348,16 @@ class ElasticVectorSearch(VectorStore):
             self.client.delete(index=self.index_name, id=id)
 
 
+@deprecated("0.0.265", alternative="ElasticsearchStore class.", pending=True)
 class ElasticKnnSearch(VectorStore):
     """[DEPRECATED] `Elasticsearch` with k-nearest neighbor search
     (`k-NN`) vector store.
+
+    Recommended to use ElasticsearchStore instead, which supports
+    metadata filtering, customising the query retriever and much more!
+
+    You can read more on ElasticsearchStore:
+    https://python.langchain.com/docs/integrations/vectorstores/elasticsearch
 
     It creates an Elasticsearch index of text data that
     can be searched using k-NN search. The text data is transformed into


### PR DESCRIPTION
We noticed that as we have been moving developers to the new `ElasticsearchStore` implementation, we want to keep the ElasticVectorSearch class still available as developers transition slowly to the new store.

To speed up this process, I updated the blurb giving them a better recommendation of why they should use ElasticsearchStore.
