### PR TITLE
QoL improvements to query constructor

### DIFF
--- a/libs/langchain/langchain/chains/query_constructor/base.py
+++ b/libs/langchain/langchain/chains/query_constructor/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 from langchain.chains.llm import LLMChain
 from langchain.chains.query_constructor.ir import (
@@ -14,17 +14,18 @@ from langchain.chains.query_constructor.parser import get_parser
 from langchain.chains.query_constructor.prompt import (
     DEFAULT_EXAMPLES,
     DEFAULT_PREFIX,
-    DEFAULT_SCHEMA,
+    DEFAULT_SCHEMA_PROMPT,
     DEFAULT_SUFFIX,
     EXAMPLE_PROMPT,
     EXAMPLES_WITH_LIMIT,
-    SCHEMA_WITH_LIMIT,
+    SCHEMA_WITH_LIMIT_PROMPT,
 )
 from langchain.chains.query_constructor.schema import AttributeInfo
 from langchain.output_parsers.json import parse_and_check_json_markdown
 from langchain.prompts.few_shot import FewShotPromptTemplate
 from langchain.schema import BaseOutputParser, BasePromptTemplate, OutputParserException
 from langchain.schema.language_model import BaseLanguageModel
+from langchain.schema.runnable import Runnable
 
 
 class StructuredQueryOutputParser(BaseOutputParser[StructuredQuery]):
@@ -76,7 +77,7 @@ class StructuredQueryOutputParser(BaseOutputParser[StructuredQuery]):
         return cls(ast_parse=ast_parser.parse)
 
 
-def _format_attribute_info(info: Sequence[AttributeInfo]) -> str:
+def _format_attribute_info(info: Sequence[Union[AttributeInfo, dict]]) -> str:
     info_dicts = {}
     for i in info:
         i_dict = dict(i)
@@ -84,56 +85,66 @@ def _format_attribute_info(info: Sequence[AttributeInfo]) -> str:
     return json.dumps(info_dicts, indent=4).replace("{", "{{").replace("}", "}}")
 
 
-def _get_prompt(
+def get_query_constructor_prompt(
     document_contents: str,
-    attribute_info: Sequence[AttributeInfo],
-    examples: Optional[List] = None,
-    allowed_comparators: Optional[Sequence[Comparator]] = None,
-    allowed_operators: Optional[Sequence[Operator]] = None,
+    attribute_info: Sequence[Union[AttributeInfo, dict]],
+    *,
+    examples: Optional[Sequence] = None,
+    allowed_comparators: Sequence[Comparator] = tuple(Comparator),
+    allowed_operators: Sequence[Operator] = tuple(Operator),
     enable_limit: bool = False,
+    schema_prompt: Optional[BasePromptTemplate] = None,
+    **kwargs: Any,
 ) -> BasePromptTemplate:
-    attribute_str = _format_attribute_info(attribute_info)
-    allowed_comparators = allowed_comparators or list(Comparator)
-    allowed_operators = allowed_operators or list(Operator)
-    if enable_limit:
-        schema = SCHEMA_WITH_LIMIT.format(
-            allowed_comparators=" | ".join(allowed_comparators),
-            allowed_operators=" | ".join(allowed_operators),
-        )
+    """Create query construction prompt.
 
-        examples = examples or EXAMPLES_WITH_LIMIT
-    else:
-        schema = DEFAULT_SCHEMA.format(
-            allowed_comparators=" | ".join(allowed_comparators),
-            allowed_operators=" | ".join(allowed_operators),
-        )
-
-        examples = examples or DEFAULT_EXAMPLES
+    Args:
+        document_contents: The contents of the document to be queried.
+        attribute_info: A list of AttributeInfo objects describing
+            the attributes of the document.
+        examples: Optional list of examples to use for the chain.
+        allowed_comparators: Sequence of allowed comparators.
+        allowed_operators: Sequence of allowed operators.
+        enable_limit: Whether to enable the limit operator. Defaults to False.
+        schema_prompt: Prompt for describing query schema. Should have string input
+            variables allowed_comparators and allowed_operators.
+        **kwargs: Additional named params to pass to FewShotPromptTemplate init.
+    """
+    default_schema_prompt = (
+        SCHEMA_WITH_LIMIT_PROMPT if enable_limit else DEFAULT_SCHEMA_PROMPT
+    )
+    schema_prompt = schema_prompt or default_schema_prompt
+    default_examples = EXAMPLES_WITH_LIMIT if enable_limit else DEFAULT_EXAMPLES
+    examples = examples or default_examples
+    schema = schema_prompt.format(
+        allowed_comparators=" | ".join(allowed_comparators),
+        allowed_operators=" | ".join(allowed_operators),
+    )
     prefix = DEFAULT_PREFIX.format(schema=schema)
+    attribute_str = _format_attribute_info(attribute_info)
     suffix = DEFAULT_SUFFIX.format(
         i=len(examples) + 1, content=document_contents, attributes=attribute_str
     )
-    output_parser = StructuredQueryOutputParser.from_components(
-        allowed_comparators=allowed_comparators, allowed_operators=allowed_operators
-    )
     return FewShotPromptTemplate(
-        examples=examples,
+        examples=list(examples),
         example_prompt=EXAMPLE_PROMPT,
         input_variables=["query"],
         suffix=suffix,
         prefix=prefix,
-        output_parser=output_parser,
+        **kwargs,
     )
 
 
 def load_query_constructor_chain(
     llm: BaseLanguageModel,
     document_contents: str,
-    attribute_info: List[AttributeInfo],
+    attribute_info: Sequence[Union[AttributeInfo, dict]],
+    *,
     examples: Optional[List] = None,
-    allowed_comparators: Optional[Sequence[Comparator]] = None,
-    allowed_operators: Optional[Sequence[Operator]] = None,
+    allowed_comparators: Sequence[Comparator] = tuple(Comparator),
+    allowed_operators: Sequence[Operator] = tuple(Operator),
     enable_limit: bool = False,
+    schema_prompt: Optional[BasePromptTemplate] = None,
     **kwargs: Any,
 ) -> LLMChain:
     """Load a query constructor chain.
@@ -141,25 +152,75 @@ def load_query_constructor_chain(
     Args:
         llm: BaseLanguageModel to use for the chain.
         document_contents: The contents of the document to be queried.
-        attribute_info: A list of AttributeInfo objects describing
-            the attributes of the document.
+        attribute_info: Sequence of attributes in the document.
         examples: Optional list of examples to use for the chain.
-        allowed_comparators: An optional list of allowed comparators.
-        allowed_operators: An optional list of allowed operators.
+        allowed_comparators: Sequence of allowed comparators. Defaults to all
+            Comparators.
+        allowed_operators: Sequence of allowed operators. Defaults to all Operators.
         enable_limit: Whether to enable the limit operator. Defaults to False.
-        **kwargs:
+        schema_prompt: Prompt for describing query schema. Should have string input
+            variables allowed_comparators and allowed_operators.
+        **kwargs: Arbitrary named params to pass to LLMChain.
 
     Returns:
         A LLMChain that can be used to construct queries.
     """
-    prompt = _get_prompt(
+    prompt = get_query_constructor_prompt(
         document_contents,
         attribute_info,
         examples=examples,
         allowed_comparators=allowed_comparators,
         allowed_operators=allowed_operators,
         enable_limit=enable_limit,
+        schema_prompt=schema_prompt,
     )
-    return LLMChain(
-        llm=llm, prompt=prompt, output_parser=prompt.output_parser, **kwargs
+    output_parser = StructuredQueryOutputParser.from_components(
+        allowed_comparators=allowed_comparators, allowed_operators=allowed_operators
     )
+    return LLMChain(llm=llm, prompt=prompt, output_parser=output_parser, **kwargs)
+
+
+def load_query_constructor_runnable(
+    llm: BaseLanguageModel,
+    document_contents: str,
+    attribute_info: Sequence[Union[AttributeInfo, dict]],
+    *,
+    examples: Optional[Sequence] = None,
+    allowed_comparators: Sequence[Comparator] = tuple(Comparator),
+    allowed_operators: Sequence[Operator] = tuple(Operator),
+    enable_limit: bool = False,
+    schema_prompt: Optional[BasePromptTemplate] = None,
+    **kwargs: Any,
+) -> Runnable:
+    """Load a query constructor runnable chain.
+
+    Args:
+        llm: BaseLanguageModel to use for the chain.
+        document_contents: The contents of the document to be queried.
+        attribute_info: Sequence of attributes in the document.
+        examples: Optional list of examples to use for the chain.
+        allowed_comparators: Sequence of allowed comparators. Defaults to all
+            Comparators.
+        allowed_operators: Sequence of allowed operators. Defaults to all Operators.
+        enable_limit: Whether to enable the limit operator. Defaults to False.
+        schema_prompt: Prompt for describing query schema. Should have string input
+            variables allowed_comparators and allowed_operators.
+        **kwargs: Additional named params to pass to FewShotPromptTemplate init.
+
+    Returns:
+        A Runnable that can be used to construct queries.
+    """
+    prompt = get_query_constructor_prompt(
+        document_contents,
+        attribute_info,
+        examples=examples,
+        allowed_comparators=allowed_comparators,
+        allowed_operators=allowed_operators,
+        enable_limit=enable_limit,
+        schema_prompt=schema_prompt,
+        **kwargs,
+    )
+    output_parser = StructuredQueryOutputParser.from_components(
+        allowed_comparators=allowed_comparators, allowed_operators=allowed_operators
+    )
+    return prompt | llm | output_parser

--- a/libs/langchain/langchain/chains/query_constructor/base.py
+++ b/libs/langchain/langchain/chains/query_constructor/base.py
@@ -134,7 +134,7 @@ def fix_filter_directive(
         args = [arg for arg in args if arg is not None]
         if not args:
             return None
-        elif len(args) == 1:
+        elif len(args) == 1 and filter.operator in (Operator.AND, Operator.OR):
             return args[0]
         else:
             return Operation(
@@ -157,10 +157,7 @@ def construct_examples(input_output_pairs: Sequence[Tuple[str, dict]]) -> List[d
     examples = []
     for i, (_input, output) in enumerate(input_output_pairs):
         structured_request = (
-            json.dumps(output, indent=4)
-            .replace("{", "{{")
-            .replace("}", "}}")
-            .replace('"', '"')
+            json.dumps(output, indent=4).replace("{", "{{").replace("}", "}}")
         )
         example = {
             "i": i + 1,
@@ -235,7 +232,6 @@ def load_query_constructor_chain(
     llm: BaseLanguageModel,
     document_contents: str,
     attribute_info: Sequence[Union[AttributeInfo, dict]],
-    *,
     examples: Optional[List] = None,
     allowed_comparators: Sequence[Comparator] = tuple(Comparator),
     allowed_operators: Sequence[Operator] = tuple(Operator),

--- a/libs/langchain/langchain/chains/query_constructor/prompt.py
+++ b/libs/langchain/langchain/chains/query_constructor/prompt.py
@@ -3,36 +3,31 @@ from langchain.prompts import PromptTemplate
 
 SONG_DATA_SOURCE = """\
 ```json
-{
+{{
     "content": "Lyrics of a song",
-    "attributes": {
-        "artist": {
+    "attributes": {{
+        "artist": {{
             "type": "string",
             "description": "Name of the song artist"
-        },
-        "length": {
+        }},
+        "length": {{
             "type": "integer",
             "description": "Length of the song in seconds"
-        },
-        "genre": {
+        }},
+        "genre": {{
             "type": "string",
             "description": "The song genre, one of \"pop\", \"rock\" or \"rap\""
-        }
-    }
-}
+        }}
+    }}
+}}
 ```\
-""".replace(
-    "{", "{{"
-).replace(
-    "}", "}}"
-)
+"""
 
 FULL_ANSWER = """\
 ```json
 {{
     "query": "teenager love",
-    "filter": "and(or(eq(\\"artist\\", \\"Taylor Swift\\"), eq(\\"artist\\", \\"Katy Perry\\")), \
-lt(\\"length\\", 180), eq(\\"genre\\", \\"pop\\"))"
+    "filter": "and(or(eq(\\"artist\\", \\"Taylor Swift\\"), eq(\\"artist\\", \\"Katy Perry\\")), lt(\\"length\\", 180), eq(\\"genre\\", \\"pop\\"))"
 }}
 ```\
 """
@@ -104,16 +99,12 @@ Structured Request:
 {structured_request}
 """
 
-EXAMPLE_PROMPT = PromptTemplate(
-    input_variables=["i", "data_source", "user_query", "structured_request"],
-    template=EXAMPLE_PROMPT_TEMPLATE,
-)
+EXAMPLE_PROMPT = PromptTemplate.from_template(EXAMPLE_PROMPT_TEMPLATE)
 
 
 DEFAULT_SCHEMA = """\
 << Structured Request Schema >>
-When responding use a markdown code snippet with a JSON object formatted in the \
-following schema:
+When responding use a markdown code snippet with a JSON object formatted in the following schema:
 
 ```json
 {{{{
@@ -122,11 +113,9 @@ following schema:
 }}}}
 ```
 
-The query string should contain only text that is expected to match the contents of \
-documents. Any conditions in the filter should not be mentioned in the query as well.
+The query string should contain only text that is expected to match the contents of documents. Any conditions in the filter should not be mentioned in the query as well.
 
-A logical condition statement is composed of one or more comparison and logical \
-operation statements.
+A logical condition statement is composed of one or more comparison and logical operation statements.
 
 A comparison statement takes the form: `comp(attr, val)`:
 - `comp` ({allowed_comparators}): comparator
@@ -135,24 +124,20 @@ A comparison statement takes the form: `comp(attr, val)`:
 
 A logical operation statement takes the form `op(statement1, statement2, ...)`:
 - `op` ({allowed_operators}): logical operator
-- `statement1`, `statement2`, ... (comparison statements or logical operation \
-statements): one or more statements to apply the operation to
+- `statement1`, `statement2`, ... (comparison statements or logical operation statements): one or more statements to apply the operation to
 
-Make sure that you only use the comparators and logical operators listed above and \
-no others.
+Make sure that you only use the comparators and logical operators listed above and no others.
 Make sure that filters only refer to attributes that exist in the data source.
 Make sure that filters only use the attributed names with its function names if there are functions applied on them.
 Make sure that filters only use format `YYYY-MM-DD` when handling timestamp data typed values.
-Make sure that filters take into account the descriptions of attributes and only make \
-comparisons that are feasible given the type of data being stored.
-Make sure that filters are only used as needed. If there are no filters that should be \
-applied return "NO_FILTER" for the filter value.\
+Make sure that filters take into account the descriptions of attributes and only make comparisons that are feasible given the type of data being stored.
+Make sure that filters are only used as needed. If there are no filters that should be applied return "NO_FILTER" for the filter value.\
 """
+DEFAULT_SCHEMA_PROMPT = PromptTemplate.from_template(DEFAULT_SCHEMA)
 
 SCHEMA_WITH_LIMIT = """\
 << Structured Request Schema >>
-When responding use a markdown code snippet with a JSON object formatted in the \
-following schema:
+When responding use a markdown code snippet with a JSON object formatted in the following schema:
 
 ```json
 {{{{
@@ -162,11 +147,9 @@ following schema:
 }}}}
 ```
 
-The query string should contain only text that is expected to match the contents of \
-documents. Any conditions in the filter should not be mentioned in the query as well.
+The query string should contain only text that is expected to match the contents of documents. Any conditions in the filter should not be mentioned in the query as well.
 
-A logical condition statement is composed of one or more comparison and logical \
-operation statements.
+A logical condition statement is composed of one or more comparison and logical operation statements.
 
 A comparison statement takes the form: `comp(attr, val)`:
 - `comp` ({allowed_comparators}): comparator
@@ -175,20 +158,17 @@ A comparison statement takes the form: `comp(attr, val)`:
 
 A logical operation statement takes the form `op(statement1, statement2, ...)`:
 - `op` ({allowed_operators}): logical operator
-- `statement1`, `statement2`, ... (comparison statements or logical operation \
-statements): one or more statements to apply the operation to
+- `statement1`, `statement2`, ... (comparison statements or logical operation statements): one or more statements to apply the operation to
 
-Make sure that you only use the comparators and logical operators listed above and \
-no others.
+Make sure that you only use the comparators and logical operators listed above and no others.
 Make sure that filters only refer to attributes that exist in the data source.
 Make sure that filters only use the attributed names with its function names if there are functions applied on them.
 Make sure that filters only use format `YYYY-MM-DD` when handling timestamp data typed values.
-Make sure that filters take into account the descriptions of attributes and only make \
-comparisons that are feasible given the type of data being stored.
-Make sure that filters are only used as needed. If there are no filters that should be \
-applied return "NO_FILTER" for the filter value.
-Make sure the `limit` is always an int value. It is an optional parameter so leave it blank if it is does not make sense.
+Make sure that filters take into account the descriptions of attributes and only make comparisons that are feasible given the type of data being stored.
+Make sure that filters are only used as needed. If there are no filters that should be applied return "NO_FILTER" for the filter value.
+Make sure the `limit` is always an int value. It is an optional parameter so leave it blank if it does not make sense.
 """
+SCHEMA_WITH_LIMIT_PROMPT = PromptTemplate.from_template(SCHEMA_WITH_LIMIT)
 
 DEFAULT_PREFIX = """\
 Your goal is to structure the user's query to match the request schema provided below.

--- a/libs/langchain/langchain/chains/query_constructor/prompt.py
+++ b/libs/langchain/langchain/chains/query_constructor/prompt.py
@@ -101,6 +101,18 @@ Structured Request:
 
 EXAMPLE_PROMPT = PromptTemplate.from_template(EXAMPLE_PROMPT_TEMPLATE)
 
+USER_SPECIFIED_EXAMPLE_PROMPT = PromptTemplate.from_template(
+    """\
+<< Example {i}. >>
+User Query:
+{user_query}
+
+Structured Request:
+```json
+{structured_request}
+```
+"""
+)
 
 DEFAULT_SCHEMA = """\
 << Structured Request Schema >>
@@ -176,6 +188,20 @@ Your goal is to structure the user's query to match the request schema provided 
 {schema}\
 """
 
+PREFIX_WITH_DATA_SOURCE = (
+    DEFAULT_PREFIX
+    + """
+
+<< Data Source >>
+```json
+{{{{
+    "content": "{content}",
+    "attributes": {attributes}
+}}}}
+```
+"""
+)
+
 DEFAULT_SUFFIX = """\
 << Example {i}. >>
 Data Source:
@@ -186,6 +212,14 @@ Data Source:
 }}}}
 ```
 
+User Query:
+{{query}}
+
+Structured Request:
+"""
+
+SUFFIX_WITHOUT_DATA_SOURCE = """\
+<< Example {i}. >>
 User Query:
 {{query}}
 


### PR DESCRIPTION
updating query constructor and self query retriever to
- make it easier to pass in examples
- validate attributes used in query
- remove invalid parts of query
- make it easier to get + edit prompt
- make query constructor a runnable
- make self query retriever use as runnable