### PR TITLE
Update to doc Pydantic example to Pydantic 2

### DIFF
--- a/docs/snippets/modules/model_io/output_parsers/get_started.mdx
+++ b/docs/snippets/modules/model_io/output_parsers/get_started.mdx
@@ -9,7 +9,7 @@ from langchain.llms import OpenAI
 from langchain.chat_models import ChatOpenAI
 
 from langchain.output_parsers import PydanticOutputParser
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from typing import List
 ```
 
@@ -28,11 +28,11 @@ class Joke(BaseModel):
     punchline: str = Field(description="answer to resolve the joke")
     
     # You can add custom validation logic easily with Pydantic.
-    @validator('setup')
-    def question_ends_with_question_mark(cls, field):
-        if field[-1] != '?':
+    @field_validator('setup')
+    def question_ends_with_question_mark(cls, value):
+        if value[-1] != '?':
             raise ValueError("Badly formed question!")
-        return field
+        return value
 ```
 
 


### PR DESCRIPTION
**Description:**
Currently, the example uses Pydantic 1 format and crashes with the following error:
```
    452 if isinstance(info, ValidatorDecoratorInfo):
--> 453     res.validators[var_name] = Decorator.build(
    454         model_dc, cls_var_name=var_name, shim=var_value.shim, info=info
    455     )
    456 elif isinstance(info, FieldValidatorDecoratorInfo):
    457     res.field_validators[var_name] = Decorator.build(
    458         model_dc, cls_var_name=var_name, shim=var_value.shim, info=info
...
     83         needs_values_kw = True

PydanticUserError: The `field` and `config` parameters are not available in Pydantic V2, please use the `info` parameter instead.
```

Additionally, it produces a warning:
```
PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/
  @validator('setup')
```
------
Here I'm updating it to use Pydantic2 syntax
