### PR TITLE
Comprehend moderation: update to default threshold and callback property for prompt safety

### DIFF
--- a/libs/experimental/langchain_experimental/comprehend_moderation/base_moderation_config.py
+++ b/libs/experimental/langchain_experimental/comprehend_moderation/base_moderation_config.py
@@ -29,7 +29,7 @@ class ModerationToxicityConfig(BaseModel):
 
 
 class ModerationPromptSafetyConfig(BaseModel):
-    threshold: float = 0.5
+    threshold: float = 0.8
     """
     Threshold for Prompt Safety classification
     confidence score, defaults to 0.5 i.e. 50%

--- a/libs/experimental/langchain_experimental/comprehend_moderation/prompt_safety.py
+++ b/libs/experimental/langchain_experimental/comprehend_moderation/prompt_safety.py
@@ -78,7 +78,9 @@ class ComprehendPromptSafety:
             if unsafe_prompt:
                 self.moderation_beacon["moderation_status"] = "LABELS_FOUND"
             asyncio.create_task(
-                self.callback.on_after_prompt_safety(self.moderation_beacon, self.unique_id)
+                self.callback.on_after_prompt_safety(
+                    self.moderation_beacon, self.unique_id
+                )
             )
 
         if unsafe_prompt:


### PR DESCRIPTION
This PR has following minor updates:

1. Updated the callback block for `prompt safety`. The callback property name was incorrect.
2. Updated the default threshold for prompt safety from 0.5 to 0.8.

