### PR TITLE
Fixing the Issue with DashScopeEmbeddings Handling More than 25 Rows of Data

### DIFF
--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -45,20 +45,27 @@ def embed_with_retry(embeddings: DashScopeEmbeddings, **kwargs: Any) -> Any:
 
     @retry_decorator
     def _embed_with_retry(**kwargs: Any) -> Any:
-        resp = embeddings.client.call(**kwargs)
-        if resp.status_code == 200:
-            return resp.output["embeddings"]
-        elif resp.status_code in [400, 401]:
-            raise ValueError(
-                f"status_code: {resp.status_code} \n "
-                f"code: {resp.code} \n message: {resp.message}"
-            )
-        else:
-            raise HTTPError(
-                f"HTTP error occurred: status_code: {resp.status_code} \n "
-                f"code: {resp.code} \n message: {resp.message}",
-                response=resp,
-            )
+        result = []
+        i = 0
+        input_data = kwargs['input']
+        while i < len(input_data):
+            kwargs['input'] = input_data[i:i + 25]
+            resp = embeddings.client.call(**kwargs)
+            if resp.status_code == 200:
+                result += resp.output["embeddings"]
+            elif resp.status_code in [400, 401]:
+                raise ValueError(
+                    f"status_code: {resp.status_code} \n "
+                    f"code: {resp.code} \n message: {resp.message}"
+                )
+            else:
+                raise HTTPError(
+                    f"HTTP error occurred: status_code: {resp.status_code} \n "
+                    f"code: {resp.code} \n message: {resp.message}",
+                    response=resp,
+                )
+            i += 25
+        return result
 
     return _embed_with_retry(**kwargs)
 

--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -47,9 +47,9 @@ def embed_with_retry(embeddings: DashScopeEmbeddings, **kwargs: Any) -> Any:
     def _embed_with_retry(**kwargs: Any) -> Any:
         result = []
         i = 0
-        input_data = kwargs['input']
+        input_data = kwargs["input"]
         while i < len(input_data):
-            kwargs['input'] = input_data[i:i + 25]
+            kwargs["input"] = input_data[i : i + 25]
             resp = embeddings.client.call(**kwargs)
             if resp.status_code == 200:
                 result += resp.output["embeddings"]

--- a/libs/community/tests/integration_tests/embeddings/test_dashscope.py
+++ b/libs/community/tests/integration_tests/embeddings/test_dashscope.py
@@ -15,10 +15,39 @@ def test_dashscope_embedding_documents() -> None:
 
 def test_dashscope_embedding_documents_multiple() -> None:
     """Test dashscope embeddings."""
-    documents = ["foo bar", "bar foo", "foo"]
+    documents = [
+        "foo bar",
+        "bar foo",
+        "foo",
+        "foo0",
+        "foo1",
+        "foo2",
+        "foo3",
+        "foo4",
+        "foo5",
+        "foo6",
+        "foo7",
+        "foo8",
+        "foo9",
+        "foo10",
+        "foo11",
+        "foo12",
+        "foo13",
+        "foo14",
+        "foo15",
+        "foo16",
+        "foo17",
+        "foo18",
+        "foo19",
+        "foo20",
+        "foo21",
+        "foo22",
+        "foo23",
+        "foo24",
+    ]
     embedding = DashScopeEmbeddings(model="text-embedding-v1")
     output = embedding.embed_documents(documents)
-    assert len(output) == 3
+    assert len(output) == 28
     assert len(output[0]) == 1536
     assert len(output[1]) == 1536
     assert len(output[2]) == 1536


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
 
This change addresses the issue where DashScopeEmbeddingAPI limits requests to 25 lines of data, and DashScopeEmbeddings did not handle cases with more than 25 lines, leading to errors. I have implemented a fix to manage data exceeding this limit efficiently.

