### PR TITLE
fix: updating internal batch size for gradient embeddings.

### DIFF
--- a/libs/langchain/langchain/embeddings/gradient_ai.py
+++ b/libs/langchain/langchain/embeddings/gradient_ai.py
@@ -203,7 +203,7 @@ class TinyAsyncGradientEmbeddingClient:  #: :meta private:
 
         if self.host is None or len(self.host) < 3:
             raise ValueError(" param `host` must be set to a valid url")
-        self._batch_size = 128
+        self._batch_size = 64
 
     @staticmethod
     def _permute(


### PR DESCRIPTION
background: i am author of the gradient integrations.

Issue: 
Gradient.ai accepts batch_sizes until 100. This integration sets up to 128, which leads to errors when > 101 embeddings are requested in a function call.

Fix: This PR sets the size per Request to 64.

```bash
Cell In[5], [line 7](vscode-notebook-cell:?execution_count=5&line=7)
      [5](vscode-notebook-cell:?execution_count=5&line=5) import timeit
      [6](vscode-notebook-cell:?execution_count=5&line=6) start = timeit.default_timer()
----> [7](vscode-notebook-cell:?execution_count=5&line=7) documents_embedded = embeddings.embed_documents(documents)
      [8](vscode-notebook-cell:?execution_count=5&line=8) end = timeit.default_timer()
     [10](vscode-notebook-cell:?execution_count=5&line=10) print("Query result:", query_result)

File [~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:103](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:103), in GradientEmbeddings.embed_documents(self, texts)
     [94](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:94) def embed_documents(self, texts: List[str]) -> List[List[float]]:
     [95](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:95)     """Call out to Gradient's embedding endpoint.
     [96](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:96) 
     [97](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:97)     Args:
   (...)
    [101](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:101)         List of embeddings, one for each text.
    [102](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:102)     """
--> [103](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:103)     embeddings = self.client.embed(
    [104](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:104)         model=self.model,
    [105](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:105)         texts=texts,
    [106](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:106)     )
    [107](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:107)     return embeddings

File [~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:331](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:331), in TinyAsyncGradientEmbeddingClient.embed(self, model, texts)
    [329](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:329) else:
    [330](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:330)     with ThreadPoolExecutor(32) as p:
--> [331](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:331)         embeddings_batch_perm = list(p.map(*map_args))
    [333](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:333) embeddings_perm = self._unbatch(embeddings_batch_perm)
    [334](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:334) embeddings = unpermute_func(embeddings_perm)

File [~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:621](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:621), in Executor.map.<locals>.result_iterator()
    [618](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:618) while fs:
    [619](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:619)     # Careful not to keep a reference to the popped future
    [620](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:620)     if timeout is None:
--> [621](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:621)         yield _result_or_cancel(fs.pop())
    [622](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:622)     else:
    [623](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:623)         yield _result_or_cancel(fs.pop(), end_time - time.monotonic())

File [~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:319](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:319), in _result_or_cancel(***failed resolving arguments***)
    [317](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:317) try:
    [318](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:318)     try:
--> [319](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:319)         return fut.result(timeout)
    [320](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:320)     finally:
    [321](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/concurrent/futures/_base.py:321)         fut.cancel()
...
    [304](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:304)         f"{response.status_code}: {response.text}"
    [305](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:305)     )
    [306](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/michi/langchain/docs/docs/integrations/text_embedding/~/miniconda3/envs/hf_env/lib/python3.10/site-packages/langchain/embeddings/gradient_ai.py:306) return [e["embedding"] for e in response.json()["embeddings"]]

Exception: Gradient returned an unexpected response with status 400: {"message":"Invalid input: {\"detail\":[{\"type\":\"too_long\",\"loc\":[\"body\",\"texts\"],\"msg\"
```













































<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
