### PR TITLE
adding parameter for changing the language in SpacyEmbeddings

### DIFF
--- a/docs/docs/integrations/text_embedding/spacy_embedding.ipynb
+++ b/docs/docs/integrations/text_embedding/spacy_embedding.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedder = SpacyEmbeddings()"
+    "embedder = SpacyEmbeddings(nlp=\"en_core_web_sm\")"
    ]
   },
   {

--- a/libs/langchain/langchain/embeddings/spacy_embeddings.py
+++ b/libs/langchain/langchain/embeddings/spacy_embeddings.py
@@ -20,7 +20,8 @@ class SpacyEmbeddings(BaseModel, Embeddings):
 
     nlp: Optional[
         Any
-    ] = "en_core_web_sm"  # The spaCy model loaded into memory, defaulting to "en_core_web_sm"
+    ] = "en_core_web_sm" # The spaCy model loaded into memory, 
+                        # defaulting to "en_core_web_sm"
 
     class Config:
         """Configuration for this pydantic object."""

--- a/libs/langchain/langchain/embeddings/spacy_embeddings.py
+++ b/libs/langchain/langchain/embeddings/spacy_embeddings.py
@@ -1,5 +1,5 @@
 import importlib.util
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from langchain.pydantic_v1 import BaseModel, Extra, root_validator
 from langchain.schema.embeddings import Embeddings
@@ -7,8 +7,6 @@ from langchain.schema.embeddings import Embeddings
 
 class SpacyEmbeddings(BaseModel, Embeddings):
     """Embeddings by SpaCy models.
-
-    It only supports the 'en_core_web_sm' model.
 
     Attributes:
         nlp (Any): The Spacy model loaded into memory.
@@ -20,7 +18,9 @@ class SpacyEmbeddings(BaseModel, Embeddings):
             Generates an embedding for a single piece of text.
     """
 
-    nlp: Any  # The Spacy model loaded into memory
+    nlp: Optional[
+        Any
+    ] = "en_core_web_sm"  # The SpaCy model loaded into memory, defaulting to "en_core_web_sm"
 
     class Config:
         """Configuration for this pydantic object."""
@@ -30,7 +30,7 @@ class SpacyEmbeddings(BaseModel, Embeddings):
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """
-        Validates that the Spacy package and the 'en_core_web_sm' model are installed.
+        Validates that the Spacy package and the model are installed.
 
         Args:
             values (Dict): The values provided to the class constructor.
@@ -39,9 +39,11 @@ class SpacyEmbeddings(BaseModel, Embeddings):
             The validated values.
 
         Raises:
-            ValueError: If the Spacy package or the 'en_core_web_sm'
+            ValueError: If the Spacy package or the
             model are not installed.
         """
+        nlp = values.get("nlp")
+
         # Check if the Spacy package is installed
         if importlib.util.find_spec("spacy") is None:
             raise ValueError(
@@ -49,16 +51,16 @@ class SpacyEmbeddings(BaseModel, Embeddings):
                 "Please install it with `pip install spacy`."
             )
         try:
-            # Try to load the 'en_core_web_sm' Spacy model
+            # Try to load the Spacy model
             import spacy
 
-            values["nlp"] = spacy.load("en_core_web_sm")
+            values["nlp"] = spacy.load(nlp)
         except OSError:
             # If the model is not found, raise a ValueError
             raise ValueError(
-                "Spacy model 'en_core_web_sm' not found. "
-                "Please install it with"
-                " `python -m spacy download en_core_web_sm`."
+                f"Spacy model '{nlp}' not found. "
+                f"Please install it with"
+                " `python -m spacy download {nlp}` or provide a valid Spacy model name."
             )
         return values  # Return the validated values
 

--- a/libs/langchain/langchain/embeddings/spacy_embeddings.py
+++ b/libs/langchain/langchain/embeddings/spacy_embeddings.py
@@ -6,10 +6,10 @@ from langchain.schema.embeddings import Embeddings
 
 
 class SpacyEmbeddings(BaseModel, Embeddings):
-    """Embeddings by SpaCy models.
+    """Embeddings by spaCy models.
 
     Attributes:
-        nlp (Any): The Spacy model loaded into memory.
+        nlp (Any): The spaCy model loaded into memory.
 
     Methods:
         embed_documents(texts: List[str]) -> List[List[float]]:
@@ -20,7 +20,7 @@ class SpacyEmbeddings(BaseModel, Embeddings):
 
     nlp: Optional[
         Any
-    ] = "en_core_web_sm"  # The SpaCy model loaded into memory, defaulting to "en_core_web_sm"
+    ] = "en_core_web_sm"  # The spaCy model loaded into memory, defaulting to "en_core_web_sm"
 
     class Config:
         """Configuration for this pydantic object."""
@@ -30,7 +30,7 @@ class SpacyEmbeddings(BaseModel, Embeddings):
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """
-        Validates that the Spacy package and the model are installed.
+        Validates that the spaCy package and the model are installed.
 
         Args:
             values (Dict): The values provided to the class constructor.
@@ -39,28 +39,28 @@ class SpacyEmbeddings(BaseModel, Embeddings):
             The validated values.
 
         Raises:
-            ValueError: If the Spacy package or the
+            ValueError: If the spaCy package or the
             model are not installed.
         """
         nlp = values.get("nlp")
 
-        # Check if the Spacy package is installed
+        # Check if the spaCy package is installed
         if importlib.util.find_spec("spacy") is None:
             raise ValueError(
-                "Spacy package not found. "
+                "SpaCy package not found. "
                 "Please install it with `pip install spacy`."
             )
         try:
-            # Try to load the Spacy model
+            # Try to load the spaCy model
             import spacy
 
             values["nlp"] = spacy.load(nlp)
         except OSError:
             # If the model is not found, raise a ValueError
             raise ValueError(
-                f"Spacy model '{nlp}' not found. "
+                f"SpaCy model '{nlp}' not found. "
                 f"Please install it with"
-                " `python -m spacy download {nlp}` or provide a valid Spacy model name."
+                " `python -m spacy download {nlp}` or provide a valid spaCy model name."
             )
         return values  # Return the validated values
 


### PR DESCRIPTION
  - **Description:** Added the parameter for a possibility to change a language model in SpacyEmbeddings. The default value is still the same: "en_core_web_sm", so it shouldn't affect a code which previously did not specify this parameter, but it is not hard-coded anymore and easy to change in case you want to use it with other languages or models.
  
  - **Issue:** At Barcelona Supercomputing Center in Aina project (https://github.com/projecte-aina), a project for Catalan Language Models and Resources, we would like to use Langchain for one of our current projects and we would like to comment that Langchain, while being a very powerful and useful open-source tool, is pretty much focused on English language. We would like to contribute to make it a bit more adaptable for using with other languages.
  
  - **Dependencies:**  This change requires the Spacy library and a language model, specified in the model parameter.
  - **Tag maintainer:** @dev2049
  - **Twitter handle:** @projecte_aina


