### PR TITLE
demonstrate use of RetrievalQAWithSourcesChain.from_chain

### DIFF
--- a/libs/langchain/tests/integration_tests/chains/test_retrieval_qa_with_sources.py
+++ b/libs/langchain/tests/integration_tests/chains/test_retrieval_qa_with_sources.py
@@ -17,22 +17,22 @@ def test_retrieval_qa_with_sources_chain_saving_loading(tmp_path: str) -> None:
     embeddings = OpenAIEmbeddings()
     docsearch = FAISS.from_documents(texts, embeddings)
     qa = RetrievalQAWithSourcesChain.from_llm(
-        llm=OpenAI(),
-        retriever=docsearch.as_retriever()
+        llm=OpenAI(), retriever=docsearch.as_retriever()
     )
     result = qa("What did the president say about Ketanji Brown Jackson?")
-    assert ('question' in result.keys())
-    assert ('answer' in result.keys())
-    assert ('sources' in result.keys())
+    assert "question" in result.keys()
+    assert "answer" in result.keys()
+    assert "sources" in result.keys()
     file_path = str(tmp_path) + "/RetrievalQAWithSourcesChain.yaml"
     qa.save(file_path=file_path)
     qa_loaded = load_chain(file_path, retriever=docsearch.as_retriever())
 
     assert qa_loaded == qa
 
-    qa2 = RetrievalQAWithSourcesChain.from_chain_type(llm=OpenAI(), retriever=docsearch.as_retriever(),
-                                                      chain_type="stuff")
+    qa2 = RetrievalQAWithSourcesChain.from_chain_type(
+        llm=OpenAI(), retriever=docsearch.as_retriever(), chain_type="stuff"
+    )
     result2 = qa2("What did the president say about Ketanji Brown Jackson?")
-    assert ('question' in result2.keys())
-    assert ('answer' in result2.keys())
-    assert ('sources' in result2.keys())
+    assert "question" in result2.keys()
+    assert "answer" in result2.keys()
+    assert "sources" in result2.keys()

--- a/libs/langchain/tests/integration_tests/chains/test_retrieval_qa_with_sources.py
+++ b/libs/langchain/tests/integration_tests/chains/test_retrieval_qa_with_sources.py
@@ -17,12 +17,22 @@ def test_retrieval_qa_with_sources_chain_saving_loading(tmp_path: str) -> None:
     embeddings = OpenAIEmbeddings()
     docsearch = FAISS.from_documents(texts, embeddings)
     qa = RetrievalQAWithSourcesChain.from_llm(
-        llm=OpenAI(), retriever=docsearch.as_retriever()
+        llm=OpenAI(),
+        retriever=docsearch.as_retriever()
     )
-    qa("What did the president say about Ketanji Brown Jackson?")
-
-    file_path = tmp_path + "/RetrievalQAWithSourcesChain.yaml"
+    result = qa("What did the president say about Ketanji Brown Jackson?")
+    assert ('question' in result.keys())
+    assert ('answer' in result.keys())
+    assert ('sources' in result.keys())
+    file_path = str(tmp_path) + "/RetrievalQAWithSourcesChain.yaml"
     qa.save(file_path=file_path)
     qa_loaded = load_chain(file_path, retriever=docsearch.as_retriever())
 
     assert qa_loaded == qa
+
+    qa2 = RetrievalQAWithSourcesChain.from_chain_type(llm=OpenAI(), retriever=docsearch.as_retriever(),
+                                                      chain_type="stuff")
+    result2 = qa2("What did the president say about Ketanji Brown Jackson?")
+    assert ('question' in result2.keys())
+    assert ('answer' in result2.keys())
+    assert ('sources' in result2.keys())


### PR DESCRIPTION
 **Description:** 
Documents further   usage of  RetrievalQAWithSourcesChain in an existing test. I'd not found much documented usage of RetrievalQAWithSourcesChain and how to get the sources out.  This additional code will hopefully  be useful to other potential users of this retriever.

 **Issue:** No raised issue
 
**Dependencies:** No new dependencies needed to run the test (it already needs `open-ai`, `faiss-cpu` and  `unstructured`).

Note - `make lint` showed 8 linting errors  in unrelated files

