### PR TITLE
fix agenerate return value

### DIFF
--- a/docs/docs/integrations/chat/yandex.ipynb
+++ b/docs/docs/integrations/chat/yandex.ipynb
@@ -46,8 +46,6 @@
     "- [API key](https://cloud.yandex.com/en/docs/iam/operations/api-key/create)\n",
     "    You can specify the key in a constructor parameter `api_key` or in an environment variable `YC_API_KEY`.\n",
     "\n",
-    "In the `model_uri` parameter, specify the model used, see [the documentation](https://cloud.yandex.com/en/docs/yandexgpt/concepts/models#yandexgpt-generation) for more details.\n",
-    "\n",
     "To specify the model you can use `model_uri` parameter, see [the documentation](https://cloud.yandex.com/en/docs/yandexgpt/concepts/models#yandexgpt-generation) for more details.\n",
     "\n",
     "By default, the latest version of `yandexgpt-lite` is used from the folder specified in the parameter `folder_id` or `YC_FOLDER_ID` environment variable."

--- a/docs/docs/integrations/llms/yandex.ipynb
+++ b/docs/docs/integrations/llms/yandex.ipynb
@@ -33,8 +33,6 @@
     "- [API key](https://cloud.yandex.com/en/docs/iam/operations/api-key/create)\n",
     "    You can specify the key in a constructor parameter `api_key` or in an environment variable `YC_API_KEY`.\n",
     "\n",
-    "In the `model_uri` parameter, specify the model used, see [the documentation](https://cloud.yandex.com/en/docs/yandexgpt/concepts/models#yandexgpt-generation) for more details.\n",
-    "\n",
     "To specify the model you can use `model_uri` parameter, see [the documentation](https://cloud.yandex.com/en/docs/yandexgpt/concepts/models#yandexgpt-generation) for more details.\n",
     "\n",
     "By default, the latest version of `yandexgpt-lite` is used from the folder specified in the parameter `folder_id` or `YC_FOLDER_ID` environment variable."

--- a/libs/community/langchain_community/chat_models/yandex.py
+++ b/libs/community/langchain_community/chat_models/yandex.py
@@ -192,9 +192,9 @@ class ChatYandexGPT(_BaseYandexGPT, BaseChatModel):
                         operation_request, metadata=self._grpc_metadata
                     )
 
-            instruct_response = CompletionResponse()
-            operation.response.Unpack(instruct_response)
-            text = instruct_response.alternatives[0].message.text
-            if stop is not None:
-                text = enforce_stop_tokens(text, stop)
-            return text
+            completion_response = CompletionResponse()
+            operation.response.Unpack(completion_response)
+            text = completion_response.alternatives[0].message.text
+            text = text if stop is None else enforce_stop_tokens(text, stop)
+            message = AIMessage(content=text)
+            return ChatResult(generations=[ChatGeneration(message=message)])

--- a/libs/community/langchain_community/llms/yandex.py
+++ b/libs/community/langchain_community/llms/yandex.py
@@ -232,9 +232,9 @@ class YandexGPT(_BaseYandexGPT, LLM):
                         operation_request, metadata=self._grpc_metadata
                     )
 
-            instruct_response = CompletionResponse()
-            operation.response.Unpack(instruct_response)
-            text = instruct_response.alternatives[0].message.text
+            completion_response = CompletionResponse()
+            operation.response.Unpack(completion_response)
+            text = completion_response.alternatives[0].message.text
             if stop is not None:
                 text = enforce_stop_tokens(text, stop)
             return text


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes (if applicable),
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
Fixed:
  -  `_agenerate` return value in the YandexGPT Chat Model
  - duplicate line in the documentation