### PR TITLE
Fix default impl of aparse_result

### DIFF
--- a/libs/langchain/langchain/schema/output_parser.py
+++ b/libs/langchain/langchain/schema/output_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from abc import ABC, abstractmethod
 from typing import (
     Any,
@@ -251,7 +252,7 @@ class BaseOutputParser(
             Structured output.
         """
         return await asyncio.get_running_loop().run_in_executor(
-            None, self.parse_result, result
+            None, functools.partial(self.parse_result, partial=partial), result
         )
 
     async def aparse(self, text: str) -> T:

--- a/libs/langchain/langchain/schema/output_parser.py
+++ b/libs/langchain/langchain/schema/output_parser.py
@@ -250,7 +250,9 @@ class BaseOutputParser(
         Returns:
             Structured output.
         """
-        return await self.aparse(result[0].text)
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.parse_result, result
+        )
 
     async def aparse(self, text: str) -> T:
         """Parse a single string model output into some structure.


### PR DESCRIPTION
Should delegate to parse_result, not to aparse, as parse_result is a method that some output parsers override

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
