### PR TITLE
fix: set maxsplit when parse python function docstring

### DIFF
--- a/libs/langchain/langchain/chains/openai_functions/base.py
+++ b/libs/langchain/langchain/chains/openai_functions/base.py
@@ -75,7 +75,7 @@ def _parse_python_function_docstring(function: Callable) -> Tuple[str, dict]:
         arg = None
         for line in args_block.split("\n")[1:]:
             if ":" in line:
-                arg, desc = line.split(":")
+                arg, desc = line.split(":", maxsplit=1)
                 arg_descriptions[arg.strip()] = desc.strip()
             elif arg:
                 arg_descriptions[arg.strip()] += " " + line.strip()


### PR DESCRIPTION
Description

when the desc of arg in python docstring contains ":", the `_parse_python_function_docstring` will raise **ValueError: too many values to unpack (expected 2)**.

A sample desc would be:
"""
Args: 
    error_arg: this is an arg with an additional ":" symbol
"""

So, set `maxsplit` parameter to fix it.

