### PR TITLE
Set default region from boto3 session for Bedrock

### DIFF
--- a/libs/langchain/langchain/llms/bedrock.py
+++ b/libs/langchain/langchain/llms/bedrock.py
@@ -204,7 +204,7 @@ class BedrockBase(BaseModel, ABC):
                 values,
                 "region_name",
                 "AWS_DEFAULT_REGION",
-                default=None,
+                default=session.region_name,
             )
 
             client_params = {}


### PR DESCRIPTION
- **Description:** Set default region from boto3 session for Bedrock 
- **Issue:** #13683 