### PR TITLE
Anthropic system message fix

### DIFF
--- a/libs/langchain/langchain/chat_models/anthropic.py
+++ b/libs/langchain/langchain/chat_models/anthropic.py
@@ -17,7 +17,6 @@ from langchain.schema.messages import (
     ChatMessage,
     HumanMessage,
     SystemMessage,
-    _merge_kwargs_dict,
 )
 from langchain.schema.output import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain.schema.prompt import PromptValue
@@ -64,13 +63,7 @@ def convert_messages_to_prompt_anthropic(
         sys = messages[0]
         human = messages[1]
         content = "<admin>" + sys.content + "</admin>\n\n" + human.content
-        consolidated = HumanMessage(
-            content=content,
-            additional_kwargs=_merge_kwargs_dict(
-                sys.additional_kwargs, human.additional_kwargs
-            ),
-        )
-        messages = [consolidated] + messages[2:].copy()
+        messages = [HumanMessage(content=content)] + messages[2:].copy()
     else:
         messages = messages.copy()
     if not isinstance(messages[-1], AIMessage):

--- a/libs/langchain/langchain/chat_models/anthropic.py
+++ b/libs/langchain/langchain/chat_models/anthropic.py
@@ -34,7 +34,7 @@ def _convert_one_message_to_text(
     elif isinstance(message, AIMessage):
         message_text = f"{ai_prompt} {message.content}"
     elif isinstance(message, SystemMessage):
-        message_text = f"{human_prompt} <admin>{message.content}</admin>"
+        message_text = f"<admin>{message.content}</admin>"
     else:
         raise ValueError(f"Got unknown type {message}")
     return message_text
@@ -55,17 +55,7 @@ def convert_messages_to_prompt_anthropic(
         str: Combined string with necessary human_prompt and ai_prompt tags.
     """
 
-    if (
-        len(messages) >= 2
-        and isinstance(messages[0], SystemMessage)
-        and isinstance(messages[1], HumanMessage)
-    ):
-        sys = messages[0]
-        human = messages[1]
-        content = "<admin>" + sys.content + "</admin>\n\n" + human.content
-        messages = [HumanMessage(content=content)] + messages[2:].copy()
-    else:
-        messages = messages.copy()
+    messages = messages.copy()
     if not isinstance(messages[-1], AIMessage):
         messages.append(AIMessage(content=""))
 

--- a/libs/langchain/langchain/chat_models/anthropic.py
+++ b/libs/langchain/langchain/chat_models/anthropic.py
@@ -34,7 +34,7 @@ def _convert_one_message_to_text(
     elif isinstance(message, AIMessage):
         message_text = f"{ai_prompt} {message.content}"
     elif isinstance(message, SystemMessage):
-        message_text = f"<admin>{message.content}</admin>"
+        message_text = message.content
     else:
         raise ValueError(f"Got unknown type {message}")
     return message_text

--- a/libs/langchain/langchain/chat_models/anthropic.py
+++ b/libs/langchain/langchain/chat_models/anthropic.py
@@ -76,7 +76,7 @@ def convert_messages_to_prompt_anthropic(
     if not isinstance(messages[-1], AIMessage):
         messages.append(AIMessage(content=""))
 
-    text = "\n\n".join(
+    text = "".join(
         _convert_one_message_to_text(message, human_prompt, ai_prompt)
         for message in messages
     )

--- a/libs/langchain/langchain/chat_models/anthropic.py
+++ b/libs/langchain/langchain/chat_models/anthropic.py
@@ -55,7 +55,7 @@ def convert_messages_to_prompt_anthropic(
         str: Combined string with necessary human_prompt and ai_prompt tags.
     """
 
-    messages = messages.copy()
+    messages = messages.copy()  # don't mutate the original list
     if not isinstance(messages[-1], AIMessage):
         messages.append(AIMessage(content=""))
 

--- a/libs/langchain/langchain/llms/bedrock.py
+++ b/libs/langchain/langchain/llms/bedrock.py
@@ -42,12 +42,12 @@ def _human_assistant_format(input_text: str) -> str:
             if count % 2 == 0:
                 count += 1
             else:
-                raise ValueError(ALTERNATION_ERROR)
+                raise ValueError(ALTERNATION_ERROR + f" Received {input_text}")
         if input_text[i : i + len(ASSISTANT_PROMPT)] == ASSISTANT_PROMPT:
             if count % 2 == 1:
                 count += 1
             else:
-                raise ValueError(ALTERNATION_ERROR)
+                raise ValueError(ALTERNATION_ERROR + f" Received {input_text}")
 
     if count % 2 == 1:  # Only saw Human, no Assistant
         input_text = input_text + ASSISTANT_PROMPT  # SILENT CORRECTION

--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -117,6 +117,24 @@ class BaseMessageChunk(BaseMessage):
     ) -> Dict[str, Any]:
         """Merge additional_kwargs from another BaseMessageChunk into this one."""
         return _merge_kwargs_dict(left, right)
+        merged = left.copy()
+        for k, v in right.items():
+            if k not in merged:
+                merged[k] = v
+            elif type(merged[k]) != type(v):
+                raise ValueError(
+                    f'additional_kwargs["{k}"] already exists in this message,'
+                    " but with a different type."
+                )
+            elif isinstance(merged[k], str):
+                merged[k] += v
+            elif isinstance(merged[k], dict):
+                merged[k] = self._merge_kwargs_dict(merged[k], v)
+            else:
+                raise ValueError(
+                    f"Additional kwargs key {k} already exists in this message."
+                )
+        return merged
 
     def __add__(self, other: Any) -> BaseMessageChunk:  # type: ignore
         if isinstance(other, BaseMessageChunk):

--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -87,28 +87,6 @@ class BaseMessage(Serializable):
         return prompt + other
 
 
-def _merge_kwargs_dict(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
-    """Merge additional_kwargs from another BaseMessageChunk into this one."""
-    merged = left.copy()
-    for k, v in right.items():
-        if k not in merged:
-            merged[k] = v
-        elif type(merged[k]) != type(v):
-            raise ValueError(
-                f'additional_kwargs["{k}"] already exists in this message,'
-                " but with a different type."
-            )
-        elif isinstance(merged[k], str):
-            merged[k] += v
-        elif isinstance(merged[k], dict):
-            merged[k] = _merge_kwargs_dict(merged[k], v)
-        else:
-            raise ValueError(
-                f"Additional kwargs key {k} already exists in this message."
-            )
-    return merged
-
-
 class BaseMessageChunk(BaseMessage):
     """A Message chunk, which can be concatenated with other Message chunks."""
 
@@ -116,7 +94,6 @@ class BaseMessageChunk(BaseMessage):
         self, left: Dict[str, Any], right: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Merge additional_kwargs from another BaseMessageChunk into this one."""
-        return _merge_kwargs_dict(left, right)
         merged = left.copy()
         for k, v in right.items():
             if k not in merged:

--- a/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
@@ -66,13 +66,6 @@ def test_anthropic_initialization() -> None:
             ],
             "You're an assistant\n\nHuman: Hello\n\nAssistant: Answer:",
         ),
-        (
-            [
-                SystemMessage(content="You're an assistant"),
-                AIMessage(content="Answer:"),
-            ],
-            "You're an assistant\n\nAssistant: Answer:",
-        ),
     ],
 )
 def test_formatting(messages: List[BaseMessage], expected: str) -> None:

--- a/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
@@ -6,7 +6,7 @@ import pytest
 
 from langchain.chat_models import ChatAnthropic
 from langchain.chat_models.anthropic import convert_messages_to_prompt_anthropic
-from langchain.schema import AIMessage, BaseMessage, HumanMessage
+from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
 
 os.environ["ANTHROPIC_API_KEY"] = "foo"
 
@@ -50,11 +50,24 @@ def test_anthropic_initialization() -> None:
     ChatAnthropic(model="test", anthropic_api_key="test")
 
 
-def test_formatting() -> None:
-    messages: List[BaseMessage] = [HumanMessage(content="Hello")]
+@pytest.mark.parametrize(
+    ("messages", "expected"),
+    [
+        ([HumanMessage(content="Hello")], "\n\nHuman: Hello\n\nAssistant:"),
+        (
+            [HumanMessage(content="Hello"), AIMessage(content="Answer:")],
+            "\n\nHuman: Hello\n\nAssistant: Answer:",
+        ),
+        (
+            [
+                SystemMessage(content="You're an assistant"),
+                HumanMessage(content="Hello"),
+                AIMessage(content="Answer:"),
+            ],
+            "<admin>You're an assistant</admin>\n\nHuman: Hello\n\nAssistant: Answer:",
+        ),
+    ],
+)
+def test_formatting(messages: List[BaseMessage], expected: str) -> None:
     result = convert_messages_to_prompt_anthropic(messages)
-    assert result == "\n\nHuman: Hello\n\nAssistant:"
-
-    messages = [HumanMessage(content="Hello"), AIMessage(content="Answer:")]
-    result = convert_messages_to_prompt_anthropic(messages)
-    assert result == "\n\nHuman: Hello\n\nAssistant: Answer:"
+    assert result == expected

--- a/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
@@ -64,14 +64,14 @@ def test_anthropic_initialization() -> None:
                 HumanMessage(content="Hello"),
                 AIMessage(content="Answer:"),
             ],
-            "<admin>You're an assistant</admin>\n\nHuman: Hello\n\nAssistant: Answer:",
+            "You're an assistant\n\nHuman: Hello\n\nAssistant: Answer:",
         ),
         (
             [
                 SystemMessage(content="You're an assistant"),
                 AIMessage(content="Answer:"),
             ],
-            "<admin>You're an assistant</admin>\n\nAssistant: Answer:",
+            "You're an assistant\n\nAssistant: Answer:",
         ),
     ],
 )

--- a/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_anthropic.py
@@ -66,6 +66,13 @@ def test_anthropic_initialization() -> None:
             ],
             "<admin>You're an assistant</admin>\n\nHuman: Hello\n\nAssistant: Answer:",
         ),
+        (
+            [
+                SystemMessage(content="You're an assistant"),
+                AIMessage(content="Answer:"),
+            ],
+            "<admin>You're an assistant</admin>\n\nAssistant: Answer:",
+        ),
     ],
 )
 def test_formatting(messages: List[BaseMessage], expected: str) -> None:


### PR DESCRIPTION
Bedrock anthropic api enforces that Human and Assistant messages must be interleaved (cannot have same type twice in a row). We current treat System Messages as human messages when converting messages -> string prompt. Our validation when using Bedrock/BedrockChat raises an error when this happens. For ChatAnthropic we don't validate this so no error is raised, but perhaps the behavior is still suboptimal.

Would love input from folks more familiar with Anthropic intended usage and Bedrock API.