### PR TITLE
Passthrough kwargs in runnable lambda

### DIFF
--- a/libs/langchain/langchain/schema/runnable/base.py
+++ b/libs/langchain/langchain/schema/runnable/base.py
@@ -2437,8 +2437,11 @@ class RunnableLambda(Runnable[Input, Output]):
         input: Input,
         run_manager: CallbackManagerForChainRun,
         config: RunnableConfig,
+        **kwargs: Any,
     ) -> Output:
-        output = call_func_with_variable_args(self.func, input, config, run_manager)
+        output = call_func_with_variable_args(
+            self.func, input, config, run_manager, **kwargs
+        )
         # If the output is a runnable, invoke it
         if isinstance(output, Runnable):
             recursion_limit = config["recursion_limit"]
@@ -2461,9 +2464,10 @@ class RunnableLambda(Runnable[Input, Output]):
         input: Input,
         run_manager: AsyncCallbackManagerForChainRun,
         config: RunnableConfig,
+        **kwargs: Any,
     ) -> Output:
         output = await acall_func_with_variable_args(
-            self.afunc, input, config, run_manager
+            self.afunc, input, config, run_manager, **kwargs
         )
         # If the output is a runnable, invoke it
         if isinstance(output, Runnable):
@@ -2509,6 +2513,7 @@ class RunnableLambda(Runnable[Input, Output]):
                 self._invoke,
                 input,
                 self._config(config, self.func),
+                **kwargs,
             )
         else:
             raise TypeError(
@@ -2528,6 +2533,7 @@ class RunnableLambda(Runnable[Input, Output]):
                 self._ainvoke,
                 input,
                 self._config(config, self.afunc),
+                **kwargs,
             )
         else:
             # Delegating to super implementation of ainvoke.


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
