### PR TITLE
Fix Anthropic Functions ainvoke

### DIFF
--- a/libs/experimental/langchain_experimental/llms/anthropic_functions.py
+++ b/libs/experimental/langchain_experimental/llms/anthropic_functions.py
@@ -196,18 +196,6 @@ class AnthropicFunctions(BaseChatModel):
         else:
             return ChatResult(generations=[ChatGeneration(message=response)])
 
-    async def agenerate(
-        self,
-        messages: List[List[BaseMessage]],
-        stop: Optional[List[str]] = None,
-        callbacks: Callbacks = None,
-        *,
-        tags: Optional[List[str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
-    ) -> LLMResult:
-        raise NotImplementedError
-
     @property
     def _llm_type(self) -> str:
         return "anthropic_functions"

--- a/libs/experimental/langchain_experimental/llms/anthropic_functions.py
+++ b/libs/experimental/langchain_experimental/llms/anthropic_functions.py
@@ -5,14 +5,12 @@ from typing import Any, DefaultDict, Dict, List, Optional
 
 from langchain.callbacks.manager import (
     CallbackManagerForLLMRun,
-    Callbacks,
 )
 from langchain.chat_models.anthropic import ChatAnthropic
 from langchain.chat_models.base import BaseChatModel
 from langchain.schema import (
     ChatGeneration,
     ChatResult,
-    LLMResult,
 )
 from langchain.schema.messages import (
     AIMessage,


### PR DESCRIPTION
Removes custom `NotImplementedError` in experimental anthropic functions, allowing it to fallback on default `ainvoke` implementation.