### PR TITLE
Fixed a bug in reporting Python code validation

### DIFF
--- a/libs/experimental/langchain_experimental/pal_chain/base.py
+++ b/libs/experimental/langchain_experimental/pal_chain/base.py
@@ -229,21 +229,24 @@ class PALChain(Chain):
                 if (
                     (not code_validations.allow_command_exec)
                     and isinstance(node, ast.Call)
-                    and (
-                        (
-                            hasattr(node.func, "id")
-                            and node.func.id in COMMAND_EXECUTION_FUNCTIONS
-                        )
-                        or (
-                            isinstance(node.func, ast.Attribute)
-                            and node.func.attr in COMMAND_EXECUTION_FUNCTIONS
-                        )
-                    )
                 ):
-                    raise ValueError(
-                        f"Found illegal command execution function "
-                        f"{node.func.id} in code {code}"
-                    )
+                    if (
+                        hasattr(node.func, "id")
+                        and node.func.id in COMMAND_EXECUTION_FUNCTIONS
+                    ):
+                        raise ValueError(
+                            f"Found illegal command execution function "
+                            f"{node.func.id} in code {code}"
+                        )
+                        
+                    if (
+                        isinstance(node.func, ast.Attribute)
+                        and node.func.attr in COMMAND_EXECUTION_FUNCTIONS
+                    ):
+                        raise ValueError(
+                            f"Found illegal command execution function "
+                            f"{node.func.attr} in code {code}"
+                        )
 
                 if (not code_validations.allow_imports) and (
                     isinstance(node, ast.Import) or isinstance(node, ast.ImportFrom)

--- a/libs/experimental/langchain_experimental/pal_chain/base.py
+++ b/libs/experimental/langchain_experimental/pal_chain/base.py
@@ -226,9 +226,8 @@ class PALChain(Chain):
             or not code_validations.allow_imports
         ):
             for node in ast.walk(code_tree):
-                if (
-                    (not code_validations.allow_command_exec)
-                    and isinstance(node, ast.Call)
+                if (not code_validations.allow_command_exec) and isinstance(
+                    node, ast.Call
                 ):
                     if (
                         hasattr(node.func, "id")
@@ -238,7 +237,7 @@ class PALChain(Chain):
                             f"Found illegal command execution function "
                             f"{node.func.id} in code {code}"
                         )
-                        
+
                     if (
                         isinstance(node.func, ast.Attribute)
                         and node.func.attr in COMMAND_EXECUTION_FUNCTIONS


### PR DESCRIPTION
- **Description:** fixed a bug in pal-chain when it reports Python
    code validation errors. When node.func does not have any ids, the
    original code tried to print node.func.id in raising ValueError.
- **Issue:** n/a,
- **Dependencies:** no dependencies,
- **Tag maintainer:** @hazzel-cn, @eyurtsev
- **Twitter handle:** @lazyswamp