### PR TITLE
Update MosaicML Embedding Input Key

### DIFF
--- a/libs/langchain/langchain/embeddings/mosaicml.py
+++ b/libs/langchain/langchain/embeddings/mosaicml.py
@@ -64,7 +64,7 @@ class MosaicMLInstructorEmbeddings(BaseModel, Embeddings):
     def _embed(
         self, input: List[Tuple[str, str]], is_retry: bool = False
     ) -> List[List[float]]:
-        payload = {"input_strings": input}
+        payload = {"inputs": input}
 
         # HTTP headers for authorization
         headers = {


### PR DESCRIPTION
This input key was missed in the last update PR: https://github.com/langchain-ai/langchain/pull/7391

The input/output formats are intended to be like this:

```
{"inputs": [<prompt>]} 

{"outputs": [<output_text>]}
```
