### PR TITLE
Support of custom hugging face inference endpoints url

### DIFF
--- a/libs/langchain/langchain/embeddings/huggingface.py
+++ b/libs/langchain/langchain/embeddings/huggingface.py
@@ -279,9 +279,15 @@ class HuggingFaceInferenceAPIEmbeddings(BaseModel, Embeddings):
     """Your API key for the HuggingFace Inference API."""
     model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
     """The name of the model to use for text embeddings."""
+    api_url: Optional[str] = None
+    """Custom inference endpoint url. None for using default public url."""
 
     @property
     def _api_url(self) -> str:
+        return self.api_url or self._default_api_url
+
+    @property
+    def _default_api_url(self) -> str:
         return (
             "https://api-inference.huggingface.co"
             "/pipeline"


### PR DESCRIPTION
  - **Description:** to support not only publicly available Hugging Face endpoints, but also protected ones (created with "Inference Endpoints" Hugging Face feature), I have added ability to specify custom api_url. But if not specified, default behaviour won't change
  - **Issue:** #9181,
  - **Dependencies:** no extra dependencies