### PR TITLE
docs: align custom_tool document headers

### DIFF
--- a/docs/docs/modules/agents/tools/custom_tools.ipynb
+++ b/docs/docs/modules/agents/tools/custom_tools.ipynb
@@ -29,7 +29,8 @@
    "outputs": [],
    "source": [
     "# Import things that are needed generically\n",
-    "from langchain.chains import LLMMathChain\nfrom langchain.utilities import SerpAPIWrapper\n",
+    "from langchain.chains import LLMMathChain\n",
+    "from langchain.utilities import SerpAPIWrapper\n",
     "from langchain.agents import AgentType, initialize_agent\n",
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.tools import BaseTool, StructuredTool, Tool, tool"
@@ -230,7 +231,7 @@
    "id": "6f12eaf0",
    "metadata": {},
    "source": [
-    "### Subclassing the BaseTool class\n",
+    "### Subclassing the BaseTool\n",
     "\n",
     "You can also directly subclass `BaseTool`. This is useful if you want more control over the instance variables or if you want to propagate callbacks to nested chains or other tools."
    ]
@@ -367,7 +368,7 @@
    "id": "824eaf74",
    "metadata": {},
    "source": [
-    "## Using the `tool` decorator\n",
+    "### Using the decorator\n",
     "\n",
     "To make it easier to define custom tools, a `@tool` decorator is provided. This decorator can be used to quickly create a `Tool` from a simple function. The decorator uses the function name as the tool name by default, but this can be overridden by passing a string as the first argument. Additionally, the decorator will use the function's docstring as the tool's description."
    ]
@@ -531,7 +532,7 @@
    "id": "fb0a38eb",
    "metadata": {},
    "source": [
-    "## Subclassing the BaseTool\n",
+    "### Subclassing the BaseTool\n",
     "\n",
     "The BaseTool automatically infers the schema from the `_run` method's signature."
    ]
@@ -624,7 +625,7 @@
    "id": "7d68b0ac",
    "metadata": {},
    "source": [
-    "## Using the decorator\n",
+    "### Using the decorator\n",
     "\n",
     "The `tool` decorator creates a structured tool automatically if the signature has multiple arguments."
    ]
@@ -774,7 +775,8 @@
     "from langchain.agents import initialize_agent, Tool\n",
     "from langchain.agents import AgentType\n",
     "from langchain.llms import OpenAI\n",
-    "from langchain.chains import LLMMathChain\nfrom langchain.utilities import SerpAPIWrapper\n",
+    "from langchain.chains import LLMMathChain\n",
+    "from langchain.utilities import SerpAPIWrapper\n",
     "\n",
     "search = SerpAPIWrapper()\n",
     "tools = [\n",


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

On the [Defining Custom Tools](https://python.langchain.com/docs/modules/agents/tools/custom_tools) page, there's a 'Subclassing the BaseTool class' paragraph under the 'Completely New Tools - String Input and Output' header. Also there's another 'Subclassing the BaseTool' paragraph under no header, which I think may belong to the 'Custom Structured Tools' header.

Another thing is, there's a 'Using the tool decorator' and a 'Using the decorator' paragraph, I think should belong to 'Completely New Tools - String Input and Output' and 'Custom Structured Tools' separately.

This PR moves those paragraphs to corresponding headers.