### PR TITLE
Add support for vectorstores that return cosine similarity (and not d…

### DIFF
--- a/libs/langchain/langchain/schema/vectorstore.py
+++ b/libs/langchain/langchain/schema/vectorstore.py
@@ -184,6 +184,13 @@ class VectorStore(ABC):
         return 1.0 - distance / math.sqrt(2)
 
     @staticmethod
+    def _cosine_similarity_relevance_score_fn(similarity: float) -> float:
+        """Return the 0..1 score as is. Value of 1 for cosine similarity
+        is most similar(or most relevant)"""
+
+        return similarity
+
+    @staticmethod
     def _cosine_relevance_score_fn(distance: float) -> float:
         """Normalize the distance to a score on a scale [0, 1]."""
 

--- a/libs/langchain/langchain/vectorstores/pinecone.py
+++ b/libs/langchain/langchain/vectorstores/pinecone.py
@@ -45,7 +45,9 @@ class Pinecone(VectorStore):
         embedding: Union[Embeddings, Callable],
         text_key: str,
         namespace: Optional[str] = None,
-        distance_strategy: Optional[DistanceStrategy] = DistanceStrategy.COSINE,
+        distance_strategy: Optional[
+            DistanceStrategy
+        ] = DistanceStrategy.COSINE_SIMILARITY,
     ):
         """Initialize with Pinecone client."""
         try:
@@ -240,6 +242,8 @@ class Pinecone(VectorStore):
 
         if self.distance_strategy == DistanceStrategy.COSINE:
             return self._cosine_relevance_score_fn
+        elif self.distance_strategy == DistanceStrategy.COSINE_SIMILARITY:
+            return self._cosine_similarity_relevance_score_fn
         elif self.distance_strategy == DistanceStrategy.MAX_INNER_PRODUCT:
             return self._max_inner_product_relevance_score_fn
         elif self.distance_strategy == DistanceStrategy.EUCLIDEAN_DISTANCE:

--- a/libs/langchain/langchain/vectorstores/utils.py
+++ b/libs/langchain/langchain/vectorstores/utils.py
@@ -18,6 +18,7 @@ class DistanceStrategy(str, Enum):
     DOT_PRODUCT = "DOT_PRODUCT"
     JACCARD = "JACCARD"
     COSINE = "COSINE"
+    COSINE_SIMILARITY = "COSINE_SIMILARITY"
 
 
 def maximal_marginal_relevance(


### PR DESCRIPTION
Issue: https://github.com/langchain-ai/langchain/issues/12707

Pinecone's default distance strategy on index creation is cosine similarity and not cosine distance. While, we can have a custom _cosine_similarity_relevance_score_fn for Pinecone, I think other vectorstores may also return cosine similarity (and/or distance),i.e. we should expose this to the user so that we can choose the appropriate relevance function

