### PR TITLE
Fix failing serpapi response processing for Google Maps API

### DIFF
--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -211,8 +211,8 @@ class SerpAPIWrapper(BaseModel):
 
         if "buying_guide" in res.keys():
             snippets.append(res["buying_guide"])
-        if "local_results" in res.keys() and "places" in res["local_results"].keys():
-            snippets.append(res["local_results"]["places"])
+        if "local_results" in res.keys() and isinstance(res["local_results"], list):
+            snippets += res["local_results"]
 
         if len(snippets) > 0:
             return str(snippets)

--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -211,7 +211,7 @@ class SerpAPIWrapper(BaseModel):
 
         if "buying_guide" in res.keys():
             snippets.append(res["buying_guide"])
-        if "local_results" in res.keys() and isinstance(res["local_results"], list):
+        if "local_results" in res and isinstance(res["local_results"], list):
             snippets += res["local_results"]
 
         if len(snippets) > 0:

--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -213,7 +213,11 @@ class SerpAPIWrapper(BaseModel):
             snippets.append(res["buying_guide"])
         if "local_results" in res and isinstance(res["local_results"], list):
             snippets += res["local_results"]
-        if "local_results" in res.keys() and isinstance(res["local_results"], dict) and "places" in res["local_results"].keys():
+        if (
+            "local_results" in res.keys()
+            and isinstance(res["local_results"], dict)
+            and "places" in res["local_results"].keys()
+        ):
             snippets.append(res["local_results"]["places"])
         if len(snippets) > 0:
             return str(snippets)

--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -213,7 +213,8 @@ class SerpAPIWrapper(BaseModel):
             snippets.append(res["buying_guide"])
         if "local_results" in res.keys() and isinstance(res["local_results"], list):
             snippets += res["local_results"]
-
+        if "local_results" in res.keys() and isinstance(res["local_results"], dict) and "places" in res["local_results"].keys():
+            snippets.append(res["local_results"]["places"])
         if len(snippets) > 0:
             return str(snippets)
         else:


### PR DESCRIPTION
**Description:** Fix for processing for serpapi response for Google Maps API 
**Issue:** Due to the fact corresponding [api](https://serpapi.com/google-maps-api) returns 'local_results' as list, and old version requested `res["local_results"].keys()` of the list. As the result we got exception: ```AttributeError: 'list' object has no attribute 'keys'```.

Way to reproduce wrong behaviour:
```
    params = {
        "engine": "google_maps",
        "type": "search",
        "google_domain": "google.de",
        "ll": "@51.1917,10.525,14z",
        "hl": "de",
        "gl": "de",
    }
    search = SerpAPIWrapper(params=params)
    results = search.run("cafe")
```