### PR TITLE
Fix: Correct trailing commas in JSON before parsing

### DIFF
--- a/libs/langchain/langchain/output_parsers/pydantic.py
+++ b/libs/langchain/langchain/output_parsers/pydantic.py
@@ -9,6 +9,12 @@ from langchain.schema import BaseOutputParser, OutputParserException
 T = TypeVar("T", bound=BaseModel)
 
 
+def correct_trailing_commas(json_str: str) -> str:
+    """Corrects trailing commas in a JSON string."""
+    regex = r',(\s*[\}\]])'  # Matches trailing commas before } or ]
+    return re.sub(regex, r'\1', json_str)
+
+
 class PydanticOutputParser(BaseOutputParser[T]):
     """Parse an output using a pydantic model."""
 
@@ -24,7 +30,9 @@ class PydanticOutputParser(BaseOutputParser[T]):
             json_str = ""
             if match:
                 json_str = match.group()
-            json_object = json.loads(json_str, strict=False)
+            # Correct trailing commas
+            corrected_json_str = correct_trailing_commas(json_str)
+            json_object = json.loads(corrected_json_str, strict=False)
             return self.pydantic_object.parse_obj(json_object)
 
         except (json.JSONDecodeError, ValidationError) as e:


### PR DESCRIPTION
This commit addresses the issue where JSON strings with trailing commas would cause parsing to fail. We have added a preprocessing step to correct these commas before attempting to parse the JSON string using the `json.loads()` function.

Changes:
- Added a `correct_trailing_commas` function that removes trailing commas from a given JSON string.
- Used this function to preprocess the JSON string inside the `parse` method of `PydanticOutputParser`.

Reason:
Some JSON producing systems or manual entries might inadvertently add trailing commas, which are not valid in standard JSON. This change aims to make our parser more robust and forgiving of such common mistakes, thereby reducing potential disruptions or failures due to invalid JSON formats.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
