### PR TITLE
Ollama pass kwargs as options instead of top

### DIFF
--- a/libs/langchain/langchain/llms/ollama.py
+++ b/libs/langchain/langchain/llms/ollama.py
@@ -129,11 +129,19 @@ class _OllamaCommon(BaseLanguageModel):
         elif stop is None:
             stop = []
         params = {**self._default_params}
-        params["options"] = {
-            **params["options"],
-            "stop": stop,
-            **kwargs,
-        }
+
+        if "model" in kwargs:
+            params["model"] = kwargs["model"]
+
+        if "options" in kwargs:
+            params["options"] = kwargs["options"]
+        else:
+            params["options"] = {
+                **params["options"],
+                "stop": stop,
+                **kwargs,
+            }
+
         response = requests.post(
             url=f"{self.base_url}/api/generate/",
             headers={"Content-Type": "application/json"},

--- a/libs/langchain/langchain/llms/ollama.py
+++ b/libs/langchain/langchain/llms/ollama.py
@@ -128,7 +128,12 @@ class _OllamaCommon(BaseLanguageModel):
             stop = self.stop
         elif stop is None:
             stop = []
-        params = {**self._default_params, "stop": stop, **kwargs}
+        params = {**self._default_params}
+        params["options"] = {
+            **params["options"],
+            "stop": stop,
+            **kwargs,
+        }
         response = requests.post(
             url=f"{self.base_url}/api/generate/",
             headers={"Content-Type": "application/json"},


### PR DESCRIPTION
Noticed params are really in `options` instead while reviewing #12895 