### PR TITLE
Use traceable context

### DIFF
--- a/libs/langchain/langchain/callbacks/manager.py
+++ b/libs/langchain/langchain/callbacks/manager.py
@@ -25,6 +25,7 @@ from typing import (
 )
 from uuid import UUID
 
+from langsmith.run_helpers import get_run_tree_context
 from tenacity import RetryCallState
 
 from langchain.callbacks.base import (
@@ -1882,7 +1883,9 @@ def _configure(
     Returns:
         T: The configured callback manager.
     """
-    callback_manager = callback_manager_cls(handlers=[])
+    run_tree = get_run_tree_context()
+    parent_run_id = None if run_tree is None else getattr(run_tree, "id")
+    callback_manager = callback_manager_cls(handlers=[], parent_run_id=parent_run_id)
     if inheritable_callbacks or local_callbacks:
         if isinstance(inheritable_callbacks, list) or inheritable_callbacks is None:
             inheritable_callbacks_ = inheritable_callbacks or []


### PR DESCRIPTION
Example

```
from langchain.schema.runnable import RunnableLambda
from langsmith import traceable

chain = RunnableLambda(lambda x: x)

@traceable(run_type = "chain")
def my_traceable(a):
    chain.invoke(a)
my_traceable(5)
```

Would have a nested result.

This would NOT work for interleaving chains and traceables. E.g., things like thiswould still not work well

```
from langchain.schema.runnable import RunnableLambda
from langsmith import traceable

@traceable()
def other_traceable(a):
    return a

def foo(x):
    return other_traceable(x)
    
chain = RunnableLambda(foo)

@traceable(run_type = "chain")
def my_traceable(a):
    chain.invoke(a)
my_traceable(5)
```