### PR TITLE
Remove extra spaces

### DIFF
--- a/docs/extras/modules/agents/agent_types/chat_conversation_agent.ipynb
+++ b/docs/extras/modules/agents/agent_types/chat_conversation_agent.ipynb
@@ -38,7 +38,7 @@
     "search = SerpAPIWrapper()\n",
     "tools = [\n",
     "    Tool(\n",
-    "        name = \"Current Search\",\n",
+    "        name=\"Current Search\",\n",
     "        func=search.run,\n",
     "        description=\"useful for when you need to answer questions about current events or the current state of the world\"\n",
     "    ),\n",

--- a/docs/extras/modules/agents/agent_types/openai_functions_agent.ipynb
+++ b/docs/extras/modules/agents/agent_types/openai_functions_agent.ipynb
@@ -63,7 +63,7 @@
     "db_chain = SQLDatabaseChain.from_llm(llm, db, verbose=True)\n",
     "tools = [\n",
     "    Tool(\n",
-    "        name = \"Search\",\n",
+    "        name=\"Search\",\n",
     "        func=search.run,\n",
     "        description=\"useful for when you need to answer questions about current events. You should ask targeted questions\"\n",
     "    ),\n",

--- a/docs/extras/use_cases/more/agents/autonomous_agents/plan_and_execute.mdx
+++ b/docs/extras/use_cases/more/agents/autonomous_agents/plan_and_execute.mdx
@@ -27,7 +27,7 @@ llm = OpenAI(temperature=0)
 llm_math_chain = LLMMathChain.from_llm(llm=llm, verbose=True)
 tools = [
     Tool(
-        name = "Search",
+        name="Search",
         func=search.run,
         description="useful for when you need to answer questions about current events"
     ),

--- a/docs/snippets/modules/agents/how_to/custom_llm_agent.mdx
+++ b/docs/snippets/modules/agents/how_to/custom_llm_agent.mdx
@@ -36,7 +36,7 @@ Set up any tools the agent may want to use. This may be necessary to put in the 
 search = SerpAPIWrapper()
 tools = [
     Tool(
-        name = "Search",
+        name="Search",
         func=search.run,
         description="useful for when you need to answer questions about current events"
     )

--- a/docs/snippets/modules/agents/how_to/custom_llm_chat_agent.mdx
+++ b/docs/snippets/modules/agents/how_to/custom_llm_chat_agent.mdx
@@ -51,7 +51,7 @@ SERPAPI_API_KEY = getpass()
 search = SerpAPIWrapper(serpapi_api_key=SERPAPI_API_KEY)
 tools = [
     Tool(
-        name = "Search",
+        name="Search",
         func=search.run,
         description="useful for when you need to answer questions about current events"
     )

--- a/docs/snippets/modules/agents/how_to/mrkl.mdx
+++ b/docs/snippets/modules/agents/how_to/mrkl.mdx
@@ -13,7 +13,7 @@ db = SQLDatabase.from_uri("sqlite:///../../../../../notebooks/Chinook.db")
 db_chain = SQLDatabaseChain.from_llm(llm, db, verbose=True)
 tools = [
     Tool(
-        name = "Search",
+        name="Search",
         func=search.run,
         description="useful for when you need to answer questions about current events. You should ask targeted questions"
     ),

--- a/docs/snippets/modules/agents/how_to/mrkl_chat.mdx
+++ b/docs/snippets/modules/agents/how_to/mrkl_chat.mdx
@@ -9,7 +9,7 @@ db = SQLDatabase.from_uri("sqlite:///../../../../../notebooks/Chinook.db")
 db_chain = SQLDatabaseChain.from_llm(llm1, db, verbose=True)
 tools = [
     Tool(
-        name = "Search",
+        name="Search",
         func=search.run,
         description="useful for when you need to answer questions about current events. You should ask targeted questions"
     ),


### PR DESCRIPTION
  ### Description
When I was reading the document, I found that some examples had extra spaces and violated "Unexpected spaces around keyword / parameter equals (E251)" in pep8. I removed these extra spaces.
  
**like is** in https://python.langchain.com/docs/modules/agents/agent_types/openai_functions_agent
![pr01.png](https://s2.loli.net/2023/10/02/P4WCDzTBmaIFK9H.png)
### Issue
None
### Dependencies
None
### Tag maintainer
@eyurtsev 
### Twitter handle
[billvsme](https://twitter.com/billvsme)