### PR TITLE
Fix for oracle schema parsing stated on the issue #7928

### DIFF
--- a/libs/langchain/langchain/utilities/sql_database.py
+++ b/libs/langchain/langchain/utilities/sql_database.py
@@ -402,6 +402,8 @@ class SQLDatabase:
                     # but `duckdb_engine` seemed to struggle with all of them:
                     # https://github.com/Mause/duckdb_engine/issues/796
                     connection.exec_driver_sql(f"SET search_path TO {self._schema}")
+                elif self.dialect == "oracle":
+                    connection.exec_driver_sql(f"ALTER SESSION SET CURRENT_SCHEMA = {self._schema}")
                 else:  # postgresql and other compatible dialects
                     connection.exec_driver_sql("SET search_path TO %s", (self._schema,))
             cursor = connection.execute(text(command))

--- a/libs/langchain/langchain/utilities/sql_database.py
+++ b/libs/langchain/langchain/utilities/sql_database.py
@@ -403,7 +403,9 @@ class SQLDatabase:
                     # https://github.com/Mause/duckdb_engine/issues/796
                     connection.exec_driver_sql(f"SET search_path TO {self._schema}")
                 elif self.dialect == "oracle":
-                    connection.exec_driver_sql(f"ALTER SESSION SET CURRENT_SCHEMA = {self._schema}")
+                    connection.exec_driver_sql(
+                        f"ALTER SESSION SET CURRENT_SCHEMA = {self._schema}"
+                    )
                 else:  # postgresql and other compatible dialects
                     connection.exec_driver_sql("SET search_path TO %s", (self._schema,))
             cursor = connection.execute(text(command))


### PR DESCRIPTION
  - **Description:** In this pull request, we address an issue related to assigning a schema to the SQLDatabase class when utilizing an Oracle database. The current implementation encounters a bug where, upon attempting to execute a query, the alter session parse is not appropriately defined for Oracle, leading to an error, 
  - **Issue:** #7928,
  - **Dependencies:** No dependencies,
  - **Tag maintainer:** @baskaryan,
