### PR TITLE
Update toolkit.py to remove single quotes around table names

### DIFF
--- a/libs/langchain/langchain/agents/agent_toolkits/sql/toolkit.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/sql/toolkit.py
@@ -38,7 +38,7 @@ class SQLDatabaseToolkit(BaseToolkit):
             "schema and sample rows for those tables. "
             "Be sure that the tables actually exist by calling "
             f"{list_sql_database_tool.name} first! "
-            "Example Input: 'table1, table2, table3'"
+            "Example Input: table1, table2, table3"
         )
         info_sql_database_tool = InfoSQLDatabaseTool(
             db=self.db, description=info_sql_database_tool_description


### PR DESCRIPTION
**Description:** Removing the single quote wrapper around the table names in the SQL agent toolkit.py file as it misleads the LLM into querying against tables with single quotes around their names.
**Issue:** #7457 
**Dependencies:** None
**Tag maintainer:** @hwchase17 
**Twitter handle:** None