### PR TITLE
feat: patch chroma.similarity_search_with_score to return vector id

### DIFF
--- a/libs/langchain/langchain/vectorstores/chroma.py
+++ b/libs/langchain/langchain/vectorstores/chroma.py
@@ -36,15 +36,16 @@ def _results_to_docs(results: Any) -> List[Document]:
     return [doc for doc, _ in _results_to_docs_and_scores(results)]
 
 
-def _results_to_docs_and_scores(results: Any) -> List[Tuple[Document, float]]:
+def _results_to_docs_and_scores(results: Any) -> List[Tuple[Document, float, str]]:
     return [
         # TODO: Chroma can do batch querying,
         # we shouldn't hard code to the 1st result
-        (Document(page_content=result[0], metadata=result[1] or {}), result[2])
+        (Document(page_content=result[0], metadata=result[1] or {}), result[2], result[3])
         for result in zip(
             results["documents"][0],
             results["metadatas"][0],
             results["distances"][0],
+            results["ids"][0],
         )
     ]
 
@@ -379,7 +380,7 @@ class Chroma(VectorStore):
         filter: Optional[Dict[str, str]] = None,
         where_document: Optional[Dict[str, str]] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> List[Tuple[Document, float, str]]:
         """
         Return docs most similar to embedding vector and similarity score.
 
@@ -389,8 +390,8 @@ class Chroma(VectorStore):
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
-            List[Tuple[Document, float]]: List of documents most similar to
-            the query text and cosine distance in float for each.
+            List[Tuple[Document, float, str]]: List of documents most similar to
+            the query text, cosine distance in float, and vector id for each.
             Lower score represents more similarity.
         """
         results = self.__query_collection(
@@ -408,7 +409,7 @@ class Chroma(VectorStore):
         filter: Optional[Dict[str, str]] = None,
         where_document: Optional[Dict[str, str]] = None,
         **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+    ) -> List[Tuple[Document, float, str]]:
         """Run similarity search with Chroma with distance.
 
         Args:
@@ -417,8 +418,8 @@ class Chroma(VectorStore):
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
-            List[Tuple[Document, float]]: List of documents most similar to
-            the query text and cosine distance in float for each.
+            List[Tuple[Document, float, str]]: List of documents most similar to
+            the query text, cosine distance in float, and vector id for each.
             Lower score represents more similarity.
         """
         if self._embedding_function is None:

--- a/libs/langchain/tests/integration_tests/vectorstores/test_chroma.py
+++ b/libs/langchain/tests/integration_tests/vectorstores/test_chroma.py
@@ -52,13 +52,14 @@ def test_chroma_with_metadatas_with_scores() -> None:
     texts = ["foo", "bar", "baz"]
     metadatas = [{"page": str(i)} for i in range(len(texts))]
     docsearch = Chroma.from_texts(
+        ids=["foo_id", "bar_id", "baz_id"],
         collection_name="test_collection",
         texts=texts,
         embedding=FakeEmbeddings(),
         metadatas=metadatas,
     )
     output = docsearch.similarity_search_with_score("foo", k=1)
-    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 0.0)]
+    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 0.0, "foo_id")]
 
 
 def test_chroma_with_metadatas_with_scores_using_vector() -> None:
@@ -68,6 +69,7 @@ def test_chroma_with_metadatas_with_scores_using_vector() -> None:
     embeddings = FakeEmbeddings()
 
     docsearch = Chroma.from_texts(
+        ids=["foo_id", "bar_id", "baz_id"],
         collection_name="test_collection",
         texts=texts,
         embedding=embeddings,
@@ -77,7 +79,7 @@ def test_chroma_with_metadatas_with_scores_using_vector() -> None:
     output = docsearch.similarity_search_by_vector_with_relevance_scores(
         embedding=embedded_query, k=1
     )
-    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 0.0)]
+    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 0.0, "foo_id")]
 
 
 def test_chroma_search_filter() -> None:
@@ -101,6 +103,7 @@ def test_chroma_search_filter_with_scores() -> None:
     texts = ["far", "bar", "baz"]
     metadatas = [{"first_letter": "{}".format(text[0])} for text in texts]
     docsearch = Chroma.from_texts(
+        ids=["foo_id", "bar_id", "baz_id"],
         collection_name="test_collection",
         texts=texts,
         embedding=FakeEmbeddings(),
@@ -110,13 +113,13 @@ def test_chroma_search_filter_with_scores() -> None:
         "far", k=1, filter={"first_letter": "f"}
     )
     assert output == [
-        (Document(page_content="far", metadata={"first_letter": "f"}), 0.0)
+        (Document(page_content="far", metadata={"first_letter": "f"}), 0.0, "foo_id")
     ]
     output = docsearch.similarity_search_with_score(
         "far", k=1, filter={"first_letter": "b"}
     )
     assert output == [
-        (Document(page_content="bar", metadata={"first_letter": "b"}), 1.0)
+        (Document(page_content="bar", metadata={"first_letter": "b"}), 1.0, "bar_id")
     ]
 
 


### PR DESCRIPTION
**Description:** In chroma, return the vector_ids for associated vectors when using the `similarity_search_with_score` and `similarity_search_by_vector_with_relevance_scores` so that turning around to manage the vector (update/delete) is instantly available. Right now, there is no easy way to get similarity and get the associated vector id for the results. Given the id on creation can be created in-library or _optionally_ set by the user we should greedily return the id so the user can always manage their vectors easily.
**Issue:** #11592,
**Dependencies:** N/A
**Tag maintainer:** N/A,
**Twitter handle:** @mintplexlabs

