### PR TITLE
Fix a Typo in Documentation

### DIFF
--- a/docs/extras/use_cases/more/agents/agents.ipynb
+++ b/docs/extras/use_cases/more/agents/agents.ipynb
@@ -284,7 +284,7 @@
     "```\n",
     "\n",
     "* The search is executed\n",
-    "* The results frum search are passed back to the LLM for synthesis into an answer\n",
+    "* The results from search are passed back to the LLM for synthesis into an answer\n",
     "\n",
     "![Image description](/img/oai_function_agent.png)"
    ]


### PR DESCRIPTION
- **Description:** This commit corrects a minor typo in the documentation. It changes "frum" to "from" in the sentence: "The results from search are passed back to the LLM for synthesis into an answer" in the file `docs/extras/use_cases/more/agents/agents.ipynb`. This typo fix enhances the clarity and accuracy of the documentation.
- **Tag maintainer:** @baskaryan