### PR TITLE
Fix BeautifulSoupTransformer: no more duplicates and correct order of tags + tests

### DIFF
--- a/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
+++ b/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
@@ -98,7 +98,7 @@ class BeautifulSoupTransformer(BaseDocumentTransformer):
         from bs4 import BeautifulSoup
 
         soup = BeautifulSoup(html_content, "html.parser")
-        text_parts: list[str] = []
+        text_parts: List[str] = []
         for element in soup.find_all():
             if element.name in tags:
                 # Extract all strings recursively in this element.

--- a/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
+++ b/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
@@ -101,10 +101,10 @@ class BeautifulSoupTransformer(BaseDocumentTransformer):
         text_parts: List[str] = []
         for element in soup.find_all():
             if element.name in tags:
-                # Extract all strings recursively in this element.
+                # Extract all navigable strings recursively from this element.
                 text_parts += get_navigable_strings(element)
 
-                # To avoid duplicate text, we remove all descendants from the soup
+                # To avoid duplicate text, remove all descendants from the soup.
                 element.decompose()
 
         return " ".join(text_parts)
@@ -123,13 +123,7 @@ class BeautifulSoupTransformer(BaseDocumentTransformer):
         lines = content.split("\n")
         stripped_lines = [line.strip() for line in lines]
         non_empty_lines = [line for line in stripped_lines if line]
-        seen = set()
-        deduped_lines = []
-        for line in non_empty_lines:
-            if line not in seen:
-                seen.add(line)
-                deduped_lines.append(line)
-        cleaned_content = " ".join(deduped_lines)
+        cleaned_content = " ".join(non_empty_lines)
         return cleaned_content
 
     async def atransform_documents(

--- a/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
+++ b/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
@@ -104,7 +104,7 @@ class BeautifulSoupTransformer(BaseDocumentTransformer):
                 # Extract all strings recursively in this element.
                 text_parts += get_navigable_strings(element)
 
-                # To avoid duplicate text, we remove all descendents from the soup
+                # To avoid duplicate text, we remove all descendants from the soup
                 element.decompose()
 
         return " ".join(text_parts)

--- a/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
+++ b/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
@@ -1,6 +1,4 @@
-from typing import Any, Iterator, List, Sequence
-
-from bs4 import NavigableString, Tag
+from typing import Any, Iterator, List, Sequence, cast
 
 from langchain.schema import BaseDocumentTransformer, Document
 
@@ -150,8 +148,10 @@ class BeautifulSoupTransformer(BaseDocumentTransformer):
         raise NotImplementedError
 
 
-def get_strings(element: Tag, exclude_tags: Sequence[str]) -> Iterator[str]:
-    for child in element.children:
+def get_strings(element: Any, exclude_tags: Sequence[str]) -> Iterator[str]:
+    from bs4 import NavigableString, Tag
+
+    for child in cast(Tag, element).children:
         if isinstance(child, Tag):
             if child.name not in exclude_tags:
                 yield from get_strings(child, exclude_tags)

--- a/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
+++ b/libs/langchain/langchain/document_transformers/beautiful_soup_transformer.py
@@ -147,4 +147,7 @@ def get_navigable_strings(element: Any) -> Iterator[str]:
         if isinstance(child, Tag):
             yield from get_navigable_strings(child)
         elif isinstance(child, NavigableString):
-            yield child.strip()
+            if (element.name == "a") and (href := element.get("href")):
+                yield f"{child.strip()} ({href})"
+            else:
+                yield child.strip()

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -78,7 +78,7 @@ def test_remove_style() -> None:
 @pytest.mark.requires("bs4")
 def test_remove_nested_tags() -> None:
     """
-    If a tag_to_extract is _inside_ an unwanted tag, it should be removed
+    If a tag_to_extract is _inside_ an unwanted_tag, it should be removed
     (e.g. a <p> inside a <table> if <table> is unwanted).)
     If an unwanted tag is _inside_ a tag_to_extract, it should be removed,
     but the rest of the tag_to_extract should stay.
@@ -95,7 +95,7 @@ def test_remove_nested_tags() -> None:
     docs_transformed = bs_transformer.transform_documents(
         documents, unwanted_tags=["script", "style", "table"]
     )
-    assert docs_transformed[0].page_content == ("Second paragraph.")
+    assert docs_transformed[0].page_content == "Second paragraph."
 
 
 @pytest.mark.requires("bs4")

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -43,23 +43,18 @@ def test_remove_unwanted_lines() -> None:
     assert docs_transformed[0].page_content == "First paragraph."
 
 
-# FIXME: This test proves that extracting nested tags fails with a _double_
-#        extraction, once for the outer and once again for the inner tag.
 @pytest.mark.requires("bs4")
 def test_fails_extract_nested_tags() -> None:
     bs_transformer = BeautifulSoupTransformer()
     nested_html = (
         "<html><div class='some_style'>"
-        "<p>First paragraph.</p>"
-        "<p>Second paragraph.</p>"
+        "<p><span>First</span> paragraph.</p>"
+        "<p>Second <div>paragraph.</div></p>"
         "</div><html>"
     )
     documents = [Document(page_content=nested_html)]
     docs_transformed = bs_transformer.transform_documents(documents)
-    assert (
-        docs_transformed[0].page_content
-        == "First paragraph. Second paragraph. First paragraph.Second paragraph."
-    )
+    assert docs_transformed[0].page_content == "First paragraph. Second paragraph."
 
     # The correct result should extract the text only one time.
     #

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -43,10 +43,33 @@ def test_remove_unwanted_lines() -> None:
     assert docs_transformed[0].page_content == "First paragraph."
 
 
+# FIXME: This test proves that extracting nested tags fails with a _double_
+#        extraction, once for the outer and once again for the inner tag.
+@pytest.mark.requires("bs4")
+def test_fails_extract_nested_tags() -> None:
+    bs_transformer = BeautifulSoupTransformer()
+    nested_html = (
+        "<html><div class='some_style'>"
+        "<p>First paragraph.</p>"
+        "<p>Second paragraph.</p>"
+        "</div><html>"
+    )
+    documents = [Document(page_content=nested_html)]
+    docs_transformed = bs_transformer.transform_documents(documents)
+    assert (
+        docs_transformed[0].page_content
+        == "First paragraph. Second paragraph. First paragraph.Second paragraph."
+    )
+
+    # The correct result should extract the text only one time.
+    #
+    #   "First paragraph. Second paragraph."
+
+
 # FIXME: This test proves that the order of the tags is NOT preserved.
 #        Documenting the current behavior here, but this should be fixed.
 @pytest.mark.requires("bs4")
-def test_transform_keeps_order() -> None:
+def test_fails_transform_keeps_order() -> None:
     bs_transformer = BeautifulSoupTransformer()
     multiple_tags_html = (
         "<h1>First heading.</h1>"

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -184,3 +184,22 @@ def test_transform_keeps_order() -> None:
         docs_transformed_h1_then_p[0].page_content
         == "First heading. First paragraph. Second heading. Second paragraph."
     )
+
+
+@pytest.mark.requires("bs4")
+def test_extracts_href() -> None:
+    bs_transformer = BeautifulSoupTransformer()
+    multiple_tags_html = (
+        "<h1>First heading.</h1>"
+        "<p>First paragraph with an <a href='http://example.com'>example</a></p>"
+        "<p>Second paragraph with an <a>a tag without href</a></p>"
+    )
+    documents = [Document(page_content=multiple_tags_html)]
+
+    docs_transformed = bs_transformer.transform_documents(
+        documents, tags_to_extract=["p"]
+    )
+    assert docs_transformed[0].page_content == (
+        "First paragraph with an example (http://example.com) "
+        "Second paragraph with an a tag without href"
+    )

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -44,7 +44,7 @@ def test_remove_unwanted_lines() -> None:
 
 
 @pytest.mark.requires("bs4")
-def test_fails_extract_nested_tags() -> None:
+def test_extract_nested_tags() -> None:
     bs_transformer = BeautifulSoupTransformer()
     nested_html = (
         "<html><div class='some_style'>"
@@ -55,10 +55,6 @@ def test_fails_extract_nested_tags() -> None:
     documents = [Document(page_content=nested_html)]
     docs_transformed = bs_transformer.transform_documents(documents)
     assert docs_transformed[0].page_content == "First paragraph. Second paragraph."
-
-    # The correct result should extract the text only one time.
-    #
-    #   "First paragraph. Second paragraph."
 
 
 # FIXME: This test proves that the order of the tags is NOT preserved.

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -57,6 +57,30 @@ def test_extract_nested_tags() -> None:
     assert docs_transformed[0].page_content == "First paragraph. Second paragraph."
 
 
+@pytest.mark.requires("bs4")
+def test_extract_more_nested_tags() -> None:
+    bs_transformer = BeautifulSoupTransformer()
+    nested_html = (
+        "<html><div class='some_style'>"
+        "<p><span>First</span> paragraph.</p>"
+        "<p>Second paragraph.</p>"
+        "<p>Third paragraph with a list:"
+        "<ul>"
+        "<li>First list item.</li>"
+        "<li>Second list item.</li>"
+        "</ul>"
+        "</p>"
+        "</div><html>"
+    )
+    documents = [Document(page_content=nested_html)]
+    docs_transformed = bs_transformer.transform_documents(documents)
+    assert docs_transformed[0].page_content == (
+        "First paragraph. Second paragraph. "
+        "Third paragraph with a list: "
+        "First list item. Second list item."
+    )
+
+
 # FIXME: This test proves that the order of the tags is NOT preserved.
 #        Documenting the current behavior here, but this should be fixed.
 @pytest.mark.requires("bs4")

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -18,7 +18,8 @@ def test_transform_empty_html() -> None:
 def test_extract_paragraphs() -> None:
     bs_transformer = BeautifulSoupTransformer()
     paragraphs_html = (
-        "<html><h1>Header</h1><p>First paragraph.</p><p>Second paragraph.</p><html>"
+        "<html><h1>Header</h1><p>First paragraph.</p>"
+        "<p>Second paragraph.</p><h1>Ignore at end</h1></html>"
     )
     documents = [Document(page_content=paragraphs_html)]
     docs_transformed = bs_transformer.transform_documents(documents)
@@ -30,7 +31,7 @@ def test_strip_whitespace() -> None:
     bs_transformer = BeautifulSoupTransformer()
     paragraphs_html = (
         "<html><h1>Header</h1><p><span>First</span>   paragraph.</p>"
-        "<p>Second paragraph. </p><html>"
+        "<p>Second paragraph. </p></html>"
     )
     documents = [Document(page_content=paragraphs_html)]
     docs_transformed = bs_transformer.transform_documents(documents)
@@ -212,3 +213,20 @@ def test_extracts_href() -> None:
         "First paragraph with an example (http://example.com) "
         "Second paragraph with an a tag without href"
     )
+
+
+@pytest.mark.requires("bs4")
+def test_invalid_html() -> None:
+    bs_transformer = BeautifulSoupTransformer()
+    invalid_html_1 = "<html><h1>First heading."
+    invalid_html_2 = "<html 1234 xyz"
+    documents = [
+        Document(page_content=invalid_html_1),
+        Document(page_content=invalid_html_2),
+    ]
+
+    docs_transformed = bs_transformer.transform_documents(
+        documents, tags_to_extract=["h1"]
+    )
+    assert docs_transformed[0].page_content == "First heading."
+    assert docs_transformed[1].page_content == ""

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -18,7 +18,7 @@ def test_transform_empty_html() -> None:
 def test_extract_paragraphs() -> None:
     bs_transformer = BeautifulSoupTransformer()
     paragraphs_html = (
-        "<html><h1>Header</h1><p>First paragraph.</p>" "<p>Second paragraph.</p><html>"
+        "<html><h1>Header</h1><p>First paragraph.</p><p>Second paragraph.</p><html>"
     )
     documents = [Document(page_content=paragraphs_html)]
     docs_transformed = bs_transformer.transform_documents(documents)
@@ -103,8 +103,17 @@ def test_remove_unwanted_lines() -> None:
     bs_transformer = BeautifulSoupTransformer()
     with_lines_html = "<html>\n\n<p>First \n\n     paragraph.</p>\n</html>\n\n"
     documents = [Document(page_content=with_lines_html)]
-    docs_transformed = bs_transformer.transform_documents(documents)
+    docs_transformed = bs_transformer.transform_documents(documents, remove_lines=True)
     assert docs_transformed[0].page_content == "First paragraph."
+
+
+@pytest.mark.requires("bs4")
+def test_do_not_remove_repeated_content() -> None:
+    bs_transformer = BeautifulSoupTransformer()
+    with_lines_html = "<p>1\n1\n1\n1</p>"
+    documents = [Document(page_content=with_lines_html)]
+    docs_transformed = bs_transformer.transform_documents(documents)
+    assert docs_transformed[0].page_content == "1 1 1 1"
 
 
 @pytest.mark.requires("bs4")

--- a/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
+++ b/libs/langchain/tests/unit_tests/document_transformers/test_beautiful_soup_transformer.py
@@ -35,6 +35,29 @@ def test_remove_style() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_remove_nested_tags() -> None:
+    """
+    If a tag_to_extract is _inside_ an unwanted tag, it should be removed
+    (e.g. a <p> inside a <table> if <table> is unwanted).)
+    If an unwanted tag is _inside_ a tag_to_extract, it should be removed,
+    but the rest of the tag_to_extract should stay.
+    This means that "unwanted_tags" have a higher "priority" than "tags_to_extract".
+    """
+    bs_transformer = BeautifulSoupTransformer()
+    with_style_html = (
+        "<html><style>my_funky_style</style>"
+        "<table><td><p>First paragraph, inside a table.</p></td></table>"
+        "<p>Second paragraph<table><td> with a cell </td></table>.</p>"
+        "</html>"
+    )
+    documents = [Document(page_content=with_style_html)]
+    docs_transformed = bs_transformer.transform_documents(
+        documents, unwanted_tags=["script", "style", "table"]
+    )
+    assert docs_transformed[0].page_content == ("Second paragraph.")
+
+
+@pytest.mark.requires("bs4")
 def test_remove_unwanted_lines() -> None:
     bs_transformer = BeautifulSoupTransformer()
     with_lines_html = "<html>\n\n<p>First \n\n     paragraph.</p>\n</html>\n\n"


### PR DESCRIPTION
  - **Description:** Fix extracting nested tags in correct order and without duplication
  - **Issue:** None
  - **Dependencies:** None
  - **Tag maintainer:** @baskaryan reviewed and merged my previous similar PR
  - **Twitter handle:** peter_v

Run `make format`, `make lint` and `make test` => OK