### PR TITLE
Reduce the number of tokens required to describe a Cypher/Neo4j schema

### DIFF
--- a/docs/docs/use_cases/graph/graph_cypher_qa.ipynb
+++ b/docs/docs/use_cases/graph/graph_cypher_qa.ipynb
@@ -48,16 +48,7 @@
    "execution_count": 2,
    "id": "0928915d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/tomaz/neo4j/langchain/libs/langchain/langchain/graphs/neo4j_graph.py:52: ExperimentalWarning: The configuration may change in the future.\n",
-      "  self._driver.verify_connectivity()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "graph = Neo4jGraph(\n",
     "    url=\"bolt://localhost:7687\", username=\"neo4j\", password=\"pleaseletmein\"\n",
@@ -132,14 +123,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Node properties are the following:\n",
+      "Movie {name: STRING},Actor {name: STRING}\n",
+      "Relationship properties are the following:\n",
       "\n",
-      "        Node properties are the following:\n",
-      "        [{'properties': [{'property': 'name', 'type': 'STRING'}], 'labels': 'Movie'}, {'properties': [{'property': 'name', 'type': 'STRING'}], 'labels': 'Actor'}]\n",
-      "        Relationship properties are the following:\n",
-      "        []\n",
-      "        The relationships are the following:\n",
-      "        ['(:Actor)-[:ACTED_IN]->(:Movie)']\n",
-      "        \n"
+      "The relationships are the following:\n",
+      "(:Actor)-[:ACTED_IN]->(:Movie)\n"
      ]
     }
    ],
@@ -556,12 +545,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Node properties are the following: \n",
-      " {'Actor': [{'property': 'name', 'type': 'STRING'}]}\n",
-      "Relationships properties are the following: \n",
-      " {}\n",
-      "Relationships are: \n",
-      "[]\n"
+      "Node properties are the following:\n",
+      "Actor {name: STRING}\n",
+      "Relationship properties are the following:\n",
+      "\n",
+      "The relationships are the following:\n",
+      "\n"
      ]
     }
    ],
@@ -656,7 +645,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -168,11 +168,9 @@ class GraphCypherQAChain(Chain):
         """Initialize from LLM."""
 
         if not cypher_llm and not llm:
-            raise ValueError(
-                "Either `llm` or `cypher_llm` parameters must be provided")
+            raise ValueError("Either `llm` or `cypher_llm` parameters must be provided")
         if not qa_llm and not llm:
-            raise ValueError(
-                "Either `llm` or `qa_llm` parameters must be provided")
+            raise ValueError("Either `llm` or `qa_llm` parameters must be provided")
         if cypher_llm and qa_llm and llm:
             raise ValueError(
                 "You can specify up to two of 'cypher_llm', 'qa_llm'"
@@ -256,8 +254,7 @@ class GraphCypherQAChain(Chain):
         if self.cypher_query_corrector:
             generated_cypher = self.cypher_query_corrector(generated_cypher)
 
-        _run_manager.on_text("Generated Cypher:",
-                             end="\n", verbose=self.verbose)
+        _run_manager.on_text("Generated Cypher:", end="\n", verbose=self.verbose)
         _run_manager.on_text(
             generated_cypher, color="green", end="\n", verbose=self.verbose
         )
@@ -274,8 +271,7 @@ class GraphCypherQAChain(Chain):
         if self.return_direct:
             final_result = context
         else:
-            _run_manager.on_text("Full Context:", end="\n",
-                                 verbose=self.verbose)
+            _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
             _run_manager.on_text(
                 str(context), color="green", end="\n", verbose=self.verbose
             )

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import BasePromptTemplate

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -46,7 +46,7 @@ def construct_schema(
     def filter_func(x: str) -> bool:
         return x in include_types if include_types else x not in exclude_types
 
-    filtered_schema = {
+    filtered_schema: Dict[str, Any] = {
         "node_props": {
             k: v
             for k, v in structured_schema.get("node_props", {}).items()
@@ -168,11 +168,9 @@ class GraphCypherQAChain(Chain):
         """Initialize from LLM."""
 
         if not cypher_llm and not llm:
-            raise ValueError(
-                "Either `llm` or `cypher_llm` parameters must be provided")
+            raise ValueError("Either `llm` or `cypher_llm` parameters must be provided")
         if not qa_llm and not llm:
-            raise ValueError(
-                "Either `llm` or `qa_llm` parameters must be provided")
+            raise ValueError("Either `llm` or `qa_llm` parameters must be provided")
         if cypher_llm and qa_llm and llm:
             raise ValueError(
                 "You can specify up to two of 'cypher_llm', 'qa_llm'"
@@ -256,8 +254,7 @@ class GraphCypherQAChain(Chain):
         if self.cypher_query_corrector:
             generated_cypher = self.cypher_query_corrector(generated_cypher)
 
-        _run_manager.on_text("Generated Cypher:",
-                             end="\n", verbose=self.verbose)
+        _run_manager.on_text("Generated Cypher:", end="\n", verbose=self.verbose)
         _run_manager.on_text(
             generated_cypher, color="green", end="\n", verbose=self.verbose
         )
@@ -274,8 +271,7 @@ class GraphCypherQAChain(Chain):
         if self.return_direct:
             final_result = context
         else:
-            _run_manager.on_text("Full Context:", end="\n",
-                                 verbose=self.verbose)
+            _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
             _run_manager.on_text(
                 str(context), color="green", end="\n", verbose=self.verbose
             )

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -64,16 +64,37 @@ def construct_schema(
         ],
     }
 
-    return (
-        f"Node properties are the following: \n {filtered_schema['node_props']}\n"
-        f"Relationships properties are the following: \n {filtered_schema['rel_props']}"
-        "\nRelationships are: \n"
-        + str(
-            [
-                f"(:{el['start']})-[:{el['type']}]->(:{el['end']})"
-                for el in filtered_schema["relationships"]
-            ]
+    # Format node properties
+    formatted_node_props = []
+    for label, properties in filtered_schema["node_props"].items():
+        props_str = ", ".join(
+            [f"{prop['property']}: {prop['type']}" for prop in properties]
         )
+        formatted_node_props.append(f"{label} {{{props_str}}}")
+
+    # Format relationship properties
+    formatted_rel_props = []
+    for rel_type, properties in filtered_schema["rel_props"].items():
+        props_str = ", ".join(
+            [f"{prop['property']}: {prop['type']}" for prop in properties]
+        )
+        formatted_rel_props.append(f"{rel_type} {{{props_str}}}")
+
+    # Format relationships
+    formatted_rels = [
+        f"(:{el['start']})-[:{el['type']}]->(:{el['end']})"
+        for el in filtered_schema["relationships"]
+    ]
+
+    return "\n".join(
+        [
+            "Node properties are the following:",
+            ",".join(formatted_node_props),
+            "Relationship properties are the following:",
+            ",".join(formatted_rel_props),
+            "The relationships are the following:",
+            ",".join(formatted_rels),
+        ]
     )
 
 

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -46,12 +46,17 @@ def construct_schema(
     def filter_func(x: str) -> bool:
         return x in include_types if include_types else x not in exclude_types
 
-    node_props: Dict[str, Any] = structured_schema.get("node_props", {})
-    rel_props: Dict[str, Any] = structured_schema.get("rel_props", {})
-
     filtered_schema = {
-        "node_props": {k: v for k, v in node_props.items() if filter_func(k)},
-        "rel_props": {k: v for k, v in rel_props.items() if filter_func(k)},
+        "node_props": {
+            k: v
+            for k, v in structured_schema.get("node_props", {}).items()
+            if filter_func(k)
+        },
+        "rel_props": {
+            k: v
+            for k, v in structured_schema.get("rel_props", {}).items()
+            if filter_func(k)
+        },
         "relationships": [
             r
             for r in structured_schema.get("relationships", [])

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import BasePromptTemplate
@@ -37,7 +37,7 @@ def extract_cypher(text: str) -> str:
 
 
 def construct_schema(
-    structured_schema: Dict[str, Any],
+    structured_schema: Dict[str, Union[Any, Dict[str, Any]]],
     include_types: List[str],
     exclude_types: List[str],
 ) -> str:

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -37,7 +37,7 @@ def extract_cypher(text: str) -> str:
 
 
 def construct_schema(
-    structured_schema: Dict[str, Dict[str, Any]],
+    structured_schema: Dict[str, Any],
     include_types: List[str],
     exclude_types: List[str],
 ) -> str:
@@ -46,17 +46,12 @@ def construct_schema(
     def filter_func(x: str) -> bool:
         return x in include_types if include_types else x not in exclude_types
 
+    node_props: Dict[str, Any] = structured_schema.get("node_props", {})
+    rel_props: Dict[str, Any] = structured_schema.get("rel_props", {})
+
     filtered_schema = {
-        "node_props": {
-            k: v
-            for k, v in structured_schema.get("node_props", {}).items()
-            if filter_func(k)
-        },
-        "rel_props": {
-            k: v
-            for k, v in structured_schema.get("rel_props", {}).items()
-            if filter_func(k)
-        },
+        "node_props": {k: v for k, v in node_props.items() if filter_func(k)},
+        "rel_props": {k: v for k, v in rel_props.items() if filter_func(k)},
         "relationships": [
             r
             for r in structured_schema.get("relationships", [])

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -37,7 +37,7 @@ def extract_cypher(text: str) -> str:
 
 
 def construct_schema(
-    structured_schema: Dict[str, Union[Any, Dict[str, Any]]],
+    structured_schema: Dict[str, Any],
     include_types: List[str],
     exclude_types: List[str],
 ) -> str:
@@ -168,9 +168,11 @@ class GraphCypherQAChain(Chain):
         """Initialize from LLM."""
 
         if not cypher_llm and not llm:
-            raise ValueError("Either `llm` or `cypher_llm` parameters must be provided")
+            raise ValueError(
+                "Either `llm` or `cypher_llm` parameters must be provided")
         if not qa_llm and not llm:
-            raise ValueError("Either `llm` or `qa_llm` parameters must be provided")
+            raise ValueError(
+                "Either `llm` or `qa_llm` parameters must be provided")
         if cypher_llm and qa_llm and llm:
             raise ValueError(
                 "You can specify up to two of 'cypher_llm', 'qa_llm'"
@@ -254,7 +256,8 @@ class GraphCypherQAChain(Chain):
         if self.cypher_query_corrector:
             generated_cypher = self.cypher_query_corrector(generated_cypher)
 
-        _run_manager.on_text("Generated Cypher:", end="\n", verbose=self.verbose)
+        _run_manager.on_text("Generated Cypher:",
+                             end="\n", verbose=self.verbose)
         _run_manager.on_text(
             generated_cypher, color="green", end="\n", verbose=self.verbose
         )
@@ -271,7 +274,8 @@ class GraphCypherQAChain(Chain):
         if self.return_direct:
             final_result = context
         else:
-            _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
+            _run_manager.on_text("Full Context:", end="\n",
+                                 verbose=self.verbose)
             _run_manager.on_text(
                 str(context), color="green", end="\n", verbose=self.verbose
             )

--- a/libs/langchain/langchain/chains/graph_qa/cypher.py
+++ b/libs/langchain/langchain/chains/graph_qa/cypher.py
@@ -37,7 +37,7 @@ def extract_cypher(text: str) -> str:
 
 
 def construct_schema(
-    structured_schema: Dict[str, Any],
+    structured_schema: Dict[str, Dict[str, Any]],
     include_types: List[str],
     exclude_types: List[str],
 ) -> str:
@@ -168,9 +168,11 @@ class GraphCypherQAChain(Chain):
         """Initialize from LLM."""
 
         if not cypher_llm and not llm:
-            raise ValueError("Either `llm` or `cypher_llm` parameters must be provided")
+            raise ValueError(
+                "Either `llm` or `cypher_llm` parameters must be provided")
         if not qa_llm and not llm:
-            raise ValueError("Either `llm` or `qa_llm` parameters must be provided")
+            raise ValueError(
+                "Either `llm` or `qa_llm` parameters must be provided")
         if cypher_llm and qa_llm and llm:
             raise ValueError(
                 "You can specify up to two of 'cypher_llm', 'qa_llm'"
@@ -254,7 +256,8 @@ class GraphCypherQAChain(Chain):
         if self.cypher_query_corrector:
             generated_cypher = self.cypher_query_corrector(generated_cypher)
 
-        _run_manager.on_text("Generated Cypher:", end="\n", verbose=self.verbose)
+        _run_manager.on_text("Generated Cypher:",
+                             end="\n", verbose=self.verbose)
         _run_manager.on_text(
             generated_cypher, color="green", end="\n", verbose=self.verbose
         )
@@ -271,7 +274,8 @@ class GraphCypherQAChain(Chain):
         if self.return_direct:
             final_result = context
         else:
-            _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
+            _run_manager.on_text("Full Context:", end="\n",
+                                 verbose=self.verbose)
             _run_manager.on_text(
                 str(context), color="green", end="\n", verbose=self.verbose
             )

--- a/libs/langchain/langchain/graphs/neo4j_graph.py
+++ b/libs/langchain/langchain/graphs/neo4j_graph.py
@@ -127,14 +127,38 @@ class Neo4jGraph(GraphStore):
             "rel_props": {el["type"]: el["properties"] for el in rel_properties},
             "relationships": relationships,
         }
-        self.schema = f"""
-        Node properties are the following:
-        {node_properties}
-        Relationship properties are the following:
-        {rel_properties}
-        The relationships are the following:
-        {[f"(:{el['start']})-[:{el['type']}]->(:{el['end']})" for el in relationships]}
-        """
+
+        # Format node properties
+        formatted_node_props = []
+        for el in node_properties:
+            props_str = ", ".join(
+                [f"{prop['property']}: {prop['type']}" for prop in el["properties"]]
+            )
+            formatted_node_props.append(f"{el['labels']} {{{props_str}}}")
+
+        # Format relationship properties
+        formatted_rel_props = []
+        for el in rel_properties:
+            props_str = ", ".join(
+                [f"{prop['property']}: {prop['type']}" for prop in el["properties"]]
+            )
+            formatted_rel_props.append(f"{el['type']} {{{props_str}}}")
+
+        # Format relationships
+        formatted_rels = [
+            f"(:{el['start']})-[:{el['type']}]->(:{el['end']})" for el in relationships
+        ]
+
+        self.schema = "\n".join(
+            [
+                "Node properties are the following:",
+                ",".join(formatted_node_props),
+                "Relationship properties are the following:",
+                ",".join(formatted_rel_props),
+                "The relationships are the following:",
+                ",".join(formatted_rels),
+            ]
+        )
 
     def add_graph_documents(
         self, graph_documents: List[GraphDocument], include_source: bool = False

--- a/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
@@ -213,12 +213,11 @@ def test_exclude_types() -> None:
     exclude_types = ["Person", "DIRECTED"]
     output = construct_schema(structured_schema, [], exclude_types)
     expected_schema = (
-        "Node properties are the following: \n"
-        " {'Movie': [{'property': 'title', 'type': 'STRING'}], "
-        "'Actor': [{'property': 'name', 'type': 'STRING'}]}\n"
-        "Relationships properties are the following: \n"
-        " {}\nRelationships are: \n"
-        "['(:Actor)-[:ACTED_IN]->(:Movie)']"
+        "Node properties are the following:\n"
+        "Movie {title: STRING},Actor {name: STRING}\n"
+        "Relationship properties are the following:\n\n"
+        "The relationships are the following:\n"
+        "(:Actor)-[:ACTED_IN]->(:Movie)"
     )
     assert output == expected_schema
 
@@ -239,12 +238,11 @@ def test_include_types() -> None:
     include_types = ["Movie", "Actor", "ACTED_IN"]
     output = construct_schema(structured_schema, include_types, [])
     expected_schema = (
-        "Node properties are the following: \n"
-        " {'Movie': [{'property': 'title', 'type': 'STRING'}], "
-        "'Actor': [{'property': 'name', 'type': 'STRING'}]}\n"
-        "Relationships properties are the following: \n"
-        " {}\nRelationships are: \n"
-        "['(:Actor)-[:ACTED_IN]->(:Movie)']"
+        "Node properties are the following:\n"
+        "Movie {title: STRING},Actor {name: STRING}\n"
+        "Relationship properties are the following:\n\n"
+        "The relationships are the following:\n"
+        "(:Actor)-[:ACTED_IN]->(:Movie)"
     )
     assert output == expected_schema
 
@@ -265,12 +263,10 @@ def test_include_types2() -> None:
     include_types = ["Movie", "Actor"]
     output = construct_schema(structured_schema, include_types, [])
     expected_schema = (
-        "Node properties are the following: \n"
-        " {'Movie': [{'property': 'title', 'type': 'STRING'}], "
-        "'Actor': [{'property': 'name', 'type': 'STRING'}]}\n"
-        "Relationships properties are the following: \n"
-        " {}\nRelationships are: \n"
-        "[]"
+        "Node properties are the following:\n"
+        "Movie {title: STRING},Actor {name: STRING}\n"
+        "Relationship properties are the following:\n\n"
+        "The relationships are the following:\n"
     )
     assert output == expected_schema
 
@@ -291,12 +287,11 @@ def test_include_types3() -> None:
     include_types = ["Movie", "Actor", "ACTED_IN"]
     output = construct_schema(structured_schema, include_types, [])
     expected_schema = (
-        "Node properties are the following: \n"
-        " {'Movie': [{'property': 'title', 'type': 'STRING'}], "
-        "'Actor': [{'property': 'name', 'type': 'STRING'}]}\n"
-        "Relationships properties are the following: \n"
-        " {}\nRelationships are: \n"
-        "['(:Actor)-[:ACTED_IN]->(:Movie)']"
+        "Node properties are the following:\n"
+        "Movie {title: STRING},Actor {name: STRING}\n"
+        "Relationship properties are the following:\n\n"
+        "The relationships are the following:\n"
+        "(:Actor)-[:ACTED_IN]->(:Movie)"
     )
     assert output == expected_schema
 

--- a/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
@@ -47,8 +47,7 @@ def test_graph_cypher_qa_chain_prompt_selection_1() -> None:
     qa_prompt_template = "QA Prompt"
     cypher_prompt_template = "Cypher Prompt"
     qa_prompt = PromptTemplate(template=qa_prompt_template, input_variables=[])
-    cypher_prompt = PromptTemplate(
-        template=cypher_prompt_template, input_variables=[])
+    cypher_prompt = PromptTemplate(template=cypher_prompt_template, input_variables=[])
     chain = GraphCypherQAChain.from_llm(
         llm=FakeLLM(),
         graph=FakeGraphStore(),
@@ -96,8 +95,7 @@ def test_graph_cypher_qa_chain_prompt_selection_4() -> None:
     memory = ConversationBufferMemory(memory_key="chat_history")
     readonlymemory = ReadOnlySharedMemory(memory=memory)
     qa_prompt = PromptTemplate(template=qa_prompt_template, input_variables=[])
-    cypher_prompt = PromptTemplate(
-        template=cypher_prompt_template, input_variables=[])
+    cypher_prompt = PromptTemplate(template=cypher_prompt_template, input_variables=[])
     chain = GraphCypherQAChain.from_llm(
         llm=FakeLLM(),
         graph=FakeGraphStore(),
@@ -117,8 +115,7 @@ def test_graph_cypher_qa_chain_prompt_selection_5() -> None:
     memory = ConversationBufferMemory(memory_key="chat_history")
     readonlymemory = ReadOnlySharedMemory(memory=memory)
     qa_prompt = PromptTemplate(template=qa_prompt_template, input_variables=[])
-    cypher_prompt = PromptTemplate(
-        template=cypher_prompt_template, input_variables=[])
+    cypher_prompt = PromptTemplate(template=cypher_prompt_template, input_variables=[])
     try:
         GraphCypherQAChain.from_llm(
             llm=FakeLLM(),

--- a/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/langchain/tests/unit_tests/chains/test_graph_qa.py
@@ -47,7 +47,8 @@ def test_graph_cypher_qa_chain_prompt_selection_1() -> None:
     qa_prompt_template = "QA Prompt"
     cypher_prompt_template = "Cypher Prompt"
     qa_prompt = PromptTemplate(template=qa_prompt_template, input_variables=[])
-    cypher_prompt = PromptTemplate(template=cypher_prompt_template, input_variables=[])
+    cypher_prompt = PromptTemplate(
+        template=cypher_prompt_template, input_variables=[])
     chain = GraphCypherQAChain.from_llm(
         llm=FakeLLM(),
         graph=FakeGraphStore(),
@@ -95,7 +96,8 @@ def test_graph_cypher_qa_chain_prompt_selection_4() -> None:
     memory = ConversationBufferMemory(memory_key="chat_history")
     readonlymemory = ReadOnlySharedMemory(memory=memory)
     qa_prompt = PromptTemplate(template=qa_prompt_template, input_variables=[])
-    cypher_prompt = PromptTemplate(template=cypher_prompt_template, input_variables=[])
+    cypher_prompt = PromptTemplate(
+        template=cypher_prompt_template, input_variables=[])
     chain = GraphCypherQAChain.from_llm(
         llm=FakeLLM(),
         graph=FakeGraphStore(),
@@ -115,7 +117,8 @@ def test_graph_cypher_qa_chain_prompt_selection_5() -> None:
     memory = ConversationBufferMemory(memory_key="chat_history")
     readonlymemory = ReadOnlySharedMemory(memory=memory)
     qa_prompt = PromptTemplate(template=qa_prompt_template, input_variables=[])
-    cypher_prompt = PromptTemplate(template=cypher_prompt_template, input_variables=[])
+    cypher_prompt = PromptTemplate(
+        template=cypher_prompt_template, input_variables=[])
     try:
         GraphCypherQAChain.from_llm(
             llm=FakeLLM(),
@@ -152,16 +155,18 @@ def test_graph_cypher_qa_chain() -> None:
     readonlymemory = ReadOnlySharedMemory(memory=memory)
     prompt1 = (
         "You are a nice chatbot having a conversation with a human.\n\n    "
-        "Schema:\n    Node properties are the following: \n {}\nRelationships "
-        "properties are the following: \n {}\nRelationships are: \n[]\n\n    "
+        "Schema:\n    Node properties are the following:\n\nRelationship "
+        "properties are the following:\n\nThe relationships are the "
+        "following:\n\n\n    "
         "Previous conversation:\n    \n\n    New human question: "
         "Test question\n    Response:"
     )
 
     prompt2 = (
         "You are a nice chatbot having a conversation with a human.\n\n    "
-        "Schema:\n    Node properties are the following: \n {}\nRelationships "
-        "properties are the following: \n {}\nRelationships are: \n[]\n\n    "
+        "Schema:\n    Node properties are the following:\n\nRelationship "
+        "properties are the following:\n\nThe relationships are the "
+        "following:\n\n\n    "
         "Previous conversation:\n    Human: Test question\nAI: foo\n\n    "
         "New human question: Test new question\n    Response:"
     )


### PR DESCRIPTION
Instead of using JSON-like syntax to describe node and relationship properties we changed to a shorter and more concise schema description

Old:

```
        Node properties are the following:
        [{'properties': [{'property': 'name', 'type': 'STRING'}], 'labels': 'Movie'}, {'properties': [{'property': 'name', 'type': 'STRING'}], 'labels': 'Actor'}]
        Relationship properties are the following:
        []
        The relationships are the following:
        ['(:Actor)-[:ACTED_IN]->(:Movie)']
```

New:

```
Node properties are the following:
Movie {name: STRING},Actor {name: STRING}
Relationship properties are the following:

The relationships are the following:
(:Actor)-[:ACTED_IN]->(:Movie)
```

