### PR TITLE
Adding `BaseChatMessageHistory.__str__`

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -7,7 +7,6 @@ from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     HumanMessage,
-    SystemMessage,
     get_buffer_string,
 )
 
@@ -58,14 +57,6 @@ class BaseChatMessageHistory(ABC):
             message: The string contents of an AI message.
         """
         self.add_message(AIMessage(content=message))
-
-    def add_system_message(self, message: str) -> None:
-        """Convenience method for adding a system message string to the store.
-
-        Args:
-            message: The string contents of a system message.
-        """
-        self.add_message(SystemMessage(content=message))
 
     @abstractmethod
     def add_message(self, message: BaseMessage) -> None:

--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    get_buffer_string,
+)
 
 
 class BaseChatMessageHistory(ABC):
@@ -53,6 +59,14 @@ class BaseChatMessageHistory(ABC):
         """
         self.add_message(AIMessage(content=message))
 
+    def add_system_message(self, message: str) -> None:
+        """Convenience method for adding a system message string to the store.
+
+        Args:
+            message: The string contents of a system message.
+        """
+        self.add_message(SystemMessage(content=message))
+
     @abstractmethod
     def add_message(self, message: BaseMessage) -> None:
         """Add a Message object to the store.
@@ -65,3 +79,6 @@ class BaseChatMessageHistory(ABC):
     @abstractmethod
     def clear(self) -> None:
         """Remove all messages from the store"""
+
+    def __str__(self) -> str:
+        return get_buffer_string(self.messages)

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -8,6 +8,15 @@ from langchain_core.runnables.history import RunnableWithMessageHistory
 from tests.unit_tests.fake.memory import ChatMessageHistory
 
 
+def test_interfaces() -> None:
+    history = ChatMessageHistory()
+    history.add_system_message("system")
+    history.add_user_message("human 1")
+    history.add_ai_message("ai")
+    history.add_message(HumanMessage(content="human 2"))
+    assert str(history) == "System: system\nHuman: human 1\nAI: ai\nHuman: human 2"
+
+
 def _get_get_session_history() -> Callable[..., ChatMessageHistory]:
     chat_history_store = {}
 

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Sequence, Union
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import RunnableLambda
 from langchain_core.runnables.config import RunnableConfig
@@ -10,7 +10,7 @@ from tests.unit_tests.fake.memory import ChatMessageHistory
 
 def test_interfaces() -> None:
     history = ChatMessageHistory()
-    history.add_system_message("system")
+    history.add_message(SystemMessage(content="system"))
     history.add_user_message("human 1")
     history.add_ai_message("ai")
     history.add_message(HumanMessage(content="human 2"))

--- a/libs/langchain/langchain/memory/chat_message_histories/zep.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/zep.py
@@ -152,17 +152,6 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         """
         self.add_message(AIMessage(content=message), metadata=metadata)
 
-    def add_system_message(
-        self, message: str, metadata: Optional[Dict[str, Any]] = None
-    ) -> None:
-        """Convenience method for adding a system message string to the store.
-
-        Args:
-            message: The string contents of a system message.
-            metadata: Optional metadata to attach to the message.
-        """
-        self.add_message(SystemMessage(content=message), metadata=metadata)
-
     def add_message(
         self, message: BaseMessage, metadata: Optional[Dict[str, Any]] = None
     ) -> None:

--- a/libs/langchain/langchain/memory/chat_message_histories/zep.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/zep.py
@@ -152,6 +152,17 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         """
         self.add_message(AIMessage(content=message), metadata=metadata)
 
+    def add_system_message(
+        self, message: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Convenience method for adding a system message string to the store.
+
+        Args:
+            message: The string contents of a system message.
+            metadata: Optional metadata to attach to the message.
+        """
+        self.add_message(SystemMessage(content=message), metadata=metadata)
+
     def add_message(
         self, message: BaseMessage, metadata: Optional[Dict[str, Any]] = None
     ) -> None:


### PR DESCRIPTION
Increasing the usability of `BaseChatMessageHistory` by implementing:
- ~`add_system_message`: for parity with human and AI messages~
- `__str__` for easy debugging

~I also added `add_system_message` to the one subclasser that changes the adders~