### PR TITLE
added rrf argument in ApproxRetrievalStrategy class __init__()

### DIFF
--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -121,7 +121,7 @@ class ApproxRetrievalStrategy(BaseRetrievalStrategy):
     ):
         self.query_model_id = query_model_id
         self.hybrid = hybrid
-        
+
         # RRF has two optional parameters
         # 'rank_constant', 'window_size'
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/rrf.html
@@ -167,7 +167,7 @@ class ApproxRetrievalStrategy(BaseRetrievalStrategy):
 
         # If hybrid, add a query to the knn query
         # RRF is used to even the score from the knn query and text query
-        if self.hybrid:            
+        if self.hybrid:
             return {
                 "knn": knn,
                 "query": {
@@ -1165,13 +1165,15 @@ class ElasticsearchStore(VectorStore):
             hybrid: Optional. If True, will perform a hybrid search
                     using both the knn query and a text query.
                     Defaults to False.
-            rrf: Optional. If the hybrid argument is True, rrf(Reciprocal Rank Fusion) argument 
-                 could be passed for adjusting 'rank_constant' and 'window_size' 
-                 to combine multiple result sets with different relevance indicators 
+            rrf: Optional. If the hybrid is True, rrf(Reciprocal Rank Fusion)
+                 could be passed for adjusting 'rank_constant' and 'window_size'
+                 to combine multiple result sets with different relevance indicators
                  into a single result set.
                  Defaults to {}.
         """
-        return ApproxRetrievalStrategy(query_model_id=query_model_id, hybrid=hybrid, rrf=rrf)
+        return ApproxRetrievalStrategy(
+            query_model_id=query_model_id, hybrid=hybrid, rrf=rrf
+        )
 
     @staticmethod
     def SparseVectorRetrievalStrategy(

--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -1177,11 +1177,11 @@ class ElasticsearchStore(VectorStore):
             hybrid: Optional. If True, will perform a hybrid search
                     using both the knn query and a text query.
                     Defaults to False.
-            rrf: Optional. rrf is rrf(Reciprocal Rank Fusion).
-                 When `hybrid` is True
+            rrf: Optional. rrf is Reciprocal Rank Fusion.
+                 When `hybrid` is True,
                     and `rrf` is True, then rrf: {}.
                     and `rrf` is False, then rrf is omitted.
-                    and isinstance(rrf, dict) is True, then pass in the dict values to the rrf key.
+                    and isinstance(rrf, dict) is True, then pass in the dict values.
                  rrf could be passed for adjusting 'rank_constant' and 'window_size'.
         """
         return ApproxRetrievalStrategy(

--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -601,7 +601,7 @@ class ElasticsearchStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        fetch_k: Optional[int] = 50,
+        fetch_k: int = 50,
         filter: Optional[List[dict]] = None,
         **kwargs: Any,
     ) -> List[Document]:

--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -604,7 +604,7 @@ class ElasticsearchStore(VectorStore):
         Args:
             query: Text to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-            fetch_k (int): Number of Documents to fetch to pass to knn num_candidates. Defaults to 50.
+            fetch_k (int): Number of Documents to fetch to pass to knn num_candidates.
             filter: Array of Elasticsearch filter clauses to apply to the query.
 
         Returns:

--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -117,15 +117,9 @@ class ApproxRetrievalStrategy(BaseRetrievalStrategy):
         self,
         query_model_id: Optional[str] = None,
         hybrid: Optional[bool] = False,
-        rrf: Optional[dict] = {},
     ):
         self.query_model_id = query_model_id
         self.hybrid = hybrid
-
-        # RRF has two optional parameters
-        # 'rank_constant', 'window_size'
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/rrf.html
-        self.rrf = rrf
 
     def query(
         self,
@@ -1152,7 +1146,6 @@ class ElasticsearchStore(VectorStore):
     def ApproxRetrievalStrategy(
         query_model_id: Optional[str] = None,
         hybrid: Optional[bool] = False,
-        rrf: Optional[dict] = {},
     ) -> "ApproxRetrievalStrategy":
         """Used to perform approximate nearest neighbor search
         using the HNSW algorithm.
@@ -1175,15 +1168,8 @@ class ElasticsearchStore(VectorStore):
             hybrid: Optional. If True, will perform a hybrid search
                     using both the knn query and a text query.
                     Defaults to False.
-            rrf: Optional. If the hybrid is True, rrf(Reciprocal Rank Fusion)
-                 could be passed for adjusting 'rank_constant' and 'window_size'
-                 to combine multiple result sets with different relevance indicators
-                 into a single result set.
-                 Defaults to {}.
         """
-        return ApproxRetrievalStrategy(
-            query_model_id=query_model_id, hybrid=hybrid, rrf=rrf
-        )
+        return ApproxRetrievalStrategy(query_model_id=query_model_id, hybrid=hybrid)
 
     @staticmethod
     def SparseVectorRetrievalStrategy(

--- a/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
@@ -474,7 +474,9 @@ class TestElasticsearch:
             )
 
             def assert_query(
-                query_body: dict, query: str, rrf: Optional[Union[dict, bool, None]] = True
+                query_body: dict,
+                query: str,
+                rrf: Optional[Union[dict, bool, None]] = True,
             ) -> dict:
                 cmp_query_body = {
                     "knn": {

--- a/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
@@ -461,7 +461,12 @@ class TestElasticsearch:
         from typing import Optional
 
         # 1. check query_body is okay
-        for rrf_option in [True, False, {"rank_constant": 1, "window_size": 5}]:
+        rrf_test_cases: List[Optional[Union[dict, bool]]] = [
+            True,
+            False,
+            {"rank_constant": 1, "window_size": 5},
+        ]
+        for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
             docsearch = ElasticsearchStore.from_texts(
                 texts,
@@ -469,14 +474,14 @@ class TestElasticsearch:
                 **elasticsearch_connection,
                 index_name=index_name,
                 strategy=ElasticsearchStore.ApproxRetrievalStrategy(
-                    hybrid=True, rrf=rrf_option
+                    hybrid=True, rrf=rrf_test_case
                 ),
             )
 
             def assert_query(
                 query_body: dict,
                 query: str,
-                rrf: Optional[Union[dict, bool, None]] = True,
+                rrf: Optional[Union[dict, bool]] = True,
             ) -> dict:
                 cmp_query_body = {
                     "knn": {
@@ -516,7 +521,7 @@ class TestElasticsearch:
 
             ## without fetch_k parameter
             output = docsearch.similarity_search(
-                "foo", k=3, custom_query=partial(assert_query, rrf=rrf_option)
+                "foo", k=3, custom_query=partial(assert_query, rrf=rrf_test_case)
             )
 
         # 2. check query result is okay

--- a/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
@@ -517,11 +517,6 @@ class TestElasticsearch:
             rank={"rrf": {"rank_constant": 1, "window_size": 5}},
         )
 
-        print(f"similarity_search output: {[o.page_content for o in output]}")
-        print(
-            f"es_client.search  output: {[e['_source']['text'] for e in es_output['hits']['hits']]}"
-        )
-
         assert [o.page_content for o in output] == [
             e["_source"]["text"] for e in es_output["hits"]["hits"]
         ]

--- a/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
@@ -517,19 +517,6 @@ class TestElasticsearch:
                 "foo", k=3, custom_query=partial(assert_query, rrf=rrf_option)
             )
 
-        docsearch = ElasticsearchStore.from_texts(
-            texts,
-            FakeEmbeddings(),
-            **elasticsearch_connection,
-            index_name=index_name,
-            strategy=ElasticsearchStore.ApproxRetrievalStrategy(hybrid=True),
-        )
-
-        ## with fetch_k parameter
-        output = docsearch.similarity_search(
-            "foo", k=3, fetch_k=50, custom_query=assert_query
-        )
-
         # 2. check query result is okay
         es_output = es_client.search(
             index=index_name,
@@ -553,6 +540,20 @@ class TestElasticsearch:
         assert [o.page_content for o in output] == [
             e["_source"]["text"] for e in es_output["hits"]["hits"]
         ]
+
+        # 3. check rrf default option is okay
+        docsearch = ElasticsearchStore.from_texts(
+            texts,
+            FakeEmbeddings(),
+            **elasticsearch_connection,
+            index_name=index_name,
+            strategy=ElasticsearchStore.ApproxRetrievalStrategy(hybrid=True),
+        )
+
+        ## with fetch_k parameter
+        output = docsearch.similarity_search(
+            "foo", k=3, fetch_k=50, custom_query=assert_query
+        )
 
     def test_similarity_search_approx_with_custom_query_fn(
         self, elasticsearch_connection: dict, index_name: str

--- a/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
@@ -457,8 +457,8 @@ class TestElasticsearch:
         self, es_client: Any, elasticsearch_connection: dict, index_name: str
     ) -> None:
         """Test end to end construction and rrf hybrid search with metadata."""
-        from typing import Optional
         from functools import partial
+        from typing import Optional
 
         # 1. check query_body is okay
         for rrf_option in [True, False, {"rank_constant": 1, "window_size": 5}]:

--- a/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_elasticsearch.py
@@ -474,7 +474,7 @@ class TestElasticsearch:
             )
 
             def assert_query(
-                query_body: dict, query: str, rrf: Optional[Union[dict, bool]] = True
+                query_body: dict, query: str, rrf: Optional[Union[dict, bool, None]] = True
             ) -> dict:
                 cmp_query_body = {
                     "knn": {


### PR DESCRIPTION
  - **Description: To handle the hybrid search with RRF(Reciprocal Rank Fusion) in the Elasticsearch, rrf argument was added for adjusting 'rank_constant' and 'window_size' to combine multiple result sets with different relevance indicators into a single result set. (ref: https://www.elastic.co/kr/blog/whats-new-elastic-enterprise-search-8-9-0), 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** No dependencies changed,
  - **Tag maintainer:** @baskaryan,

Nice to meet you,
I'm a newbie for contributions and it's my first PR.

I only changed the langchain/vectorstores/elasticsearch.py file.
I did make format&lint 
I got this message,
```shell
make lint_diff  
./scripts/check_pydantic.sh .
./scripts/check_imports.sh
poetry run ruff .
[ "langchain/vectorstores/elasticsearch.py" = "" ] || poetry run black langchain/vectorstores/elasticsearch.py --check
All done! ✨ 🍰 ✨
1 file would be left unchanged.
[ "langchain/vectorstores/elasticsearch.py" = "" ] || poetry run mypy langchain/vectorstores/elasticsearch.py
langchain/__init__.py: error: Source file found twice under different module names: "mvp.nlp.langchain.libs.langchain.langchain" and "langchain"
Found 1 error in 1 file (errors prevented further checking)
make: *** [lint_diff] Error 2
```

Thank you