### PR TITLE
Trigger Docker release workflow after new langchain release is made.

### DIFF
--- a/.github/workflows/langchain_release.yml
+++ b/.github/workflows/langchain_release.yml
@@ -12,6 +12,13 @@ jobs:
       working-directory: libs/langchain
     secrets: inherit
 
+  # N.B.: It's possible that PyPI doesn't make the new release visible / available
+  #       immediately after publishing. If that happens, the docker build might not
+  #       create a new docker image for the new release, since it won't see it.
+  #
+  #       If this ends up being a problem, add a check to the end of the `_release.yml`
+  #       workflow that prevents the workflow from finishing until the new release
+  #       is visible and installable on PyPI.
   release-docker:
     needs:
       - release

--- a/.github/workflows/langchain_release.yml
+++ b/.github/workflows/langchain_release.yml
@@ -11,3 +11,9 @@ jobs:
     with:
       working-directory: libs/langchain
     secrets: inherit
+
+  release-docker:
+    needs:
+      - release
+    uses:
+      ./.github/workflows/langchain_release_docker.yml

--- a/.github/workflows/langchain_release_docker.yml
+++ b/.github/workflows/langchain_release_docker.yml
@@ -3,6 +3,7 @@ name: docker/langchain/langchain Release
 
 on:
   workflow_dispatch: # Allows to trigger the workflow manually in GitHub UI
+  workflow_call: # Allows triggering from another workflow
 
 jobs:
   release:


### PR DESCRIPTION
We want to publish a new Docker image after a new langchain Python package version is published.
