### PR TITLE
fix a bug in RedisNum filter againt value 0

### DIFF
--- a/libs/community/langchain_community/vectorstores/redis/filters.py
+++ b/libs/community/langchain_community/vectorstores/redis/filters.py
@@ -214,7 +214,7 @@ class RedisNum(RedisFilterField):
 
     def __str__(self) -> str:
         """Return the query syntax for a RedisNum filter expression."""
-        if not self._value:
+        if self._value is None:
             return "*"
 
         if (


### PR DESCRIPTION

  - **Description:** There is a bug in RedisNum filter that filter towards value 0 will be parsed as "*". This is a fix to it.
  - **Issue:** NA
  - **Dependencies:** NA
  - **Tag maintainer:** NA
  - **Twitter handle:** NA
