### PR TITLE
fix: typo in pgvector.ipynb

### DIFF
--- a/docs/docs/integrations/vectorstores/pgvector.ipynb
+++ b/docs/docs/integrations/vectorstores/pgvector.ipynb
@@ -141,7 +141,7 @@
     "# PGVector needs the connection string to the database.\n",
     "CONNECTION_STRING = \"postgresql+psycopg2://harrisonchase@localhost:5432/test3\"\n",
     "\n",
-    "# # Alternatively, you can create it from enviornment variables.\n",
+    "# # Alternatively, you can create it from environment variables.\n",
     "# import os\n",
     "\n",
     "# CONNECTION_STRING = PGVector.connection_string_from_db_params(\n",


### PR DESCRIPTION
fix: typo in docs/docs/integrations/vectorstores/pgvector.ipynb