### PR TITLE
Remove the CLI package's pydantic compatibility tests.

### DIFF
--- a/.github/workflows/langchain_cli_ci.yml
+++ b/.github/workflows/langchain_cli_ci.yml
@@ -45,10 +45,3 @@ jobs:
     with:
       working-directory: libs/cli
     secrets: inherit
-
-  pydantic-compatibility:
-    uses:
-      ./.github/workflows/_pydantic_compatibility.yml
-    with:
-      working-directory: libs/cli
-    secrets: inherit


### PR DESCRIPTION
They aren't necessary, since the CLI package doesn't have a direct dependency on pydantic.
