### PR TITLE
Quote tool names

### DIFF
--- a/docs/snippets/modules/agents/how_to/custom_llm_agent.mdx
+++ b/docs/snippets/modules/agents/how_to/custom_llm_agent.mdx
@@ -97,7 +97,7 @@ class CustomPromptTemplate(StringPromptTemplate):
         # Create a tools variable from the list of tools provided
         kwargs["tools"] = "\n".join([f"{tool.name}: {tool.description}" for tool in self.tools])
         # Create a list of tool names for the tools provided
-        kwargs["tool_names"] = ", ".join([tool.name for tool in self.tools])
+        kwargs["tool_names"] = ", ".join([json.dumps(tool.name) for tool in self.tools])
         return self.template.format(**kwargs)
 ```
 

--- a/docs/snippets/modules/agents/how_to/custom_llm_chat_agent.mdx
+++ b/docs/snippets/modules/agents/how_to/custom_llm_chat_agent.mdx
@@ -116,7 +116,7 @@ class CustomPromptTemplate(BaseChatPromptTemplate):
         # Create a tools variable from the list of tools provided
         kwargs["tools"] = "\n".join([f"{tool.name}: {tool.description}" for tool in self.tools])
         # Create a list of tool names for the tools provided
-        kwargs["tool_names"] = ", ".join([tool.name for tool in self.tools])
+        kwargs["tool_names"] = ", ".join([json.dumps(tool.name) for tool in self.tools])
         formatted = self.template.format(**kwargs)
         return [HumanMessage(content=formatted)]
 ```

--- a/libs/langchain/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/openapi/planner.py
@@ -257,7 +257,7 @@ def _create_api_controller_agent(
         partial_variables={
             "api_url": api_url,
             "api_docs": api_docs,
-            "tool_names": ", ".join([tool.name for tool in tools]),
+            "tool_names": ", ".join([json.dumps(tool.name) for tool in tools]),
             "tool_descriptions": "\n".join(
                 [f"{tool.name}: {tool.description}" for tool in tools]
             ),
@@ -335,7 +335,7 @@ def create_openapi_agent(
         template=API_ORCHESTRATOR_PROMPT,
         input_variables=["input", "agent_scratchpad"],
         partial_variables={
-            "tool_names": ", ".join([tool.name for tool in tools]),
+            "tool_names": ", ".join([json.dumps(tool.name) for tool in tools]),
             "tool_descriptions": "\n".join(
                 [f"{tool.name}: {tool.description}" for tool in tools]
             ),

--- a/libs/langchain/langchain/agents/chat/base.py
+++ b/libs/langchain/langchain/agents/chat/base.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, List, Optional, Sequence, Tuple
 
 from langchain.agents.agent import Agent, AgentOutputParser
@@ -20,7 +21,6 @@ from langchain.pydantic_v1 import Field
 from langchain.schema import AgentAction, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool
-import json
 
 
 class ChatAgent(Agent):
@@ -78,7 +78,6 @@ class ChatAgent(Agent):
         input_variables: Optional[List[str]] = None,
     ) -> BasePromptTemplate:
         tool_strings = "\n".join([f"{tool.name}: {tool.description}" for tool in tools])
-        
         tool_names = ", ".join([json.dumps(tool.name) for tool in tools])
         format_instructions = format_instructions.format(tool_names=tool_names)
         template = "\n\n".join(

--- a/libs/langchain/langchain/agents/chat/base.py
+++ b/libs/langchain/langchain/agents/chat/base.py
@@ -20,6 +20,7 @@ from langchain.pydantic_v1 import Field
 from langchain.schema import AgentAction, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool
+import json
 
 
 class ChatAgent(Agent):
@@ -77,7 +78,8 @@ class ChatAgent(Agent):
         input_variables: Optional[List[str]] = None,
     ) -> BasePromptTemplate:
         tool_strings = "\n".join([f"{tool.name}: {tool.description}" for tool in tools])
-        tool_names = ", ".join([tool.name for tool in tools])
+        
+        tool_names = ", ".join([json.dumps(tool.name) for tool in tools])
         format_instructions = format_instructions.format(tool_names=tool_names)
         template = "\n\n".join(
             [

--- a/libs/langchain/langchain/agents/conversational/base.py
+++ b/libs/langchain/langchain/agents/conversational/base.py
@@ -14,6 +14,7 @@ from langchain.prompts import PromptTemplate
 from langchain.pydantic_v1 import Field
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool
+import json
 
 
 class ConversationalAgent(Agent):
@@ -73,7 +74,7 @@ class ConversationalAgent(Agent):
         tool_strings = "\n".join(
             [f"> {tool.name}: {tool.description}" for tool in tools]
         )
-        tool_names = ", ".join([tool.name for tool in tools])
+        tool_names = ", ".join([json.dumps(tool.name) for tool in tools])
         format_instructions = format_instructions.format(
             tool_names=tool_names, ai_prefix=ai_prefix, human_prefix=human_prefix
         )

--- a/libs/langchain/langchain/agents/conversational/base.py
+++ b/libs/langchain/langchain/agents/conversational/base.py
@@ -1,6 +1,7 @@
 """An agent designed to hold a conversation in addition to using tools."""
 from __future__ import annotations
 
+import json
 from typing import Any, List, Optional, Sequence
 
 from langchain.agents.agent import Agent, AgentOutputParser
@@ -14,7 +15,6 @@ from langchain.prompts import PromptTemplate
 from langchain.pydantic_v1 import Field
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool
-import json
 
 
 class ConversationalAgent(Agent):

--- a/libs/langchain/langchain/agents/conversational_chat/base.py
+++ b/libs/langchain/langchain/agents/conversational_chat/base.py
@@ -24,6 +24,7 @@ from langchain.schema import AgentAction, BaseOutputParser, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.schema.messages import AIMessage, BaseMessage, HumanMessage
 from langchain.tools.base import BaseTool
+import json
 
 
 class ConversationalChatAgent(Agent):
@@ -67,7 +68,7 @@ class ConversationalChatAgent(Agent):
         tool_strings = "\n".join(
             [f"> {tool.name}: {tool.description}" for tool in tools]
         )
-        tool_names = ", ".join([tool.name for tool in tools])
+        tool_names = ", ".join([json.dumps(tool.name) for tool in tools])
         _output_parser = output_parser or cls._get_default_output_parser()
         format_instructions = human_message.format(
             format_instructions=_output_parser.get_format_instructions()

--- a/libs/langchain/langchain/agents/conversational_chat/base.py
+++ b/libs/langchain/langchain/agents/conversational_chat/base.py
@@ -1,6 +1,7 @@
 """An agent designed to hold a conversation in addition to using tools."""
 from __future__ import annotations
 
+import json
 from typing import Any, List, Optional, Sequence, Tuple
 
 from langchain.agents.agent import Agent, AgentOutputParser
@@ -24,7 +25,6 @@ from langchain.schema import AgentAction, BaseOutputParser, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.schema.messages import AIMessage, BaseMessage, HumanMessage
 from langchain.tools.base import BaseTool
-import json
 
 
 class ConversationalChatAgent(Agent):

--- a/libs/langchain/langchain/agents/mrkl/base.py
+++ b/libs/langchain/langchain/agents/mrkl/base.py
@@ -1,6 +1,7 @@
 """Attempt to implement MRKL systems as described in arxiv.org/pdf/2205.00445.pdf."""
 from __future__ import annotations
 
+import json
 from typing import Any, Callable, List, NamedTuple, Optional, Sequence
 
 from langchain.agents.agent import Agent, AgentExecutor, AgentOutputParser
@@ -15,7 +16,6 @@ from langchain.prompts import PromptTemplate
 from langchain.pydantic_v1 import Field
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool
-import json
 
 
 class ChainConfig(NamedTuple):

--- a/libs/langchain/langchain/agents/mrkl/base.py
+++ b/libs/langchain/langchain/agents/mrkl/base.py
@@ -15,6 +15,7 @@ from langchain.prompts import PromptTemplate
 from langchain.pydantic_v1 import Field
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools.base import BaseTool
+import json
 
 
 class ChainConfig(NamedTuple):
@@ -77,7 +78,7 @@ class ZeroShotAgent(Agent):
             A PromptTemplate with the template assembled from the pieces here.
         """
         tool_strings = "\n".join([f"{tool.name}: {tool.description}" for tool in tools])
-        tool_names = ", ".join([tool.name for tool in tools])
+        tool_names = ", ".join([json.dumps(tool.name) for tool in tools])
         format_instructions = format_instructions.format(tool_names=tool_names)
         template = "\n\n".join([prefix, tool_strings, format_instructions, suffix])
         if input_variables is None:

--- a/libs/langchain/langchain/agents/structured_chat/base.py
+++ b/libs/langchain/langchain/agents/structured_chat/base.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Any, List, Optional, Sequence, Tuple
 
@@ -17,7 +18,6 @@ from langchain.pydantic_v1 import Field
 from langchain.schema import AgentAction, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools import BaseTool
-import json
 
 HUMAN_MESSAGE_TEMPLATE = "{input}\n\n{agent_scratchpad}"
 

--- a/libs/langchain/langchain/agents/structured_chat/base.py
+++ b/libs/langchain/langchain/agents/structured_chat/base.py
@@ -17,6 +17,7 @@ from langchain.pydantic_v1 import Field
 from langchain.schema import AgentAction, BasePromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain.tools import BaseTool
+import json
 
 HUMAN_MESSAGE_TEMPLATE = "{input}\n\n{agent_scratchpad}"
 
@@ -84,7 +85,7 @@ class StructuredChatAgent(Agent):
             args_schema = re.sub("}", "}}}}", re.sub("{", "{{{{", str(tool.args)))
             tool_strings.append(f"{tool.name}: {tool.description}, args: {args_schema}")
         formatted_tools = "\n".join(tool_strings)
-        tool_names = ", ".join([tool.name for tool in tools])
+        tool_names = ", ".join([json.dumps(tool.name) for tool in tools])
         format_instructions = format_instructions.format(tool_names=tool_names)
         template = "\n\n".join([prefix, formatted_tools, format_instructions, suffix])
         if input_variables is None:

--- a/libs/langchain/langchain/agents/tools.py
+++ b/libs/langchain/langchain/agents/tools.py
@@ -1,4 +1,5 @@
 """Interface for tools."""
+import json
 from typing import List, Optional
 
 from langchain.callbacks.manager import (
@@ -6,7 +7,7 @@ from langchain.callbacks.manager import (
     CallbackManagerForToolRun,
 )
 from langchain.tools.base import BaseTool, Tool, tool
-import json
+
 
 class InvalidTool(BaseTool):
     """Tool that is run when invalid tool name is encountered by agent."""
@@ -21,7 +22,9 @@ class InvalidTool(BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool."""
-        available_tool_names_str = ", ".join([json.dumps(tool) for tool in available_tool_names])
+        available_tool_names_str = ", ".join(
+            [json.dumps(tool) for tool in available_tool_names]
+        )
         return (
             f"{requested_tool_name} is not a valid tool, "
             f"try one of [{available_tool_names_str}]."
@@ -34,7 +37,9 @@ class InvalidTool(BaseTool):
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool asynchronously."""
-        available_tool_names_str = ", ".join([json.dumps(tool) for tool in available_tool_names])
+        available_tool_names_str = ", ".join(
+            [json.dumps(tool) for tool in available_tool_names]
+        )
         return (
             f"{requested_tool_name} is not a valid tool, "
             f"try one of [{available_tool_names_str}]."

--- a/libs/langchain/langchain/agents/tools.py
+++ b/libs/langchain/langchain/agents/tools.py
@@ -6,7 +6,7 @@ from langchain.callbacks.manager import (
     CallbackManagerForToolRun,
 )
 from langchain.tools.base import BaseTool, Tool, tool
-
+import json
 
 class InvalidTool(BaseTool):
     """Tool that is run when invalid tool name is encountered by agent."""
@@ -21,7 +21,7 @@ class InvalidTool(BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool."""
-        available_tool_names_str = ", ".join([tool for tool in available_tool_names])
+        available_tool_names_str = ", ".join([json.dumps(tool) for tool in available_tool_names])
         return (
             f"{requested_tool_name} is not a valid tool, "
             f"try one of [{available_tool_names_str}]."
@@ -34,7 +34,7 @@ class InvalidTool(BaseTool):
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool asynchronously."""
-        available_tool_names_str = ", ".join([tool for tool in available_tool_names])
+        available_tool_names_str = ", ".join([json.dumps(tool) for tool in available_tool_names])
         return (
             f"{requested_tool_name} is not a valid tool, "
             f"try one of [{available_tool_names_str}]."

--- a/libs/langchain/tests/unit_tests/agents/test_mrkl.py
+++ b/libs/langchain/tests/unit_tests/agents/test_mrkl.py
@@ -152,7 +152,7 @@ def test_from_chains() -> None:
     ]
     agent = ZeroShotAgent.from_llm_and_tools(FakeLLM(), chain_configs)
     expected_tools_prompt = "foo: foobar1\nbar: foobar2"
-    expected_tool_names = "foo, bar"
+    expected_tool_names = "\"foo\", \"bar\""
     expected_template = "\n\n".join(
         [
             PREFIX,

--- a/libs/langchain/tests/unit_tests/agents/test_mrkl.py
+++ b/libs/langchain/tests/unit_tests/agents/test_mrkl.py
@@ -152,7 +152,7 @@ def test_from_chains() -> None:
     ]
     agent = ZeroShotAgent.from_llm_and_tools(FakeLLM(), chain_configs)
     expected_tools_prompt = "foo: foobar1\nbar: foobar2"
-    expected_tool_names = "\"foo\", \"bar\""
+    expected_tool_names = '"foo", "bar"'
     expected_template = "\n\n".join(
         [
             PREFIX,


### PR DESCRIPTION
  - **Description:** Quote tool names in prompt templates
  - **Issue:** https://github.com/langchain-ai/langchain/issues/1657 https://github.com/langchain-ai/langchain/issues/1477 https://github.com/langchain-ai/langchain/issues/1358
  - **Tag maintainer:** @hwchase17

The original prompt template is ambiguous because it does not tell whether the tool names should be quoted or not. This PR makes it clear that the tool names should be quoted. It fixes #1358 for Nous-Hermes-Llama2-13b according to my tests.