### PR TITLE
Fixed hardcoded "vector" and replaced with vector_query_field variable

### DIFF
--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -662,7 +662,7 @@ class ElasticsearchStore(VectorStore):
 
         if remove_vector_query_field_from_metadata:
             for doc in selected_docs:
-                del doc.metadata["vector"]
+                del doc.metadata[self.vector_query_field]
 
         return selected_docs
 


### PR DESCRIPTION
  - **Description:** In the max_marginal_relevance_search function of the ElasticsearchStore vector store, the name of the field corresponding to the vector embedding of the document is hard coded in the delete statement that drops the field from the document metadata. This results in an exception if the vector embedding field is customized. This PR changes the hard-coded "vector" into the vector_query_field variable.
  - **Issue:** None
  - **Dependencies:** None
  - **Tag maintainer:** @hwchase17