### PR TITLE
Document: Fix "Biadu" typo

### DIFF
--- a/docs/docs/integrations/vectorstores/baiducloud_vector_search.ipynb
+++ b/docs/docs/integrations/vectorstores/baiducloud_vector_search.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Biadu Cloud ElasticSearch VectorSearch\n",
+    "# Baidu Cloud ElasticSearch VectorSearch\n",
     "\n",
     ">[Baidu Cloud VectorSearch](https://cloud.baidu.com/doc/BES/index.html?from=productToDoc) is a fully managed, enterprise-level distributed search and analysis service which is 100% compatible to open source. Baidu Cloud VectorSearch provides low-cost, high-performance, and reliable retrieval and analysis platform level product services for structured/unstructured data. As a vector database , it supports multiple index types and similarity distance methods. \n",
     "\n",


### PR DESCRIPTION
Fix document "Baidu Cloud ElasticSearch VectorSearch" `Biadu` typo.
