### PR TITLE
Fixed OpenAIFunctionsAgent not returning when receiving AgentFinish

### DIFF
--- a/libs/langchain/langchain/agents/openai_functions_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_agent/base.py
@@ -162,7 +162,7 @@ class OpenAIFunctionsAgent(BaseSingleActionAgent):
             agent_decision = self.plan(
                 intermediate_steps, with_functions=False, **kwargs
             )
-            if type(agent_decision) == AgentFinish:
+            if isinstance(agent_decision, AgentFinish):
                 return agent_decision
             else:
                 raise ValueError(


### PR DESCRIPTION
**Description:** The way the condition is checked in the `return_stopped_response` function of `OpenAIAgent` may not be correct, when the value returned is `AgentFinish` from the tools it does not work properly.


Thanks for review, @baskaryan, @eyurtsev, @hwchase17.