### PR TITLE
Make a copy of external data instead of mutating another object's attributes.

### DIFF
--- a/libs/experimental/langchain_experimental/comprehend_moderation/base_moderation.py
+++ b/libs/experimental/langchain_experimental/comprehend_moderation/base_moderation.py
@@ -70,7 +70,10 @@ class BaseModeration:
         elif isinstance(prompt, str):
             return text
         elif isinstance(prompt, ChatPromptValue):
-            messages = prompt.messages
+            # Copy the messages because we may need to mutate them.
+            # We don't want to mutate data we don't own.
+            messages = list(prompt.messages)
+
             message = messages[self.chat_message_index]
 
             if isinstance(message, HumanMessage):


### PR DESCRIPTION
Fix for a bug surfaced as part of #11339. `mypy` caught this since the types didn't match up.
