### PR TITLE
coockbook: Fix typo in wikibase_agent.ipynb

### DIFF
--- a/cookbook/wikibase_agent.ipynb
+++ b/cookbook/wikibase_agent.ipynb
@@ -35,7 +35,7 @@
     "tags": []
    },
    "source": [
-    "### API keys and other secrats\n",
+    "### API keys and other secrets\n",
     "\n",
     "We use an `.ini` file, like this: \n",
     "```\n",


### PR DESCRIPTION
This patch fixes a spelling typo in message
within wikibase_agent.ipynb.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>

