### PR TITLE
Tests: Fix regression in `ConsistentFakeEmbeddings.embed_query`

### DIFF
--- a/libs/langchain/tests/integration_tests/vectorstores/fake_embeddings.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/fake_embeddings.py
@@ -52,7 +52,6 @@ class ConsistentFakeEmbeddings(FakeEmbeddings):
     def embed_query(self, text: str) -> List[float]:
         """Return consistent embeddings for the text, if seen before, or a constant
         one if the text is unknown."""
-        return self.embed_documents([text])[0]
         if text not in self.known_texts:
             return [float(1.0)] * (self.dimensionality - 1) + [float(0.0)]
         return [float(1.0)] * (self.dimensionality - 1) + [


### PR DESCRIPTION
**Description**: Fixes a regression in `ConsistentFakeEmbeddings.embed_query`.
**Issue**: The function did not return the correct values.
**Dependencies**: -,
**Tag maintainer**: @baskaryan

----

Hi there,

first things first: Thanks a stack for conceiving and maintaining LangChain.

At https://github.com/crate-workbench/langchain/pull/1, we are working on a database adapter for [CrateDB](https://github.com/crate/crate) [^1], where we may have discovered a minor flaw recently introduced to the test utility `ConsistentFakeEmbeddings`.

The function `ConsistentFakeEmbeddings.embed_query` was changed to only return the embedding of the query expression, without considering the known texts, as advertised. It was the recent commit a28eea57674a9 which may have changed it inadvertently this way.

The fix works well on behalf of the test cases we are running (`pytest -vvv tests/ -k cratedb`) [^2], but we didn't run it on any other vector store adapters. It may well have some impact, depending on where `ConsistentFakeEmbeddings` has been used, and how its outcomes are being evaluated on behalf of other test cases.

With kind regards,
Andreas.

[^1]: After sorting out some remaining issues, we hope to be able to contribute this adapter soon, and hope it will be well received.
[^2]: Actually, it was needed by a test case we added with https://github.com/crate-workbench/langchain/pull/15, where it also has been discovered.
