### PR TITLE
doc: update langchain version for mongodb integration

### DIFF
--- a/docs/docs/integrations/vectorstores/mongodb_atlas.ipynb
+++ b/docs/docs/integrations/vectorstores/mongodb_atlas.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "> Note: \n",
     ">* This feature is in Public Preview and available for evaluation purposes, to validate functionality, and to gather feedback from public preview users. It is not recommended for production deployments as we may introduce breaking changes.\n",
-    ">* The langchain version 0.0.35 ([release notes](https://github.com/langchain-ai/langchain/releases/tag/v0.0.305)) introduces the support for $vectorSearch MQL stage, which is available with MongoDB Atlas 6.0.11 and 7.0.2. Users utilizing earlier versions of MongoDB Atlas need to pin their LangChain version to <=0.0.304\n",
+    ">* The langchain version 0.0.305 ([release notes](https://github.com/langchain-ai/langchain/releases/tag/v0.0.305)) introduces the support for $vectorSearch MQL stage, which is available with MongoDB Atlas 6.0.11 and 7.0.2. Users utilizing earlier versions of MongoDB Atlas need to pin their LangChain version to <=0.0.304\n",
     "> \n",
     "> "
    ]


### PR DESCRIPTION
- **Description:** update minimal supported langchain version for [mongodb atlast integration webpage](https://python.langchain.com/docs/integrations/vectorstores/mongodb_atlas)
- **Issue:** none
- **Dependencies:** none

-----

Just fixing a typo. 
In [mongodb atlas vectorstore integration page](https://python.langchain.com/docs/integrations/vectorstores/mongodb_atlas), `langchain` support for `$vectorSearch MQL stage` should be `0.0.305` rather than `0.0.35`