### PR TITLE
Add mask API key to Petals LLM

### DIFF
--- a/libs/langchain/langchain/llms/petals.py
+++ b/libs/langchain/langchain/llms/petals.py
@@ -141,8 +141,7 @@ class Petals(LLM):
     ) -> str:
         """Call the Petals API."""
         params = self._default_params
-        params = {**params, **kwargs}
-        # self.huggingface_api_key = cast(SecretStr, self.huggingface_api_key)
+        params = {**params, **kwargs},
         inputs = self.tokenizer(prompt, return_tensors="pt")["input_ids"]
         outputs = self.client.generate(inputs, **params)
         text = self.tokenizer.decode(outputs[0])

--- a/libs/langchain/tests/unit_tests/llms/test_petals.py
+++ b/libs/langchain/tests/unit_tests/llms/test_petals.py
@@ -1,0 +1,40 @@
+from typing import cast
+
+from pytest import CaptureFixture, MonkeyPatch
+
+from langchain.llms import Petals
+from langchain.pydantic_v1 import SecretStr
+
+
+def test_api_key_is_secret_string() -> None:
+    llm = Petals(huggingface_api_key="my-api-key")
+    assert isinstance(llm.huggingface_api_key, SecretStr)
+
+
+def test_api_key_masked_when_passed_from_env(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    """Test initialization with an API key provided via an env variable"""
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "my-api-key")
+    llm = Petals()
+    print(llm.huggingface_api_key, end="")
+    captured = capsys.readouterr()
+
+    assert captured.out == "**********"
+
+
+def test_api_key_masked_when_passed_via_constructor(
+    capsys: CaptureFixture,
+) -> None:
+    """Test initialization with an API key provided via the initializer"""
+    llm = Petals(huggingface_api_key="my-api-key")
+    print(llm.huggingface_api_key, end="")
+    captured = capsys.readouterr()
+
+    assert captured.out == "**********"
+
+
+def test_uses_actual_secret_value_from_secretstr() -> None:
+    """Test that actual secret is retrieved using `.get_secret_value()`."""
+    llm = Petals(huggingface_api_key="my-api-key")
+    assert cast(SecretStr, llm.huggingface_api_key).get_secret_value() == "my-api-key"


### PR DESCRIPTION
- **Description:** Add masking of API Key for `Petals` LLM when printed.
   -  Added unit tests to validate API key handling and representation in the `Petals` class.
- **Issue:** https://github.com/langchain-ai/langchain/issues/12165
- **Dependencies:** None
- **Tag maintainer:** @eyurtsev

```py
# output of `__repr__()` method
# llm = Petals(model_name="bigscience/bloom-petals")
# llm

Petals(client=DistributedBloomForCausalLM(
  (transformer): DistributedBloomModel(
    (word_embeddings): Embedding(250880, 14336)
    (word_embeddings_layernorm): LayerNorm((14336,), eps=1e-05, elementwise_affine=True)
    (h): RemoteSequential(modules=bigscience/bloom-petals.0..bigscience/bloom-petals.69)
    (ln_f): LayerNorm((14336,), eps=1e-05, elementwise_affine=True)
  )
  (lm_head): LMHead()
), tokenizer=BloomTokenizerFast(name_or_path='bigscience/bloom-petals', vocab_size=250680, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='left', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '<pad>'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={
	0: AddedToken("<unk>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	1: AddedToken("<s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	3: AddedToken("<pad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}, huggingface_api_key=SecretStr('**********'))

```