### PR TITLE
use jq schema for content_key in json_loader

### DIFF
--- a/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
+++ b/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
@@ -173,7 +173,7 @@ Another option is set `jq_schema='.'` and provide `content_key`:
 loader = JSONLoader(
     file_path='./example_data/facebook_chat_messages.jsonl',
     jq_schema='.',
-    content_key='.sender_name',
+    content_key='sender_name',
     json_lines=True)
 
 data = loader.load()
@@ -189,6 +189,59 @@ pprint(data)
     [Document(page_content='User 2', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 1}),
      Document(page_content='User 1', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 2}),
      Document(page_content='User 2', metadata={'source': 'langchain/docs/modules/indexes/document_loaders/examples/example_data/facebook_chat_messages.jsonl', 'seq_num': 3})]
+```
+
+</CodeOutputBlock>
+
+### JSON file with jq schema `content_key`
+
+If you want to load documents from a JSON file using content_key in the jq schema,
+pass is_content_key_jq_parsable=True and ensure content_key is parsable with the jq schema.
+
+```python
+file_path = './sample.json'
+pprint(Path(file_path).read_text())
+```
+
+<CodeOutputBlock lang="python">
+
+```json
+    {"data": [
+        {"attributes": {
+            "message": "message1",
+            "tags": [
+            "tag1"]},
+        "id": "1"},
+        {"attributes": {
+            "message": "message2",
+            "tags": [
+            "tag2"]},
+        "id": "2"}]}
+```
+
+</CodeOutputBlock>
+
+
+```python
+loader = JSONLoader(
+    file_path=file_path,
+    jq_schema=".data[]",
+    content_key=".attributes.message",
+    is_content_key_jq_parsable=True,
+)
+
+data = loader.load()
+```
+
+```python
+pprint(data)
+```
+
+<CodeOutputBlock lang="python">
+
+```
+    [Document(page_content='message1', metadata={'source': '/path/to/sample.json', 'seq_num': 1}),
+     Document(page_content='message2', metadata={'source': '/path/to/sample.json', 'seq_num': 2})]
 ```
 
 </CodeOutputBlock>
@@ -216,8 +269,6 @@ This allows us to pass the records (dict) into the `metadata_func` that has to b
 
 Additionally, we now have to explicitly specify in the loader, via the `content_key` argument, the key from the record where the value for the `page_content` needs to be extracted from.
 
-The `content_key` also needs to be described according to the [jq schema](https://en.wikipedia.org/wiki/Jq_(programming_language)), just like `jq_schema`.
-
 ```python
 # Define the metadata extraction function.
 def metadata_func(record: dict, metadata: dict) -> dict:
@@ -231,7 +282,7 @@ def metadata_func(record: dict, metadata: dict) -> dict:
 loader = JSONLoader(
     file_path='./example_data/facebook_chat.json',
     jq_schema='.messages[]',
-    content_key=".content",
+    content_key="content",
     metadata_func=metadata_func
 )
 
@@ -290,7 +341,7 @@ def metadata_func(record: dict, metadata: dict) -> dict:
 loader = JSONLoader(
     file_path='./example_data/facebook_chat.json',
     jq_schema='.messages[]',
-    content_key=".content",
+    content_key="content",
     metadata_func=metadata_func
 )
 
@@ -319,6 +370,8 @@ pprint(data)
 ```
 
 </CodeOutputBlock>
+
+### with jq schema `content_key`
 
 ## Common JSON structures with jq schema
 

--- a/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
+++ b/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
@@ -173,7 +173,7 @@ Another option is set `jq_schema='.'` and provide `content_key`:
 loader = JSONLoader(
     file_path='./example_data/facebook_chat_messages.jsonl',
     jq_schema='.',
-    content_key='sender_name',
+    content_key='.sender_name',
     json_lines=True)
 
 data = loader.load()
@@ -216,6 +216,7 @@ This allows us to pass the records (dict) into the `metadata_func` that has to b
 
 Additionally, we now have to explicitly specify in the loader, via the `content_key` argument, the key from the record where the value for the `page_content` needs to be extracted from.
 
+The `content_key` also needs to be described according to the [jq schema](https://en.wikipedia.org/wiki/Jq_(programming_language)), just like `jq_schema`.
 
 ```python
 # Define the metadata extraction function.
@@ -230,7 +231,7 @@ def metadata_func(record: dict, metadata: dict) -> dict:
 loader = JSONLoader(
     file_path='./example_data/facebook_chat.json',
     jq_schema='.messages[]',
-    content_key="content",
+    content_key=".content",
     metadata_func=metadata_func
 )
 
@@ -289,7 +290,7 @@ def metadata_func(record: dict, metadata: dict) -> dict:
 loader = JSONLoader(
     file_path='./example_data/facebook_chat.json',
     jq_schema='.messages[]',
-    content_key="content",
+    content_key=".content",
     metadata_func=metadata_func
 )
 

--- a/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
+++ b/docs/snippets/modules/data_connection/document_loaders/how_to/json.mdx
@@ -371,8 +371,6 @@ pprint(data)
 
 </CodeOutputBlock>
 
-### with jq schema `content_key`
-
 ## Common JSON structures with jq schema
 
 The list below provides a reference to the possible `jq_schema` the user can use to extract content from the JSON data depending on the structure.

--- a/libs/langchain/langchain/document_loaders/json_loader.py
+++ b/libs/langchain/langchain/document_loaders/json_loader.py
@@ -2,6 +2,11 @@ import json
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
+try:
+    import jq  # noqa:F401
+except ImportError:
+    raise ImportError("jq package not found, please install it with `pip install jq`")
+
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
@@ -20,6 +25,7 @@ class JSONLoader(BaseLoader):
         file_path: Union[str, Path],
         jq_schema: str,
         content_key: Optional[str] = None,
+        is_content_key_jq_parsable: Optional[bool] = False,
         metadata_func: Optional[Callable[[Dict, Dict], Dict]] = None,
         text_content: bool = True,
         json_lines: bool = False,
@@ -30,9 +36,16 @@ class JSONLoader(BaseLoader):
             file_path (Union[str, Path]): The path to the JSON or JSON Lines file.
             jq_schema (str): The jq schema to use to extract the data or text from
                 the JSON.
-            content_key (str): The key to use to extract the content from the JSON if
-                the jq_schema results to a list of objects (dict). This have to be
-                matched jq schema.
+            content_key (str, optional): The key to use to extract the content from
+                the JSON if the jq_schema results to a list of objects (dict).
+                If is_content_key_jq_parsable is True, this has to be a jq compatible
+                schema. If is_content_key_jq_parsable is False, this should be a simple
+                string key.
+            is_content_key_jq_parsable (bool, optional): A flag to determine if
+                content_key is parsable by jq or not. If True, content_key is
+                treated as a jq schema and compiled accordingly. If False or if
+                content_key is None, content_key is used as a simple string.
+                Default is False.
             metadata_func (Callable[Dict, Dict]): A function that takes in the JSON
                 object extracted by the jq_schema and the default metadata and returns
                 a dict of the updated metadata.
@@ -41,16 +54,11 @@ class JSONLoader(BaseLoader):
             json_lines (bool): Boolean flag to indicate whether the input is in
                 JSON Lines format.
         """
-        try:
-            import jq  # noqa:F401
-        except ImportError:
-            raise ImportError(
-                "jq package not found, please install it with `pip install jq`"
-            )
 
         self.file_path = Path(file_path).resolve()
         self._jq_schema = jq.compile(jq_schema)
-        self._content_key = jq.compile(content_key) if content_key else None
+        self._is_content_key_jq_parsable = is_content_key_jq_parsable
+        self._content_key = content_key
         self._metadata_func = metadata_func
         self._text_content = text_content
         self._json_lines = json_lines
@@ -90,7 +98,11 @@ class JSONLoader(BaseLoader):
     def _get_text(self, sample: Any) -> str:
         """Convert sample to string format"""
         if self._content_key is not None:
-            content = self._content_key.input(sample).first()
+            if self._is_content_key_jq_parsable:
+                compiled_content_key = jq.compile(self._content_key)
+                content = compiled_content_key.input(sample).first()
+            else:
+                content = sample[self._content_key]
         else:
             content = sample
 
@@ -132,10 +144,22 @@ class JSONLoader(BaseLoader):
                     so sample must be a dict but got `{type(sample)}`"
             )
 
-        if self._content_key and self._content_key.input(sample).text() is None:
+        if (
+            not self._is_content_key_jq_parsable
+            and sample.get(self._content_key) is None
+        ):
             raise ValueError(
                 f"Expected the jq schema to result in a list of objects (dict) \
                     with the key `{self._content_key}`"
+            )
+
+        if (
+            self._is_content_key_jq_parsable
+            and jq.compile(self._content_key).input(sample).text() is None
+        ):
+            raise ValueError(
+                f"Expected the jq schema to result in a list of objects (dict) \
+                    with the key `{self._content_key}` which should be parsable by jq"
             )
 
     def _validate_metadata_func(self, data: Any) -> None:

--- a/libs/langchain/langchain/document_loaders/json_loader.py
+++ b/libs/langchain/langchain/document_loaders/json_loader.py
@@ -2,11 +2,6 @@ import json
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
-try:
-    import jq  # noqa:F401
-except ImportError:
-    raise ImportError("jq package not found, please install it with `pip install jq`")
-
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
 
@@ -55,6 +50,13 @@ class JSONLoader(BaseLoader):
                 JSON Lines format.
         """
 
+        try:
+            import jq  # noqa:F401
+        except ImportError:
+            raise ImportError(
+                "jq package not found, please install it with `pip install jq`"
+            )
+
         self.file_path = Path(file_path).resolve()
         self._jq_schema = jq.compile(jq_schema)
         self._is_content_key_jq_parsable = is_content_key_jq_parsable
@@ -97,6 +99,8 @@ class JSONLoader(BaseLoader):
 
     def _get_text(self, sample: Any) -> str:
         """Convert sample to string format"""
+        import jq
+
         if self._content_key is not None:
             if self._is_content_key_jq_parsable:
                 compiled_content_key = jq.compile(self._content_key)
@@ -137,6 +141,8 @@ class JSONLoader(BaseLoader):
 
     def _validate_content_key(self, data: Any) -> None:
         """Check if a content key is valid"""
+        import jq
+
         sample = data.first()
         if not isinstance(sample, dict):
             raise ValueError(

--- a/libs/langchain/tests/unit_tests/document_loaders/test_json_loader.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_json_loader.py
@@ -162,7 +162,7 @@ def test_load_jsonlines(mocker: MockerFixture) -> None:
     )
 
     loader = JSONLoader(
-        file_path=file_path, jq_schema=".", content_key=".text", json_lines=True
+        file_path=file_path, jq_schema=".", content_key="text", json_lines=True
     )
     result = loader.load()
 
@@ -173,7 +173,7 @@ def test_load_jsonlines(mocker: MockerFixture) -> None:
     "params",
     (
         {"jq_schema": ".[].text"},
-        {"jq_schema": ".[]", "content_key": ".text"},
+        {"jq_schema": ".[]", "content_key": "text"},
     ),
 )
 def test_load_jsonlines_list(params: Dict, mocker: MockerFixture) -> None:
@@ -229,7 +229,7 @@ def test_load_empty_jsonlines(mocker: MockerFixture) -> None:
         (
             "pathlib.Path.read_text",
             '[{"text": "value1"}, {"text": "value2"}]',
-            {"jq_schema": ".[]", "content_key": ".text"},
+            {"jq_schema": ".[]", "content_key": "text"},
         ),
         # JSON Lines content.
         (
@@ -240,7 +240,7 @@ def test_load_empty_jsonlines(mocker: MockerFixture) -> None:
                 {"text": "value2"}
                 """
             ),
-            {"jq_schema": ".", "content_key": ".text", "json_lines": True},
+            {"jq_schema": ".", "content_key": "text", "json_lines": True},
         ),
     ),
 )
@@ -279,7 +279,7 @@ def test_json_meta_01(
         (
             "pathlib.Path.read_text",
             '[{"text": "value1"}, {"text": "value2"}]',
-            {"jq_schema": ".[]", "content_key": ".text"},
+            {"jq_schema": ".[]", "content_key": "text"},
         ),
         # JSON Lines content.
         (
@@ -290,7 +290,7 @@ def test_json_meta_01(
                         {"text": "value2"}
                         """
             ),
-            {"jq_schema": ".", "content_key": ".text", "json_lines": True},
+            {"jq_schema": ".", "content_key": "text", "json_lines": True},
         ),
     ),
 )
@@ -316,6 +316,126 @@ def test_json_meta_02(
         return {**metadata, "x": f"{record['text']}-meta"}
 
     loader = JSONLoader(file_path=file_path, metadata_func=metadata_func, **kwargs)
+    result = loader.load()
+
+    assert result == expected_docs
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        {"jq_schema": ".[].text"},
+        {"jq_schema": ".[]", "content_key": "text"},
+        {
+            "jq_schema": ".[]",
+            "content_key": ".text",
+            "is_content_key_jq_parsable": True,
+        },
+    ),
+)
+def test_load_json_with_jq_parsable_content_key(
+    params: Dict, mocker: MockerFixture
+) -> None:
+    file_path = "/workspaces/langchain/test.json"
+    expected_docs = [
+        Document(
+            page_content="value1",
+            metadata={"source": file_path, "seq_num": 1},
+        ),
+        Document(
+            page_content="value2",
+            metadata={"source": file_path, "seq_num": 2},
+        ),
+    ]
+
+    mocker.patch(
+        "pathlib.Path.open",
+        return_value=io.StringIO(
+            """
+            [{"text": "value1"}, {"text": "value2"}]
+            """
+        ),
+    )
+
+    loader = JSONLoader(file_path=file_path, json_lines=True, **params)
+    result = loader.load()
+
+    assert result == expected_docs
+
+
+def test_load_json_with_nested_jq_parsable_content_key(mocker: MockerFixture) -> None:
+    file_path = "/workspaces/langchain/test.json"
+    expected_docs = [
+        Document(
+            page_content="message1",
+            metadata={"source": file_path, "seq_num": 1},
+        ),
+        Document(
+            page_content="message2",
+            metadata={"source": file_path, "seq_num": 2},
+        ),
+    ]
+
+    mocker.patch(
+        "pathlib.Path.open",
+        return_value=io.StringIO(
+            """
+            {"data": [
+                    {"attributes": {"message": "message1","tags": ["tag1"]},"id": "1"},
+                    {"attributes": {"message": "message2","tags": ["tag2"]},"id": "2"}]}
+            """
+        ),
+    )
+
+    loader = JSONLoader(
+        file_path=file_path,
+        jq_schema=".data[]",
+        content_key=".attributes.message",
+        is_content_key_jq_parsable=True,
+    )
+    result = loader.load()
+
+    assert result == expected_docs
+
+
+def test_load_json_with_nested_jq_parsable_content_key_with_metadata(
+    mocker: MockerFixture,
+) -> None:
+    file_path = "/workspaces/langchain/test.json"
+    expected_docs = [
+        Document(
+            page_content="message1",
+            metadata={"source": file_path, "seq_num": 1, "id": "1", "tags": ["tag1"]},
+        ),
+        Document(
+            page_content="message2",
+            metadata={"source": file_path, "seq_num": 2, "id": "2", "tags": ["tag2"]},
+        ),
+    ]
+
+    mocker.patch(
+        "pathlib.Path.open",
+        return_value=io.StringIO(
+            """
+            {"data": [
+                    {"attributes": {"message": "message1","tags": ["tag1"]},"id": "1"},
+                    {"attributes": {"message": "message2","tags": ["tag2"]},"id": "2"}]}
+            """
+        ),
+    )
+
+    def _metadata_func(record: dict, metadata: dict) -> dict:
+        metadata["id"] = record.get("id")
+        metadata["tags"] = record["attributes"].get("tags")
+        return metadata
+
+    loader = JSONLoader(
+        file_path=file_path,
+        jq_schema=".data[]",
+        content_key=".attributes.message",
+        is_content_key_jq_parsable=True,
+        metadata_func=_metadata_func,
+    )
     result = loader.load()
 
     assert result == expected_docs

--- a/libs/langchain/tests/unit_tests/document_loaders/test_json_loader.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_json_loader.py
@@ -162,7 +162,7 @@ def test_load_jsonlines(mocker: MockerFixture) -> None:
     )
 
     loader = JSONLoader(
-        file_path=file_path, jq_schema=".", content_key="text", json_lines=True
+        file_path=file_path, jq_schema=".", content_key=".text", json_lines=True
     )
     result = loader.load()
 
@@ -173,7 +173,7 @@ def test_load_jsonlines(mocker: MockerFixture) -> None:
     "params",
     (
         {"jq_schema": ".[].text"},
-        {"jq_schema": ".[]", "content_key": "text"},
+        {"jq_schema": ".[]", "content_key": ".text"},
     ),
 )
 def test_load_jsonlines_list(params: Dict, mocker: MockerFixture) -> None:
@@ -229,7 +229,7 @@ def test_load_empty_jsonlines(mocker: MockerFixture) -> None:
         (
             "pathlib.Path.read_text",
             '[{"text": "value1"}, {"text": "value2"}]',
-            {"jq_schema": ".[]", "content_key": "text"},
+            {"jq_schema": ".[]", "content_key": ".text"},
         ),
         # JSON Lines content.
         (
@@ -240,7 +240,7 @@ def test_load_empty_jsonlines(mocker: MockerFixture) -> None:
                 {"text": "value2"}
                 """
             ),
-            {"jq_schema": ".", "content_key": "text", "json_lines": True},
+            {"jq_schema": ".", "content_key": ".text", "json_lines": True},
         ),
     ),
 )
@@ -279,7 +279,7 @@ def test_json_meta_01(
         (
             "pathlib.Path.read_text",
             '[{"text": "value1"}, {"text": "value2"}]',
-            {"jq_schema": ".[]", "content_key": "text"},
+            {"jq_schema": ".[]", "content_key": ".text"},
         ),
         # JSON Lines content.
         (
@@ -290,7 +290,7 @@ def test_json_meta_01(
                         {"text": "value2"}
                         """
             ),
-            {"jq_schema": ".", "content_key": "text", "json_lines": True},
+            {"jq_schema": ".", "content_key": ".text", "json_lines": True},
         ),
     ),
 )


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this comment with:
  - Description: a description of the change, 
  - Issue: the issue # it fixes (if applicable),
  - Dependencies: any dependencies required for this change,
  - Tag maintainer: for a quicker response, tag the relevant maintainer (see below),
  - Twitter handle: we announce bigger features on Twitter. If your PR gets announced and you'd like a mention, we'll gladly shout you out!

Please make sure you're PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use.

Maintainer responsibilities:
  - General / Misc / if you don't know who to tag: @baskaryan
  - DataLoaders / VectorStores / Retrievers: @rlancemartin, @eyurtsev
  - Models / Prompts: @hwchase17, @baskaryan
  - Memory: @hwchase17
  - Agents / Tools / Toolkits: @hinthornw
  - Tracing / Callbacks: @agola11
  - Async: @agola11

If no one reviews your PR within a few days, feel free to @-mention the same people again.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
 -->

### Description
Changed the value specified for `content_key` in JSONLoader from a single key to a value based on jq schema.

Sorry, I created the [same Pull Request](https://github.com/langchain-ai/langchain/pull/8075) in the past, but some time has elapsed and it was closed, so I am recreating it.

### Why
For json data like the following, specify `.data[].attributes.message` for page_content and `.data[].attributes.id` or `.data[].attributes.attributes. tags`, etc., the `content_key` must also parse the json structure.

<details>
<summary>sample json data</summary>

```json
{
  "data": [
    {
      "attributes": {
        "attributes": {
          "dd": {
            "service": "worker",
            "env": "production",
            "version": "6b2c46a5883a9097aa2cb09907786b5c06ca3bd0"
          },
          "source": "stderr",
          "service": "worker",
          "name": "app.services.predict_services",
          "levelname": "ERROR",
          "container_id": "f9f880b243cc41f1a7d9bae5bf922d60-1262558729",
          "timestamp": 1686679407827.0
        },
        "message": "error while processing user #19084: 'numpy.dtype[bool_]' object is not callable",
        "service": "worker",
        "status": "error",
        "tags": [
          "datadog.submission_auth:private_api_key",
          "env:production"
        ],
        "timestamp": "2023-06-14T03:03:27.827000+09:00"
      },
      "id": "AgAAAYi17UzTUeIczgAAAAAAAAAYAAAAAEFZaTE3VThXQUFEOF9sS2J4Z3psRmdBRAAAACQAAAAAMDE4OGI2MzYtMmZlNC00ZDEwLThjZDMtMzhkZTI0NmUyNWMz",
      "type": "log"
    },
    {
      "attributes": {
        "attributes": {
          "dd": {
            "service": "worker",
            "env": "production",
            "version": "6b2c46a5883a9097aa2cb09907786b5c06ca3bd0"
          },
          "process": 42.0,
          "messages": "error while processing user #19084: 'numpy.dtype[bool_]' object is not callable",
          "levelname": "ERROR",
          "container_id": "f9f880b243cc41f1a7d9bae5bf922d60-1262558729",
          "timestamp": 1686679407831.0
        },
        "message": "{\"messages\": \"error while processing user #19084: 'numpy.dtype[bool_]' object is not callable\"}",
        "service": "worker",
        "status": "error",
        "tags": [
          "datadog.submission_auth:private_api_key",
          "env:production"
        ],
        "timestamp": "2023-06-14T03:03:27.831000+09:00"
      },
      "id": "AgAAAYi17UzXUeIczwAAAAAAAAAYAAAAAEFZaTE3VThXQUFEOF9sS2J4Z3psRmdBRQAAACQAAAAAMDE4OGI2MzYtMmZlNC00ZDEwLThjZDMtMzhkZTI0NmUyNWMz",
      "type": "log"
    }
  ],
  "meta": {
    "elapsed": 26,
    "request_id": "pddv1ChY0SmttaDA0a1REeXZRM01yNkFwYnd3Ii0KHWIANr8mghGpsMIX2cOarI6t4WyTVObXx3wrAuudEgzSbtmduLtPxFVkSo0",
    "status": "done"
  }
}

```

</details>

<details>
<summary>sample code</summary>

```python
def metadata_func(record: dict, metadata: dict) -> dict:
    print(record)

    metadata["id"] = record.get("id")
    metadata["tags"] = record["attributes"].get("tags")

    return metadata

sample_file = "sample.json"
loader = JSONLoader(
    file_path=sample_file,
    jq_schema=".data[]",
    content_key=".attributes.message",
    metadata_func=metadata_func
)
```

</details>

### Dependencies
none

### Tag maintainer
@rlancemartin, @eyurtsev

### Twitter handle
[kzk_maeda](https://twitter.com/kzk_maeda)