### PR TITLE
Docs: 'memory' -> 'history' typo.

### DIFF
--- a/docs/docs/expression_language/cookbook/memory.ipynb
+++ b/docs/docs/expression_language/cookbook/memory.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "chain = (\n",
     "    RunnablePassthrough.assign(\n",
-    "        memory=RunnableLambda(memory.load_memory_variables) | itemgetter(\"history\")\n",
+    "        history=RunnableLambda(memory.load_memory_variables) | itemgetter(\"history\")\n",
     "    )\n",
     "    | prompt\n",
     "    | model\n",


### PR DESCRIPTION
The 'MessagesPlaceholder' expects 'history' but 'RunnablePassthrough' is assigning 'memory'.
