### PR TITLE
docs `OpenAI` platform page update

### DIFF
--- a/docs/docs/integrations/platforms/openai.mdx
+++ b/docs/docs/integrations/platforms/openai.mdx
@@ -99,3 +99,10 @@ See a [usage example](/docs/guides/safety/moderation).
 from langchain.chains import OpenAIModerationChain
 ```
 
+## Adapter
+
+See a [usage example](/docs/integrations/adapters/openai).
+
+```python
+from langchain.adapters import openai as lc_openai
+```


### PR DESCRIPTION
Missed the OpenAI adapter reference in the OpenAI platform page
- Added this reference
