### PR TITLE
Shorten wget commands

### DIFF
--- a/docs/docs/integrations/toolkits/openapi.ipynb
+++ b/docs/docs/integrations/toolkits/openapi.ipynb
@@ -93,12 +93,9 @@
     }
    ],
    "source": [
-    "!wget https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml\n",
-    "!mv openapi.yaml openai_openapi.yaml\n",
-    "!wget https://www.klarna.com/us/shopping/public/openai/v0/api-docs\n",
-    "!mv api-docs klarna_openapi.yaml\n",
-    "!wget https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/spotify.com/1.0.0/openapi.yaml\n",
-    "!mv openapi.yaml spotify_openapi.yaml"
+    "!wget https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml -O openai_openapi.yaml\n",
+    "!wget https://www.klarna.com/us/shopping/public/openai/v0/api-docs -O klarna_openapi.yaml\n",
+    "!wget https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/spotify.com/1.0.0/openapi.yaml -O spotify_openapi.yaml"
    ]
   },
   {


### PR DESCRIPTION
  - **Description:** The commands can be more efficient if the output name is set to the destined filename instead of renaming in the second command. 
