### PR TITLE
Add safe lookup to OpenAI response adapter

### DIFF
--- a/libs/community/langchain_community/adapters/openai.py
+++ b/libs/community/langchain_community/adapters/openai.py
@@ -71,27 +71,30 @@ def convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
     Returns:
         The LangChain message.
     """
-    role = _dict["role"]
+    role = _dict.get("role")
     if role == "user":
-        return HumanMessage(content=_dict["content"])
+        return HumanMessage(content=_dict.get("content"))
     elif role == "assistant":
         # Fix for azure
         # Also OpenAI returns None for tool invocations
-        content = _dict.get("content", "") or ""
+        content = _dict.get("content", "")
         additional_kwargs: Dict = {}
-        if _dict.get("function_call"):
-            additional_kwargs["function_call"] = dict(_dict["function_call"])
-        if _dict.get("tool_calls"):
-            additional_kwargs["tool_calls"] = _dict["tool_calls"]
+        if function_call := _dict.get("function_call"):
+            additional_kwargs["function_call"] = dict(function_call)
+        if tool_calls := _dict.get("tool_calls"):
+            additional_kwargs["tool_calls"] = tool_calls
         return AIMessage(content=content, additional_kwargs=additional_kwargs)
     elif role == "system":
-        return SystemMessage(content=_dict["content"])
+        return SystemMessage(content=_dict.get("content", ""))
     elif role == "function":
-        return FunctionMessage(content=_dict["content"], name=_dict["name"])
+        return FunctionMessage(content=_dict.get("content", ""), name=_dict.get("name"))
     elif role == "tool":
-        return ToolMessage(content=_dict["content"], tool_call_id=_dict["tool_call_id"])
+        return ToolMessage(
+            content=_dict.get("content", ""),
+            tool_call_id=_dict.get("tool_call_id"),
+        )
     else:
-        return ChatMessage(content=_dict["content"], role=role)
+        return ChatMessage(content=_dict.get("content", ""), role=role)
 
 
 def convert_message_to_dict(message: BaseMessage) -> dict:

--- a/libs/community/langchain_community/adapters/openai.py
+++ b/libs/community/langchain_community/adapters/openai.py
@@ -91,7 +91,7 @@ def convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
     elif role == "tool":
         additional_kwargs = {}
         if "name" in _dict:
-            additional_kwargs["name"] = _dict.get("name")
+            additional_kwargs["name"] = _dict["name"]
         return ToolMessage(
             content=_dict.get("content", ""),
             tool_call_id=_dict.get("tool_call_id"),

--- a/libs/community/langchain_community/adapters/openai.py
+++ b/libs/community/langchain_community/adapters/openai.py
@@ -73,11 +73,11 @@ def convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
     """
     role = _dict.get("role")
     if role == "user":
-        return HumanMessage(content=_dict.get("content"))
+        return HumanMessage(content=_dict.get("content", ""))
     elif role == "assistant":
         # Fix for azure
         # Also OpenAI returns None for tool invocations
-        content = _dict.get("content", "")
+        content = _dict.get("content", "") or ""
         additional_kwargs: Dict = {}
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
## Description
Similar to https://github.com/langchain-ai/langchain/issues/5861, I've experienced `KeyError`s resulting from unsafe lookups in the `convert_dict_to_message` function in [this file](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/adapters/openai.py). While that issue focused on `KeyError 'content'`, I've opened another issue (#14764) about how the problem still exists in the same function but with `KeyError 'role'`. The fix for #5861 only added a safe lookup to the specific line that was giving them trouble.. This PR fixes the unsafe lookup in the rest of the function but the problem still exists across the repo.

## Issues
* #14764
* #5861 

## Dependencies
* None

## Checklist
[x] make format
[x] make lint
[ ] make test - Results in `make: *** No rule to make target 'test'.  Stop.`

## Maintainers
* @hinthornw