### PR TITLE
Added custom retry decorator support in ChatOpenAI

### DIFF
--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -87,7 +87,11 @@ async def acompletion_with_retry(
     **kwargs: Any,
 ) -> Any:
     """Use tenacity to retry the async completion call."""
-    retry_decorator = llm.custom_retry_decorator if llm.custom_retry_decorator else _create_retry_decorator(llm, run_manager=run_manager)
+    retry_decorator = (
+        llm.custom_retry_decorator
+        if llm.custom_retry_decorator
+        else _create_retry_decorator(llm, run_manager=run_manager)
+    )
 
     @retry_decorator
     async def _completion_with_retry(**kwargs: Any) -> Any:
@@ -182,11 +186,12 @@ class ChatOpenAI(BaseChatModel):
     when tiktoken is called, you can specify a model name to use here."""
     custom_retry_decorator: Optional[Callable[[Any], Any]] = None
     """Custom retry decorator for handling specific use cases and errors.
-    
-    This decorator will be used in the `acompletion_with_retry` and `completion_with_retry` methods.
+    This decorator will be used in the `acompletion_with_retry` and 
+    `completion_with_retry` methods.
     If not provided, the default retry decorator will be used.
-    The custom decorator should take a function that makes the API call and return a function that handles retries.
-    """
+    The custom decorator should take a function that makes the API call and 
+    return a function that handles retries."""
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -281,7 +286,11 @@ class ChatOpenAI(BaseChatModel):
         self, run_manager: Optional[CallbackManagerForLLMRun] = None, **kwargs: Any
     ) -> Any:
         """Use tenacity to retry the completion call."""
-        retry_decorator = self.custom_retry_decorator if self.custom_retry_decorator else _create_retry_decorator(self, run_manager=run_manager)
+        retry_decorator = (
+            self.custom_retry_decorator
+            if self.custom_retry_decorator
+            else _create_retry_decorator(self, run_manager=run_manager)
+        )
 
         @retry_decorator
         def _completion_with_retry(**kwargs: Any) -> Any:

--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -187,10 +187,9 @@ class ChatOpenAI(BaseChatModel):
     custom_retry_decorator: Optional[Callable[[Any], Any]] = None
     """Custom retry decorator for handling specific use cases and errors.
     This decorator will be used in the `acompletion_with_retry` and 
-    `completion_with_retry` methods.
-    If not provided, the default retry decorator will be used.
-    The custom decorator should take a function that makes the API call and 
-    return a function that handles retries."""
+    `completion_with_retry` methods. If not provided, the default retry 
+    decorator will be used. The custom decorator should take a function that 
+    makes the API call and return a function that handles retries."""
 
     class Config:
         """Configuration for this pydantic object."""


### PR DESCRIPTION
Description: 
This PR adds the ability for users to provide a custom retry decorator when creating an instance of the ChatOpenAI class. The custom decorator will be used in the acompletion_with_retry and completion_with_retry methods to handle retries for the API calls. If a custom decorator is not provided, the default retry decorator will be used. This feature provides users the flexibility to handle specific use cases and errors in specific ways.

Issue: https://github.com/langchain-ai/langchain/issues/3109

Dependencies: No new dependencies are required for this change.