### PR TITLE
chore: change chatCompletion function  to latest api change

### DIFF
--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -267,7 +267,9 @@ class ChatOpenAI(BaseChatModel):
                 "Please install it with `pip install openai`."
             )
         try:
-            values["client"] = openai.ChatCompletion
+            from openai import OpenAI
+            client = OpenAI()
+            values["client"] = client.chat.completions
         except AttributeError:
             raise ValueError(
                 "`openai` has no `ChatCompletion` attribute, this is likely "


### PR DESCRIPTION
- **Description:** Updated the method of obtaining chat completions to be compatible with the latest OpenAI API. OpenAI has deprecated `chatCompletion` in their recent release. This update replaces the deprecated method with the current `client.chat.completions` method, ensuring compatibility with the latest API standards.

- **Twitter handle:** @nish306 

I have made sure the PR is passing linting and testing before submitting. I have run `make format`, `make lint`, and `make test` to check this locally.

