### PR TITLE
Fireworks: plumb stop words through for streaming

### DIFF
--- a/libs/langchain/langchain/llms/fireworks.py
+++ b/libs/langchain/langchain/llms/fireworks.py
@@ -150,7 +150,7 @@ class Fireworks(LLM):
     ) -> Iterator[str]:
         prompt = self._convert_input(input).to_string()
         generation: Optional[GenerationChunk] = None
-        for chunk in self._stream(prompt):
+        for chunk in self._stream(prompt, stop=stop):
             yield chunk.text
             if generation is None:
                 generation = chunk
@@ -168,7 +168,7 @@ class Fireworks(LLM):
     ) -> AsyncIterator[str]:
         prompt = self._convert_input(input).to_string()
         generation: Optional[GenerationChunk] = None
-        async for chunk in self._astream(prompt):
+        async for chunk in self._astream(prompt, stop=stop):
             yield chunk.text
             if generation is None:
                 generation = chunk


### PR DESCRIPTION
Fireworks was not plumbing through stop words for streaming (was for non streaming). Note that there is this other PR for the same llm that does not solve this problem and also seems to be missing stop words in some cases (I will leave a comment in the PR): https://github.com/langchain-ai/langchain/pull/11489

For now, this is a pretty bad issue preventing us from using non-chat models in fireworks so I appreciate a quick merge for this one. We are not blocked since we temporarily forked langchain but would like to unfork quickly.

Requesting review: @baskaryan et al