### PR TITLE
docs(prompt_templates): fix typo in prompt template

### DIFF
--- a/docs/docs/modules/model_io/prompts/prompt_templates/index.ipynb
+++ b/docs/docs/modules/model_io/prompts/prompt_templates/index.ipynb
@@ -67,7 +67,7 @@
    "id": "d54c803c-0f80-412d-9156-b8390e0265c0",
    "metadata": {},
    "source": [
-    "The template supports any number of variables, including no variables:n"
+    "The template supports any number of variables, including no variables:"
    ]
   },
   {


### PR DESCRIPTION
 - **Description:** Fixes a small typo in the [Prompt template document](https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/)
  - **Dependencies:** none
