### PR TITLE
Add explanations to GoogleDriveLoader how to avoid errors

### DIFF
--- a/docs/extras/integrations/document_loaders/google_drive.ipynb
+++ b/docs/extras/integrations/document_loaders/google_drive.ipynb
@@ -20,6 +20,9 @@
     "\n",
     "## 🧑 Instructions for ingesting your Google Docs data\n",
     "By default, the `GoogleDriveLoader` expects the `credentials.json` file to be `~/.credentials/credentials.json`, but this is configurable using the `credentials_path` keyword argument. Same thing with `token.json` - `token_path`. Note that `token.json` will be created automatically the first time you use the loader.\n",
+    "The first time you use GoogleDriveLoader, you will be displayed with the consent screen in your browser.\n",
+    "\n",
+    "Note that sometimes it doesn't happen and you get the `RefreshError: ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})` error. If it happens, do not use `credentials_path` in your `GoogleDriveLoader` constructor call - instead, put that path in `GOOGLE_APPLICATION_CREDENTIALS` environmental variable, e.g. via `os.environ[\"GOOGLE_APPLICATION_CREDENTIALS\"] = ...`.\n",
     "\n",
     "`GoogleDriveLoader` can load from a list of Google Docs document ids or a folder id. You can obtain your folder and document id from the URL:\n",
     "* Folder: https://drive.google.com/drive/u/0/folders/1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5 -> folder id is `\"1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5\"`\n",
@@ -60,6 +63,7 @@
     "loader = GoogleDriveLoader(\n",
     "    folder_id=\"1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5\",\n",
     "    # Optional: configure whether to recursively fetch files from subfolders. Defaults to False.\n",
+    "    token_path='/path/where/you/want/token/to/be/created/google_token.json'\n",
     "    recursive=False,\n",
     ")"
    ]

--- a/docs/extras/integrations/document_loaders/google_drive.ipynb
+++ b/docs/extras/integrations/document_loaders/google_drive.ipynb
@@ -20,9 +20,8 @@
     "\n",
     "## 🧑 Instructions for ingesting your Google Docs data\n",
     "By default, the `GoogleDriveLoader` expects the `credentials.json` file to be `~/.credentials/credentials.json`, but this is configurable using the `credentials_path` keyword argument. Same thing with `token.json` - `token_path`. Note that `token.json` will be created automatically the first time you use the loader.\n",
-    "The first time you use GoogleDriveLoader, you will be displayed with the consent screen in your browser.\n",
     "\n",
-    "Note that sometimes it doesn't happen and you get the `RefreshError: ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})` error. If it happens, do not use `credentials_path` in your `GoogleDriveLoader` constructor call - instead, put that path in `GOOGLE_APPLICATION_CREDENTIALS` environmental variable, e.g. via `os.environ[\"GOOGLE_APPLICATION_CREDENTIALS\"] = ...`.\n",
+    "The first time you use GoogleDriveLoader, you will be displayed with the consent screen in your browser. If this doesn't happen and you get a `RefreshError`, do not use `credentials_path` in your `GoogleDriveLoader` constructor call. Instead, put that path in a `GOOGLE_APPLICATION_CREDENTIALS` environmental variable.\n",
     "\n",
     "`GoogleDriveLoader` can load from a list of Google Docs document ids or a folder id. You can obtain your folder and document id from the URL:\n",
     "* Folder: https://drive.google.com/drive/u/0/folders/1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5 -> folder id is `\"1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5\"`\n",
@@ -62,8 +61,8 @@
    "source": [
     "loader = GoogleDriveLoader(\n",
     "    folder_id=\"1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5\",\n",
-    "    # Optional: configure whether to recursively fetch files from subfolders. Defaults to False.\n",
     "    token_path='/path/where/you/want/token/to/be/created/google_token.json'\n",
+    "    # Optional: configure whether to recursively fetch files from subfolders. Defaults to False.\n",
     "    recursive=False,\n",
     ")"
    ]


### PR DESCRIPTION
  - **Description:** add a paragraph to the GoogleDriveLoader doc on how to bypass errors on authentication.

For some reason, specifying credential path via `credentials_path` constructor parameter when creating `GoogleDriveLoader` makes it so that the oAuth screen is never showing up when first using GoogleDriveLoader. Instead, the `RefreshError: ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})` error happens. Setting it via `os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ...` solves the problem. Also, `token_path` constructor parameter is mandatory, otherwise another error happens when trying to `load()` for the first time.

These errors are tricky and time-consuming to figure out, so I believe it's good to mention them in the docs.