### PR TITLE
Use InferenceClient instead of InferenceAPI for HuggingFaceHubEmbeddings

### DIFF
--- a/libs/langchain/langchain/embeddings/huggingface_hub.py
+++ b/libs/langchain/langchain/embeddings/huggingface_hub.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional
 
 from langchain.pydantic_v1 import BaseModel, Extra, root_validator
@@ -87,8 +88,8 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
         # replace newlines, which can negatively affect performance.
         texts = [text.replace("\n", " ") for text in texts]
         _model_kwargs = self.model_kwargs or {}
-        responses = self.client(inputs=texts, params=_model_kwargs)
-        return responses
+        responses = self.client.post(json={"inputs": texts, "parameters": _model_kwargs}, task=self.task)
+        return json.loads(responses.decode())
 
     def embed_query(self, text: str) -> List[float]:
         """Call out to HuggingFaceHub's embedding endpoint for embedding query text.

--- a/libs/langchain/langchain/embeddings/huggingface_hub.py
+++ b/libs/langchain/langchain/embeddings/huggingface_hub.py
@@ -31,7 +31,7 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
     client: Any  #: :meta private:
     repo_id: str = DEFAULT_REPO_ID
     """Model name to use."""
-    task: Optional[str] = "feature-extraction"
+    task: str = "feature-extraction"
     """Task to call the model with."""
     model_kwargs: Optional[dict] = None
     """Keyword arguments to pass to the model."""

--- a/libs/langchain/langchain/embeddings/huggingface_hub.py
+++ b/libs/langchain/langchain/embeddings/huggingface_hub.py
@@ -88,7 +88,9 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
         # replace newlines, which can negatively affect performance.
         texts = [text.replace("\n", " ") for text in texts]
         _model_kwargs = self.model_kwargs or {}
-        responses = self.client.post(json={"inputs": texts, "parameters": _model_kwargs}, task=self.task)
+        responses = self.client.post(
+            json={"inputs": texts, "parameters": _model_kwargs}, task=self.task
+        )
         return json.loads(responses.decode())
 
     def embed_query(self, text: str) -> List[float]:

--- a/libs/langchain/langchain/embeddings/huggingface_hub.py
+++ b/libs/langchain/langchain/embeddings/huggingface_hub.py
@@ -49,7 +49,7 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
             values, "huggingfacehub_api_token", "HUGGINGFACEHUB_API_TOKEN"
         )
         try:
-            from huggingface_hub.inference_api import InferenceApi
+            from huggingface_hub import InferenceClient
 
             repo_id = values["repo_id"]
             if not repo_id.startswith("sentence-transformers"):
@@ -57,14 +57,14 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
                     "Currently only 'sentence-transformers' embedding models "
                     f"are supported. Got invalid 'repo_id' {repo_id}."
                 )
-            client = InferenceApi(
-                repo_id=repo_id,
+            client = InferenceClient(
+                model=repo_id,
                 token=huggingfacehub_api_token,
-                task=values.get("task"),
             )
-            if client.task not in VALID_TASKS:
+
+            if values["task"] not in VALID_TASKS:
                 raise ValueError(
-                    f"Got invalid task {client.task}, "
+                    f"Got invalid task {values['task']}, "
                     f"currently only {VALID_TASKS} are supported"
                 )
             values["client"] = client


### PR DESCRIPTION
**Description:**
Replace deprecated `InferenceAPI` of Hugging Face Inference with `InferenceClient` in the module `embeddings.huggingface_hub`.

**Issue:**
#10483 

**Remarks:**
- A similar PR is open for the module `llms.huggingface_hub`: #10514 
- It's my first contribution to an open source project. Then don't hesitate to send me your comments 😃. 

