### PR TITLE
SingleStoreDBChatMessageHistory: Add jupiter notebook with usage example

### DIFF
--- a/docs/docs/integrations/memory/singlestoredb_chat_message_history.ipynb
+++ b/docs/docs/integrations/memory/singlestoredb_chat_message_history.ipynb
@@ -1,0 +1,65 @@
+{
+    "cells": [
+     {
+      "attachments": {},
+      "cell_type": "markdown",
+      "id": "91c6a7ef",
+      "metadata": {},
+      "source": [
+       "# SingleStoreDB\n",
+       "\n",
+       "This notebook goes over how to use SingleStoreDB to store chat message history."
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d15e3302",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "from langchain.memory import SingleStoreDBChatMessageHistory\n",
+       "\n",
+       "history = SingleStoreDBChatMessageHistory(\n",
+       "    session_id=\"foo\",\n",
+       "    host=\"root:pass@localhost:3306/db\"\n",
+       ")\n",
+       "\n",
+       "history.add_user_message(\"hi!\")\n",
+       "\n",
+       "history.add_ai_message(\"whats up?\")"
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "64fc465e",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "history.messages"
+      ]
+     }
+    ],
+    "metadata": {
+     "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+     },
+     "language_info": {
+      "codemirror_mode": {
+       "name": "ipython",
+       "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.2"
+     }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}


### PR DESCRIPTION
The Docs folder changed its structure, and the notebook example for SingleStoreDChatMessageHistory has not been copied to the new place due to a merge conflict. Adding the example to the correct place.