### PR TITLE
docs: fix link to `local_retrieval_qa`

### DIFF
--- a/docs/docs/use_cases/question_answering/index.ipynb
+++ b/docs/docs/use_cases/question_answering/index.ipynb
@@ -743,7 +743,7 @@
     "- [Docs](/docs/modules/model_io/llms)\n",
     "- [Integrations](/docs/integrations/llms): Explore over 75 `LLM` integrations.\n",
     "\n",
-    "See a guide on RAG with locally-running models [here](/docs/modules/use_cases/question_answering/local_retrieval_qa)."
+    "See a guide on RAG with locally-running models [here](/docs/use_cases/question_answering/local_retrieval_qa)."
    ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
The original link in [this section](https://python.langchain.com/docs/use_cases/question_answering/#:~:text=locally%2Drunning%20models-,here,-.):
https://python.langchain.com/docs/modules/use_cases/question_answering/local_retrieval_qa

After fix:
https://python.langchain.com/docs/use_cases/question_answering/local_retrieval_qa