### PR TITLE
Add source metadata to OutlookMessageLoader

### DIFF
--- a/libs/langchain/langchain/document_loaders/email.py
+++ b/libs/langchain/langchain/document_loaders/email.py
@@ -107,6 +107,7 @@ class OutlookMessageLoader(BaseLoader):
             Document(
                 page_content=msg.body,
                 metadata={
+                    "source": self.file_path,
                     "subject": msg.subject,
                     "sender": msg.sender,
                     "date": msg.date,


### PR DESCRIPTION
Description: Add "source" metadata to OutlookMessageLoader

This pull request adds the "source" metadata to the OutlookMessageLoader class in the load method. The "source" metadata is required when indexing with RecordManager in order to sync the index documents with a source.

Issue: None

Dependencies: None

Twitter handle: @ATelders