### PR TITLE
fix cli release

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -108,8 +108,7 @@ jobs:
         # TODO: add more in-depth pre-publish tests after testing that importing works
         run: |
           pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
+            --extra-index-url https://test.pypi.org/simple/ \
             "$PKG_NAME==$VERSION"
 
           # Replace all dashes in the package name with underscores,

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -97,13 +97,13 @@ jobs:
         env:
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
           VERSION: ${{ needs.build.outputs.version }}
-        # Here we specify:
-        # - The test PyPI index as the *primary* index, meaning that it takes priority.
-        # - The regular PyPI index as an extra index, so that any dependencies that
+        # Here we use:
+        # - The default regular PyPI index as the *primary* index, meaning 
+        #   that it takes priority (https://pypi.org/simple)
+        # - The test PyPI index as an extra index, so that any dependencies that
         #   are not found on test PyPI can be resolved and installed anyway.
-        #
-        # Without the former, we might install the wrong langchain release.
-        # Without the latter, we might not be able to install langchain's dependencies.
+        #   (https://test.pypi.org/simple). This will include the PKG_NAME==VERSION
+        #   package because VERSION will not have been uploaded to regular PyPI yet.
         #
         # TODO: add more in-depth pre-publish tests after testing that importing works
         run: |


### PR DESCRIPTION
My thought is that the ==version would prevent pip from finding the package on regular [pypi.org](http://pypi.org/), so it would look at [test.pypi.org](http://test.pypi.org/) for that. Otherwise it'll pull package from [pypi.org](http://pypi.org/) (e.g. sub deps)

Right now, the cli release is failing because it's going to test.pypi.org by default, so it finds this incorrect FASTAPI package instead of the real one: https://test.pypi.org/project/FASTAPI/