### PR TITLE
adding support to modify documents in azure search vectorstore

### DIFF
--- a/docs/extras/modules/vectorstore/azure_search_modify_documents.ipynb
+++ b/docs/extras/modules/vectorstore/azure_search_modify_documents.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import openai\n",
+    "from dotenv import load_dotenv\n",
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from langchain.vectorstores.azuresearch import AzureSearch\n",
+    "from langchain.text_splitter import TokenTextSplitter\n",
+    "\n",
+    "load_dotenv(\".env\")\n",
+    "\n",
+    "embeddings = OpenAIEmbeddings(deployment_id=EMBEDDING_DEPLOYMENT_NAME, chunk_size=450)\n",
+    "\n",
+    "acs = AzureSearch(azure_search_endpoint=os.getenv('AZURE_COGNITIVE_SEARCH_SERVICE_NAME'),\n",
+    "                 azure_search_key=os.getenv('AZURE_COGNITIVE_SEARCH_API_KEY'),\n",
+    "                 index_name=os.getenv('AZURE_COGNITIVE_SEARCH_INDEX_NAME'),\n",
+    "                 embedding_function=embeddings.embed_query)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "acs.client.get_document_count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = DirectoryLoader('./', glob=\"*9.json\", loader_cls=TextLoader, loader_kwargs={'autodetect_encoding': True})\n",
+    "\n",
+    "documents = loader.load()\n",
+    "text_splitter = TokenTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
+    "docs = text_splitter.split_documents(documents)\n",
+    "\n",
+    "# Add documents to Azure Search\n",
+    "# doc_ids = acs.add_documents(documents=docs)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Title': 'what is a+B', 'Body': 'a+b = b+a'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "data = json.loads(docs[0].page_content)\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keys = data['Title'].lower().replace(\" \", \"-\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'what-is-a+b'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'what-is-a+b'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc_ids = acs.add_or_modify_documents(docs, keys=[keys])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'd2hhdC1pcy1hK2I='"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "doc_ids[0].encode()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'what-is-a+b'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import base64\n",
+    "base64.urlsafe_b64decode(doc_ids[0].encode())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"Title\": \"what is a+B\",\n",
+      "  \"Body\": \"a+b = b+a\"\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "docs = acs.similarity_search(\n",
+    "    query=\"what is a+b\",\n",
+    "    k=3,\n",
+    "    search_type=\"similarity\",\n",
+    ")\n",
+    "for doc in docs:\n",
+    "    print(doc.page_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Changed the body of that file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = DirectoryLoader('./', glob=\"*9.json\", loader_cls=TextLoader, loader_kwargs={'autodetect_encoding': True})\n",
+    "\n",
+    "documents = loader.load()\n",
+    "text_splitter = TokenTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
+    "docs = text_splitter.split_documents(documents)\n",
+    "\n",
+    "# Add documents to Azure Search\n",
+    "# doc_ids = acs.add_documents(documents=docs)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Title': 'what is a+B', 'Body': \"I don't know\"}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "data = json.loads(docs[0].page_content)\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keys = data['Title'].lower().replace(\" \", \"-\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'what-is-a+b'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc_ids = acs.add_or_modify_documents(docs, keys=[keys])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'd2hhdC1pcy1hK2I='"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "doc_ids[0].encode()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'what-is-a+b'"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import base64\n",
+    "base64.urlsafe_b64decode(doc_ids[0].encode())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Same document key "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"Title\": \"what is a+B\",\n",
+      "  \"Body\": \"I don't know\"\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "docs = acs.similarity_search(\n",
+    "    query=\"what is a+b\",\n",
+    "    k=3,\n",
+    "    search_type=\"similarity\",\n",
+    ")\n",
+    "for doc in docs:\n",
+    "    print(doc.page_content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "acs.client.get_document_count()  # With same count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "taxslyenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "3a0f3e867c6b476f88a138b24067857b21b08fa9cc650ee53fe078dd48733190"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libs/langchain/langchain/schema/vectorstore.py
+++ b/libs/langchain/langchain/schema/vectorstore.py
@@ -58,6 +58,24 @@ class VectorStore(ABC):
             List of ids from adding the texts into the vectorstore.
         """
 
+    @abstractmethod
+    def add_or_modify_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Run more texts through the embeddings and add to the vectorstore.
+
+        Args:
+            texts: Iterable of strings to add to the vectorstore.
+            metadatas: Optional list of metadatas associated with the texts.
+            kwargs: vectorstore specific parameters
+
+        Returns:
+            List of ids from adding the texts into the vectorstore.
+        """
+
     @property
     def embeddings(self) -> Optional[Embeddings]:
         """Access the query embedding object if available."""
@@ -104,6 +122,22 @@ class VectorStore(ABC):
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
         return self.add_texts(texts, metadatas, **kwargs)
+
+    def add_or_modify_documents(
+        self, documents: List[Document], **kwargs: Any
+    ) -> List[str]:
+        """Run more documents through the embeddings and add to the vectorstore.
+
+        Args:
+            documents (List[Document]: Documents to add to the vectorstore.
+
+        Returns:
+            List[str]: List of IDs of the added texts.
+        """
+        # TODO: Handle the case where the user doesn't provide ids on the Collection
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+        return self.add_or_modify_texts(texts, metadatas, **kwargs)
 
     async def aadd_documents(
         self, documents: List[Document], **kwargs: Any

--- a/libs/langchain/tests/unit_tests/indexes/test_indexing.py
+++ b/libs/langchain/tests/unit_tests/indexes/test_indexing.py
@@ -65,7 +65,39 @@ class InMemoryVectorStore(VectorStore):
                 )
             self.store[_id] = document
 
+    def add_or_modify_documents(  # type: ignore
+        self,
+        documents: Sequence[Document],
+        *,
+        ids: Optional[Sequence[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Add the given documents to the store (insert behavior)."""
+        if ids and len(ids) != len(documents):
+            raise ValueError(
+                f"Expected {len(ids)} ids, got {len(documents)} documents."
+            )
+
+        if not ids:
+            raise NotImplementedError("This is not implemented yet.")
+
+        for _id, document in zip(ids, documents):
+            if _id in self.store:
+                raise ValueError(
+                    f"Document with uid {_id} already exists in the store."
+                )
+            self.store[_id] = document
+
     def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Add the given texts to the store (insert behavior)."""
+        raise NotImplementedError()
+
+    def add_or_modify_texts(
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,

--- a/libs/langchain/tests/unit_tests/retrievers/test_time_weighted_retriever.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_time_weighted_retriever.py
@@ -48,6 +48,24 @@ class MockVectorStore(VectorStore):
         """
         return list(texts)
 
+    def add_or_modify_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Run more texts through the embeddings and add to the vectorstore.
+
+        Args:
+            texts: Iterable of strings to add to the vectorstore.
+            metadatas: Optional list of metadatas associated with the texts.
+            kwargs: vectorstore specific parameters
+
+        Returns:
+            List of ids from adding the texts into the vectorstore.
+        """
+        return list(texts)
+
     async def aadd_texts(
         self,
         texts: Iterable[str],


### PR DESCRIPTION
**Description** 
Adding support to replace documents in Azure Cognitive Search. Right now, we can only upload documents but azure [azure-search-documents](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/search/azure-search-documents/azure/search/documents/_search_client.py#L623) provides the option to modify the documents. 


**References**
- https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/search/azure-search-documents/azure/search/documents/_search_client.py#L623
- https://learn.microsoft.com/en-us/rest/api/searchservice/addupdate-or-delete-documents


**Issue** 
None

**Dependencies** 
None

**Tag maintainer** 
@eyurtsev 

**Example**
[azure_search_modify_documents.ipynb](https://github.com/bhanu-pappala/langchain/blob/azure_modify_documents/docs/extras/modules/vectorstore/azure_search_modify_documents.ipynb)
