### PR TITLE
Adds missing `urllib.parse` for IDE warning of `PubMedAPIWrapper`

### DIFF
--- a/libs/langchain/langchain/utilities/pubmed.py
+++ b/libs/langchain/langchain/utilities/pubmed.py
@@ -2,6 +2,7 @@ import json
 import logging
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, Iterator, List
 


### PR DESCRIPTION
Resolves an IDE (PyCharm 2023.2.3 PE) warning around `urllib.parse.quote`, also enabling CTRL-click