### PR TITLE
GITLAB_URL should take default https://gitlab.com instead of error

### DIFF
--- a/libs/langchain/langchain/utilities/gitlab.py
+++ b/libs/langchain/langchain/utilities/gitlab.py
@@ -40,7 +40,7 @@ class GitLabAPIWrapper(BaseModel):
         """Validate that api key and python package exists in environment."""
 
         gitlab_url = get_from_dict_or_env(
-            values, "gitlab_url", "GITLAB_URL", default=None
+            values, "gitlab_url", "GITLAB_URL", default="https://gitlab.com"
         )
         gitlab_repository = get_from_dict_or_env(
             values, "gitlab_repository", "GITLAB_REPOSITORY"


### PR DESCRIPTION
The fix #14221 has broken default gitlab url which is forcing the users to specify GITLAB_URL  for default one.  With this fix if GITLAB_URL  is not set, the default gitlab url  will be taken.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:**  Add a Default URL with https://gitlab.com instead of None
  - **Issue:** The fix #14221 has broken default gitlab url which is forcing the users to specify GITLAB_URL
  - **Dependencies:** None
  - **Tag maintainer:** @hwchase17
  - **Twitter handle:**  @manjunath_shiva

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
