### PR TITLE
fix: use async_embed_with_retry in _aget_len_safe_embeddings

### DIFF
--- a/libs/langchain/langchain/embeddings/openai.py
+++ b/libs/langchain/langchain/embeddings/openai.py
@@ -523,7 +523,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         for i in range(len(texts)):
             _result = results[i]
             if len(_result) == 0:
-                average_embedded = embed_with_retry(
+                average_embedded = await async_embed_with_retry(
                     self,
                     input="",
                     **self._invocation_params,


### PR DESCRIPTION
**Description**

`embed_with_retry` is for sync operations and not for async operations.
Use `async_embed_with_retry` for appropriate async operations.


I'm using `OpenAIEmbedding(http_client=httpx.AsyncClient())` with only async operations.
However, I got an error when I use `embedding.aembed_documents` because `embed_with_retry` uses sync OpenAI client with async http client. 