### PR TITLE
Add ERNIE-Bot-4 model support for ErnieBotChat.

### DIFF
--- a/libs/langchain/langchain/chat_models/ernie.py
+++ b/libs/langchain/langchain/chat_models/ernie.py
@@ -107,6 +107,7 @@ class ErnieBotChat(BaseChatModel):
         model_paths = {
             "ERNIE-Bot-turbo": "eb-instant",
             "ERNIE-Bot": "completions",
+            "ERNIE-Bot-4": "completions_pro",
             "BLOOMZ-7B": "bloomz_7b1",
             "Llama-2-7b-chat": "llama_2_7b",
             "Llama-2-13b-chat": "llama_2_13b",


### PR DESCRIPTION
- **Description:** According to the document https://cloud.baidu.com/doc/WENXINWORKSHOP/s/clntwmv7t, add ERNIE-Bot-4 model support for ErnieBotChat.
- **Dependencies:** Before using the ERNIE-Bot-4, you should have the model's access authority.