### PR TITLE
Improvement: Allow passing parameters to the underlying es_client. Closes: #14403

### DIFF
--- a/libs/community/langchain_community/vectorstores/elasticsearch.py
+++ b/libs/community/langchain_community/vectorstores/elasticsearch.py
@@ -256,7 +256,7 @@ class ExactRetrievalStrategy(BaseRetrievalStrategy):
         elif similarity is DistanceStrategy.DOT_PRODUCT:
             similarityAlgo = f"""
             double value = dotProduct(params.query_vector, '{vector_query_field}');
-            return sigmoid(1, Math.E, -value); 
+            return sigmoid(1, Math.E, -value);
             """
         else:
             raise ValueError(f"Similarity {similarity} not supported.")
@@ -512,6 +512,7 @@ class ElasticsearchStore(VectorStore):
             ]
         ] = None,
         strategy: BaseRetrievalStrategy = ApproxRetrievalStrategy(),
+        es_params: Optional[Dict[str, Any]] = None,
     ):
         self.embedding = embedding
         self.index_name = index_name
@@ -535,6 +536,7 @@ class ElasticsearchStore(VectorStore):
                 password=es_password,
                 cloud_id=es_cloud_id,
                 api_key=es_api_key,
+                es_params=es_params,
             )
         else:
             raise ValueError(
@@ -556,6 +558,7 @@ class ElasticsearchStore(VectorStore):
         api_key: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
+        es_params: Optional[Dict[str, Any]] = None,
     ) -> "Elasticsearch":
         try:
             import elasticsearch
@@ -583,6 +586,9 @@ class ElasticsearchStore(VectorStore):
             connection_params["api_key"] = api_key
         elif username and password:
             connection_params["basic_auth"] = (username, password)
+
+        if es_params is not None:
+            connection_params.update(es_params)
 
         es_client = elasticsearch.Elasticsearch(
             **connection_params,


### PR DESCRIPTION
### Description

In https://github.com/langchain-ai/langchain/issues/14403, the user mentioned that he hopes not to verify ssl and needs to pass more parameters

I found that the `Elasticsearch` class [has very many parameters](https://github.com/elastic/elasticsearch-py/blob/98f2af2134dfc3f2b2054b87a4056e2508b9b8db/elasticsearch/_sync/client/__init__.py#L131-L191
):

<img width="1097" alt="Screenshot 2023-12-08 at 4 24 39 PM" src="https://github.com/langchain-ai/langchain/assets/10000925/f2201554-b41a-4388-a8e8-c14a2d0466d4">

In order to adapt to more situations, I want to add the kwargs parameter so that users can enter more `Elasticsearch` parameters. Like [redis](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/vectorstores/redis/base.py#L253), [tair](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/vectorstores/tair.py#L32), [myscale](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/vectorstores/myscale.py#L112) and so on.