### PR TITLE
Use langchain core in-tree as a dev dependency

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -7,10 +7,6 @@ on:
         required: true
         type: string
         description: "From which folder this pipeline executes"
-      langchain-core-location:
-        required: false
-        type: string
-        description: "Relative path to the langchain core library folder"
 
 env:
   POETRY_VERSION: "1.6.1"
@@ -43,14 +39,6 @@ jobs:
       - name: Install integration dependencies
         shell: bash
         run: poetry install --with=test_integration
-
-      - name: Install langchain core editable
-        working-directory: ${{ inputs.working-directory }}
-        if: ${{ inputs.langchain-core-location }}
-        env:
-          LANGCHAIN_CORE_LOCATION: ${{ inputs.langchain-core-location }}
-        run: |
-          poetry run pip install -e "$LANGCHAIN_CORE_LOCATION"
 
       - name: Check integration tests compile
         shell: bash

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -11,10 +11,6 @@ on:
         required: false
         type: string
         description: "Relative path to the langchain library folder"
-      langchain-core-location:
-        required: false
-        type: string
-        description: "Relative path to the langchain core library folder"
 
 env:
   POETRY_VERSION: "1.6.1"
@@ -81,14 +77,6 @@ jobs:
           LANGCHAIN_LOCATION: ${{ inputs.langchain-location }}
         run: |
           poetry run pip install -e "$LANGCHAIN_LOCATION"
-
-      - name: Install langchain core editable
-        working-directory: ${{ inputs.working-directory }}
-        if: ${{ inputs.langchain-core-location }}
-        env:
-          LANGCHAIN_CORE_LOCATION: ${{ inputs.langchain-core-location }}
-        run: |
-          poetry run pip install -e "$LANGCHAIN_CORE_LOCATION"
 
       - name: Get .mypy_cache to speed up mypy
         uses: actions/cache@v3

--- a/.github/workflows/_pydantic_compatibility.yml
+++ b/.github/workflows/_pydantic_compatibility.yml
@@ -11,10 +11,6 @@ on:
         required: false
         type: string
         description: "Relative path to the langchain library folder"
-      langchain-core-location:
-        required: false
-        type: string
-        description: "Relative path to the langchain core library folder"
 
 env:
   POETRY_VERSION: "1.6.1"
@@ -55,14 +51,6 @@ jobs:
           LANGCHAIN_LOCATION: ${{ inputs.langchain-location }}
         run: |
           poetry run pip install -e "$LANGCHAIN_LOCATION"
-
-      - name: Install langchain core editable
-        working-directory: ${{ inputs.working-directory }}
-        if: ${{ inputs.langchain-core-location }}
-        env:
-          LANGCHAIN_CORE_LOCATION: ${{ inputs.langchain-core-location }}
-        run: |
-          poetry run pip install -e "$LANGCHAIN_CORE_LOCATION"
 
       - name: Install the opposite major version of pydantic
         # If normal tests use pydantic v1, here we'll use v2, and vice versa.

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -11,10 +11,6 @@ on:
         required: false
         type: string
         description: "Relative path to the langchain library folder"
-      langchain-core-location:
-        required: false
-        type: string
-        description: "Relative path to the langchain core library folder"
 
 env:
   POETRY_VERSION: "1.6.1"
@@ -55,14 +51,6 @@ jobs:
           LANGCHAIN_LOCATION: ${{ inputs.langchain-location }}
         run: |
           poetry run pip install -e "$LANGCHAIN_LOCATION"
-
-      - name: Install langchain core editable
-        working-directory: ${{ inputs.working-directory }}
-        if: ${{ inputs.langchain-core-location }}
-        env:
-          LANGCHAIN_CORE_LOCATION: ${{ inputs.langchain-core-location }}
-        run: |
-          poetry run pip install -e "$LANGCHAIN_CORE_LOCATION"
 
       - name: Run core tests
         shell: bash

--- a/.github/workflows/langchain_ci.yml
+++ b/.github/workflows/langchain_ci.yml
@@ -3,19 +3,19 @@ name: libs/langchain CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     paths:
-      - '.github/actions/poetry_setup/action.yml'
-      - '.github/tools/**'
-      - '.github/workflows/_lint.yml'
-      - '.github/workflows/_test.yml'
-      - '.github/workflows/_pydantic_compatibility.yml'
-      - '.github/workflows/langchain_ci.yml'
-      - 'libs/*'
-      - 'libs/langchain/**'
-      - 'libs/core/**'
-  workflow_dispatch:  # Allows to trigger the workflow manually in GitHub UI
+      - ".github/actions/poetry_setup/action.yml"
+      - ".github/tools/**"
+      - ".github/workflows/_lint.yml"
+      - ".github/workflows/_test.yml"
+      - ".github/workflows/_pydantic_compatibility.yml"
+      - ".github/workflows/langchain_ci.yml"
+      - "libs/*"
+      - "libs/langchain/**"
+      - "libs/core/**"
+  workflow_dispatch: # Allows to trigger the workflow manually in GitHub UI
 
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
@@ -33,35 +33,27 @@ env:
 
 jobs:
   lint:
-    uses:
-      ./.github/workflows/_lint.yml
+    uses: ./.github/workflows/_lint.yml
     with:
       working-directory: libs/langchain
-      langchain-core-location: ../core
     secrets: inherit
 
   test:
-    uses:
-      ./.github/workflows/_test.yml
+    uses: ./.github/workflows/_test.yml
     with:
       working-directory: libs/langchain
-      langchain-core-location: ../core
     secrets: inherit
 
   compile-integration-tests:
-    uses:
-      ./.github/workflows/_compile_integration_test.yml
+    uses: ./.github/workflows/_compile_integration_test.yml
     with:
       working-directory: libs/langchain
-      langchain-core-location: ../core
     secrets: inherit
 
   pydantic-compatibility:
-    uses:
-      ./.github/workflows/_pydantic_compatibility.yml
+    uses: ./.github/workflows/_pydantic_compatibility.yml
     with:
       working-directory: libs/langchain
-      langchain-core-location: ../core
     secrets: inherit
 
   # It's possible that langchain works fine with the latest *published* langchain-core,

--- a/.github/workflows/langchain_ci.yml
+++ b/.github/workflows/langchain_ci.yml
@@ -56,46 +56,6 @@ jobs:
       working-directory: libs/langchain
     secrets: inherit
 
-  # It's possible that langchain works fine with the latest *published* langchain-core,
-  # but is broken with the langchain-core on `master`.
-  #
-  # We want to catch situations like that *before* releasing a new langchain-core, hence this test.
-  test-with-latest-langchain-core:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ env.WORKDIR }}
-    strategy:
-      matrix:
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-    name: test with unpublished langchain-core - Python ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }} + Poetry ${{ env.POETRY_VERSION }}
-        uses: "./.github/actions/poetry_setup"
-        with:
-          python-version: ${{ matrix.python-version }}
-          poetry-version: ${{ env.POETRY_VERSION }}
-          working-directory: ${{ env.WORKDIR }}
-          cache-key: unpublished-langchain-core
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          echo "Running tests with unpublished langchain, installing dependencies with poetry..."
-          poetry install
-
-          echo "Editably installing langchain-core outside of poetry, to avoid messing up lockfile..."
-          poetry run pip install -e ../core
-
-      - name: Run tests
-        run: make test
-
   extended-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/langchain_experimental_ci.yml
+++ b/.github/workflows/langchain_experimental_ci.yml
@@ -3,19 +3,19 @@ name: libs/experimental CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     paths:
-      - '.github/actions/poetry_setup/action.yml'
-      - '.github/tools/**'
-      - '.github/workflows/_lint.yml'
-      - '.github/workflows/_test.yml'
-      - '.github/workflows/langchain_experimental_ci.yml'
-      - 'libs/*'
-      - 'libs/experimental/**'
-      - 'libs/langchain/**'
-      - 'libs/core/**'
-  workflow_dispatch:  # Allows to trigger the workflow manually in GitHub UI
+      - ".github/actions/poetry_setup/action.yml"
+      - ".github/tools/**"
+      - ".github/workflows/_lint.yml"
+      - ".github/workflows/_test.yml"
+      - ".github/workflows/langchain_experimental_ci.yml"
+      - "libs/*"
+      - "libs/experimental/**"
+      - "libs/langchain/**"
+      - "libs/core/**"
+  workflow_dispatch: # Allows to trigger the workflow manually in GitHub UI
 
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
@@ -33,26 +33,21 @@ env:
 
 jobs:
   lint:
-    uses:
-      ./.github/workflows/_lint.yml
+    uses: ./.github/workflows/_lint.yml
     with:
       working-directory: libs/experimental
       langchain-location: ../langchain
-      langchain-core-location: ../core
     secrets: inherit
 
   test:
-    uses:
-      ./.github/workflows/_test.yml
+    uses: ./.github/workflows/_test.yml
     with:
       working-directory: libs/experimental
       langchain-location: ../langchain
-      langchain-core-location: ../core
     secrets: inherit
 
   compile-integration-tests:
-    uses:
-      ./.github/workflows/_compile_integration_test.yml
+    uses: ./.github/workflows/_compile_integration_test.yml
     with:
       working-directory: libs/experimental
     secrets: inherit

--- a/libs/langchain/poetry.lock
+++ b/libs/langchain/poetry.lock
@@ -4178,16 +4178,18 @@ version = "0.0.6"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
-files = [
-    {file = "langchain_core-0.0.6-py3-none-any.whl", hash = "sha256:dcc727ff811159e09fc1d72caae4aaea892611349d5c3fc1c18b3a19573faf27"},
-    {file = "langchain_core-0.0.6.tar.gz", hash = "sha256:cffd1031764d838ad2a2f3f64477b710923ddad58eb9fe3130ff94b3669e8dd8"},
-]
+files = []
+develop = true
 
 [package.dependencies]
-jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.0.63,<0.1.0"
+jsonpatch = "^1.33"
+langsmith = "~0.0.63"
 pydantic = ">=1,<3"
-tenacity = ">=8.1.0,<9.0.0"
+tenacity = "^8.1.0"
+
+[package.source]
+type = "directory"
+url = "../core"
 
 [[package]]
 name = "langkit"
@@ -11194,4 +11196,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "d57493dcdb7c864d71aa43463a57491f0c9cbd8fa8674d21c0b11117e8d7ea67"
+content-hash = "d049735bc75655dbdda59770b6f5b2fe9fe3c1985c75e3ad662f0863158f1e7b"

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -165,6 +165,7 @@ pytest-mock  = "^3.10.0"
 pytest-socket = "^0.6.0"
 syrupy = "^4.0.2"
 requests-mock = "^1.11.0"
+langchain-core = {path = "../core", develop = true}
 
 
 [tool.poetry.group.codespell.dependencies]

--- a/libs/langchain/tests/unit_tests/test_dependencies.py
+++ b/libs/langchain/tests/unit_tests/test_dependencies.py
@@ -74,6 +74,7 @@ def test_test_group_dependencies(poetry_conf: Mapping[str, Any]) -> None:
         [
             "duckdb-engine",
             "freezegun",
+            "langchain-core",
             "lark",
             "pandas",
             "pytest",


### PR DESCRIPTION
Using the published version means master is broken for contributors whenever we make changes in one lib that depend on the other.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
