### PR TITLE
Allowing openapi agent to communicate with multiple APIs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -18,7 +18,7 @@ For more info, check out the [GitHub documentation](https://docs.github.com/en/f
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/langchain-ai/langchain)
 
 Note: If you click this link you will open the main repo and not your local cloned repo, you can use this link and replace with your username and cloned repo name: 
-https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/<yourusername>/<yourclonedreponame>
+https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/<"yourusername">/<"yourclonedreponame">
 
 
 If you already have VS Code and Docker installed, you can use the button above to get started. This will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.

--- a/libs/langchain/langchain/agents/agent_toolkits/openapi/planner_prompt.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/openapi/planner_prompt.py
@@ -3,14 +3,14 @@
 from langchain.prompts.prompt import PromptTemplate
 
 
-API_PLANNER_PROMPT = """You are a planner that plans a sequence of API calls to assist with user queries against an API.
+API_PLANNER_PROMPT = """You are a planner that plans a sequence of API calls to assist with user queries against APIs.
 
 You should:
-1) evaluate whether the user query can be solved by the API documentated below. If no, say why.
+1) evaluate whether the user query can be solved by the APIs documentated below. If no, say why.
 2) if yes, generate a plan of API calls and say what they are doing step by step.
 3) If the plan includes a DELETE call, you should always return an ask from the User for authorization first unless the User has specifically asked to delete something.
 
-You should only use API endpoints documented below ("Endpoints you can use:").
+You should only use APIs and their endpoints documented below ("Endpoints you can use:").
 You can only use the DELETE tool if the User has specifically asked to delete something. Otherwise, you should return a request authorization from the User first.
 Some user queries can be resolved in a single API call, but some will require several API calls.
 The plan will be passed to an API controller that can format it into web requests and return the responses.
@@ -55,7 +55,7 @@ Plan: 1. GET /user to find the user's id
 3. Are you sure you want to delete your cart? 
 ----
 
-Here are endpoints you can use. Do not reference any of the endpoints above.
+Here are the APIs and their endpoints you can use. Do not reference any of the endpoints above.
 
 {endpoints}
 


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** Changed planner and API_PLANNER_PROMPT in planner_prompt to enable create_openapi_agent communication with multiple APIs (list of ReducedOpenAPISpec). This is useful when more than one API is required to complete a task, for example in a software that is built on micro services. In addition, I changed the README in the devcontainer folder to clarify how to use the link of VS Code Dev Container (before that the following were not shown: /<yourusername>/<yourclonedreponame>).
  - **Issue:**
  - **Dependencies:**
  - **Tag maintainer:** @baskaryan , @eyurtsev , @hwchase17
  - **Twitter handle:** @Ido_Nitsan

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
