### PR TITLE
updated `clickup` example

### DIFF
--- a/docs/docs/integrations/toolkits/clickup.ipynb
+++ b/docs/docs/integrations/toolkits/clickup.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ClickUp Langchain Toolkit"
+    "# ClickUp\n",
+    "\n",
+    ">[ClickUp](https://clickup.com/) is an all-in-one productivity platform that provides small and large teams across industries with flexible and customizable work management solutions, tools, and functions. \n",
+    "\n",
+    ">It is a cloud-based project management solution for businesses of all sizes featuring communication and collaboration tools to help achieve organizational goals."
    ]
   },
   {
@@ -27,14 +31,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Init"
+    "## Initializing"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Get Authenticated\n",
+    "### Get Authenticated\n",
     "1. Create a [ClickUp App](https://help.clickup.com/hc/en-us/articles/6303422883095-Create-your-own-app-with-the-ClickUp-API)\n",
     "2. Follow [these steps](https://clickup.com/api/developer-portal/authentication/) to get your `client_id` and `client_secret`.\n",
     "    - *Suggestion: use `https://google.com` as the redirect_uri. This is what we assume in the defaults for this toolkit.*\n",
@@ -112,18 +116,7 @@
    "source": [
     "access_token = ClickupAPIWrapper.get_access_token(\n",
     "    oauth_client_id, oauth_client_secret, code\n",
-    ")\n",
-    "\n",
-    "if access_token is not None:\n",
-    "    print(\"Copy/paste this code, into the next cell so you can reuse it!\")\n",
-    "    print(access_token)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create Toolkit"
+    ")"
    ]
   },
   {
@@ -142,12 +135,6 @@
     }
    ],
    "source": [
-    "# Set your access token here\n",
-    "access_token = \"12345678_myaccesstokengoeshere123\"\n",
-    "access_token = (\n",
-    "    \"81928627_c009bf122ccf36ec3ba3e0ef748b07042c5e4217260042004a5934540cb61527\"\n",
-    ")\n",
-    "\n",
     "# Init toolkit\n",
     "clickup_api_wrapper = ClickupAPIWrapper(access_token=access_token)\n",
     "toolkit = ClickupToolkit.from_clickup_api_wrapper(clickup_api_wrapper)\n",
@@ -160,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create Agent"
+    "### Create Agent"
    ]
   },
   {
@@ -180,7 +167,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Run"
+    "## Use an Agent"
    ]
   },
   {
@@ -203,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Navigation\n",
+    "### Navigation\n",
     "You can get the teams, folder and spaces your user has access to"
    ]
   },
@@ -287,7 +274,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Task Operations\n",
+    "### Task Operations\n",
     "You can get, ask question about tasks and update them"
    ]
   },
@@ -594,7 +581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creation\n",
+    "### Creation\n",
     "You can create tasks, lists and folders"
    ]
   },
@@ -778,7 +765,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Multi-Step Tasks"
+    "## Multi-Step Tasks"
    ]
   },
   {
@@ -848,7 +835,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "clickup-copilot",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -862,10 +849,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
-  },
-  "orig_nbformat": 4
+   "version": "3.10.12"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- Fixed headers (was more then 1 Titles)
- Removed security token value. It was OK to have it, because it is temporary token, but the automatic security swippers raise warnings on that.
- Added `ClickUp` service description and link.