### PR TITLE
Moderation: migrate to new openai api

### DIFF
--- a/libs/langchain/langchain/chains/moderation.py
+++ b/libs/langchain/langchain/chains/moderation.py
@@ -49,8 +49,6 @@ class OpenAIModerationChain(Chain):
             default="",
         )
         try:
-            # import openai
-
             openai.api_key = openai_api_key
             if openai_organization:
                 openai.organization = openai_organization


### PR DESCRIPTION
Fixes issue #13685 : OpenAIModerationChain still uses the old OpenAI API.
### Description
The following snippet:
```python
from langchain.chains import OpenAIModerationChain
from openai import moderations

print(OpenAIModerationChain(client=moderations).run("i want to kill you"))
```
Gives the following error :
```
Traceback (most recent call last):
  File "moderate.py", line 4, in <module>
    print(OpenAIModerationChain(client=moderations).run("i want to kill you"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Lib\site-packages\langchain\chains\base.py", line 507, in run
    return self(args[0], callbacks=callbacks, tags=tags, metadata=metadata)[
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Lib\site-packages\langchain\chains\base.py", line 312, in __call__
    raise e
  File "\Lib\site-packages\langchain\chains\base.py", line 306, in __call__
    self._call(inputs, run_manager=run_manager)
  File "\Lib\site-packages\langchain\chains\moderation.py", line 94, in _call
    results = self.client.create(text)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Lib\site-packages\openai\lib\_old_api.py", line 39, in __call__
    raise APIRemovedInV1(symbol=self._symbol)
openai.lib._old_api.APIRemovedInV1:

You tried to access openai.Moderation, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.

You can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface.

Alternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`

A detailed migration guide is available here: https://github.com/openai/openai-python/discussions/742
```
