### PR TITLE
PGVector needs to close its connection if it is garbage collected

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -147,6 +147,10 @@ class PGVector(VectorStore):
         self.create_tables_if_not_exists()
         self.create_collection()
 
+    def __del__(self) -> None:
+        if self._conn:
+            self._conn.close()
+
     @property
     def embeddings(self) -> Embeddings:
         return self.embedding_function


### PR DESCRIPTION
Description: Without this change, PGVector was using lots of connections and would eventually be unable to keep making connections. 
Issue: Resolves #9696 
Dependencies: None 
Twitter: @sumukhsridhara 

More context: 

The `__del__` method gets called when the object is about to be garbage collected.  Without this, users (like us) have run into errors like the below 

```
psql: FATAL: remaining connection slots are reserved for non-replication superuser connections
```


<!-- Thank you for contributing to LangChain!

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
