### PR TITLE
DOCS: fixed error in the docstring of RunnablePassthrough class

### DIFF
--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -62,8 +62,11 @@ class RunnablePassthrough(RunnableSerializable[Other, Other]):
 
         .. code-block:: python
 
-            from langchain_core.runnables import RunnablePassthrough, RunnableParallel
-            from langchain_core.runnables import RunnableLambda
+            from langchain_core.runnables import (
+                RunnableLambda,
+                RunnableParallel,
+                RunnablePassthrough,
+            )
 
             runnable = RunnableParallel(
                 origin=RunnablePassthrough(),

--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -63,6 +63,7 @@ class RunnablePassthrough(RunnableSerializable[Other, Other]):
         .. code-block:: python
 
             from langchain_core.runnables import RunnablePassthrough, RunnableParallel
+            from langchain_core.runnables import RunnableLambda
 
             runnable = RunnableParallel(
                 origin=RunnablePassthrough(),
@@ -72,7 +73,7 @@ class RunnablePassthrough(RunnableSerializable[Other, Other]):
             runnable.invoke(1) # {'origin': 1, 'modified': 2}
 
 
-             def fake_llm(prompt: str) -> str: # Fake LLM for the example
+            def fake_llm(prompt: str) -> str: # Fake LLM for the example
                 return "completion"
 
             chain = RunnableLambda(fake_llm) | {
@@ -89,7 +90,7 @@ class RunnablePassthrough(RunnableSerializable[Other, Other]):
 
             from langchain_core.runnables import RunnablePassthrough, RunnableParallel
 
-             def fake_llm(prompt: str) -> str: # Fake LLM for the example
+            def fake_llm(prompt: str) -> str: # Fake LLM for the example
                 return "completion"
 
             runnable = {


### PR DESCRIPTION
This pull request addresses an issue found in the example code within the docstring of `libs/core/langchain_core/runnables/passthrough.py`

The original code snippet caused a `NameError` due to the missing import of `RunnableLambda`. The error was as follows:
```
     12     return "completion"
     13 
---> 14 chain = RunnableLambda(fake_llm) | {
     15     'original': RunnablePassthrough(), # Original LLM output
     16     'parsed': lambda text: text[::-1] # Parsing logic

NameError: name 'RunnableLambda' is not defined
```
To resolve this, I have modified the example code to include the necessary import statement for `RunnableLambda`. Additionally, I have adjusted the indentation in the code snippet to ensure consistency and readability.

The modified code now successfully defines and utilizes `RunnableLambda`, ensuring that users referencing the docstring will have a functional and clear example to follow.

There are no related GitHub issues for this particular change.

Modified Code:
```python
from langchain_core.runnables import RunnablePassthrough, RunnableParallel
from langchain_core.runnables import RunnableLambda

runnable = RunnableParallel(
    origin=RunnablePassthrough(),
    modified=lambda x: x+1
)

runnable.invoke(1) # {'origin': 1, 'modified': 2}

def fake_llm(prompt: str) -> str: # Fake LLM for the example
    return "completion"

chain = RunnableLambda(fake_llm) | {
    'original': RunnablePassthrough(), # Original LLM output
    'parsed': lambda text: text[::-1] # Parsing logic
}

chain.invoke('hello') # {'original': 'completion', 'parsed': 'noitelpmoc'}
```