### PR TITLE
feat: acquire advisory lock before creating extension in pgvector

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -159,6 +159,11 @@ class PGVector(VectorStore):
     def create_vector_extension(self) -> None:
         try:
             with Session(self._conn) as session:
+                # The advisor lock fixes issue arising from concurrent
+                # creation of the vector extension.
+                # https://github.com/langchain-ai/langchain/issues/12933
+                # For more information see:
+                # https://www.postgresql.org/docs/16/explicit-locking.html#ADVISORY-LOCKS
                 statement = sqlalchemy.text(
                     "BEGIN;"
                     "SELECT pg_advisory_xact_lock(1573678846307946496);"

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -159,7 +159,12 @@ class PGVector(VectorStore):
     def create_vector_extension(self) -> None:
         try:
             with Session(self._conn) as session:
-                statement = sqlalchemy.text("CREATE EXTENSION IF NOT EXISTS vector")
+                statement = sqlalchemy.text(
+                    "BEGIN;"
+                    "SELECT pg_advisory_xact_lock(1573678846307946496);"
+                    "CREATE EXTENSION IF NOT EXISTS vector;"
+                    "COMMIT;"
+                )
                 session.execute(statement)
                 session.commit()
         except Exception as e:


### PR DESCRIPTION
  - **Description:** Acquire advisory lock before attempting to create extension on postgres server, preventing errors in concurrent executions.
  - **Issue:** #12933
  - **Dependencies:** None
