### PR TITLE
convert date and timestamp to string format for qdrant

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/qdrant.py
+++ b/libs/langchain/langchain/retrievers/self_query/qdrant.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, Tuple
 
 from langchain.chains.query_constructor.ir import (
@@ -64,6 +65,12 @@ class QdrantTranslator(Visitor):
             ) from e
 
         self._validate_func(comparison.comparator)
+        if isinstance(comparison.value, datetime.date):
+            # ISO 8601 date format YYYY-MM-DD
+            comparison.value = comparison.value.strftime("%Y-%m-%d")
+        elif isinstance(comparison.value, datetime.datetime):
+            # ISO 8601 timestamp, formatted as RFC3339
+            comparison.value = comparison.value.strftime("%Y-%m-%dT%H:%M:%SZ")
         attribute = self.metadata_key + "." + comparison.attribute
         if comparison.comparator == Comparator.EQ:
             return rest.FieldCondition(


### PR DESCRIPTION
**Description:**
Convert the datetime values to string format to solve `qdrant_client.http.models.MatchValue` pydantic validation errors in QdrantTranslator. 


**Details:**
If the filter value output from llm contains "YYYY-MM-DD" formated datetime, the output parser will format it to `datetime.date`. 
https://github.com/langchain-ai/langchain/blob/d6acb3ed7e8338e42cbe25df38072b2bd15e0092/libs/langchain/langchain/chains/query_constructor/parser.py#L134

However, Qdrant client doesn't support datetime or date format, so this will result in pydantic error: 
https://github.com/qdrant/qdrant-client/blob/6875996cad0b4d15c891e9e81c725aaa3e9afdb5/qdrant_client/http/models/models.py#L1995
```
3 validation errors for MatchValue
value.bool
  Input should be a valid boolean [type=bool_type, input_value=datetime.date(2023, 10, 10), input_type=date]
    For further information visit https://errors.pydantic.dev/2.4/v/bool_type
value.int
  Input should be a valid integer [type=int_type, input_value=datetime.date(2023, 10, 10), input_type=date]
    For further information visit https://errors.pydantic.dev/2.4/v/int_type
value.str
  Input should be a valid string [type=string_type, input_value=datetime.date(2023, 10, 10), input_type=date]
    For further information visit https://errors.pydantic.dev/2.4/v/string_type
```

Similar convertion has been implemented in WeaviateTranslator:
https://github.com/langchain-ai/langchain/blob/d6acb3ed7e8338e42cbe25df38072b2bd15e0092/libs/langchain/langchain/retrievers/self_query/weaviate.py#L56

