### PR TITLE
added `Templates Hub` menu item

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -186,6 +186,10 @@ const config = {
                 label: "Templates",
               },
               {
+                label: "Templates Hub",
+                href: "https://templates.langchain.com",
+              },
+              {
                 to: "/docs/community",
                 label: "Community",
               },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -186,10 +186,6 @@ const config = {
                 label: "Templates",
               },
               {
-                label: "Templates Hub",
-                href: "https://templates.langchain.com",
-              },
-              {
                 to: "/docs/community",
                 label: "Community",
               },
@@ -240,6 +236,10 @@ const config = {
               {
                 href: "https://github.com/langchain-ai/langchain/tree/master/templates",
                 label: "Templates GitHub",
+              },
+              {
+                label: "Templates Hub",
+                href: "https://templates.langchain.com",
               },
               {
                 href: "https://smith.langchain.com/hub",


### PR DESCRIPTION
This link was missing in Docs.
Added it.