### PR TITLE
fix: VLLMOpenAI -- create() got an unexpected keyword argument 'api_key'

### DIFF
--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -150,16 +150,18 @@ class VLLMOpenAI(BaseOpenAI):
     def _invocation_params(self) -> Dict[str, Any]:
         """Get the parameters used to invoke the model."""
 
-        params: Dict[str: Any] = {
+        params: Dict[str:Any] = {
             "model": self.model_name,
             **self._default_params,
             "logit_bias": None,
         }
         if not is_openai_v1():
-            params.update({
-                "api_key": self.openai_api_key,
-                "api_base": self.openai_api_base,
-            })
+            params.update(
+                {
+                    "api_key": self.openai_api_key,
+                    "api_base": self.openai_api_base,
+                }
+            )
 
         return params
 

--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -150,7 +150,7 @@ class VLLMOpenAI(BaseOpenAI):
     def _invocation_params(self) -> Dict[str, Any]:
         """Get the parameters used to invoke the model."""
 
-        params: Dict[str:Any] = {
+        params: Dict[str, Any] = {
             "model": self.model_name,
             **self._default_params,
             "logit_bias": None,

--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -5,6 +5,7 @@ from langchain.llms.base import BaseLLM
 from langchain.llms.openai import BaseOpenAI
 from langchain.pydantic_v1 import Field, root_validator
 from langchain.schema.output import Generation, LLMResult
+from langchain.utils.openai import is_openai_v1
 
 
 class VLLM(BaseLLM):
@@ -148,17 +149,19 @@ class VLLMOpenAI(BaseOpenAI):
     @property
     def _invocation_params(self) -> Dict[str, Any]:
         """Get the parameters used to invoke the model."""
-        openai_creds: Dict[str, Any] = {
-            "api_key": self.openai_api_key,
-            "api_base": self.openai_api_base,
-        }
 
-        return {
+        params: Dict[str: Any] = {
             "model": self.model_name,
-            **openai_creds,
             **self._default_params,
             "logit_bias": None,
         }
+        if not is_openai_v1():
+            params.update({
+                "api_key": self.openai_api_key,
+                "api_base": self.openai_api_base,
+            })
+
+        return params
 
     @property
     def _llm_type(self) -> str:


### PR DESCRIPTION
The issue was occurring because of an `OpenAI` update in `Completions`. It's not accepting the `api_key` and `api_base` arguments.

The fix is we check for the openai version and if it's v1 or greater then remove these keys from args before passing them to `Compilation.create(...)` when sending from `VLLMOpenAI`

Fixed: #13507 

@eyu
@efriis 
@hwchase17 