### PR TITLE
Handling inline references to .ipynb files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ docs/docs/node_modules
 docs/docs/yarn.lock
 _dist
 docs/docs/templates
+docs/.inline_ipynb.json

--- a/docs/.local_build.sh
+++ b/docs/.local_build.sh
@@ -12,6 +12,7 @@ mkdir -p ../_dist
 rsync -ruv --exclude node_modules . ../_dist
 cd ../_dist
 poetry run python scripts/model_feat_table.py
+poetry run python scripts/replace_inline_ipynb_filename.py
 cp ../cookbook/README.md src/pages/cookbook.mdx
 cp ../.github/CONTRIBUTING.md docs/contributing.md
 mkdir -p docs/templates

--- a/docs/scripts/recover_inline_ipynb_filename.py
+++ b/docs/scripts/recover_inline_ipynb_filename.py
@@ -1,0 +1,13 @@
+import json
+import pathlib
+
+
+here = pathlib.Path(__file__).parent.absolute()
+json_file = here.parent / ".inline_ipynb.json"
+
+with json_file.open() as f:
+    files = json.load(f)
+
+for filename, content in files:
+    with open(filename, "w") as f:
+        f.write(content)

--- a/docs/scripts/recover_inline_ipynb_filename.py
+++ b/docs/scripts/recover_inline_ipynb_filename.py
@@ -1,7 +1,6 @@
 import json
 import pathlib
 
-
 here = pathlib.Path(__file__).parent.absolute()
 json_file = here.parent / ".inline_ipynb.json"
 

--- a/docs/scripts/replace_inline_ipynb_filename.py
+++ b/docs/scripts/replace_inline_ipynb_filename.py
@@ -1,0 +1,30 @@
+import re
+import json
+import pathlib
+
+here = pathlib.Path(__file__).parent.absolute()
+json_file = here.parent / ".inline_ipynb.json"
+url_pattern = re.compile('(\./.*)\.ipynb(.*)')
+
+doc = pathlib.Path("docs")
+files = []
+
+for file in doc.rglob("*.ipynb"):
+    if ".ipynb_checkpoints" in file.as_posix():
+        continue
+    with file.open() as f:
+        for line in f:
+            if ".ipynb" in line:
+                if (match := url_pattern.search(line)):
+                    f.seek(0)
+                    files.append([file, f.read()])
+
+with json_file.open("w") as f:
+    json.dump([[file.as_posix(), content] for file, content in files], f)
+
+for file, content in files:
+    content = re.sub(url_pattern, r"\1\2", content)
+    with file.open("w") as f:
+        f.write(content)
+
+

--- a/docs/scripts/replace_inline_ipynb_filename.py
+++ b/docs/scripts/replace_inline_ipynb_filename.py
@@ -1,10 +1,10 @@
-import re
 import json
 import pathlib
+import re
 
 here = pathlib.Path(__file__).parent.absolute()
 json_file = here.parent / ".inline_ipynb.json"
-url_pattern = re.compile('(\./.*)\.ipynb(.*)')
+url_pattern = re.compile("(\./.*)\.ipynb(.*)")
 
 doc = pathlib.Path("docs")
 files = []
@@ -15,7 +15,7 @@ for file in doc.rglob("*.ipynb"):
     with file.open() as f:
         for line in f:
             if ".ipynb" in line:
-                if (match := url_pattern.search(line)):
+                if match := url_pattern.search(line):
                     f.seek(0)
                     files.append([file, f.read()])
 
@@ -26,5 +26,3 @@ for file, content in files:
     content = re.sub(url_pattern, r"\1\2", content)
     with file.open("w") as f:
         f.write(content)
-
-

--- a/docs/vercel_build.sh
+++ b/docs/vercel_build.sh
@@ -15,10 +15,13 @@ source .venv/bin/activate
 python3.8 -m pip install --upgrade pip
 python3.8 -m pip install -r vercel_requirements.txt
 python3.8 scripts/model_feat_table.py
+python3.8 scripts/replace_inline_ipynb_filename.py
 mkdir docs/templates
 cp ../templates/docs/INDEX.md docs/templates/index.md
 python3.8 scripts/copy_templates.py
 cp ../cookbook/README.md src/pages/cookbook.mdx
 cp ../.github/CONTRIBUTING.md docs/contributing.md
 wget -q https://raw.githubusercontent.com/langchain-ai/langserve/main/README.md -O docs/langserve.md
+
 quarto render docs/
+python3.8 scripts/recover_inline_ipynb_filename.py


### PR DESCRIPTION
### Description

I found that [the OpenAI Adapter document](https://python.langchain.com/docs/integrations/adapters/openai) cannot correctly jump to other internal links. Clicking on the link will download it as an ipynb file.

If it works normally on both jupyter notebook and doc websites, additional processing needs to be done, that is, replacing the link before rendering.

I added 2 scripts and tested `make docs_build` and `./vercel_build.sh`. In both cases, the link can be generated correctly without affecting the original ipynb file content.

@efriis Please review this.