### PR TITLE
[DEV] Update import paths for StrOutputParser and RunnablePassthrough

### DIFF
--- a/docs/docs/expression_language/how_to/map.ipynb
+++ b/docs/docs/expression_language/how_to/map.ipynb
@@ -28,28 +28,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "267d1460-53c1-4fdb-b2c3-b6a1eb7fccff",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Harrison worked at Kensho.'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.embeddings import OpenAIEmbeddings\n",
     "from langchain.prompts import ChatPromptTemplate\n",
     "from langchain.vectorstores import FAISS\n",
-    "from langchain_core.output_parsers import StrOutputParser\n",
-    "from langchain_core.runnables import RunnablePassthrough\n",
+    "from langchain.schema.runnable  import RunnablePassthrough\n",
+    "from langchain.schema  import StrOutputParser\n",
     "\n",
     "vectorstore = FAISS.from_texts(\n",
     "    [\"harrison worked at kensho\"], embedding=OpenAIEmbeddings()\n",
@@ -110,21 +99,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "84fc49e1-2daf-4700-ae33-a0a6ed47d5f6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Harrison ha lavorato a Kensho.'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from operator import itemgetter\n",
     "\n",
@@ -175,22 +153,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "31f18442-f837-463f-bef4-8729368f5f8b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'joke': AIMessage(content=\"Why don't bears wear shoes?\\n\\nBecause they have bear feet!\"),\n",
-       " 'poem': AIMessage(content=\"In the wild's embrace, bear roams free,\\nStrength and grace, a majestic decree.\")}"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.prompts import ChatPromptTemplate\n",
@@ -219,18 +185,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "38e47834-45af-4281-991f-86f150001510",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "958 ms ± 402 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%timeit\n",
     "\n",
@@ -239,18 +197,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "d0cd40de-b37e-41fa-a2f6-8aaa49f368d6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.22 s ± 508 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%timeit\n",
     "\n",
@@ -259,18 +209,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "799894e1-8e18-4a73-b466-f6aea6af3920",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.15 s ± 119 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%timeit\n",
     "\n",
@@ -294,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Changed import paths:
  - From 'langchain_core.output_parsers' to 'langchain.schema' for StrOutputParser.
  - From 'langchain_core.runnables' to 'langchain.schema.runnable' for RunnablePassthrough.

<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** Updates import paths StrOutputParser and RunnablePassthrough
  - **Issue:** related to  #14287


Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

 -->
