### PR TITLE
Add progress bar to OllamaEmbeddings

### DIFF
--- a/libs/langchain/langchain/embeddings/ollama.py
+++ b/libs/langchain/langchain/embeddings/ollama.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import BaseModel, Extra
-from tqdm import tqdm
+
 
 class OllamaEmbeddings(BaseModel, Embeddings):
     """Ollama locally runs large language models.
@@ -186,7 +186,13 @@ class OllamaEmbeddings(BaseModel, Embeddings):
         Returns:
             List of embeddings, one for each text.
         """
-        instruction_pairs = [f"{self.embed_instruction}{text}" for text in tqdm(texts, desc="OllamaEmbeddings)]
+        try:
+            from tqdm import tqdm
+
+            text_iter = tqdm(texts, desc="OllamaEmbeddings")
+        except ImportError:
+            text_iter = texts
+        instruction_pairs = [f"{self.embed_instruction}{text}" for text in text_iter]
         embeddings = self._embed(instruction_pairs)
         return embeddings
 

--- a/libs/langchain/langchain/embeddings/ollama.py
+++ b/libs/langchain/langchain/embeddings/ollama.py
@@ -170,15 +170,16 @@ class OllamaEmbeddings(BaseModel, Embeddings):
             )
 
     def _embed(self, input: List[str]) -> List[List[float]]:
-        embeddings_list: List[List[float]] = []
-        for prompt in input:
-            embeddings = self._process_emb_response(prompt)
-            embeddings_list.append(embeddings)
+        try:
+            from tqdm import tqdm
 
-        return embeddings_list
+            iter_ = tqdm(input, desc="OllamaEmbeddings")
+        except ImportError:
+            iter_ = input
+        return [self._process_emb_response(prompt) for prompt in iter_]
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
-        """Embed documents using a Ollama deployed embedding model.
+        """Embed documents using an Ollama deployed embedding model.
 
         Args:
             texts: The list of texts to embed.
@@ -186,13 +187,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
         Returns:
             List of embeddings, one for each text.
         """
-        try:
-            from tqdm import tqdm
-
-            text_iter = tqdm(texts, desc="OllamaEmbeddings")
-        except ImportError:
-            text_iter = texts
-        instruction_pairs = [f"{self.embed_instruction}{text}" for text in text_iter]
+        instruction_pairs = [f"{self.embed_instruction}{text}" for text in texts]
         embeddings = self._embed(instruction_pairs)
         return embeddings
 

--- a/libs/langchain/langchain/embeddings/ollama.py
+++ b/libs/langchain/langchain/embeddings/ollama.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import BaseModel, Extra
-
+from tqdm import tqdm
 
 class OllamaEmbeddings(BaseModel, Embeddings):
     """Ollama locally runs large language models.
@@ -186,7 +186,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
         Returns:
             List of embeddings, one for each text.
         """
-        instruction_pairs = [f"{self.embed_instruction}{text}" for text in texts]
+        instruction_pairs = [f"{self.embed_instruction}{text}" for text in tqdm(texts, desc="OllamaEmbeddings)]
         embeddings = self._embed(instruction_pairs)
         return embeddings
 

--- a/libs/langchain/langchain/embeddings/ollama.py
+++ b/libs/langchain/langchain/embeddings/ollama.py
@@ -102,7 +102,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
     to more diverse text, while a lower value (e.g., 0.5) will
     generate more focused and conservative text. (Default: 0.9)"""
 
-    show_progress_bar: bool = False
+    show_progress: bool = False
     """Whether to show a tqdm progress bar. Must have `tqdm` installed."""
 
     @property
@@ -176,7 +176,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
             )
 
     def _embed(self, input: List[str]) -> List[List[float]]:
-        if self.show_progress_bar:
+        if self.show_progress:
             try:
                 from tqdm import tqdm
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -22,8 +22,8 @@ aiohttp = "^3.8.3"
 tenacity = "^8.1.0"
 anyio = "<4.0"
 jsonpatch = "^1.33"
-tqdm = ">=4.48.0"
 azure-core = {version = "^1.26.4", optional=true}
+tqdm = {version = ">=4.48.0", optional = true}
 openapi-pydantic = {version = "^0.3.2", optional = true}
 faiss-cpu = {version = "^1", optional = true}
 wikipedia = {version = "^1", optional = true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -22,8 +22,8 @@ aiohttp = "^3.8.3"
 tenacity = "^8.1.0"
 anyio = "<4.0"
 jsonpatch = "^1.33"
+tqdm = ">=4.48.0"
 azure-core = {version = "^1.26.4", optional=true}
-tqdm = {version = ">=4.48.0", optional = true}
 openapi-pydantic = {version = "^0.3.2", optional = true}
 faiss-cpu = {version = "^1", optional = true}
 wikipedia = {version = "^1", optional = true}


### PR DESCRIPTION
- **Description:** Adds a tqdm progress bar to OllamaEmbeddings when embedding a list.
- **Issue:** Related to #13637, but extended to Ollama.
- **Dependencies:** `tqdm` made a necessary dependency.

Thanks to @ugm2 for helping identify a common problem. Embeddings take a very long time to finish on local machines, and require a progress bar to help identify if one should even attempt the workload.