### PR TITLE
Add graceful fallback for ES vectorstore when content field is missing

### DIFF
--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -775,7 +775,7 @@ class ElasticsearchStore(VectorStore):
             docs_and_scores.append(
                 (
                     Document(
-                        page_content=hit["_source"][self.query_field],
+                        page_content=hit["_source"].get(self.query_field, ""),
                         metadata=hit["_source"]["metadata"],
                     ),
                     hit["_score"],


### PR DESCRIPTION
  - **Description:**
    -  If the Elasticsearch field used for Langchain > Document.page_content is missing because the specific document is 
        somehow malformed fail gracefully.

  - **Tag maintainer:** 
    - @joemcelroy
