### PR TITLE
AstraDB: use includeSimilarity option instead of $similarity

### DIFF
--- a/libs/langchain/langchain/vectorstores/astradb.py
+++ b/libs/langchain/langchain/vectorstores/astradb.py
@@ -480,12 +480,11 @@ class AstraDB(VectorStore):
             self.collection.paginated_find(
                 filter=metadata_parameter,
                 sort={"$vector": embedding},
-                options={"limit": k},
+                options={"limit": k, "includeSimilarity": True},
                 projection={
                     "_id": 1,
                     "content": 1,
                     "metadata": 1,
-                    "$similarity": 1,
                 },
             )
         )
@@ -609,12 +608,11 @@ class AstraDB(VectorStore):
             self.collection.paginated_find(
                 filter=metadata_parameter,
                 sort={"$vector": embedding},
-                options={"limit": fetch_k},
+                options={"limit": fetch_k, "includeSimilarity": True},
                 projection={
                     "_id": 1,
                     "content": 1,
                     "metadata": 1,
-                    "$similarity": 1,
                     "$vector": 1,
                 },
             )


### PR DESCRIPTION
- **Description:** AstraDB is going to deprecate the `$similarity` projection property in favor of the ´includeSimilarity´ option flag. I moved all the queries to the new format. 
- **Tag maintainer:** @hemidactylus 
- **Twitter handle:** nicoloboschi