### PR TITLE
feat: Add ERNIE-Bot-8K model support for ErnieBotChat.

### DIFF
--- a/libs/langchain/langchain/chat_models/ernie.py
+++ b/libs/langchain/langchain/chat_models/ernie.py
@@ -107,6 +107,7 @@ class ErnieBotChat(BaseChatModel):
         model_paths = {
             "ERNIE-Bot-turbo": "eb-instant",
             "ERNIE-Bot": "completions",
+            "ERNIE-Bot-8K": "ernie_bot_8k",
             "ERNIE-Bot-4": "completions_pro",
             "BLOOMZ-7B": "bloomz_7b1",
             "Llama-2-7b-chat": "llama_2_7b",


### PR DESCRIPTION
 - **Description:** According to the document https://cloud.baidu.com/doc/WENXINWORKSHOP/s/6lp69is2a, add ERNIE-Bot-8K model support for ErnieBotChat.
- **Dependencies:** Before using the ERNIE-Bot-8K, you should have the model's access authority.
