### PR TITLE
Update azuresearch.py following recent change from azure-search-documents library

### DIFF
--- a/docs/docs/integrations/vectorstores/azuresearch.ipynb
+++ b/docs/docs/integrations/vectorstores/azuresearch.ipynb
@@ -6,18 +6,17 @@
     "collapsed": false
    },
    "source": [
-    "# Azure Cognitive Search\n",
+    "# Azure AI Search\n",
     "\n",
-    "[Azure Cognitive Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search) (formerly known as `Azure Search`) is a cloud search service that gives developers infrastructure, APIs, and tools for building a rich search experience over private, heterogeneous content in web, mobile, and enterprise applications.\n",
+    "[Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search) (formerly known as `Azure Search` and `Azure Cognitive Search`) is a cloud search service that gives developers infrastructure, APIs, and tools for building a rich search experience over private, heterogeneous content in web, mobile, and enterprise applications.\n",
     "\n",
-    "Vector search is currently in public preview. It's available through the Azure portal, preview REST API and beta client libraries. [More info](https://learn.microsoft.com/en-us/azure/search/vector-search-overview) Beta client libraries are subject to potential breaking changes, please be sure to use the SDK package version identified below. azure-search-documents==11.4.0b8"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Install Azure Cognitive Search SDK"
+    "# Install Azure AI Search SDK"
    ]
   },
   {
@@ -26,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install azure-search-documents==11.4.0b8\n",
+    "!pip install azure-search-documents\n",
     "!pip install azure-identity"
    ]
   },

--- a/docs/docs/integrations/vectorstores/azuresearch.ipynb
+++ b/docs/docs/integrations/vectorstores/azuresearch.ipynb
@@ -9,7 +9,7 @@
     "# Azure AI Search\n",
     "\n",
     "[Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search) (formerly known as `Azure Search` and `Azure Cognitive Search`) is a cloud search service that gives developers infrastructure, APIs, and tools for building a rich search experience over private, heterogeneous content in web, mobile, and enterprise applications.\n",
-    "\n",
+    "\n"
    ]
   },
   {

--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -39,10 +39,11 @@ if TYPE_CHECKING:
         SearchField,
         VectorSearch,
     )
+
     try:
         from azure.search.documents.indexes.models import SemanticSearch
     except ImportError:
-        from azure.search.documents.indexes.models import SemanticSettings # <11.4.0
+        from azure.search.documents.indexes.models import SemanticSettings  # <11.4.0
 
 # Allow overriding field names for Azure Search
 FIELDS_ID = get_from_env(
@@ -93,17 +94,19 @@ def _get_search_client(
     # class names changed for versions >= 11.4.0
     try:
         from azure.search.documents.indexes.models import (
-            HnswAlgorithmConfiguration, #HnswVectorSearchAlgorithmConfiguration outdated
-            SemanticPrioritizedFields,  #PrioritizedFields outdated
-            SemanticSearch,             #SemanticSettings outdated
+            HnswAlgorithmConfiguration,  # HnswVectorSearchAlgorithmConfiguration is old
+            SemanticPrioritizedFields,  # PrioritizedFields outdated
+            SemanticSearch,  # SemanticSettings outdated
         )
+
         NEW_VERSION = True
     except ImportError:
         from azure.search.documents.indexes.models import (
-            HnswVectorSearchAlgorithmConfiguration, 
+            HnswVectorSearchAlgorithmConfiguration,
             PrioritizedFields,
             SemanticSettings,
         )
+
         NEW_VERSION = False
 
     default_fields = default_fields or []
@@ -151,11 +154,11 @@ def _get_search_client(
             fields = default_fields
         # Vector search configuration
         if vector_search is None:
-            
-            if NEW_VERSION: 
-                # >= 11.4.0: VectorSearch(algorithm_configuration) --> VectorSearch(algorithms)
+            if NEW_VERSION:
+                # >= 11.4.0:
+                #   VectorSearch(algorithm_configuration) --> VectorSearch(algorithms)
                 # HnswVectorSearchAlgorithmConfiguration --> HnswAlgorithmConfiguration
-                vector_search = VectorSearch(    
+                vector_search = VectorSearch(
                     algorithms=[
                         HnswAlgorithmConfiguration(
                             name="default",
@@ -169,8 +172,8 @@ def _get_search_client(
                         )
                     ]
                 )
-            else: # < 11.4.0
-                vector_search = VectorSearch(    
+            else:  # < 11.4.0
+                vector_search = VectorSearch(
                     algorithm_configurations=[
                         HnswVectorSearchAlgorithmConfiguration(
                             name="default",
@@ -187,10 +190,10 @@ def _get_search_client(
 
         # Create the semantic settings with the configuration
         if semantic_settings is None and semantic_configuration_name is not None:
-
             if NEW_VERSION:
-                # <=11.4.0: SemanticSettings --> SemanticSearch 
-                # PrioritizedFields(prioritized_content_fields) --> SemanticPrioritizedFields(content_fields)
+                # <=11.4.0: SemanticSettings --> SemanticSearch
+                # PrioritizedFields(prioritized_content_fields)
+                #   --> SemanticPrioritizedFields(content_fields)
                 semantic_settings = SemanticSearch(
                     configurations=[
                         SemanticConfiguration(
@@ -203,7 +206,7 @@ def _get_search_client(
                         )
                     ]
                 )
-            else: # < 11.4.0
+            else:  # < 11.4.0
                 semantic_settings = SemanticSettings(
                     configurations=[
                         SemanticConfiguration(

--- a/libs/langchain/langchain/vectorstores/azuresearch.py
+++ b/libs/langchain/langchain/vectorstores/azuresearch.py
@@ -81,7 +81,7 @@ def _get_search_client(
     from azure.search.documents import SearchClient
     from azure.search.documents.indexes import SearchIndexClient
     from azure.search.documents.indexes.models import (
-        HnswVectorSearchAlgorithmConfiguration,
+        HnswAlgorithmConfiguration, # HnswVectorSearchAlgorithmConfiguration outdated in version 11.4.0
         PrioritizedFields,
         SearchIndex,
         SemanticConfiguration,
@@ -137,7 +137,7 @@ def _get_search_client(
         if vector_search is None:
             vector_search = VectorSearch(
                 algorithm_configurations=[
-                    HnswVectorSearchAlgorithmConfiguration(
+                    HnswAlgorithmConfiguration(
                         name="default",
                         kind="hnsw",
                         parameters={  # type: ignore


### PR DESCRIPTION
  - **Description:** 

Reference library azure-search-documents has been adapted in version 11.4.0:

1. Notebook explaining Azure AI Search updated with most recent info
2. HnswVectorSearchAlgorithmConfiguration --> HnswAlgorithmConfiguration
3. PrioritizedFields(prioritized_content_fields) --> SemanticPrioritizedFields(content_fields)
4. SemanticSettings --> SemanticSearch
5. VectorSearch(algorithm_configurations) --> VectorSearch(configurations)

--> Changes now reflected on Langchain: default vector search config from langchain is now compatible with officially released library from Azure.

  - **Issue:**
Issue creating a new index (due to wrong class used for default vector search configuration) if using latest version of azure-search-documents with current langchain version
  - **Dependencies:** azure-search-documents>=11.4.0,
  - **Tag maintainer:** ,

