### PR TITLE
fix templates dockerfile

### DIFF
--- a/libs/cli/langchain_cli/project_template/Dockerfile
+++ b/libs/cli/langchain_cli/project_template/Dockerfile
@@ -6,7 +6,7 @@ RUN poetry config virtualenvs.create false
 
 WORKDIR /code
 
-COPY ./pyproject.toml ./poetry.lock* ./
+COPY ./pyproject.toml ./README.md ./poetry.lock* ./
 
 COPY ./packages ./packages
 


### PR DESCRIPTION
  - **Description:**  We need to update the Dockerfile for templates to also copy your README.md. This is because poetry requires that a readme exists if it is specified in the pyproject.toml 
