### PR TITLE
Openai key leakages

### DIFF
--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -540,3 +540,10 @@ class ChatOpenAI(BaseChatModel):
         # every reply is primed with <im_start>assistant
         num_tokens += 3
         return num_tokens
+
+    def __repr_args__(self) -> "ReprArgs":
+        return [
+            (key, value)
+            for key, value in super().__repr_args__()
+            if key != "openai_api_key"
+        ]

--- a/libs/langchain/langchain/embeddings/openai.py
+++ b/libs/langchain/langchain/embeddings/openai.py
@@ -528,3 +528,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         """
         embeddings = await self.aembed_documents([text])
         return embeddings[0]
+
+    def __repr_args__(self) -> "ReprArgs":
+        return [
+            (key, value)
+            for key, value in super().__repr_args__()
+            if key != "openai_api_key"
+        ]

--- a/libs/langchain/langchain/schema/language_model.py
+++ b/libs/langchain/langchain/schema/language_model.py
@@ -289,3 +289,10 @@ class BaseLanguageModel(
         Use get_pydantic_field_names.
         """
         return get_pydantic_field_names(cls)
+
+    def __repr_args__(self) -> "ReprArgs":
+        return [
+            (key, value)
+            for key, value in super().__repr_args__()
+            if key != "openai_api_key"
+        ]

--- a/libs/langchain/langchain/schema/language_model.py
+++ b/libs/langchain/langchain/schema/language_model.py
@@ -289,10 +289,3 @@ class BaseLanguageModel(
         Use get_pydantic_field_names.
         """
         return get_pydantic_field_names(cls)
-
-    def __repr_args__(self) -> "ReprArgs":
-        return [
-            (key, value)
-            for key, value in super().__repr_args__()
-            if key != "openai_api_key"
-        ]

--- a/libs/langchain/tests/unit_tests/chains/test_key_leakage.py
+++ b/libs/langchain/tests/unit_tests/chains/test_key_leakage.py
@@ -9,5 +9,5 @@ def test_openai_key_leakage():
     input = ChatPromptTemplate.from_messages([SystemMessagePromptTemplate.from_template("Foobar")])
     chat = ChatOpenAI(openai_api_key=key)
     chain = input | chat
-    assert key not in str(input)
-    assert key not in repr(chat)
+    assert key not in str(chain)
+    assert key not in repr(chain)

--- a/libs/langchain/tests/unit_tests/chains/test_key_leakage.py
+++ b/libs/langchain/tests/unit_tests/chains/test_key_leakage.py
@@ -1,0 +1,13 @@
+import pytest
+from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate
+from langchain.chat_models.openai import ChatOpenAI
+
+
+@pytest.mark.requires("openai")
+def test_openai_key_leakage():
+    key = "sk-TESTKEY"
+    input = ChatPromptTemplate.from_messages([SystemMessagePromptTemplate.from_template("Foobar")])
+    chat = ChatOpenAI(openai_api_key=key)
+    chain = input | chat
+    assert key not in str(input)
+    assert key not in repr(chat)

--- a/libs/langchain/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_openai.py
@@ -121,3 +121,11 @@ async def test_openai_apredict(mock_completion: dict) -> None:
         res = llm.predict("bar")
         assert res == "Bar Baz"
     assert completed
+
+
+@pytest.mark.requires("openai")
+def test_openai_chat_key_leakage():
+    key = "sk-TESTKEY"
+    chat = ChatOpenAI(openai_api_key=key)
+    assert key not in str(chat)
+    assert key not in repr(chat)

--- a/libs/langchain/tests/unit_tests/embeddings/test_openai.py
+++ b/libs/langchain/tests/unit_tests/embeddings/test_openai.py
@@ -18,3 +18,11 @@ def test_openai_incorrect_field() -> None:
     with pytest.warns(match="not default parameter"):
         llm = OpenAIEmbeddings(foo="bar")
     assert llm.model_kwargs == {"foo": "bar"}
+
+
+@pytest.mark.requires("openai")
+def test_openai_embeddings_key_leakage():
+    key = "sk-TESTKEY"
+    embedder = OpenAIEmbeddings(openai_api_key=key)
+    assert key not in str(embedder)
+    assert key not in repr(embedder)


### PR DESCRIPTION
**Description:**

By default - `ChatOpenAI` implementation and `OpenAIEmbeddings` implementations do not hide `openai_api_key` from `repr` implementation.

Which may lead to key leakages. Like I were working on some project with Jupyter Notebook, I am used to show intermediate stages - and I am far from being cautious. So I made something like:

```python
key = _read_key_from_some_gitignored_env_file()
input = ChatPromptTemplate.from_messages([SystemMessagePromptTemplate.from_template("Foobar")])
chat = ChatOpenAI(openai_api_key=key)
chain = input | chat
chain
```
or, for instance (you can run this code in python interactive session):
```python
from langchain.chat_models import ChatOpenAI
ChatOpenAI(openai_api_key="sk-TEST")
```
you can see this output
```
ChatOpenAI(client=<class 'openai.api_resources.chat_completion.ChatCompletion'>, openai_api_key='sk-TEST', openai_api_base='', openai_organization='', openai_proxy='')
```

And since I were used to show intermediate stages I have shown what chain is without noticing it contains key.

Fortunately, OpenAI monitor key leakages on their side, but they can only do it on public resources, like public github repositorys.

This PR:
- add tests regards this matter
- fix `OpenAIEmbeddings::__repr_args__` and `ChatOpenAI::__repr_args__` in such a way so `repr(someobject)` do not contains `openai_api_key` anymore:

```python
from langchain.chat_models import ChatOpenAI
ChatOpenAI(openai_api_key="sk-TEST")
```
```
ChatOpenAI(client=<class 'openai.api_resources.chat_completion.ChatCompletion'>, openai_api_base='', openai_organization='', openai_proxy='')
```
No `openai_api_key="sk-TEST"` anymore

- **Dependencies:** 

No additional dependencies
