### PR TITLE
add getattr case for llms.type_to_cls_dict

### DIFF
--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -617,6 +617,12 @@ def __getattr__(name: str) -> Any:
         return _import_writer()
     elif name == "Xinference":
         return _import_xinference()
+    elif name == "type_to_cls_dict":
+        # for backwards compatibility
+        type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
+            k: v() for k, v in get_type_to_cls_dict().items()
+        }
+        return type_to_cls_dict
     else:
         raise AttributeError(f"Could not find: {name}")
 


### PR DESCRIPTION
For external libraries that depend on `type_to_cls_dict`, adds a workaround to continue using the old format.

Recommend people use `get_type_to_cls_dict()` instead and only resolve the imports when they're used.