### PR TITLE
Supporting LLM Models over REST endpoints

### DIFF
--- a/docs/docs/integrations/llms/llm_over_rest.ipynb
+++ b/docs/docs/integrations/llms/llm_over_rest.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "169eda47-d480-4311-9556-74e900e892a7",
+   "metadata": {},
+   "source": [
+    "# LLM Over REST\n",
+    "\n",
+    "This notebook explains how to use the LLM Over REST integration with LangChain. There is no additional dependencies that you would need to install. It uses `httpx` under the hood, if it is available, otherwise falling back to `requests`.\n",
+    "\n",
+    "\n",
+    "## Configuration Parameters\n",
+    "\n",
+    "Most of basic HTTP configurations are available as parameters during initialization of the LLM object. There is a provision to pass a Callable to create the JSON body for the REST API from the prompt, stop-words and other model parameters. By default, it adds the prompt and stop-words as keys `prompt` and `stop` respectively at the root of the JSON, and appends the entire model parameters object to the JSON. An example of how to provide a custom implementation is provided below.\n",
+    "\n",
+    "## Advanced SSL settings\n",
+    "\n",
+    "SSL settings are controlled via `ssl_verify` and `client_certs` parameters. \n",
+    "\n",
+    "### Disabling Server Certificate Check\n",
+    "\n",
+    "You can set the parameter `ssl_verify` to `False` in order to disable validating the server certificate. In this case, even basic checks like Certificate expiry, Certificate and Server name mismatches are also ignored. **This mode is not recommended for production use as it makes your application vulnerable to Man-in-the-Middle attacks**\n",
+    "\n",
+    "### Adding Custom CAs\n",
+    "`ssl_verify` can be set to the path for the CA certificate file in case you want to use custom Certificate Authorities to validate certificates. If the path is a folder it should be rehashed using `openssl rehash`\n",
+    "\n",
+    "### Using Client Certificates for mTLS\n",
+    "To authenticate the client with the server via mTLS, you can set the parameter `client_certs` parameter. It can either be a string to the path for the client certificate or a two-Tuple containing the path to the client certificate and the *unencrypted* private key file for the client.\n",
+    "\n",
+    "## Generating the JSON body\n",
+    "Users can provide a Callable to generate the JSON body for the request. The method takes three parameters - a prompt string, an optional list of stop words and a dictionary containing all other model parameters. By default, the JSON Body is structured like:\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "    \"prompt\": prompt,\n",
+    "    \"stop\": stop,\n",
+    "}.update(model_kwargs)\n",
+    "```\n",
+    "\n",
+    "The callable should return a `Dict[str, Any]` by combining all the parameters.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9c7f0f0a-34cd-454c-a2c2-bfa3f580ef8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.llms.llm_over_rest import LLMOverREST\n",
+    "from typing import Optional, List, Dict, Any\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d77981c1-de30-4585-b9ca-4e6e8124d380",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_json(prompt: str, \n",
+    "                stop: Optional[List[str]] = None, \n",
+    "                model_kwargs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:\n",
+    "    try:\n",
+    "        model_params = model_kwargs.get(\"parameters\") or {}\n",
+    "        model_kwargs[\"prompt\"] = prompt\n",
+    "        if stop and len(stop) > 0:\n",
+    "            model_params[\"stop\"] = stop\n",
+    "    except BaseException as e:\n",
+    "        raise ValueError(f\"Error in creating json: {e}\")\n",
+    "\n",
+    "    return model_kwargs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1218fc2d-ef6a-4ad4-85ac-8da5f82cb1ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The world did not end in 2012 as the Mayans predicted.🤫\n"
+     ]
+    }
+   ],
+   "source": [
+    "headers = {\n",
+    "    \"X-Auth-Key\": secrets.get_password(\"auth-key\"),\n",
+    "    \"Content-Type\": \"application/json\"\n",
+    "}\n",
+    "\n",
+    "model_params = {\n",
+    "  \"model\": \"highly-secret-llm\",\n",
+    "  \"parameters\": {\n",
+    "    \"max_new_tokens\": 2023,\n",
+    "    \"return_full_text\": True,\n",
+    "    \"temperature\": 0.8,\n",
+    "    \"top_p\": 0.95,\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "llm = LLMOverREST(api_endpoint=\"https://llmgateway.mycompany.com/v1/generate\",\n",
+    "                  method=\"POST\",\n",
+    "                  headers=headers,\n",
+    "                  ssl_verify=\"/etc/ssl/certs/ca-certificates\",\n",
+    "                  model_kwargs=json_body,\n",
+    "                  json_body_creator=create_json_wmt_endpoint\n",
+    "                 )\n",
+    "response = llm(\"Tell me something highly secret\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b520228-4fed-474a-8b8f-058af2913eaa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/langchain/langchain/llms/llm_over_rest.py
+++ b/libs/langchain/langchain/llms/llm_over_rest.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from http.cookiejar import CookieJar
+from typing import Optional, List, Any, Dict, Tuple, Mapping
+
+import requests
+
+from langchain.llms.base import LLM
+from langchain.llms.utils import enforce_stop_tokens
+from langchain_core.callbacks import CallbackManagerForLLMRun
+
+
+def _get_generated_text(resp: Dict[str, Any]) -> str:
+    if 'generated_text' in resp.keys():
+        return resp.get('generated_text')
+    else:
+        raise ValueError('JSON response does not have "generated_keys" parameter')
+
+
+class LLMOverREST(LLM):
+    api_endpoint: str
+    """The REST API endpoint from where the LLM will be served."""
+    method: str = "POST"
+    """The HTTP Method to use."""
+    headers: Optional[List[Tuple] | Dict[str, str]] = None
+    """A key-value map for all the request headers."""
+    cookies: Optional[Dict[str, str] | CookieJar] = None
+    """An optional CookieJar to retrieve cookies from during the request and write back 
+    the response cookies."""
+    proxies: Optional[Dict[str, str]] = None
+    """Dictionary containing the protocol to the proxy server configuration."""
+    ssl_verify: bool | str = True
+    """Either a boolean, which determines whether the server certificate is verified, or a string, which 
+    should a path to a PEM file containing the trusted CAs which will be used to verify the server
+    certificate. Note: Setting this parameter to ``False`` makes it vulnerable to MitM attacks and is not 
+    recommended to be used in production."""
+    client_cert: str | Tuple[str, str] = None
+    """The path to a client certificate or a Tuple containing the paths to the client certificate and 
+    unencrypted private key file to be used."""
+    model_kwargs: Dict[str, Any] = None
+    """Set of model parameters to be sent as part of the JSON body of the request. This dict will be 
+    json-ified and appended to the request body."""
+    generated_text_key: str = 'generated_text'
+    """A key in the JSON response that corresponds to the generated text from the LLM. This is used to
+    extract the generated text and apply the stop sequence on it. If this is ``None``, the ``stop`` 
+    parameter in the LLM call will not be honored. Note: currently, it does not support nested keys and expect
+    the keys to be available at the root level of the response JSON"""
+
+    def _call(self,
+              prompt: str,
+              stop: Optional[List[str]] = None,
+              run_manager: Optional[CallbackManagerForLLMRun] = None,
+              **kwargs: Any) -> str:
+        json_body = {"prompt": prompt}
+        json_body.update(self.model_kwargs)
+
+        with requests.Session() as session:
+            try:
+                response = session.request(
+                    method=self.method,
+                    url=self.api_endpoint,
+                    headers=self.headers,
+                    cookies=self.cookies,
+                    json=json_body,
+                    proxies=self.proxies,
+                    verify=self.ssl_verify,
+                    cert=self.client_cert)
+            except requests.exceptions.RequestException as e:
+                raise ValueError(f"Error in invoking the REST API: {e}")
+
+            if not response.ok:
+                raise ValueError(f"Error response from the API: {response.status_code}: {response.text}")
+
+            if self.generated_text_key is not None:
+                try:
+                    resp_json = response.json()
+                    gen_text = resp_json.get(self.generated_text_key)
+                    if stop is not None and gen_text is not None:
+                        gen_text = enforce_stop_tokens(gen_text, stop)
+                        resp_json[self.generated_text_key] = gen_text
+                        return json.dumps(resp_json)
+                except requests.exceptions.JSONDecodeError as e:
+                    raise ValueError(f"Error in parsing the response JSON: {e}")
+            else:
+                return response.text
+
+    @property
+    def _identifying_params(self) -> Mapping[str, Any]:
+        return {
+            "method": self.method,
+            "endpoint": self.api_endpoint,
+            "model_kwargs": self.model_kwargs or {}
+        }
+
+    @property
+    def _llm_type(self) -> str:
+        return "llm_over_rest"
+

--- a/libs/langchain/langchain/llms/llm_over_rest.py
+++ b/libs/langchain/langchain/llms/llm_over_rest.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import json
-from http.cookiejar import CookieJar
-from typing import Optional, List, Any, Dict, Tuple, Mapping
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import requests
+from langchain_core.callbacks import CallbackManagerForLLMRun
 
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
-from langchain_core.callbacks import CallbackManagerForLLMRun
 
 
 def _get_generated_text(resp: Dict[str, Any]) -> str:
-    if 'generated_text' in resp.keys():
-        return resp.get('generated_text')
+    if "generated_text" in resp.keys():
+        return str(resp["generated_text"])
     else:
         raise ValueError('JSON response does not have "generated_keys" parameter')
 
@@ -23,55 +22,66 @@ class LLMOverREST(LLM):
     """The REST API endpoint from where the LLM will be served."""
     method: str = "POST"
     """The HTTP Method to use."""
-    headers: Optional[List[Tuple] | Dict[str, str]] = None
+    headers: Optional[Dict[str, str]] = None
     """A key-value map for all the request headers."""
-    cookies: Optional[Dict[str, str] | CookieJar] = None
-    """An optional CookieJar to retrieve cookies from during the request and write back 
-    the response cookies."""
     proxies: Optional[Dict[str, str]] = None
     """Dictionary containing the protocol to the proxy server configuration."""
-    ssl_verify: bool | str = True
-    """Either a boolean, which determines whether the server certificate is verified, or a string, which 
-    should a path to a PEM file containing the trusted CAs which will be used to verify the server
-    certificate. Note: Setting this parameter to ``False`` makes it vulnerable to MitM attacks and is not 
-    recommended to be used in production."""
-    client_cert: str | Tuple[str, str] = None
-    """The path to a client certificate or a Tuple containing the paths to the client certificate and 
-    unencrypted private key file to be used."""
-    model_kwargs: Dict[str, Any] = None
-    """Set of model parameters to be sent as part of the JSON body of the request. This dict will be 
-    json-ified and appended to the request body."""
-    generated_text_key: str = 'generated_text'
-    """A key in the JSON response that corresponds to the generated text from the LLM. This is used to
-    extract the generated text and apply the stop sequence on it. If this is ``None``, the ``stop`` 
-    parameter in the LLM call will not be honored. Note: currently, it does not support nested keys and expect
-    the keys to be available at the root level of the response JSON"""
+    ssl_verify: Union[bool, str] = True
+    """Either a boolean, which determines whether the server certificate is verified, 
+    or a string, which should a path to a PEM file containing the trusted CAs,
+    which will be used to verify the server certificate. 
+    Note: Setting this parameter to ``False`` makes it vulnerable to MitM attacks 
+    and is not recommended to be used in production."""
+    client_cert: Optional[Union[str, Tuple[str, str]]] = None
+    """The path to a client certificate or a Tuple containing the paths to the client 
+    certificate and unencrypted private key file to be used."""
+    model_kwargs: Dict[str, Any] = {}
+    """Set of model parameters to be sent as part of the JSON body of the request. 
+    This dict will be json-ified and appended to the request body."""
+    generated_text_key: str = "generated_text"
+    """A key in the JSON response that corresponds to the generated text from the LLM. 
+    This is used to extract the generated text and apply the stop sequence on it. 
+    If this is ``None``, the ``stop`` parameter in the LLM call will not be honored. 
+    Note: currently, it does not support nested keys and expect the keys to be 
+    available at the root level of the response JSON"""
 
-    def _call(self,
-              prompt: str,
-              stop: Optional[List[str]] = None,
-              run_manager: Optional[CallbackManagerForLLMRun] = None,
-              **kwargs: Any) -> str:
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
         json_body = {"prompt": prompt}
         json_body.update(self.model_kwargs)
 
-        with requests.Session() as session:
+        if len(stop) > 0 and len(self.generated_text_key) == 0:
+            raise ValueError(
+                "``stop`` argument cannot be honored if "
+                "``self.generated_text_key`` is None"
+            )
+
+        with requests.Session() as session:  # type: requests.Session
             try:
                 response = session.request(
                     method=self.method,
                     url=self.api_endpoint,
                     headers=self.headers,
-                    cookies=self.cookies,
                     json=json_body,
                     proxies=self.proxies,
                     verify=self.ssl_verify,
-                    cert=self.client_cert)
+                    cert=self.client_cert,
+                )
             except requests.exceptions.RequestException as e:
                 raise ValueError(f"Error in invoking the REST API: {e}")
 
             if not response.ok:
-                raise ValueError(f"Error response from the API: {response.status_code}: {response.text}")
+                raise ValueError(
+                    f"Error response from the API: "
+                    f"{response.status_code}: {response.text}"
+                )
 
+            final_resp: str = ""
             if self.generated_text_key is not None:
                 try:
                     resp_json = response.json()
@@ -79,21 +89,19 @@ class LLMOverREST(LLM):
                     if stop is not None and gen_text is not None:
                         gen_text = enforce_stop_tokens(gen_text, stop)
                         resp_json[self.generated_text_key] = gen_text
-                        return json.dumps(resp_json)
+                        final_resp = json.dumps(resp_json)
                 except requests.exceptions.JSONDecodeError as e:
                     raise ValueError(f"Error in parsing the response JSON: {e}")
-            else:
-                return response.text
+            return final_resp if len(final_resp) > 0 else response.text
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
         return {
             "method": self.method,
             "endpoint": self.api_endpoint,
-            "model_kwargs": self.model_kwargs or {}
+            "model_kwargs": self.model_kwargs or {},
         }
 
     @property
     def _llm_type(self) -> str:
         return "llm_over_rest"
-

--- a/libs/langchain/langchain/llms/llm_over_rest.py
+++ b/libs/langchain/langchain/llms/llm_over_rest.py
@@ -72,6 +72,8 @@ class LLMOverREST(LLM):
     """A key-value map for all the request headers."""
     retries: int = 0
     """Number of retries to make in case the REST call fails"""
+    timeout: float = 300.0
+    """Timeout in seconds for the call to go through"""
     proxies: Optional[Dict[str, str]] = None
     """Dictionary containing the protocol to the proxy server configuration."""
     ssl_verify: Union[bool, str] = True
@@ -162,6 +164,7 @@ class LLMOverREST(LLM):
                 url=self.api_endpoint,
                 headers=self.headers,
                 json=json_body,
+                timeout=self.timeout,
                 proxies=self.proxies,
                 verify=self.ssl_verify,
                 cert=self.client_cert,
@@ -180,6 +183,7 @@ class LLMOverREST(LLM):
                 url=self.api_endpoint,
                 json=json_body,
                 headers=self.headers,
+                timeout=self.timeout,
             )
             response.raise_for_status()
             return response.text

--- a/libs/langchain/langchain/llms/llm_over_rest.py
+++ b/libs/langchain/langchain/llms/llm_over_rest.py
@@ -120,13 +120,7 @@ class LLMOverREST(LLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
-        if stop is not None and len(stop) > 0 and len(self.generated_text_key) == 0:
-            raise ValueError(
-                "``stop`` argument cannot be honored if "
-                "``self.generated_text_key`` is None"
-            )
         json_body = self.json_body_creator(prompt, stop, self.model_kwargs)
-
         try:
             response_text = completion_with_retry(
                 llm=self, run_manager=run_manager, json_body=json_body

--- a/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
+++ b/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
@@ -2,8 +2,10 @@ import json
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
+from langchain.llms import llm_over_rest
 from langchain.llms.llm_over_rest import LLMOverREST
 
 
@@ -16,6 +18,29 @@ def mock_generated_json() -> Dict[str, Any]:
         "generated_text": "This is what we have generated",
         "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
     }
+
+
+def _patched_retry(*args: Any, **kwargs: Any) -> Any:
+    """Patched retry for unit tests that does not wait."""
+    from tenacity import (
+        retry,
+        retry_base,
+        retry_if_exception_type,
+        stop_after_attempt,
+        wait_none,
+    )
+
+    assert "error_types" in kwargs
+    error_types = kwargs["error_types"]
+    retry_instance: retry_base = retry_if_exception_type(error_types[0])
+    for error in error_types[1:]:
+        retry_instance = retry_instance | retry_if_exception_type(error)
+    return retry(
+        reraise=True,
+        stop=stop_after_attempt(2),
+        wait=wait_none(),
+        retry=retry_instance,
+    )
 
 
 def test_llmoverrest_call_requests() -> None:
@@ -36,17 +61,14 @@ def test_llmoverrest_call_requests() -> None:
     assert json.loads(prediction) == mock_generated_json()
 
 
+@pytest.mark.requires("httpx")
 def test_llmoverrest_call_httpx() -> None:
-    try:
-        import httpx
-    except ImportError:
-        # Dont test httpx if its not available
-        assert True
-        return
+    import httpx
 
     def mock_response(*args: Any, **kwargs: Any) -> httpx.Response:
-        tmp_resp = httpx.Response(status_code=200, json=mock_generated_json(),
-                                  request=MagicMock())
+        tmp_resp = httpx.Response(
+            status_code=200, json=mock_generated_json(), request=MagicMock()
+        )
         return tmp_resp
 
     llm = LLMOverREST(api_endpoint="https://some.dummy.url/v1/api")
@@ -85,9 +107,26 @@ def test_llmoverrest_call_retry() -> None:
     mock_client.return_value.__enter__ = lambda x: mock_client
     mock_client.request = mock_response
 
-    with patch.multiple(llm, client=mock_client, use_httpx=False):
-        prediction = llm.predict("hello")
+    with patch.object(llm_over_rest, "create_base_retry_decorator", _patched_retry):
+        with patch.multiple(llm, client=mock_client, use_httpx=False):
+            prediction = llm.predict("hello")
     mock_client.assert_called()
     assert json.loads(prediction) == mock_generated_json()
     assert completed
     assert counts == 2
+
+
+def test_llmoverrest_call_timeout() -> None:
+    def mock_response(*args: Any, **kwargs: Any) -> Any:
+        raise requests.exceptions.Timeout("Timed out request")
+
+    llm = LLMOverREST(api_endpoint="https://some.dummy.url/v1/api", retries=2)
+    mock_client = MagicMock()
+    mock_client.return_value.__enter__ = lambda x: mock_client
+    mock_client.request = mock_response
+    with patch.object(llm_over_rest, "create_base_retry_decorator", _patched_retry):
+        with patch.multiple(llm, client=mock_client, use_httpx=False):
+            with pytest.raises(ValueError) as e:
+                _ = llm.predict("hello")
+
+    assert "Timed out request" in str(e)

--- a/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
+++ b/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
@@ -1,2 +1,93 @@
-def test_llmover_rest() -> None:
-    assert 0
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from langchain.llms.llm_over_rest import LLMOverREST
+
+
+def mock_generated_json() -> Dict[str, Any]:
+    return {
+        "id": "mock-result-42",
+        "object": "completion",
+        "created": 1689989000,
+        "model": "test-llm-model",
+        "generated_text": "This is what we have generated",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+    }
+
+
+def test_llmoverrest_call_requests() -> None:
+    def mock_response(*args: Any, **kwargs: Any) -> requests.Response:
+        tmp_resp = requests.Response()
+        tmp_resp.status_code = 200
+        tmp_resp._content = json.dumps(mock_generated_json()).encode("utf-8")
+        return tmp_resp
+
+    llm = LLMOverREST(api_endpoint="https://some.dummy.url/v1/api")
+    mock_client = MagicMock()
+    mock_client.return_value.__enter__ = lambda x: mock_client
+    mock_client.request = mock_response
+
+    with patch.multiple(llm, client=mock_client, use_httpx=False):
+        prediction = llm.predict("hello")
+    mock_client.assert_called()
+    assert json.loads(prediction) == mock_generated_json()
+
+
+def test_llmoverrest_call_httpx() -> None:
+    try:
+        import httpx
+    except ImportError:
+        # Dont test httpx if its not available
+        assert True
+        return
+
+    def mock_response(*args: Any, **kwargs: Any) -> httpx.Response:
+        tmp_resp = httpx.Response(status_code=200, json=mock_generated_json(),
+                                  request=MagicMock())
+        return tmp_resp
+
+    llm = LLMOverREST(api_endpoint="https://some.dummy.url/v1/api")
+    mock_client = MagicMock()
+    mock_client.return_value.__enter__ = lambda x: mock_client
+    mock_client.request = mock_response
+
+    with patch.multiple(llm, client=mock_client, use_httpx=True):
+        prediction = llm.predict("hello")
+    mock_client.assert_called()
+    assert json.loads(prediction) == mock_generated_json()
+
+
+def test_llmoverrest_call_retry() -> None:
+    raised = False
+    completed = False
+    counts = 0
+
+    def mock_response(*args: Any, **kwargs: Any) -> requests.Response:
+        nonlocal raised, completed, counts
+        counts += 1
+        if completed:
+            assert False, "This should not be called twice"
+
+        if not raised:
+            raised = True
+            raise requests.exceptions.RequestException()
+        tmp_resp = requests.Response()
+        tmp_resp.status_code = 200
+        tmp_resp._content = json.dumps(mock_generated_json()).encode("utf-8")
+        completed = True
+        return tmp_resp
+
+    llm = LLMOverREST(api_endpoint="https://some.dummy.url/v1/api", retries=2)
+    mock_client = MagicMock()
+    mock_client.return_value.__enter__ = lambda x: mock_client
+    mock_client.request = mock_response
+
+    with patch.multiple(llm, client=mock_client, use_httpx=False):
+        prediction = llm.predict("hello")
+    mock_client.assert_called()
+    assert json.loads(prediction) == mock_generated_json()
+    assert completed
+    assert counts == 2

--- a/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
+++ b/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
@@ -1,2 +1,2 @@
-def test_llmover_rest():
-    assert True
+def test_llmover_rest() -> None:
+    assert 0

--- a/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
+++ b/libs/langchain/tests/unit_tests/llms/test_llm_over_rest.py
@@ -1,0 +1,2 @@
+def test_llmover_rest():
+    assert True


### PR DESCRIPTION
**Description** 

With multiple LLMs being developed by various organizations, and in-house LLMs developed for internal consumption, we at Walmart want to expose all these LLMs over simple REST endpoint. This enables each team to independently develop their LLMs and their API signatures - which can then be easily exposed to users via LangChain. This PR adds the support to serve LLMs over REST endpoints. 

For the initial PR, this is a simple implementation of Sync HTTP REST call. Based on approval and interests, we would be enhancing this further with support for Async HTTP and Streaming HTTP as well in future PRs.

**Dependencies**
This is built on top of `requests`. If `httpx` is available on the PYTHONPATH, then httpx is preferred over requests.

**Twitter Handles**
@daichi_majumdar
