### PR TITLE
Pass filters and other search_kwargs through retrieval chain at query time (#9195)

### DIFF
--- a/docs/docs/use_cases/question_answering/vector_db_qa.mdx
+++ b/docs/docs/use_cases/question_answering/vector_db_qa.mdx
@@ -203,6 +203,73 @@ result["source_documents"]
 
 </CodeOutputBlock>
 
+For hybrid searches, we can also pass `search_qwargs` with the query, rather than determining them during construction of the retriever.
+This way we can ingest different documents with custom metadata, then query on the metadata in addition to the usual similarity. (Hence, 'hybrid' search.)
+
+First, let's ingest some more documents into the same Chroma database, using metadata to record the author of each document:
+
+```python
+more_documents = TextLoader("../../paul_graham_essay.txt").load()
+for doc in more_documents:
+    doc.metadata.update({ "author": "paulgraham" })
+more_texts = text_splitter.split_documents(more_documents)
+docsearch.add_documents(more_texts)
+```
+
+Then, we can pass a filter to the retriever to only retrieve documents with a specific author:
+
+```python
+search_kwargs = { "filter": { "author": "paulgraham" }}
+query = "What is this speech about?"
+result = qa({"query": query, "search_kwargs": search_kwargs})
+print("Result:")
+print(result["result"])
+
+# Let's use a set to get a simple, unique list of sources.
+sources = set([d.metadata["source"] for d in result["source_documents"]])
+print("Sources:")
+print(sources)
+```
+
+Note how only the document that was ingested with the metadata matching the filter is represented in the source documents.
+
+<CodeOutputBlock lang="python">
+
+```
+Result:
+ This speech is about how to choose what to work on and how to start a startup.
+Sources:
+{'../../paul_graham_essay.txt'}
+```
+
+</CodeOutputBlock>
+
+Try this again, *without* the filter:
+
+```python
+result = qa({"query": query})  # No filter
+
+print("Result:")
+print(result["result"])
+sources = set([d.metadata["source"] for d in result["source_documents"]])
+print("Sources:")
+print(sources)
+```
+
+Without the filter, both documents were retrieved, but the state-of-the-union document was considered more relevant.
+
+<CodeOutputBlock lang="python">
+
+```
+Result:
+ This speech is about the state of the economy during the pandemic and how to deal with inflation.
+Sources:
+{'../../state_of_the_union.txt', '../../paul_graham_essay.txt'}
+
+```
+
+</CodeOutputBlock>
+
 Alternatively, if our document have a "source" metadata key, we can use the `RetrievalQAWithSourcesChain` to cite our sources:
 
 ```python

--- a/libs/langchain/langchain/chains/conversational_retrieval/base.py
+++ b/libs/langchain/langchain/chains/conversational_retrieval/base.py
@@ -302,8 +302,10 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain):
         run_manager: CallbackManagerForChainRun,
     ) -> List[Document]:
         """Get docs."""
+
+        search_kwargs = inputs.get("search_kwargs", None)
         docs = self.retriever.get_relevant_documents(
-            question, callbacks=run_manager.get_child()
+            question, callbacks=run_manager.get_child(), search_kwargs=search_kwargs
         )
         return self._reduce_tokens_below_limit(docs)
 
@@ -315,8 +317,9 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain):
         run_manager: AsyncCallbackManagerForChainRun,
     ) -> List[Document]:
         """Get docs."""
+        search_kwargs = inputs.get("search_kwargs", None)
         docs = await self.retriever.aget_relevant_documents(
-            question, callbacks=run_manager.get_child()
+            question, callbacks=run_manager.get_child(), search_kwargs=search_kwargs
         )
         return self._reduce_tokens_below_limit(docs)
 

--- a/libs/langchain/langchain/chains/retrieval_qa/base.py
+++ b/libs/langchain/langchain/chains/retrieval_qa/base.py
@@ -311,6 +311,7 @@ class VectorDBQA(BaseRetrievalQA):
         question: str,
         *,
         run_manager: AsyncCallbackManagerForChainRun,
+        search_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[Document]:
         """Get docs."""
         raise NotImplementedError("VectorDBQA does not support async")

--- a/libs/langchain/langchain/chains/retrieval_qa/base.py
+++ b/libs/langchain/langchain/chains/retrieval_qa/base.py
@@ -139,7 +139,9 @@ class BaseRetrievalQA(Chain):
             "run_manager" in inspect.signature(self._get_docs).parameters
         )
         if accepts_run_manager:
-            docs = self._get_docs(question, run_manager=_run_manager, search_kwargs=search_kwargs)
+            docs = self._get_docs(
+                question, run_manager=_run_manager, search_kwargs=search_kwargs
+            )
         else:
             docs = self._get_docs(question, search_kwargs=search_kwargs)  # type: ignore[call-arg]
         answer = self.combine_documents_chain.run(
@@ -184,7 +186,9 @@ class BaseRetrievalQA(Chain):
             "run_manager" in inspect.signature(self._aget_docs).parameters
         )
         if accepts_run_manager:
-            docs = await self._aget_docs(question, run_manager=_run_manager, search_kwargs=search_kwargs)
+            docs = await self._aget_docs(
+                question, run_manager=_run_manager, search_kwargs=search_kwargs
+            )
         else:
             docs = await self._aget_docs(question, search_kwargs=search_kwargs)  # type: ignore[call-arg]
         answer = await self.combine_documents_chain.arun(

--- a/libs/langchain/langchain/schema/vectorstore.py
+++ b/libs/langchain/langchain/schema/vectorstore.py
@@ -651,7 +651,11 @@ class VectorStoreRetriever(BaseRetriever):
         return values
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, search_kwargs = None
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun,
+        search_kwargs=None,
     ) -> List[Document]:
         merged_search_kwargs: dict = self.search_kwargs
         if search_kwargs is not None:
@@ -659,7 +663,7 @@ class VectorStoreRetriever(BaseRetriever):
                 merged_search_kwargs = self.search_kwargs.copy()
                 merged_search_kwargs.update(search_kwargs)
             else:
-                merged_search_kwargs = search_kwargs 
+                merged_search_kwargs = search_kwargs
         if self.search_type == "similarity":
             docs = self.vectorstore.similarity_search(query, **merged_search_kwargs)
         elif self.search_type == "similarity_score_threshold":
@@ -678,7 +682,11 @@ class VectorStoreRetriever(BaseRetriever):
         return docs
 
     async def _aget_relevant_documents(
-        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun, search_kwargs = None
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun,
+        search_kwargs=None,
     ) -> List[Document]:
         merged_search_kwargs: dict = self.search_kwargs
         if search_kwargs is not None:

--- a/libs/langchain/langchain/schema/vectorstore.py
+++ b/libs/langchain/langchain/schema/vectorstore.py
@@ -655,7 +655,7 @@ class VectorStoreRetriever(BaseRetriever):
         query: str,
         *,
         run_manager: CallbackManagerForRetrieverRun,
-        search_kwargs=None,
+        search_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[Document]:
         merged_search_kwargs: dict = self.search_kwargs
         if search_kwargs is not None:
@@ -686,7 +686,7 @@ class VectorStoreRetriever(BaseRetriever):
         query: str,
         *,
         run_manager: AsyncCallbackManagerForRetrieverRun,
-        search_kwargs=None,
+        search_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[Document]:
         merged_search_kwargs: dict = self.search_kwargs
         if search_kwargs is not None:

--- a/libs/langchain/langchain/schema/vectorstore.py
+++ b/libs/langchain/langchain/schema/vectorstore.py
@@ -651,42 +651,56 @@ class VectorStoreRetriever(BaseRetriever):
         return values
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, search_kwargs = None
     ) -> List[Document]:
+        merged_search_kwargs: dict = self.search_kwargs
+        if search_kwargs is not None:
+            if self.search_kwargs is not None:
+                merged_search_kwargs = self.search_kwargs.copy()
+                merged_search_kwargs.update(search_kwargs)
+            else:
+                merged_search_kwargs = search_kwargs 
         if self.search_type == "similarity":
-            docs = self.vectorstore.similarity_search(query, **self.search_kwargs)
+            docs = self.vectorstore.similarity_search(query, **merged_search_kwargs)
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 self.vectorstore.similarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **merged_search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = self.vectorstore.max_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **merged_search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
 
     async def _aget_relevant_documents(
-        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun, search_kwargs = None
     ) -> List[Document]:
+        merged_search_kwargs: dict = self.search_kwargs
+        if search_kwargs is not None:
+            if self.search_kwargs is not None:
+                merged_search_kwargs = self.search_kwargs.copy()
+                merged_search_kwargs.update(search_kwargs)
+            else:
+                merged_search_kwargs = search_kwargs
         if self.search_type == "similarity":
             docs = await self.vectorstore.asimilarity_search(
-                query, **self.search_kwargs
+                query, **merged_search_kwargs
             )
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 await self.vectorstore.asimilarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **merged_search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = await self.vectorstore.amax_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **merged_search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")

--- a/libs/langchain/langchain/vectorstores/redis/base.py
+++ b/libs/langchain/langchain/vectorstores/redis/base.py
@@ -1420,28 +1420,40 @@ class RedisVectorStoreRetriever(VectorStoreRetriever):
         arbitrary_types_allowed = True
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun,
+        search_kwargs: Optional[Dict[str, Any]] = None,
     ) -> List[Document]:
+        merged_search_kwargs: dict = self.search_kwargs
+        if search_kwargs is not None:
+            if self.search_kwargs is not None:
+                merged_search_kwargs = self.search_kwargs.copy()
+                merged_search_kwargs.update(search_kwargs)
+            else:
+                merged_search_kwargs = search_kwargs
+
         if self.search_type == "similarity":
-            docs = self.vectorstore.similarity_search(query, **self.search_kwargs)
+            docs = self.vectorstore.similarity_search(query, **merged_search_kwargs)
         elif self.search_type == "similarity_distance_threshold":
             if self.search_kwargs["distance_threshold"] is None:
                 raise ValueError(
                     "distance_threshold must be provided for "
                     + "similarity_distance_threshold retriever"
                 )
-            docs = self.vectorstore.similarity_search(query, **self.search_kwargs)
+            docs = self.vectorstore.similarity_search(query, **merged_search_kwargs)
 
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 self.vectorstore.similarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **merged_search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = self.vectorstore.max_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **merged_search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")


### PR DESCRIPTION
**Description:**

Adds the ability to pass filters and other search_kwargs to a vector store when *calling* a conversational retriever . (#9195)

Existing functionality allows setting the search_kwargs only when *constructing* the retriever - which limits the ability to create a single retriever then alter filters during chat sessions.

My use case (backed by the others in the Issue) is to be able to ingest documents into a vector database with different 'tags', then during a long-running RAG0-based chat session, specify the tags to filter ingested documents on with each question.

The existing support for search_kwargs is still useful - args like 'k', the number of results, are likely to be definitely determined at construction time. Hence this fix *merges* the search_kwargs provided with the query with any that were set during construction. That is: query-time values *override* construction-time values, but only those with the same key. Hence you can set 'k', 'score_threshold', etc, during construction, then pass in a custom 'filter' with the query. 

Query-time search_kwargs are provided in the `inputs` parameter, but are not listed in the input_keys, since they are not mandatory. This preserves compatibility, and makes sense, given the search_kwargs, very much are inputs.

The documentation is updated with an example on the vector_db_qa.mdx page.


Details on the rationale behind this PR:

1. Many of the vector store implementations take “filter” as a parameter in their similarity_search (chroma, elastic, pgvector, open_search), and some, like weaviate, take more complex kwargs, accepting in them “where_filter”.
 We need a way to pass down arguments for these parameters from the original __call__ method on the base chain, in such a way as they get to - and only to - the vector stores that can use them.

2. The generic VectorStoreRetriever has a search_kwargs field (Pydantic) that is intended to hold just this sort of parameter, and passes it into similarty_search() (and other search methods). But is limited in that it can only be set when the VectorRetriever is constructed.  

3. The abstract BaseRetriever._get_relevant_documents doesn’t take extra args, but BaseRetriever allows for the concrete implementations in different retrievers to have extra args (which only just slightly freaks me out as an old OO Java programmer :)). BaseRetriever detects this and sets _expects_other_args to True which causes it to pass on kwargs from its get_relevant_documents() method to the specific retrievers _get_relevant_documents implementation. 

So… to get our filter down where it’s needed, we need to get it in a more dynamic search_kwargs dictionary, and get that merged with the one passed in from VectorStoreRetriever, without interfering with the base retriever.

For this we need one change to VectoreStoreRetriever:
- add a search_kwargs dictionary to its _get_relevant_documents method
- merge that with the base search kwargs (dictionary update - to override, treating the construction-time search_kwargs as defaults

We have to change one more class though, to get the search_kwargs into the get_relevant_documents incoming kwargs parameter: we can do that in ConversationalRetrievalChain._get_docs which currently does not call it with any kwargs. But  _get_docs just happens to get the inputs dictionary from which history and question are taken, which is passed in from the original __call__. Hence we:
- Modifiy ConversationalRetrievalChain._get_docs to retrieve the search_kwargs, if there are any, from the inputs[] list and add them to the kwargs going into get_relevant_documents

So, we can put search_kwargs in inputs- because they are just as much inputs as the question and chat_history, then we can extract them in _get_docs and pass them into  get_relevant_documents, and we get them where they need to go with only two changes.

The modifications needed for base retrievers is slightly different, but similar enough.

**Issue:**
Passing filter through ConversationalRetrievalChain to the underlying vector store  #9195


**Tag maintainer:** @baskaryan 