### PR TITLE
Update agents\conversational\output_parser.py

### DIFF
--- a/libs/langchain/langchain/agents/conversational/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational/output_parser.py
@@ -22,7 +22,7 @@ class ConvoOutputParser(AgentOutputParser):
             return AgentFinish(
                 {"output": text.split(f"{self.ai_prefix}:")[-1].strip()}, text
             )
-        regex = r"Action: (.*?)[\n]*Action Input: (.*)"
+        regex = r"Action: (.*?)[\n]*Action Input: ([\s\S]*)"
         match = re.search(regex, text)
         if not match:
             raise OutputParserException(f"Could not parse LLM output: `{text}`")


### PR DESCRIPTION
The regular expression  regex = r"Action: (.*?)[\n]*Action Input: (.*)", with .* being the default greedy match.This results in the action_input variable not including the part after the newline character.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
