### PR TITLE
Update openai.py: Fix the bug where openai_proxy is not effective.

### DIFF
--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -287,6 +287,9 @@ class ChatOpenAI(BaseChatModel):
             "OPENAI_PROXY",
             default="",
         )
+        values["http_client"] = values["http_client"] or httpx.Client(
+            proxies=values["openai_proxy"]
+        )
         try:
             import openai
 


### PR DESCRIPTION
Fix the bug where ChatOpenAI().openai_proxy = HTTP_PROXY is not effective.

Reproduce&Test:

from langchain.chat_models import ChatOpenAI
llm = ChatOpenAI()
llm.openai_proxy = "http://127.0.0.1:8001"
llm.predict("Hello")

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
