### PR TITLE
Add option to prefix config keys in configurable_alts

### DIFF
--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -13,7 +13,7 @@ tests:
 	poetry run pytest $(TEST_FILE)
 
 test_watch:
-	poetry run ptw --snapshot-update --now . -- -x tests/unit_tests
+	poetry run ptw --snapshot-update --now . -- -vv -x tests/unit_tests
 
 
 ######################

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1205,6 +1205,7 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
         self,
         which: ConfigurableField,
         default_key: str = "default",
+        prefix_keys: bool = False,
         **kwargs: Union[Runnable[Input, Output], Callable[[], Runnable[Input, Output]]],
     ) -> RunnableSerializable[Input, Output]:
         from langchain_core.runnables.configurable import (
@@ -1212,7 +1213,11 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
         )
 
         return RunnableConfigurableAlternatives(
-            which=which, default=self, alternatives=kwargs, default_key=default_key
+            which=which,
+            default=self,
+            alternatives=kwargs,
+            default_key=default_key,
+            prefix_keys=prefix_keys,
         )
 
 

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1204,6 +1204,7 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
     def configurable_alternatives(
         self,
         which: ConfigurableField,
+        *,
         default_key: str = "default",
         prefix_keys: bool = False,
         **kwargs: Union[Runnable[Input, Output], Callable[[], Runnable[Input, Output]]],

--- a/libs/core/langchain_core/runnables/configurable.py
+++ b/libs/core/langchain_core/runnables/configurable.py
@@ -220,6 +220,7 @@ class RunnableConfigurableFields(DynamicRunnable[Input, Output]):
                     annotation=spec.annotation
                     or self.default.__fields__[field_name].annotation,
                     default=getattr(self.default, field_name),
+                    is_shared=spec.is_shared,
                 )
                 if isinstance(spec, ConfigurableField)
                 else make_options_spec(
@@ -324,6 +325,7 @@ class RunnableConfigurableAlternatives(DynamicRunnable[Input, Output]):
                     description=self.which.description,
                     annotation=which_enum,
                     default=self.default_key,
+                    is_shared=self.which.is_shared,
                 ),
             ]
             # config specs of the default option
@@ -375,12 +377,17 @@ class RunnableConfigurableAlternatives(DynamicRunnable[Input, Output]):
 def prefix_config_spec(
     spec: ConfigurableFieldSpec, prefix: str
 ) -> ConfigurableFieldSpec:
-    return ConfigurableFieldSpec(
-        id=f"{prefix}/{spec.id}",
-        name=spec.name,
-        description=spec.description,
-        annotation=spec.annotation,
-        default=spec.default,
+    return (
+        ConfigurableFieldSpec(
+            id=f"{prefix}/{spec.id}",
+            name=spec.name,
+            description=spec.description,
+            annotation=spec.annotation,
+            default=spec.default,
+            is_shared=spec.is_shared,
+        )
+        if not spec.is_shared
+        else spec
     )
 
 
@@ -406,6 +413,7 @@ def make_options_spec(
             description=spec.description or description,
             annotation=enum,
             default=spec.default,
+            is_shared=spec.is_shared,
         )
     else:
         return ConfigurableFieldSpec(
@@ -414,4 +422,5 @@ def make_options_spec(
             description=spec.description or description,
             annotation=Sequence[enum],  # type: ignore[valid-type]
             default=spec.default,
+            is_shared=spec.is_shared,
         )

--- a/libs/core/langchain_core/runnables/configurable.py
+++ b/libs/core/langchain_core/runnables/configurable.py
@@ -299,8 +299,12 @@ class RunnableConfigurableAlternatives(DynamicRunnable[Input, Output]):
     ]
 
     default_key: str = "default"
+    """The enum value to use for the default option. Defaults to "default"."""
 
     prefix_keys: bool
+    """Whether to prefix configurable fields of each alternative with a namespace
+    of the form <which.id>==<alternative_key>, eg. a key named "temperature" used by 
+    the alternative named "gpt3" becomes "model==gpt3/temperature"."""
 
     @property
     def config_specs(self) -> List[ConfigurableFieldSpec]:

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -169,6 +169,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
                     name="Session ID",
                     description="Unique identifier for a session.",
                     default="",
+                    is_shared=True,
                 ),
             ]
         )

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -302,12 +302,12 @@ class ConfigurableFieldSpec(NamedTuple):
     """A field that can be configured by the user. It is a specification of a field."""
 
     id: str
-    name: Optional[str]
-    description: Optional[str]
-
-    default: Any
     annotation: Any
-    is_shared: bool
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    default: Any = None
+    is_shared: bool = False
 
 
 def get_unique_config_specs(

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -257,6 +257,7 @@ class ConfigurableField(NamedTuple):
     name: Optional[str] = None
     description: Optional[str] = None
     annotation: Optional[Any] = None
+    is_shared: bool = False
 
     def __hash__(self) -> int:
         return hash((self.id, self.annotation))
@@ -271,6 +272,7 @@ class ConfigurableFieldSingleOption(NamedTuple):
 
     name: Optional[str] = None
     description: Optional[str] = None
+    is_shared: bool = False
 
     def __hash__(self) -> int:
         return hash((self.id, tuple(self.options.keys()), self.default))
@@ -285,6 +287,7 @@ class ConfigurableFieldMultiOption(NamedTuple):
 
     name: Optional[str] = None
     description: Optional[str] = None
+    is_shared: bool = False
 
     def __hash__(self) -> int:
         return hash((self.id, tuple(self.options.keys()), tuple(self.default)))
@@ -304,6 +307,7 @@ class ConfigurableFieldSpec(NamedTuple):
 
     default: Any
     annotation: Any
+    is_shared: bool
 
 
 def get_unique_config_specs(

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -1032,6 +1032,7 @@ def test_configurable_fields_prefix_keys() -> None:
             },
             default=["hello", "bye"],
         ),
+        # (sleep is a configurable field in FakeListChatModel)
         sleep=ConfigurableField(
             id="chat_sleep",
             is_shared=True,
@@ -1094,34 +1095,36 @@ def test_configurable_fields_prefix_keys() -> None:
                 "title": "Configurable",
                 "type": "object",
                 "properties": {
-                    # not prefixed because marked as shared
-                    "chat_sleep": {
-                        "title": "Chat Sleep",
-                        "type": "number",
+                    "prompt_template": {
+                        "title": "Prompt Template",
+                        "description": "The prompt template for this chain",
+                        "default": "hello",
+                        "allOf": [{"$ref": "#/definitions/Prompt_Template"}],
                     },
                     "llm": {
                         "title": "LLM",
                         "default": "default",
                         "allOf": [{"$ref": "#/definitions/LLM"}],
                     },
+                    # not prefixed because marked as shared
+                    "chat_sleep": {
+                        "title": "Chat Sleep",
+                        "type": "number",
+                    },
+                    # prefixed for "chat" option
                     "llm==chat/responses": {
                         "title": "Chat Responses",
                         "default": ["hello", "bye"],
                         "type": "array",
                         "items": {"$ref": "#/definitions/Chat_Responses"},
                     },
+                    # prefixed for "default" option
                     "llm==default/responses": {
                         "title": "LLM Responses",
                         "description": "A list of fake responses for this LLM",
                         "default": ["a"],
                         "type": "array",
                         "items": {"type": "string"},
-                    },
-                    "prompt_template": {
-                        "title": "Prompt Template",
-                        "description": "The prompt template for this chain",
-                        "default": "hello",
-                        "allOf": [{"$ref": "#/definitions/Prompt_Template"}],
                     },
                 },
             },

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -1031,7 +1031,11 @@ def test_configurable_fields_prefix_keys() -> None:
                 "helpful": "How can I help you?",
             },
             default=["hello", "bye"],
-        )
+        ),
+        sleep=ConfigurableField(
+            id="chat_sleep",
+            is_shared=True,
+        ),
     )
     fake_llm = (
         FakeListLLM(responses=["a"])
@@ -1090,6 +1094,11 @@ def test_configurable_fields_prefix_keys() -> None:
                 "title": "Configurable",
                 "type": "object",
                 "properties": {
+                    # not prefixed because marked as shared
+                    "chat_sleep": {
+                        "title": "Chat Sleep",
+                        "type": "number",
+                    },
                     "llm": {
                         "title": "LLM",
                         "default": "default",


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
