### PR TITLE
Fix `config` arg detection for wrapped lambdarunnable

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -6,7 +6,7 @@ import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import FIRST_COMPLETED, wait
 from copy import deepcopy
-from functools import partial
+from functools import partial, wraps
 from itertools import tee
 from operator import itemgetter
 from typing import (
@@ -2518,6 +2518,7 @@ class RunnableLambda(Runnable[Input, Output]):
             afunc = self.afunc
         else:
 
+            @wraps(self.func)
             async def f(*args, **kwargs):  # type: ignore[no-untyped-def]
                 return await asyncio.get_running_loop().run_in_executor(
                     None, partial(self.func, **kwargs), *args


### PR DESCRIPTION
**Description:**
When a RunnableLambda only receives a synchronous callback, this callback is wrapped into an async one since #13408. However, this wrapping with `(*args, **kwargs)` causes the `accepts_config` check at [/libs/core/langchain_core/runnables/config.py#L342](https://github.com/langchain-ai/langchain/blob/ee94ef55ee6ab064da08340817955f821dfa6261/libs/core/langchain_core/runnables/config.py#L342) to fail, as this checks for the presence of a "config" argument in the method signature. 

Adding a `functools.wraps` around it, resolves it.


**Issue:** 
None, writing this PR already took longer than the fix ;)

**Tag maintainer:** 
@nbondoux @efriis (participants of the original PR)
