### PR TITLE
Update mongodb_atlas.py to fix ImportError: cannot import name 'DriverInfo' from 'pymongo'

### DIFF
--- a/libs/langchain/langchain/vectorstores/mongodb_atlas.py
+++ b/libs/langchain/langchain/vectorstores/mongodb_atlas.py
@@ -104,7 +104,8 @@ class MongoDBAtlasVectorSearch(VectorStore):
         try:
             from importlib.metadata import version
 
-            from pymongo import DriverInfo, MongoClient
+            from pymongo import MongoClient
+            from pymongo.driver_info import DriverInfo
         except ImportError:
             raise ImportError(
                 "Could not import pymongo, please install it with "


### PR DESCRIPTION


<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** fix ImportError: cannot import name 'DriverInfo' from 'pymongo'
  - **Issue:** As above
  - **Dependencies:** NA
  - **Tag maintainer:** @efriis @jarib 

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
