### PR TITLE
Fix: invalid link to chat model in openai platform docs

### DIFF
--- a/docs/docs_skeleton/docs/integrations/platforms/openai.mdx
+++ b/docs/docs_skeleton/docs/integrations/platforms/openai.mdx
@@ -41,7 +41,7 @@ For a more detailed walkthrough of the `Azure` wrapper, see [here](/docs/integra
 
 ## Chat model
 
-See a [usage example](/docs/integrations/chat_models/openai).
+See a [usage example](/docs/integrations/chat/openai).
 
 ```python
 from langchain.chat_models import ChatOpenAI
@@ -51,7 +51,7 @@ If you are using a model hosted on `Azure`, you should use different wrapper for
 ```python
 from langchain.llms import AzureChatOpenAI
 ```
-For a more detailed walkthrough of the `Azure` wrapper, see [here](/docs/integrations/chat_models/azure_openai)
+For a more detailed walkthrough of the `Azure` wrapper, see [here](/docs/integrations/chat/azure_chat_openai)
 
 
 ## Text Embedding Model


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

There is some invalid link in open ai platform [docs](https://python.langchain.com/docs/integrations/platforms/openai).
So i fixed it to valid links.
- `/docs/integrations/chat_models/openai` -> `/docs/integrations/chat/openai`
- `/docs/integrations/chat_models/azure_openai` -> `/docs/integrations/chat/azure_chat_openai`

Thanks! ☺️
