### PR TITLE
docs[patch] Fix some typos in merger_retriever.ipynb

### DIFF
--- a/docs/docs/integrations/retrievers/merger_retriever.ipynb
+++ b/docs/docs/integrations/retrievers/merger_retriever.ipynb
@@ -41,7 +41,7 @@
     "ABS_PATH = os.path.dirname(os.path.abspath(__file__))\n",
     "DB_DIR = os.path.join(ABS_PATH, \"db\")\n",
     "\n",
-    "# Instantiate 2 diff cromadb indexs, each one with a diff embedding.\n",
+    "# Instantiate 2 diff chromadb indexes, each one with a diff embedding.\n",
     "client_settings = chromadb.config.Settings(\n",
     "    is_persistent=True,\n",
     "    persist_directory=DB_DIR,\n",
@@ -68,7 +68,7 @@
     "    search_type=\"mmr\", search_kwargs={\"k\": 5, \"include_metadata\": True}\n",
     ")\n",
     "\n",
-    "# The Lord of the Retrievers will hold the ouput of boths retrievers and can be used as any other\n",
+    "# The Lord of the Retrievers will hold the output of both retrievers and can be used as any other\n",
     "# retriever on different types of chains.\n",
     "lotr = MergerRetriever(retrievers=[retriever_all, retriever_multi_qa])"
    ]
@@ -145,7 +145,7 @@
    "metadata": {},
    "source": [
     "## Re-order results to avoid performance degradation.\n",
-    "No matter the architecture of your model, there is a sustancial performance degradation when you include 10+ retrieved documents.\n",
+    "No matter the architecture of your model, there is a substantial performance degradation when you include 10+ retrieved documents.\n",
     "In brief: When models must access relevant information  in the middle of long contexts, then tend to ignore the provided documents.\n",
     "See: https://arxiv.org/abs//2307.03172"
    ]
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# You can use an additional document transformer to reorder documents after removing redundance.\n",
+    "# You can use an additional document transformer to reorder documents after removing redundancy.\n",
     "from langchain.document_transformers import LongContextReorder\n",
     "\n",
     "filter = EmbeddingsRedundantFilter(embeddings=filter_embeddings)\n",


### PR DESCRIPTION
This patch fixes some typos.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
