### PR TITLE
docs `API Reference` top menu update

### DIFF
--- a/docs/api_reference/themes/scikit-learn-modern/nav.html
+++ b/docs/api_reference/themes/scikit-learn-modern/nav.html
@@ -32,10 +32,10 @@
     <div class="sk-navbar-collapse collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" href="{{ pathto('api_reference') }}">API</a>
+          <a class="sk-nav-link nav-link" href="{{ pathto('core_api_reference') }}">Core</a>
         </li>
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" href="{{ pathto('core_api_reference') }}">Core</a>
+          <a class="sk-nav-link nav-link" href="{{ pathto('api_reference') }}">Langchain</a>
         </li>
         <li class="nav-item">
           <a class="sk-nav-link nav-link" href="{{ pathto('community_api_reference') }}">Community</a>
@@ -44,7 +44,7 @@
           <a class="sk-nav-link nav-link" href="{{ pathto('experimental_api_reference') }}">Experimental</a>
         </li>
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" target="_blank" rel="noopener noreferrer" href="https://python.langchain.com/">Python Docs</a>
+          <a class="sk-nav-link nav-link" target="_blank" rel="noopener noreferrer" href="https://python.langchain.com/"><b>Docs</b></a>
         </li>
         {%- for title, link, link_attrs in drop_down_navigation %}
         <li class="nav-item">


### PR DESCRIPTION
An issue with the top menu. It is not in the right priority order: "API/Core/Community/Experimental/Python Docs".
The second issue is that the "API" menu item is actually not for the whole API docs, but only for the "langchain" package.
I've updated menu to: "Core/Langchain/Community/Experimental/Docs"
Now, "Core" is the top namespace, then "Langchain".

Notes:
- "Langchain", not "LangChain" (the capital "C" inside). Reason: namespaces are in the lower case. So, here the capitalization helps to visually separate one menu item from another. "LangChain" messes with this visual comprehension.
- The last item, "Python Docs" replaced with "Docs". Reason: A 2-word item makes an impression of two menu items. Now we have more menu items and all but this are 1-word items. This single 2-word item looks like two menu items. Since we don't have a link to the JS Docs, removing "Python" is OK.
- "Docs" menu item is bold. It visually separates Docs from other menu items. Other menu items are linked to API Refernce, but Docs is linked to Documentation. 