### PR TITLE
Expose configuration options in GraphCypherQAChain

### DIFF
--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -161,13 +161,25 @@ class GraphCypherQAChain(Chain):
                 ", and 'llm_kwargs', but not all three simultaneously."
             )
 
-        use_qa_llm_kwargs = qa_llm_kwargs if qa_llm_kwargs is not None else llm_kwargs if llm_kwargs is not None else {"prompt": qa_prompt}
-        use_cypher_llm_kwargs = cypher_llm_kwargs if cypher_llm_kwargs is not None else llm_kwargs if llm_kwargs is not None else {"prompt": cypher_prompt}
-        print (use_qa_llm_kwargs)
-        print (use_cypher_llm_kwargs)
+        use_qa_llm_kwargs = (
+            qa_llm_kwargs
+            if qa_llm_kwargs is not None
+            else llm_kwargs
+            if llm_kwargs is not None
+            else {"prompt": qa_prompt}
+        )
+        use_cypher_llm_kwargs = (
+            cypher_llm_kwargs
+            if cypher_llm_kwargs is not None
+            else llm_kwargs
+            if llm_kwargs is not None
+            else {"prompt": cypher_prompt}
+        )
         qa_chain = LLMChain(llm=qa_llm or llm, **use_qa_llm_kwargs)
 
-        cypher_generation_chain = LLMChain(llm=cypher_llm or llm, **use_cypher_llm_kwargs)
+        cypher_generation_chain = LLMChain(
+            llm=cypher_llm or llm, **use_cypher_llm_kwargs
+        )
 
         if exclude_types and include_types:
             raise ValueError(

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -139,6 +139,9 @@ class GraphCypherQAChain(Chain):
         exclude_types: List[str] = [],
         include_types: List[str] = [],
         validate_cypher: bool = False,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        qa_llm_kwargs: Optional[Dict[str, Any]] = None,
+        cypher_llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> GraphCypherQAChain:
         """Initialize from LLM."""
@@ -152,9 +155,19 @@ class GraphCypherQAChain(Chain):
                 "You can specify up to two of 'cypher_llm', 'qa_llm'"
                 ", and 'llm', but not all three simultaneously."
             )
+        if cypher_llm_kwargs and qa_llm_kwargs and llm_kwargs:
+            raise ValueError(
+                "You can specify up to two of 'cypher_llm_kwargs', 'qa_llm_kwargs'"
+                ", and 'llm_kwargs', but not all three simultaneously."
+            )
 
-        qa_chain = LLMChain(llm=qa_llm or llm, prompt=qa_prompt)
-        cypher_generation_chain = LLMChain(llm=cypher_llm or llm, prompt=cypher_prompt)
+        use_qa_llm_kwargs = qa_llm_kwargs if qa_llm_kwargs is not None else llm_kwargs if llm_kwargs is not None else {"prompt": qa_prompt}
+        use_cypher_llm_kwargs = cypher_llm_kwargs if cypher_llm_kwargs is not None else llm_kwargs if llm_kwargs is not None else {"prompt": cypher_prompt}
+        print (use_qa_llm_kwargs)
+        print (use_cypher_llm_kwargs)
+        qa_chain = LLMChain(llm=qa_llm or llm, **use_qa_llm_kwargs)
+
+        cypher_generation_chain = LLMChain(llm=cypher_llm or llm, **use_cypher_llm_kwargs)
 
         if exclude_types and include_types:
             raise ValueError(

--- a/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
@@ -1,15 +1,19 @@
-from typing import List
-
-import pandas as pd
 from typing import Any, Dict, List
 
-from langchain.graphs.graph_document import GraphDocument
-from langchain.memory import ConversationBufferMemory, ReadOnlySharedMemory
-from langchain.chains.graph_qa.cypher import construct_schema, extract_cypher, GraphCypherQAChain
+import pandas as pd
+
+from langchain.chains.graph_qa.cypher import (
+    GraphCypherQAChain,
+    construct_schema,
+    extract_cypher,
+)
 from langchain.chains.graph_qa.cypher_utils import CypherQueryCorrector, Schema
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.graphs.graph_document import GraphDocument
 from langchain.graphs.graph_store import GraphStore
+from langchain.memory import ConversationBufferMemory, ReadOnlySharedMemory
 from langchain.prompts import PromptTemplate
+from tests.unit_tests.llms.fake_llm import FakeLLM
+
 
 class FakeGraphStore(GraphStore):
     @property
@@ -36,6 +40,7 @@ class FakeGraphStore(GraphStore):
         """Take GraphDocument as input as uses it to construct a graph."""
         pass
 
+
 def test_graph_cypher_qa_chain() -> None:
     template = """You are a nice chatbot having a conversation with a human.
 
@@ -49,29 +54,41 @@ def test_graph_cypher_qa_chain() -> None:
     Response:"""
 
     prompt = PromptTemplate(
-        input_variables=["schema", "question", "chat_history"],
-        template=template
+        input_variables=["schema", "question", "chat_history"], template=template
     )
 
     memory = ConversationBufferMemory(memory_key="chat_history")
     readonlymemory = ReadOnlySharedMemory(memory=memory)
-    prompt1 = 'You are a nice chatbot having a conversation with a human.\n\n    Schema:\n    Node properties are the following: \n {}\nRelationships properties are the following: \n {}\nRelationships are: \n[]\n\n    Previous conversation:\n    \n\n    New human question: Test question\n    Response:'
+    prompt1 = (
+        "You are a nice chatbot having a conversation with a human.\n\n    "
+        "Schema:\n    Node properties are the following: \n {}\nRelationships "
+        "properties are the following: \n {}\nRelationships are: \n[]\n\n    "
+        "Previous conversation:\n    \n\n    New human question: "
+        "Test question\n    Response:"
+    )
 
-    prompt2 = 'You are a nice chatbot having a conversation with a human.\n\n    Schema:\n    Node properties are the following: \n {}\nRelationships properties are the following: \n {}\nRelationships are: \n[]\n\n    Previous conversation:\n    Human: Test question\nAI: foo\n\n    New human question: Test new question\n    Response:'
+    prompt2 = (
+        "You are a nice chatbot having a conversation with a human.\n\n    "
+        "Schema:\n    Node properties are the following: \n {}\nRelationships "
+        "properties are the following: \n {}\nRelationships are: \n[]\n\n    "
+        "Previous conversation:\n    Human: Test question\nAI: foo\n\n    "
+        "New human question: Test new question\n    Response:"
+    )
 
-    llm = FakeLLM(queries = {prompt1: "answer1", prompt2: "answer2"})
+    llm = FakeLLM(queries={prompt1: "answer1", prompt2: "answer2"})
     chain = GraphCypherQAChain.from_llm(
         cypher_llm=llm,
-        qa_llm = FakeLLM(),
+        qa_llm=FakeLLM(),
         graph=FakeGraphStore(),
         verbose=True,
         return_intermediate_steps=False,
-        cypher_llm_kwargs = {"prompt": prompt, "memory": readonlymemory},
-        memory=memory
+        cypher_llm_kwargs={"prompt": prompt, "memory": readonlymemory},
+        memory=memory,
     )
     chain.run("Test question")
     chain.run("Test new question")
-    //If we get here without a key error, that means memory was used properly to create prompts.
+    # If we get here without a key error, that means memory
+    # was used properly to create prompts.
     assert True
 
 

--- a/libs/langchain/tests/unit_tests/llms/fake_llm.py
+++ b/libs/langchain/tests/unit_tests/llms/fake_llm.py
@@ -39,11 +39,11 @@ class FakeLLM(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
-        print (prompt)
+        print(prompt)
         if self.sequential_responses:
             return self._get_next_response_in_sequence
-        print (repr(prompt))
-        print (self.queries)
+        print(repr(prompt))
+        print(self.queries)
         if self.queries is not None:
             return self.queries[prompt]
         if stop is None:

--- a/libs/langchain/tests/unit_tests/llms/fake_llm.py
+++ b/libs/langchain/tests/unit_tests/llms/fake_llm.py
@@ -39,9 +39,11 @@ class FakeLLM(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
+        print (prompt)
         if self.sequential_responses:
             return self._get_next_response_in_sequence
-
+        print (repr(prompt))
+        print (self.queries)
         if self.queries is not None:
             return self.queries[prompt]
         if stop is None:


### PR DESCRIPTION
Allows for passing arguments into the LLM chains used by the GraphCypherQAChain. This is to address a request by a user to include memory in the Cypher creating chain. Will keep the prompt variables as-is to be backward compatible. But, would be a good idea to deprecate them and use the **kwargs variables. Added a test case. 

In general, I think it would be good for any chain to automatically pass in a readonlymemory(of its input) to its subchains whilist allowing for an override. But, this would be a different change.