### PR TITLE
Adding `STRUCTURED_FORMAT_SIMPLE_INSTRUCTIONS` missing backticks

### DIFF
--- a/libs/langchain/langchain/output_parsers/format_instructions.py
+++ b/libs/langchain/langchain/output_parsers/format_instructions.py
@@ -13,7 +13,7 @@ STRUCTURED_FORMAT_SIMPLE_INSTRUCTIONS = """
 {{
 {format}
 }}
-"""
+```"""
 
 
 PYDANTIC_FORMAT_INSTRUCTIONS = """The output should be formatted as a JSON instance that conforms to the JSON schema below.

--- a/libs/langchain/langchain/output_parsers/structured.py
+++ b/libs/langchain/langchain/output_parsers/structured.py
@@ -77,6 +77,7 @@ class StructuredOutputParser(BaseOutputParser):
         #     "foo": List[string]  // a list of strings
         #     "bar": string  // a string
         # }
+        # ```
 
         Args:
             only_json (bool): If True, only the json in the Markdown code snippet


### PR DESCRIPTION
This PR fixes the fact that `STRUCTURED_FORMAT_SIMPLE_INSTRUCTIONS` was missing backticks at the end