### PR TITLE
Update gitlab.py to support On Prims GitLab URL's

### DIFF
--- a/libs/langchain/langchain/utilities/gitlab.py
+++ b/libs/langchain/langchain/utilities/gitlab.py
@@ -40,7 +40,7 @@ class GitLabAPIWrapper(BaseModel):
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
-        gitlab_url= get_from_dict_or_env(
+        gitlab_url = get_from_dict_or_env(
             values, "gitlab_url", "GITLAB_URL", default="https://gitlab.com"
         )
 
@@ -68,7 +68,7 @@ class GitLabAPIWrapper(BaseModel):
                 "Please install it with `pip install python-gitlab`"
             )
 
-        g = gitlab.Gitlab(url=gitlab_url,private_token=gitlab_personal_access_token)
+        g = gitlab.Gitlab(url=gitlab_url, private_token=gitlab_personal_access_token)
 
         g.auth()
 


### PR DESCRIPTION
Gitlab defaults to public URL : https://gitlab.com which is preventing to use self hosted Gilab instances. Add a Support to pass self hosted URL by setting GITLAB_URL env variable.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
