### PR TITLE
Add Runnable.with_listeners()

### DIFF
--- a/libs/langchain/langchain/callbacks/manager.py
+++ b/libs/langchain/langchain/callbacks/manager.py
@@ -1496,6 +1496,18 @@ class CallbackManagerForChainGroup(CallbackManager):
         self.parent_run_manager = parent_run_manager
         self.ended = False
 
+    def copy(self) -> CallbackManagerForChainGroup:
+        return self.__class__(
+            handlers=self.handlers,
+            inheritable_handlers=self.inheritable_handlers,
+            parent_run_id=self.parent_run_id,
+            tags=self.tags,
+            inheritable_tags=self.inheritable_tags,
+            metadata=self.metadata,
+            inheritable_metadata=self.inheritable_metadata,
+            parent_run_manager=self.parent_run_manager,
+        )
+
     def on_chain_end(self, outputs: Union[Dict[str, Any], Any], **kwargs: Any) -> None:
         """Run when traced chain group ends.
 

--- a/libs/langchain/langchain/callbacks/tracers/root_listeners.py
+++ b/libs/langchain/langchain/callbacks/tracers/root_listeners.py
@@ -1,0 +1,42 @@
+from typing import Callable, Optional
+
+from langchain.callbacks.tracers.base import BaseTracer
+from langchain.callbacks.tracers.schemas import Run
+
+
+class RootListenersTracer(BaseTracer):
+    def __init__(
+        self,
+        *,
+        on_start: Optional[Callable[[Run], None]],
+        on_end: Optional[Callable[[Run], None]],
+        on_error: Optional[Callable[[Run], None]]
+    ) -> None:
+        super().__init__()
+
+        self._arg_on_start = on_start
+        self._arg_on_end = on_end
+        self._arg_on_error = on_error
+
+    def _persist_run(self, run: Run) -> None:
+        # This is a legacy method only called once for an entire run tree
+        # therefore not useful here
+        pass
+
+    def _on_run_create(self, run: Run) -> None:
+        if run.parent_run_id is not None:
+            return
+
+        if self._arg_on_start is not None:
+            self._arg_on_start(run)
+
+    def _on_run_update(self, run: Run) -> None:
+        if run.parent_run_id is not None:
+            return
+
+        if run.error is None:
+            if self._arg_on_end is not None:
+                self._arg_on_end(run)
+        else:
+            if self._arg_on_error is not None:
+                self._arg_on_error(run)

--- a/libs/langchain/langchain/schema/runnable/base.py
+++ b/libs/langchain/langchain/schema/runnable/base.py
@@ -593,6 +593,17 @@ class Runnable(Generic[Input, Output], ABC):
         on_end: Optional[Callable[[Run], None]] = None,
         on_error: Optional[Callable[[Run], None]] = None,
     ) -> Runnable[Input, Output]:
+        """
+        Bind lifecycle listeners to a Runnable, returning a new Runnable.
+
+        on_start: Called before the runnable starts running, with the Run object.
+        on_end: Called after the runnable finishes running, with the Run object.
+        on_error: Called if the runnable throws an error, with the Run object.
+
+        The Run object contains information about the run, including its id,
+        type, input, output, error, start_time, end_time, and any tags or metadata
+        added to the run.
+        """
         from langchain.callbacks.tracers.root_listeners import RootListenersTracer
 
         return RunnableBinding(
@@ -2353,6 +2364,17 @@ class RunnableEach(RunnableSerializable[List[Input], List[Output]]):
         on_end: Optional[Callable[[Run], None]] = None,
         on_error: Optional[Callable[[Run], None]] = None,
     ) -> RunnableEach[Input, Output]:
+        """
+        Bind lifecycle listeners to a Runnable, returning a new Runnable.
+
+        on_start: Called before the runnable starts running, with the Run object.
+        on_end: Called after the runnable finishes running, with the Run object.
+        on_error: Called if the runnable throws an error, with the Run object.
+
+        The Run object contains information about the run, including its id,
+        type, input, output, error, start_time, end_time, and any tags or metadata
+        added to the run.
+        """
         return RunnableEach(
             bound=self.bound.with_listeners(
                 on_start=on_start, on_end=on_end, on_error=on_error
@@ -2519,6 +2541,17 @@ class RunnableBinding(RunnableSerializable[Input, Output]):
         on_end: Optional[Callable[[Run], None]] = None,
         on_error: Optional[Callable[[Run], None]] = None,
     ) -> Runnable[Input, Output]:
+        """
+        Bind lifecycle listeners to a Runnable, returning a new Runnable.
+
+        on_start: Called before the runnable starts running, with the Run object.
+        on_end: Called after the runnable finishes running, with the Run object.
+        on_error: Called if the runnable throws an error, with the Run object.
+
+        The Run object contains information about the run, including its id,
+        type, input, output, error, start_time, end_time, and any tags or metadata
+        added to the run.
+        """
         from langchain.callbacks.tracers.root_listeners import RootListenersTracer
 
         return self.__class__(

--- a/libs/langchain/langchain/schema/runnable/config.py
+++ b/libs/langchain/langchain/schema/runnable/config.py
@@ -220,6 +220,51 @@ def merge_configs(*configs: Optional[RunnableConfig]) -> RunnableConfig:
                     **base.get(key, {}),  # type: ignore
                     **(config.get(key) or {}),  # type: ignore
                 }
+            elif key == "callbacks":
+                base_callbacks = base.get("callbacks")
+                these_callbacks = config["callbacks"]
+                # callbacks can be either None, list[handler] or manager
+                # so merging two callbacks values has 6 cases
+                if isinstance(these_callbacks, list):
+                    if base_callbacks is None:
+                        base["callbacks"] = these_callbacks
+                    elif isinstance(base_callbacks, list):
+                        base["callbacks"] = base_callbacks + these_callbacks
+                    else:
+                        # base_callbacks is a manager
+                        mngr = base_callbacks.copy()
+                        for callback in these_callbacks:
+                            mngr.add_handler(callback, inherit=True)
+                        base["callbacks"] = mngr
+                elif these_callbacks is not None:
+                    # these_callbacks is a manager
+                    if base_callbacks is None:
+                        base["callbacks"] = these_callbacks
+                    elif isinstance(base_callbacks, list):
+                        mngr = these_callbacks.copy()
+                        for callback in base_callbacks:
+                            mngr.add_handler(callback, inherit=True)
+                        base["callbacks"] = mngr
+                    else:
+                        # base_callbacks is also a manager
+                        base["callbacks"] = base_callbacks.__class__(
+                            parent_run_id=base_callbacks.parent_run_id
+                            or these_callbacks.parent_run_id,
+                            handlers=base_callbacks.handlers + these_callbacks.handlers,
+                            inheritable_handlers=base_callbacks.inheritable_handlers
+                            + these_callbacks.inheritable_handlers,
+                            tags=list(set(base_callbacks.tags + these_callbacks.tags)),
+                            inheritable_tags=list(
+                                set(
+                                    base_callbacks.inheritable_tags
+                                    + these_callbacks.inheritable_tags
+                                )
+                            ),
+                            metadata={
+                                **base_callbacks.metadata,
+                                **these_callbacks.metadata,
+                            },
+                        )
             else:
                 base[key] = config[key] or base.get(key)  # type: ignore
     return base

--- a/libs/langchain/tests/unit_tests/schema/runnable/__snapshots__/test_runnable.ambr
+++ b/libs/langchain/tests/unit_tests/schema/runnable/__snapshots__/test_runnable.ambr
@@ -3748,6 +3748,7 @@
                   ]
                 },
                 "config": {},
+                "config_factories": [],
                 "custom_input_type": null,
                 "custom_output_type": null
               }

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_config.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_config.py
@@ -2,30 +2,31 @@ from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks.stdout import StdOutCallbackHandler
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.callbacks.tracers.stdout import ConsoleCallbackHandler
-from langchain.schema.runnable.config import merge_configs
+from langchain.schema.runnable.config import RunnableConfig, merge_configs
 
 
 def test_merge_config_callbacks() -> None:
-    manager = CallbackManager(handlers=[StdOutCallbackHandler()])
-    handlers = [ConsoleCallbackHandler()]
+    manager: RunnableConfig = {
+        "callbacks": CallbackManager(handlers=[StdOutCallbackHandler()])
+    }
+    handlers: RunnableConfig = {"callbacks": [ConsoleCallbackHandler()]}
+    other_handlers: RunnableConfig = {"callbacks": [StreamingStdOutCallbackHandler()]}
 
-    merged = merge_configs({"callbacks": manager}, {"callbacks": handlers})["callbacks"]
-
-    assert isinstance(merged, CallbackManager)
-    assert len(merged.handlers) == 2
-    assert isinstance(merged.handlers[0], StdOutCallbackHandler)
-    assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
-
-    merged = merge_configs({"callbacks": handlers}, {"callbacks": manager})["callbacks"]
+    merged = merge_configs(manager, handlers)["callbacks"]
 
     assert isinstance(merged, CallbackManager)
     assert len(merged.handlers) == 2
     assert isinstance(merged.handlers[0], StdOutCallbackHandler)
     assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
 
-    merged = merge_configs(
-        {"callbacks": handlers}, {"callbacks": [StreamingStdOutCallbackHandler()]}
-    )["callbacks"]
+    merged = merge_configs(handlers, manager)["callbacks"]
+
+    assert isinstance(merged, CallbackManager)
+    assert len(merged.handlers) == 2
+    assert isinstance(merged.handlers[0], StdOutCallbackHandler)
+    assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
+
+    merged = merge_configs(handlers, other_handlers)["callbacks"]
 
     assert isinstance(merged, list)
     assert len(merged) == 2

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_config.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_config.py
@@ -1,0 +1,33 @@
+from langchain.callbacks.manager import CallbackManager
+from langchain.callbacks.stdout import StdOutCallbackHandler
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain.callbacks.tracers.stdout import ConsoleCallbackHandler
+from langchain.schema.runnable.config import merge_configs
+
+
+def test_merge_config_callbacks() -> None:
+    manager = CallbackManager(handlers=[StdOutCallbackHandler()])
+    handlers = [ConsoleCallbackHandler()]
+
+    merged = merge_configs({"callbacks": manager}, {"callbacks": handlers})["callbacks"]
+
+    assert isinstance(merged, CallbackManager)
+    assert len(merged.handlers) == 2
+    assert isinstance(merged.handlers[0], StdOutCallbackHandler)
+    assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
+
+    merged = merge_configs({"callbacks": handlers}, {"callbacks": manager})["callbacks"]
+
+    assert isinstance(merged, CallbackManager)
+    assert len(merged.handlers) == 2
+    assert isinstance(merged.handlers[0], StdOutCallbackHandler)
+    assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
+
+    merged = merge_configs(
+        {"callbacks": handlers}, {"callbacks": [StreamingStdOutCallbackHandler()]}
+    )["callbacks"]
+
+    assert isinstance(merged, list)
+    assert len(merged) == 2
+    assert isinstance(merged[0], ConsoleCallbackHandler)
+    assert isinstance(merged[1], StreamingStdOutCallbackHandler)

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -1495,6 +1495,27 @@ def test_prompt_template_params() -> None:
         prompt.invoke({})
 
 
+def test_with_listeners(mocker: MockerFixture) -> None:
+    prompt = (
+        SystemMessagePromptTemplate.from_template("You are a nice assistant.")
+        + "{question}"
+    )
+    chat = FakeListChatModel(responses=["foo"])
+
+    chain = prompt | chat
+
+    mock_start = mocker.Mock()
+    mock_end = mocker.Mock()
+
+    chain.with_listeners(on_start=mock_start, on_end=mock_end).invoke(
+        {"question": "Who are you?"}
+    )
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+
+
 @pytest.mark.asyncio
 @freeze_time("2023-01-01")
 async def test_prompt_with_chat_model(

--- a/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
+++ b/libs/langchain/tests/unit_tests/schema/runnable/test_runnable.py
@@ -19,7 +19,12 @@ from freezegun import freeze_time
 from pytest_mock import MockerFixture
 from syrupy import SnapshotAssertion
 
-from langchain.callbacks.manager import Callbacks, atrace_as_chain_group, collect_runs
+from langchain.callbacks.manager import (
+    Callbacks,
+    atrace_as_chain_group,
+    collect_runs,
+    trace_as_chain_group,
+)
 from langchain.callbacks.tracers.base import BaseTracer
 from langchain.callbacks.tracers.log_stream import RunLog, RunLogPatch
 from langchain.callbacks.tracers.schemas import Run
@@ -1510,6 +1515,18 @@ def test_with_listeners(mocker: MockerFixture) -> None:
     chain.with_listeners(on_start=mock_start, on_end=mock_end).invoke(
         {"question": "Who are you?"}
     )
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+
+    mock_start.reset_mock()
+    mock_end.reset_mock()
+
+    with trace_as_chain_group("hello") as manager:
+        chain.with_listeners(on_start=mock_start, on_end=mock_end).invoke(
+            {"question": "Who are you?"}, {"callbacks": manager}
+        )
 
     assert mock_start.call_count == 1
     assert mock_start.call_args[0][0].name == "RunnableSequence"


### PR DESCRIPTION
- This binds start/end/error listeners to a runnable, which will be called with the Run object

