### PR TITLE
info sql tool remove whitespaces in table names

### DIFF
--- a/libs/langchain/langchain/tools/sql_database/tool.py
+++ b/libs/langchain/langchain/tools/sql_database/tool.py
@@ -60,7 +60,9 @@ class InfoSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Get the schema for tables in a comma-separated list."""
-        return self.db.get_table_info_no_throw([t.strip() for t in table_names.split(",")])
+        return self.db.get_table_info_no_throw(
+            [t.strip() for t in table_names.split(",")]
+        )
 
 
 class ListSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):

--- a/libs/langchain/langchain/tools/sql_database/tool.py
+++ b/libs/langchain/langchain/tools/sql_database/tool.py
@@ -60,7 +60,7 @@ class InfoSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Get the schema for tables in a comma-separated list."""
-        return self.db.get_table_info_no_throw(table_names.split(", "))
+        return self.db.get_table_info_no_throw(table_names.replace(" ", "").split(","))
 
 
 class ListSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):

--- a/libs/langchain/langchain/tools/sql_database/tool.py
+++ b/libs/langchain/langchain/tools/sql_database/tool.py
@@ -60,7 +60,7 @@ class InfoSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Get the schema for tables in a comma-separated list."""
-        return self.db.get_table_info_no_throw(table_names.replace(" ", "").split(","))
+        return self.db.get_table_info_no_throw([t.strip() for t in table_names.split(",")])
 
 
 class ListSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):


### PR DESCRIPTION
Remove whitespaces from the input of the ListSQLDatabaseTool for better support.
for example, the input "table1,table2,table3" will throw an exception whiteout the change although it's a valid input.
