### PR TITLE
feat(embeddings): display token usage and cost for OpenAIEmbeddings

### DIFF
--- a/libs/langchain/langchain/callbacks/openai_info.py
+++ b/libs/langchain/langchain/callbacks/openai_info.py
@@ -49,6 +49,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-35-turbo-16k-0613-completion": 0.004,
     # Others
     "text-ada-001": 0.0004,
+    "text-embedding-ada-002": 0.0001,
     "ada": 0.0004,
     "text-babbage-001": 0.0005,
     "babbage": 0.0005,


### PR DESCRIPTION
This PR aims at (optionally) displaying the token usage and its cost for `OpenAIEmbeddings`, addressing #11093.

Since I don't see the need to support callbacks for embeddings [^1], I only added the logic to log the number of total tokens (which corresponds to the prompt tokens) and its cost as well as a flag to enable It.

[^1]: It's easy to export or store the embeddings in langchain and I don't think any use case would benefit from "postprocessing the embeddings".

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
 @baskaryan @hwchase17 
