### PR TITLE
add docs for where_document argument and add to missing methods

### DIFF
--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -255,12 +255,15 @@ class Chroma(VectorStore):
             query (str): Query text to search for.
             k (int): Number of results to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+            where_document (Optional[Dict[str, str]]): filter by match to document
+                        content. Defaults to None
 
         Returns:
             List[Document]: List of documents most similar to the query text.
         """
-        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter, where_document= where_document)
+        docs_and_scores = self.similarity_search_with_score(
+            query, k, filter=filter, where_document=where_document
+        )
         return [doc for doc, _ in docs_and_scores]
 
     def similarity_search_by_vector(
@@ -276,7 +279,8 @@ class Chroma(VectorStore):
             embedding (List[float]): Embedding to look up documents similar to.
             k (int): Number of Documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+            where_document (Optional[Dict[str, str]]): filter by match to document
+                        content. Defaults to None
         Returns:
             List of Documents most similar to the query vector.
         """
@@ -303,7 +307,8 @@ class Chroma(VectorStore):
             embedding (List[float]): Embedding to look up documents similar to.
             k (int): Number of Documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+            where_document (Optional[Dict[str, str]]): filter by match to document
+                        content. Defaults to None
 
         Returns:
             List[Tuple[Document, float]]: List of documents most similar to
@@ -332,7 +337,8 @@ class Chroma(VectorStore):
             query (str): Query text to search for.
             k (int): Number of results to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+            where_document (Optional[Dict[str, str]]): filter by match to document
+                        content. Defaults to None
 
 
         Returns:
@@ -413,7 +419,8 @@ class Chroma(VectorStore):
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+            where_document (Optional[Dict[str, str]]): filter by match to document
+                        content. Defaults to None
 
 
         Returns:
@@ -462,7 +469,8 @@ class Chroma(VectorStore):
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+            where_document (Optional[Dict[str, str]]): filter by match to document
+                        content. Defaults to None
 
 
         Returns:

--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -246,6 +246,7 @@ class Chroma(VectorStore):
         query: str,
         k: int = DEFAULT_K,
         filter: Optional[Dict[str, str]] = None,
+        where_document: (Optional[Dict[str, str]]) = None,
         **kwargs: Any,
     ) -> List[Document]:
         """Run similarity search with Chroma.
@@ -254,11 +255,12 @@ class Chroma(VectorStore):
             query (str): Query text to search for.
             k (int): Number of results to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
 
         Returns:
             List[Document]: List of documents most similar to the query text.
         """
-        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter)
+        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter, where_document= where_document)
         return [doc for doc, _ in docs_and_scores]
 
     def similarity_search_by_vector(
@@ -274,6 +276,7 @@ class Chroma(VectorStore):
             embedding (List[float]): Embedding to look up documents similar to.
             k (int): Number of Documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
         Returns:
             List of Documents most similar to the query vector.
         """
@@ -300,6 +303,7 @@ class Chroma(VectorStore):
             embedding (List[float]): Embedding to look up documents similar to.
             k (int): Number of Documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
 
         Returns:
             List[Tuple[Document, float]]: List of documents most similar to
@@ -328,6 +332,8 @@ class Chroma(VectorStore):
             query (str): Query text to search for.
             k (int): Number of results to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+
 
         Returns:
             List[Tuple[Document, float]]: List of documents most similar to
@@ -407,6 +413,8 @@ class Chroma(VectorStore):
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+
 
         Returns:
             List of Documents selected by maximal marginal relevance.
@@ -454,6 +462,8 @@ class Chroma(VectorStore):
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            where_document (Optional[Dict[str, str]]): filter by match to document content. Defaults to None
+
 
         Returns:
             List of Documents selected by maximal marginal relevance.

--- a/libs/langchain/tests/integration_tests/vectorstores/test_chroma.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_chroma.py
@@ -97,6 +97,31 @@ def test_chroma_search_filter() -> None:
     assert output == [Document(page_content="bar", metadata={"first_letter": "b"})]
 
 
+def test_chroma_search_where_document() -> None:
+    """Test end to end construction and search with 'where_document' to filter
+    by search content'."""
+    texts = ["far", "bar fizz", "baz fizz", "buzz fizz"]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection",
+        texts=texts,
+        embedding=FakeEmbeddings(),
+    )
+    output = docsearch.similarity_search_with_score("anything", k=4)
+    assert len(output) == 4
+
+    output = docsearch.similarity_search("anything", k=4, where_document={"$contains": "fizz"})
+    assert len(output) == 3
+
+    output = docsearch.similarity_search("anything", k=4,
+                                         where_document={"$and": [{"$contains": "bar"}, {"$contains": "fizz"}]})
+    assert len(output) == 1
+    assert output == [Document(page_content="bar fizz", metadata={})]
+
+    output = docsearch.similarity_search("anything", k=4,
+                                         where_document={"$or": [{"$contains": "far"}, {"$contains": "fizz"}]})
+    assert len(output) == 4
+
+
 def test_chroma_search_filter_with_scores() -> None:
     """Test end to end construction and scored search with metadata filtering."""
     texts = ["far", "bar", "baz"]

--- a/libs/langchain/tests/integration_tests/vectorstores/test_chroma.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_chroma.py
@@ -109,16 +109,24 @@ def test_chroma_search_where_document() -> None:
     output = docsearch.similarity_search_with_score("anything", k=4)
     assert len(output) == 4
 
-    output = docsearch.similarity_search("anything", k=4, where_document={"$contains": "fizz"})
+    output = docsearch.similarity_search(
+        "anything", k=4, where_document={"$contains": "fizz"}
+    )
     assert len(output) == 3
 
-    output = docsearch.similarity_search("anything", k=4,
-                                         where_document={"$and": [{"$contains": "bar"}, {"$contains": "fizz"}]})
+    output = docsearch.similarity_search(
+        "anything",
+        k=4,
+        where_document={"$and": [{"$contains": "bar"}, {"$contains": "fizz"}]},
+    )
     assert len(output) == 1
     assert output == [Document(page_content="bar fizz", metadata={})]
 
-    output = docsearch.similarity_search("anything", k=4,
-                                         where_document={"$or": [{"$contains": "far"}, {"$contains": "fizz"}]})
+    output = docsearch.similarity_search(
+        "anything",
+        k=4,
+        where_document={"$or": [{"$contains": "far"}, {"$contains": "fizz"}]},
+    )
     assert len(output) == 4
 
 


### PR DESCRIPTION
**Description:**

Chroma vector store was missing documentation and  tests for the `where_document` argument. 

In addition, `similarity_search` method did not accept `where_document` as an argument. This PR fixes these issues.
  
**Issue:** 

No issue raised for this but relates to #10082

**Dependencies:** :
 None
 
