### PR TITLE
Add multiple models and streaming support to OpenAICallbackHandler

### DIFF
--- a/docs/docs/integrations/chat_loaders/facebook.ipynb
+++ b/docs/docs/integrations/chat_loaders/facebook.ipynb
@@ -253,7 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.adapters.openai import convert_messages_for_finetuning"
+    "from langchain.utils.openai import convert_messages_for_finetuning"
    ]
   },
   {

--- a/docs/docs/integrations/chat_loaders/imessage.ipynb
+++ b/docs/docs/integrations/chat_loaders/imessage.ipynb
@@ -166,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.adapters.openai import convert_messages_for_finetuning"
+    "from langchain.utils.openai import convert_messages_for_finetuning"
    ]
   },
   {

--- a/docs/docs/integrations/chat_loaders/langsmith_dataset.ipynb
+++ b/docs/docs/integrations/chat_loaders/langsmith_dataset.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.adapters.openai import convert_messages_for_finetuning\n",
+    "from langchain.utils.openai import convert_messages_for_finetuning\n",
     "\n",
     "training_data = convert_messages_for_finetuning(chat_sessions)"
    ]

--- a/docs/docs/integrations/chat_loaders/langsmith_llm_runs.ipynb
+++ b/docs/docs/integrations/chat_loaders/langsmith_llm_runs.ipynb
@@ -287,7 +287,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.adapters.openai import convert_messages_for_finetuning\n",
+    "from langchain.utils.openai import convert_messages_for_finetuning\n",
     "\n",
     "training_data = convert_messages_for_finetuning(chat_sessions)"
    ]

--- a/docs/docs/integrations/chat_loaders/twitter.ipynb
+++ b/docs/docs/integrations/chat_loaders/twitter.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import json\n",
     "from langchain.schema import AIMessage\n",
-    "from langchain.adapters.openai import convert_message_to_dict"
+    "from langchain.utils.openai import convert_message_to_dict"
    ]
   },
   {

--- a/docs/docs/modules/callbacks/token_counting.ipynb
+++ b/docs/docs/modules/callbacks/token_counting.ipynb
@@ -6,65 +6,206 @@
    "metadata": {},
    "source": [
     "# Token counting\n",
-    "LangChain offers a context manager that allows you to count tokens."
+    "LangChain offers callback and a context manager that allows you to count tokens when using OpenAI models."
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Using the context manager"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "d1e7aedb690437aa"
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "195fd686",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-10-20T10:28:13.030762Z",
+     "start_time": "2023-10-20T10:28:09.149740Z"
+    }
+   },
    "outputs": [],
    "source": [
+    "from langchain.schema import HumanMessage\n",
     "import asyncio\n",
     "\n",
     "from langchain.callbacks import get_openai_callback\n",
-    "from langchain.llms import OpenAI\n",
+    "from langchain.chat_models import ChatOpenAI\n",
     "\n",
-    "llm = OpenAI(temperature=0)\n",
+    "llm = ChatOpenAI(temperature=0)\n",
     "with get_openai_callback() as cb:\n",
-    "    llm(\"What is the square root of 4?\")\n",
+    "    llm([HumanMessage(content=\"What is the square root of 4?\")])\n",
     "\n",
     "total_tokens = cb.total_tokens\n",
     "assert total_tokens > 0\n",
     "\n",
     "with get_openai_callback() as cb:\n",
-    "    llm(\"What is the square root of 4?\")\n",
-    "    llm(\"What is the square root of 4?\")\n",
+    "    llm([HumanMessage(content=\"What is the square root of 4?\")])\n",
+    "    llm([HumanMessage(content=\"What is the square root of 4?\")])\n",
     "\n",
     "assert cb.total_tokens == total_tokens * 2\n",
     "\n",
     "# You can kick off concurrent runs from within the context manager\n",
     "with get_openai_callback() as cb:\n",
     "    await asyncio.gather(\n",
-    "        *[llm.agenerate([\"What is the square root of 4?\"]) for _ in range(3)]\n",
+    "        *[llm.agenerate([[HumanMessage(content=\"What is the square root of 4?\")]]) for _ in range(3)]\n",
     "    )\n",
     "\n",
     "assert cb.total_tokens == total_tokens * 3\n",
     "\n",
     "# The context manager is concurrency safe\n",
-    "task = asyncio.create_task(llm.agenerate([\"What is the square root of 4?\"]))\n",
+    "task = asyncio.create_task(llm.agenerate([[HumanMessage(content=\"What is the square root of 4?\")]]))\n",
     "with get_openai_callback() as cb:\n",
-    "    await llm.agenerate([\"What is the square root of 4?\"])\n",
+    "    await llm.agenerate([[HumanMessage(content=\"What is the square root of 4?\")]])\n",
     "\n",
     "await task\n",
     "assert cb.total_tokens == total_tokens"
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Using the callback"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6267c55f1d5e284"
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "5e94e0d3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-10-20T10:28:13.546038Z",
+     "start_time": "2023-10-20T10:28:13.033124Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "OpenAI Token Usage:\ngpt-3.5-turbo:\n\tPrompt tokens: 16\n\tCompletion tokens: 10\nTotal cost (USD): $4.4e-05"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.schema import HumanMessage\n",
+    "\n",
+    "from langchain.callbacks import OpenAICallbackHandler\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "\n",
+    "cb = OpenAICallbackHandler()\n",
+    "llm = ChatOpenAI(temperature=0, callbacks=[cb])\n",
+    "llm([HumanMessage(content=\"What is the square root of 4?\")])\n",
+    "\n",
+    "cb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Using multiple models"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "c54c6871b642f7a5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "OpenAI Token Usage:\ngpt-3.5-turbo:\n\tPrompt tokens: 16\n\tCompletion tokens: 10\ngpt-4:\n\tPrompt tokens: 16\n\tCompletion tokens: 1\nTotal cost (USD): $0.0005840000000000001"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.schema import HumanMessage\n",
+    "\n",
+    "from langchain.callbacks import OpenAICallbackHandler\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "\n",
+    "cb = OpenAICallbackHandler()\n",
+    "llm = ChatOpenAI(temperature=0, callbacks=[cb])\n",
+    "llm2 = ChatOpenAI(model_name=\"gpt-4\", temperature=0, callbacks=[cb])\n",
+    "llm([HumanMessage(content=\"What is the square root of 4?\")])\n",
+    "llm2([HumanMessage(content=\"What is the square root of 4?\")])\n",
+    "\n",
+    "cb"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-10-20T10:28:14.732831Z",
+     "start_time": "2023-10-20T10:28:13.543478Z"
+    }
+   },
+   "id": "c03db29132a09cb3"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Using the callback with streaming models"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "99b474eb14fe2d94"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "OpenAI Token Usage:\ngpt-3.5-turbo:\n\tPrompt tokens: 16\n\tCompletion tokens: 10\nTotal cost (USD): $4.4e-05"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain.schema import HumanMessage\n",
+    "\n",
+    "from langchain.callbacks import OpenAICallbackHandler\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "\n",
+    "cb = OpenAICallbackHandler()\n",
+    "llm = ChatOpenAI(temperature=0, streaming=True, callbacks=[cb])\n",
+    "llm([HumanMessage(content=\"What is the square root of 4?\")])\n",
+    "\n",
+    "cb"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-10-20T10:28:15.321452Z",
+     "start_time": "2023-10-20T10:28:14.731571Z"
+    }
+   },
+   "id": "fcfe5f74d422f3ec"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "name": "python3",
    "language": "python",
-   "name": "venv"
+   "display_name": "Python 3 (ipykernel)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/libs/langchain/langchain/adapters/openai.py
+++ b/libs/langchain/langchain/adapters/openai.py
@@ -6,8 +6,6 @@ from typing import (
     AsyncIterator,
     Dict,
     Iterable,
-    List,
-    Mapping,
     Sequence,
     Union,
     overload,
@@ -15,17 +13,11 @@ from typing import (
 
 from typing_extensions import Literal
 
-from langchain.schema.chat import ChatSession
 from langchain.schema.messages import (
-    AIMessage,
     AIMessageChunk,
-    BaseMessage,
     BaseMessageChunk,
-    ChatMessage,
-    FunctionMessage,
-    HumanMessage,
-    SystemMessage,
 )
+from langchain.utils.openai import convert_message_to_dict, convert_openai_messages
 
 
 async def aenumerate(
@@ -36,67 +28,6 @@ async def aenumerate(
     async for x in iterable:
         yield i, x
         i += 1
-
-
-def convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
-    role = _dict["role"]
-    if role == "user":
-        return HumanMessage(content=_dict["content"])
-    elif role == "assistant":
-        # Fix for azure
-        # Also OpenAI returns None for tool invocations
-        content = _dict.get("content", "") or ""
-        if _dict.get("function_call"):
-            additional_kwargs = {"function_call": dict(_dict["function_call"])}
-        else:
-            additional_kwargs = {}
-        return AIMessage(content=content, additional_kwargs=additional_kwargs)
-    elif role == "system":
-        return SystemMessage(content=_dict["content"])
-    elif role == "function":
-        return FunctionMessage(content=_dict["content"], name=_dict["name"])
-    else:
-        return ChatMessage(content=_dict["content"], role=role)
-
-
-def convert_message_to_dict(message: BaseMessage) -> dict:
-    message_dict: Dict[str, Any]
-    if isinstance(message, ChatMessage):
-        message_dict = {"role": message.role, "content": message.content}
-    elif isinstance(message, HumanMessage):
-        message_dict = {"role": "user", "content": message.content}
-    elif isinstance(message, AIMessage):
-        message_dict = {"role": "assistant", "content": message.content}
-        if "function_call" in message.additional_kwargs:
-            message_dict["function_call"] = message.additional_kwargs["function_call"]
-            # If function call only, content is None not empty string
-            if message_dict["content"] == "":
-                message_dict["content"] = None
-    elif isinstance(message, SystemMessage):
-        message_dict = {"role": "system", "content": message.content}
-    elif isinstance(message, FunctionMessage):
-        message_dict = {
-            "role": "function",
-            "content": message.content,
-            "name": message.name,
-        }
-    else:
-        raise TypeError(f"Got unknown type {message}")
-    if "name" in message.additional_kwargs:
-        message_dict["name"] = message.additional_kwargs["name"]
-    return message_dict
-
-
-def convert_openai_messages(messages: Sequence[Dict[str, Any]]) -> List[BaseMessage]:
-    """Convert dictionaries representing OpenAI messages to LangChain format.
-
-    Args:
-        messages: List of dictionaries representing OpenAI messages
-
-    Returns:
-        List of LangChain BaseMessage objects.
-    """
-    return [convert_dict_to_message(m) for m in messages]
 
 
 def _convert_message_chunk_to_delta(chunk: BaseMessageChunk, i: int) -> Dict[str, Any]:
@@ -207,19 +138,3 @@ class ChatCompletion:
                 _convert_message_chunk_to_delta(c, i)
                 async for i, c in aenumerate(model_config.astream(converted_messages))
             )
-
-
-def _has_assistant_message(session: ChatSession) -> bool:
-    """Check if chat session has an assistant message."""
-    return any([isinstance(m, AIMessage) for m in session["messages"]])
-
-
-def convert_messages_for_finetuning(
-    sessions: Iterable[ChatSession],
-) -> List[List[dict]]:
-    """Convert messages to a list of lists of dictionaries for fine-tuning."""
-    return [
-        [convert_message_to_dict(s) for s in session["messages"]]
-        for session in sessions
-        if _has_assistant_message(session)
-    ]

--- a/libs/langchain/langchain/callbacks/openai_info.py
+++ b/libs/langchain/langchain/callbacks/openai_info.py
@@ -3,9 +3,9 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 from uuid import UUID
 
-from langchain.adapters.openai import convert_message_to_dict
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import BaseMessage, LLMResult
+from langchain.utils.openai import convert_message_to_dict
 
 if TYPE_CHECKING:
     import tiktoken

--- a/libs/langchain/langchain/chat_loaders/langsmith.py
+++ b/libs/langchain/langchain/chat_loaders/langsmith.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Unio
 from langchain.chat_loaders.base import BaseChatLoader
 from langchain.load import load
 from langchain.schema.chat import ChatSession
+from langchain.utils.openai import convert_dict_to_message
 
 if TYPE_CHECKING:
     from langsmith.client import Client
@@ -141,7 +142,6 @@ class LangSmithDatasetChatLoader(BaseChatLoader):
 
         :return: Iterator of chat sessions containing messages.
         """
-        from langchain.adapters import openai as oai_adapter  # noqa: E402
 
         data = self.client.read_dataset_openai_finetuning(
             dataset_name=self.dataset_name
@@ -149,8 +149,7 @@ class LangSmithDatasetChatLoader(BaseChatLoader):
         for data_point in data:
             yield ChatSession(
                 messages=[
-                    oai_adapter.convert_dict_to_message(m)
-                    for m in data_point.get("messages", [])
+                    convert_dict_to_message(m) for m in data_point.get("messages", [])
                 ],
                 functions=data_point.get("functions"),
             )

--- a/libs/langchain/langchain/chat_models/anyscale.py
+++ b/libs/langchain/langchain/chat_models/anyscale.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Dict, Optional, Set
 
 import requests
 
-from langchain.adapters.openai import convert_message_to_dict
 from langchain.chat_models.openai import (
     ChatOpenAI,
     _import_tiktoken,
@@ -16,6 +15,7 @@ from langchain.chat_models.openai import (
 from langchain.pydantic_v1 import Field, root_validator
 from langchain.schema.messages import BaseMessage
 from langchain.utils import get_from_dict_or_env
+from langchain.utils.openai import convert_message_to_dict
 
 if TYPE_CHECKING:
     import tiktoken

--- a/libs/langchain/langchain/chat_models/everlyai.py
+++ b/libs/langchain/langchain/chat_models/everlyai.py
@@ -5,7 +5,6 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Dict, Optional, Set
 
-from langchain.adapters.openai import convert_message_to_dict
 from langchain.chat_models.openai import (
     ChatOpenAI,
     _import_tiktoken,
@@ -13,6 +12,7 @@ from langchain.chat_models.openai import (
 from langchain.pydantic_v1 import Field, root_validator
 from langchain.schema.messages import BaseMessage
 from langchain.utils import get_from_dict_or_env
+from langchain.utils.openai import convert_message_to_dict
 
 if TYPE_CHECKING:
     import tiktoken

--- a/libs/langchain/langchain/chat_models/fireworks.py
+++ b/libs/langchain/langchain/chat_models/fireworks.py
@@ -10,7 +10,6 @@ from typing import (
     Union,
 )
 
-from langchain.adapters.openai import convert_message_to_dict
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -34,6 +33,7 @@ from langchain.schema.messages import (
 )
 from langchain.schema.output import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain.utils.env import get_from_dict_or_env
+from langchain.utils.openai import convert_message_to_dict
 
 
 def _convert_delta_to_message_chunk(

--- a/libs/langchain/langchain/chat_models/konko.py
+++ b/libs/langchain/langchain/chat_models/konko.py
@@ -17,7 +17,6 @@ from typing import (
 
 import requests
 
-from langchain.adapters.openai import convert_dict_to_message, convert_message_to_dict
 from langchain.callbacks.manager import (
     CallbackManagerForLLMRun,
 )
@@ -28,6 +27,7 @@ from langchain.schema import ChatGeneration, ChatResult
 from langchain.schema.messages import AIMessageChunk, BaseMessage
 from langchain.schema.output import ChatGenerationChunk
 from langchain.utils import get_from_dict_or_env
+from langchain.utils.openai import convert_dict_to_message, convert_message_to_dict
 
 DEFAULT_API_BASE = "https://api.konko.ai/v1"
 DEFAULT_MODEL = "meta-llama/Llama-2-13b-chat-hf"

--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
 )
 
-from langchain.adapters.openai import convert_dict_to_message, convert_message_to_dict
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -42,6 +41,7 @@ from langchain.schema.messages import (
 )
 from langchain.schema.output import ChatGenerationChunk
 from langchain.utils import get_from_dict_or_env, get_pydantic_field_names
+from langchain.utils.openai import convert_dict_to_message, convert_message_to_dict
 
 if TYPE_CHECKING:
     import tiktoken

--- a/libs/langchain/langchain/utils/openai.py
+++ b/libs/langchain/langchain/utils/openai.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+from langchain.schema import (
+    AIMessage,
+    BaseMessage,
+    ChatMessage,
+    FunctionMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain.schema.chat import ChatSession
+
+
+def convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
+    role = _dict["role"]
+    if role == "user":
+        return HumanMessage(content=_dict["content"])
+    elif role == "assistant":
+        # Fix for azure
+        # Also OpenAI returns None for tool invocations
+        content = _dict.get("content", "") or ""
+        if _dict.get("function_call"):
+            additional_kwargs = {"function_call": dict(_dict["function_call"])}
+        else:
+            additional_kwargs = {}
+        return AIMessage(content=content, additional_kwargs=additional_kwargs)
+    elif role == "system":
+        return SystemMessage(content=_dict["content"])
+    elif role == "function":
+        return FunctionMessage(content=_dict["content"], name=_dict["name"])
+    else:
+        return ChatMessage(content=_dict["content"], role=role)
+
+
+def convert_message_to_dict(message: BaseMessage) -> dict:
+    message_dict: Dict[str, Any]
+    if isinstance(message, ChatMessage):
+        message_dict = {"role": message.role, "content": message.content}
+    elif isinstance(message, HumanMessage):
+        message_dict = {"role": "user", "content": message.content}
+    elif isinstance(message, AIMessage):
+        message_dict = {"role": "assistant", "content": message.content}
+        if "function_call" in message.additional_kwargs:
+            message_dict["function_call"] = message.additional_kwargs["function_call"]
+            # If function call only, content is None not empty string
+            if message_dict["content"] == "":
+                message_dict["content"] = None
+    elif isinstance(message, SystemMessage):
+        message_dict = {"role": "system", "content": message.content}
+    elif isinstance(message, FunctionMessage):
+        message_dict = {
+            "role": "function",
+            "content": message.content,
+            "name": message.name,
+        }
+    else:
+        raise TypeError(f"Got unknown type {message}")
+    if "name" in message.additional_kwargs:
+        message_dict["name"] = message.additional_kwargs["name"]
+    return message_dict
+
+
+def convert_openai_messages(messages: Sequence[Dict[str, Any]]) -> List[BaseMessage]:
+    """Convert dictionaries representing OpenAI messages to LangChain format.
+
+    Args:
+        messages: List of dictionaries representing OpenAI messages
+
+    Returns:
+        List of LangChain BaseMessage objects.
+    """
+    return [convert_dict_to_message(m) for m in messages]
+
+
+def _has_assistant_message(session: ChatSession) -> bool:
+    """Check if chat session has an assistant message."""
+    return any([isinstance(m, AIMessage) for m in session["messages"]])
+
+
+def convert_messages_for_finetuning(
+    sessions: Iterable[ChatSession],
+) -> List[List[dict]]:
+    """Convert messages to a list of lists of dictionaries for fine-tuning."""
+    return [
+        [convert_message_to_dict(s) for s in session["messages"]]
+        for session in sessions
+        if _has_assistant_message(session)
+    ]

--- a/libs/langchain/scripts/check_imports.sh
+++ b/libs/langchain/scripts/check_imports.sh
@@ -12,7 +12,7 @@ git grep '^from langchain' langchain/load | grep -vE 'from langchain.(pydantic_v
 git grep '^from langchain' langchain/utils | grep -vE 'from langchain.(pydantic_v1|utils)' && errors=$((errors+1))
 git grep '^from langchain' langchain/schema | grep -vE 'from langchain.(pydantic_v1|utils|schema|load)' && errors=$((errors+1))
 git grep '^from langchain' langchain/adapters | grep -vE 'from langchain.(pydantic_v1|utils|schema|load)' && errors=$((errors+1))
-git grep '^from langchain' langchain/callbacks | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env)' && errors=$((errors+1))
+git grep '^from langchain' langchain/callbacks | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|adapters)' && errors=$((errors+1))
 # TODO: it's probably not amazing so that so many other modules depend on `langchain.utilities`, because there can be a lot of imports there
 git grep '^from langchain' langchain/utilities | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|utilities)' && errors=$((errors+1))
 git grep '^from langchain' langchain/storage | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|storage|utilities)' && errors=$((errors+1))

--- a/libs/langchain/scripts/check_imports.sh
+++ b/libs/langchain/scripts/check_imports.sh
@@ -12,7 +12,7 @@ git grep '^from langchain' langchain/load | grep -vE 'from langchain.(pydantic_v
 git grep '^from langchain' langchain/utils | grep -vE 'from langchain.(pydantic_v1|utils)' && errors=$((errors+1))
 git grep '^from langchain' langchain/schema | grep -vE 'from langchain.(pydantic_v1|utils|schema|load)' && errors=$((errors+1))
 git grep '^from langchain' langchain/adapters | grep -vE 'from langchain.(pydantic_v1|utils|schema|load)' && errors=$((errors+1))
-git grep '^from langchain' langchain/callbacks | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|adapters)' && errors=$((errors+1))
+git grep '^from langchain' langchain/callbacks | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env)' && errors=$((errors+1))
 # TODO: it's probably not amazing so that so many other modules depend on `langchain.utilities`, because there can be a lot of imports there
 git grep '^from langchain' langchain/utilities | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|utilities)' && errors=$((errors+1))
 git grep '^from langchain' langchain/storage | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|storage|utilities)' && errors=$((errors+1))

--- a/libs/langchain/tests/unit_tests/callbacks/test_openai_info.py
+++ b/libs/langchain/tests/unit_tests/callbacks/test_openai_info.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -13,7 +13,12 @@ def handler() -> OpenAICallbackHandler:
     return OpenAICallbackHandler()
 
 
-def test_on_llm_end(handler: OpenAICallbackHandler) -> None:
+@pytest.fixture
+def run_id() -> UUID:
+    return uuid4()
+
+
+def test_on_llm_end(handler: OpenAICallbackHandler, run_id: UUID) -> None:
     response = LLMResult(
         generations=[],
         llm_output={
@@ -25,7 +30,7 @@ def test_on_llm_end(handler: OpenAICallbackHandler) -> None:
             "model_name": BaseOpenAI.__fields__["model_name"].default,
         },
     )
-    handler.on_llm_end(response)
+    handler.on_llm_end(response, run_id=run_id)
     assert handler.successful_requests == 1
     assert handler.total_tokens == 3
     assert handler.prompt_tokens == 2
@@ -33,7 +38,7 @@ def test_on_llm_end(handler: OpenAICallbackHandler) -> None:
     assert handler.total_cost > 0
 
 
-def test_on_llm_end_custom_model(handler: OpenAICallbackHandler) -> None:
+def test_on_llm_end_custom_model(handler: OpenAICallbackHandler, run_id: UUID) -> None:
     response = LLMResult(
         generations=[],
         llm_output={
@@ -45,11 +50,13 @@ def test_on_llm_end_custom_model(handler: OpenAICallbackHandler) -> None:
             "model_name": "foo-bar",
         },
     )
-    handler.on_llm_end(response)
+    handler.on_llm_end(response, run_id=run_id)
     assert handler.total_cost == 0
 
 
-def test_on_llm_end_finetuned_model(handler: OpenAICallbackHandler) -> None:
+def test_on_llm_end_finetuned_model(
+    handler: OpenAICallbackHandler, run_id: UUID
+) -> None:
     response = LLMResult(
         generations=[],
         llm_output={
@@ -61,7 +68,7 @@ def test_on_llm_end_finetuned_model(handler: OpenAICallbackHandler) -> None:
             "model_name": "ada:ft-your-org:custom-model-name-2022-02-15-04-21-04",
         },
     )
-    handler.on_llm_end(response)
+    handler.on_llm_end(response, run_id=run_id)
     assert handler.total_cost > 0
 
 
@@ -91,7 +98,7 @@ def test_on_llm_end_finetuned_model(handler: OpenAICallbackHandler) -> None:
     ],
 )
 def test_on_llm_end_azure_openai(
-    handler: OpenAICallbackHandler, model_name: str, expected_cost: float
+    handler: OpenAICallbackHandler, model_name: str, expected_cost: float, run_id: UUID
 ) -> None:
     response = LLMResult(
         generations=[],
@@ -104,7 +111,7 @@ def test_on_llm_end_azure_openai(
             "model_name": model_name,
         },
     )
-    handler.on_llm_end(response)
+    handler.on_llm_end(response, run_id=run_id)
     assert handler.total_cost == expected_cost
 
 
@@ -112,7 +119,7 @@ def test_on_llm_end_azure_openai(
     "model_name", ["gpt-35-turbo-16k-0301", "gpt-4-0301", "gpt-4-32k-0301"]
 )
 def test_on_llm_end_no_cost_invalid_model(
-    handler: OpenAICallbackHandler, model_name: str
+    handler: OpenAICallbackHandler, model_name: str, run_id: UUID
 ) -> None:
     response = LLMResult(
         generations=[],
@@ -125,9 +132,70 @@ def test_on_llm_end_no_cost_invalid_model(
             "model_name": model_name,
         },
     )
-    handler.on_llm_end(response)
+    handler.on_llm_end(response, run_id=run_id)
     assert handler.total_cost == 0
 
 
-def test_on_retry_works(handler: OpenAICallbackHandler) -> None:
-    handler.on_retry(MagicMock(), run_id=uuid4())
+def test_on_retry_works(handler: OpenAICallbackHandler, run_id: UUID) -> None:
+    handler.on_retry(MagicMock(), run_id=run_id)
+
+
+def test_on_llm_end_multiple_models(
+    handler: OpenAICallbackHandler, run_id: UUID
+) -> None:
+    models = ["gpt-3.5-turbo", "gpt-4"]
+    for model in models:
+        llm_result = LLMResult(
+            generations=[],
+            llm_output={
+                "token_usage": {
+                    "prompt_tokens": 2,
+                    "completion_tokens": 1,
+                    "total_tokens": 3,
+                },
+                "model_name": model,
+            },
+        )
+        handler.on_llm_end(llm_result, run_id=run_id)
+    assert handler.total_cost == 0.000125
+    assert handler.prompt_tokens == 4
+    assert handler.completion_tokens == 2
+    assert handler.total_tokens == 6
+    assert handler.successful_requests == 2
+
+
+def test_on_new_token(handler: OpenAICallbackHandler, run_id: UUID) -> None:
+    handler.current_model_name[run_id] = "gpt-3.5-turbo"
+    handler.on_llm_new_token("", run_id=run_id)
+    for _ in range(10):
+        handler.on_llm_new_token(token="a", run_id=run_id)
+    handler.on_llm_new_token("", run_id=run_id)
+    handler.on_llm_end(
+        LLMResult(generations=[]),
+        run_id=run_id,
+    )
+    assert handler.total_cost == 2e-05
+    assert handler.prompt_tokens == 0
+    assert handler.completion_tokens == 10
+    assert handler.total_tokens == 10
+    assert handler.successful_requests == 0
+
+
+def test_on_new_token_multiple_models(handler: OpenAICallbackHandler) -> None:
+    models = ["gpt-3.5-turbo", "gpt-4"]
+    for model in models:
+        run_id = uuid4()
+        handler.current_model_name[run_id] = model
+        handler.on_llm_new_token("", run_id=run_id)
+        for _ in range(10):
+            handler.on_llm_new_token(token="a", run_id=run_id)
+        handler.on_llm_new_token("", run_id=run_id)
+        handler.on_llm_end(
+            LLMResult(generations=[]),
+            run_id=run_id,
+        )
+    assert handler.total_cost == 0.00062
+    assert handler.prompt_tokens == 0
+    assert handler.completion_tokens == 20
+    assert handler.total_tokens == 20
+    assert handler.successful_requests == 0

--- a/libs/langchain/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_openai.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from langchain.adapters.openai import convert_dict_to_message
 from langchain.chat_models.openai import ChatOpenAI
 from langchain.schema.messages import (
     AIMessage,
@@ -13,6 +12,7 @@ from langchain.schema.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langchain.utils.openai import convert_dict_to_message
 
 
 @pytest.mark.requires("openai")


### PR DESCRIPTION
### Description

Old OpenAICalbackHandler does not support streaming mode, which is used widely today. Also, it is hard to differentiate between models when using the same callback with different models. It is particularly useful when used in agents combinig "smart" and "fast" models. This PR is an attempt to solve these problems.

If tiktoken is not installed, my solution will work as it previously did, except that it will show a warning if used in conjunction with streaming model.

Additionally it adds per-model methods to get prompt, completion and total tokens, as well as total cost.
If a user will try to use total_tokens, prompt_tokens, completion_tokens after using the callback with multiple models, a warning will be displayed.

### Issue
#3114 #4583

### Dependencies
N/A

### Tag maintainer
Not yet :)

### Twitter handle
N/A

