### PR TITLE
Initialize HuggingFacePipeline parameters when transformers pipeline passed in directly

### DIFF
--- a/libs/langchain/langchain/llms/huggingface_pipeline.py
+++ b/libs/langchain/langchain/llms/huggingface_pipeline.py
@@ -10,8 +10,6 @@ from langchain.llms.utils import enforce_stop_tokens
 from langchain.pydantic_v1 import Extra
 from langchain.schema import Generation, LLMResult
 
-DEFAULT_MODEL_ID = "gpt2"
-DEFAULT_TASK = "text-generation"
 VALID_TASKS = ("text2text-generation", "text-generation", "summarization")
 DEFAULT_BATCH_SIZE = 4
 
@@ -50,7 +48,7 @@ class HuggingFacePipeline(BaseLLM):
     """
 
     pipeline: Any  #: :meta private:
-    model_id: str = DEFAULT_MODEL_ID
+    model_id: Optional[str] = None
     """Model name to use."""
     model_kwargs: Optional[dict] = None
     """Keyword arguments passed to the model."""
@@ -58,6 +56,23 @@ class HuggingFacePipeline(BaseLLM):
     """Keyword arguments passed to the pipeline."""
     batch_size: int = DEFAULT_BATCH_SIZE
     """Batch size to use when passing multiple documents to generate."""
+
+    def __init__(self, **data: Any):
+        """Initialize parameters if pipeline passed in directly."""
+
+        super().__init__(**data)
+        if self.pipeline is not None:
+            try:
+                self.model_id = (
+                    self.pipeline.model.name_or_path if self.pipeline.model else None
+                )
+                self.pipeline_kwargs = (
+                    self.pipeline._forward_params
+                    if self.pipeline._forward_params
+                    else None
+                )
+            except AttributeError:
+                raise ValueError("Pipeline must be a valid transformers pipeline.")
 
     class Config:
         """Configuration for this pydantic object."""


### PR DESCRIPTION
When a transformers pipeline is passed directly into `HuggingFacePipeline`, it always sets `model_id` to 'gpt2' no matter what model has been loaded into the pipeline. 

To replicate the problem: 
```python
model_id = "Salesforce/codegen-350M-mono"
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id)

pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, max_new_tokens=10, temperature=0.3, top_p=0.95)
hf = HuggingFacePipeline(pipeline=pipe)
print(hf)
print(hf.pipeline.model.name_or_path)
```
`print(hf)` returns
```python
HuggingFacePipeline
Params: {'model_id': 'gpt2', 'model_kwargs': None, 'pipeline_kwargs': None}
```
despite the pipeline model having correctly loaded `Salesforce/codegen-350M-mono`. 

This is confusing and can lead to folks assuming that the pipeline model has been loaded incorrectly. 
Additionally, `model_id` and `kwargs` are convenient parameters to use when initialized
This issue was reported in #3451 and #8280

This PR addresses this by initializing the `HuggingFacePipeline` parameters whenever a pipeline object is passed directly. 
After this change, using the above example: 

```python
pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, max_new_tokens=10, temperature=0.3, top_p=0.95)
hf = HuggingFacePipeline(pipeline=pipe)
print(hf)
```
returns
```python
HuggingFacePipeline
Params: {'model_id': 'Salesforce/codegen-350M-mono', 'model_kwargs': None, 'pipeline_kwargs': {'max_new_tokens': 10, 'temperature': 0.3, 'top_p': 0.95}}
```




<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
