### PR TITLE
VertexAI LLM count_tokens method requires list of prompts

### DIFF
--- a/libs/langchain/langchain/llms/vertexai.py
+++ b/libs/langchain/langchain/llms/vertexai.py
@@ -288,7 +288,7 @@ class VertexAI(_VertexAICommon, BaseLLM):
             The integer number of tokens in the text.
         """
         try:
-            result = self.client.count_tokens(text)
+            result = self.client.count_tokens([text])
         except AttributeError:
             raise NotImplementedError(
                 "Your google-cloud-aiplatform version didn't implement count_tokens."


### PR DESCRIPTION
I encountered this during summarization with VertexAI. I was receiving an INVALID_ARGUMENT error, as it was trying to send a list of about 17000 single characters. 

The [count_tokens method](https://github.com/googleapis/python-aiplatform/blob/main/vertexai/language_models/_language_models.py#L658) made available by Google takes in a list of prompts. It does not fail for small texts, but it does for longer documents because the argument list will be exceeding Googles allowed limit. Enforcing the list type makes it work successfully.

This change will cast the input text to count to a list of that single text so that the input format is always correct.

[Twitter](https://www.x.com/stijn_tratsaert)