### PR TITLE
new course on `DeepLearning.ai`

### DIFF
--- a/docs/docs/additional_resources/tutorials.mdx
+++ b/docs/docs/additional_resources/tutorials.mdx
@@ -1,15 +1,16 @@
 # Tutorials
 
-Below are links to tutorials and courses on LangChain. For written guides on common use cases for LangChain, check out the [use cases guides](/docs/use_cases/qa_structured/sql).
+Below are links to tutorials and courses on LangChain. For written guides on common use cases for LangChain, check out the [use cases guides](/docs/use_cases).
 
 ⛓ icon marks a new addition [last update 2023-09-21]
 
 ---------------------
 
 ### DeepLearning.AI courses
- by [Harrison Chase](https://github.com/hwchase17) and [Andrew Ng](https://en.wikipedia.org/wiki/Andrew_Ng)
+ by [Harrison Chase](https://en.wikipedia.org/wiki/LangChain) and [Andrew Ng](https://en.wikipedia.org/wiki/Andrew_Ng)
 - [LangChain for LLM Application Development](https://learn.deeplearning.ai/langchain)
 - [LangChain Chat with Your Data](https://learn.deeplearning.ai/langchain-chat-with-your-data)
+- ⛓ [Functions, Tools and Agents with LangChain](https://learn.deeplearning.ai/functions-tools-agents-langchain)
 
 ### Handbook
 [LangChain AI Handbook](https://www.pinecone.io/learn/langchain/) By **James Briggs** and **Francisco Ingham**

--- a/docs/docs/additional_resources/tutorials.mdx
+++ b/docs/docs/additional_resources/tutorials.mdx
@@ -6,6 +6,8 @@ Below are links to tutorials and courses on LangChain. For written guides on com
 
 ---------------------
 
+### [LangChain on Wikipedia](https://en.wikipedia.org/wiki/LangChain)
+
 ### DeepLearning.AI courses
  by [Harrison Chase](https://en.wikipedia.org/wiki/LangChain) and [Andrew Ng](https://en.wikipedia.org/wiki/Andrew_Ng)
 - [LangChain for LLM Application Development](https://learn.deeplearning.ai/langchain)


### PR DESCRIPTION
Added a new course on [DeepLearning.ai](https://learn.deeplearning.ai/functions-tools-agents-langchain)
Added the LangChain `Wikipedia` link. Probably, it can be placed in the "More" menu.