### PR TITLE
missing wiki from the URL path

### DIFF
--- a/libs/langchain/langchain/document_loaders/confluence.py
+++ b/libs/langchain/langchain/document_loaders/confluence.py
@@ -539,7 +539,7 @@ class ConfluenceLoader(BaseLoader):
         texts = []
         for attachment in attachments:
             media_type = attachment["metadata"]["mediaType"]
-            absolute_url = self.base_url + attachment["_links"]["download"]
+            absolute_url = self.base_url + "/wiki" + attachment["_links"]["download"]
             title = attachment["title"]
             try:
                 if media_type == "application/pdf":


### PR DESCRIPTION
- Include `/wiki` to URL path
- My issue: [11842](https://github.com/langchain-ai/langchain/issues/11824)

