### PR TITLE
Support for indexes that do not return a 'metadata' field in '_source'

### DIFF
--- a/libs/langchain/langchain/vectorstores/elasticsearch.py
+++ b/libs/langchain/langchain/vectorstores/elasticsearch.py
@@ -798,6 +798,8 @@ class ElasticsearchStore(VectorStore):
                     "metadata",
                     self.query_field,
                 ]:
+                    if "metadata" not in hit["_source"]:
+                        hit["_source"]["metadata"] = {}
                     hit["_source"]["metadata"][field] = hit["_source"][field]
 
             docs_and_scores.append(


### PR DESCRIPTION

Description: Some Elastic indexes do not return a 'metadata' field in '_source'. However, prior to this PR, the code assumed  there always is a 'metadata' field. This PR adds support for cases where the field is missing by adding it manually.

Issue: #13869 
