### PR TITLE
Add limit_to_domains to APIChain based tools

### DIFF
--- a/libs/langchain/langchain/agents/load_tools.py
+++ b/libs/langchain/langchain/agents/load_tools.py
@@ -163,7 +163,10 @@ _LLM_TOOLS: Dict[str, Callable[[BaseLanguageModel], BaseTool]] = {
 def _get_news_api(llm: BaseLanguageModel, **kwargs: Any) -> BaseTool:
     news_api_key = kwargs["news_api_key"]
     chain = APIChain.from_llm_and_api_docs(
-        llm, news_docs.NEWS_DOCS, headers={"X-Api-Key": news_api_key}
+        llm,
+        news_docs.NEWS_DOCS,
+        headers={"X-Api-Key": news_api_key},
+        limit_to_domains=["https://newsapi.org/"],
     )
     return Tool(
         name="News-API",

--- a/libs/langchain/langchain/agents/load_tools.py
+++ b/libs/langchain/langchain/agents/load_tools.py
@@ -347,8 +347,7 @@ def _get_google_cloud_texttospeech(**kwargs: Any) -> BaseTool:
 
 _EXTRA_LLM_TOOLS: Dict[
     str,
-    Tuple[Callable[[Arg(BaseLanguageModel, "llm"),
-                    KwArg(Any)], BaseTool], List[str]],
+    Tuple[Callable[[Arg(BaseLanguageModel, "llm"), KwArg(Any)], BaseTool], List[str]],
 ] = {
     "news-api": (_get_news_api, ["news_api_key"]),
     "tmdb-api": (_get_tmdb_api, ["tmdb_bearer_token"]),

--- a/libs/langchain/langchain/agents/load_tools.py
+++ b/libs/langchain/langchain/agents/load_tools.py
@@ -142,7 +142,11 @@ def _get_llm_math(llm: BaseLanguageModel) -> BaseTool:
 
 
 def _get_open_meteo_api(llm: BaseLanguageModel) -> BaseTool:
-    chain = APIChain.from_llm_and_api_docs(llm, open_meteo_docs.OPEN_METEO_DOCS)
+    chain = APIChain.from_llm_and_api_docs(
+        llm,
+        open_meteo_docs.OPEN_METEO_DOCS,
+        limit_to_domains=["https://api.open-meteo.com/"],
+    )
     return Tool(
         name="Open-Meteo-API",
         description="Useful for when you want to get weather information from the OpenMeteo API. The input should be a question in natural language that this API can answer.",
@@ -174,6 +178,7 @@ def _get_tmdb_api(llm: BaseLanguageModel, **kwargs: Any) -> BaseTool:
         llm,
         tmdb_docs.TMDB_DOCS,
         headers={"Authorization": f"Bearer {tmdb_bearer_token}"},
+        limit_to_domains=["https://api.themoviedb.org/"],
     )
     return Tool(
         name="TMDB-API",
@@ -188,6 +193,7 @@ def _get_podcast_api(llm: BaseLanguageModel, **kwargs: Any) -> BaseTool:
         llm,
         podcast_docs.PODCAST_DOCS,
         headers={"X-ListenAPI-Key": listen_api_key},
+        limit_to_domains=["https://listen-api.listennotes.com/"],
     )
     return Tool(
         name="Podcast-API",
@@ -338,7 +344,8 @@ def _get_google_cloud_texttospeech(**kwargs: Any) -> BaseTool:
 
 _EXTRA_LLM_TOOLS: Dict[
     str,
-    Tuple[Callable[[Arg(BaseLanguageModel, "llm"), KwArg(Any)], BaseTool], List[str]],
+    Tuple[Callable[[Arg(BaseLanguageModel, "llm"),
+                    KwArg(Any)], BaseTool], List[str]],
 ] = {
     "news-api": (_get_news_api, ["news_api_key"]),
     "tmdb-api": (_get_tmdb_api, ["tmdb_bearer_token"]),


### PR DESCRIPTION
  - **Description:**  Adds `limit_to_domains` param to the APIChain based tools  (open_meteo, TMDB, podcast_docs, and news_api)
  - **Issue:** I didn't open an issue, but after upgrading to 0.0.328 using these tools would throw an error.
  - **Dependencies:** N/A
  - **Tag maintainer:** @baskaryan 
  
  
 **Note**: I included the trailing / simply because the docs here did https://github.com/langchain-ai/langchain/blob/fc886cc3039c2479bb13287f48fcbdb097a44c70/docs/docs/use_cases/apis.ipynb#L246 , but I checked the code and it is using `urlparse`. SoI followed the docs since it comes down to stylee.