### PR TITLE
Add some transformers and a transformers pipeline

### DIFF
--- a/libs/langchain/langchain/retrievers/document_transformers/base.py
+++ b/libs/langchain/langchain/retrievers/document_transformers/base.py
@@ -1,0 +1,35 @@
+from typing import List, Sequence, Any
+from xml.dom.minidom import Document
+
+from langchain.schema import BaseDocumentTransformer
+
+class DocumentTransformerPipeline(BaseDocumentTransformer):
+    """Document transformer that uses a pipeline of Transformers."""
+
+    def __init__(self,
+                 transformers: Sequence[BaseDocumentTransformer]
+                 ):
+        self.transformers = transformers
+
+    """List of document transformer that are applied in sequence."""
+
+    def transform_documents(
+            self, documents: Sequence[Document],
+            **kwargs: Any
+    ) -> Sequence[Document]:
+        """Transform a list of documents."""
+        all_documents = []
+        for _transformer in self.transformers:
+            all_documents.extend(_transformer.transform_documents(documents, **kwargs))
+        return all_documents
+
+    async def atransform_documents(
+            self,
+            documents: Sequence[Document],
+            **kwargs: Any
+    ) -> Sequence[Document]:
+        """Compress retrieved documents given the query context."""
+        all_documents = []
+        for _transformer in self.transformers:
+            all_documents.extend(await _transformer.atransform_documents(documents))
+        return documents

--- a/libs/langchain/langchain/retrievers/document_transformers/copy_transformer.py
+++ b/libs/langchain/langchain/retrievers/document_transformers/copy_transformer.py
@@ -1,0 +1,5 @@
+class CopyDocumentTransformer(BaseDocumentTransformer):
+    def transform_documents(
+            self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        return documents

--- a/libs/langchain/langchain/retrievers/document_transformers/generate_questions.py
+++ b/libs/langchain/langchain/retrievers/document_transformers/generate_questions.py
@@ -1,0 +1,134 @@
+import asyncio
+from functools import partial
+from typing import Callable, Sequence, Optional, Dict, Any, Generator, cast
+
+from langchain.chains import LLMChain
+from langchain.output_parsers import NumberedListOutputParser
+from langchain.prompts import PromptTemplate
+from langchain.schema import Document, BaseDocumentTransformer
+from langchain.schema.language_model import BaseLanguageModel
+
+
+def _default_get_input(doc: Document) -> Dict[str, Any]:
+    """Return the context chain input."""
+    return {
+        "context": doc.page_content,
+    }
+
+
+_default_template = """
+Given a text input, generate {nb_of_questions} questions from it in the same language. 
+Context:
+```
+{context}
+```
+{format_instructions}"""
+
+_default_parser = NumberedListOutputParser()
+
+
+def _get_default_chain_prompt() -> PromptTemplate:
+    return PromptTemplate.from_template(
+        template=_default_template,
+        output_parser=_default_parser,
+        partial_variables={"format_instructions": _default_parser.get_format_instructions()}
+    )
+
+
+class GenerateQuestions(BaseDocumentTransformer):
+    """Generate questions for each Documents."""
+
+    def __init__(
+            self,
+            llm_chain: LLMChain,
+            get_input: Callable[[Document], dict] = _default_get_input,
+            nb_of_questions: int = 3,
+    ):
+        self.llm_chain = llm_chain
+        self.get_input = get_input
+        self.nb_of_questions = nb_of_questions
+
+    """LLM wrapper to use for compressing documents."""
+
+    """Callable for constructing the chain input from the query and a Document."""
+
+    def lazy_transform_documents(
+            self,
+            documents: Sequence[Document],
+            **kwargs: Any,
+    ) -> Generator[Document, None, None]:
+        """Compress page content of raw documents."""
+        _callbacks = kwargs.get("callbacks", None)
+        for doc in documents:
+            _input = {**self.get_input(doc),
+                      **{"nb_of_questions": self.nb_of_questions}}
+            output = cast(Sequence[str],self.llm_chain.predict_and_parse(
+                callbacks=_callbacks,
+                **_input))
+            if not output:
+                continue
+            for question in output:
+                yield Document(page_content=question, metadata=doc.metadata)
+
+    def transform_documents(
+            self,
+            documents: Sequence[Document],
+            **kwargs: Any
+    ) -> Sequence[Document]:
+        return list(self.lazy_transform_documents(
+            documents=documents,
+            **kwargs
+        ))
+
+    async def lazy_atransform_documents(
+            self, documents: Sequence[Document], **kwargs: Any
+    ) -> Generator[Document, None, None]:
+
+        """Compress page content of raw documents asynchronously."""
+        _callbacks = kwargs.get("callbacks", None)
+        outputs = await asyncio.gather(
+            *[
+                self.llm_chain.apredict_and_parse(
+                    **self.get_input(documents),
+                    callbacks=_callbacks
+                )
+                for doc in documents
+            ]
+        )
+        for i, doc in enumerate(documents):
+            if not outputs[i]:
+                continue
+            yield Document(page_content=outputs[i],
+                           metadata=doc.metadata)
+
+    async def atransform_documents(
+            self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Asynchronously transform a list of documents.
+
+        Args:
+            documents: A sequence of Documents to be transformed.
+
+        Returns:
+            A list of transformed Documents.
+        """
+        return await asyncio.get_running_loop().run_in_executor(
+            None, partial(self.transform_documents, **kwargs), documents
+        )
+
+    @classmethod
+    def from_llm(
+            cls,
+            llm: BaseLanguageModel,
+            prompt: Optional[PromptTemplate] = None,
+            get_input: Optional[Callable[[Document], dict]] = None,
+            nb_of_questions: int = 3,
+            llm_chain_kwargs: Optional[dict] = None,
+    ) -> 'GenerateQuestions':
+        """Initialize from LLM."""
+        _prompt = prompt if prompt is not None else _get_default_chain_prompt()
+        _get_input = get_input if get_input is not None else _default_get_input
+        llm_chain = LLMChain(llm=llm, prompt=_prompt, **(llm_chain_kwargs or {}))
+        return cls(llm_chain=llm_chain,
+                   get_input=_get_input,
+                   nb_of_questions=nb_of_questions)

--- a/libs/langchain/langchain/retrievers/document_transformers/generate_questions.py
+++ b/libs/langchain/langchain/retrievers/document_transformers/generate_questions.py
@@ -35,7 +35,7 @@ def _get_default_chain_prompt() -> PromptTemplate:
     )
 
 
-class GenerateQuestions(BaseDocumentTransformer):
+class GenerateQuestionsTransformer(BaseDocumentTransformer):
     """Generate questions for each Documents."""
 
     def __init__(
@@ -124,7 +124,7 @@ class GenerateQuestions(BaseDocumentTransformer):
             get_input: Optional[Callable[[Document], dict]] = None,
             nb_of_questions: int = 3,
             llm_chain_kwargs: Optional[dict] = None,
-    ) -> 'GenerateQuestions':
+    ) -> 'GenerateQuestionsTransformer':
         """Initialize from LLM."""
         _prompt = prompt if prompt is not None else _get_default_chain_prompt()
         _get_input = get_input if get_input is not None else _default_get_input

--- a/libs/langchain/langchain/retrievers/document_transformers/sumarize_transformer.py
+++ b/libs/langchain/langchain/retrievers/document_transformers/sumarize_transformer.py
@@ -1,0 +1,125 @@
+import asyncio
+from functools import partial
+from typing import Callable, Sequence, Optional, Dict, Any, Generator
+
+from langchain.chains import LLMChain
+from langchain.output_parsers import NumberedListOutputParser
+from langchain.prompts import PromptTemplate
+from langchain.schema import Document, BaseDocumentTransformer
+from langchain.schema.language_model import BaseLanguageModel
+
+
+def _default_get_input(doc: Document) -> Dict[str, Any]:
+    """Return the context chain input."""
+    return {
+        "context": doc.page_content,
+    }
+
+
+_default_template = """
+Sumarize a text input in the same language. 
+Context:
+```
+{context}
+```
+"""
+_default_format_instruction = NumberedListOutputParser()
+
+
+def _get_default_chain_prompt() -> PromptTemplate:
+    return PromptTemplate.from_template(
+        template=_default_template,
+    )
+
+
+class SummarizeTransformer(BaseDocumentTransformer):
+    """Generate questions for each Documents."""
+
+    def __init__(
+            self,
+            llm_chain: LLMChain,
+            get_input: Callable[[Document], dict] = _default_get_input,
+    ):
+        self.llm_chain = llm_chain
+        self.get_input = get_input
+
+    """LLM wrapper to use for compressing documents."""
+
+    """Callable for constructing the chain input from the query and a Document."""
+
+    def lazy_transform_documents(
+            self,
+            documents: Sequence[Document],
+            **kwargs: Any,
+    ) -> Generator[Document, None, None]:
+        """Compress page content of raw documents."""
+        _callbacks = kwargs.get("callbacks", None)
+        for doc in documents:
+            _input = self.get_input(doc)
+            output = self.llm_chain.predict_and_parse(
+                callbacks=_callbacks,
+                **_input)
+            if not output:
+                continue
+            yield Document(page_content=str(output), metadata=doc.metadata)
+
+    def transform_documents(
+            self,
+            documents: Sequence[Document],
+            **kwargs: Any
+    ) -> Sequence[Document]:
+        return list(self.lazy_transform_documents(
+            documents=documents,
+            **kwargs
+        ))
+
+    async def lazy_atransform_documents(
+            self, documents: Sequence[Document], **kwargs: Any
+    ) -> Generator[Document, None, None]:
+
+        """Summarize the page content of raw documents asynchronously."""
+        _callbacks = kwargs.get("callbacks", None)
+        outputs = await asyncio.gather(
+            *[
+                self.llm_chain.apredict_and_parse(
+                    **self.get_input(documents),
+                    callbacks=_callbacks
+                )
+                for doc in documents
+            ]
+        )
+        for i, doc in enumerate(documents):
+            if not outputs[i]:
+                continue
+            yield Document(page_content=outputs[i],
+                           metadata=doc.metadata)
+
+    async def atransform_documents(
+            self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Asynchronously transform a list of documents.
+
+        Args:
+            documents: A sequence of Documents to be transformed.
+
+        Returns:
+            A list of transformed Documents.
+        """
+        return await asyncio.get_running_loop().run_in_executor(
+            None, partial(self.transform_documents, **kwargs), documents
+        )
+
+    @classmethod
+    def from_llm(
+            cls,
+            llm: BaseLanguageModel,
+            prompt: Optional[PromptTemplate] = None,
+            get_input: Optional[Callable[[Document], dict]] = None,
+            llm_chain_kwargs: Optional[dict] = None,
+    ) -> 'SummarizeTransformer':
+        """Initialize from LLM."""
+        _prompt = prompt if prompt is not None else _get_default_chain_prompt()
+        _get_input = get_input if get_input is not None else _default_get_input
+        llm_chain = LLMChain(llm=llm, prompt=_prompt, **(llm_chain_kwargs or {}))
+        return cls(llm_chain=llm_chain,
+                   get_input=_get_input)


### PR DESCRIPTION
**Description:**
As with `document_compressors`, it seems important to provide a pipeline for transformers.
The algorithm is different of `DocumentCompressorPipeline`. The idea is to have several transformers to apply to the same document, in order to have several embeddings for the same fragment (via a `ParentDocumentRetriever`). You therefore need to retrieve all the transformations, rather than chaining them together as `DocumentCompressorPipeline` does.

- `DocumentTransformerPipeline` is used when importing data into a vector store, to have multiple embedding for the same fragment. 
- `DocumentCompressorPipelinè is used when reading documents, to filter them.


Combined with this [pull-request](https://github.com/langchain-ai/langchain/pull/11968), it's easy to chain transformations while maintaining the link with the original document.

I propose 3 more transformers, to generate a summary and ask questions about the document.
The last one is a simple transformer without transformation. A simple copy of input to output.

I must explain the usage.

1. You split a big document to fragments
2. For each fragment, you want to generate a summary
3. For each fragment, you want to generate 3 questions, and generate a document one for each question
4. Then, you want to save the original fragment, the summary and the 3 questions in a vectorstore
5. You can use `ParentDocumentRetriever` to maintain the association with the original fragment.
6. When you use the `ParentDocumentRetriever`, all the embedding from the summary, the questions or the orginal fragment can select the same fragment.

But, `BaseDocumentTransformer` invoke a list of transformer to apply. If I use it with only the `SummarizeTransformer` and `GenerateQuestionsTransformer`, the result is composed with the summary and questions. But the original fragment are not in the result.

So the ̀`CopyDocumentTransformer` can add the original fragment.

Then, with `ParentDocumentVectorStore`, you can write:

```
vs = ParentDocumentVectorStore(
    vectorstore=vs,
    docstore=self.docstore,
    id_key=ID_KEY,
    parent_transformer=RecursiveCharacterTextSplitter(),
    child_transformer=DocumentTransformerPipeline(
        transformers=[
            GenerateQuestions.from_llm(llm),
            SummarizeTransformer.from_llm(llm),
            CopyDocumentTransformer(),
        ]
    ),
)
vs.add_documents(documents) # Split, summarize, ask questions and import
```