### PR TITLE
fix typos in cookbook/self_query_hotel_search.ipynb

### DIFF
--- a/cookbook/self_query_hotel_search.ipynb
+++ b/cookbook/self_query_hotel_search.ipynb
@@ -622,7 +622,7 @@
     "\n",
     "We can see that at least two issues above. First is that when we ask for a Southern European destination we're only getting a filter for Italy, and second when we ask for AC we get a literal string lookup for AC (which isn't so bad but will miss things like 'Air conditioning').\n",
     "\n",
-    "As a first step, let's try to update our description of the 'country' attribute to emphasize that equality shoul only be used when a specific country is mentioned."
+    "As a first step, let's try to update our description of the 'country' attribute to emphasize that equality should only be used when a specific country is mentioned."
    ]
   },
   {


### PR DESCRIPTION
I have fixed some typos in file `cookbook/self_query_hotel_search.ipynb`. I kindly request the repo maintainers to review and merge it. Thanks!