### PR TITLE
fix: superfluous List Parser doc

### DIFF
--- a/docs/docs/modules/model_io/output_parsers/comma_separated.mdx
+++ b/docs/docs/modules/model_io/output_parsers/comma_separated.mdx
@@ -4,9 +4,8 @@ This output parser can be used when you want to return a list of comma-separated
 
 ```python
 from langchain.output_parsers import CommaSeparatedListOutputParser
-from langchain.prompts import PromptTemplate, ChatPromptTemplate, HumanMessagePromptTemplate
+from langchain.prompts import PromptTemplate
 from langchain.llms import OpenAI
-from langchain.chat_models import ChatOpenAI
 
 output_parser = CommaSeparatedListOutputParser()
 


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** This PR fixes the superfluous [List Parser documentation](https://python.langchain.com/docs/modules/model_io/output_parsers/comma_separated) that unnecessary modules are imported inside the example, 
  - **Issue:** N/A,
  - **Dependencies:** N/A,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** @dosuken123 

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.