### PR TITLE
Add support for using metadata vars to form llm prompts. Add test cas…

### DIFF
--- a/libs/langchain/langchain/chains/base.py
+++ b/libs/langchain/langchain/chains/base.py
@@ -351,7 +351,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
             A dict of named outputs. Should contain all outputs specified in
                 `Chain.output_keys`.
         """
-        inputs = self.prep_inputs(inputs)
+        inputs = self.prep_inputs(inputs, metadata)
         callback_manager = AsyncCallbackManager.configure(
             callbacks,
             self.callbacks,

--- a/libs/langchain/langchain/evaluation/agents/trajectory_eval_chain.py
+++ b/libs/langchain/langchain/evaluation/agents/trajectory_eval_chain.py
@@ -276,11 +276,15 @@ The following is the expected answer. Use this to measure correctness:
         """
         return ["score", "reasoning"]
 
-    def prep_inputs(self, inputs: Union[Dict[str, Any], Any]) -> Dict[str, str]:
+    def prep_inputs(
+        self,
+        inputs: Union[Dict[str, Any], Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, str]:
         """Validate and prep inputs."""
         if "reference" not in inputs:
             inputs["reference"] = self._format_reference(inputs.get("reference"))
-        return super().prep_inputs(inputs)
+        return super().prep_inputs(inputs, metadata)
 
     def _call(
         self,

--- a/libs/langchain/tests/unit_tests/chains/test_llm.py
+++ b/libs/langchain/tests/unit_tests/chains/test_llm.py
@@ -60,6 +60,16 @@ def test_predict_method(fake_llm_chain: LLMChain) -> None:
     assert output == "foo"
 
 
+def test_metadata() -> None:
+    prompt = PromptTemplate(
+        input_variables=["text", "metadata_var"], template="{text} and {metadata_var}"
+    )
+    llm = FakeLLM(queries={"q1 and q2": "two q's"})
+    chain = LLMChain(prompt=prompt, llm=llm)
+    output = chain.run({"text": "q1"}, metadata={"metadata_var": "q2"})
+    assert output == "two q's"
+
+
 def test_predict_and_parse() -> None:
     """Test parsing ability."""
     prompt = PromptTemplate(


### PR DESCRIPTION
The LLM chain does allow prompt variables to be filled in by metadata variables. This commit allows for this. Also, an example for a structured chat agent that shows how metadata can be passed and used by a tool (Discussion here: https://github.com/langchain-ai/langchain/issues/12410)