### PR TITLE
Add LCEL-compatible `SerpApiRun` and `SerpApiResults` tools

### DIFF
--- a/docs/docs/integrations/tools/serpapi.ipynb
+++ b/docs/docs/integrations/tools/serpapi.ipynb
@@ -5,9 +5,9 @@
    "id": "dc23c48e",
    "metadata": {},
    "source": [
-    "# SerpAPI\n",
+    "# SerpApi\n",
     "\n",
-    "This notebook goes over how to use the SerpAPI component to search the web."
+    "This notebook goes over how to use the SerpApi component to search the web."
    ]
   },
   {
@@ -57,7 +57,7 @@
    "metadata": {},
    "source": [
     "## Custom Parameters\n",
-    "You can also customize the SerpAPI wrapper with arbitrary parameters. For example, in the below example we will use `bing` instead of `google`."
+    "You can also customize the SerpApi wrapper with arbitrary parameters. For example, in the below example we will use `bing` instead of `google`."
    ]
   },
   {
@@ -111,6 +111,95 @@
     "    description=\"A Python shell. Use this to execute python commands. Input should be a valid python command. If you want to see the output of a value, you should print it out with `print(...)`.\",\n",
     "    func=search.run,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe3ee213",
+   "metadata": {},
+   "source": [
+    "## LCEL\n",
+    "You can also use the SerpApi tool following the [LangChain Expression Language (LCEL)](/docs/expression_language/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be115825",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install google-search-results\n",
+    "!pip install openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea075e34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.prompts import ChatPromptTemplate\n",
+    "from langchain.schema.output_parser import StrOutputParser\n",
+    "from langchain.tools import SerpApiRun"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "73724dfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search = SerpApiRun()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "c6b96e45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template = \"\"\"turn the following user input into a search query for a search engine:\n",
+    "\n",
+    "{input}\"\"\"\n",
+    "prompt = ChatPromptTemplate.from_template(template)\n",
+    "\n",
+    "model = ChatOpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "32988807",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chain = prompt | model | StrOutputParser() | search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "42318054",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[{\\'title\\': \\'What NBA games are on tonight? Time, TV channel, schedule for ESPN national TV slate\\', \\'link\\': \\'https://www.sportingnews.com/us/nba/news/nba-games-tonight-time-tv-channel-schedule-espn/b263ddf04a70daee0d176a6b\\', \\'source\\': \\'Sporting News\\', \\'date\\': \\'16 hours ago\\', \\'thumbnail\\': \\'https://serpapi.com/searches/65435e524d443dcf851588f1/images/74795ddf1358c0f0ecb00b4bc92524010283791435ae4cc5.jpeg\\'}, {\\'title\\': \\'Ryan O\\\\\\'Reilly Celebrates 1000 Career NHL Games Tonight: \"I Still Have A Lot of Hockey Left to Play\"\\', \\'link\\': \\'https://thehockeynews.com/nhl/nashville-predators/news/ryan-oreilly-celebrates-1000-career-nhl-games-tonight-i-still-have-a-lot-of-hockey-left-to-play\\', \\'source\\': \\'The Hockey News\\', \\'date\\': \\'1 day ago\\', \\'thumbnail\\': \\'https://serpapi.com/searches/65435e524d443dcf851588f1/images/74795ddf1358c0f05a266068d4b180944cb239ee3a6bf139.jpeg\\'}, {\\'title\\': \\'NHL Odds, Preview, Prediction: Best Bets for All 4 Games Tonight (Wednesday, November 1)\\', \\'link\\': \\'https://www.actionnetwork.com/nhl/nhl-odds-preview-prediction-best-bets-wednesday-november-1\\', \\'source\\': \\'Action Network\\', \\'date\\': \\'12 hours ago\\', \\'thumbnail\\': \\'https://serpapi.com/searches/65435e524d443dcf851588f1/images/74795ddf1358c0f062b16115ac91e54645ebe5e3f7be7b63.jpeg\\'}]'"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.invoke({\"input\": \"I'd like to figure out what games are tonight\"})"
    ]
   }
  ],

--- a/libs/langchain/langchain/agents/load_tools.py
+++ b/libs/langchain/langchain/agents/load_tools.py
@@ -37,6 +37,7 @@ from langchain.tools.google_cloud.texttospeech import GoogleCloudTextToSpeechToo
 from langchain.tools.google_search.tool import GoogleSearchResults, GoogleSearchRun
 from langchain.tools.google_scholar.tool import GoogleScholarQueryRun
 from langchain.tools.metaphor_search.tool import MetaphorSearchResults
+from langchain.tools.serpapi.tool import SerpApiResults, SerpApiRun
 from langchain.tools.google_serper.tool import GoogleSerperResults, GoogleSerperRun
 from langchain.tools.searchapi.tool import SearchAPIResults, SearchAPIRun
 from langchain.tools.graphql.tool import BaseGraphQLTool
@@ -253,12 +254,7 @@ def _get_searchapi_results_json(**kwargs: Any) -> BaseTool:
 
 
 def _get_serpapi(**kwargs: Any) -> BaseTool:
-    return Tool(
-        name="Search",
-        description="A search engine. Useful for when you need to answer questions about current events. Input should be a search query.",
-        func=SerpAPIWrapper(**kwargs).run,
-        coroutine=SerpAPIWrapper(**kwargs).arun,
-    )
+    return SerpApiRun(api_wrapper=SerpAPIWrapper(**kwargs))
 
 
 def _get_dalle_image_generator(**kwargs: Any) -> Tool:

--- a/libs/langchain/langchain/tools/__init__.py
+++ b/libs/langchain/langchain/tools/__init__.py
@@ -264,6 +264,18 @@ def _import_google_search_tool_GoogleSearchRun() -> Any:
     return GoogleSearchRun
 
 
+def _import_serpapi_tool_SerpApiResults() -> Any:
+    from langchain.tools.serpapi.tool import SerpApiResults
+
+    return SerpApiResults
+
+
+def _import_serpapi_tool_SerpApiRun() -> Any:
+    from langchain.tools.serpapi.tool import SerpApiRun
+
+    return SerpApiRun
+
+
 def _import_google_serper_tool_GoogleSerperResults() -> Any:
     from langchain.tools.google_serper.tool import GoogleSerperResults
 
@@ -861,6 +873,10 @@ def __getattr__(name: str) -> Any:
         return _import_sql_database_tool_QuerySQLCheckerTool()
     elif name == "QuerySQLDataBaseTool":
         return _import_sql_database_tool_QuerySQLDataBaseTool()
+    elif name == "SerpApiResults":
+        return _import_serpapi_tool_SerpApiResults()
+    elif name == "SerpApiRun":
+        return _import_serpapi_tool_SerpApiRun()
     elif name == "SteamshipImageGenerationTool":
         return _import_steamship_image_generation()
     elif name == "VectorStoreQATool":
@@ -978,6 +994,8 @@ __all__ = [
     "SceneXplainTool",
     "SearxSearchResults",
     "SearxSearchRun",
+    "SerpApiResults",
+    "SerpApiRun",
     "ShellTool",
     "SleepTool",
     "StdInInquireTool",

--- a/libs/langchain/langchain/tools/serpapi/__init__.py
+++ b/libs/langchain/langchain/tools/serpapi/__init__.py
@@ -1,0 +1,6 @@
+from langchain.tools.serpapi.tool import SerpApiResults, SerpApiRun
+
+"""SerpApi Toolkit."""
+"""Tool for the SerpApi.com Search API."""
+
+__all__ = ["SerpApiRun", "SerpApiResults"]

--- a/libs/langchain/langchain/tools/serpapi/tool.py
+++ b/libs/langchain/langchain/tools/serpapi/tool.py
@@ -1,0 +1,68 @@
+"""Tool for the SerpApi.com API."""
+
+from typing import Optional
+
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForToolRun,
+    CallbackManagerForToolRun,
+)
+from langchain.pydantic_v1 import Field
+from langchain.tools.base import BaseTool
+from langchain.utilities.serpapi import SerpAPIWrapper
+
+
+class SerpApiRun(BaseTool):
+    """Tool that queries the SerpApi.com API."""
+
+    name: str = "serpapi"
+    description: str = (
+        "Fast, easy, and complete API for Google, Bing, and other search engines."
+        "Useful for when you need to answer questions about current events."
+        "Input should be a search query."
+    )
+    api_wrapper: SerpAPIWrapper = Field(default_factory=SerpAPIWrapper)
+
+    def _run(
+        self,
+        query: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool."""
+        return str(self.api_wrapper.run(query))
+
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        return (await self.api_wrapper.arun(query)).__str__()
+
+
+class SerpApiResults(BaseTool):
+    """Tool that queries the SerpApi.com API
+    and get back json."""
+
+    name: str = "serpapi_results"
+    description: str = (
+        "Fast, easy, and complete API for Google, Bing, and other search engines."
+        "Useful for when you need to answer questions about current events."
+        "Input should be a search query."
+    )
+    api_wrapper: SerpAPIWrapper = Field(default_factory=SerpAPIWrapper)
+
+    def _run(
+        self,
+        query: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool."""
+        return str(self.api_wrapper.results(query))
+
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the tool asynchronously."""
+        return (await self.api_wrapper.aresults(query)).__str__()

--- a/libs/langchain/tests/unit_tests/tools/test_imports.py
+++ b/libs/langchain/tests/unit_tests/tools/test_imports.py
@@ -91,6 +91,8 @@ EXPECTED_ALL = [
     "SceneXplainTool",
     "SearxSearchResults",
     "SearxSearchRun",
+    "SerpApiResults",
+    "SerpApiRun",
     "ShellTool",
     "SleepTool",
     "StdInInquireTool",

--- a/libs/langchain/tests/unit_tests/tools/test_public_api.py
+++ b/libs/langchain/tests/unit_tests/tools/test_public_api.py
@@ -92,6 +92,8 @@ _EXPECTED = [
     "SceneXplainTool",
     "SearxSearchResults",
     "SearxSearchRun",
+    "SerpApiResults",
+    "SerpApiRun",
     "ShellTool",
     "SleepTool",
     "StdInInquireTool",


### PR DESCRIPTION
  - **Description:** Add LCEL-compatible `SerpApiRun` and `SerpApiResults` tools
  - **Tag maintainer:** @baskaryan
  - **Twitter handle:** [@ilyazub_](https://twitter.com/ilyazub_)

Example usage:

```python
# docs/docs/expression_language/cookbook/tools.ipynb
search = SerpApiRun()

template = """turn the following user input into a search query for a search engine:

{input}"""
prompt = ChatPromptTemplate.from_template(template)

model = ChatOpenAI()

chain = prompt | model | StrOutputParser() | search

chain.invoke({"input": "Which club is Cristiano Ronaldo playing right now?"})
```

