### PR TITLE
Fix Mathpix PDF loader integration

### DIFF
--- a/libs/langchain/langchain/document_loaders/pdf.py
+++ b/libs/langchain/langchain/document_loaders/pdf.py
@@ -392,8 +392,8 @@ class MathpixPDFLoader(BasePDFLoader):
         )
 
         # The base class isn't expecting these and doesn't collect **kwargs
-        kwargs.pop("mathpix_api_key")
-        kwargs.pop("mathpix_api_id")
+        kwargs.pop("mathpix_api_key", None)
+        kwargs.pop("mathpix_api_id", None)
 
         super().__init__(file_path, **kwargs)
         self.processed_file_format = processed_file_format


### PR DESCRIPTION
  - **Description:** Fixes the Mathpix PDF loader API integration. Specifically, ensures that Mathpix auth headers are provided for every request, and ensures that we recognize all errors that can occur during a request. Also, the option to provide API keys as kwargs never actually worked before, but now that's fixed too.
  - **Issue:** #11249
  - **Dependencies:** None