### PR TITLE
Improve Redis add_documents efficiency

### DIFF
--- a/libs/langchain/langchain/vectorstores/redis/schema.py
+++ b/libs/langchain/langchain/vectorstores/redis/schema.py
@@ -52,7 +52,7 @@ class TextFieldSchema(RedisField):
             self.name,
             weight=self.weight,
             no_stem=self.no_stem,
-            phonetic_matcher=self.phonetic_matcher,
+            phonetic_matcher=self.phonetic_matcher,  # type: ignore
             sortable=self.sortable,
             no_index=self.no_index,
         )


### PR DESCRIPTION
  - **Description:** Small fix to make the `add_documents` functionality a bit more performant regarding embedding creation
  - **Issue:** https://github.com/langchain-ai/langchain/issues/11496
  - **Dependencies:** nothing new
  - **Tag maintainer:** @baskaryan @Spartee 
  - **Twitter handle:** N/A

Addresses the inefficiency noted in the tagged issue when `add_documents()` is used on the Redis vectorstore.
