### PR TITLE
docs: removed DocCardList in `guides/` indexes

### DIFF
--- a/docs/docs/guides/evaluation/comparison/index.mdx
+++ b/docs/docs/guides/evaluation/comparison/index.mdx
@@ -21,8 +21,3 @@ The [run_on_dataset](https://api.python.langchain.com/en/latest/api_reference.ht
 :::
 
 Detailed information about creating custom evaluators and the available built-in comparison evaluators is provided in the following sections.
-
-import DocCardList from "@theme/DocCardList";
-
-<DocCardList />
-

--- a/docs/docs/guides/evaluation/examples/index.mdx
+++ b/docs/docs/guides/evaluation/examples/index.mdx
@@ -5,8 +5,4 @@ sidebar_position: 5
 
 🚧 _Docs under construction_ 🚧
 
-Below are some examples for inspecting and checking different chains.
-
-import DocCardList from "@theme/DocCardList";
-
-<DocCardList />
+Examples for inspecting and checking different chains.

--- a/docs/docs/guides/evaluation/index.mdx
+++ b/docs/docs/guides/evaluation/index.mdx
@@ -1,5 +1,3 @@
-import DocCardList from "@theme/DocCardList";
-
 # Evaluation
 
 Building applications with language models involves many moving parts. One of the most critical components is ensuring that the outcomes produced by your models are reliable and useful across a broad array of inputs, and that they work well with your application's other software components. Ensuring reliability usually boils down to some combination of application design, testing & evaluation, and runtime checks. 
@@ -23,5 +21,3 @@ We also are working to share guides and cookbooks that demonstrate how to use th
 ## Reference Docs
 
 For detailed information on the available evaluators, including how to instantiate, configure, and customize them, check out the [reference documentation](https://api.python.langchain.com/en/latest/api_reference.html#module-langchain.evaluation) directly.
-
-<DocCardList />

--- a/docs/docs/guides/evaluation/string/index.mdx
+++ b/docs/docs/guides/evaluation/string/index.mdx
@@ -21,7 +21,3 @@ String evaluators also implement the following methods:
 - `evaluate_strings`: Synchronously evaluates the output of the Chain or Language Model, with support for optional input and label.
 
 The following sections provide detailed information on available string evaluator implementations as well as how to create a custom string evaluator.
-
-import DocCardList from "@theme/DocCardList";
-
-<DocCardList />

--- a/docs/docs/guides/evaluation/trajectory/index.mdx
+++ b/docs/docs/guides/evaluation/trajectory/index.mdx
@@ -21,8 +21,3 @@ These methods return a dictionary. It is recommended that custom implementations
 You can capture an agent's trajectory by initializing the agent with the `return_intermediate_steps=True` parameter. This lets you collect all intermediate steps without relying on special callbacks.
 
 For a deeper dive into the implementation and use of Trajectory Evaluators, refer to the sections below.
-
-import DocCardList from "@theme/DocCardList";
-
-<DocCardList />
-

--- a/docs/docs/guides/langsmith/index.md
+++ b/docs/docs/guides/langsmith/index.md
@@ -1,7 +1,5 @@
 # LangSmith
 
-import DocCardList from "@theme/DocCardList";
-
 [LangSmith](https://smith.langchain.com) helps you trace and evaluate your language model applications and intelligent agents to help you
 move from prototype to production.
 
@@ -17,6 +15,3 @@ check out the [LangSmith Cookbook](https://github.com/langchain-ai/langsmith-coo
 - How to evaluate and audit your RAG workflows ([link](https://github.com/langchain-ai/langsmith-cookbook/tree/main/testing-examples/qa-correctness)).
 - How to fine-tune a LLM on real usage data ([link](https://github.com/langchain-ai/langsmith-cookbook/blob/main/fine-tuning-examples/export-to-openai/fine-tuning-on-chat-runs.ipynb)).
 - How to use the [LangChain Hub](https://smith.langchain.com/hub) to version your prompts ([link](https://github.com/langchain-ai/langsmith-cookbook/blob/main/hub-examples/retrieval-qa-chain/retrieval-qa.ipynb))
-
-
-<DocCardList />


### PR DESCRIPTION
Removed unnecessary `DocCardList` in the `index` files. They create unnecessary duplicate of ToC in the end of pages (we also have ToC on sidebars).

this PR is continuing after #12745 12307
Problem statement:
Here is an [example](https://python.langchain.com/docs/integrations/document_transformers).
We have a sidebar with Toc and we also have a ToC at the end of the page.
The ToC at the end of the page is not necessary and it is confusing when we mix the index page styles, moreover, it requires manual work.
So, instead of the generated index.mdx pages with CardLists, I've created them manually with small text about an entity