### PR TITLE
rename repo namespace to langchain-ai

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,7 +8,7 @@ You can use the dev container configuration in this folder to build and run the 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hwchase17/langchain)
 
 You may use the button above, or follow these steps to open this repo in a Codespace:
-1. Click the **Code** drop-down menu at the top of https://github.com/hwchase17/langchain.
+1. Click the **Code** drop-down menu at the top of https://github.com/langchain-ai/langchain.
 1. Click on the **Codespaces** tab.
 1. Click **Create codespace on master** .
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,7 +5,7 @@ This project includes a [dev container](https://containers.dev/), which lets you
 You can use the dev container configuration in this folder to build and run the app without needing to install any of its tools locally! You can use it in [GitHub Codespaces](https://github.com/features/codespaces) or the [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
 ## GitHub Codespaces
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hwchase17/langchain)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/langchain-ai/langchain)
 
 You may use the button above, or follow these steps to open this repo in a Codespace:
 1. Click the **Code** drop-down menu at the top of https://github.com/langchain-ai/langchain.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ best way to get our attention.
 
 ### 🚩GitHub Issues
 
-Our [issues](https://github.com/hwchase17/langchain/issues) page is kept up to date
+Our [issues](https://github.com/langchain-ai/langchain/issues) page is kept up to date
 with bugs, improvements, and feature requests.
 
 There is a taxonomy of labels to help with sorting and discovery of issues of interest. Please use these to help
@@ -60,7 +60,7 @@ we do not want these to get in the way of getting good code into the codebase.
 ## 🚀 Quick Start
 
 This quick start describes running the repository locally.
-For a [development container](https://containers.dev/), see the [.devcontainer folder](https://github.com/hwchase17/langchain/tree/master/.devcontainer).
+For a [development container](https://containers.dev/), see the [.devcontainer folder](https://github.com/langchain-ai/langchain/tree/master/.devcontainer).
 
 ### Dependency Management: Poetry and other env/dependency managers
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -27,4 +27,4 @@ body:
     attributes:
       label: Your contribution
       description: |
-        Is there any way that you could help, e.g. by submitting a PR? Make sure to read the CONTRIBUTING.MD [readme](https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md)
+        Is there any way that you could help, e.g. by submitting a PR? Make sure to read the CONTRIBUTING.MD [readme](https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Replace this entire comment with:
 Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.
 
 See contribution guidelines for more information on how to write/run tests, lint, etc: 
-https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
+https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md
 
 If you're adding a new integration, please include:
   1. a test for the integration, preferably unit tests that do not rely on network access,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,4 +5,4 @@ authors:
   given-names: "Harrison"
 title: "LangChain"
 date-released: 2022-10-17
-url: "https://github.com/hwchase17/langchain"
+url: "https://github.com/langchain-ai/langchain"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Open Issues](https://img.shields.io/github/issues-raw/langchain-ai/langchain)](https://github.com/langchain-ai/langchain/issues)
 
 
-Looking for the JS/TS version? Check out [LangChain.js](https://github.com/hwchase17/langchainjs).
+Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langchain-ai/langchainjs).
 
 **Production Support:** As you move your LangChains into production, we'd love to offer more hands-on support.
 Fill out [this form](https://airtable.com/appwQzlErAS2qiP0L/shrGtGaVBVAz7NcV2) to share more about what you're building, and our team will get in touch.
@@ -26,7 +26,7 @@ Fill out [this form](https://airtable.com/appwQzlErAS2qiP0L/shrGtGaVBVAz7NcV2) t
 In an effort to make `langchain` leaner and safer, we are moving select chains to `langchain_experimental`.
 This migration has already started, but we are remaining backwards compatible until 7/28.
 On that date, we will remove functionality from `langchain`.
-Read more about the motivation and the progress [here](https://github.com/hwchase17/langchain/discussions/8043).
+Read more about the motivation and the progress [here](https://github.com/langchain-ai/langchain/discussions/8043).
 Read how to migrate your code [here](MIGRATE.md).
 
 ## Quick Install
@@ -49,7 +49,7 @@ This library aims to assist in the development of those types of applications. C
 **💬 Chatbots**
 
 - [Documentation](https://python.langchain.com/docs/use_cases/chatbots/)
-- End-to-end Example: [Chat-LangChain](https://github.com/hwchase17/chat-langchain)
+- End-to-end Example: [Chat-LangChain](https://github.com/langchain-ai/chat-langchain)
 
 **🤖 Agents**
 

--- a/docs/docs_skeleton/docs/get_started/introduction.mdx
+++ b/docs/docs_skeleton/docs/get_started/introduction.mdx
@@ -20,7 +20,7 @@ Off-the-shelf chains make it easy to get started. For complex applications, comp
 
 We recommend following our [Quickstart](/docs/get_started/quickstart) guide to familiarize yourself with the framework by building your first LangChain application.
 
-_**Note**: These docs are for the LangChain [Python package](https://github.com/hwchase17/langchain). For documentation on [LangChain.js](https://github.com/hwchase17/langchainjs), the JS/TS version, [head here](https://js.langchain.com/docs)._
+_**Note**: These docs are for the LangChain [Python package](https://github.com/langchain-ai/langchain). For documentation on [LangChain.js](https://github.com/langchain-ai/langchainjs), the JS/TS version, [head here](https://js.langchain.com/docs)._
 
 ## Modules
 

--- a/docs/docs_skeleton/docusaurus.config.js
+++ b/docs/docs_skeleton/docusaurus.config.js
@@ -196,7 +196,7 @@ const config = {
           },
           // Please keep GitHub link to the right for consistency.
           {
-            href: "https://github.com/hwchase17/langchain",
+            href: "https://github.com/langchain-ai/langchain",
             position: "right",
             className: "header-github-link",
             "aria-label": "GitHub repository",
@@ -224,11 +224,11 @@ const config = {
             items: [
               {
                 label: "Python",
-                href: "https://github.com/hwchase17/langchain",
+                href: "https://github.com/langchain-ai/langchain",
               },
               {
                 label: "JS/TS",
-                href: "https://github.com/hwchase17/langchainjs",
+                href: "https://github.com/langchain-ai/langchainjs",
               },
             ],
           },

--- a/docs/extras/additional_resources/dependents.mdx
+++ b/docs/extras/additional_resources/dependents.mdx
@@ -93,7 +93,7 @@ Dependents stats for `langchain-ai/langchain`
 |[thomas-yanxin/LangChain-ChatGLM-Webui](https://github.com/thomas-yanxin/LangChain-ChatGLM-Webui) | 2039 |
 |[NVIDIA/NeMo-Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | 1992 |
 |[Farama-Foundation/PettingZoo](https://github.com/Farama-Foundation/PettingZoo) | 1949 |
-|[langchain-ai/notion-qa](https://github.com/hwchase17/notion-qa) | 1915 |
+|[hwchase17/notion-qa](https://github.com/hwchase17/notion-qa) | 1915 |
 |[paulpierre/RasaGPT](https://github.com/paulpierre/RasaGPT) | 1783 |
 |[jupyterlab/jupyter-ai](https://github.com/jupyterlab/jupyter-ai) | 1761 |
 |[vocodedev/vocode-python](https://github.com/vocodedev/vocode-python) | 1627 |
@@ -249,7 +249,7 @@ Dependents stats for `langchain-ai/langchain`
 |[shaman-ai/agent-actors](https://github.com/shaman-ai/agent-actors) | 227 |
 |[gia-guar/JARVIS-ChatGPT](https://github.com/gia-guar/JARVIS-ChatGPT) | 224 |
 |[shamspias/customizable-gpt-chatbot](https://github.com/shamspias/customizable-gpt-chatbot) | 223 |
-|[hwchase17/langchain-streamlit-template](https://github.com/langchain-ai/langchain-streamlit-template) | 222 |
+|[hwchase17/langchain-streamlit-template](https://github.com/hwchase17/langchain-streamlit-template) | 222 |
 |[alvarosevilla95/autolang](https://github.com/alvarosevilla95/autolang) | 221 |
 |[radi-cho/datasetGPT](https://github.com/radi-cho/datasetGPT) | 221 |
 |[gustavz/DataChad](https://github.com/gustavz/DataChad) | 219 |

--- a/docs/extras/additional_resources/dependents.mdx
+++ b/docs/extras/additional_resources/dependents.mdx
@@ -39,7 +39,7 @@ Dependents stats for `langchain-ai/langchain`
 |[go-skynet/LocalAI](https://github.com/go-skynet/LocalAI) | 9955 |
 |[AIGC-Audio/AudioGPT](https://github.com/AIGC-Audio/AudioGPT) | 9081 |
 |[gventuri/pandas-ai](https://github.com/gventuri/pandas-ai) | 8201 |
-|[hwchase17/langchainjs](https://github.com/hwchase17/langchainjs) | 7754 |
+|[langchain-ai/langchainjs](https://github.com/langchain-ai/langchainjs) | 7754 |
 |[langgenius/dify](https://github.com/langgenius/dify) | 7348 |
 |[PipedreamHQ/pipedream](https://github.com/PipedreamHQ/pipedream) | 6950 |
 |[h2oai/h2ogpt](https://github.com/h2oai/h2ogpt) | 6858 |
@@ -93,7 +93,7 @@ Dependents stats for `langchain-ai/langchain`
 |[thomas-yanxin/LangChain-ChatGLM-Webui](https://github.com/thomas-yanxin/LangChain-ChatGLM-Webui) | 2039 |
 |[NVIDIA/NeMo-Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | 1992 |
 |[Farama-Foundation/PettingZoo](https://github.com/Farama-Foundation/PettingZoo) | 1949 |
-|[hwchase17/notion-qa](https://github.com/hwchase17/notion-qa) | 1915 |
+|[langchain-ai/notion-qa](https://github.com/hwchase17/notion-qa) | 1915 |
 |[paulpierre/RasaGPT](https://github.com/paulpierre/RasaGPT) | 1783 |
 |[jupyterlab/jupyter-ai](https://github.com/jupyterlab/jupyter-ai) | 1761 |
 |[vocodedev/vocode-python](https://github.com/vocodedev/vocode-python) | 1627 |
@@ -249,7 +249,7 @@ Dependents stats for `langchain-ai/langchain`
 |[shaman-ai/agent-actors](https://github.com/shaman-ai/agent-actors) | 227 |
 |[gia-guar/JARVIS-ChatGPT](https://github.com/gia-guar/JARVIS-ChatGPT) | 224 |
 |[shamspias/customizable-gpt-chatbot](https://github.com/shamspias/customizable-gpt-chatbot) | 223 |
-|[hwchase17/langchain-streamlit-template](https://github.com/hwchase17/langchain-streamlit-template) | 222 |
+|[hwchase17/langchain-streamlit-template](https://github.com/langchain-ai/langchain-streamlit-template) | 222 |
 |[alvarosevilla95/autolang](https://github.com/alvarosevilla95/autolang) | 221 |
 |[radi-cho/datasetGPT](https://github.com/radi-cho/datasetGPT) | 221 |
 |[gustavz/DataChad](https://github.com/gustavz/DataChad) | 219 |

--- a/docs/extras/guides/deployments/template_repos.mdx
+++ b/docs/extras/guides/deployments/template_repos.mdx
@@ -6,13 +6,13 @@ This section covers several options for that. Note that these options are meant 
 
 What follows is a list of template GitHub repositories designed to be easily forked and modified to use your chain. This list is far from exhaustive, and we are EXTREMELY open to contributions here.
 
-## [Streamlit](https://github.com/langchain-ai/langchain-streamlit-template)
+## [Streamlit](https://github.com/hwchase17/langchain-streamlit-template)
 
 This repo serves as a template for how to deploy a LangChain with Streamlit.
 It implements a chatbot interface.
 It also contains instructions for how to deploy this app on the Streamlit platform.
 
-## [Gradio (on Hugging Face)](https://github.com/langchain-ai/langchain-gradio-template)
+## [Gradio (on Hugging Face)](https://github.com/hwchase17/langchain-gradio-template)
 
 This repo serves as a template for how to deploy a LangChain with Gradio.
 It implements a chatbot interface, with a "Bring-Your-Own-Token" approach (nice for not wracking up big bills).

--- a/docs/extras/guides/deployments/template_repos.mdx
+++ b/docs/extras/guides/deployments/template_repos.mdx
@@ -6,13 +6,13 @@ This section covers several options for that. Note that these options are meant 
 
 What follows is a list of template GitHub repositories designed to be easily forked and modified to use your chain. This list is far from exhaustive, and we are EXTREMELY open to contributions here.
 
-## [Streamlit](https://github.com/hwchase17/langchain-streamlit-template)
+## [Streamlit](https://github.com/langchain-ai/langchain-streamlit-template)
 
 This repo serves as a template for how to deploy a LangChain with Streamlit.
 It implements a chatbot interface.
 It also contains instructions for how to deploy this app on the Streamlit platform.
 
-## [Gradio (on Hugging Face)](https://github.com/hwchase17/langchain-gradio-template)
+## [Gradio (on Hugging Face)](https://github.com/langchain-ai/langchain-gradio-template)
 
 This repo serves as a template for how to deploy a LangChain with Gradio.
 It implements a chatbot interface, with a "Bring-Your-Own-Token" approach (nice for not wracking up big bills).

--- a/docs/extras/integrations/document_loaders/git.ipynb
+++ b/docs/extras/integrations/document_loaders/git.ipynb
@@ -40,7 +40,7 @@
     "from git import Repo\n",
     "\n",
     "repo = Repo.clone_from(\n",
-    "    \"https://github.com/hwchase17/langchain\", to_path=\"./example_data/test_repo1\"\n",
+    "    \"https://github.com/langchain-ai/langchain\", to_path=\"./example_data/test_repo1\"\n",
     ")\n",
     "branch = repo.head.reference"
    ]
@@ -123,7 +123,7 @@
    "outputs": [],
    "source": [
     "loader = GitLoader(\n",
-    "    clone_url=\"https://github.com/hwchase17/langchain\",\n",
+    "    clone_url=\"https://github.com/langchain-ai/langchain\",\n",
     "    repo_path=\"./example_data/test_repo2/\",\n",
     "    branch=\"master\",\n",
     ")"

--- a/docs/extras/integrations/document_loaders/github.ipynb
+++ b/docs/extras/integrations/document_loaders/github.ipynb
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "loader = GitHubIssuesLoader(\n",
-    "    repo=\"hwchase17/langchain\",\n",
+    "    repo=\"langchain-ai/langchain\",\n",
     "    access_token=ACCESS_TOKEN,  # delete/comment out this argument if you've set the access token as an env var.\n",
     "    creator=\"UmerHA\",\n",
     ")"
@@ -117,7 +117,7 @@
       "DataLoaders\r\n",
       "- @eyurtsev\r\n",
       "\n",
-      "{'url': 'https://github.com/hwchase17/langchain/pull/5408', 'title': 'DocumentLoader for GitHub', 'creator': 'UmerHA', 'created_at': '2023-05-29T14:50:53Z', 'comments': 0, 'state': 'open', 'labels': ['enhancement', 'lgtm', 'doc loader'], 'assignee': None, 'milestone': None, 'locked': False, 'number': 5408, 'is_pull_request': True}\n"
+      "{'url': 'https://github.com/langchain-ai/langchain/pull/5408', 'title': 'DocumentLoader for GitHub', 'creator': 'UmerHA', 'created_at': '2023-05-29T14:50:53Z', 'comments': 0, 'state': 'open', 'labels': ['enhancement', 'lgtm', 'doc loader'], 'assignee': None, 'milestone': None, 'locked': False, 'number': 5408, 'is_pull_request': True}\n"
      ]
     }
    ],
@@ -147,7 +147,7 @@
    "outputs": [],
    "source": [
     "loader = GitHubIssuesLoader(\n",
-    "    repo=\"hwchase17/langchain\",\n",
+    "    repo=\"langchain-ai/langchain\",\n",
     "    access_token=ACCESS_TOKEN,  # delete/comment out this argument if you've set the access token as an env var.\n",
     "    creator=\"UmerHA\",\n",
     "    include_prs=False,\n",
@@ -220,7 +220,7 @@
       "### Expected behavior\n",
       "\n",
       "Chain should run\n",
-      "{'url': 'https://github.com/hwchase17/langchain/issues/5027', 'title': \"ChatOpenAI models don't work with prompts created via ChatPromptTemplate.from_role_strings\", 'creator': 'UmerHA', 'created_at': '2023-05-20T10:39:18Z', 'comments': 1, 'state': 'open', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 5027, 'is_pull_request': False}\n"
+      "{'url': 'https://github.com/langchain-ai/langchain/issues/5027', 'title': \"ChatOpenAI models don't work with prompts created via ChatPromptTemplate.from_role_strings\", 'creator': 'UmerHA', 'created_at': '2023-05-20T10:39:18Z', 'comments': 1, 'state': 'open', 'labels': [], 'assignee': None, 'milestone': None, 'locked': False, 'number': 5027, 'is_pull_request': False}\n"
      ]
     }
    ],

--- a/docs/extras/integrations/document_loaders/readthedocs_documentation.ipynb
+++ b/docs/extras/integrations/document_loaders/readthedocs_documentation.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "This notebook covers how to load content from HTML that was generated as part of a `Read-The-Docs` build.\n",
     "\n",
-    "For an example of this in the wild, see [here](https://github.com/hwchase17/chat-langchain).\n",
+    "For an example of this in the wild, see [here](https://github.com/langchain-ai/chat-langchain).\n",
     "\n",
     "This assumes that the HTML has already been scraped into a folder. This can be done by uncommenting and running the following command"
    ]

--- a/docs/extras/integrations/document_loaders/tomarkdown.ipynb
+++ b/docs/extras/integrations/document_loaders/tomarkdown.ipynb
@@ -173,7 +173,7 @@
       "\n",
       "Additional resources we think may be useful as you develop your application!\n",
       "\n",
-      "- [LangChainHub](https://github.com/langchain-ai/langchain-hub): The LangChainHub is a place to share and explore other prompts, chains, and agents.\n",
+      "- [LangChainHub](https://github.com/hwchase17/langchain-hub): The LangChainHub is a place to share and explore other prompts, chains, and agents.\n",
       "\n",
       "- [Gallery](https://python.langchain.com/en/latest/additional_resources/gallery.html): A collection of our favorite projects that use LangChain. Useful for finding inspiration or seeing how things were done in other applications.\n",
       "\n",

--- a/docs/extras/integrations/document_loaders/tomarkdown.ipynb
+++ b/docs/extras/integrations/document_loaders/tomarkdown.ipynb
@@ -173,7 +173,7 @@
       "\n",
       "Additional resources we think may be useful as you develop your application!\n",
       "\n",
-      "- [LangChainHub](https://github.com/hwchase17/langchain-hub): The LangChainHub is a place to share and explore other prompts, chains, and agents.\n",
+      "- [LangChainHub](https://github.com/langchain-ai/langchain-hub): The LangChainHub is a place to share and explore other prompts, chains, and agents.\n",
       "\n",
       "- [Gallery](https://python.langchain.com/en/latest/additional_resources/gallery.html): A collection of our favorite projects that use LangChain. Useful for finding inspiration or seeing how things were done in other applications.\n",
       "\n",

--- a/docs/extras/integrations/llms/modal.ipynb
+++ b/docs/extras/integrations/llms/modal.ipynb
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [`langchain.llms.modal.Modal`](https://github.com/hwchase17/langchain/blame/master/langchain/llms/modal.py) integration class requires that you deploy a Modal application with a web endpoint that complies with the following JSON interface:\n",
+    "The [`langchain.llms.modal.Modal`](https://github.com/langchain-ai/langchain/blame/master/langchain/llms/modal.py) integration class requires that you deploy a Modal application with a web endpoint that complies with the following JSON interface:\n",
     "\n",
     "1. The LLM prompt is accepted as a `str` value under the key `\"prompt\"`\n",
     "2. The LLM response returned as a `str` value under the key `\"prompt\"`\n",

--- a/docs/extras/integrations/providers/vectara/vectara_chat.ipynb
+++ b/docs/extras/integrations/providers/vectara/vectara_chat.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Chat Over Documents with Vectara\n",
     "\n",
-    "This notebook is based on the [chat_vector_db](https://github.com/hwchase17/langchain/blob/master/docs/modules/chains/index_examples/chat_vector_db.html) notebook, but using Vectara as the vector database."
+    "This notebook is based on the [chat_vector_db](https://github.com/langchain-ai/langchain/blob/master/docs/modules/chains/index_examples/chat_vector_db.html) notebook, but using Vectara as the vector database."
    ]
   },
   {

--- a/docs/extras/integrations/providers/vectara/vectara_text_generation.ipynb
+++ b/docs/extras/integrations/providers/vectara/vectara_text_generation.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Vectara Text Generation\n",
     "\n",
-    "This notebook is based on [text generation](https://github.com/hwchase17/langchain/blob/master/docs/modules/chains/index_examples/vector_db_text_generation.ipynb) notebook and adapted to Vectara."
+    "This notebook is based on [text generation](https://github.com/langchain-ai/langchain/blob/master/docs/modules/chains/index_examples/vector_db_text_generation.ipynb) notebook and adapted to Vectara."
    ]
   },
   {

--- a/docs/extras/modules/chains/how_to/from_hub.ipynb
+++ b/docs/extras/modules/chains/how_to/from_hub.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Loading from LangChainHub\n",
     "\n",
-    "This notebook covers how to load chains from [LangChainHub](https://github.com/langchain-ai/langchain-hub)."
+    "This notebook covers how to load chains from [LangChainHub](https://github.com/hwchase17/langchain-hub)."
    ]
   },
   {

--- a/docs/extras/modules/chains/how_to/from_hub.ipynb
+++ b/docs/extras/modules/chains/how_to/from_hub.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Loading from LangChainHub\n",
     "\n",
-    "This notebook covers how to load chains from [LangChainHub](https://github.com/hwchase17/langchain-hub)."
+    "This notebook covers how to load chains from [LangChainHub](https://github.com/langchain-ai/langchain-hub)."
    ]
   },
   {

--- a/docs/extras/modules/model_io/prompts/prompt_templates/formats.mdx
+++ b/docs/extras/modules/model_io/prompts/prompt_templates/formats.mdx
@@ -26,4 +26,4 @@ prompt.format(adjective="funny", content="chickens")
 # Output: Tell me a funny joke about chickens.
 ```
 
-Currently, only `jinja2` and `f-string` are supported. For other formats, kindly raise an issue on the [Github page](https://github.com/hwchase17/langchain/issues).
+Currently, only `jinja2` and `f-string` are supported. For other formats, kindly raise an issue on the [Github page](https://github.com/langchain-ai/langchain/issues).

--- a/docs/extras/use_cases/code_understanding.ipynb
+++ b/docs/extras/use_cases/code_understanding.ipynb
@@ -92,7 +92,7 @@
    "source": [
     "# Clone\n",
     "repo_path = \"/Users/rlm/Desktop/test_repo\"\n",
-    "# repo = Repo.clone_from(\"https://github.com/hwchase17/langchain\", to_path=repo_path)"
+    "# repo = Repo.clone_from(\"https://github.com/langchain-ai/langchain\", to_path=repo_path)"
    ]
   },
   {

--- a/docs/extras/use_cases/more/agents/agent_simulations/multiagent_bidding.ipynb
+++ b/docs/extras/use_cases/more/agents/agent_simulations/multiagent_bidding.ipynb
@@ -414,7 +414,7 @@
     "1. define a format they will produce their outputs in\n",
     "2. parse their outputs\n",
     "\n",
-    "We can subclass the [RegexParser](https://github.com/hwchase17/langchain/blob/master/langchain/output_parsers/regex.py) to implement our own custom output parser for bids."
+    "We can subclass the [RegexParser](https://github.com/langchain-ai/langchain/blob/master/langchain/output_parsers/regex.py) to implement our own custom output parser for bids."
    ]
   },
   {

--- a/docs/extras/use_cases/more/agents/agents/sales_agent_with_context.ipynb
+++ b/docs/extras/use_cases/more/agents/agents/sales_agent_with_context.ipynb
@@ -19,7 +19,7 @@
     "Here, we show how the AI Sales Agent can use a **Product Knowledge Base** to speak about a particular's company offerings,\n",
     "hence increasing relevance and reducing hallucinations.\n",
     "\n",
-    "We leverage the [`langchain`](https://github.com/hwchase17/langchain) library in this implementation, specifically [Custom Agent Configuration](https://langchain-langchain.vercel.app/docs/modules/agents/how_to/custom_agent_with_tool_retrieval) and are inspired by [BabyAGI](https://github.com/yoheinakajima/babyagi) architecture ."
+    "We leverage the [`langchain`](https://github.com/langchain-ai/langchain) library in this implementation, specifically [Custom Agent Configuration](https://langchain-langchain.vercel.app/docs/modules/agents/how_to/custom_agent_with_tool_retrieval) and are inspired by [BabyAGI](https://github.com/yoheinakajima/babyagi) architecture ."
    ]
   },
   {

--- a/docs/extras/use_cases/more/code_writing/cpal.ipynb
+++ b/docs/extras/use_cases/more/code_writing/cpal.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "The CPAL chain builds on the recent PAL to stop LLM hallucination. The problem with the PAL approach is that it hallucinates on a math problem with a nested chain of dependence. The innovation here is that this new CPAL approach includes causal structure to fix hallucination.\n",
     "\n",
-    "The original [PR's description](https://github.com/hwchase17/langchain/pull/6255) contains a full overview.\n",
+    "The original [PR's description](https://github.com/langchain-ai/langchain/pull/6255) contains a full overview.\n",
     "\n",
     "Using the CPAL chain, the LLM translated this\n",
     "\n",

--- a/docs/extras/use_cases/question_answering/how_to/local_retrieval_qa.ipynb
+++ b/docs/extras/use_cases/question_answering/how_to/local_retrieval_qa.ipynb
@@ -617,7 +617,7 @@
     "\n",
     "For an even simpler flow, use `RetrievalQA`.\n",
     "\n",
-    "This will use a QA default prompt (shown [here](https://github.com/hwchase17/langchain/blob/275b926cf745b5668d3ea30236635e20e7866442/langchain/chains/retrieval_qa/prompt.py#L4)) and will retrieve from the vectorDB.\n",
+    "This will use a QA default prompt (shown [here](https://github.com/langchain-ai/langchain/blob/275b926cf745b5668d3ea30236635e20e7866442/langchain/chains/retrieval_qa/prompt.py#L4)) and will retrieve from the vectorDB.\n",
     "\n",
     "But, you can still pass in a prompt, as before, if desired."
    ]

--- a/docs/snippets/modules/data_connection/retrievers/get_started.mdx
+++ b/docs/snippets/modules/data_connection/retrievers/get_started.mdx
@@ -66,7 +66,7 @@ from langchain.chains import RetrievalQA
 from langchain.llms import OpenAI
 ```
 
-Next in the generic setup, let's specify the document loader we want to use. You can download the `state_of_the_union.txt` file [here](https://github.com/hwchase17/langchain/blob/master/docs/extras/modules/state_of_the_union.txt).
+Next in the generic setup, let's specify the document loader we want to use. You can download the `state_of_the_union.txt` file [here](https://github.com/langchain-ai/langchain/blob/master/docs/extras/modules/state_of_the_union.txt).
 
 
 ```python

--- a/docs/snippets/modules/model_io/models/llms/how_to/streaming_llm.mdx
+++ b/docs/snippets/modules/model_io/models/llms/how_to/streaming_llm.mdx
@@ -1,4 +1,4 @@
-Currently, we support streaming for a broad range of LLM implementations, including but not limited to `OpenAI`, `ChatOpenAI`, `ChatAnthropic`, `Hugging Face Text Generation Inference`, and `Replicate`. This feature has been expanded to accommodate most of the models. To utilize streaming, use a [`CallbackHandler`](https://github.com/hwchase17/langchain/blob/master/langchain/callbacks/base.py) that implements `on_llm_new_token`. In this example, we are using `StreamingStdOutCallbackHandler`.
+Currently, we support streaming for a broad range of LLM implementations, including but not limited to `OpenAI`, `ChatOpenAI`, `ChatAnthropic`, `Hugging Face Text Generation Inference`, and `Replicate`. This feature has been expanded to accommodate most of the models. To utilize streaming, use a [`CallbackHandler`](https://github.com/langchain-ai/langchain/blob/master/langchain/callbacks/base.py) that implements `on_llm_new_token`. In this example, we are using `StreamingStdOutCallbackHandler`.
 ```python
 from langchain.llms import OpenAI
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler

--- a/libs/experimental/langchain_experimental/cpal/README.md
+++ b/libs/experimental/langchain_experimental/cpal/README.md
@@ -1,4 +1,4 @@
 # Causal program-aided language (CPAL) chain
 
 
-see https://github.com/hwchase17/langchain/pull/6255
+see https://github.com/langchain-ai/langchain/pull/6255

--- a/libs/experimental/langchain_experimental/pal_chain/__init__.py
+++ b/libs/experimental/langchain_experimental/pal_chain/__init__.py
@@ -3,7 +3,7 @@
 As in https://arxiv.org/pdf/2211.10435.pdf.
 
 This is vulnerable to arbitrary code execution:
-https://github.com/hwchase17/langchain/issues/5872
+https://github.com/langchain-ai/langchain/issues/5872
 """
 from langchain_experimental.pal_chain.base import PALChain
 

--- a/libs/experimental/langchain_experimental/prompts/load.py
+++ b/libs/experimental/langchain_experimental/prompts/load.py
@@ -1,4 +1,4 @@
-# Susceptible to arbitrary code execution: https://github.com/hwchase17/langchain/issues/4849
+# Susceptible to arbitrary code execution: https://github.com/langchain-ai/langchain/issues/4849
 import importlib
 import json
 from pathlib import Path

--- a/libs/experimental/tests/integration_tests/chains/test_cpal.py
+++ b/libs/experimental/tests/integration_tests/chains/test_cpal.py
@@ -46,7 +46,7 @@ class TestUnitCPALChain_MathWordProblems(unittest.TestCase):
     """Unit Test the CPAL chain and its component chains on math word problems.
 
     These tests can't run in the standard unit test directory because of
-    this issue, https://github.com/hwchase17/langchain/issues/7451
+    this issue, https://github.com/langchain-ai/langchain/issues/7451
 
     """
 
@@ -398,7 +398,7 @@ class TestCPALChain_MathWordProblems(unittest.TestCase):
         """
         Test CPAL chain against the first example in the PAL chain notebook doc:
 
-        https://github.com/hwchase17/langchain/blob/master/docs/extras/modules/chains/additional/pal.ipynb
+        https://github.com/langchain-ai/langchain/blob/master/docs/extras/modules/chains/additional/pal.ipynb
         """
 
         narrative_input = (

--- a/libs/langchain/README.md
+++ b/libs/langchain/README.md
@@ -2,21 +2,21 @@
 
 ⚡ Building applications with LLMs through composability ⚡
 
-[![Release Notes](https://img.shields.io/github/release/hwchase17/langchain)](https://github.com/hwchase17/langchain/releases)
-[![lint](https://github.com/hwchase17/langchain/actions/workflows/lint.yml/badge.svg)](https://github.com/hwchase17/langchain/actions/workflows/lint.yml)
-[![test](https://github.com/hwchase17/langchain/actions/workflows/test.yml/badge.svg)](https://github.com/hwchase17/langchain/actions/workflows/test.yml)
+[![Release Notes](https://img.shields.io/github/release/hwchase17/langchain)](https://github.com/langchain-ai/langchain/releases)
+[![lint](https://github.com/langchain-ai/langchain/actions/workflows/lint.yml/badge.svg)](https://github.com/langchain-ai/langchain/actions/workflows/lint.yml)
+[![test](https://github.com/langchain-ai/langchain/actions/workflows/test.yml/badge.svg)](https://github.com/langchain-ai/langchain/actions/workflows/test.yml)
 [![Downloads](https://static.pepy.tech/badge/langchain/month)](https://pepy.tech/project/langchain)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/langchainai.svg?style=social&label=Follow%20%40LangChainAI)](https://twitter.com/langchainai)
 [![](https://dcbadge.vercel.app/api/server/6adMQxSpJS?compact=true&style=flat)](https://discord.gg/6adMQxSpJS)
-[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/hwchase17/langchain)
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/langchain-ai/langchain)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hwchase17/langchain)
 [![GitHub star chart](https://img.shields.io/github/stars/hwchase17/langchain?style=social)](https://star-history.com/#hwchase17/langchain)
 [![Dependency Status](https://img.shields.io/librariesio/github/hwchase17/langchain)](https://libraries.io/github/hwchase17/langchain)
-[![Open Issues](https://img.shields.io/github/issues-raw/hwchase17/langchain)](https://github.com/hwchase17/langchain/issues)
+[![Open Issues](https://img.shields.io/github/issues-raw/hwchase17/langchain)](https://github.com/langchain-ai/langchain/issues)
 
 
-Looking for the JS/TS version? Check out [LangChain.js](https://github.com/hwchase17/langchainjs).
+Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langchain-ai/langchainjs).
 
 **Production Support:** As you move your LangChains into production, we'd love to offer more hands-on support.
 Fill out [this form](https://airtable.com/appwQzlErAS2qiP0L/shrGtGaVBVAz7NcV2) to share more about what you're building, and our team will get in touch.
@@ -41,7 +41,7 @@ This library aims to assist in the development of those types of applications. C
 **💬 Chatbots**
 
 - [Documentation](https://python.langchain.com/docs/use_cases/chatbots/)
-- End-to-end Example: [Chat-LangChain](https://github.com/hwchase17/chat-langchain)
+- End-to-end Example: [Chat-LangChain](https://github.com/langchain-ai/chat-langchain)
 
 **🤖 Agents**
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -175,7 +175,7 @@ optional = true
 #    Instead write unit tests that use the `responses` library or mock.patch with
 #    fixtures. Keep the fixtures minimal.
 # See CONTRIBUTING.md for more instructions on working with optional dependencies.
-# https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md#working-with-optional-dependencies
+# https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md#working-with-optional-dependencies
 pytest-vcr = "^1.0.2"
 wrapt = "^1.15.0"
 openai = "^0.27.4"

--- a/libs/langchain/tests/integration_tests/examples/example.mht
+++ b/libs/langchain/tests/integration_tests/examples/example.mht
@@ -51,11 +51,11 @@ a>=20
   <tr>
     <td height=3D"45" valign=3D"top" width=3D"50%">
       <ul>
-        <li><a href=3D"https://github.com/hwchase17/langchain">Python Repo<=
+        <li><a href=3D"https://github.com/langchain-ai/langchain">Python Repo<=
 /a></li></ul></td>
     <td height=3D"45" valign=3D"top" width=3D"50%">
 		  <ul>
-        <li><a href=3D"https://github.com/hwchase17/langchainjs">JavaScript=
+        <li><a href=3D"https://github.com/langchain-ai/langchainjs">JavaScript=
  Repo</a></li></ul></td></tr>
  =20
 =09
@@ -72,7 +72,7 @@ ation</a>
   <tr>
     <td height=3D"45" valign=3D"top" width=3D"50%">
       <ul>
-        <li><a href=3D"https://github.com/hwchase17/chat-langchain">Python =
+        <li><a href=3D"https://github.com/langchain-ai/chat-langchain">Python =
 ChatLangChain</a> </li></ul></td>
     <td height=3D"45" valign=3D"top" width=3D"50%">
       <ul>


### PR DESCRIPTION
### Description
renamed several repository links from `hwchase17` to `langchain-ai`.

### Why
I discovered that the README file in the devcontainer contains an old repository name, so I took the opportunity to rename the old repository name in all files within the repository, excluding those that do not require changes.

### Dependencies
none

### Tag maintainer
@baskaryan

### Twitter handle
[kzk_maeda](https://twitter.com/kzk_maeda)