### PR TITLE
GitHubIssuesLoader Custom API URL Support 

### DIFF
--- a/libs/langchain/langchain/document_loaders/github.py
+++ b/libs/langchain/langchain/document_loaders/github.py
@@ -17,6 +17,8 @@ class BaseGitHubLoader(BaseLoader, BaseModel, ABC):
     """Name of repository"""
     access_token: str
     """Personal access token - see https://github.com/settings/tokens?type=beta"""
+    github_api_url: str = "https://api.github.com"
+    """URL of GitHub API"""
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:
@@ -183,4 +185,4 @@ class GitHubIssuesLoader(BaseGitHubLoader):
     @property
     def url(self) -> str:
         """Create URL for GitHub API."""
-        return f"https://api.github.com/repos/{self.repo}/issues?{self.query_params}"
+        return f"{self.github_api_url}/repos/{self.repo}/issues?{self.query_params}"

--- a/libs/langchain/tests/unit_tests/document_loaders/test_github.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_github.py
@@ -15,6 +15,18 @@ def test_initialization() -> None:
     }
 
 
+def test_initialization_ghe() -> None:
+    loader = GitHubIssuesLoader(repo="repo", access_token="access_token",
+                                github_api_url="https://github.example.com/api/v3")
+    assert loader.repo == "repo"
+    assert loader.access_token == "access_token"
+    assert loader.github_api_url == "https://github.example.com/api/v3"
+    assert loader.headers == {
+        "Accept": "application/vnd.github+json",
+        "Authorization": "Bearer access_token",
+    }
+
+
 def test_invalid_initialization() -> None:
     # Invalid parameter
     with pytest.raises(ValueError):
@@ -89,7 +101,7 @@ def test_url() -> None:
         repo="repo", access_token="access_token", state="open", sort="created"
     )
     assert (
-        loader.url == "https://api.github.com/repos/repo/issues?state=open&sort=created"
+            loader.url == "https://api.github.com/repos/repo/issues?state=open&sort=created"
     )
 
     # parameters: milestone, state, assignee, creator, mentioned, labels, sort,

--- a/libs/langchain/tests/unit_tests/document_loaders/test_github.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/test_github.py
@@ -16,8 +16,11 @@ def test_initialization() -> None:
 
 
 def test_initialization_ghe() -> None:
-    loader = GitHubIssuesLoader(repo="repo", access_token="access_token",
-                                github_api_url="https://github.example.com/api/v3")
+    loader = GitHubIssuesLoader(
+        repo="repo",
+        access_token="access_token",
+        github_api_url="https://github.example.com/api/v3",
+    )
     assert loader.repo == "repo"
     assert loader.access_token == "access_token"
     assert loader.github_api_url == "https://github.example.com/api/v3"
@@ -101,7 +104,7 @@ def test_url() -> None:
         repo="repo", access_token="access_token", state="open", sort="created"
     )
     assert (
-            loader.url == "https://api.github.com/repos/repo/issues?state=open&sort=created"
+        loader.url == "https://api.github.com/repos/repo/issues?state=open&sort=created"
     )
 
     # parameters: milestone, state, assignee, creator, mentioned, labels, sort,


### PR DESCRIPTION
  - **Description:** Adds support for custom API URL in the GitHubIssuesLoader. This allows it to be used with Github enterprise instances. 
  
  
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** Adds support for custom API URL in the GitHubIssuesLoader. This allows it to be used with Github enterprise instances. 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
