### PR TITLE
Adds "NIN" metadata filter for pgvector to all checking for set absence

### DIFF
--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -434,16 +434,22 @@ class PGVector(VectorStore):
 
             if filter is not None:
                 filter_clauses = []
+                IN, NIN = "in", "nin"
                 for key, value in filter.items():
-                    IN = "in"
-                    if isinstance(value, dict) and IN in map(str.lower, value):
+                    if isinstance(value, dict):
                         value_case_insensitive = {
                             k.lower(): v for k, v in value.items()
                         }
-                        filter_by_metadata = self.EmbeddingStore.cmetadata[
-                            key
-                        ].astext.in_(value_case_insensitive[IN])
-                        filter_clauses.append(filter_by_metadata)
+                        if IN in map(str.lower, value):
+                            filter_by_metadata = self.EmbeddingStore.cmetadata[
+                                key
+                            ].astext.in_(value_case_insensitive[IN])
+                        elif NIN in map(str.lower, value):
+                            filter_by_metadata = self.EmbeddingStore.cmetadata[
+                                key
+                            ].astext.not_in(value_case_insensitive[NIN])
+                        if filter_by_metadata is not None:
+                            filter_clauses.append(filter_by_metadata)
                     else:
                         filter_by_metadata = self.EmbeddingStore.cmetadata[
                             key

--- a/libs/langchain/langchain/vectorstores/pgvector.py
+++ b/libs/langchain/langchain/vectorstores/pgvector.py
@@ -448,6 +448,8 @@ class PGVector(VectorStore):
                             filter_by_metadata = self.EmbeddingStore.cmetadata[
                                 key
                             ].astext.not_in(value_case_insensitive[NIN])
+                        else:
+                            filter_by_metadata = None
                         if filter_by_metadata is not None:
                             filter_clauses.append(filter_by_metadata)
                     else:

--- a/libs/langchain/tests/integration_tests/vectorstores/test_pgvector.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_pgvector.py
@@ -17,7 +17,6 @@ CONNECTION_STRING = PGVector.connection_string_from_db_params(
     password=os.environ.get("TEST_PGVECTOR_PASSWORD", "postgres"),
 )
 
-
 ADA_TOKEN_COUNT = 1536
 
 
@@ -179,6 +178,27 @@ def test_pgvector_with_filter_in_set() -> None:
     )
     output = docsearch.similarity_search_with_score(
         "foo", k=2, filter={"page": {"IN": ["0", "2"]}}
+    )
+    assert output == [
+        (Document(page_content="foo", metadata={"page": "0"}), 0.0),
+        (Document(page_content="baz", metadata={"page": "2"}), 0.0013003906671379406),
+    ]
+
+
+def test_pgvector_with_filter_nin_set() -> None:
+    """Test end to end construction and search."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    docsearch = PGVector.from_texts(
+        texts=texts,
+        collection_name="test_collection_filter",
+        embedding=FakeEmbeddingsWithAdaDimension(),
+        metadatas=metadatas,
+        connection_string=CONNECTION_STRING,
+        pre_delete_collection=True,
+    )
+    output = docsearch.similarity_search_with_score(
+        "foo", k=2, filter={"page": {"NIN": ["1"]}}
     )
     assert output == [
         (Document(page_content="foo", metadata={"page": "0"}), 0.0),


### PR DESCRIPTION
This PR adds support for metadata filters of the form:

`{"filter": {"key": { "NIN" : ["list", "of", "values"]}}}`

"IN" is already supported, so this is a quick & related update to add "NIN"




