### PR TITLE
remove optional from ids param

### DIFF
--- a/libs/langchain/langchain/vectorstores/faiss.py
+++ b/libs/langchain/langchain/vectorstores/faiss.py
@@ -785,7 +785,7 @@ class FAISS(VectorStore):
         )
         return docs
 
-    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+    def delete(self, ids: List[str] = None, **kwargs: Any) -> Optional[bool]:
         """Delete by ID. These are the IDs in the vectorstore.
 
         Args:


### PR DESCRIPTION
delete() requires ids to remove documents from the db. 
Remove the optional type hinting for ids param.

fixed #14409


@efriis 
@hwchase17 
@baskaryan 

Do you think we can add a separate function which remove's all documents without ids?
