### PR TITLE
Fix documentation typo in Clickhouse Class

### DIFF
--- a/libs/langchain/langchain/vectorstores/clickhouse.py
+++ b/libs/langchain/langchain/vectorstores/clickhouse.py
@@ -410,7 +410,7 @@ CREATE TABLE IF NOT EXISTS {self.config.database}.{self.config.table}(
                   alone. The default name for it is `metadata`.
 
         Returns:
-            List[Document]: List of (Document, similarity)
+            List[Document]: List of documents
         """
         q_str = self._build_query_sql(embedding, k, where_str)
         try:
@@ -442,7 +442,7 @@ CREATE TABLE IF NOT EXISTS {self.config.database}.{self.config.table}(
                   alone. The default name for it is `metadata`.
 
         Returns:
-            List[Document]: List of documents
+            List[Document]: List of (Document, similarity)
         """
         q_str = self._build_query_sql(
             self.embedding_function.embed_query(query), k, where_str


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
  - **Description:**  The return info in the documentation for similarity_search_by_vector and similarity_search_with_relevance_scores is wrong
