### PR TITLE
Sometime, the json generated with the llm is not correct. This pull request fix it

### DIFF
--- a/libs/langchain/langchain/output_parsers/format_instructions.py
+++ b/libs/langchain/langchain/output_parsers/format_instructions.py
@@ -19,7 +19,7 @@ STRUCTURED_FORMAT_SIMPLE_INSTRUCTIONS = """
 PYDANTIC_FORMAT_INSTRUCTIONS = """The output should be formatted as a JSON instance that conforms to the JSON schema below.
 
 As an example, for the schema {{"properties": {{"foo": {{"title": "Foo", "description": "a list of strings", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}}
-the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of the schema. The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
+the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of the schema. The object {{"properties": {{"foo": ["bar", "baz",]}}}} is not well-formatted.
 
 Here is the output schema:
 ```


### PR DESCRIPTION
** Description**
Help the llm to generate a correct json format.
This patch reduces the probability to generating this error.

*** Issue **
Sometime, the json generated with the llm is not correct.  When the llm must generate a list of objects. The last item has an invalid comma.
```
{"a":["a",
        "b",  # Not, invalid comma at end
        ]
 }
```
** Tag maintainer:***
@baskaryan

**Twitter handler:**
pprados

