### PR TITLE
Parse string arguments correctly when using a structured tool

### DIFF
--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -272,8 +272,15 @@ class ChildTool(BaseTool):
         input_args = self.args_schema
         if isinstance(tool_input, str):
             if input_args is not None:
-                key_ = next(iter(input_args.__fields__.keys()))
-                input_args.validate({key_: tool_input})
+                try:
+                    # try parse to obj, convert to dict and validate schema
+                    # e.g. '{"arg1":"foo", "arg2":"bar"}'
+                    tool_input = input_args.parse_raw(tool_input).dict()
+                except ValidationError:
+                    # old style with one argument
+                    # e.g. "test"
+                    key_ = next(iter(input_args.__fields__.keys()))
+                    input_args.validate({key_: tool_input})
             return tool_input
         else:
             if input_args is not None:


### PR DESCRIPTION
**Description:**
Previously when setting up a structured tool with multiple parameters e.g. `arg1, arg2`
we got a schema validation error by pydantic. The reason for this was simple: Although the required parameters for the tool were correctly identified, they were propagated as string e.g. `'{"arg1": "foo", "arg2": "bar"}'`

This PR fixes this issue by using the `parse_raw` method if the args are of type string

**Issue:** 
Didn't find a related issue.

**Dependencies:**
None

**Tag maintainer:**
None

**Twitter handle:**
None

/CC @Depaccu
