### PR TITLE
add llm kwargs as loading parameter

### DIFF
--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -37,9 +37,9 @@ def _load_llm_chain(config: dict, **kwargs: Any) -> LLMChain:
     """Load LLM chain from config dict."""
     if "llm" in config:
         llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config)
+        llm = load_llm_from_config(llm_config, **(kwargs.get('llm_extras', {})))
     elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"))
+        llm = load_llm(config.pop("llm_path"), **(kwargs.get('llm_extras', {})))
     else:
         raise ValueError("One of `llm` or `llm_path` must be present.")
 
@@ -194,11 +194,11 @@ def _load_llm_bash_chain(config: dict, **kwargs: Any) -> Any:
     # llm attribute is deprecated in favor of llm_chain, here to support old configs
     elif "llm" in config:
         llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config)
+        llm = load_llm_from_config(llm_config, **(kwargs.get('llm_extras', {})))
     # llm_path attribute is deprecated in favor of llm_chain_path,
     # its to support old configs
     elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"))
+        llm = load_llm(config.pop("llm_path"), **(kwargs.get('llm_extras', {})))
     else:
         raise ValueError("One of `llm_chain` or `llm_chain_path` must be present.")
     if "prompt" in config:
@@ -215,9 +215,9 @@ def _load_llm_bash_chain(config: dict, **kwargs: Any) -> Any:
 def _load_llm_checker_chain(config: dict, **kwargs: Any) -> LLMCheckerChain:
     if "llm" in config:
         llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config)
+        llm = load_llm_from_config(llm_config, **(kwargs.get('llm_extras', {})))
     elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"))
+        llm = load_llm(config.pop("llm_path"), **(kwargs.get('llm_extras', {})))
     else:
         raise ValueError("One of `llm` or `llm_path` must be present.")
     if "create_draft_answer_prompt" in config:
@@ -268,11 +268,11 @@ def _load_llm_math_chain(config: dict, **kwargs: Any) -> LLMMathChain:
     # llm attribute is deprecated in favor of llm_chain, here to support old configs
     elif "llm" in config:
         llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config)
+        llm = load_llm_from_config(llm_config, **(kwargs.get('llm_extras', {})))
     # llm_path attribute is deprecated in favor of llm_chain_path,
     # its to support old configs
     elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"))
+        llm = load_llm(config.pop("llm_path"), **(kwargs.get('llm_extras', {})))
     else:
         raise ValueError("One of `llm_chain` or `llm_chain_path` must be present.")
     if "prompt" in config:
@@ -371,9 +371,9 @@ def _load_sql_database_chain(config: dict, **kwargs: Any) -> Any:
         return SQLDatabaseChain(llm_chain=chain, database=database, **config)
     if "llm" in config:
         llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config)
+        llm = load_llm_from_config(llm_config, **(kwargs.get('llm_extras', {})))
     elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"))
+        llm = load_llm(config.pop("llm_path"), **(kwargs.get('llm_extras', {})))
     else:
         raise ValueError("One of `llm` or `llm_path` must be present.")
     if "prompt" in config:

--- a/libs/langchain/langchain/llms/loading.py
+++ b/libs/langchain/langchain/llms/loading.py
@@ -9,8 +9,8 @@ from langchain.llms import get_type_to_cls_dict
 from langchain.llms.base import BaseLLM
 
 
-def load_llm_from_config(config: dict) -> BaseLLM:
-    """Load LLM from Config Dict."""
+def load_llm_from_config(config: dict, **llm_kwargs) -> BaseLLM:
+    """Load LLM from Config Dict. Allow extra paramters with the kwargs"""
     if "_type" not in config:
         raise ValueError("Must specify an LLM Type in config")
     config_type = config.pop("_type")
@@ -19,12 +19,12 @@ def load_llm_from_config(config: dict) -> BaseLLM:
 
     if config_type not in type_to_cls_dict:
         raise ValueError(f"Loading {config_type} LLM not supported")
-
+    extras = llm_kwargs.get(config_type, {})
     llm_cls = type_to_cls_dict[config_type]()
-    return llm_cls(**config)
+    return llm_cls(**config, **extras)
 
 
-def load_llm(file: Union[str, Path]) -> BaseLLM:
+def load_llm(file: Union[str, Path], **llm_kwargs) -> BaseLLM:
     """Load LLM from file."""
     # Convert file to Path object.
     if isinstance(file, str):
@@ -41,4 +41,4 @@ def load_llm(file: Union[str, Path]) -> BaseLLM:
     else:
         raise ValueError("File type must be json or yaml")
     # Load the LLM from the config now.
-    return load_llm_from_config(config)
+    return load_llm_from_config(config, **llm_kwargs)

--- a/libs/langchain/tests/integration_tests/llms/test_openai.py
+++ b/libs/langchain/tests/integration_tests/llms/test_openai.py
@@ -87,6 +87,20 @@ def test_saving_loading_llm(tmp_path: Path) -> None:
     assert loaded_llm == llm
 
 
+def test_saving_loading_llm_with_params(tmp_path: Path) -> None:
+    """Test saving/loading an OpenAI LLM."""
+    import os
+    api_key = os.environ['OPENAI_API_KEY']
+    if api_key:
+        del os.environ['OPENAI_API_KEY']
+    llm = OpenAI(max_tokens=10)
+    llm.save(file_path=tmp_path / "openai.yaml")
+    loaded_llm = load_llm(tmp_path / "openai.yaml", **{'openai_api_key': api_key})
+    assert loaded_llm == llm
+    if api_key:
+        os.environ['OPENAI_API_KEY'] = api_key
+
+
 @pytest.mark.scheduled
 def test_openai_streaming() -> None:
     """Test streaming tokens from OpenAI."""


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

 **Description:**
Enables runtime parameter injection while loading serialized chains.

 **Issue:**
Current approach does not supports runtime credential loading if there is multiple or conditional logic with the LLM settings while loading. 

For e.g. If we have serialized object like this one 
```python

chain_config = {
    "memory": None,
    "verbose": False,
    "prompt": {
        "input_variables": [
            "topic"
        ],
        "output_parser": None,
        "template": "Tell me a joke about {topic}:",
        "template_format": "f-string",
        "_type": "prompt"
    },
    "llm": {
        "model_name": "text-davinci-003",
        "temperature": 0.9,
        "max_tokens": 256,
        "top_p": 1,
        "frequency_penalty": 0,
        "presence_penalty": 0,
        "n": 1,
        "best_of": 1,
        "request_timeout": None,
        "logit_bias": {},
        "_type": "openai"
    },
    "output_key": "text",
    "_type": "llm_chain"
}
```
and if we try to load without environment variable it raises an error because of the api key does not exists in either env variables or inside the serialized object (as expected)

```python
from langchain.chains.loading import load_chain_from_config

chain = load_chain_from_config(chain_config)

# Did not find openai_api_key, please add an environment variable `OPENAI_API_KEY` which contains it, or pass  `openai_api_key` as a named parameter. (type=value_error)
``` 

and what I hgumbly propose in here is using the kwargs which is already defined in current version to add LLM parameters for using as settings like this one

```python
chain = load_chain_from_config(chain_config, **{
  "llm_extras": {
    "openai": {
      "openai_api_key": "<super_secret>"
    }
  }
})
```

**Dependencies:** 
No extra dependency needed.

**Tag maintainer:**
I don't know you are the right person to tag but @eyurtsev I will be very appreciated if there is any direction or review. Thanks in advance!

 **Twitter handle:**
This is not a big feature/fix bug but here it is `@cureef`