### PR TITLE
Expose lc_id as a classmethod

### DIFF
--- a/libs/langchain/langchain/load/serializable.py
+++ b/libs/langchain/langchain/load/serializable.py
@@ -50,20 +50,29 @@ class Serializable(BaseModel, ABC):
 
     @property
     def lc_secrets(self) -> Dict[str, str]:
-        """
-        Return a map of constructor argument names to secret ids.
-        eg. {"openai_api_key": "OPENAI_API_KEY"}
+        """A map of constructor argument names to secret ids.
+
+        For example,
+            {"openai_api_key": "OPENAI_API_KEY"}
         """
         return dict()
 
     @property
     def lc_attributes(self) -> Dict:
-        """
-        Return a list of attribute names that should be included in the
-        serialized kwargs. These attributes must be accepted by the
-        constructor.
+        """List of attribute names that should be included in the serialized kwargs.
+
+        These attributes must be accepted by the constructor.
         """
         return {}
+
+    @classmethod
+    def lc_id(cls) -> List[str]:
+        """A unique identifier for this class for serialization purposes.
+
+        The unique identifier is a list of strings that describes the path
+        to the object.
+        """
+        return [*cls.get_lc_namespace(), cls.__name__]
 
     class Config:
         extra = "ignore"
@@ -122,7 +131,7 @@ class Serializable(BaseModel, ABC):
         return {
             "lc": 1,
             "type": "constructor",
-            "id": [*self.get_lc_namespace(), self.__class__.__name__],
+            "id": self.lc_id(),
             "kwargs": lc_kwargs
             if not secrets
             else _replace_secrets(lc_kwargs, secrets),

--- a/libs/langchain/tests/unit_tests/load/test_dump.py
+++ b/libs/langchain/tests/unit_tests/load/test_dump.py
@@ -57,6 +57,7 @@ def test_person(snapshot: Any) -> None:
     assert dumps(p, pretty=True) == snapshot
     sp = SpecialPerson(another_secret="Wooo", secret="Hmm")
     assert dumps(sp, pretty=True) == snapshot
+    assert Person.lc_id() == ["test_dump", "Person"]
 
 
 @pytest.mark.requires("openai")


### PR DESCRIPTION
* Expose LC id as a class method 
* User should not need to know that the last part of the id is the class name
