### PR TITLE
added `OpenGPTs GitHub` menu item

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -230,6 +230,10 @@ const config = {
                 label: "LangSmith Docs",
               },
               {
+                href: "https://github.com/langchain-ai/opengpts",
+                label: "OpenGPTs GitHub",
+              },
+              {
                 href: "https://github.com/langchain-ai/langserve",
                 label: "LangServe GitHub",
               },


### PR DESCRIPTION
The `OpenGPTs GitHub` link was missing on the LangChain docs. OpenGPTs is an important LangChain.ai project, right?
Added this link. 