### PR TITLE
Make langchain compatible with SQLAlchemy<1.4.0

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgembedding.py
+++ b/libs/langchain/langchain/vectorstores/pgembedding.py
@@ -8,6 +8,7 @@ import sqlalchemy
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Session, relationship
+
 try:
     from sqlalchemy.orm import declarative_base
 except ImportError:

--- a/libs/langchain/langchain/vectorstores/pgembedding.py
+++ b/libs/langchain/langchain/vectorstores/pgembedding.py
@@ -7,7 +7,11 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 import sqlalchemy
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSON, UUID
-from sqlalchemy.orm import Session, declarative_base, relationship
+from sqlalchemy.orm import Session, relationship
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 
 from langchain.docstore.document import Document
 from langchain.schema.embeddings import Embeddings

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -24,6 +24,7 @@ import sqlalchemy
 from sqlalchemy import delete
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Session
+
 try:
     from sqlalchemy.orm import declarative_base
 except ImportError:

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -23,7 +23,11 @@ import numpy as np
 import sqlalchemy
 from sqlalchemy import delete
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Session, declarative_base
+from sqlalchemy.orm import Session
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 
 from langchain.docstore.document import Document
 from langchain.schema.embeddings import Embeddings


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

## Description
Currently SQLAlchemy >=1.4.0 is a hard requirement. We are unable to run `from langchain.vectorstores import FAISS` with SQLAlchemy <1.4.0 due to top-level imports, even if we aren't even using parts of the library that use SQLAlchemy. See Testing section for repro. Let's make it so that langchain is still compatible with SQLAlchemy <1.4.0, especially if we aren't using parts of langchain that require it.

The main conflict is that SQLAlchemy removed `declarative_base` from `sqlalchemy.ext.declarative` in 1.4.0 and moved it to `sqlalchemy.orm`. We can fix this by try-catching the import. This is the same fix as applied in https://github.com/langchain-ai/langchain/pull/883.

(I see that there seems to be some refactoring going on about isolating dependencies, e.g. https://github.com/langchain-ai/langchain/commit/c87e9fb2ce0ae617e3b2edde52421c80adef54cc, so if this issue will be eventually fixed by isolating imports in langchain.vectorstores that also works).

## Issue
I can't find a matching issue.

## Dependencies
No additional dependencies

## Maintainer
@hwchase17 since you reviewed https://github.com/langchain-ai/langchain/pull/883

## Testing
I didn't add a test, but I manually tested this.

1. Current failure:
```
langchain==0.0.305
sqlalchemy==1.3.24
```

``` python
python -i
>>> from langchain.vectorstores import FAISS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/pay/src/zoolander/vendor3/lib/python3.8/site-packages/langchain/vectorstores/__init__.py", line 58, in <module>
    from langchain.vectorstores.pgembedding import PGEmbedding
  File "/pay/src/zoolander/vendor3/lib/python3.8/site-packages/langchain/vectorstores/pgembedding.py", line 10, in <module>
    from sqlalchemy.orm import Session, declarative_base, relationship
ImportError: cannot import name 'declarative_base' from 'sqlalchemy.orm' (/pay/src/zoolander/vendor3/lib/python3.8/site-packages/sqlalchemy/orm/__init__.py)
```

2. This fix:
```
langchain==<this PR>
sqlalchemy==1.3.24
```

``` python
python -i
>>> from langchain.vectorstores import FAISS
<succeeds>
```


