### PR TITLE
Add possibility to pass on_artifacts for a specific conversation

### DIFF
--- a/libs/langchain/langchain/tools/e2b_data_analysis/tool.py
+++ b/libs/langchain/langchain/tools/e2b_data_analysis/tool.py
@@ -10,6 +10,7 @@ from typing import IO, TYPE_CHECKING, Any, Callable, List, Optional, Type
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
+    CallbackManager,
 )
 from langchain.pydantic_v1 import BaseModel, Field, PrivateAttr
 from langchain.tools import BaseTool, Tool
@@ -151,14 +152,21 @@ class E2BDataAnalysisTool(BaseTool):
         return "\n".join(lines)
 
     def _run(
-        self, python_code: str, run_manager: Optional[CallbackManagerForToolRun] = None
+        self,
+        python_code: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+        callbacks: CallbackManager = None,
     ) -> str:
         python_code = add_last_line_print(python_code)
-        stdout, stderr, _ = self.session.run_python(python_code)
+        on_artifact = getattr(callbacks.metadata, "on_artifact", None)
+        stdout, stderr, artifacts = self.session.run_python(
+            python_code, on_artifact=on_artifact
+        )
 
         out = {
             "stdout": stdout,
             "stderr": stderr,
+            "artifacts": list(map(lambda artifact: artifact.name, artifacts)),
         }
         return json.dumps(out)
 

--- a/libs/langchain/langchain/tools/e2b_data_analysis/tool.py
+++ b/libs/langchain/langchain/tools/e2b_data_analysis/tool.py
@@ -155,10 +155,15 @@ class E2BDataAnalysisTool(BaseTool):
         self,
         python_code: str,
         run_manager: Optional[CallbackManagerForToolRun] = None,
-        callbacks: CallbackManager = None,
+        callbacks: Optional[CallbackManager] = None,
     ) -> str:
         python_code = add_last_line_print(python_code)
-        on_artifact = getattr(callbacks.metadata, "on_artifact", None)
+
+        if callbacks is not None:
+            on_artifact = getattr(callbacks.metadata, "on_artifact", None)
+        else:
+            on_artifact = None
+
         stdout, stderr, artifacts = self.session.run_python(
             python_code, on_artifact=on_artifact
         )

--- a/libs/langchain/langchain/tools/e2b_data_analysis/tool.py
+++ b/libs/langchain/langchain/tools/e2b_data_analysis/tool.py
@@ -9,8 +9,8 @@ from typing import IO, TYPE_CHECKING, Any, Callable, List, Optional, Type
 
 from langchain.callbacks.manager import (
     AsyncCallbackManagerForToolRun,
-    CallbackManagerForToolRun,
     CallbackManager,
+    CallbackManagerForToolRun,
 )
 from langchain.pydantic_v1 import BaseModel, Field, PrivateAttr
 from langchain.tools import BaseTool, Tool


### PR DESCRIPTION
Possibility to pass on_artifacts to a conversation. It can be then achieved by adding this way:

```python
result = agent.run(
    input=message.text,
    metadata={
        "on_artifact": CALLBACK_FUNCTION
    },
)
```

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
