### PR TITLE
[docs]: add missing tiktoken dependency

### DIFF
--- a/docs/docs/expression_language/get_started.ipynb
+++ b/docs/docs/expression_language/get_started.ipynb
@@ -321,7 +321,7 @@
    "outputs": [],
    "source": [
     "# Requires:\n",
-    "# pip install langchain docarray\n",
+    "# pip install langchain docarray tiktoken\n",
     "\n",
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.embeddings import OpenAIEmbeddings\n",


### PR DESCRIPTION
Description: I was following the docs and got an error about missing tiktoken dependency. Adding it to the comment where the langchain and docarray libs are.