### PR TITLE
[docs] fix reduce prompt in summarization example

### DIFF
--- a/docs/docs/use_cases/summarization.ipynb
+++ b/docs/docs/use_cases/summarization.ipynb
@@ -356,7 +356,7 @@
    "source": [
     "# Reduce\n",
     "reduce_template = \"\"\"The following is set of summaries:\n",
-    "{doc_summaries}\n",
+    "{docs}\n",
     "Take these and distill it into a final, consolidated summary of the main themes. \n",
     "Helpful Answer:\"\"\"\n",
     "reduce_prompt = PromptTemplate.from_template(reduce_template)"


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

Small fix to _summarization_ example, `reduce_template` should use `{docs}` variable.

Bug likely introduced as following code suggests using `hub.pull("rlm/map-prompt")` instead of defined prompt.
