### PR TITLE
minor fix: remove redundant code from OpenAIFunctionsAgent

### DIFF
--- a/libs/langchain/langchain/agents/openai_functions_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_agent/base.py
@@ -50,7 +50,7 @@ class OpenAIFunctionsAgent(BaseSingleActionAgent):
 
     def get_allowed_tools(self) -> List[str]:
         """Get allowed tools."""
-        return list([t.name for t in self.tools])
+        return [t.name for t in self.tools]
 
     @root_validator
     def validate_llm(cls, values: dict) -> dict:


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** A very minor fix. Just changed `list([t.name for t in self.tools])` to `[t.name for t in self.tools]` because the `list()` is redundant.
  - **Issue:** None
  - **Dependencies:** None
  - **Tag maintainer:** @baskaryan 

