### PR TITLE
Add metadata to blob

### DIFF
--- a/libs/langchain/tests/unit_tests/document_loaders/blob_loaders/test_schema.py
+++ b/libs/langchain/tests/unit_tests/document_loaders/blob_loaders/test_schema.py
@@ -131,3 +131,20 @@ def test_blob_loader() -> None:
             yield Blob(data=b"Hello, World!")
 
     assert list(TestLoader().yield_blobs()) == [Blob(data=b"Hello, World!")]
+
+
+def test_metadata_and_source() -> None:
+    """Test metadata and source"""
+    blob = Blob(path="some_file", data="b")
+    assert blob.source == "some_file"
+    assert blob.metadata == {}
+    blob = Blob(data=b"", metadata={"source": "hello"})
+    assert blob.source == "hello"
+    assert blob.metadata == {"source": "hello"}
+
+    blob = Blob.from_data("data", metadata={"source": "somewhere"})
+    assert blob.source == "somewhere"
+
+    with get_temp_file(b"hello") as path:
+        blob = Blob.from_path(path, metadata={"source": "somewhere"})
+        assert blob.source == "somewhere"


### PR DESCRIPTION
Add metadata to the blob object. This makes it easier
to make a pipeline that properly propagates metadata information
from raw content to the derived content.
