### PR TITLE
Update clarifai.ipynb

### DIFF
--- a/docs/docs/integrations/vectorstores/clarifai.ipynb
+++ b/docs/docs/integrations/vectorstores/clarifai.ipynb
@@ -322,8 +322,7 @@
    "source": [
     "clarifai_vector_db = Clarifai(\n",
     "    user_id=USER_ID,\n",
-    "    app_id=APP_ID,\n",
-    "    documents=docs,\n",
+    "    app_id=APP_ID,\n",    
     "    pat=CLARIFAI_PAT,\n",
     "    number_of_docs=NUMBER_OF_DOCS,\n",
     ")"


### PR DESCRIPTION
documents=docs not required when making a vector search on an existing Clarifai application

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
