### PR TITLE
`Yi` model from `01.ai` , example

### DIFF
--- a/docs/docs/integrations/llms/huggingface_hub.ipynb
+++ b/docs/docs/integrations/llms/huggingface_hub.ipynb
@@ -101,8 +101,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains import LLMChain\n",
-    "from langchain.prompts import PromptTemplate"
+    "from langchain.prompts import PromptTemplate\n",
+    "from langchain.chains import LLMChain"
    ]
   },
   {
@@ -398,9 +398,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e3871376-ed0e-49a8-8d9b-7e60dbbd2b35",
+   "metadata": {},
+   "source": [
+    "### `Yi` series models, by `01.ai`\n",
+    "\n",
+    ">The `Yi` series models are large language models trained from scratch by developers at [01.ai](https://01.ai/). The first public release contains two bilingual(English/Chinese) base models with the parameter sizes of 6B(`Yi-6B`) and 34B(`Yi-34B`). Both of them are trained with 4K sequence length and can be extended to 32K during inference time. The `Yi-6B-200K` and `Yi-34B-200K` are base model with 200K context length.\n",
+    "\n",
+    "Here we test the [Yi-34B](https://huggingface.co/01-ai/Yi-34B) model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1c9d3125-3f50-48b8-93b6-b50847207afa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_id = \"01-ai/Yi-34B\""
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dd67c1e-1efc-4def-bde4-2e5265725303",
+   "id": "8b661069-8229-4850-9f13-c4ca28c0c96b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = HuggingFaceHub(\n",
+    "    repo_id=repo_id, model_kwargs={\"max_length\": 128, \"temperature\": 0.5}\n",
+    ")\n",
+    "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
+    "print(llm_chain.run(question))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd6f3edc-9f97-47a6-ab2c-116756babbe6",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Added an example with new soa `Yi` model to `HuggingFace-hub` notebook