### PR TITLE
Added ability to pass arguments to the Playwright browser

### DIFF
--- a/libs/langchain/langchain/tools/playwright/utils.py
+++ b/libs/langchain/langchain/tools/playwright/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Coroutine, List, TypeVar
+from typing import TYPE_CHECKING, Any, Coroutine, List, Optional, TypeVar
 
 if TYPE_CHECKING:
     from playwright.async_api import Browser as AsyncBrowser
@@ -51,7 +51,7 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
 
 
 def create_async_playwright_browser(
-    headless: bool = True, args: List[str] = None
+    headless: bool = True, args: Optional[List[str]] = None
 ) -> AsyncBrowser:
     """
     Create an async playwright browser.
@@ -70,7 +70,7 @@ def create_async_playwright_browser(
 
 
 def create_sync_playwright_browser(
-    headless: bool = True, args: List[str] = None
+    headless: bool = True, args: Optional[List[str]] = None
 ) -> SyncBrowser:
     """
     Create a playwright browser.

--- a/libs/langchain/langchain/tools/playwright/utils.py
+++ b/libs/langchain/langchain/tools/playwright/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Coroutine, TypeVar, List
+from typing import TYPE_CHECKING, Any, Coroutine, List, TypeVar
 
 if TYPE_CHECKING:
     from playwright.async_api import Browser as AsyncBrowser
@@ -50,7 +50,9 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def create_async_playwright_browser(headless: bool = True, args: List[str] = None) -> AsyncBrowser:
+def create_async_playwright_browser(
+    headless: bool = True, args: List[str] = None
+) -> AsyncBrowser:
     """
     Create an async playwright browser.
 
@@ -67,7 +69,9 @@ def create_async_playwright_browser(headless: bool = True, args: List[str] = Non
     return run_async(browser.chromium.launch(headless=headless, args=args))
 
 
-def create_sync_playwright_browser(headless: bool = True, args: List[str] = None) -> SyncBrowser:
+def create_sync_playwright_browser(
+    headless: bool = True, args: List[str] = None
+) -> SyncBrowser:
     """
     Create a playwright browser.
 

--- a/libs/langchain/langchain/tools/playwright/utils.py
+++ b/libs/langchain/langchain/tools/playwright/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Coroutine, TypeVar
+from typing import TYPE_CHECKING, Any, Coroutine, TypeVar, List
 
 if TYPE_CHECKING:
     from playwright.async_api import Browser as AsyncBrowser
@@ -50,12 +50,13 @@ def get_current_page(browser: SyncBrowser) -> SyncPage:
     return context.pages[-1]
 
 
-def create_async_playwright_browser(headless: bool = True) -> AsyncBrowser:
+def create_async_playwright_browser(headless: bool = True, args: List[str] = None) -> AsyncBrowser:
     """
     Create an async playwright browser.
 
     Args:
         headless: Whether to run the browser in headless mode. Defaults to True.
+        args: arguments to pass to browser.chromium.launch
 
     Returns:
         AsyncBrowser: The playwright browser.
@@ -63,15 +64,16 @@ def create_async_playwright_browser(headless: bool = True) -> AsyncBrowser:
     from playwright.async_api import async_playwright
 
     browser = run_async(async_playwright().start())
-    return run_async(browser.chromium.launch(headless=headless))
+    return run_async(browser.chromium.launch(headless=headless, args=args))
 
 
-def create_sync_playwright_browser(headless: bool = True) -> SyncBrowser:
+def create_sync_playwright_browser(headless: bool = True, args: List[str] = None) -> SyncBrowser:
     """
     Create a playwright browser.
 
     Args:
         headless: Whether to run the browser in headless mode. Defaults to True.
+        args: arguments to pass to browser.chromium.launch
 
     Returns:
         SyncBrowser: The playwright browser.
@@ -79,7 +81,7 @@ def create_sync_playwright_browser(headless: bool = True) -> SyncBrowser:
     from playwright.sync_api import sync_playwright
 
     browser = sync_playwright().start()
-    return browser.chromium.launch(headless=headless)
+    return browser.chromium.launch(headless=headless, args=args)
 
 
 T = TypeVar("T")


### PR DESCRIPTION
  - **Description:** Enhanced `create_sync_playwright_browser` and `create_async_playwright_browser` functions to accept a list of arguments. These arguments are now forwarded to `browser.chromium.launch()` for customizable browser instantiation.
  - **Issue:** #13143
  - **Dependencies:** None
  - **Tag maintainer:** @eyurtsev,
  - **Twitter handle:** Dr_Bearden