### PR TITLE
Pass kwargs in runnable retry

### DIFF
--- a/libs/langchain/langchain/schema/runnable/retry.py
+++ b/libs/langchain/langchain/schema/runnable/retry.py
@@ -89,12 +89,14 @@ class RunnableRetry(RunnableBinding[Input, Output]):
         input: Input,
         run_manager: "CallbackManagerForChainRun",
         config: RunnableConfig,
+        **kwargs: Any
     ) -> Output:
         for attempt in self._sync_retrying(reraise=True):
             with attempt:
                 result = super().invoke(
                     input,
                     self._patch_config(config, run_manager, attempt.retry_state),
+                    **kwargs,
                 )
             if attempt.retry_state.outcome and not attempt.retry_state.outcome.failed:
                 attempt.retry_state.set_result(result)
@@ -110,12 +112,14 @@ class RunnableRetry(RunnableBinding[Input, Output]):
         input: Input,
         run_manager: "AsyncCallbackManagerForChainRun",
         config: RunnableConfig,
+        **kwargs: Any
     ) -> Output:
         async for attempt in self._async_retrying(reraise=True):
             with attempt:
                 result = await super().ainvoke(
                     input,
                     self._patch_config(config, run_manager, attempt.retry_state),
+                    **kwargs,
                 )
             if attempt.retry_state.outcome and not attempt.retry_state.outcome.failed:
                 attempt.retry_state.set_result(result)
@@ -131,6 +135,7 @@ class RunnableRetry(RunnableBinding[Input, Output]):
         inputs: List[Input],
         run_manager: List["CallbackManagerForChainRun"],
         config: List[RunnableConfig],
+        **kwargs: Any
     ) -> List[Union[Output, Exception]]:
         results_map: Dict[int, Output] = {}
 
@@ -147,6 +152,7 @@ class RunnableRetry(RunnableBinding[Input, Output]):
                             pending(config), pending(run_manager), attempt.retry_state
                         ),
                         return_exceptions=True,
+                        **kwargs,
                     )
                     # Register the results of the inputs that have succeeded.
                     first_exception = None
@@ -195,6 +201,7 @@ class RunnableRetry(RunnableBinding[Input, Output]):
         inputs: List[Input],
         run_manager: List["AsyncCallbackManagerForChainRun"],
         config: List[RunnableConfig],
+        **kwargs: Any
     ) -> List[Union[Output, Exception]]:
         results_map: Dict[int, Output] = {}
 
@@ -211,6 +218,7 @@ class RunnableRetry(RunnableBinding[Input, Output]):
                             pending(config), pending(run_manager), attempt.retry_state
                         ),
                         return_exceptions=True,
+                        **kwargs,
                     )
                     # Register the results of the inputs that have succeeded.
                     first_exception = None


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
