### PR TITLE
Fix typing imports in extraction usecase

### DIFF
--- a/docs/extras/use_cases/extraction.ipynb
+++ b/docs/extras/use_cases/extraction.ipynb
@@ -443,7 +443,7 @@
     }
    ],
    "source": [
-    "from typing import Sequence\n",
+    "from typing import Sequence, Optional\n",
     "from langchain.prompts import (\n",
     "    PromptTemplate,\n",
     "    ChatPromptTemplate,\n",


### PR DESCRIPTION
The person class here: https://python.langchain.com/docs/use_cases/extraction#pydantic-1 has attributes `dog_breed` and `dog_name` that use `Optional` from typing, but it hasn't been imported. Fixed the import here

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** Fix python imports in example, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
