### PR TITLE
Check for ls project in run tree context

### DIFF
--- a/libs/langchain/langchain/callbacks/manager.py
+++ b/libs/langchain/langchain/callbacks/manager.py
@@ -1936,8 +1936,12 @@ def _configure(
     tracing_v2_enabled_ = (
         env_var_is_set("LANGCHAIN_TRACING_V2") or tracer_v2 is not None
     )
-    tracer_project = os.environ.get(
-        "LANGCHAIN_PROJECT", os.environ.get("LANGCHAIN_SESSION", "default")
+    tracer_project = getattr(
+        run_tree,
+        "session_name",
+        os.environ.get(
+            "LANGCHAIN_PROJECT", os.environ.get("LANGCHAIN_SESSION", "default")
+        ),
     )
     run_collector_ = run_collector_var.get()
     debug = _get_debug()


### PR DESCRIPTION
If I go traceable -> runnable when the project is manually specified, the runnable wont be logged. This makes sure the session/project is threaded through appropriately.