### PR TITLE
fixed: Missing escape in llms.utils.enforce_stop_tokens()

### DIFF
--- a/libs/langchain/langchain/llms/utils.py
+++ b/libs/langchain/langchain/llms/utils.py
@@ -5,4 +5,8 @@ from typing import List
 
 def enforce_stop_tokens(text: str, stop: List[str]) -> str:
     """Cut off the text as soon as any stop words occur."""
-    return re.split("|".join(stop), text, maxsplit=1)[0]
+
+    escaped_stop = [re.escape(word) for word in stop]
+    pattern = "|".join(escaped_stop)
+
+    return re.split(pattern, text, maxsplit=1)[0]


### PR DESCRIPTION
**Problem:**
The problem with the enforce_stop_tokens method as currently implemented is that it directly joins the stop words with the | character for the re.split function. This approach works well if the stop words don't contain any regex special characters. However, if they do, this can lead to unintended behavior because the special characters are interpreted as part of the regex pattern, not as literal characters.

**Solution**
To fix this issue, each stop word should be escaped so that any special characters it contains are treated as literals. 


fixed: #13397 