### PR TITLE
(Astra DB/Cassandra) Minor clarification about dependencies in the demo notebook

### DIFF
--- a/docs/docs/integrations/vectorstores/astradb.ipynb
+++ b/docs/docs/integrations/vectorstores/astradb.ipynb
@@ -25,9 +25,7 @@
    "id": "dbe7c156-0413-47e3-9237-4769c4248869",
    "metadata": {},
    "source": [
-    "Use of the integration requires the following Python package.\n",
-    "\n",
-    "_Note: depending on your LangChain setup, you may need to install other dependencies needed for this demo._"
+    "Use of the integration requires the following Python package."
    ]
   },
   {
@@ -38,6 +36,15 @@
    "outputs": [],
    "source": [
     "!pip install --quiet \"astrapy>=0.5.3\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2453d83a-bc8f-41e1-a692-befe4dd90156",
+   "metadata": {},
+   "source": [
+    "_Note: depending on your LangChain setup, you may need to install/upgrade other dependencies needed for this demo_\n",
+    "_(specifically, recent versions of `datasets` `openai` `pypdf` and `tiktoken` are required)._"
    ]
   },
   {


### PR DESCRIPTION
This PR helps developers trying the Astra DB / Cassandra vector store quickstart notebook by making it clear what other dependencies are required.
