### PR TITLE
fleet_context docs update

### DIFF
--- a/docs/docs/integrations/retrievers/fleet_context.ipynb
+++ b/docs/docs/integrations/retrievers/fleet_context.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install langchain openai pandas faiss-cpu # faiss-gpu for CUDA supported GPU"
+    "!pip install langchain fleet-context openai pandas faiss-cpu # faiss-gpu for CUDA supported GPU"
    ]
   },
   {
@@ -41,15 +41,17 @@
     "from langchain.schema.vectorstore import VectorStore\n",
     "from langchain.vectorstores import FAISS\n",
     "\n",
+    "from context import download_embeddings",
+    "\n",
     "\n",
     "def load_fleet_retriever(\n",
-    "    url: str,\n",
+    "    library_name: str,\n",
     "    *,\n",
     "    vectorstore_cls: Type[VectorStore] = FAISS,\n",
     "    docstore: Optional[BaseStore] = None,\n",
     "    **kwargs: Any,\n",
     "):\n",
-    "    df = pd.read_parquet(url)\n",
+    "    df = download_embeddings(library_name)\n",
     "    vectorstore = _populate_vectorstore(df, vectorstore_cls)\n",
     "    if docstore is None:\n",
     "        return vectorstore.as_retriever(**kwargs)\n",
@@ -116,9 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vecstore_retriever = load_fleet_retriever(\n",
-    "    \"https://www.dropbox.com/scl/fi/4rescpkrg9970s3huz47l/libraries_langchain_release.parquet?rlkey=283knw4wamezfwiidgpgptkep&dl=1\",\n",
-    ")"
+    "vecstore_retriever = load_fleet_retriever(\"langchain\")"
    ]
   },
   {

--- a/docs/docs/integrations/retrievers/fleet_context.ipynb
+++ b/docs/docs/integrations/retrievers/fleet_context.ipynb
@@ -41,17 +41,14 @@
     "from langchain.schema.vectorstore import VectorStore\n",
     "from langchain.vectorstores import FAISS\n",
     "\n",
-    "from context import download_embeddings",
-    "\n",
     "\n",
     "def load_fleet_retriever(\n",
-    "    library_name: str,\n",
+    "    df: pd.DataFrame,\n",
     "    *,\n",
     "    vectorstore_cls: Type[VectorStore] = FAISS,\n",
     "    docstore: Optional[BaseStore] = None,\n",
     "    **kwargs: Any,\n",
     "):\n",
-    "    df = download_embeddings(library_name)\n",
     "    vectorstore = _populate_vectorstore(df, vectorstore_cls)\n",
     "    if docstore is None:\n",
     "        return vectorstore.as_retriever(**kwargs)\n",
@@ -108,7 +105,10 @@
    "source": [
     "## Retriever chunks\n",
     "\n",
-    "As part of their embedding process, the Fleet AI team first chunked long documents before embedding them. This means the vectors correspond to sections of pages in the LangChain docs, not entire pages. By default, when we spin up a retriever from these embeddings, we'll be retrieving these embedded chunks:"
+    "As part of their embedding process, the Fleet AI team first chunked long documents before embedding them. This means the vectors correspond to sections of pages in the LangChain docs, not entire pages. By default, when we spin up a retriever from these embeddings, we'll be retrieving these embedded chunks.",
+    "\n",
+    "\n",
+    "We will be using Fleet Context's `download_embeddings()` to grab Langchain's documentation embeddings. You can view all supported libraries' documentation at https://fleet.so/context."
    ]
   },
   {
@@ -118,7 +118,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vecstore_retriever = load_fleet_retriever(\"langchain\")"
+    "from context import download_embeddings\n",
+    "\n",
+    "df = download_embeddings(\"langchain\")\n",
+    "vecstore_retriever = load_fleet_retriever(df)"
    ]
   },
   {


### PR DESCRIPTION

  - **Description:** Changed the fleet_context documentation to use `context.download_embeddings()` from the latest release from our package. More details here: https://github.com/fleet-ai/context/tree/main#api
  - **Issue:** n/a
  - **Dependencies:** n/a
  - **Tag maintainer:** @baskaryan 
  - **Twitter handle:** @andrewthezhou
