### PR TITLE
fix: PromptTemplate with OutputParser documentation not working

### DIFF
--- a/docs/docs/modules/model_io/prompts/prompt_templates/prompt_with_output_parser.json
+++ b/docs/docs/modules/model_io/prompts/prompt_templates/prompt_with_output_parser.json
@@ -13,7 +13,7 @@
         "_type": "regex_parser"
     },
     "partial_variables": {},
-    "template": "Given the following question and student answer, provide a correct answer and score the student answer.\nQuestion: {question}\nStudent Answer: {student_answer}\nCorrect Answer:",
+    "template": "Given the following question and student answer, provide a correct answer and score the student answer. Question: {question} Student Answer: {student_answer} Correct Answer:",
     "template_format": "f-string",
     "validate_template": true,
     "_type": "prompt"


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** [PromptTemplate with OutputParser](https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/prompt_serialization#prompttemplate-with-outputparser) has an example with "template": `"Given the following question and student answer, provide a correct answer and score the student answer.\nQuestion: {question}\nStudent Answer: {student_answer}\nCorrect Answer:"`, however, `\n` is a control character therefore `load_prompt ` results in an error like `ERROR Invalid control character at: line 1 column 202 (char 202)`. This is expected behavior from the `json` package (See https://stackoverflow.com/questions/22394235/invalid-control-character-with-python-json-loads for more information). This PR removes these control characters. I've confirmed that the fixed example is working on Google Colab .
  - **Issue:** Not found,
  - **Dependencies:** Nope,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** @dosuken123

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.