### PR TITLE
Improve output of Runnable.astream_log()

### DIFF
--- a/libs/langchain/langchain/callbacks/tracers/log_stream.py
+++ b/libs/langchain/langchain/callbacks/tracers/log_stream.py
@@ -57,7 +57,7 @@ class RunState(TypedDict):
     """Final output of the run, usually the result of aggregating streamed_output.
     Only available after the run has finished successfully."""
 
-    logs: list[LogEntry]
+    logs: Dict[str, LogEntry]
     """List of sub-runs contained in this run, if any, in the order they were started.
     If filters were supplied, this list will contain only the runs that matched the 
     filters."""

--- a/libs/langchain/langchain/callbacks/tracers/log_stream.py
+++ b/libs/langchain/langchain/callbacks/tracers/log_stream.py
@@ -87,6 +87,7 @@ class RunLogPatch:
     def __repr__(self) -> str:
         from pprint import pformat
 
+        # 1:-1 to get rid of the [] around the list
         return f"RunLogPatch({pformat(self.ops)[1:-1]})"
 
     def __eq__(self, other: object) -> bool:
@@ -250,6 +251,7 @@ class LogStreamCallbackHandler(BaseTracer):
                     {
                         "op": "add",
                         "path": f"/logs/{index}/final_output",
+                        # to undo the dumpd done by some runnables / tracer / etc
                         "value": load(run.outputs),
                     },
                     {

--- a/libs/langchain/langchain/callbacks/tracers/log_stream.py
+++ b/libs/langchain/langchain/callbacks/tracers/log_stream.py
@@ -87,7 +87,7 @@ class RunLogPatch:
     def __repr__(self) -> str:
         from pprint import pformat
 
-        return f"RunLogPatch({pformat(self.ops)})"
+        return f"RunLogPatch({pformat(self.ops)[1:-1]})"
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, RunLogPatch) and self.ops == other.ops

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -1417,7 +1417,7 @@ async def test_stream_log_retriever() -> None:
     )
     llm = FakeListLLM(responses=["foo", "bar"])
 
-    chain = (
+    chain: Runnable = (
         {"documents": FakeRetriever(), "question": itemgetter("question")}
         | prompt
         | {"one": llm, "two": llm}
@@ -1568,7 +1568,7 @@ async def test_stream_log_retriever() -> None:
                     messages=[
                         SystemMessage(content="You are a nice assistant."),
                         HumanMessage(
-                            content="[Document(page_content='foo'), Document(page_content='bar')]"
+                            content="[Document(page_content='foo'), Document(page_content='bar')]"  # noqa: E501
                         ),
                         HumanMessage(content="What is your name?"),
                     ]

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 from operator import itemgetter
 from typing import (


### PR DESCRIPTION
- Make logs a dictionary keyed by run name (and counter for repeats)
- Ensure no output shows up in lc_serializable format
- Fix up repr for RunLog and RunLogPatch

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
