### PR TITLE
Fix typo in lcel example for rerank in doc

### DIFF
--- a/docs/docs/modules/chains/document/map_rerank.ipynb
+++ b/docs/docs/modules/chains/document/map_rerank.ipynb
@@ -61,7 +61,7 @@
     "        description=\"The answer to the question, which is based ONLY on the provided context.\"\n",
     "    )\n",
     "    score: float = Field(\n",
-    "        decsription=\"A 0.0-1.0 relevance score, where 1.0 indicates the provided context answers the question completely and 0.0 indicates the provided context does not answer the question at all.\"\n",
+    "        description=\"A 0.0-1.0 relevance score, where 1.0 indicates the provided context answers the question completely and 0.0 indicates the provided context does not answer the question at all.\"\n",
     "    )\n",
     "\n",
     "\n",


### PR DESCRIPTION
fix typo in lcel example for rerank in doc