### PR TITLE
Type hints on varargs and kwargs that take anything should be `Any`.

### DIFF
--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/spark/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/spark/base.py
@@ -42,7 +42,7 @@ def create_spark_dataframe_agent(
     max_execution_time: Optional[float] = None,
     early_stopping_method: str = "force",
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Spark agent from an LLM and dataframe."""
 

--- a/libs/experimental/langchain_experimental/autonomous_agents/baby_agi/baby_agi.py
+++ b/libs/experimental/langchain_experimental/autonomous_agents/baby_agi/baby_agi.py
@@ -203,7 +203,7 @@ class BabyAGI(Chain, BaseModel):  # type: ignore[misc]
         vectorstore: VectorStore,
         verbose: bool = False,
         task_execution_chain: Optional[Chain] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> "BabyAGI":
         """Initialize the BabyAGI Controller."""
         task_creation_chain = TaskCreationChain.from_llm(llm, verbose=verbose)

--- a/libs/langchain/langchain/agents/agent_toolkits/json/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/json/base.py
@@ -21,7 +21,7 @@ def create_json_agent(
     input_variables: Optional[List[str]] = None,
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a json agent from an LLM and tools."""
     tools = toolkit.get_tools()

--- a/libs/langchain/langchain/agents/agent_toolkits/openapi/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/openapi/base.py
@@ -28,7 +28,7 @@ def create_openapi_agent(
     verbose: bool = False,
     return_intermediate_steps: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct an OpenAPI agent from an LLM and tools."""
     tools = toolkit.get_tools()

--- a/libs/langchain/langchain/agents/agent_toolkits/openapi/planner.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/openapi/planner.py
@@ -320,7 +320,7 @@ def create_openapi_agent(
     callback_manager: Optional[BaseCallbackManager] = None,
     verbose: bool = True,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Instantiate OpenAI API planner and controller for a given spec.
 

--- a/libs/langchain/langchain/agents/agent_toolkits/pandas/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/pandas/base.py
@@ -283,7 +283,7 @@ def create_pandas_dataframe_agent(
     include_df_in_prompt: Optional[bool] = True,
     number_of_head_rows: int = 5,
     extra_tools: Sequence[BaseTool] = (),
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a pandas agent from an LLM and dataframe."""
     warn_deprecated(

--- a/libs/langchain/langchain/agents/agent_toolkits/powerbi/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/powerbi/base.py
@@ -28,7 +28,7 @@ def create_pbi_agent(
     top_k: int = 10,
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Power BI agent from an LLM and tools."""
     if toolkit is None:

--- a/libs/langchain/langchain/agents/agent_toolkits/powerbi/chat_base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/powerbi/chat_base.py
@@ -30,7 +30,7 @@ def create_pbi_chat_agent(
     top_k: int = 10,
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Power BI agent from a Chat LLM and tools.
 

--- a/libs/langchain/langchain/agents/agent_toolkits/python/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/python/base.py
@@ -23,7 +23,7 @@ def create_python_agent(
     verbose: bool = False,
     prefix: str = PREFIX,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a python agent from an LLM and tool."""
     warn_deprecated(

--- a/libs/langchain/langchain/agents/agent_toolkits/spark/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/spark/base.py
@@ -42,7 +42,7 @@ def create_spark_dataframe_agent(
     max_execution_time: Optional[float] = None,
     early_stopping_method: str = "force",
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Spark agent from an LLM and dataframe."""
     warn_deprecated(

--- a/libs/langchain/langchain/agents/agent_toolkits/spark_sql/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/spark_sql/base.py
@@ -26,7 +26,7 @@ def create_spark_sql_agent(
     early_stopping_method: str = "force",
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Spark SQL agent from an LLM and tools."""
     tools = toolkit.get_tools()

--- a/libs/langchain/langchain/agents/agent_toolkits/sql/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/sql/base.py
@@ -40,7 +40,7 @@ def create_sql_agent(
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
     extra_tools: Sequence[BaseTool] = (),
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct an SQL agent from an LLM and tools."""
     tools = toolkit.get_tools() + list(extra_tools)

--- a/libs/langchain/langchain/agents/agent_toolkits/vectorstore/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/vectorstore/base.py
@@ -20,7 +20,7 @@ def create_vectorstore_agent(
     prefix: str = PREFIX,
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a VectorStore agent from an LLM and tools.
 
@@ -61,7 +61,7 @@ def create_vectorstore_router_agent(
     prefix: str = ROUTER_PREFIX,
     verbose: bool = False,
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a VectorStore router agent from an LLM and tools.
 

--- a/libs/langchain/langchain/agents/agent_toolkits/xorbits/base.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/xorbits/base.py
@@ -29,7 +29,7 @@ def create_xorbits_agent(
     max_execution_time: Optional[float] = None,
     early_stopping_method: str = "force",
     agent_executor_kwargs: Optional[Dict[str, Any]] = None,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a xorbits agent from an LLM and dataframe."""
     warn_deprecated(

--- a/libs/langchain/langchain/vectorstores/redis/filters.py
+++ b/libs/langchain/langchain/vectorstores/redis/filters.py
@@ -81,7 +81,7 @@ def check_operator_misuse(func: Callable) -> Callable:
     """Decorator to check for misuse of equality operators."""
 
     @wraps(func)
-    def wrapper(instance: Any, *args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+    def wrapper(instance: Any, *args: Any, **kwargs: Any) -> Any:
         # Extracting 'other' from positional arguments or keyword arguments
         other = kwargs.get("other") if "other" in kwargs else None
         if not other:


### PR DESCRIPTION
Type hinting `*args` as `List[Any]` means that each positional argument should be a list. Type hinting `**kwargs` as `Dict[str, Any]` means that each keyword argument should be a dict of strings.

This is almost never what we actually wanted, and doesn't seem to be what we want in any of the cases I'm replacing here.
