### PR TITLE
docs[patch]: fix ipynb links

### DIFF
--- a/docs/docs/integrations/adapters/openai-old.ipynb
+++ b/docs/docs/integrations/adapters/openai-old.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# OpenAI Adapter(Old)\n",
     "\n",
-    "**Please ensure OpenAI library is less than 1.0.0; otherwise, refer to the newer doc [OpenAI Adapter](./openai).**\n",
+    "**Please ensure OpenAI library is less than 1.0.0; otherwise, refer to the newer doc [OpenAI Adapter](./openai.ipynb).**\n",
     "\n",
     "A lot of people get started with OpenAI but want to explore other models. LangChain's integrations with many model providers make this easy to do so. While LangChain has it's own message and model APIs, we've also made it as easy as possible to explore other models by exposing an adapter to adapt LangChain models to the OpenAI api.\n",
     "\n",

--- a/docs/docs/integrations/adapters/openai-old.ipynb
+++ b/docs/docs/integrations/adapters/openai-old.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# OpenAI Adapter(Old)\n",
     "\n",
-    "**Please ensure OpenAI library is less than 1.0.0; otherwise, refer to the newer doc [OpenAI Adapter](./openai.ipynb).**\n",
+    "**Please ensure OpenAI library is less than 1.0.0; otherwise, refer to the newer doc [OpenAI Adapter](./openai).**\n",
     "\n",
     "A lot of people get started with OpenAI but want to explore other models. LangChain's integrations with many model providers make this easy to do so. While LangChain has it's own message and model APIs, we've also made it as easy as possible to explore other models by exposing an adapter to adapt LangChain models to the OpenAI api.\n",
     "\n",

--- a/docs/docs/integrations/adapters/openai.ipynb
+++ b/docs/docs/integrations/adapters/openai.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# OpenAI Adapter\n",
     "\n",
-    "**Please ensure OpenAI library is version 1.0.0 or higher; otherwise, refer to the older doc [OpenAI Adapter(Old)](./openai-old.ipynb).**\n",
+    "**Please ensure OpenAI library is version 1.0.0 or higher; otherwise, refer to the older doc [OpenAI Adapter(Old)](./openai-old).**\n",
     "\n",
     "A lot of people get started with OpenAI but want to explore other models. LangChain's integrations with many model providers make this easy to do so. While LangChain has it's own message and model APIs, we've also made it as easy as possible to explore other models by exposing an adapter to adapt LangChain models to the OpenAI api.\n",
     "\n",

--- a/docs/docs/integrations/adapters/openai.ipynb
+++ b/docs/docs/integrations/adapters/openai.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# OpenAI Adapter\n",
     "\n",
-    "**Please ensure OpenAI library is version 1.0.0 or higher; otherwise, refer to the older doc [OpenAI Adapter(Old)](./openai-old).**\n",
+    "**Please ensure OpenAI library is version 1.0.0 or higher; otherwise, refer to the older doc [OpenAI Adapter(Old)](./openai-old.ipynb).**\n",
     "\n",
     "A lot of people get started with OpenAI but want to explore other models. LangChain's integrations with many model providers make this easy to do so. While LangChain has it's own message and model APIs, we've also made it as easy as possible to explore other models by exposing an adapter to adapt LangChain models to the OpenAI api.\n",
     "\n",

--- a/docs/docs/integrations/providers/alibabacloud_opensearch.md
+++ b/docs/docs/integrations/providers/alibabacloud_opensearch.md
@@ -24,7 +24,7 @@ supported functions:
 - `delete_doc_by_texts`
 
 
-For a more detailed walk through of the Alibaba Cloud OpenSearch wrapper, see [this notebook](../modules/indexes/vectorstores/examples/alibabacloud_opensearch.ipynb)
+For a more detailed walk through of the Alibaba Cloud OpenSearch wrapper, see [this notebook](../modules/indexes/vectorstores/examples/alibabacloud_opensearch)
 
 If you encounter any problems during use, please feel free to contact [xingshaomin.xsm@alibaba-inc.com](xingshaomin.xsm@alibaba-inc.com) , and we will do our best to provide you with assistance and support.
 

--- a/docs/docs/integrations/providers/alibabacloud_opensearch.md
+++ b/docs/docs/integrations/providers/alibabacloud_opensearch.md
@@ -24,7 +24,7 @@ supported functions:
 - `delete_doc_by_texts`
 
 
-For a more detailed walk through of the Alibaba Cloud OpenSearch wrapper, see [this notebook](../modules/indexes/vectorstores/examples/alibabacloud_opensearch)
+For a more detailed walk through of the Alibaba Cloud OpenSearch wrapper, see [this notebook](/docs/integrations/vectorstores/alibabacloud_opensearch)
 
 If you encounter any problems during use, please feel free to contact [xingshaomin.xsm@alibaba-inc.com](xingshaomin.xsm@alibaba-inc.com) , and we will do our best to provide you with assistance and support.
 

--- a/docs/docs/integrations/providers/dataforseo.mdx
+++ b/docs/docs/integrations/providers/dataforseo.mdx
@@ -16,7 +16,7 @@ The DataForSEO utility wraps the API. To import this utility, use:
 from langchain.utilities.dataforseo_api_search import DataForSeoAPIWrapper
 ```
 
-For a detailed walkthrough of this wrapper, see [this notebook](/docs/integrations/tools/dataforseo.ipynb).
+For a detailed walkthrough of this wrapper, see [this notebook](/docs/integrations/tools/dataforseo).
 
 ### Tool
 

--- a/docs/docs/integrations/providers/jina.mdx
+++ b/docs/docs/integrations/providers/jina.mdx
@@ -17,4 +17,4 @@ embeddings = JinaEmbeddings(jina_api_key='jina_**', model_name='jina-embeddings-
 
 You can check the list of available models from [here](https://jina.ai/embeddings/)
 
-For a more detailed walkthrough of this, see [this notebook](/docs/integrations/text_embedding/jina.ipynb)
+For a more detailed walkthrough of this, see [this notebook](/docs/integrations/text_embedding/jina)

--- a/docs/docs/integrations/providers/vearch.md
+++ b/docs/docs/integrations/providers/vearch.md
@@ -8,7 +8,7 @@ Vearch Python SDK enables vearch to use locally. Vearch python sdk can be instal
 
 # Vectorstore
 
-Vearch also can used as vectorstore. Most detalis in [this notebook](docs/modules/indexes/vectorstores/examples/vearch.ipynb)
+Vearch also can used as vectorstore. Most detalis in [this notebook](/docs/integrations/vectorstores/vearch)
 
 ```python
 from langchain.vectorstores import Vearch


### PR DESCRIPTION
Keeping it simple for now.

Still iterating on our docs build in pursuit of making everything mdxv2 compatible for docusaurus 3, and the fewer custom scripts we're reliant on through that, the less likely the docs will break again.

Other things to consider in future:

Quarto rewriting in ipynbs: https://quarto.org/docs/extensions/nbfilter.html (but this won't do md/mdx files)

Docusaurus plugins for rewriting these paths