### PR TITLE
Set openai_api_type to be passed as values to leverage azure openai's default

### DIFF
--- a/libs/langchain/langchain/embeddings/azure_openai.py
+++ b/libs/langchain/langchain/embeddings/azure_openai.py
@@ -133,7 +133,7 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
                 "azure_ad_token": values["azure_ad_token"],
                 "azure_ad_token_provider": values["azure_ad_token_provider"],
                 "organization": values["openai_organization"],
-                "openai_api_type":values["openai_api_type"],
+                "api_type":values["openai_api_type"],
                 "base_url": values["openai_api_base"],
                 "timeout": values["request_timeout"],
                 "max_retries": values["max_retries"],

--- a/libs/langchain/langchain/embeddings/azure_openai.py
+++ b/libs/langchain/langchain/embeddings/azure_openai.py
@@ -133,7 +133,7 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
                 "azure_ad_token": values["azure_ad_token"],
                 "azure_ad_token_provider": values["azure_ad_token_provider"],
                 "organization": values["openai_organization"],
-                "api_type":values["openai_api_type"],
+                "api_type": values["openai_api_type"],
                 "base_url": values["openai_api_base"],
                 "timeout": values["request_timeout"],
                 "max_retries": values["max_retries"],

--- a/libs/langchain/langchain/embeddings/azure_openai.py
+++ b/libs/langchain/langchain/embeddings/azure_openai.py
@@ -133,6 +133,7 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
                 "azure_ad_token": values["azure_ad_token"],
                 "azure_ad_token_provider": values["azure_ad_token_provider"],
                 "organization": values["openai_organization"],
+                "openai_api_type":values["openai_api_type"],
                 "base_url": values["openai_api_base"],
                 "timeout": values["request_timeout"],
                 "max_retries": values["max_retries"],


### PR DESCRIPTION
  - **Description:** 
Recently, this was introduced: https://github.com/langchain-ai/langchain/pull/10707

However, the changes are not taking effect unless you create the AzureOpenAIEmbeddings class with parameter openai_api_type="azure".. In the code it's already getting set by default if openAI version > 1 but it's never getting accessed when the embed_documents is actually happening because it was never surfaced up
  - **Issue:** Not so much an issue but leveraging existing default code of api type of azure when used.
  - **Twitter handle:** @kevin_neum