### PR TITLE
Update Bedrock service name to "bedrock-runtime" and model identifiers

### DIFF
--- a/docs/extras/integrations/llms/bedrock.ipynb
+++ b/docs/extras/integrations/llms/bedrock.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "llm = Bedrock(\n",
     "    credentials_profile_name=\"bedrock-admin\",\n",
-    "    model_id=\"amazon.titan-tg1-large\"\n",
+    "    model_id=\"amazon.titan-text-express-v1\"\n",
     ")"
    ]
   },
@@ -82,7 +82,7 @@
     "\n",
     "llm = Bedrock(\n",
     "    credentials_profile_name=\"bedrock-admin\",\n",
-    "    model_id=\"amazon.titan-tg1-large\",\n",
+    "    model_id=\"amazon.titan-text-express-v1\",\n",
     "    streaming=True,\n",
     "    callbacks=[StreamingStdOutCallbackHandler()],\n",
     ")"

--- a/libs/langchain/langchain/embeddings/bedrock.py
+++ b/libs/langchain/langchain/embeddings/bedrock.py
@@ -30,7 +30,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             
             region_name ="us-east-1"
             credentials_profile_name = "default"
-            model_id = "amazon.titan-e1t-medium"
+            model_id = "amazon.titan-embed-text-v1"
 
             be = BedrockEmbeddings(
                 credentials_profile_name=credentials_profile_name,
@@ -54,8 +54,8 @@ class BedrockEmbeddings(BaseModel, Embeddings):
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
     """
 
-    model_id: str = "amazon.titan-e1t-medium"
-    """Id of the model to call, e.g., amazon.titan-e1t-medium, this is
+    model_id: str = "amazon.titan-embed-text-v1"
+    """Id of the model to call, e.g., amazon.titan-embed-text-v1, this is
     equivalent to the modelId property in the list-foundation-models api"""
 
     model_kwargs: Optional[Dict] = None
@@ -92,7 +92,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
 
-            values["client"] = session.client("bedrock", **client_params)
+            values["client"] = session.client("bedrock-runtime", **client_params)
 
         except ImportError:
             raise ModuleNotFoundError(

--- a/libs/langchain/langchain/llms/bedrock.py
+++ b/libs/langchain/langchain/llms/bedrock.py
@@ -143,7 +143,7 @@ class BedrockBase(BaseModel, ABC):
     """
 
     model_id: str
-    """Id of the model to call, e.g., amazon.titan-tg1-large, this is
+    """Id of the model to call, e.g., amazon.titan-text-express-v1, this is
     equivalent to the modelId property in the list-foundation-models api"""
 
     model_kwargs: Optional[Dict] = None
@@ -184,7 +184,7 @@ class BedrockBase(BaseModel, ABC):
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
 
-            values["client"] = session.client("bedrock", **client_params)
+            values["client"] = session.client("bedrock-runtime", **client_params)
 
         except ImportError:
             raise ModuleNotFoundError(
@@ -307,7 +307,7 @@ class Bedrock(LLM, BedrockBase):
 
             llm = BedrockLLM(
                 credentials_profile_name="default", 
-                model_id="amazon.titan-tg1-large",
+                model_id="amazon.titan-text-express-v1",
                 streaming=True
             )
 


### PR DESCRIPTION
- **Description:** Bedrock updated boto service name to "bedrock-runtime" for the InvokeModel and InvokeModelWithResponseStream APIs. This update also includes new model identifiers for Titan text, embedding and Anthropic.
