### PR TITLE
Add the collection_description parameter to Milvus

### DIFF
--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -40,6 +40,8 @@ class Milvus(VectorStore):
         embedding_function (Embeddings): Function used to embed the text.
         collection_name (str): Which Milvus collection to use. Defaults to
             "LangChainCollection".
+        collection_description (str): The description of the collection. Defaults to
+            "".
         connection_args (Optional[dict[str, any]]): The connection args used for
             this class comes in the form of a dict.
         consistency_level (str): The consistency level to use for a collection.
@@ -103,6 +105,7 @@ class Milvus(VectorStore):
         self,
         embedding_function: Embeddings,
         collection_name: str = "LangChainCollection",
+        collection_description: str = "",
         connection_args: Optional[dict[str, Any]] = None,
         consistency_level: str = "Session",
         index_params: Optional[dict] = None,
@@ -138,6 +141,7 @@ class Milvus(VectorStore):
 
         self.embedding_func = embedding_function
         self.collection_name = collection_name
+        self.collection_description = collection_description
         self.index_params = index_params
         self.search_params = search_params
         self.consistency_level = consistency_level
@@ -285,7 +289,7 @@ class Milvus(VectorStore):
         )
 
         # Create the schema for the collection
-        schema = CollectionSchema(fields)
+        schema = CollectionSchema(fields, description=self.collection_description)
 
         # Create the collection
         try:


### PR DESCRIPTION
Because Milvus' collection_name doesn't support UFT8 characters in other languages, I want the `collection_descriotion`.


<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
