### PR TITLE
Bug fix tongyi.py to be compatible with DashScope API

### DIFF
--- a/libs/langchain/langchain/chat_models/tongyi.py
+++ b/libs/langchain/langchain/chat_models/tongyi.py
@@ -318,10 +318,19 @@ class ChatTongyi(BaseChatModel):
             )
             return _generate_from_stream(stream_iter)
 
+        if not messages:
+            raise ValueError("No messages provided.")
+        
         message_dicts, params = self._create_message_dicts(messages, stop)
+
+        if message_dicts[-1]['role'] != 'user':
+            raise ValueError("Last message should be user message.")
+        
         params = {**params, **kwargs}
+        prompt = message_dicts[-1]['content']
+        message_dicts = message_dicts[:-1]
         response = self.completion_with_retry(
-            messages=message_dicts, run_manager=run_manager, **params
+            messages=message_dicts, prompt=prompt, run_manager=run_manager, **params
         )
         return self._create_chat_result(response)
 
@@ -374,7 +383,7 @@ class ChatTongyi(BaseChatModel):
     def _client_params(self) -> Dict[str, Any]:
         """Get the parameters used for the openai client."""
         creds: Dict[str, Any] = {
-            "dashscope_api_key": self.dashscope_api_key,
+            "api_key": self.dashscope_api_key,
         }
         return {**self._default_params, **creds}
 

--- a/libs/langchain/langchain/chat_models/tongyi.py
+++ b/libs/langchain/langchain/chat_models/tongyi.py
@@ -320,12 +320,12 @@ class ChatTongyi(BaseChatModel):
 
         if not messages:
             raise ValueError("No messages provided.")
-        
+
         message_dicts, params = self._create_message_dicts(messages, stop)
 
-        if message_dicts[-1]['role'] != 'user':
+        if message_dicts[-1]["role"] != "user":
             raise ValueError("Last message should be user message.")
-        
+
         params = {**params, **kwargs}
         response = self.completion_with_retry(
             messages=message_dicts, run_manager=run_manager, **params

--- a/libs/langchain/langchain/chat_models/tongyi.py
+++ b/libs/langchain/langchain/chat_models/tongyi.py
@@ -327,10 +327,8 @@ class ChatTongyi(BaseChatModel):
             raise ValueError("Last message should be user message.")
         
         params = {**params, **kwargs}
-        prompt = message_dicts[-1]['content']
-        message_dicts = message_dicts[:-1]
         response = self.completion_with_retry(
-            messages=message_dicts, prompt=prompt, run_manager=run_manager, **params
+            messages=message_dicts, run_manager=run_manager, **params
         )
         return self._create_chat_result(response)
 


### PR DESCRIPTION
Current ChatTongyi is not compatible with DashScope API, which will cause error when passing api key to chat model directly.
  - **Description:** Update tongyi.py to be compatible with DashScope API. Specifically, update parameter name "dashscope_api_key" to "api_key".
  - **Issue:** None.
  - **Dependencies:** Nothing new, Tongyi would require DashScope as before.
