### PR TITLE
Add missing doc key to metadata field in AzureSearch Vectorstore

### DIFF
--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -277,8 +277,6 @@ class AzureSearch(VectorStore):
             # Encoding key for Azure Search valid characters
             key = base64.urlsafe_b64encode(bytes(key, "utf-8")).decode("ascii")
             metadata = metadatas[i] if metadatas else {}
-            # Add doc key to metadata
-            metadata[FIELDS_ID] = key
             # Add data to index
             # Additional metadata to fields mapping
             doc = {
@@ -393,10 +391,21 @@ class AzureSearch(VectorStore):
             (
                 Document(
                     page_content=result.pop(FIELDS_CONTENT),
-                    metadata=json.loads(result[FIELDS_METADATA])
-                    if FIELDS_METADATA in result
-                    else {
-                        k: v for k, v in result.items() if k != FIELDS_CONTENT_VECTOR
+                    metadata={
+                        **(
+                            {FIELDS_ID: result.pop(FIELDS_ID)}
+                            if FIELDS_ID in result
+                            else {}
+                        ),
+                        **(
+                            json.loads(result[FIELDS_METADATA])
+                            if FIELDS_METADATA in result
+                            else {
+                                k: v
+                                for k, v in result.items()
+                                if k != FIELDS_CONTENT_VECTOR
+                            }
+                        ),
                     },
                 ),
                 float(result["@search.score"]),
@@ -454,10 +463,21 @@ class AzureSearch(VectorStore):
             (
                 Document(
                     page_content=result.pop(FIELDS_CONTENT),
-                    metadata=json.loads(result[FIELDS_METADATA])
-                    if FIELDS_METADATA in result
-                    else {
-                        k: v for k, v in result.items() if k != FIELDS_CONTENT_VECTOR
+                    metadata={
+                        **(
+                            {FIELDS_ID: result.pop(FIELDS_ID)}
+                            if FIELDS_ID in result
+                            else {}
+                        ),
+                        **(
+                            json.loads(result[FIELDS_METADATA])
+                            if FIELDS_METADATA in result
+                            else {
+                                k: v
+                                for k, v in result.items()
+                                if k != FIELDS_CONTENT_VECTOR
+                            }
+                        ),
                     },
                 ),
                 float(result["@search.score"]),
@@ -549,6 +569,11 @@ class AzureSearch(VectorStore):
                 Document(
                     page_content=result.pop(FIELDS_CONTENT),
                     metadata={
+                        **(
+                            {FIELDS_ID: result.pop(FIELDS_ID)}
+                            if FIELDS_ID in result
+                            else {}
+                        ),
                         **(
                             json.loads(result[FIELDS_METADATA])
                             if FIELDS_METADATA in result

--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -277,6 +277,8 @@ class AzureSearch(VectorStore):
             # Encoding key for Azure Search valid characters
             key = base64.urlsafe_b64encode(bytes(key, "utf-8")).decode("ascii")
             metadata = metadatas[i] if metadatas else {}
+            # Add doc key to metadata
+            metadata[FIELDS_ID] = key
             # Add data to index
             # Additional metadata to fields mapping
             doc = {


### PR DESCRIPTION
  - **Description:** Adds doc key to metadata field when adding document to Azure Search.
  - **Issue:** -,
  - **Dependencies:** -,
  - **Tag maintainer:** @eyurtsev,
  - **Twitter handle:** @finnless

Right now the document key with the name FIELDS_ID is not included in the FIELDS_METADATA field, and therefore is not included in the Document returned from a query. This is really annoying if you want to be able to modify that item in the vectorstore.

Other's thoughts on this are welcome.