### PR TITLE
Fix langsmith walkthrough doc dataset

### DIFF
--- a/docs/docs/guides/langsmith/walkthrough.ipynb
+++ b/docs/docs/guides/langsmith/walkthrough.ipynb
@@ -200,7 +200,6 @@
     "    \"What is LangChain?\",\n",
     "    \"What's LangSmith?\",\n",
     "    \"When was Llama-v2 released?\",\n",
-    "    \"Who trained Llama-v2?\",\n",
     "    \"What is the langsmith cookbook?\",\n",
     "    \"When did langchain first announce the hub?\",\n",
     "]\n",


### PR DESCRIPTION
- **Description:** the walkthrough notebook for langsmith created a dataset with an unequal number of input questions and reference answers.
- **Issue:** when the dataset was created with a python `zip` iteration, an off-by-one error was created which meant the last few questions had incorrect reference answers
- **Dependencies:** none
- **Tag maintainer:** Not sure
- **Twitter handle:** none