### PR TITLE
Improve exclude path filesystem logic

### DIFF
--- a/libs/langchain/langchain/document_loaders/blob_loaders/file_system.py
+++ b/libs/langchain/langchain/document_loaders/blob_loaders/file_system.py
@@ -118,11 +118,19 @@ class FileSystemBlobLoader(BlobLoader):
 
     def _yield_paths(self) -> Iterable[Path]:
         """Yield paths that match the requested pattern."""
+
+        def match_exclude(path: Path) -> bool:
+            """Check if the path matches any of the exclude patterns."""
+            for exclude_pattern in self.exclude:
+                for part in path.parents:
+                    if part.match(exclude_pattern):
+                        return True
+            return False
+
         paths = self.path.glob(self.glob)
         for path in paths:
-            if self.exclude:
-                if any(path.match(glob) for glob in self.exclude):
-                    continue
+            if self.exclude and match_exclude(path):
+                continue
             if path.is_file():
                 if self.suffixes and path.suffix not in self.suffixes:
                     continue


### PR DESCRIPTION
  - **Description:** Improving the use of the exclude arguments for `FileSystemBlobLoader`
  - **Issue:** #13751
  - **Dependencies:** n/a
  - **Tag maintainer:** 
  - **Twitter handle:** this PR won't get announced, but @jlarks32

See the issue above for more detail, but I don't think that the `exclude` parameter is being handled really like what the API is indicating / what we were thinking (largely due to annoyances with pathlib's `Path.match`). Let me know if you all want me to add some more unit tests and build this out a little bit more. 

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
