### PR TITLE
docs: clean up vestigial markdown

### DIFF
--- a/docs/docs/integrations/chat_loaders/discord.ipynb
+++ b/docs/docs/integrations/chat_loaders/discord.ipynb
@@ -65,9 +65,7 @@
    "id": "359565a7-dad3-403c-a73c-6414b1295127",
    "metadata": {},
    "source": [
-    "## 2. Define chat loader\n",
-    "\n",
-    "LangChain currently does not support "
+    "## 2. Define chat loader"
    ]
   },
   {


### PR DESCRIPTION
  - **Description:** Remove text "LangChain currently does not support" which appears to be vestigial leftovers from a previous change.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Tag maintainer:** @baskaryan, @eyurtsev
  - **Twitter handle:** thezanke