### PR TITLE
Fix PyMuPDFLoader kwargs

### DIFF
--- a/libs/langchain/langchain/document_loaders/pdf.py
+++ b/libs/langchain/langchain/document_loaders/pdf.py
@@ -299,10 +299,7 @@ class PyMuPDFLoader(BasePDFLoader):
     """Load `PDF` files using `PyMuPDF`."""
 
     def __init__(
-        self, file_path: str,
-        *, 
-        headers: Optional[Dict] = None,
-        **kwargs: Optional[Any]
+        self, file_path: str, *, headers: Optional[Dict] = None, **kwargs: Any
     ) -> None:
         """Initialize with a file path."""
         try:
@@ -313,12 +310,18 @@ class PyMuPDFLoader(BasePDFLoader):
                 "`pip install pymupdf`"
             )
         super().__init__(file_path, headers=headers)
-        self.kwargs = kwargs
+        self.text_kwargs = kwargs
 
-    def load(self) -> List[Document]:
+    def load(self, **kwargs: Any) -> List[Document]:
         """Load file."""
+        if kwargs:
+            logger.warning(
+                f"Received runtime arguments {kwargs}. Passing runtime args to `load`"
+                f" is deprecated. Please pass arguments during initialization instead."
+            )
 
-        parser = PyMuPDFParser(text_kwargs=self.kwargs)
+        text_kwargs = {**self.text_kwargs, **kwargs}
+        parser = PyMuPDFParser(text_kwargs=text_kwargs)
         blob = Blob.from_path(self.file_path)
         return parser.parse(blob)
 

--- a/libs/langchain/langchain/document_loaders/pdf.py
+++ b/libs/langchain/langchain/document_loaders/pdf.py
@@ -298,7 +298,12 @@ class PDFMinerPDFasHTMLLoader(BasePDFLoader):
 class PyMuPDFLoader(BasePDFLoader):
     """Load `PDF` files using `PyMuPDF`."""
 
-    def __init__(self, file_path: str, *, headers: Optional[Dict] = None) -> None:
+    def __init__(
+        self, file_path: str,
+        *, 
+        headers: Optional[Dict] = None,
+        **kwargs: Optional[Any]
+    ) -> None:
         """Initialize with a file path."""
         try:
             import fitz  # noqa:F401
@@ -307,13 +312,13 @@ class PyMuPDFLoader(BasePDFLoader):
                 "`PyMuPDF` package not found, please install it with "
                 "`pip install pymupdf`"
             )
-
         super().__init__(file_path, headers=headers)
+        self.kwargs = kwargs
 
-    def load(self, **kwargs: Optional[Any]) -> List[Document]:
+    def load(self) -> List[Document]:
         """Load file."""
 
-        parser = PyMuPDFParser(text_kwargs=kwargs)
+        parser = PyMuPDFParser(text_kwargs=self.kwargs)
         blob = Blob.from_path(self.file_path)
         return parser.parse(blob)
 


### PR DESCRIPTION
- **Description:**  Fix the `PyMuPDFLoader` to accept `loader_kwargs` from the document loader's `loader_kwargs` option. This provides more flexibility in formatting the output from documents.

- **Issue:**  The `loader_kwargs` is not passed into the `load` method from the document loader, which limits configuration options.

- **Dependencies:**  None