### PR TITLE
Support `openai_proxy` compatible with openai>1.0.0

### DIFF
--- a/libs/community/langchain_community/chat_models/anyscale.py
+++ b/libs/community/langchain_community/chat_models/anyscale.py
@@ -16,7 +16,10 @@ from langchain_community.chat_models.openai import (
     ChatOpenAI,
     _import_tiktoken,
 )
-from langchain_community.utils.openai import is_openai_v1, configure_http_client_by_proxy
+from langchain_community.utils.openai import (
+    configure_http_client_by_proxy,
+    is_openai_v1,
+)
 
 if TYPE_CHECKING:
     import tiktoken

--- a/libs/community/langchain_community/chat_models/anyscale.py
+++ b/libs/community/langchain_community/chat_models/anyscale.py
@@ -16,7 +16,7 @@ from langchain_community.chat_models.openai import (
     ChatOpenAI,
     _import_tiktoken,
 )
-from langchain_community.utils.openai import is_openai_v1
+from langchain_community.utils.openai import is_openai_v1, configure_http_client_by_proxy
 
 if TYPE_CHECKING:
     import tiktoken
@@ -142,14 +142,18 @@ class ChatAnyscale(ChatOpenAI):
                 client_params = {
                     "api_key": values["openai_api_key"],
                     "base_url": values["openai_api_base"],
+                    "http_client": values["http_client"],
                     # To do: future support
                     # "organization": values["openai_organization"],
                     # "timeout": values["request_timeout"],
                     # "max_retries": values["max_retries"],
                     # "default_headers": values["default_headers"],
                     # "default_query": values["default_query"],
-                    # "http_client": values["http_client"],
                 }
+                if values["openai_proxy"] and client_params["http_client"] is None:
+                    client_params["http_client"] = configure_http_client_by_proxy(
+                        values["openai_proxy"]
+                    )
                 values["client"] = openai.OpenAI(**client_params).chat.completions
             else:
                 values["client"] = openai.ChatCompletion

--- a/libs/community/langchain_community/chat_models/azure_openai.py
+++ b/libs/community/langchain_community/chat_models/azure_openai.py
@@ -11,7 +11,11 @@ from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_community.chat_models.openai import ChatOpenAI
-from langchain_community.utils.openai import is_openai_v1, configure_http_async_client_by_proxy, configure_http_client_by_proxy
+from langchain_community.utils.openai import (
+    configure_http_async_client_by_proxy,
+    configure_http_client_by_proxy,
+    is_openai_v1,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -53,7 +53,11 @@ from langchain_community.adapters.openai import (
     convert_dict_to_message,
     convert_message_to_dict,
 )
-from langchain_community.utils.openai import is_openai_v1, configure_http_async_client_by_proxy, configure_http_client_by_proxy
+from langchain_community.utils.openai import (
+    configure_http_async_client_by_proxy,
+    configure_http_client_by_proxy,
+    is_openai_v1,
+)
 
 if TYPE_CHECKING:
     import tiktoken

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -53,7 +53,7 @@ from langchain_community.adapters.openai import (
     convert_dict_to_message,
     convert_message_to_dict,
 )
-from langchain_community.utils.openai import is_openai_v1
+from langchain_community.utils.openai import is_openai_v1, configure_http_async_client_by_proxy, configure_http_client_by_proxy
 
 if TYPE_CHECKING:
     import tiktoken
@@ -316,9 +316,19 @@ class ChatOpenAI(BaseChatModel):
                 "http_client": values["http_client"],
             }
 
+            has_custom_http_client = client_params["http_client"] is not None
+
             if not values.get("client"):
+                if values["openai_proxy"] and not has_custom_http_client:
+                    client_params["http_client"] = configure_http_client_by_proxy(
+                        values["openai_proxy"]
+                    )
                 values["client"] = openai.OpenAI(**client_params).chat.completions
             if not values.get("async_client"):
+                if values["openai_proxy"] and not has_custom_http_client:
+                    client_params["http_client"] = configure_http_async_client_by_proxy(
+                        values["openai_proxy"]
+                    )
                 values["async_client"] = openai.AsyncOpenAI(
                     **client_params
                 ).chat.completions

--- a/libs/community/langchain_community/embeddings/azure_openai.py
+++ b/libs/community/langchain_community/embeddings/azure_openai.py
@@ -9,7 +9,7 @@ from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_community.embeddings.openai import OpenAIEmbeddings
-from langchain_community.utils.openai import is_openai_v1
+from langchain_community.utils.openai import is_openai_v1, configure_http_async_client_by_proxy, configure_http_client_by_proxy
 
 
 class AzureOpenAIEmbeddings(OpenAIEmbeddings):
@@ -145,7 +145,16 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
                 "default_query": values["default_query"],
                 "http_client": values["http_client"],
             }
+            has_custom_http_client = client_params["http_client"] is not None
+            if values["openai_proxy"] and not has_custom_http_client:
+                client_params["http_client"] = configure_http_client_by_proxy(
+                    values["openai_proxy"]
+                )
             values["client"] = openai.AzureOpenAI(**client_params).embeddings
+            if values["openai_proxy"] and not has_custom_http_client:
+                client_params["http_client"] = configure_http_async_client_by_proxy(
+                    values["openai_proxy"]
+                )
             values["async_client"] = openai.AsyncAzureOpenAI(**client_params).embeddings
         else:
             values["client"] = openai.Embedding

--- a/libs/community/langchain_community/embeddings/azure_openai.py
+++ b/libs/community/langchain_community/embeddings/azure_openai.py
@@ -9,7 +9,11 @@ from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_community.embeddings.openai import OpenAIEmbeddings
-from langchain_community.utils.openai import is_openai_v1, configure_http_async_client_by_proxy, configure_http_client_by_proxy
+from langchain_community.utils.openai import (
+    configure_http_async_client_by_proxy,
+    configure_http_client_by_proxy,
+    is_openai_v1,
+)
 
 
 class AzureOpenAIEmbeddings(OpenAIEmbeddings):

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -32,6 +32,10 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
+from langchain_community.utils.openai import (
+    configure_http_async_client_by_proxy,
+    configure_http_client_by_proxy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +198,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
     # to support Azure OpenAI Service custom endpoints
     openai_api_base: Optional[str] = Field(default=None, alias="base_url")
-    """Base URL path for API requests, leave blank if not using a proxy or service 
+    """Base URL path for API requests, leave blank if not using a proxy or service
         emulator."""
     # to support Azure OpenAI Service custom endpoints
     openai_api_type: Optional[str] = None
@@ -215,21 +219,21 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     request_timeout: Optional[Union[float, Tuple[float, float], Any]] = Field(
         default=None, alias="timeout"
     )
-    """Timeout for requests to OpenAI completion API. Can be float, httpx.Timeout or 
+    """Timeout for requests to OpenAI completion API. Can be float, httpx.Timeout or
         None."""
     headers: Any = None
     tiktoken_enabled: bool = True
     """Set this to False for non-OpenAI implementations of the embeddings API, e.g.
     the `--extensions openai` extension for `text-generation-webui`"""
     tiktoken_model_name: Optional[str] = None
-    """The model name to pass to tiktoken when using this class. 
-    Tiktoken is used to count the number of tokens in documents to constrain 
-    them to be under a certain limit. By default, when set to None, this will 
-    be the same as the embedding model name. However, there are some cases 
-    where you may want to use this Embedding class with a model name not 
-    supported by tiktoken. This can include when using Azure embeddings or 
-    when using one of the many model providers that expose an OpenAI-like 
-    API but with different models. In those cases, in order to avoid erroring 
+    """The model name to pass to tiktoken when using this class.
+    Tiktoken is used to count the number of tokens in documents to constrain
+    them to be under a certain limit. By default, when set to None, this will
+    be the same as the embedding model name. However, there are some cases
+    where you may want to use this Embedding class with a model name not
+    supported by tiktoken. This can include when using Azure embeddings or
+    when using one of the many model providers that expose an OpenAI-like
+    API but with different models. In those cases, in order to avoid erroring
     when tiktoken is called, you can specify a model name to use here."""
     show_progress_bar: bool = False
     """Whether to show a progress bar when embedding."""
@@ -346,9 +350,18 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     "default_query": values["default_query"],
                     "http_client": values["http_client"],
                 }
+                has_custom_http_client = client_params["http_client"] is not None
                 if not values.get("client"):
+                    if values["openai_proxy"] and not has_custom_http_client:
+                        client_params["http_client"] = configure_http_client_by_proxy(
+                            values["openai_proxy"]
+                        )
                     values["client"] = openai.OpenAI(**client_params).embeddings
                 if not values.get("async_client"):
+                    if values["openai_proxy"] and not has_custom_http_client:
+                        client_params[
+                            "http_client"
+                        ] = configure_http_async_client_by_proxy(values["openai_proxy"])
                     values["async_client"] = openai.AsyncOpenAI(
                         **client_params
                     ).embeddings

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -32,6 +32,7 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
+
 from langchain_community.utils.openai import (
     configure_http_async_client_by_proxy,
     configure_http_client_by_proxy,

--- a/libs/community/langchain_community/llms/openai.py
+++ b/libs/community/langchain_community/llms/openai.py
@@ -31,7 +31,11 @@ from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env, get_pydantic_field_names
 from langchain_core.utils.utils import build_extra_kwargs
 
-from langchain_community.utils.openai import is_openai_v1, configure_http_async_client_by_proxy, configure_http_client_by_proxy
+from langchain_community.utils.openai import (
+    configure_http_async_client_by_proxy,
+    configure_http_client_by_proxy,
+    is_openai_v1,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/langchain_community/utils/openai.py
+++ b/libs/community/langchain_community/utils/openai.py
@@ -13,7 +13,7 @@ def is_openai_v1() -> bool:
 
 
 def configure_http_client_by_proxy(
-    proxies: Optional[str] = None
+    proxies: Optional[str] = None,
 ) -> Union[httpx.Client, None]:
     if proxies is None or not is_openai_v1():
         return None
@@ -21,7 +21,7 @@ def configure_http_client_by_proxy(
 
 
 def configure_http_async_client_by_proxy(
-    proxies: Optional[str] = None
+    proxies: Optional[str] = None,
 ) -> Union[httpx.AsyncClient, None]:
     if proxies is None or not is_openai_v1():
         return None

--- a/libs/community/langchain_community/utils/openai.py
+++ b/libs/community/langchain_community/utils/openai.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
 from importlib.metadata import version
+from typing import Optional, Union
 
+import httpx
 from packaging.version import parse
 
 
 def is_openai_v1() -> bool:
     _version = parse(version("openai"))
     return _version.major >= 1
+
+
+def configure_http_client_by_proxy(
+    proxies: Optional[str] = None
+) -> Union[httpx.Client, None]:
+    if proxies is None or not is_openai_v1():
+        return None
+    return httpx.Client(proxies=proxies)
+
+
+def configure_http_async_client_by_proxy(
+    proxies: Optional[str] = None
+) -> Union[httpx.AsyncClient, None]:
+    if proxies is None or not is_openai_v1():
+        return None
+    return httpx.AsyncClient(proxies=proxies)

--- a/libs/community/poetry.lock
+++ b/libs/community/poetry.lock
@@ -8485,4 +8485,4 @@ extended-testing = ["aiosqlite", "aleph-alpha-client", "anthropic", "arxiv", "as
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "e3bacf389a13d283c4dd29e3a673e1863826b4e98785c666fefc10cf714c2f6f"
+content-hash = "11c32bfd83cb4752829e18c269bf8d34422a944bb1c20bc33574bbcd3ae39728"

--- a/libs/community/poetry.lock
+++ b/libs/community/poetry.lock
@@ -8485,4 +8485,4 @@ extended-testing = ["aiosqlite", "aleph-alpha-client", "anthropic", "arxiv", "as
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "11c32bfd83cb4752829e18c269bf8d34422a944bb1c20bc33574bbcd3ae39728"
+content-hash = "7e5c043edec4677d594f4f292263bc3157a493df20ff1bbf7049ee8a65b2168b"

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -83,6 +83,7 @@ msal = {version = "^1.25.0", optional = true}
 databricks-vectorsearch = {version = "^0.21", optional = true}
 dgml-utils = {version = "^0.3.0", optional = true}
 datasets = {version = "^2.15.0", optional = true}
+httpx = "^0.24.1"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/community/tests/unit_tests/test_dependencies.py
+++ b/libs/community/tests/unit_tests/test_dependencies.py
@@ -41,6 +41,7 @@ def test_required_dependencies(poetry_conf: Mapping[str, Any]) -> None:
             "SQLAlchemy",
             "aiohttp",
             "dataclasses-json",
+            "httpx",
             "langchain-core",
             "langsmith",
             "numpy",

--- a/libs/community/tests/unit_tests/utils/test_openai.py
+++ b/libs/community/tests/unit_tests/utils/test_openai.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+
+from langchain_community.utils.openai import (
+    configure_http_async_client_by_proxy,
+    configure_http_client_by_proxy,
+)
+
+
+def test_configure_http_client_by_proxy() -> None:
+    actual = configure_http_client_by_proxy(None)
+    assert actual is None
+
+    actual2 = configure_http_async_client_by_proxy(None)
+    assert actual is None
+
+    proxies = "https://foobar.com"
+
+    with patch(
+        "langchain_community.utils.openai.is_openai_v1", side_effect=lambda: False
+    ):
+        actual = configure_http_client_by_proxy(proxies)
+        assert actual is None
+
+    with patch(
+        "langchain_community.utils.openai.is_openai_v1", side_effect=lambda: True
+    ):
+        actual = configure_http_client_by_proxy(proxies)
+        assert isinstance(actual, httpx.Client)
+
+    with patch(
+        "langchain_community.utils.openai.is_openai_v1", side_effect=lambda: False
+    ):
+        actual2 = configure_http_async_client_by_proxy(proxies)
+        assert actual2 is None
+
+    with patch(
+        "langchain_community.utils.openai.is_openai_v1", side_effect=lambda: True
+    ):
+        actual2 = configure_http_async_client_by_proxy(proxies)
+        assert isinstance(actual2, httpx.AsyncClient)

--- a/libs/experimental/poetry.lock
+++ b/libs/experimental/poetry.lock
@@ -1047,6 +1047,61 @@ docs = ["Sphinx"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
+name = "httpcore"
+version = "0.17.3"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpcore-0.17.3-py3-none-any.whl", hash = "sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87"},
+    {file = "httpcore-0.17.3.tar.gz", hash = "sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888"},
+]
+
+[package.dependencies]
+anyio = ">=3.0,<5.0"
+certifi = "*"
+h11 = ">=0.13,<0.15"
+sniffio = "==1.*"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+
+[[package]]
+name = "httpx"
+version = "0.24.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpx-0.24.1-py3-none-any.whl", hash = "sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd"},
+    {file = "httpx-0.24.1.tar.gz", hash = "sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd"},
+]
+
+[package.dependencies]
+certifi = "*"
+httpcore = ">=0.15.0,<0.18.0"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+
+[[package]]
 name = "huggingface-hub"
 version = "0.17.3"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
@@ -4966,4 +5021,4 @@ extended-testing = ["faker", "jinja2", "presidio-analyzer", "presidio-anonymizer
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "fa6e98d24fbc70725b680ae05593488f3a53f27622b40a036029701c7a831370"
+content-hash = "32aaaa76754e1b05c3b212e23f0a2d4eca8c09da3a4ef70521cadfdc52518aaf"

--- a/libs/experimental/poetry.lock
+++ b/libs/experimental/poetry.lock
@@ -1708,6 +1708,7 @@ develop = true
 aiohttp = "^3.8.3"
 async-timeout = {version = "^4.0.0", markers = "python_version < \"3.11\""}
 dataclasses-json = ">= 0.5.7, < 0.7"
+httpx = "^0.24.1"
 jsonpatch = "^1.33"
 langchain-community = ">=0.0.2,<0.1"
 langchain-core = "^0.1"
@@ -1750,6 +1751,7 @@ develop = true
 [package.dependencies]
 aiohttp = "^3.8.3"
 dataclasses-json = ">= 0.5.7, < 0.7"
+httpx = "^0.24.1"
 langchain-core = "^0.1"
 langsmith = "~0.0.63"
 numpy = "^1"
@@ -5021,4 +5023,4 @@ extended-testing = ["faker", "jinja2", "presidio-analyzer", "presidio-anonymizer
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "32aaaa76754e1b05c3b212e23f0a2d4eca8c09da3a4ef70521cadfdc52518aaf"
+content-hash = "efe8a58cc572da7115fadb6765915a52a0bbb17b7a35669bf1b4ef9e1f51e354"

--- a/libs/experimental/pyproject.toml
+++ b/libs/experimental/pyproject.toml
@@ -18,6 +18,7 @@ faker = {version = "^19.3.1", optional = true}
 vowpal-wabbit-next = {version = "0.6.0", optional = true}
 sentence-transformers = {version = "^2", optional = true}
 jinja2 = {version = "^3", optional = true}
+httpx = "^0.24.1"
 
 [tool.poetry.group.lint]
 optional = true

--- a/libs/experimental/pyproject.toml
+++ b/libs/experimental/pyproject.toml
@@ -18,7 +18,7 @@ faker = {version = "^19.3.1", optional = true}
 vowpal-wabbit-next = {version = "0.6.0", optional = true}
 sentence-transformers = {version = "^2", optional = true}
 jinja2 = {version = "^3", optional = true}
-httpx = "^0.24.1"
+httpx = {version = "^0.24.1", optional = true}
 
 [tool.poetry.group.lint]
 optional = true

--- a/libs/langchain/poetry.lock
+++ b/libs/langchain/poetry.lock
@@ -9103,4 +9103,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "0b232a037505cefcdf2203edc9d750e70e2e52a297475490022402994c3036a3"
+content-hash = "0e3417eb1634412ea8ae6b1677f25de5af8b30842fec3225ec1372254bba28f0"

--- a/libs/langchain/poetry.lock
+++ b/libs/langchain/poetry.lock
@@ -3457,6 +3457,7 @@ develop = true
 [package.dependencies]
 aiohttp = "^3.8.3"
 dataclasses-json = ">= 0.5.7, < 0.7"
+httpx = "^0.24.1"
 langchain-core = "^0.1"
 langsmith = "~0.0.63"
 numpy = "^1"
@@ -9103,4 +9104,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "0e3417eb1634412ea8ae6b1677f25de5af8b30842fec3225ec1372254bba28f0"
+content-hash = "f80cddaa31f721c8ddda48024217b35c0dbc89ffe7171c000ea0a4859720a361"

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -17,6 +17,7 @@ langchain-community = ">=0.0.2,<0.1"
 pydantic = ">=1,<3"
 SQLAlchemy = ">=1.4,<3"
 requests = "^2"
+httpx = "^0.24.1"
 PyYAML = ">=5.3"
 numpy = "^1"
 aiohttp = "^3.8.3"
@@ -110,7 +111,6 @@ databricks-vectorsearch = {version = "^0.21", optional = true}
 couchbase = {version = "^4.1.9", optional = true}
 dgml-utils = {version = "^0.3.0", optional = true}
 datasets = {version = "^2.15.0", optional = true}
-httpx = "^0.24.1"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -110,6 +110,7 @@ databricks-vectorsearch = {version = "^0.21", optional = true}
 couchbase = {version = "^4.1.9", optional = true}
 dgml-utils = {version = "^0.3.0", optional = true}
 datasets = {version = "^2.15.0", optional = true}
+httpx = "^0.24.1"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/langchain/tests/unit_tests/test_dependencies.py
+++ b/libs/langchain/tests/unit_tests/test_dependencies.py
@@ -42,6 +42,7 @@ def test_required_dependencies(poetry_conf: Mapping[str, Any]) -> None:
             "aiohttp",
             "async-timeout",
             "dataclasses-json",
+            "httpx",
             "jsonpatch",
             "langchain-core",
             "langsmith",


### PR DESCRIPTION
 ### **Description:** 

`openai` v1 no longer supports the method of setting `openai.proxy`. If using `OPENAI_PRPXY`, the user needs to initialize an http_client.

 ### **Issue:**

https://github.com/langchain-ai/langchain/issues/13939