### PR TITLE
Update langchain to langchain-cli in README.md

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -17,7 +17,7 @@ pip install -U "langchain-cli[serve]"
 Next, create a new LangChain project:
 
 ```shell
-langchain app new my-app
+langchain-cli app new my-app
 ```
 
 This will create a new directory called `my-app` with two folders:
@@ -36,7 +36,7 @@ In this getting started guide, we will add a simple `pirate-speak` project.
 All this project does is convert user input into pirate speak.
 
 ```shell
-langchain app add pirate-speak
+langchain-cli app add pirate-speak
 ```
 
 This will pull in the specified template into `packages/pirate-speak`
@@ -96,7 +96,7 @@ export OPENAI_API_KEY=sk-...
 You can then spin up production-ready endpoints, along with a playground, by running:
 
 ```shell
-langchain serve
+langchain-cli serve
 ```
 
 This now gives a fully deployed LangServe application.


### PR DESCRIPTION
When I tried this quick start, I had to substitute all the `langchain` command for `langchain-cli` commands. This PR updates the README to reflect that.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
