### PR TITLE
Fix .env file path in integration_test README.md

### DIFF
--- a/libs/langchain/tests/README.md
+++ b/libs/langchain/tests/README.md
@@ -77,8 +77,8 @@ For environments that requires more involving preparation, look for `*.sh`. For 
 
 ### Prepare environment variables for local testing:
 
-- copy `tests/.env.example` to `tests/.env`
-- set variables in `tests/.env` file, e.g `OPENAI_API_KEY`
+- copy `tests/integration_tests/.env.example` to `tests/integration_tests/.env`
+- set variables in `tests/integration_tests/.env` file, e.g `OPENAI_API_KEY`
 
 Additionally, it's important to note that some integration tests may require certain
 environment variables to be set, such as `OPENAI_API_KEY`. Be sure to set any required


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!



Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

### Description
Hello, 

The [integration_test README](https://github.com/langchain-ai/langchain/tree/master/libs/langchain/tests) was indicating incorrect paths for the `.env.example` and `.env` files. 

`tests/.env.example` ->`tests/integration_tests/.env.example`

While it’s a minor error, it could **potentially lead to confusion** for the document’s readers, so I’ve made the necessary corrections.

Thank you! ☺️

### Related Issue
- https://github.com/langchain-ai/langchain/pull/2806
