### PR TITLE
Update `create_repo` CLI templates' GitHub Actions and ruff dependency.

### DIFF
--- a/libs/langchain/langchain/cli/create_repo/templates/pip/pyproject.toml
+++ b/libs/langchain/langchain/cli/create_repo/templates/pip/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
   "pytest~=7.4.0",
   "pytest-asyncio~=0.21.1",
   "mypy~=1.4.1",
-  "ruff~=0.0.278",
+  "ruff~=0.1",
   "black~=23.7.0",
   "syrupy~=4.0.2",
 ]

--- a/libs/langchain/langchain/cli/create_repo/templates/poetry/.github/workflows/lint.yml
+++ b/libs/langchain/langchain/cli/create_repo/templates/poetry/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  POETRY_VERSION: "1.4.2"
+  POETRY_VERSION: "1.6.1"
 
 jobs:
   build:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: |
-          pipx install poetry==$POETRY_VERSION
+          pipx install poetry=="$POETRY_VERSION"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/libs/langchain/langchain/cli/create_repo/templates/poetry/.github/workflows/release.yml
+++ b/libs/langchain/langchain/cli/create_repo/templates/poetry/.github/workflows/release.yml
@@ -1,38 +1,29 @@
 name: release
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - master
-    paths:
-      - 'pyproject.toml'
+  workflow_dispatch:  # Allows triggering the workflow manually in GitHub UI
 
 env:
-  POETRY_VERSION: "1.4.2"
+  POETRY_VERSION: "1.6.1"
 
 jobs:
-  if_release:
-    if: |
-        ${{ github.event.pull_request.merged == true }}
-        && ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: pipx install poetry==$POETRY_VERSION
-      - name: Set up Python 3.10
+        run: pipx install poetry=="$POETRY_VERSION"
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "poetry"
       - name: Build project for distribution
         run: poetry build
       - name: Check Version
         id: check-version
         run: |
-          echo version=$(poetry version --short) >> $GITHUB_OUTPUT
+          echo version="$(poetry version --short)" >> $GITHUB_OUTPUT
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/libs/langchain/langchain/cli/create_repo/templates/poetry/.github/workflows/test.yml
+++ b/libs/langchain/langchain/cli/create_repo/templates/poetry/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  POETRY_VERSION: "1.4.2"
+  POETRY_VERSION: "1.6.1"
 
 jobs:
   build:
@@ -21,15 +21,15 @@ jobs:
           - "3.11"
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: "./.github/actions/poetry_setup"
         with:
           python-version: ${{ matrix.python-version }}
-          poetry-version: "1.4.2"
+          poetry-version: ${{ env.POETRY_VERSION }}
           install-command: |
-              echo "Running tests, installing dependencies with poetry..."
-              poetry install
+            echo "Running tests, installing dependencies with poetry..."
+            poetry install
       - name: Run tests
         run: |
           make test

--- a/libs/langchain/langchain/cli/create_repo/templates/poetry/pyproject.toml
+++ b/libs/langchain/langchain/cli/create_repo/templates/poetry/pyproject.toml
@@ -20,7 +20,7 @@ uvicorn = {extras = ["standard"], version = "^0.22.0"}
 pytest = "^7.4.0"
 pytest-asyncio = "^0.21.1"
 mypy = "^1.4.1"
-ruff = "^0.0.278"
+ruff = "^0.1"
 black = "^23.7.0"
 syrupy = "^4.0.2"
 


### PR DESCRIPTION
This brings the templates closer to how we develop `langchain`: the same poetry and ruff versions, releasing on manual action instead of using a finicky `if` conditional trigger, etc. Also fixes minor lint and bugs in the workflows.
