### PR TITLE
OpenAI gpt-3.5-turbo-instruct cost information

### DIFF
--- a/libs/langchain/langchain/callbacks/openai_info.py
+++ b/libs/langchain/langchain/callbacks/openai_info.py
@@ -23,24 +23,28 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-3.5-turbo": 0.0015,
     "gpt-3.5-turbo-0301": 0.0015,
     "gpt-3.5-turbo-0613": 0.0015,
+    "gpt-3.5-turbo-instruct": 0.0015,
     "gpt-3.5-turbo-16k": 0.003,
     "gpt-3.5-turbo-16k-0613": 0.003,
     # GPT-3.5 output
     "gpt-3.5-turbo-completion": 0.002,
     "gpt-3.5-turbo-0301-completion": 0.002,
     "gpt-3.5-turbo-0613-completion": 0.002,
+    "gpt-3.5-turbo-instruct-completion": 0.002,
     "gpt-3.5-turbo-16k-completion": 0.004,
     "gpt-3.5-turbo-16k-0613-completion": 0.004,
     # Azure GPT-35 input
     "gpt-35-turbo": 0.0015,  # Azure OpenAI version of ChatGPT
     "gpt-35-turbo-0301": 0.0015,  # Azure OpenAI version of ChatGPT
     "gpt-35-turbo-0613": 0.0015,
+    "gpt-35-turbo-instruct": 0.0015,
     "gpt-35-turbo-16k": 0.003,
     "gpt-35-turbo-16k-0613": 0.003,
     # Azure GPT-35 output
     "gpt-35-turbo-completion": 0.002,  # Azure OpenAI version of ChatGPT
     "gpt-35-turbo-0301-completion": 0.002,  # Azure OpenAI version of ChatGPT
     "gpt-35-turbo-0613-completion": 0.002,
+    "gpt-35-turbo-instruct-completion": 0.002,
     "gpt-35-turbo-16k-completion": 0.004,
     "gpt-35-turbo-16k-0613-completion": 0.004,
     # Others


### PR DESCRIPTION
Added pricing info for `gpt-3.5-turbo-instruct` for OpenAI and Azure OpenAI.