### PR TITLE
updated `semadb` example

### DIFF
--- a/docs/docs/integrations/vectorstores/semadb.ipynb
+++ b/docs/docs/integrations/vectorstores/semadb.ipynb
@@ -7,11 +7,11 @@
    "source": [
     "# SemaDB\n",
     "\n",
-    "> SemaDB is a no fuss vector similarity database for building AI applications. The hosted SemaDB Cloud offers a no fuss developer experience to get started.\n",
+    "> [SemaDB](https://www.semafind.com/products/semadb) from [SemaFind](https://www.semafind.com) is a no fuss vector similarity database for building AI applications. The hosted `SemaDB Cloud` offers a no fuss developer experience to get started.\n",
     "\n",
     "The full documentation of the API along with examples and an interactive playground is available on [RapidAPI](https://rapidapi.com/semafind-semadb/api/semadb).\n",
     "\n",
-    "This notebook demonstrates how the `langchain` wrapper can be used with SemaDB Cloud."
+    "This notebook demonstrates usage of the `SemaDB Cloud` vector store."
    ]
   },
   {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -493,6 +493,10 @@
       "destination": "/docs/integrations/providers/astradb"
     },
     {
+      "source": "/docs/integrations/vectorstores/vectorstores/semadb",
+      "destination": "/docs/integrations/vectorstores/semadb"
+    },
+    {
       "source": "/docs/integrations/vectorstores/cassandra",
       "destination": "/docs/integrations/vectorstores/astradb"
     },


### PR DESCRIPTION
- the `SemaDB` notebook was placed in additional subfolder which breaks the vectorstore ToC. I moved file up, removed this unnecessary subfolder; updated the `vercel.json` with rerouting for the new URL
- Added SemaDB description and link
- improved text consistency