### PR TITLE
fixed _load_prompt_from_file file check

### DIFF
--- a/libs/experimental/langchain_experimental/prompts/load.py
+++ b/libs/experimental/langchain_experimental/prompts/load.py
@@ -22,6 +22,7 @@ def load_prompt(path: Union[str, Path]) -> BasePromptTemplate:
 def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
     """Load prompt from file."""
     # Convert file to a Path object.
+    assert file.__class__ in (str, Path)
     if isinstance(file, str):
         file_path = Path(file)
     else:

--- a/libs/langchain/langchain/prompts/loading.py
+++ b/libs/langchain/langchain/prompts/loading.py
@@ -140,6 +140,7 @@ def load_prompt(path: Union[str, Path]) -> BasePromptTemplate:
 def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
     """Load prompt from file."""
     # Convert file to a Path object.
+    assert file.__class__ in (str, Path)
     if isinstance(file, str):
         file_path = Path(file)
     else:


### PR DESCRIPTION
**Description:** Fixed security issue in `_load_prompt_from_file` function(s). By passing instance of `class NotStrLike(os.PathLike)`, users are able to execute arbitrary code. `file` parameter should be either `str` or `Path` instance, and nothing else.

PoC: https://github.com/tangledgroup/langchain-prompt-exploit/blob/01795ccde3bf176e148e688079af6f6c93a730c3/1_langchain_prompt_wikipedia/main.py#L67