### PR TITLE
Fix exec command in langserve Dockerfile template

### DIFF
--- a/libs/langchain/langchain/cli/create_repo/templates/poetry/Dockerfile
+++ b/libs/langchain/langchain/cli/create_repo/templates/poetry/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install poetry && \
   poetry config virtualenvs.create false && \
   poetry install --no-interaction --no-ansi --only main
 
-CMD exec uvicorn ____project_name_identifier.server:app --host 0.0.0.0 --port $PORT
+CMD exec poetry run uvicorn ____project_name_identifier.server:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
@eyurtsev -- This is a super quick and easy fix.  This is my first contribution, so please let me know if I have missed doing anything that I should have! 


Description:
Add `poetry run` to the the Dockerfile template file final exec command
```
CMD exec poetry run uvicorn test_serve.server:app --host 0.0.0.0 --port $PORT
```
instead of just
```
CMD exec uvicorn test_serve.server:app --host 0.0.0.0 --port $PORT
```

Issue:
Without the `poetry run` added, `uvicorn` is not found at the exec line when running `docker compose up`
