### PR TITLE
Fix Fake LLM tool usage example

### DIFF
--- a/docs/extras/modules/model_io/models/llms/fake_llm.ipynb
+++ b/docs/extras/modules/model_io/models/llms/fake_llm.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "responses = [\"Action: Python REPL\\nAction Input: print(2 + 2)\", \"Final Answer: 4\"]\n",
+    "responses = [\"Action: Python_REPL\\nAction Input: print(2 + 2)\", \"Final Answer: 4\"]\n",
     "llm = FakeListLLM(responses=responses)"
    ]
   },


### PR DESCRIPTION
**Description:**
 
Mock action in a FakeListLLM uses a wrong name for the REPL tool (the correct one uses '_').
Without it, an error pops up: "Python REPL is not a valid tool, try one of [Python_REPL]."