### PR TITLE
add allowed_operators property in QdrantTranslator

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/qdrant.py
+++ b/libs/langchain/langchain/retrievers/self_query/qdrant.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class QdrantTranslator(Visitor):
     """Translate `Qdrant` internal query language elements to valid filters."""
 
-    allowed_operators = （
+    allowed_operators = (
         Operator.AND,
         Operator.OR,
         Operator.NOT,

--- a/libs/langchain/langchain/retrievers/self_query/qdrant.py
+++ b/libs/langchain/langchain/retrievers/self_query/qdrant.py
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
 class QdrantTranslator(Visitor):
     """Translate `Qdrant` internal query language elements to valid filters."""
 
+    allowed_operators = （
+        Operator.AND,
+        Operator.OR,
+        Operator.NOT,
+    )
+    """Subset of allowed logical operators."""
+
     allowed_comparators = (
         Comparator.EQ,
         Comparator.LT,


### PR DESCRIPTION
  - **Description:** 
This PR adds `allowd_operators` property to `QdrantTranslator` to fix the `TypeError: can only join an iterable` bug. This property is required in `get_query_constructor_prompt` in `query_constructor\base.py`:
```
allowed_operators=" | ".join(allowed_operators),
```
  - **Issue:** 
#12061
