### PR TITLE
Fix superfluous Auto-fixing parser documents

### DIFF
--- a/docs/docs/modules/model_io/output_parsers/output_fixing_parser.mdx
+++ b/docs/docs/modules/model_io/output_parsers/output_fixing_parser.mdx
@@ -7,11 +7,9 @@ But we can do other things besides throw errors. Specifically, we can pass the m
 For this example, we'll use the above Pydantic output parser. Here's what happens if we pass it a result that does not comply with the schema:
 
 ```python
-from langchain.prompts import PromptTemplate, ChatPromptTemplate, HumanMessagePromptTemplate
-from langchain.llms import OpenAI
 from langchain.chat_models import ChatOpenAI
 from langchain.output_parsers import PydanticOutputParser
-from pydantic import BaseModel, Field, validator
+from langchain.pydantic_v1 import BaseModel, Field
 from typing import List
 ```
 


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** Fix superfluous [Auto-fixing parser](https://python.langchain.com/docs/modules/model_io/output_parsers/output_fixing_parser) docs. Also switching to `langchain.pydantic_v1` from the direct reference to `pydantic`, 
  - **Issue:** N/A,
  - **Dependencies:** N/A,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** @dosuken123 

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
