### PR TITLE
Remove trailing "`" in pip install command

### DIFF
--- a/docs/docs/guides/local_llms.ipynb
+++ b/docs/docs/guides/local_llms.ipynb
@@ -277,7 +277,7 @@
    "source": [
     "%env CMAKE_ARGS=\"-DLLAMA_METAL=on\"\n",
     "%env FORCE_CMAKE=1\n",
-    "%pip install -U llama-cpp-python --no-cache-dirclear`"
+    "%pip install -U llama-cpp-python --no-cache-dirclear"
    ]
   },
   {


### PR DESCRIPTION
hi! just a simple typo fix in the local LLM python docs

  - **Description:** removing a trailing "\`" character in a `!pip install ...` command
  - **Issue:** n/a
  - **Dependencies:** n/a
  - **Tag maintainer:** n/a
  - **Twitter handle:** n/a
