### PR TITLE
Fix `MarkdownHeaderTextSplitter` not recognizing tilde-fenced code blocks

### DIFF
--- a/libs/langchain/langchain/text_splitter.py
+++ b/libs/langchain/langchain/text_splitter.py
@@ -391,16 +391,23 @@ class MarkdownHeaderTextSplitter:
         initial_metadata: Dict[str, str] = {}
 
         in_code_block = False
+        opening_fence = ""
 
         for line in lines:
             stripped_line = line.strip()
 
-            if stripped_line.startswith("```"):
-                # code block in one row
-                if stripped_line.count("```") >= 2:
+            if not in_code_block:
+                # Exclude inline code spans
+                if stripped_line.startswith("```") and stripped_line.count("```") == 1:
+                    in_code_block = True
+                    opening_fence = "```"
+                elif stripped_line.startswith("~~~"):
+                    in_code_block = True
+                    opening_fence = "~~~"
+            else:
+                if stripped_line.startswith(opening_fence):
                     in_code_block = False
-                else:
-                    in_code_block = not in_code_block
+                    opening_fence = ""
 
             if in_code_block:
                 current_content.append(stripped_line)

--- a/libs/langchain/tests/unit_tests/test_text_splitter.py
+++ b/libs/langchain/tests/unit_tests/test_text_splitter.py
@@ -1092,7 +1092,9 @@ def test_md_header_text_splitter_fenced_code_block_interleaved(
 
     expected_output = [
         Document(
-            page_content=f"{fence}\nfoo\n# Not a header\n{other_fence}\n# Not a header\n{fence}",
+            page_content=(
+                f"{fence}\nfoo\n# Not a header\n{other_fence}\n# Not a header\n{fence}"
+            ),
             metadata={"Header 1": "This is a Header"},
         ),
     ]


### PR DESCRIPTION
 - **Description:** Previously `MarkdownHeaderTextSplitter` did not consider tilde-fenced code blocks (https://spec.commonmark.org/0.30/#fenced-code-blocks). This PR fixes that.
   ````md
   # Bug caused by previous implementation:
   ~~~py
   foo()
   # This is a comment that would be considered header
   bar()
   ~~~
   ````
 - **Tag maintainer:** @baskaryan 
