### PR TITLE
Introduce `search_kwargs` for Custom Parameters in BingSearchAPIWrapper

### DIFF
--- a/libs/langchain/langchain/utilities/bing_search.py
+++ b/libs/langchain/langchain/utilities/bing_search.py
@@ -3,11 +3,11 @@
 In order to set this up, follow instructions at:
 https://levelup.gitconnected.com/api-tutorial-how-to-use-bing-web-search-api-in-python-4165d5592a7e
 """
-from typing import Dict, List
+from typing import Dict, List, Any
 
 import requests
 
-from langchain.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain.pydantic_v1 import BaseModel, Extra, root_validator, Field
 from langchain.utils import get_from_dict_or_env
 
 
@@ -21,6 +21,8 @@ class BingSearchAPIWrapper(BaseModel):
     bing_subscription_key: str
     bing_search_url: str
     k: int = 10
+    search_kwargs: dict = Field(default_factory=dict)
+    """Additional keyword arguments to pass to the search request."""
 
     class Config:
         """Configuration for this pydantic object."""
@@ -34,6 +36,7 @@ class BingSearchAPIWrapper(BaseModel):
             "count": count,
             "textDecorations": True,
             "textFormat": "HTML",
+            **self.search_kwargs,
         }
         response = requests.get(
             self.bing_search_url,


### PR DESCRIPTION
Added a `search_kwargs` field to BingSearchAPIWrapper in `bing_search.py`, enabling users to include extra keyword arguments in Bing search queries. This update, like specifying language preferences, adds more customization to searches. The `search_kwargs` seamlessly merge with standard parameters in `_bing_search_results` method.