### PR TITLE
Add Wrapping Library Metadata to MongoDB vector store

### DIFF
--- a/libs/langchain/langchain/vectorstores/mongodb_atlas.py
+++ b/libs/langchain/langchain/vectorstores/mongodb_atlas.py
@@ -102,13 +102,15 @@ class MongoDBAtlasVectorSearch(VectorStore):
 
         """
         try:
-            from pymongo import MongoClient
+            from importlib.metadata import version
+
+            from pymongo import DriverInfo, MongoClient
         except ImportError:
             raise ImportError(
                 "Could not import pymongo, please install it with "
                 "`pip install pymongo`."
             )
-        client: MongoClient = MongoClient(connection_string)
+        client: MongoClient = MongoClient(connection_string, driver=DriverInfo(name="Langchain", version=version('langchain')))
         db_name, collection_name = namespace.split(".")
         collection = client[db_name][collection_name]
         return cls(collection, embedding, **kwargs)

--- a/libs/langchain/langchain/vectorstores/mongodb_atlas.py
+++ b/libs/langchain/langchain/vectorstores/mongodb_atlas.py
@@ -110,7 +110,10 @@ class MongoDBAtlasVectorSearch(VectorStore):
                 "Could not import pymongo, please install it with "
                 "`pip install pymongo`."
             )
-        client: MongoClient = MongoClient(connection_string, driver=DriverInfo(name="Langchain", version=version('langchain')))
+        client: MongoClient = MongoClient(
+            connection_string,
+            driver=DriverInfo(name="Langchain", version=version("langchain")),
+        )
         db_name, collection_name = namespace.split(".")
         collection = client[db_name][collection_name]
         return cls(collection, embedding, **kwargs)


### PR DESCRIPTION
**Description**
MongoDB drivers are used in various flavors and languages. Making sure we exercise our due diligence in identifying the "origin" of the library calls makes it best to understand how our Atlas servers get accessed.

