### PR TITLE
Add missing filter to max_marginal_relevance_search inner call to max_marginal_relevance_search_by_vector

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -762,6 +762,7 @@ class PGVector(VectorStore):
             k=k,
             fetch_k=fetch_k,
             lambda_mult=lambda_mult,
+            filter=filter
             **kwargs,
         )
 

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -762,8 +762,7 @@ class PGVector(VectorStore):
             k=k,
             fetch_k=fetch_k,
             lambda_mult=lambda_mult,
-            filter=filter
-            **kwargs,
+            filter=filter**kwargs,
         )
 
     def max_marginal_relevance_search_with_score(

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -762,7 +762,8 @@ class PGVector(VectorStore):
             k=k,
             fetch_k=fetch_k,
             lambda_mult=lambda_mult,
-            filter=filter**kwargs,
+            filter=filter,
+            **kwargs,
         )
 
     def max_marginal_relevance_search_with_score(


### PR DESCRIPTION
When calling max_marginal_relevance_search from PGVector the filter param is not carried over to max_marginal_relevance_search_by_vector