### PR TITLE
RFC: Implement stream/transform in RunnableRetry

### DIFF
--- a/libs/langchain/langchain/callbacks/tracers/log_stream.py
+++ b/libs/langchain/langchain/callbacks/tracers/log_stream.py
@@ -85,9 +85,7 @@ class RunLogPatch:
             state = jsonpatch.apply_patch(None, ops)
             return RunLog(*ops, state=state)
 
-        raise TypeError(
-            f"unsupported operand type(s) for +: '{type(self)}' and '{type(other)}'"
-        )
+        return NotImplemented
 
     def __repr__(self) -> str:
         from pprint import pformat
@@ -115,9 +113,7 @@ class RunLog(RunLogPatch):
             state = jsonpatch.apply_patch(self.state, other.ops)
             return RunLog(*ops, state=state)
 
-        raise TypeError(
-            f"unsupported operand type(s) for +: '{type(self)}' and '{type(other)}'"
-        )
+        return NotImplemented
 
     def __repr__(self) -> str:
         from pprint import pformat

--- a/libs/langchain/langchain/prompts/chat.py
+++ b/libs/langchain/langchain/prompts/chat.py
@@ -403,7 +403,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
             prompt = HumanMessagePromptTemplate.from_template(other)
             return ChatPromptTemplate(messages=self.messages + [prompt])
         else:
-            raise NotImplementedError(f"Unsupported operand type for +: {type(other)}")
+            return NotImplemented
 
     @root_validator(pre=True)
     def validate_input_variables(cls, values: dict) -> dict:

--- a/libs/langchain/langchain/prompts/prompt.py
+++ b/libs/langchain/langchain/prompts/prompt.py
@@ -89,7 +89,7 @@ class PromptTemplate(StringPromptTemplate):
             prompt = PromptTemplate.from_template(other)
             return self + prompt
         else:
-            raise NotImplementedError(f"Unsupported operand type for +: {type(other)}")
+            return NotImplemented
 
     @property
     def _prompt_type(self) -> str:

--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -133,11 +133,7 @@ class BaseMessageChunk(BaseMessage):
                 ),
             )
         else:
-            raise TypeError(
-                'unsupported operand type(s) for +: "'
-                f"{self.__class__.__name__}"
-                f'" and "{other.__class__.__name__}"'
-            )
+            return NotImplemented
 
 
 class HumanMessage(BaseMessage):

--- a/libs/langchain/langchain/schema/output.py
+++ b/libs/langchain/langchain/schema/output.py
@@ -42,9 +42,7 @@ class GenerationChunk(Generation):
                 generation_info=generation_info,
             )
         else:
-            raise TypeError(
-                f"unsupported operand type(s) for +: '{type(self)}' and '{type(other)}'"
-            )
+            return NotImplemented
 
 
 class ChatGeneration(Generation):
@@ -84,9 +82,7 @@ class ChatGenerationChunk(ChatGeneration):
                 generation_info=generation_info,
             )
         else:
-            raise TypeError(
-                f"unsupported operand type(s) for +: '{type(self)}' and '{type(other)}'"
-            )
+            return NotImplemented
 
 
 class RunInfo(BaseModel):

--- a/libs/langchain/langchain/schema/runnable/configurable.py
+++ b/libs/langchain/langchain/schema/runnable/configurable.py
@@ -27,6 +27,7 @@ from langchain.schema.runnable.utils import (
     ConfigurableFieldSpec,
     Input,
     Output,
+    RunnableStreamResetMarker,
     gather_with_concurrency,
 )
 
@@ -162,7 +163,7 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
         input: Input,
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Iterator[Output]:
+    ) -> Iterator[Union[Output, RunnableStreamResetMarker]]:
         return self._prepare(config).stream(input, config, **kwargs)
 
     async def astream(
@@ -170,7 +171,7 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
         input: Input,
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> AsyncIterator[Output]:
+    ) -> AsyncIterator[Union[Output, RunnableStreamResetMarker]]:
         async for chunk in self._prepare(config).astream(input, config, **kwargs):
             yield chunk
 
@@ -179,7 +180,7 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
         input: Iterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Iterator[Output]:
+    ) -> Iterator[Union[Output, RunnableStreamResetMarker]]:
         return self._prepare(config).transform(input, config, **kwargs)
 
     async def atransform(
@@ -187,7 +188,7 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
         input: AsyncIterator[Input],
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> AsyncIterator[Output]:
+    ) -> AsyncIterator[Union[Output, RunnableStreamResetMarker]]:
         async for chunk in self._prepare(config).atransform(input, config, **kwargs):
             yield chunk
 

--- a/libs/langchain/langchain/schema/runnable/router.py
+++ b/libs/langchain/langchain/schema/runnable/router.py
@@ -29,6 +29,7 @@ from langchain.schema.runnable.config import (
 )
 from langchain.schema.runnable.utils import (
     ConfigurableFieldSpec,
+    RunnableStreamResetMarker,
     gather_with_concurrency,
     get_unique_config_specs,
 )
@@ -182,7 +183,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
         input: RouterInput,
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> Iterator[Output]:
+    ) -> Iterator[Union[Output, RunnableStreamResetMarker]]:
         key = input["key"]
         actual_input = input["input"]
         if key not in self.runnables:
@@ -196,7 +197,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
         input: RouterInput,
         config: Optional[RunnableConfig] = None,
         **kwargs: Optional[Any],
-    ) -> AsyncIterator[Output]:
+    ) -> AsyncIterator[Union[Output, RunnableStreamResetMarker]]:
         key = input["key"]
         actual_input = input["input"]
         if key not in self.runnables:

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_retry.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_retry.py
@@ -1,0 +1,227 @@
+from typing import AsyncIterator, Iterator, Union
+from langchain.schema.runnable.utils import RunnableStreamResetMarker, aadd, add
+
+import pytest
+from pytest_mock import MockerFixture
+from langchain.schema.runnable.base import Runnable, RunnableGenerator, RunnableLambda
+
+
+def test_retrying(mocker: MockerFixture) -> None:
+    def _lambda(x: int) -> Union[int, Runnable]:
+        if x == 1:
+            raise ValueError("x is 1")
+        elif x == 2:
+            raise RuntimeError("x is 2")
+        else:
+            return x
+
+    _lambda_mock = mocker.Mock(side_effect=_lambda)
+    runnable = RunnableLambda(_lambda_mock)
+
+    with pytest.raises(ValueError):
+        runnable.invoke(1)
+
+    assert _lambda_mock.call_count == 1
+    _lambda_mock.reset_mock()
+
+    with pytest.raises(ValueError):
+        runnable.with_retry(
+            stop_after_attempt=2,
+            retry_if_exception_type=(ValueError,),
+        ).invoke(1)
+
+    assert _lambda_mock.call_count == 2  # retried
+    _lambda_mock.reset_mock()
+
+    with pytest.raises(RuntimeError):
+        runnable.with_retry(
+            stop_after_attempt=2,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError,),
+        ).invoke(2)
+
+    assert _lambda_mock.call_count == 1  # did not retry
+    _lambda_mock.reset_mock()
+
+    with pytest.raises(ValueError):
+        runnable.with_retry(
+            stop_after_attempt=2,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError,),
+        ).batch([1, 2, 0])
+
+    # 3rd input isn't retried because it succeeded
+    assert _lambda_mock.call_count == 3 + 2
+    _lambda_mock.reset_mock()
+
+    output = runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    ).batch([1, 2, 0], return_exceptions=True)
+
+    # 3rd input isn't retried because it succeeded
+    assert _lambda_mock.call_count == 3 + 2
+    assert len(output) == 3
+    assert isinstance(output[0], ValueError)
+    assert isinstance(output[1], RuntimeError)
+    assert output[2] == 0
+    _lambda_mock.reset_mock()
+
+
+def test_retrying_stream(mocker: MockerFixture) -> None:
+    _lambda_mock = mocker.Mock()
+    attempt = 0
+
+    def _lambda(xiter: Iterator[int]) -> Iterator[int]:
+        nonlocal attempt
+
+        _lambda_mock()
+        yield 1
+        if attempt == 0:
+            attempt += 1
+            raise ValueError("x is 1")
+        else:
+            yield add(xiter)
+
+    runnable = RunnableGenerator(_lambda)
+
+    with pytest.raises(ValueError):
+        [chunk for chunk in runnable.stream(1)]
+
+    assert _lambda_mock.call_count == 1
+    _lambda_mock.reset_mock()
+    attempt = 0
+
+    chunks = [
+        c
+        for c in runnable.with_retry(
+            stop_after_attempt=2,
+            retry_if_exception_type=(ValueError,),
+        ).stream(3)
+    ]
+
+    assert chunks == [1, RunnableStreamResetMarker(), 1, 3]
+    assert _lambda_mock.call_count == 2  # retried
+    _lambda_mock.reset_mock()
+    attempt = 0
+
+    def add_10(input: Iterator[int]) -> Iterator[int]:
+        for chunk in input:
+            yield chunk - 10
+
+    seq = (
+        runnable.with_retry(
+            stop_after_attempt=2,
+            retry_if_exception_type=(ValueError,),
+        )
+        | add_10
+    )
+
+    chunks = [c for c in seq.stream(3)]
+
+    assert chunks == [11, RunnableStreamResetMarker(), 11, 13]
+
+
+@pytest.mark.asyncio
+async def test_async_retrying(mocker: MockerFixture) -> None:
+    def _lambda(x: int) -> Union[int, Runnable]:
+        if x == 1:
+            raise ValueError("x is 1")
+        elif x == 2:
+            raise RuntimeError("x is 2")
+        else:
+            return x
+
+    _lambda_mock = mocker.Mock(side_effect=_lambda)
+    runnable = RunnableLambda(_lambda_mock)
+
+    with pytest.raises(ValueError):
+        await runnable.ainvoke(1)
+
+    assert _lambda_mock.call_count == 1
+    _lambda_mock.reset_mock()
+
+    with pytest.raises(ValueError):
+        await runnable.with_retry(
+            stop_after_attempt=2,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError, KeyError),
+        ).ainvoke(1)
+
+    assert _lambda_mock.call_count == 2  # retried
+    _lambda_mock.reset_mock()
+
+    with pytest.raises(RuntimeError):
+        await runnable.with_retry(
+            stop_after_attempt=2,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError,),
+        ).ainvoke(2)
+
+    assert _lambda_mock.call_count == 1  # did not retry
+    _lambda_mock.reset_mock()
+
+    with pytest.raises(ValueError):
+        await runnable.with_retry(
+            stop_after_attempt=2,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError,),
+        ).abatch([1, 2, 0])
+
+    # 3rd input isn't retried because it succeeded
+    assert _lambda_mock.call_count == 3 + 2
+    _lambda_mock.reset_mock()
+
+    output = await runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    ).abatch([1, 2, 0], return_exceptions=True)
+
+    # 3rd input isn't retried because it succeeded
+    assert _lambda_mock.call_count == 3 + 2
+    assert len(output) == 3
+    assert isinstance(output[0], ValueError)
+    assert isinstance(output[1], RuntimeError)
+    assert output[2] == 0
+    _lambda_mock.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_retrying_astream(mocker: MockerFixture) -> None:
+    _lambda_mock = mocker.Mock()
+    attempt = 0
+
+    async def _lambda(xiter: AsyncIterator[int]) -> AsyncIterator[int]:
+        nonlocal attempt
+
+        _lambda_mock()
+        yield 1
+        if attempt == 0:
+            attempt += 1
+            raise ValueError("x is 1")
+        else:
+            yield await aadd(xiter)
+
+    runnable = RunnableGenerator(_lambda)
+
+    with pytest.raises(ValueError):
+        [chunk async for chunk in runnable.astream(1)]
+
+    assert _lambda_mock.call_count == 1
+    _lambda_mock.reset_mock()
+    attempt = 0
+
+    chunks = [
+        c
+        async for c in runnable.with_retry(
+            stop_after_attempt=2,
+            retry_if_exception_type=(ValueError,),
+        ).astream(3)
+    ]
+
+    assert chunks == [1, RunnableStreamResetMarker(), 1, 3]
+    assert _lambda_mock.call_count == 2  # retried
+    _lambda_mock.reset_mock()
+    attempt = 0


### PR DESCRIPTION
Yield a "stream reset" marker before starting the next attempt

Open question: How to deal with this best in RunnableSequence/RunnableMap? The next steps in the sequence are probably not designed to handle the reset marker, should RunnableSequence retry all steps after "current" once it sees a retry marker?

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
