### PR TITLE
include_df_in_prompt should be True or False and not None

### DIFF
--- a/libs/langchain/langchain/agents/agent_toolkits/pandas/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/pandas/base.py
@@ -239,7 +239,7 @@ def _get_functions_prompt_and_tools(
     if input_variables is not None:
         raise ValueError("`input_variables` is not supported at the moment.")
 
-    if include_df_in_prompt is not None and suffix is not None:
+    if not include_df_in_prompt and suffix is not None:
         raise ValueError("If suffix is specified, include_df_in_prompt should not be.")
 
     if isinstance(df, list):


### PR DESCRIPTION

Replace this entire comment with:
  - **Description:** `include_df_in_prompt` does now also work with `False` instade of `None` 
  - **Issue:**   #11677
  - **Dependencies:** None
  - **Tag maintainer:**
  - **Twitter handle:** 
  
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
