### PR TITLE
Fixed the assignment of custom_llm_provider argument

### DIFF
--- a/libs/langchain/langchain/chat_models/litellm.py
+++ b/libs/langchain/langchain/chat_models/litellm.py
@@ -207,6 +207,7 @@ class ChatLiteLLM(BaseChatModel):
             "stream": self.streaming,
             "n": self.n,
             "temperature": self.temperature,
+            "custom_llm_provider":self.custom_llm_provider,
             **self.model_kwargs,
         }
 

--- a/libs/langchain/langchain/chat_models/litellm.py
+++ b/libs/langchain/langchain/chat_models/litellm.py
@@ -207,7 +207,7 @@ class ChatLiteLLM(BaseChatModel):
             "stream": self.streaming,
             "n": self.n,
             "temperature": self.temperature,
-            "custom_llm_provider":self.custom_llm_provider,
+            "custom_llm_provider": self.custom_llm_provider,
             **self.model_kwargs,
         }
 


### PR DESCRIPTION
  - **Description:** Assigning the custom_llm_provider to the default params function so that it will be passed to the  litellm
  - **Issue:** Even though the custom_llm_provider argument is being defined it's not being assigned anywhere in the code and hence its not being passed to litellm, therefore any litellm call which uses the custom_llm_provider as required parameter is being failed. This parameter is mainly used by litellm when we are doing inference via Custom API server. https://docs.litellm.ai/docs/providers/custom_openai_proxy
  - **Dependencies:** No dependencies are required

@krrishdholakia , @baskaryan 
  