### PR TITLE
small fix matching engine AttributeError - object has no attribute

### DIFF
--- a/libs/langchain/langchain/vectorstores/matching_engine.py
+++ b/libs/langchain/langchain/vectorstores/matching_engine.py
@@ -232,7 +232,7 @@ class MatchingEngine(VectorStore):
         filter = filter or []
 
         # If the endpoint is public we use the find_neighbors function.
-        if self.endpoint._public_match_client:
+        if hasattr(self.endpoint, "_public_match_client"):
             response = self.endpoint.find_neighbors(
                 deployed_index_id=self._get_index_id(),
                 queries=[embedding],

--- a/libs/langchain/langchain/vectorstores/matching_engine.py
+++ b/libs/langchain/langchain/vectorstores/matching_engine.py
@@ -232,7 +232,9 @@ class MatchingEngine(VectorStore):
         filter = filter or []
 
         # If the endpoint is public we use the find_neighbors function.
-        if hasattr(self.endpoint, "_public_match_client"):
+        if hasattr(self.endpoint, "_public_match_client") and (
+            self.endpoint._public_match_client
+        ):
             response = self.endpoint.find_neighbors(
                 deployed_index_id=self._get_index_id(),
                 queries=[embedding],


### PR DESCRIPTION
This PR is fixing an attributeError: object endpoint has no attribute "_public_match_client" when using gcp matching engine with private VPC network.

@baskaryan, @eyurtsev, @hwchase17.
