### PR TITLE
import error fix to quickstart.mdx

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -128,7 +128,7 @@ Let's see how to work with these different types of models and these different t
 First, let's import an LLM and a ChatModel.
 
 ```python
-from langchain.llms import OpenAI
+from langchain.llms.openai import OpenAI
 from langchain.chat_models import ChatOpenAI
 
 llm = OpenAI()


### PR DESCRIPTION
**Description**: I fixed a very small import error in the quickstart docs 
(from langchain.llms import OpenAI -> from langchain.llms.openai import OpenAI)