### PR TITLE
Update geodataframe.py

### DIFF
--- a/libs/langchain/langchain/document_loaders/geodataframe.py
+++ b/libs/langchain/langchain/document_loaders/geodataframe.py
@@ -34,7 +34,7 @@ class GeoDataFrameLoader(BaseLoader):
                 f"Expected data_frame to have a column named {page_content_column}"
             )
 
-        if not isinstance(data_frame[page_content_column].iloc[0], gpd.GeoSeries):
+        if not isinstance(data_frame[page_content_column], gpd.GeoSeries):
             raise ValueError(
                 f"Expected data_frame[{page_content_column}] to be a GeoSeries"
             )


### PR DESCRIPTION
here it is validating shapely.geometry.point.Point:       if not isinstance(data_frame[page_content_column].iloc[0], gpd.GeoSeries): raise ValueError(
f"Expected data_frame[{page_content_column}] to be a GeoSeries"         you need it to validate the geoSeries and not the shapely.geometry.point.Point

if not isinstance(data_frame[page_content_column], gpd.GeoSeries):
            raise ValueError(
                f"Expected data_frame[{page_content_column}] to be a GeoSeries"

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
