### PR TITLE
Fixes 'Nonetype' not iterable for ObsidianLoader

### DIFF
--- a/libs/langchain/langchain/document_loaders/obsidian.py
+++ b/libs/langchain/langchain/document_loaders/obsidian.py
@@ -127,7 +127,9 @@ class ObsidianLoader(BaseLoader):
             }
 
             if tags or front_matter.get("tags"):
-                metadata["tags"] = ",".join(tags | set(front_matter.get("tags", [])))
+                metadata["tags"] = ",".join(
+                    tags | set(front_matter.get("tags", []) or [])
+                )
 
             docs.append(Document(page_content=text, metadata=metadata))
 


### PR DESCRIPTION
Implements #12726 from @Di3mex 