### PR TITLE
Fix "additional_kwargs["arguments"] already exists in this message, but with a different type." for Azure openai API. 

### DIFF
--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -120,7 +120,17 @@ class BaseMessageChunk(BaseMessage):
     def _merge_kwargs_dict(
         self, left: Dict[str, Any], right: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Merge additional_kwargs from another BaseMessageChunk into this one."""
+        """Merge additional_kwargs from another BaseMessageChunk into this one,
+        handling specific scenarios where a key exists in both dictionaries
+        but has a value of None in 'left'. In such cases, the method uses the
+        value from 'right' for that key in the merged dictionary.
+
+        Example:
+        If left = {"function_call": {"arguments": None}} and
+        right = {"function_call": {"arguments": "{\n"}}
+        then, after merging, for the key "function_call", the value from 'right' is used,
+        resulting in merged = {"function_call": {"arguments": "{\n"}}.
+        """
         merged = left.copy()
         for k, v in right.items():
             if k not in merged:

--- a/libs/langchain/langchain/schema/messages.py
+++ b/libs/langchain/langchain/schema/messages.py
@@ -125,6 +125,8 @@ class BaseMessageChunk(BaseMessage):
         for k, v in right.items():
             if k not in merged:
                 merged[k] = v
+            elif merged[k] is None:
+                merged[k] = v
             elif type(merged[k]) != type(v):
                 raise ValueError(
                     f'additional_kwargs["{k}"] already exists in this message,'

--- a/libs/langchain/tests/unit_tests/schema/test_messages.py
+++ b/libs/langchain/tests/unit_tests/schema/test_messages.py
@@ -31,6 +31,9 @@ def test_message_chunks() -> None:
             content="", additional_kwargs={"function_call": {"name": "web_search"}}
         )
         + AIMessageChunk(
+            content="", additional_kwargs={"function_call": {"arguments": None}}
+        )
+        + AIMessageChunk(
             content="", additional_kwargs={"function_call": {"arguments": "{\n"}}
         )
         + AIMessageChunk(


### PR DESCRIPTION

  - **Description:** This PR addresses an issue with the OpenAI API streaming response, where initially the key (arguments) is provided but the value is None. Subsequently, it updates with {"arguments": "{\n"}, leading to a type inconsistency that causes an exception. The specific error encountered is ValueError: additional_kwargs["arguments"] already exists in this message, but with a different type. This change aims to resolve this inconsistency and ensure smooth API interactions.
  - **Issue:** None.
  - **Dependencies:** None.
  - **Tag maintainer:** @eyurtsev,
  