### PR TITLE
Add Azure Redis example

### DIFF
--- a/docs/docs_skeleton/docs/integrations/vectorstores/redis.ipynb
+++ b/docs/docs_skeleton/docs/integrations/vectorstores/redis.ipynb
@@ -105,6 +105,7 @@
     "- [Awesome Redis AI Resources](https://github.com/RedisVentures/redis-ai-resources) - List of examples of using Redis in AI workloads\n",
     "- [Azure OpenAI Embeddings Q&A](https://github.com/ruoccofabrizio/azure-open-ai-embeddings-qna) - OpenAI and Redis as a Q&A service on Azure.\n",
     "- [ArXiv Paper Search](https://github.com/RedisVentures/redis-arXiv-search) - Semantic search over arXiv scholarly papers\n",
+    "- [Vector Search on Azure](https://learn.microsoft.com/azure/azure-cache-for-redis/cache-tutorial-vector-similarity) - Vector search on Azure using Azure Cache for Redis and Azure OpenAI\n",
     "\n",
     "\n",
     "## More Resources\n",


### PR DESCRIPTION
**Description**
This PR adds an additional Example to the Redis integration documentation. [The example](https://learn.microsoft.com/azure/azure-cache-for-redis/cache-tutorial-vector-similarity) is a step-by-step walkthrough of using Azure Cache for Redis and Azure OpenAI for vector similarity search, using LangChain extensively throughout. 

**Issue**
Nothing specific, just adding an additional example.

**Dependencies**
None.

**Tag Maintainer**
Tagging @hwchase17 :)