### PR TITLE
Removing extra `StdOutCallbackHandler` overridden methods

### DIFF
--- a/libs/core/langchain_core/callbacks/stdout.py
+++ b/libs/core/langchain_core/callbacks/stdout.py
@@ -1,14 +1,13 @@
 """Callback Handler that prints to std out."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.utils import print_text
 
 if TYPE_CHECKING:
     from langchain_core.agents import AgentAction, AgentFinish
-    from langchain_core.outputs import LLMResult
 
 
 class StdOutCallbackHandler(BaseCallbackHandler):
@@ -17,24 +16,6 @@ class StdOutCallbackHandler(BaseCallbackHandler):
     def __init__(self, color: Optional[str] = None) -> None:
         """Initialize callback handler."""
         self.color = color
-
-    def on_llm_start(
-        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
-    ) -> None:
-        """Print out the prompts."""
-        pass
-
-    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        """Do nothing."""
-        pass
-
-    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
-        """Do nothing."""
-        pass
-
-    def on_llm_error(self, error: BaseException, **kwargs: Any) -> None:
-        """Do nothing."""
-        pass
 
     def on_chain_start(
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
@@ -46,19 +27,6 @@ class StdOutCallbackHandler(BaseCallbackHandler):
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
         """Print out that we finished a chain."""
         print("\n\033[1m> Finished chain.\033[0m")
-
-    def on_chain_error(self, error: BaseException, **kwargs: Any) -> None:
-        """Do nothing."""
-        pass
-
-    def on_tool_start(
-        self,
-        serialized: Dict[str, Any],
-        input_str: str,
-        **kwargs: Any,
-    ) -> None:
-        """Do nothing."""
-        pass
 
     def on_agent_action(
         self, action: AgentAction, color: Optional[str] = None, **kwargs: Any
@@ -80,10 +48,6 @@ class StdOutCallbackHandler(BaseCallbackHandler):
         print_text(output, color=color or self.color)
         if llm_prefix is not None:
             print_text(f"\n{llm_prefix}")
-
-    def on_tool_error(self, error: BaseException, **kwargs: Any) -> None:
-        """Do nothing."""
-        pass
 
     def on_text(
         self,


### PR DESCRIPTION
Unnecessarily overridden methods:

- Give the idea the subclass is doing something special (when it isn't)
- Block CTRL-click to the actual method

This PR removes some unnecessarily overridden methods in `StdOutCallbackHandler`

Supercedes https://github.com/langchain-ai/langchain/pull/12858