### PR TITLE
Fix for anyscale chat model api key

### DIFF
--- a/libs/langchain/langchain/chat_models/anyscale.py
+++ b/libs/langchain/langchain/chat_models/anyscale.py
@@ -30,6 +30,8 @@ DEFAULT_MODEL = "meta-llama/Llama-2-7b-chat-hf"
 class ChatAnyscale(ChatOpenAI):
     """`Anyscale` Chat large language models.
 
+    See https://www.anyscale.com/ for information about Anyscale.
+
     To use, you should have the ``openai`` python package installed, and the
     environment variable ``ANYSCALE_API_KEY`` set with your API key.
     Alternatively, you can use the anyscale_api_key keyword argument.
@@ -53,7 +55,7 @@ class ChatAnyscale(ChatOpenAI):
     def lc_secrets(self) -> Dict[str, str]:
         return {"anyscale_api_key": "ANYSCALE_API_KEY"}
 
-    anyscale_api_key: Optional[SecretStr] = None
+    anyscale_api_key: SecretStr
     """AnyScale Endpoints API keys."""
     model_name: str = Field(default=DEFAULT_MODEL, alias="model")
     """Model name to use."""
@@ -99,6 +101,13 @@ class ChatAnyscale(ChatOpenAI):
     def validate_environment_override(cls, values: dict) -> dict:
         """Validate that api key and python package exists in environment."""
         values["openai_api_key"] = convert_to_secret_str(
+            get_from_dict_or_env(
+                values,
+                "anyscale_api_key",
+                "ANYSCALE_API_KEY",
+            )
+        )
+        values["anyscale_api_key"] = convert_to_secret_str(
             get_from_dict_or_env(
                 values,
                 "anyscale_api_key",

--- a/libs/langchain/langchain/chat_models/anyscale.py
+++ b/libs/langchain/langchain/chat_models/anyscale.py
@@ -100,12 +100,10 @@ class ChatAnyscale(ChatOpenAI):
     @root_validator(pre=True)
     def validate_environment_override(cls, values: dict) -> dict:
         """Validate that api key and python package exists in environment."""
-        values["openai_api_key"] = convert_to_secret_str(
-            get_from_dict_or_env(
-                values,
-                "anyscale_api_key",
-                "ANYSCALE_API_KEY",
-            )
+        values["openai_api_key"] = get_from_dict_or_env(
+            values,
+            "anyscale_api_key",
+            "ANYSCALE_API_KEY",
         )
         values["anyscale_api_key"] = convert_to_secret_str(
             get_from_dict_or_env(

--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -172,6 +172,9 @@ class ChatOpenAI(BaseChatModel):
     """What sampling temperature to use."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not explicitly specified."""
+    # When updating this to use a SecretStr
+    # Check for classes that derive from this class (as some of them
+    # may assume openai_api_key is a str)
     openai_api_key: Optional[str] = None
     """Base URL path for API requests, 
     leave blank if not using a proxy or service emulator."""


### PR DESCRIPTION
* ChatAnyscale was missing coercion to SecretStr for anyscale api key
* The model inherits from ChatOpenAI so it should not force the openai api key to be secret str until openai model has the same changes

https://github.com/langchain-ai/langchain/issues/12841
