### PR TITLE
fix: use jsonb instead of json for pgvector

### DIFF
--- a/libs/langchain/langchain/vectorstores/_pgvector_data_models.py
+++ b/libs/langchain/langchain/vectorstores/_pgvector_data_models.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import sqlalchemy
 from pgvector.sqlalchemy import Vector
-from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Session, relationship
 
 from langchain.vectorstores.pgvector import BaseModel
@@ -14,7 +14,7 @@ class CollectionStore(BaseModel):
     __tablename__ = "langchain_pg_collection"
 
     name = sqlalchemy.Column(sqlalchemy.String)
-    cmetadata = sqlalchemy.Column(JSON)
+    cmetadata = sqlalchemy.Column(JSONB)
 
     embeddings = relationship(
         "EmbeddingStore",
@@ -65,7 +65,7 @@ class EmbeddingStore(BaseModel):
 
     embedding: Vector = sqlalchemy.Column(Vector(None))
     document = sqlalchemy.Column(sqlalchemy.String, nullable=True)
-    cmetadata = sqlalchemy.Column(JSON, nullable=True)
+    cmetadata = sqlalchemy.Column(JSONB, nullable=True)
 
     # custom_id : any user defined id
     custom_id = sqlalchemy.Column(sqlalchemy.String, nullable=True)

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -132,7 +132,7 @@ class PGVector(VectorStore):
         Initialize the store.
         """
         self._conn = self.connect()
-        # self.create_vector_extension()
+        self.create_vector_extension()
         from langchain.vectorstores._pgvector_data_models import (
             CollectionStore,
             EmbeddingStore,


### PR DESCRIPTION
## Description
When trying to integrate pgvector as a vector store with langchain, I got the following error:

```
2023-10-16 18:27:54.326 EDT [87858] ERROR:  operator does not exist: json @> unknown at character 106
2023-10-16 18:27:54.326 EDT [87858] HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
2023-10-16 18:27:54.326 EDT [87858] STATEMENT:
              SELECT *, embedding <=> $1 as "_distance"
              FROM langchain_pg_embedding
              WHERE cmetadata @> $2
              ORDER BY "_distance" ASC
              LIMIT $3;
```

## The problem
From my brief research, it appears that the `@>` operator only works with jsonb. So I'm trying to figure out how this ever worked in the first place, but I'm not a postgres expert.

## Testing / Reproduced

To test this, I ran the following against my database after langchain created it and this seemed to fix my issue:
```sql
ALTER TABLE langchain_pg_embedding ALTER COLUMN cmetadata SET DATA TYPE jsonb;
```

I'm using this python version of langchain for running my document loaders and storing my embeddings in PG, but then I have a chat client that's using the langchain-js lib to query it, so I happened to then go see if pgvector had the same problem over there, and it doesn't.
https://github.com/langchain-ai/langchainjs/blob/aa9b618786757c301e93caeb3253c56b56d05602/langchain/src/vectorstores/pgvector.ts#L244C38-L244C43

Let me know if the fix isn't as simple as this or if there's a better solution that should be considered like type casting or something else?

cc:
@baskaryan, @eyurtsev, @hwchase17
