### PR TITLE
fixed `openai_assistant` namespace

### DIFF
--- a/libs/langchain/langchain/agents/openai_assistant/__init__.py
+++ b/libs/langchain/langchain/agents/openai_assistant/__init__.py
@@ -1,3 +1,3 @@
-from langchain_experimental.openai_assistant.base import OpenAIAssistantRunnable
+from langchain.agents.openai_assistant.base import OpenAIAssistantRunnable
 
 __all__ = ["OpenAIAssistantRunnable"]


### PR DESCRIPTION
BUG: langchain.agents.openai_assistant has a reference as
`from langchain_experimental.openai_assistant.base import OpenAIAssistantRunnable`
should be 
`from langchain.agents.openai_assistant.base import OpenAIAssistantRunnable`

This prevents building of the API Reference docs