### PR TITLE
GITLAB_URL should take default https://gitlab.com instead of error

### DIFF
--- a/libs/community/langchain_community/utilities/gitlab.py
+++ b/libs/community/langchain_community/utilities/gitlab.py
@@ -39,7 +39,7 @@ class GitLabAPIWrapper(BaseModel):
         """Validate that api key and python package exists in environment."""
 
         gitlab_url = get_from_dict_or_env(
-            values, "gitlab_url", "GITLAB_URL", default=None
+            values, "gitlab_url", "GITLAB_URL", default="https://gitlab.com"
         )
         gitlab_repository = get_from_dict_or_env(
             values, "gitlab_repository", "GITLAB_REPOSITORY"


### PR DESCRIPTION
The fix #14221 has broken default gitlab url which is forcing the users to specify GITLAB_URL for default one. With this fix if GITLAB_URL is not set, the default gitlab url will be taken.

  - **Description:** Add the GITHUB URL instead of None
  - **Issue:** the issue #14221 has broken the default github URL 
  - **Dependencies:** None
  - **Tag maintainer:** @hwchase17 
  - **Twitter handle:** manjunath_shiva

