### PR TITLE
Add example of retriever usage with SingleStoreDB vector store

### DIFF
--- a/docs/docs/integrations/retrievers/singlestoredb.ipynb
+++ b/docs/docs/integrations/retrievers/singlestoredb.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ab66dd43",
+   "metadata": {},
+   "source": [
+    "# SingleStoreDB\n",
+    "\n",
+    ">[SingleStoreDB](https://singlestore.com/) is a high-performance distributed SQL database that supports deployment both in the [cloud](https://www.singlestore.com/cloud/) and on-premises. It provides vector storage, and vector functions including [dot_product](https://docs.singlestore.com/managed-service/en/reference/sql-reference/vector-functions/dot_product.html) and [euclidean_distance](https://docs.singlestore.com/managed-service/en/reference/sql-reference/vector-functions/euclidean_distance.html), thereby supporting AI applications that require text similarity matching. \n",
+    "\n",
+    "\n",
+    "This notebook shows how to use a retriever that uses `SingleStoreDB`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51b49135-a61a-49e8-869d-7c1d76794cd7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Establishing a connection to the database is facilitated through the singlestoredb Python connector.\n",
+    "# Please ensure that this connector is installed in your working environment.\n",
+    "!pip install singlestoredb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf80e7f",
+   "metadata": {},
+   "source": [
+    "## Create Retriever from vector store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcb3c8c2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "# We want to use OpenAIEmbeddings so we have to get the OpenAI API Key.\n",
+    "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")\n",
+    "\n",
+    "from langchain.embeddings.openai import OpenAIEmbeddings\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.vectorstores import SingleStoreDB\n",
+    "from langchain.document_loaders import TextLoader\n",
+    "\n",
+    "loader = TextLoader(\"../../modules/state_of_the_union.txt\")\n",
+    "documents = loader.load()\n",
+    "text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
+    "docs = text_splitter.split_documents(documents)\n",
+    "\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "\n",
+    "# Setup connection url as environment variable\n",
+    "os.environ[\"SINGLESTOREDB_URL\"] = \"root:pass@localhost:3306/db\"\n",
+    "\n",
+    "# Load documents to the store\n",
+    "docsearch = SingleStoreDB.from_documents(\n",
+    "    docs,\n",
+    "    embeddings,\n",
+    "    table_name=\"notebook\",  # use table with a custom name\n",
+    ")\n",
+    "\n",
+    "# create retriever from the vector store\n",
+    "retriever = docsearch.as_retriever(search_kwargs={\"k\": 2})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc0915db",
+   "metadata": {},
+   "source": [
+    "## Search with retriever"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b605284d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = retriever.get_relevant_documents(\"What did the president say about Ketanji Brown Jackson\")\n",
+    "print(docs[0].page_content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added a notebook with examples of the creation of a retriever from the SingleStoreDB vector store, and further usage.