### PR TITLE
Fixed vertexai streaming with codey model

### DIFF
--- a/libs/langchain/langchain/llms/vertexai.py
+++ b/libs/langchain/langchain/llms/vertexai.py
@@ -228,7 +228,7 @@ class _VertexAICommon(_VertexAIBase):
         params = {params_mapping.get(k, k): v for k, v in kwargs.items()}
         params = {**self._default_params, "stop_sequences": stop_sequences, **params}
         if stream or self.streaming:
-            params.pop("candidate_count")
+            params.pop("candidate_count", None)
         return params
 
 


### PR DESCRIPTION
When using `codey` models in vertexai there is no candidate_count parameter in default_params and it is not required in kwargs too. Need to use full syntax dict.pop(key, default).

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
