### PR TITLE
Neptune graph updates

### DIFF
--- a/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/neptune_cypher.py
@@ -173,10 +173,11 @@ class NeptuneOpenCypherQAChain(Chain):
 
         generated_cypher = self.cypher_generation_chain.run(
             {
-                "question": question, 
-                "schema": self.graph.get_schema, 
-                "extra_instructions": self.extra_instructions or ""
-            }, callbacks=callbacks
+                "question": question,
+                "schema": self.graph.get_schema,
+                "extra_instructions": self.extra_instructions or "",
+            },
+            callbacks=callbacks,
         )
 
         # Extract Cypher code if it is wrapped in backticks
@@ -203,10 +204,7 @@ class NeptuneOpenCypherQAChain(Chain):
             intermediate_steps.append({"context": context})
 
             result = self.qa_chain(
-                {
-                    "question": question,
-                    "context": context
-                },
+                {"question": question, "context": context},
                 callbacks=callbacks,
             )
             final_result = result[self.qa_chain.output_key]

--- a/libs/langchain/langchain/chains/graph_qa/prompts.py
+++ b/libs/langchain/langchain/chains/graph_qa/prompts.py
@@ -320,7 +320,7 @@ Instructions:
 Generate the query in openCypher format and follow these rules:
 Do not use `NONE`, `ALL` or `ANY` predicate functions, rather use list comprehensions.
 Do not use `REDUCE` function. Rather use a combination of list comprehension and the `UNWIND` clause to achieve similar results.
-Do not use `FOREACH` clause. Rather use a combination of `WITH` and `UNWIND` clauses to achieve similar results.
+Do not use `FOREACH` clause. Rather use a combination of `WITH` and `UNWIND` clauses to achieve similar results.{extra_instructions}
 \n"""
 
 NEPTUNE_OPENCYPHER_GENERATION_TEMPLATE = CYPHER_GENERATION_TEMPLATE.replace(
@@ -328,34 +328,19 @@ NEPTUNE_OPENCYPHER_GENERATION_TEMPLATE = CYPHER_GENERATION_TEMPLATE.replace(
 )
 
 NEPTUNE_OPENCYPHER_GENERATION_PROMPT = PromptTemplate(
-    input_variables=["schema", "question"],
+    input_variables=["schema", "question", "extra_instructions"],
     template=NEPTUNE_OPENCYPHER_GENERATION_TEMPLATE,
 )
 
 NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE = """
-Write an openCypher query to answer the following question. Do not explain the answer. Only return the query. 
+Write an openCypher query to answer the following question. Do not explain the answer. Only return the query.{extra_instructions}
 Question:  "{question}". 
 Here is the property graph schema: 
 {schema}
 \n"""
 
 NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_PROMPT = PromptTemplate(
-    input_variables=["schema", "question"],
+    input_variables=["schema", "question", "extra_instructions"],
     template=NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE,
 )
 
-
-NEPTUNE_CYPHER_QA_TEMPLATE = """You are an assistant that helps to form nice and human understandable answers.
-The information part contains the provided information that you must use to construct an answer.
-The provided information is authoritative, you must never doubt it or try to use your internal knowledge to correct it.
-Make the answer sound as a response to the question. Do not mention that you based the result on the given information.
-If the provided information is empty, say that you don't know the answer. {user_instructions}
-Information:
-{context}
-
-Question: {question}
-Helpful Answer:"""
-NEPTUNE_CYPHER_QA_PROMPT = PromptTemplate(
-    input_variables=["user_instructions", "context", "question"],
-    template=NEPTUNE_CYPHER_QA_TEMPLATE,
-)

--- a/libs/langchain/langchain/chains/graph_qa/prompts.py
+++ b/libs/langchain/langchain/chains/graph_qa/prompts.py
@@ -343,4 +343,3 @@ NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_PROMPT = PromptTemplate(
     input_variables=["schema", "question", "extra_instructions"],
     template=NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE,
 )
-

--- a/libs/langchain/langchain/chains/graph_qa/prompts.py
+++ b/libs/langchain/langchain/chains/graph_qa/prompts.py
@@ -343,3 +343,19 @@ NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_PROMPT = PromptTemplate(
     input_variables=["schema", "question"],
     template=NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE,
 )
+
+
+NEPTUNE_CYPHER_QA_TEMPLATE = """You are an assistant that helps to form nice and human understandable answers.
+The information part contains the provided information that you must use to construct an answer.
+The provided information is authoritative, you must never doubt it or try to use your internal knowledge to correct it.
+Make the answer sound as a response to the question. Do not mention that you based the result on the given information.
+If the provided information is empty, say that you don't know the answer. {user_instructions}
+Information:
+{context}
+
+Question: {question}
+Helpful Answer:"""
+NEPTUNE_CYPHER_QA_PROMPT = PromptTemplate(
+    input_variables=["user_instructions", "context", "question"],
+    template=NEPTUNE_CYPHER_QA_TEMPLATE,
+)

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -30,6 +30,7 @@ class NeptuneGraph:
         credentials_profile_name: optional AWS profile name
         region_name: optional AWS region, e.g., us-west-2
         service: optional service name, default is neptunedata
+        sign: optional, whether to sign the request payload, default is True
 
     Example:
         .. code-block:: python
@@ -60,6 +61,7 @@ class NeptuneGraph:
         credentials_profile_name: Optional[str] = None,
         region_name: Optional[str] = None,
         service: str = "neptunedata",
+        sign: bool = True,
     ) -> None:
         """Create a new Neptune graph wrapper instance."""
 
@@ -83,7 +85,17 @@ class NeptuneGraph:
 
                 client_params["endpoint_url"] = f"{protocol}://{host}:{port}"
 
-                self.client = session.client(service, **client_params)
+                if sign:
+                    self.client = session.client(service, **client_params)
+                else:
+                    from botocore import UNSIGNED
+                    from botocore.config import Config
+
+                    self.client = session.client(
+                        service,
+                        **client_params,
+                        config=Config(signature_version=UNSIGNED),
+                    )
 
         except ImportError:
             raise ModuleNotFoundError(

--- a/libs/langchain/langchain/graphs/neptune_graph.py
+++ b/libs/langchain/langchain/graphs/neptune_graph.py
@@ -132,7 +132,15 @@ class NeptuneGraph:
 
     def query(self, query: str, params: dict = {}) -> Dict[str, Any]:
         """Query Neptune database."""
-        return self.client.execute_open_cypher_query(openCypherQuery=query)
+        try:
+            return self.client.execute_open_cypher_query(openCypherQuery=query)
+        except Exception as e:
+            raise NeptuneQueryException(
+                {
+                    "message": "An error occurred while executing the query.",
+                    "details": str(e),
+                }
+            )
 
     def _get_summary(self) -> Dict:
         try:


### PR DESCRIPTION
## Description
This PR adds an option to allow unsigned requests to the Neptune database when using the `NeptuneGraph` class.

```python
graph = NeptuneGraph(
    host='<my-cluster>',
    port=8182,
    sign=False
)
```

Also, added is an option in the `NeptuneOpenCypherQAChain` to provide additional domain instructions to the graph query generation prompt. This will be injected in the prompt as-is, so you should include any provider specific tags, for example `<instructions>` or `<INSTR>`.

```python
chain = NeptuneOpenCypherQAChain.from_llm(
    llm=llm,
    graph=graph,
    extra_instructions="""
    Follow these instructions to build the query:
    1. Countries contain airports, not the other way around
    2. Use the airport code for identifying airports
    """
)
```
