### PR TITLE
Rm bedrock anthropic error 

### DIFF
--- a/libs/langchain/langchain/llms/bedrock.py
+++ b/libs/langchain/langchain/llms/bedrock.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from abc import ABC
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 
@@ -42,12 +43,12 @@ def _human_assistant_format(input_text: str) -> str:
             if count % 2 == 0:
                 count += 1
             else:
-                raise ValueError(ALTERNATION_ERROR + f" Received {input_text}")
+                warnings.warn(ALTERNATION_ERROR + f" Received {input_text}")
         if input_text[i : i + len(ASSISTANT_PROMPT)] == ASSISTANT_PROMPT:
             if count % 2 == 1:
                 count += 1
             else:
-                raise ValueError(ALTERNATION_ERROR + f" Received {input_text}")
+                warnings.warn(ALTERNATION_ERROR + f" Received {input_text}")
 
     if count % 2 == 1:  # Only saw Human, no Assistant
         input_text = input_text + ASSISTANT_PROMPT  # SILENT CORRECTION

--- a/libs/langchain/tests/unit_tests/llms/test_bedrock.py
+++ b/libs/langchain/tests/unit_tests/llms/test_bedrock.py
@@ -245,7 +245,7 @@ Assistant:""",
 def test__human_assistant_format() -> None:
     for input_text, expected_output in TEST_CASES.items():
         if expected_output == ALTERNATION_ERROR:
-            with pytest.raises(ValueError):
+            with pytest.warns(UserWarning, match=ALTERNATION_ERROR):
                 _human_assistant_format(input_text)
         else:
             output = _human_assistant_format(input_text)


### PR DESCRIPTION
Log a warning instead of raising an error when validating bedrock anthropic prompts. Let server handle actual error behavior.