### PR TITLE
'on_llm_new_token' was never awaited: resolved

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -573,7 +573,7 @@ class AsyncParentRunManager(AsyncRunManager):
 class CallbackManagerForLLMRun(RunManager, LLMManagerMixin):
     """Callback manager for LLM run."""
 
-    def on_llm_new_token(
+    async def on_llm_new_token(
         self,
         token: str,
         *,

--- a/libs/langchain/langchain/llms/bedrock.py
+++ b/libs/langchain/langchain/llms/bedrock.py
@@ -267,7 +267,12 @@ class BedrockBase(BaseModel, ABC):
             text = LLMInputOutputAdapter.prepare_output(provider, response)
 
         except Exception as e:
-            raise ValueError(f"Error raised by bedrock service: {e}")
+            if "ThrottlingException" in str(e):
+                raise ValueError(
+                    f"ThrottlingException raised by bedrock service: {e}"
+                ) from e
+            else:
+                raise ValueError(f"Error raised by bedrock service: {e}") from e
 
         if stop is not None:
             text = enforce_stop_tokens(text, stop)


### PR DESCRIPTION
Issue #14399

  - **Description:** Added async to `on_llm_new_token` function in `CallbackManagerForLLMRun` class in `manager.py` file present in `libs/core/langchain_core`, 
  - **Issue:** It fixed the RuntimeWarning: coroutine 'AsyncCallbackManagerForLLMRun.on_llm_new_token' was never awaited ChatGPT',
  - **Twitter handle:** https://twitter.com/Triyambaka58284
  
It is passing the `make format`, `make lint` and `make test` to check this locally.

Kindly reviews my PR @baskaryan, @eyurtsev, @hwchase17.
