### PR TITLE
refactor: DeterministicFakeEmbedding -> DeterministicFakeEmbeddings

### DIFF
--- a/libs/langchain/langchain/embeddings/__init__.py
+++ b/libs/langchain/langchain/embeddings/__init__.py
@@ -30,7 +30,7 @@ from langchain.embeddings.edenai import EdenAiEmbeddings
 from langchain.embeddings.elasticsearch import ElasticsearchEmbeddings
 from langchain.embeddings.embaas import EmbaasEmbeddings
 from langchain.embeddings.ernie import ErnieEmbeddings
-from langchain.embeddings.fake import DeterministicFakeEmbedding, FakeEmbeddings
+from langchain.embeddings.fake import DeterministicFakeEmbeddings, FakeEmbeddings
 from langchain.embeddings.google_palm import GooglePalmEmbeddings
 from langchain.embeddings.gpt4all import GPT4AllEmbeddings
 from langchain.embeddings.gradient_ai import GradientEmbeddings
@@ -89,7 +89,7 @@ __all__ = [
     "SelfHostedHuggingFaceEmbeddings",
     "SelfHostedHuggingFaceInstructEmbeddings",
     "FakeEmbeddings",
-    "DeterministicFakeEmbedding",
+    "DeterministicFakeEmbeddings",
     "AlephAlphaAsymmetricSemanticEmbedding",
     "AlephAlphaSymmetricSemanticEmbedding",
     "SentenceTransformerEmbeddings",

--- a/libs/langchain/langchain/embeddings/fake.py
+++ b/libs/langchain/langchain/embeddings/fake.py
@@ -23,7 +23,7 @@ class FakeEmbeddings(Embeddings, BaseModel):
         return self._get_embedding()
 
 
-class DeterministicFakeEmbedding(Embeddings, BaseModel):
+class DeterministicFakeEmbeddings(Embeddings, BaseModel):
     """
     Fake embedding model that always returns
     the same embedding vector for the same text.

--- a/libs/langchain/tests/unit_tests/embeddings/test_deterministic_embeddings.py
+++ b/libs/langchain/tests/unit_tests/embeddings/test_deterministic_embeddings.py
@@ -1,4 +1,4 @@
-from langchain.embeddings import DeterministicFakeEmbedding
+from langchain.embeddings import DeterministicFakeEmbeddings
 
 
 def test_deterministic_fake_embeddings() -> None:
@@ -6,7 +6,7 @@ def test_deterministic_fake_embeddings() -> None:
     Test that the deterministic fake embeddings return the same
     embedding vector for the same text.
     """
-    fake = DeterministicFakeEmbedding(size=10)
+    fake = DeterministicFakeEmbeddings(size=10)
     text = "Hello world!"
     assert fake.embed_query(text) == fake.embed_query(text)
     assert fake.embed_query(text) != fake.embed_query("Goodbye world!")


### PR DESCRIPTION
 **Description:** I simply add an "s" to the current `DeterministicFakeEmbedding` in order to have a unique naming that is aligned to ALL `Embeddings` classes.

Note: right now, there are also `AlephAlphaAsymmetricSemanticEmbedding` and `AlephAlphaSymmetricSemanticEmbedding` classes that don't have this "s". If you want, I can also align them as well.