### PR TITLE
Update docs

### DIFF
--- a/docs/docs/expression_language/how_to/configure.ipynb
+++ b/docs/docs/expression_language/how_to/configure.ipynb
@@ -43,6 +43,7 @@
    "source": [
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.prompts import PromptTemplate\n",
+    "from langchain.schema.runnable import ConfigurableField\n",
     "\n",
     "model = ChatOpenAI(temperature=0).configurable_fields(\n",
     "    temperature=ConfigurableField(\n",
@@ -594,7 +595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/docs/expression_language/how_to/fallbacks.ipynb
+++ b/docs/docs/expression_language/how_to/fallbacks.ipynb
@@ -190,7 +190,7 @@
     ")\n",
     "\n",
     "chain = prompt | llm\n",
-    "with patch(\"openai.ChatCompletion.create\", side_effect=RateLimitError()):\n",
+    "with patch(\"openai.ChatCompletion.create\", side_effect=error):\n",
     "    try:\n",
     "        print(chain.invoke({\"animal\": \"kangaroo\"}))\n",
     "    except:\n",

--- a/docs/docs/expression_language/how_to/functions.ipynb
+++ b/docs/docs/expression_language/how_to/functions.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "6bb221b3",
    "metadata": {},
    "outputs": [],
@@ -56,17 +56,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "5488ec85",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='3 + 9 equals 12.', additional_kwargs={}, example=False)"
+       "AIMessage(content='3 + 9 equals 12.')"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "80b3b5f6-5d58-44b9-807e-cce9a46bf49f",
    "metadata": {},
    "outputs": [],
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "ff0daf0c-49dd-4d21-9772-e5fa133c5f36",
    "metadata": {},
    "outputs": [],
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "id": "1a5e709e-9d75-48c7-bb9c-503251990505",
    "metadata": {},
    "outputs": [
@@ -133,6 +133,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "{'foo': 'bar'}\n",
       "Tokens Used: 65\n",
       "\tPrompt Tokens: 56\n",
       "\tCompletion Tokens: 9\n",
@@ -145,9 +146,10 @@
     "from langchain.callbacks import get_openai_callback\n",
     "\n",
     "with get_openai_callback() as cb:\n",
-    "    RunnableLambda(parse_or_fix).invoke(\n",
+    "    output = RunnableLambda(parse_or_fix).invoke(\n",
     "        \"{foo: bar}\", {\"tags\": [\"my-tag\"], \"callbacks\": [cb]}\n",
     "    )\n",
+    "    print(output)\n",
     "    print(cb)"
    ]
   },
@@ -176,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description

Fixed 3 doc  issues:

1. `ConfigurableField ` needs to be imported in `docs/docs/expression_language/how_to/configure.ipynb`
2. use `error` instead of `RateLimitError()` in `docs/docs/expression_language/how_to/fallbacks.ipynb`
3. I think it might be better to output the fixed json data(when I looked at this example, I didn't understand its purpose at first, but then I suddenly realized):
<img width="1219" alt="Screenshot 2023-12-05 at 10 34 13 PM" src="https://github.com/langchain-ai/langchain/assets/10000925/7623ba13-7b56-4964-8c98-b7430fabc6de">
