### PR TITLE
fix comments in output format

### DIFF
--- a/libs/langchain/langchain/agents/conversational_chat/prompt.py
+++ b/libs/langchain/langchain/agents/conversational_chat/prompt.py
@@ -18,8 +18,8 @@ Markdown code snippet formatted in the following schema:
 
 ```json
 {{{{
-    "action": string, \\ The action to take. Must be one of {tool_names}
-    "action_input": string \\ The input to the action
+    "action": string, \\\\ The action to take. Must be one of {tool_names}
+    "action_input": string \\\\ The input to the action
 }}}}
 ```
 
@@ -29,7 +29,7 @@ Use this if you want to respond directly to the human. Markdown code snippet for
 ```json
 {{{{
     "action": "Final Answer",
-    "action_input": string \\ You should put what you want to return to use here
+    "action_input": string \\\\ You should put what you want to return to use here
 }}}}
 ```"""
 


### PR DESCRIPTION
  - **Description:** Fixes the comments in the ConvoOutputParser. Because the \\\\ is escaping a single \\, they render something like:  `"action_input": string \ The input to the action` in the prompt. Changing this to \\\\\\\\ lets it escape two slashes so that it renders a proper comment: `"action_input": string \\ The input to the action`
  - **Issue:** N/A
  - **Dependencies:** 
  - **Tag maintainer:** @hwchase17
  - **Twitter handle:**