### PR TITLE
Update Prompt Format Error

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -81,13 +81,13 @@ class BasePromptTemplate(RunnableSerializable[Dict, PromptValue], ABC):
                 f" Expected: {self.input_variables}"
                 f" Received: {list(inner_input.keys())}"
             ) from e
-        return self.format(**input_dict)
+        return self.format_prompt(**input_dict)
 
     def invoke(
         self, input: Dict, config: Optional[RunnableConfig] = None
     ) -> PromptValue:
         return self._call_with_config(
-            self._format_prompt_inner,
+            self._format_prompt_with_error_handling,
             input,
             config,
             run_type="prompt",

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -70,10 +70,24 @@ class BasePromptTemplate(RunnableSerializable[Dict, PromptValue], ABC):
     def invoke(
         self, input: Dict, config: Optional[RunnableConfig] = None
     ) -> PromptValue:
+        def format_prompt(inner_input: Dict) -> PromptValue:
+            try:
+                input_dict = {key: inner_input[key] for key in self.input_variables}
+            except TypeError as e:
+                raise TypeError(
+                    f"Input to {self.__class__.__name__} was not a dictionary, "
+                    f"but was instead {type(inner_input)}."
+                ) from e
+            except KeyError as e:
+                raise KeyError(
+                    f"Input to {self.__class__.__name__} is missing variable {e}. "
+                    f" Expected: {self.input_variables}"
+                    f" Received: {list(inner_input.keys())}"
+                ) from e
+            return self.format(**input_dict)
+
         return self._call_with_config(
-            lambda inner_input: self.format_prompt(
-                **{key: inner_input[key] for key in self.input_variables}
-            ),
+            format_prompt,
             input,
             config,
             run_type="prompt",

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -75,8 +75,8 @@ class BasePromptTemplate(RunnableSerializable[Dict, PromptValue], ABC):
                 input_dict = {key: inner_input[key] for key in self.input_variables}
             except TypeError as e:
                 raise TypeError(
-                    f"Input to {self.__class__.__name__} was not a dictionary, "
-                    f"but was instead {type(inner_input)}."
+                    f"Expected mapping type as input to {self.__class__.__name__}. "
+                    f"Received {type(inner_input)}."
                 ) from e
             except KeyError as e:
                 raise KeyError(

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -67,27 +67,27 @@ class BasePromptTemplate(RunnableSerializable[Dict, PromptValue], ABC):
             **{k: (self.input_types.get(k, str), None) for k in self.input_variables},
         )
 
+    def _format_prompt_with_error_handling(self, inner_input: Dict) -> PromptValue:
+        try:
+            input_dict = {key: inner_input[key] for key in self.input_variables}
+        except TypeError as e:
+            raise TypeError(
+                f"Expected mapping type as input to {self.__class__.__name__}. "
+                f"Received {type(inner_input)}."
+            ) from e
+        except KeyError as e:
+            raise KeyError(
+                f"Input to {self.__class__.__name__} is missing variable {e}. "
+                f" Expected: {self.input_variables}"
+                f" Received: {list(inner_input.keys())}"
+            ) from e
+        return self.format(**input_dict)
+
     def invoke(
         self, input: Dict, config: Optional[RunnableConfig] = None
     ) -> PromptValue:
-        def format_prompt(inner_input: Dict) -> PromptValue:
-            try:
-                input_dict = {key: inner_input[key] for key in self.input_variables}
-            except TypeError as e:
-                raise TypeError(
-                    f"Expected mapping type as input to {self.__class__.__name__}. "
-                    f"Received {type(inner_input)}."
-                ) from e
-            except KeyError as e:
-                raise KeyError(
-                    f"Input to {self.__class__.__name__} is missing variable {e}. "
-                    f" Expected: {self.input_variables}"
-                    f" Received: {list(inner_input.keys())}"
-                ) from e
-            return self.format(**input_dict)
-
         return self._call_with_config(
-            format_prompt,
+            self._format_prompt_inner,
             input,
             config,
             run_type="prompt",


### PR DESCRIPTION
The number of times I try to format a string (especially in lcel) is embarrassingly high. Think this may be more actionable than the default error message.  Now I get nice helpful errors


```
KeyError: "Input to ChatPromptTemplate is missing variable 'input'.  Expected: ['input'] Received: ['dialogue']"
```