### PR TITLE
Fix broken link on Meilisearch vector-store documentation

### DIFF
--- a/docs/docs/integrations/vectorstores/meilisearch.ipynb
+++ b/docs/docs/integrations/vectorstores/meilisearch.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "You will need a running Meilisearch instance to use as your vector store. You can run [Meilisearch in local](https://www.meilisearch.com/docs/learn/getting_started/installation#local-installation) or create a [Meilisearch Cloud](https://cloud.meilisearch.com/) account.\n",
     "\n",
-    "As of Meilisearch v1.3, vector storage is an experimental feature. After launching your Meilisearch instance, you need to **enable vector storage**. For self-hosted Meilisearch, read the docs on [enabling experimental features](https://www.meilisearch.com/docs/learn/experimental/vector-search). On **Meilisearch Cloud**, enable _Vector Store_ via your project _Settings_ page.\n",
+    "As of Meilisearch v1.3, vector storage is an experimental feature. After launching your Meilisearch instance, you need to **enable vector storage**. For self-hosted Meilisearch, read the docs on [enabling experimental features](https://www.meilisearch.com/docs/learn/experimental/overview). On **Meilisearch Cloud**, enable _Vector Store_ via your project _Settings_ page.\n",
     "\n",
     "You should now have a running Meilisearch instance with vector storage enabled. 🎉\n",
     "\n",


### PR DESCRIPTION
  - **Description:** dead link replacement 
  - **Issue:** no open issue

**Note:**
Hi langchain team,
Sorry to open a PR for this concern but we realized that one of the links present in the documentation booklet was broken 😄 