### PR TITLE
Solves unicode [codec can't decode byte] traceback error.

### DIFF
--- a/libs/langchain/langchain/document_loaders/text.py
+++ b/libs/langchain/langchain/document_loaders/text.py
@@ -37,7 +37,7 @@ class TextLoader(BaseLoader):
         """Load from file path."""
         text = ""
         try:
-            with open(self.file_path, encoding=self.encoding) as f:
+            with open(self.file_path, encoding=self.encoding, errors='replace') as f:
                 text = f.read()
         except UnicodeDecodeError as e:
             if self.autodetect_encoding:


### PR DESCRIPTION
Following up on #11359

  - **Description:** a description of the change, 

privateGPT/ingest.py crashes when parsing a txt file with unexpected unicode.

  - **Issue:** the issue # it fixes (if applicable),

Problem solved:

Traceback (most recent call last):
File "C:\Program Files\Python3\Lib\site-packages\langchain\document_loaders\text.py", line 41, in load text = f.read()
^^^^^^^^
File "", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa7 in position 549: invalid start byte

  - **Dependencies:** any dependencies required for this change,

none

  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),

No idea.

  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

@DigitalVisor

