### PR TITLE
Fix RRF and lucene escape characters for neo4j vector store

### DIFF
--- a/libs/community/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_neo4j.py
@@ -1,0 +1,45 @@
+"""Test Neo4j functionality."""
+
+from langchain_community.vectorstores.neo4j_vector import remove_lucene_chars
+
+
+def test_escaping_lucene() -> None:
+    """Test escaping lucene characters"""
+    assert remove_lucene_chars("Hello+World") == "Hello World"
+    assert remove_lucene_chars("Hello World\\") == "Hello World"
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter!")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter&&")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("Bill&&Melinda Gates Foundation")
+        == "Bill  Melinda Gates Foundation"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter(&&)")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter??")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter^")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter+")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter-")
+        == "It is the end of the world. Take shelter"
+    )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter~")
+        == "It is the end of the world. Take shelter"
+    )


### PR DESCRIPTION
* Remove Lucene special characters (fixes https://github.com/langchain-ai/langchain/issues/14232)
* Fixes RRF normalization for hybrid search