### PR TITLE
Fix the bedrock documentation

### DIFF
--- a/docs/docs/integrations/llms/bedrock.ipynb
+++ b/docs/docs/integrations/llms/bedrock.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.llms import Bedrock\n",
+    "from langchain.llms.bedrock import Bedrock\n",
     "\n",
     "llm = Bedrock(\n",
     "    credentials_profile_name=\"bedrock-admin\", model_id=\"amazon.titan-text-express-v1\"\n",
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.llms import Bedrock\n",
+    "from langchain.llms.bedrock import Bedrock\n",
     "from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler\n",
     "\n",
     "\n",


### PR DESCRIPTION
  - **Description:** As I was working through bedrock llm for RetreivalQAChain I noticed that the imports were wrong and is corrected for documentation.
  - **Issue:** As mentioned in the documentation for langchain. The import says from `langchain.llms import Bedrock` which should rather be `from langchain.llms.bedrock import Bedrock`
  - **Dependencies:** None
