### PR TITLE
docs integration cards site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -193,7 +193,7 @@ const config = {
                 label: "Dependents",
               },
               {
-                label: "Integration Cards",
+                label: "Integrations Hub",
                 href: "https://integrations.langchain.com/",
               },
               {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -193,6 +193,10 @@ const config = {
                 label: "Dependents",
               },
               {
+                label: "Integration Cards",
+                href: "https://integrations.langchain.com/",
+              },
+              {
                 to: "/docs/additional_resources/tutorials",
                 label: "Tutorials"
               },


### PR DESCRIPTION
The `Integrations` site is hidden now.
I've added it into the `More` menu.
The name is `Integration Cards` otherwise, it is confused with the `Integrations` menu. 
