### PR TITLE
updated `Activeloop DeepMemory` notebook

### DIFF
--- a/docs/docs/integrations/retrievers/Activeloop DeepMemory+LangChain.ipynb
+++ b/docs/docs/integrations/retrievers/Activeloop DeepMemory+LangChain.ipynb
@@ -21,25 +21,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this tutorial we will parse `DeepLake` documentation, and create a RAG system that could answer the question from the docs. \n",
-    "\n",
-    "The tutorial has several parts:\n",
-    "1. [Dataset creation](#1-dataset-creation)\n",
-    "2. [Generating synthetic queries and training Deep Memory](#2-generating-synthetic-queries-and-training-deep_memory)\n",
-    "3. [Evaluating Deep Memory performance](#3-evaluating-deep-memory-performance)\n",
-    "    - 3.1 [using Deep Memory recall@10 metric](#31-using-deepmemory-recall10-metric)\n",
-    "    - 3.2 [using RAGs](#32-deepmemory--ragas)\n",
-    "    - 3.3 [Deep_Memory inference](#33-deepmemory-inference)\n",
-    "    - 3.4 [Deep_Memory cost savings](#34-cost-savings)"
+    "For this tutorial we will parse `DeepLake` documentation, and create a RAG system that could answer the question from the docs. \n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
-    "<a name=\"dataset-creation\"></a>\n",
     "## 1. Dataset Creation"
    ]
   },
@@ -235,7 +223,6 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "<a name=\"training\"></a>\n",
     "## 2. Generating synthetic queries and training Deep Memory "
    ]
   },
@@ -428,7 +415,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"evaluation\"></a>\n",
     "## 3. Evaluating Deep Memory performance"
    ]
   },
@@ -441,19 +427,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
-    "<a name=\"recall@10\"></a>\n",
-    "### 3.1 using Deep Memory recall@10 metric"
+    "### 3.1 Deep Memory evaluation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the beginning we can use deep_memory's builtin evaluation method. it can be done easily in a few lines of code:"
+    "For the beginning we can use deep_memory's builtin evaluation method. \n",
+    "It calculates several `recall` metrics.\n",
+    "It can be done easily in a few lines of code."
    ]
   },
   {
@@ -501,11 +486,8 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
-    "<a name=\"ragas\"></a>\n",
     "### 3.2 Deep Memory + RAGas"
    ]
   },
@@ -610,7 +592,6 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "<a name=\"inference\"></a>\n",
     "### 3.3 Deep Memory Inference"
    ]
   },
@@ -689,7 +670,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a name=\"cost\"></a>\n",
     "### 3.4 Deep Memory cost savings"
    ]
   },

--- a/docs/docs/integrations/retrievers/Activeloop DeepMemory+LangChain.ipynb
+++ b/docs/docs/integrations/retrievers/Activeloop DeepMemory+LangChain.ipynb
@@ -4,14 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Activeloop DeepLake's DeepMemory + LangChain + ragas or how to get +27% on RAG recall."
+    "# Activeloop Deep Memory"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Retrieval-Augmented Generators (RAGs) have recently gained significant attention. As advanced RAG techniques and agents emerge, they expand the potential of what RAGs can accomplish. However, several challenges may limit the integration of RAGs into production. The primary factors to consider when implementing RAGs in production settings are accuracy (recall), cost, and latency. For basic use cases, OpenAI's Ada model paired with a naive similarity search can produce satisfactory results. Yet, for higher accuracy or recall during searches, one might need to employ advanced retrieval techniques. These methods might involve varying data chunk sizes, rewriting queries multiple times, and more, potentially increasing latency and costs.  [Activeloop's](https://activeloop.ai/) [Deep Memory](https://www.activeloop.ai/resources/use-deep-memory-to-boost-rag-apps-accuracy-by-up-to-22/) a feature available to Activeloop Deep Lake users, addresses these issuea by introducing a tiny neural network layer trained to match user queries with relevant data from a corpus. While this addition incurs minimal latency during search, it can boost retrieval accuracy by up to 27\n",
+    ">[Activeloop Deep Memory](https://docs.activeloop.ai/performance-features/deep-memory) is a suite of tools that enables you to optimize your Vector Store for your use-case and achieve higher accuracy in your LLM apps.\n",
+    "\n",
+    "`Retrieval-Augmented Generatation` (`RAG`) has recently gained significant attention. As advanced RAG techniques and agents emerge, they expand the potential of what RAGs can accomplish. However, several challenges may limit the integration of RAGs into production. The primary factors to consider when implementing RAGs in production settings are accuracy (recall), cost, and latency. For basic use cases, OpenAI's Ada model paired with a naive similarity search can produce satisfactory results. Yet, for higher accuracy or recall during searches, one might need to employ advanced retrieval techniques. These methods might involve varying data chunk sizes, rewriting queries multiple times, and more, potentially increasing latency and costs.  [Activeloop's](https://activeloop.ai/) [Deep Memory](https://www.activeloop.ai/resources/use-deep-memory-to-boost-rag-apps-accuracy-by-up-to-22/) a feature available to `Activeloop Deep Lake` users, addresses these issuea by introducing a tiny neural network layer trained to match user queries with relevant data from a corpus. While this addition incurs minimal latency during search, it can boost retrieval accuracy by up to 27\n",
     "% and remains cost-effective and simple to use, without requiring any additional advanced rag techniques.\n"
    ]
   },
@@ -19,21 +21,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this tutorial we will parse deeplake documentation, and create a RAG system that could answer the question from the docs. \n",
+    "For this tutorial we will parse `DeepLake` documentation, and create a RAG system that could answer the question from the docs. \n",
     "\n",
-    "The tutorial can be divided into several parts:\n",
-    "1. [Dataset creation and uploading](#1-dataset-creation)\n",
-    "2. [Generating synthetic queries and training deep_memory](#2-generating-synthetic-queries-and-training-deep_memory)\n",
-    "3. [Evaluating deep memory performance](#3-evaluating-deep-memory-performance)\n",
-    "    - 3.1 [using deepmemory recall@10 metric](#31-using-deepmemory-recall10-metric)\n",
-    "    - 3.2 [using ragas](#32-deepmemory--ragas)\n",
-    "    - 3.3 [deep_memory inference](#33-deepmemory-inference)\n",
-    "    - 3.4 [deep_memory cost savings](#34-cost-savings)"
+    "The tutorial has several parts:\n",
+    "1. [Dataset creation](#1-dataset-creation)\n",
+    "2. [Generating synthetic queries and training Deep Memory](#2-generating-synthetic-queries-and-training-deep_memory)\n",
+    "3. [Evaluating Deep Memory performance](#3-evaluating-deep-memory-performance)\n",
+    "    - 3.1 [using Deep Memory recall@10 metric](#31-using-deepmemory-recall10-metric)\n",
+    "    - 3.2 [using RAGs](#32-deepmemory--ragas)\n",
+    "    - 3.3 [Deep_Memory inference](#33-deepmemory-inference)\n",
+    "    - 3.4 [Deep_Memory cost savings](#34-cost-savings)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "<a name=\"dataset-creation\"></a>\n",
     "## 1. Dataset Creation"
@@ -227,10 +231,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "<a name=\"training\"></a>\n",
-    "## 2. Generating synthetic queries and training deep_memory "
+    "## 2. Generating synthetic queries and training Deep Memory "
    ]
   },
   {
@@ -423,7 +429,7 @@
    "metadata": {},
    "source": [
     "<a name=\"evaluation\"></a>\n",
-    "## 3. Evaluating deep memory performance"
+    "## 3. Evaluating Deep Memory performance"
    ]
   },
   {
@@ -435,10 +441,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "<a name=\"recall@10\"></a>\n",
-    "### 3.1 using deepmemory recall@10 metric"
+    "### 3.1 using Deep Memory recall@10 metric"
    ]
   },
   {
@@ -493,10 +501,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "<a name=\"ragas\"></a>\n",
-    "### 3.2 DeepMemory + ragas"
+    "### 3.2 Deep Memory + RAGas"
    ]
   },
   {
@@ -596,10 +606,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "<a name=\"inference\"></a>\n",
-    "### 3.3 DeepMemory Inference"
+    "### 3.3 Deep Memory Inference"
    ]
   },
   {
@@ -678,7 +690,7 @@
    "metadata": {},
    "source": [
     "<a name=\"cost\"></a>\n",
-    "### 3.4 Cost savings"
+    "### 3.4 Deep Memory cost savings"
    ]
   },
   {
@@ -691,7 +703,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -705,10 +717,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
-  },
-  "orig_nbformat": 4
+   "version": "3.10.12"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- Fixed the title of the notebook. It created an ugly ToC element as `Activeloop DeepLake's DeepMemory + LangChain + ragas or how to get +27% on RAG recall.`
- Added Activeloop description
- improved consistency in text
- fixed ToC (it was using HTML tagas that break left-side in-page ToC). Now in-page ToC works
