### PR TITLE
Mask API key for SerpApi.com tools

### DIFF
--- a/docs/docs/integrations/tools/google_scholar.ipynb
+++ b/docs/docs/integrations/tools/google_scholar.ipynb
@@ -6,7 +6,8 @@
    "source": [
     "# Google Scholar\n",
     "\n",
-    "This notebook goes through how to use Google Scholar Tool"
+    "This notebook goes through how to use Google Scholar Tool\n",
+    "Add SERPAPI_API_KEY to your .env file (see the tests/README.md)."
    ]
   },
   {
@@ -38,7 +39,6 @@
    "outputs": [],
    "source": [
     "from langchain.tools.google_scholar import GoogleScholarQueryRun\n",
-    "from langchain.utilities.google_scholar import GoogleScholarAPIWrapper\n",
     "import os"
    ]
   },
@@ -59,8 +59,7 @@
     }
    ],
    "source": [
-    "os.environ[\"SERP_API_KEY\"] = \"\"\n",
-    "tool = GoogleScholarQueryRun(api_wrapper=GoogleScholarAPIWrapper())\n",
+    "tool = GoogleScholarQueryRun()\n",
     "tool.run(\"LLM Models\")"
    ]
   },

--- a/libs/langchain/langchain/tools/google_scholar/tool.py
+++ b/libs/langchain/langchain/tools/google_scholar/tool.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from langchain.callbacks.manager import CallbackManagerForToolRun
-from langchain.tools.base import BaseTool
+from langchain.tools.base import BaseTool, Field
 from langchain.utilities.google_scholar import GoogleScholarAPIWrapper
 
 
@@ -17,7 +17,9 @@ class GoogleScholarQueryRun(BaseTool):
         "research papers from Google Scholar"
         "Input should be a search query."
     )
-    api_wrapper: GoogleScholarAPIWrapper
+    api_wrapper: GoogleScholarAPIWrapper = Field(
+        default_factory=GoogleScholarAPIWrapper
+    )
 
     def _run(
         self,

--- a/libs/langchain/tests/integration_tests/.env.example
+++ b/libs/langchain/tests/integration_tests/.env.example
@@ -2,6 +2,9 @@
 # your api key from https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
+# SerpApi
+# Your api key from https://serpapi.com/manage-api-key
+SERPAPI_API_KEY=your_serpapi_api_key_here
 
 # searchapi
 # your api key from https://www.searchapi.io/

--- a/libs/langchain/tests/integration_tests/utilities/test_google_scholar.py
+++ b/libs/langchain/tests/integration_tests/utilities/test_google_scholar.py
@@ -1,0 +1,56 @@
+"""Integration test for SerpApi's Google Scholar API."""
+from typing import cast
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+
+from langchain.pydantic_v1 import SecretStr
+from langchain.utilities import GoogleScholarAPIWrapper
+
+
+def test_api_key_is_secret_string() -> None:
+    chain = GoogleScholarAPIWrapper(serp_api_key="secret-api-key")
+    assert isinstance(chain.serp_api_key, SecretStr)
+
+
+def test_api_key_is_secret_none(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("SERPAPI_API_KEY")
+
+    with pytest.raises(ValueError):
+        chain = GoogleScholarAPIWrapper()
+        assert chain.serpapi_api_key is None
+
+
+def test_api_key_masked_when_passed_from_env(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    """Test initialization with an API key provided via an env variable"""
+    monkeypatch.setenv("SERPAPI_API_KEY", "secret-api-key")
+    chain = GoogleScholarAPIWrapper()
+    print(chain.serp_api_key, end="")
+    captured = capsys.readouterr()
+
+    assert captured.out == "**********"
+    assert str(chain.serp_api_key) == "**********"
+    assert "secret-api-key" not in repr(chain.serp_api_key)
+    assert "secret-api-key" not in repr(chain)
+
+
+def test_api_key_masked_when_passed_via_constructor(
+    capsys: CaptureFixture,
+) -> None:
+    """Test initialization with an API key provided via the initializer"""
+    chain = GoogleScholarAPIWrapper(serp_api_key="secret-api-key")
+    print(chain.serp_api_key, end="")
+    captured = capsys.readouterr()
+
+    assert captured.out == "**********"
+    assert str(chain.serp_api_key) == "**********"
+    assert "secret-api-key" not in repr(chain.serp_api_key)
+    assert "secret-api-key" not in repr(chain)
+
+
+def test_uses_actual_secret_value_from_secretstr() -> None:
+    """Test that actual secret is retrieved using `.get_secret_value()`."""
+    chain = GoogleScholarAPIWrapper(serp_api_key="secret-api-key")
+    assert cast(SecretStr, chain.serp_api_key).get_secret_value() == "secret-api-key"

--- a/libs/langchain/tests/integration_tests/utilities/test_serpapi.py
+++ b/libs/langchain/tests/integration_tests/utilities/test_serpapi.py
@@ -1,9 +1,70 @@
-"""Integration test for SerpAPI."""
+"""Integration test for SerpApi."""
+from typing import cast
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+
+from langchain.pydantic_v1 import SecretStr
 from langchain.utilities import SerpAPIWrapper
 
 
-def test_call() -> None:
+def test_google_call() -> None:
     """Test that call gives the correct answer."""
     chain = SerpAPIWrapper()
     output = chain.run("What was Obama's first name?")
     assert output == "Barack Hussein Obama II"
+
+
+def test_bing_call() -> None:
+    """Test that call gives the correct answer."""
+    chain = SerpAPIWrapper(params={"engine": "bing"})
+    output = chain.run("What was Obama's first name?")
+    assert "Barack Hussein Obama II" in output
+
+
+def test_api_key_is_secret_string() -> None:
+    chain = SerpAPIWrapper(serpapi_api_key="secret-api-key")
+    assert isinstance(chain.serpapi_api_key, SecretStr)
+
+
+def test_api_key_is_secret_none(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("SERPAPI_API_KEY")
+
+    with pytest.raises(ValueError):
+        chain = SerpAPIWrapper()
+        assert chain.serpapi_api_key is None
+
+
+def test_api_key_masked_when_passed_from_env(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    """Test initialization with an API key provided via an env variable"""
+    monkeypatch.setenv("SERPAPI_API_KEY", "secret-api-key")
+    chain = SerpAPIWrapper()
+    print(chain.serpapi_api_key, end="")
+    captured = capsys.readouterr()
+
+    assert captured.out == "**********"
+    assert str(chain.serpapi_api_key) == "**********"
+    assert "secret-api-key" not in repr(chain.serpapi_api_key)
+    assert "secret-api-key" not in repr(chain)
+
+
+def test_api_key_masked_when_passed_via_constructor(
+    capsys: CaptureFixture,
+) -> None:
+    """Test initialization with an API key provided via the initializer"""
+    chain = SerpAPIWrapper(serpapi_api_key="secret-api-key")
+    print(chain.serpapi_api_key, end="")
+    captured = capsys.readouterr()
+
+    assert captured.out == "**********"
+    assert str(chain.serpapi_api_key) == "**********"
+    assert "secret-api-key" not in repr(chain.serpapi_api_key)
+    assert "secret-api-key" not in repr(chain)
+
+
+def test_uses_actual_secret_value_from_secretstr() -> None:
+    """Test that actual secret is retrieved using `.get_secret_value()`."""
+    chain = SerpAPIWrapper(serpapi_api_key="secret-api-key")
+    assert cast(SecretStr, chain.serpapi_api_key).get_secret_value() == "secret-api-key"


### PR DESCRIPTION
* **Description:** Mask API key for SerpApi.com tools.
  * Mask SerpApi API key in `SerpAPIWrapper` and `GoogleScholarAPIWrapper`
  * Use [`SerpApiClient#pagination`](https://github.com/serpapi/google-search-results-python#pagination-using-iterator) in the Google Scholar Search Tool (related to https://github.com/langchain-ai/langchain/issues/11513)
* **Issue:** https://github.com/langchain-ai/langchain/issues/12165
* **Tag maintainer:** @eyurtsev

@keenborder786, please review the changes in `GoogleScholarAPIWrapper`.