### PR TITLE
Adds `llm_chain_kwargs` to `BaseRetrievalQA.from_llm`

### DIFF
--- a/libs/langchain/langchain/chains/retrieval_qa/base.py
+++ b/libs/langchain/langchain/chains/retrieval_qa/base.py
@@ -68,11 +68,17 @@ class BaseRetrievalQA(Chain):
         llm: BaseLanguageModel,
         prompt: Optional[PromptTemplate] = None,
         callbacks: Callbacks = None,
+        llm_chain_kwargs: Optional[dict] = None,
         **kwargs: Any,
     ) -> BaseRetrievalQA:
         """Initialize from LLM."""
         _prompt = prompt or PROMPT_SELECTOR.get_prompt(llm)
-        llm_chain = LLMChain(llm=llm, prompt=_prompt, callbacks=callbacks)
+        llm_chain = LLMChain(
+            llm=llm,
+            prompt=_prompt,
+            callbacks=callbacks,
+            **(llm_chain_kwargs or {})
+        )
         document_prompt = PromptTemplate(
             input_variables=["page_content"], template="Context:\n{page_content}"
         )

--- a/libs/langchain/langchain/chains/retrieval_qa/base.py
+++ b/libs/langchain/langchain/chains/retrieval_qa/base.py
@@ -74,10 +74,7 @@ class BaseRetrievalQA(Chain):
         """Initialize from LLM."""
         _prompt = prompt or PROMPT_SELECTOR.get_prompt(llm)
         llm_chain = LLMChain(
-            llm=llm,
-            prompt=_prompt,
-            callbacks=callbacks,
-            **(llm_chain_kwargs or {})
+            llm=llm, prompt=_prompt, callbacks=callbacks, **(llm_chain_kwargs or {})
         )
         document_prompt = PromptTemplate(
             input_variables=["page_content"], template="Context:\n{page_content}"


### PR DESCRIPTION
- **Description:** Adds `llm_chain_kwargs` to `BaseRetrievalQA.from_llm` so these can be passed to the LLM at runtime, 
- **Issue:** https://github.com/langchain-ai/langchain/issues/14216,
