### PR TITLE
Lint for imports

### DIFF
--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -26,6 +26,8 @@ lint format: PYTHON_FILES=.
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/experimental --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 
 lint lint_diff:
+	./scripts/check_pydantic.sh .
+	./scripts/check_imports.sh
 	poetry run ruff .
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES) --diff
 	[ "$(PYTHON_FILES)" = "" ] || poetry run mypy $(PYTHON_FILES)

--- a/libs/core/scripts/check_imports.sh
+++ b/libs/core/scripts/check_imports.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu
+
+# Initialize a variable to keep track of errors
+errors=0
+
+# make sure not importing from langchain or langchain_experimental
+git --no-pager grep '^from langchain\.' . && errors=$((errors+1))
+git --no-pager grep '^from langchain_experimental\.' . && errors=$((errors+1))
+
+# Decide on an exit status based on the errors
+if [ "$errors" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/libs/core/scripts/check_pydantic.sh
+++ b/libs/core/scripts/check_pydantic.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This script searches for lines starting with "import pydantic" or "from pydantic"
+# in tracked files within a Git repository.
+#
+# Usage: ./scripts/check_pydantic.sh /path/to/repository
+
+# Check if a path argument is provided
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 /path/to/repository"
+  exit 1
+fi
+
+repository_path="$1"
+
+# Search for lines matching the pattern within the specified repository
+result=$(git -C "$repository_path" grep -E '^import pydantic|^from pydantic')
+
+# Check if any matching lines were found
+if [ -n "$result" ]; then
+  echo "ERROR: The following lines need to be updated:"
+  echo "$result"
+  echo "Please replace the code with an import from langchain_core.pydantic_v1."
+  echo "For example, replace 'from pydantic import BaseModel'"
+  echo "with 'from langchain_core.pydantic_v1 import BaseModel'"
+  exit 1
+fi

--- a/libs/langchain/scripts/check_imports.sh
+++ b/libs/langchain/scripts/check_imports.sh
@@ -24,6 +24,9 @@ git grep '^from langchain\.' langchain/embeddings | grep -vE 'from langchain.(py
 git grep '^from langchain\.' langchain/docstore | grep -vE 'from langchain.(pydantic_v1|utils|schema|docstore)' && errors=$((errors+1))
 git grep '^from langchain\.' langchain/vectorstores | grep -vE 'from langchain.(pydantic_v1|utils|schema|load|callbacks|env|_api|storage|llms|docstore|vectorstores|utilities)' && errors=$((errors+1))
 
+# make sure not importing from langchain_experimental
+git --no-pager grep '^from langchain_experimental\.' . && errors=$((errors+1))
+
 # Decide on an exit status based on the errors
 if [ "$errors" -gt 0 ]; then
     exit 1


### PR DESCRIPTION
- Adds pydantic/import linting to core
- Adds a check for `langchain_experimental` imports to langchain