### PR TITLE
Update quickstart.mdx to add backtick after `ChatMessages` 

### DIFF
--- a/docs/docs_skeleton/docs/get_started/quickstart.mdx
+++ b/docs/docs_skeleton/docs/get_started/quickstart.mdx
@@ -42,7 +42,7 @@ There are two types of language models, which in LangChain are called:
 - ChatModels: this is a language model which takes a list of messages as input and returns a message
 
 The input/output for LLMs is simple and easy to understand - a string.
-But what about ChatModels? The input there is a list of `ChatMessage`s, and the output is a single `ChatMessage`.
+But what about ChatModels? The input there is a list of `ChatMessages`, and the output is a single `ChatMessage`.
 A `ChatMessage` has two required components:
 
 - `content`: This is the content of the message.


### PR DESCRIPTION
While going through the documentation I found this small issue and wanted to contribute!

<!-- Thank you for contributing to LangChain! -->
