### PR TITLE
Sitemap specify default filter url (Fixes: CVE-2023-46229)

### DIFF
--- a/libs/langchain/langchain/document_loaders/sitemap.py
+++ b/libs/langchain/langchain/document_loaders/sitemap.py
@@ -87,6 +87,8 @@ class SitemapLoader(WebBaseLoader):
                 interpreted as regular expression syntax. For example, `.` appears
                 frequently in URLs and should be escaped if you want to match a literal
                 `.` rather than any character.
+                restrict_to_same_domain takes precedence over filter_urls when
+                restrict_to_same_domain is True and the sitemap is not a local file.
             parsing_function: Function to parse bs4.Soup output
             blocksize: number of sitemap locations per block
             blocknum: the number of the block that should be loaded - zero indexed.
@@ -114,7 +116,7 @@ class SitemapLoader(WebBaseLoader):
             import lxml  # noqa:F401
         except ImportError:
             raise ImportError(
-                "lxml package not found, please install it with " "`pip install lxml`"
+                "lxml package not found, please install it with `pip install lxml`"
             )
 
         super().__init__(web_paths=[web_path], **kwargs)

--- a/libs/langchain/langchain/document_loaders/sitemap.py
+++ b/libs/langchain/langchain/document_loaders/sitemap.py
@@ -28,7 +28,7 @@ def _extract_scheme_and_domain(url: str) -> Tuple[str, str]:
         url (str): The input URL.
 
     Returns:
-        return a 2-tuple of schema and domain
+        return a 2-tuple of scheme and domain
     """
     parsed_uri = urlparse(url)
     return parsed_uri.scheme, parsed_uri.netloc

--- a/libs/langchain/langchain/document_loaders/sitemap.py
+++ b/libs/langchain/langchain/document_loaders/sitemap.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Generator, Iterable, List, Optional
 from langchain.document_loaders.web_base import WebBaseLoader
 from langchain.schema import Document
 
+from urllib.parse import urlparse
 
 def _default_parsing_function(content: Any) -> str:
     return str(content.get_text())
@@ -18,6 +19,21 @@ def _batch_block(iterable: Iterable, size: int) -> Generator[List[dict], None, N
     it = iter(iterable)
     while item := list(itertools.islice(it, size)):
         yield item
+
+
+def _extract_domain(url: str) -> str:
+    """Extract the domain name from a given URL.
+
+    Args:
+        url (str): The input URL.
+
+    Returns:
+        str: The extracted domain name.
+    """
+    parsed_uri = urlparse(url)
+    domain = '{uri.netloc}'.format(uri=parsed_uri)
+    return domain
+
 
 
 class SitemapLoader(WebBaseLoader):

--- a/libs/langchain/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_sitemap.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from langchain.document_loaders import SitemapLoader
+from langchain.document_loaders.sitemap import _extract_domain
 
 
 def test_sitemap() -> None:
@@ -132,3 +133,17 @@ def test_local_sitemap() -> None:
     documents = loader.load()
     assert len(documents) > 1
     assert "🦜️🔗" in documents[0].page_content
+
+
+def test_extract_domain() -> None:
+    """Test domain extraction."""
+    assert _extract_domain("https://js.langchain.com/sitemap.xml") == "js.langchain.com"
+    assert _extract_domain("http://example.com/path/to/page") == "example.com"
+    assert _extract_domain("ftp://files.example.com") == "files.example.com"
+    assert (
+        _extract_domain("https://deep.subdomain.example.com")
+        == "deep.subdomain.example.com"
+    )
+
+    with pytest.raises(ValueError):
+        _extract_domain("not_a_valid_url")

--- a/libs/langchain/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_sitemap.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 
 from langchain.document_loaders import SitemapLoader
-from langchain.document_loaders.sitemap import _extract_domain_and_scheme
+from langchain.document_loaders.sitemap import _extract_scheme_and_domain
 
 
 def test_sitemap() -> None:
@@ -137,19 +137,19 @@ def test_local_sitemap() -> None:
 
 def test_extract_domain() -> None:
     """Test domain extraction."""
-    assert (
-        _extract_domain_and_scheme("https://js.langchain.com/sitemap.xml")
-        == "https://js.langchain.com"
+    assert _extract_scheme_and_domain("https://js.langchain.com/sitemap.xml") == (
+        "https",
+        "js.langchain.com",
     )
-    assert (
-        _extract_domain_and_scheme("http://example.com/path/to/page")
-        == "http://example.com"
+    assert _extract_scheme_and_domain("http://example.com/path/to/page") == (
+        "http",
+        "example.com",
     )
-    assert (
-        _extract_domain_and_scheme("ftp://files.example.com")
-        == "ftp://files.example.com"
+    assert _extract_scheme_and_domain("ftp://files.example.com") == (
+        "ftp",
+        "files.example.com",
     )
-    assert (
-        _extract_domain_and_scheme("https://deep.subdomain.example.com")
-        == "https://deep.subdomain.example.com"
+    assert _extract_scheme_and_domain("https://deep.subdomain.example.com") == (
+        "https",
+        "deep.subdomain.example.com",
     )

--- a/libs/langchain/tests/integration_tests/document_loaders/test_sitemap.py
+++ b/libs/langchain/tests/integration_tests/document_loaders/test_sitemap.py
@@ -4,12 +4,12 @@ from typing import Any
 import pytest
 
 from langchain.document_loaders import SitemapLoader
-from langchain.document_loaders.sitemap import _extract_domain
+from langchain.document_loaders.sitemap import _extract_domain_and_scheme
 
 
 def test_sitemap() -> None:
     """Test sitemap loader."""
-    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml")
+    loader = SitemapLoader("https://api.python.langchain.com/sitemap.xml")
     documents = loader.load()
     assert len(documents) > 1
     assert "LangChain Python API" in documents[0].page_content
@@ -18,7 +18,7 @@ def test_sitemap() -> None:
 def test_sitemap_block() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1, blocknum=1
+        "https://api.python.langchain.com/sitemap.xml", blocksize=1, blocknum=1
     )
     documents = loader.load()
     assert len(documents) == 1
@@ -28,7 +28,7 @@ def test_sitemap_block() -> None:
 def test_sitemap_block_only_one() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=0
+        "https://api.python.langchain.com/sitemap.xml", blocksize=1000000, blocknum=0
     )
     documents = loader.load()
     assert len(documents) > 1
@@ -38,7 +38,7 @@ def test_sitemap_block_only_one() -> None:
 def test_sitemap_block_blocknum_default() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000
+        "https://api.python.langchain.com/sitemap.xml", blocksize=1000000
     )
     documents = loader.load()
     assert len(documents) > 1
@@ -48,14 +48,14 @@ def test_sitemap_block_blocknum_default() -> None:
 def test_sitemap_block_size_to_small() -> None:
     """Test sitemap loader."""
     with pytest.raises(ValueError, match="Sitemap blocksize should be at least 1"):
-        SitemapLoader("https://langchain.readthedocs.io/sitemap.xml", blocksize=0)
+        SitemapLoader("https://api.python.langchain.com/sitemap.xml", blocksize=0)
 
 
 def test_sitemap_block_num_to_small() -> None:
     """Test sitemap loader."""
     with pytest.raises(ValueError, match="Sitemap blocknum can not be lower then 0"):
         SitemapLoader(
-            "https://langchain.readthedocs.io/sitemap.xml",
+            "https://api.python.langchain.com/sitemap.xml",
             blocksize=1000000,
             blocknum=-1,
         )
@@ -64,7 +64,7 @@ def test_sitemap_block_num_to_small() -> None:
 def test_sitemap_block_does_not_exists() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml", blocksize=1000000, blocknum=15
+        "https://api.python.langchain.com/sitemap.xml", blocksize=1000000, blocknum=15
     )
     with pytest.raises(
         ValueError,
@@ -76,7 +76,7 @@ def test_sitemap_block_does_not_exists() -> None:
 def test_filter_sitemap() -> None:
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml",
+        "https://api.python.langchain.com/sitemap.xml",
         filter_urls=["https://api.python.langchain.com/en/stable/"],
     )
     documents = loader.load()
@@ -90,7 +90,7 @@ def test_sitemap_metadata() -> None:
 
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml",
+        "https://api.python.langchain.com/sitemap.xml",
         meta_function=sitemap_metadata_one,
     )
     documents = loader.load()
@@ -108,7 +108,7 @@ def test_sitemap_metadata_extraction() -> None:
 
     """Test sitemap loader."""
     loader = SitemapLoader(
-        "https://langchain.readthedocs.io/sitemap.xml",
+        "https://api.python.langchain.com/sitemap.xml",
         meta_function=sitemap_metadata_two,
     )
     documents = loader.load()
@@ -119,7 +119,7 @@ def test_sitemap_metadata_extraction() -> None:
 
 def test_sitemap_metadata_default() -> None:
     """Test sitemap loader."""
-    loader = SitemapLoader("https://langchain.readthedocs.io/sitemap.xml")
+    loader = SitemapLoader("https://api.python.langchain.com/sitemap.xml")
     documents = loader.load()
     assert len(documents) > 1
     assert "source" in documents[0].metadata
@@ -137,13 +137,19 @@ def test_local_sitemap() -> None:
 
 def test_extract_domain() -> None:
     """Test domain extraction."""
-    assert _extract_domain("https://js.langchain.com/sitemap.xml") == "js.langchain.com"
-    assert _extract_domain("http://example.com/path/to/page") == "example.com"
-    assert _extract_domain("ftp://files.example.com") == "files.example.com"
     assert (
-        _extract_domain("https://deep.subdomain.example.com")
-        == "deep.subdomain.example.com"
+        _extract_domain_and_scheme("https://js.langchain.com/sitemap.xml")
+        == "https://js.langchain.com"
     )
-
-    with pytest.raises(ValueError):
-        _extract_domain("not_a_valid_url")
+    assert (
+        _extract_domain_and_scheme("http://example.com/path/to/page")
+        == "http://example.com"
+    )
+    assert (
+        _extract_domain_and_scheme("ftp://files.example.com")
+        == "ftp://files.example.com"
+    )
+    assert (
+        _extract_domain_and_scheme("https://deep.subdomain.example.com")
+        == "https://deep.subdomain.example.com"
+    )


### PR DESCRIPTION
Specify default filter URL in sitemap loader and add a security note

Fixes: CVE-2023-46229