### PR TITLE
Improve CSV reader which can't call .strip() on NoneType 

### DIFF
--- a/libs/langchain/langchain/document_loaders/csv_loader.py
+++ b/libs/langchain/langchain/document_loaders/csv_loader.py
@@ -102,7 +102,7 @@ class CSVLoader(BaseLoader):
                     f"Source column '{self.source_column}' not found in CSV file."
                 )
             content = "\n".join(
-                f"{k.strip()}: {v.strip()}"
+                f"{k.strip()}: {v.strip() if v is not None else v}"
                 for k, v in row.items()
                 if k not in self.metadata_columns
             )


### PR DESCRIPTION
Improve CSV reader which can't call .strip() on NoneType if there are less cells in the row compared to the header

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** 
I have a CSV file as followed

```
headerA,headerB,headerC
v1A,v1B,v1C,
v2A,v2B
v3A,v3B,v3C
```
In this case, row 2 is missing a value, which results in reading a None type. The strip() method can not be called on None, hence raising. In this PR I am making the change to only call strip if the value if not None.

  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
