### PR TITLE
Fix serialization issue in Matching Engine Vector Store

### DIFF
--- a/libs/langchain/langchain/vectorstores/matching_engine.py
+++ b/libs/langchain/langchain/vectorstores/matching_engine.py
@@ -137,7 +137,7 @@ class MatchingEngine(VectorStore):
             json_: dict = {"id": id, "embedding": embedding}
             if metadatas is not None:
                 json_["metadata"] = metadatas[idx]
-            jsons.append(json)
+            jsons.append(json_)
             self._upload_to_gcs(text, f"documents/{id}")
 
         logger.debug(f"Uploaded {len(ids)} documents to GCS.")


### PR DESCRIPTION
  - **Description:** Fixed a serialization issue in the add_texts method of the Matching Engine Vector Store caused by a typo, leading to an attempt to serialize the json module itself.
  - **Issue:** #12154 
  - **Dependencies:** ./.
  - **Tag maintainer:**