### PR TITLE
Implement similarity_score_threshold for MongoDB Vector Store

### DIFF
--- a/libs/community/langchain_community/vectorstores/mongodb_atlas.py
+++ b/libs/community/langchain_community/vectorstores/mongodb_atlas.py
@@ -11,7 +11,8 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
-    Union, Callable,
+    Union,
+    Callable,
 )
 
 import numpy as np
@@ -60,7 +61,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
         index_name: str = "default",
         text_key: str = "text",
         embedding_key: str = "embedding",
-        relevance_score_fn: str = "cosine"
+        relevance_score_fn: str = "cosine",
     ):
         """
         Args:
@@ -92,7 +93,9 @@ class MongoDBAtlasVectorSearch(VectorStore):
         elif self._relevance_score_fn == "cosine":
             return self._cosine_relevance_score_fn
         else:
-            raise NotImplementedError(f"No relevance score function for ${self._relevance_score_fn}")
+            raise NotImplementedError(
+                f"No relevance score function for ${self._relevance_score_fn}"
+            )
 
     @classmethod
     def from_connection_string(
@@ -211,7 +214,6 @@ class MongoDBAtlasVectorSearch(VectorStore):
     def similarity_search_with_score(
         self,
         query: str,
-        *,
         k: int = 4,
         pre_filter: Optional[Dict] = None,
         post_filter_pipeline: Optional[List[Dict]] = None,

--- a/libs/community/langchain_community/vectorstores/mongodb_atlas.py
+++ b/libs/community/langchain_community/vectorstores/mongodb_atlas.py
@@ -4,6 +4,7 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Generator,
     Iterable,
@@ -12,7 +13,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    Callable,
 )
 
 import numpy as np
@@ -72,7 +72,8 @@ class MongoDBAtlasVectorSearch(VectorStore):
             embedding_key: MongoDB field that will contain the embedding for
                 each document.
             index_name: Name of the Atlas Search index.
-            relevance_score_fn: The similarity score used for the index. Currently supported: Euclidean, cosine, and dot product.
+            relevance_score_fn: The similarity score used for the index.
+            Currently supported: Euclidean, cosine, and dot product.
         """
         self._collection = collection
         self._embedding = embedding


### PR DESCRIPTION
Adds the option for `similarity_score_threshold` when using `MongoDBAtlasVectorSearch` as a vector store retriever.

Example use:

```
vector_search = MongoDBAtlasVectorSearch.from_documents(...)

qa_retriever = vector_search.as_retriever(
    search_type="similarity_score_threshold",
    search_kwargs={
        "score_threshold": 0.5,
    }
)

qa = RetrievalQA.from_chain_type(
	llm=OpenAI(), 
	chain_type="stuff", 
	retriever=qa_retriever,
)

docs = qa({"query": "..."})
```

I've tested this feature locally, using a MongoDB Atlas Cluster with a vector search index.