### PR TITLE
Add Ollama multimodal llm support for image with prompt

### DIFF
--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -307,6 +307,8 @@ class Ollama(BaseLLM, _OllamaCommon):
                         chunk.text,
                         verbose=self.verbose,
                     )
+
+                    
 class OllamaMultiModal(BaseLLM, _OllamaCommon):
     """Ollama locally runs large language models with multimodal support."""
 


### PR DESCRIPTION
  - **Description:** Adds a class OllamaMultiModal to the Ollama llms file: lanchain/llms/ollama.py. This class supports sending an image to the ollama endpoint for models that support the image with a prompt message. 
  - **Twitter handle:** Daniel_OHeron

Passes make format, make lint, make test.

If this code change is useful. Will add unit test, notebook and documentation. As well as build out additional features. Please let me know.

Example usage: 
`
from OllamaMultiModalMain import OllamaMultiModal
import base64

def encode_image_to_base64(image_path):
    with open(image_path, "rb") as image_file:
        return base64.b64encode(image_file.read()).decode('utf-8')

llm = OllamaMultiModal(model="bakllava")

while True:
    user_input = input("User (text): ")

    image_input = input("User (image path, press enter to skip): ")
    image_data = encode_image_to_base64(image_input) if image_input else None

    if image_data:
        response = llm.invoke(
            input=user_input, images=[image_data])
    else:
        response = llm.invoke(input=user_input)
        # response = conversational_chain.predict(input=user_input)

    print("Chat:", response)
`