### PR TITLE
docs: fix api ref link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -168,7 +168,7 @@ const config = {
             label: "Guides",
           },
           {
-            href: "https://api.python.langchain.com/en/stable/api_reference.html",
+            href: "https://api.python.langchain.com",
             label: "API",
             position: "left",
           },


### PR DESCRIPTION
Don't point to stable, let api docs choose default version