### PR TITLE
Remove `print()` statements which seemed leftover from debugging.

### DIFF
--- a/libs/langchain/tests/unit_tests/llms/fake_llm.py
+++ b/libs/langchain/tests/unit_tests/llms/fake_llm.py
@@ -39,11 +39,8 @@ class FakeLLM(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
-        print(prompt)
         if self.sequential_responses:
             return self._get_next_response_in_sequence
-        print(repr(prompt))
-        print(self.queries)
         if self.queries is not None:
             return self.queries[prompt]
         if stop is None:


### PR DESCRIPTION
Added in #12159 presumably during debugging. Right now they cause a bit of visual noise.
