### PR TITLE
Typo fix to quickstart.mdx

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -103,7 +103,7 @@ There are two types of language models:
 Strings are simple, but what exactly are messages? The base message interface is defined by `BaseMessage`, which has two required attributes:
 
 - `content`: The content of the message. Usually a string.
-- `role`: The entity from which the `BaeMessage` is coming.
+- `role`: The entity from which the `BaseMessage` is coming.
 
 LangChain provides several objects to easily distinguish between different roles:
 


### PR DESCRIPTION
- **Description:** I fixed a very small typo in the quickstart docs (BaeMessage -> BaseMessage)

