### PR TITLE
Update typo in map.ipynb

### DIFF
--- a/docs/docs/expression_language/how_to/map.ipynb
+++ b/docs/docs/expression_language/how_to/map.ipynb
@@ -104,7 +104,7 @@
    "source": [
     "Here the input to prompt is expected to be a map with keys \"context\" and \"question\". The user input is just the question. So we need to get the context using our retriever and passthrough the user input under the \"question\" key.\n",
     "\n",
-    "Note that when composing a RunnableMap when another Runnable we don't even need to wrap our dictionary in the RunnableMap class — the type conversion is handled for us."
+    "Note that when composing a RunnableMap with another Runnable we don't even need to wrap our dictionary in the RunnableMap class — the type conversion is handled for us."
    ]
   },
   {


### PR DESCRIPTION
fix the typo in docs, using "with" instead of "when"