### PR TITLE
Improve youtube tool prompting and arg parsing

### DIFF
--- a/libs/langchain/langchain/tools/youtube/search.py
+++ b/libs/langchain/langchain/tools/youtube/search.py
@@ -47,7 +47,7 @@ class YouTubeSearchTool(BaseTool):
         values = query.split(",")
         query = values[0]
         if not num_results and len(values) > 1:
-            # if num_results was None and the number of results was passed in the query string
+            # if num_results was passed in the query string
             num_results = int(values[1])
         elif not num_results:
             # if num_results was not provided

--- a/libs/langchain/langchain/tools/youtube/search.py
+++ b/libs/langchain/langchain/tools/youtube/search.py
@@ -20,17 +20,17 @@ class YouTubeSearchTool(BaseTool):
 
     name: str = "youtube_search"
     description: str = (
-        "search for youtube videos associated with a person. "
+        "search for youtube videos associated with a topic or a person. "
         "the input to this tool should be a comma separated list, "
-        "the first part contains a person name and the second a "
-        "number that is the maximum number of video results "
-        "to return aka num_results. the second part is optional"
+        "the first part contains the name of a topic or person name "
+        "and the second a number that is the maximum number of video "
+        "results  to return aka num_results. the second part is optional"
     )
 
-    def _search(self, person: str, num_results: int) -> str:
+    def _search(self, query: str, num_results: int) -> str:
         from youtube_search import YoutubeSearch
 
-        results = YoutubeSearch(person, num_results).to_json()
+        results = YoutubeSearch(query, num_results).to_json()
         data = json.loads(results)
         url_suffix_list = [
             "https://www.youtube.com" + video["url_suffix"] for video in data["videos"]
@@ -40,13 +40,17 @@ class YouTubeSearchTool(BaseTool):
     def _run(
         self,
         query: str,
+        num_results: Optional[int] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Use the tool."""
         values = query.split(",")
-        person = values[0]
-        if len(values) > 1:
+        query = values[0]
+        if not num_results and len(values) > 1:
+            # if num_results was None and the number of results was passed in the query string
             num_results = int(values[1])
-        else:
+        elif not num_results:
+            # if num_results was not provided
             num_results = 2
-        return self._search(person, num_results)
+
+        return self._search(query, num_results)


### PR DESCRIPTION
**Description:** 

The youtube search tool does not work well with openai function calling.  OpenAI infers that it should provide two arguments: `topic: str` and `num_results: int`, but the tool accepts a single argument `query: str` which it tries to parse into a topic and num_results.

This is a backwards compatible fix that adds an argument `num_results: Optional[int]` to the tool while maintaining the previous parsing logic if the argument is not provided.

This also improves the prompting for the tool.  Previously the tool description mentioned only that you could search for a person on YouTube, when in fact the tool can be used to search for any topic.

- **Issue:** N/A
- **Dependencies:** N/A
- **Tag maintainer:** @baskaryan 
