### PR TITLE
Fixed bug in PGVector database connection

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -148,7 +148,7 @@ class PGVector(VectorStore):
         return self.embedding_function
 
     def connect(self) -> sqlalchemy.engine.Connection:
-        engine = sqlalchemy.create_engine(self.connection_string)
+        engine = sqlalchemy.create_engine(self.connection_string, future=True)
         conn = engine.connect()
         return conn
 


### PR DESCRIPTION
Description: This change turns on futures in the PGVector connection. With futures turned on, commits are enabled.
Issue: A bug occurs when you try to create an empty PGVector vector store, rather than creating it from_documents which occurs much more frequently. Under these conditions, you will not be able to commit changes to the database, leading to errors as soon as this is tried.
Dependencies: None
Tag maintainer: @hwchase17
