### PR TITLE
Add message to documents

### DIFF
--- a/libs/langchain/langchain/chat_models/cohere.py
+++ b/libs/langchain/langchain/chat_models/cohere.py
@@ -166,6 +166,16 @@ class ChatCohere(BaseChatModel, BaseCohere):
                 if run_manager:
                     await run_manager.on_llm_new_token(delta)
 
+    def _get_generation_info(response) -> Dict[str, Any]:
+        """Get the generation info from cohere API response."""
+        return {
+            "documents": response.documents,
+            "citations": response.citations,
+            "search_results": response.search_results,
+            "search_queries": response.search_queries,
+            "token_count": response.token_count,
+        }
+
     def _generate(
         self,
         messages: List[BaseMessage],
@@ -185,7 +195,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
         message = AIMessage(content=response.text)
         generation_info = None
         if hasattr(response, "documents"):
-            generation_info = {"documents": response.documents}
+            generation_info = self._get_generation_info(response)
         return ChatResult(
             generations=[
                 ChatGeneration(message=message, generation_info=generation_info)
@@ -211,7 +221,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
         message = AIMessage(content=response.text)
         generation_info = None
         if hasattr(response, "documents"):
-            generation_info = {"documents": response.documents}
+            generation_info = self._get_generation_info(response)
         return ChatResult(
             generations=[
                 ChatGeneration(message=message, generation_info=generation_info)

--- a/libs/langchain/langchain/chat_models/cohere.py
+++ b/libs/langchain/langchain/chat_models/cohere.py
@@ -166,7 +166,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
                 if run_manager:
                     await run_manager.on_llm_new_token(delta)
 
-    def _get_generation_info(response) -> Dict[str, Any]:
+    def _get_generation_info(self, response: Any) -> Dict[str, Any]:
         """Get the generation info from cohere API response."""
         return {
             "documents": response.documents,

--- a/libs/langchain/langchain/retrievers/cohere_rag_retriever.py
+++ b/libs/langchain/langchain/retrievers/cohere_rag_retriever.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 
 
 def _get_docs(response: Any) -> List[Document]:
-    return [
+    docs = [
         Document(page_content=doc["snippet"], metadata=doc)
         for doc in response.generation_info["documents"]
-    ].append(
+    ]
+    docs.append(
         Document(
             page_content=response.message,
             metadata={
@@ -29,10 +30,11 @@ def _get_docs(response: Any) -> List[Document]:
             },
         )
     )
+    return docs
 
 
 class CohereRagRetriever(BaseRetriever):
-    """`ChatGPT plugin` retriever."""
+    """Cohere Chat API with RAG."""
 
     connectors: List[Dict] = Field(default_factory=lambda: [{"id": "web-search"}])
     """

--- a/libs/langchain/langchain/retrievers/cohere_rag_retriever.py
+++ b/libs/langchain/langchain/retrievers/cohere_rag_retriever.py
@@ -19,12 +19,15 @@ def _get_docs(response: Any) -> List[Document]:
         Document(page_content=doc["snippet"], metadata=doc)
         for doc in response.generation_info["documents"]
     ].append(
-        Document(page_content=response.message, metadata={
-            "type": "model_response",
-            "citations": response.generation_info["citations"],
-            "search_results": response.generation_info["search_results"],
-            "search_queries": response.generation_info["search_queries"],
-        })
+        Document(
+            page_content=response.message,
+            metadata={
+                "type": "model_response",
+                "citations": response.generation_info["citations"],
+                "search_results": response.generation_info["search_results"],
+                "search_queries": response.generation_info["search_queries"],
+            },
+        )
     )
 
 

--- a/libs/langchain/langchain/retrievers/cohere_rag_retriever.py
+++ b/libs/langchain/langchain/retrievers/cohere_rag_retriever.py
@@ -21,12 +21,13 @@ def _get_docs(response: Any) -> List[Document]:
     ]
     docs.append(
         Document(
-            page_content=response.message,
+            page_content=response.message.content,
             metadata={
                 "type": "model_response",
                 "citations": response.generation_info["citations"],
                 "search_results": response.generation_info["search_results"],
                 "search_queries": response.generation_info["search_queries"],
+                "token_count": response.generation_info["token_count"],
             },
         )
     )


### PR DESCRIPTION
This adds the response message as a document to the rag retriever so users can choose to use this. Also drops document limit.