### PR TITLE
When using OpenAI Function Calling, change default model in ChatOpenAI

### DIFF
--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -240,6 +240,10 @@ class ChatOpenAI(BaseChatModel):
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
         extra = values.get("model_kwargs", {})
+
+        if "model" not in values and {"tools", "functions"} & values.keys():
+            values["model_name"] = "gpt-3.5-turbo-1106"
+
         for field_name in list(values):
             if field_name in extra:
                 raise ValueError(f"Found {field_name} supplied twice.")


### PR DESCRIPTION
  - **Description:** : After reviewing the OpenAI Function Calling official guide at https://platform.openai.com/docs/guides/function-calling,  the following information was noted:

> "The latest models (gpt-3.5-turbo-1106 and gpt-4-1106-preview) have been trained to both detect when a function should be called (depending on the input) and to respond with JSON that adheres to the function signature more closely than previous models. With this capability also comes potential risks. We strongly recommend building in user confirmation flows before taking actions that impact the world on behalf of users (sending an email, posting something online, making a purchase, etc)."

Therefore, I have updated the default model in ChatOpenAI from 'gpt-3.5-turbo' to 'gpt-3.5-turbo-1106' only when function calling is used and no specific model is designated by the user.
