### PR TITLE
Milvus allows to store metadata as json field

### DIFF
--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -54,7 +54,8 @@ class Milvus(VectorStore):
         text_field (str): Name of the text field. Defaults to "text".
         vector_field (str): Name of the vector field. Defaults to "vector".
         metadata_field (str): Name of the metadta field. Defaults to None.
-            When metadata_field is specified, the document's metadata will store as json.
+            When metadata_field is specified,
+            the document's metadata will store as json.
 
     The connection args used for this class comes in the form of a dict,
     here are a few of the options:
@@ -266,7 +267,10 @@ class Milvus(VectorStore):
                     # Datatype isn't compatible
                     if dtype == DataType.UNKNOWN or dtype == DataType.NONE:
                         logger.error(
-                            "Failure to create collection, unrecognized dtype for key: %s",
+                            (
+                                "Failure to create collection, "
+                                "unrecognized dtype for key: %s"
+                            ),
                             key,
                         )
                         raise ValueError(f"Unrecognized datatype for {key}.")

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -114,7 +114,7 @@ class Milvus(VectorStore):
         primary_field: str = "pk",
         text_field: str = "text",
         vector_field: str = "vector",
-        metadata_field: Optional[str] = None
+        metadata_field: Optional[str] = None,
     ):
         """Initialize the Milvus vector store."""
         try:
@@ -272,7 +272,9 @@ class Milvus(VectorStore):
                         raise ValueError(f"Unrecognized datatype for {key}.")
                     # Dataype is a string/varchar equivalent
                     elif dtype == DataType.VARCHAR:
-                        fields.append(FieldSchema(key, DataType.VARCHAR, max_length=65_535))
+                        fields.append(
+                            FieldSchema(key, DataType.VARCHAR, max_length=65_535)
+                        )
                     else:
                         fields.append(FieldSchema(key, dtype))
 
@@ -840,6 +842,6 @@ class Milvus(VectorStore):
 
     def _parse_document(self, data: dict) -> Document:
         return Document(
-                page_content=data.pop(self._text_field),
-                metadata= data.pop(self._metadata_field) if self._metadata_field else data
+            page_content=data.pop(self._text_field),
+            metadata=data.pop(self._metadata_field) if self._metadata_field else data,
         )


### PR DESCRIPTION
Because Milvus doesn't support nullable fields, but document metadata is very rich, so it makes more sense to store it as json.

https://github.com/milvus-io/pymilvus/issues/1705#issuecomment-1731112372

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
