### PR TITLE
added history and support for system_message as param

### DIFF
--- a/docs/docs/integrations/chat/google_generative_ai.ipynb
+++ b/docs/docs/integrations/chat/google_generative_ai.ipynb
@@ -137,6 +137,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9e55d043-bb2f-44e3-9134-c39a1abe3a9e",
+   "metadata": {},
+   "source": [
+    "Gemini doesn't support `SystemMessage` at the moment, but it can be added to the first human message in the row. If you want such behavior, just set the `convert_system_message_to_human` to True:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a64b523-9710-4d15-9944-1e3cc567a52b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.schema.messages import HumanMessage, SystemMessage\n",
+    "\n",
+    "model = ChatGoogleGenerativeAI(model=\"gemini-pro\", convert_system_message_to_human=True)\n",
+    "model(\n",
+    "    [\n",
+    "        SystemMessage(content=\"Answer only yes or no.\"),\n",
+    "        HumanMessage(content=\"Is apple a fruit?\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "40773fac-b24d-476d-91c8-2da8fed99b53",
    "metadata": {},
    "source": [

--- a/libs/partners/google-genai/langchain_google_genai/chat_models.py
+++ b/libs/partners/google-genai/langchain_google_genai/chat_models.py
@@ -463,7 +463,9 @@ Supported examples:
     """Number of chat completions to generate for each prompt. Note that the API may
        not return the full n completions if duplicates are generated."""
     convert_system_message_to_human: bool = False
-    "Whether to prepend a SystemMessage to the first HumanMessage or not."
+    """Whether to merge any leading SystemMessage into the following HumanMessage.
+    
+    Gemini does not support system messages; any unsupported messages will raise an error."""
 
     class Config:
         allow_population_by_field_name = True

--- a/libs/partners/google-genai/langchain_google_genai/chat_models.py
+++ b/libs/partners/google-genai/langchain_google_genai/chat_models.py
@@ -299,7 +299,13 @@ def _parse_chat_history(
             and isinstance(message, SystemMessage)
             and not convert_system_message_to_human
         ):
-            raise ValueError("SystemMessages are not yet supported!")
+            raise ValueError("""SystemMessages are not yet supported!
+
+To automatically convert the leading SystemMessage to a HumanMessage,
+set  `convert_system_message_to_human` to True. Example:
+
+llm = ChatGoogleGenerativeAI(model="gemini-pro", convert_system_message_to_human=True)
+""")
         elif i == 0 and isinstance(message, SystemMessage):
             raw_system_message = (
                 message.content if isinstance(message.content, str) else None

--- a/libs/partners/google-genai/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/google-genai/tests/integration_tests/test_chat_models.py
@@ -1,6 +1,6 @@
 """Test ChatGoogleGenerativeAI chat model."""
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
@@ -147,3 +147,40 @@ def test_chat_google_genai_invoke_multimodal_invalid_model() -> None:
     llm = ChatGoogleGenerativeAI(model=_MODEL)
     with pytest.raises(ChatGoogleGenerativeAIError):
         llm.invoke(messages)
+
+
+def test_chat_google_genai_single_call_with_history() -> None:
+    model = ChatGoogleGenerativeAI(model=_MODEL)
+    text_question1, text_answer1 = "How much is 2+2?", "4"
+    text_question2 = "How much is 3+3?"
+    message1 = HumanMessage(content=text_question1)
+    message2 = AIMessage(content=text_answer1)
+    message3 = HumanMessage(content=text_question2)
+    response = model([message1, message2, message3])
+    assert isinstance(response, AIMessage)
+    assert isinstance(response.content, str)
+
+
+def test_chat_google_genai_system_message_error() -> None:
+    model = ChatGoogleGenerativeAI(model=_MODEL)
+    text_question1, text_answer1 = "How much is 2+2?", "4"
+    text_question2 = "How much is 3+3?"
+    system_message = SystemMessage(content="You're supposed to answer math questions.")
+    message1 = HumanMessage(content=text_question1)
+    message2 = AIMessage(content=text_answer1)
+    message3 = HumanMessage(content=text_question2)
+    with pytest.raises(ValueError):
+        model([system_message, message1, message2, message3])
+
+
+def test_chat_google_genai_system_message() -> None:
+    model = ChatGoogleGenerativeAI(model=_MODEL, convert_system_message_to_human=True)
+    text_question1, text_answer1 = "How much is 2+2?", "4"
+    text_question2 = "How much is 3+3?"
+    system_message = SystemMessage(content="You're supposed to answer math questions.")
+    message1 = HumanMessage(content=text_question1)
+    message2 = AIMessage(content=text_answer1)
+    message3 = HumanMessage(content=text_question2)
+    response = model([system_message, message1, message2, message3])
+    assert isinstance(response, AIMessage)
+    assert isinstance(response.content, str)

--- a/libs/partners/google-genai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/google-genai/tests/unit_tests/test_chat_models.py
@@ -1,8 +1,12 @@
 """Test chat model integration."""
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.pydantic_v1 import SecretStr
 from pytest import CaptureFixture
 
-from langchain_google_genai.chat_models import ChatGoogleGenerativeAI
+from langchain_google_genai.chat_models import (
+    ChatGoogleGenerativeAI,
+    _parse_chat_history,
+)
 
 
 def test_integration_initialization() -> None:
@@ -36,3 +40,21 @@ def test_api_key_masked_when_passed_via_constructor(capsys: CaptureFixture) -> N
     captured = capsys.readouterr()
 
     assert captured.out == "**********"
+
+
+def test_parse_history() -> None:
+    system_input = "You're supposed to answer math questions."
+    text_question1, text_answer1 = "How much is 2+2?", "4"
+    text_question2 = "How much is 3+3?"
+    system_message = SystemMessage(content=system_input)
+    message1 = HumanMessage(content=text_question1)
+    message2 = AIMessage(content=text_answer1)
+    message3 = HumanMessage(content=text_question2)
+    messages = [system_message, message1, message2, message3]
+    history = _parse_chat_history(messages, convert_system_message_to_human=True)
+    assert len(history) == 3
+    assert history[0] == {
+        "role": "user",
+        "parts": [{"text": f"{system_input}\n{text_question1}"}],
+    }
+    assert history[1] == {"role": "model", "parts": [{"text": f"{text_answer1}"}]}

--- a/libs/partners/google-genai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/google-genai/tests/unit_tests/test_chat_models.py
@@ -55,6 +55,6 @@ def test_parse_history() -> None:
     assert len(history) == 3
     assert history[0] == {
         "role": "user",
-        "parts": [{"text": f"{system_input}\n{text_question1}"}],
+        "parts": [{"text": system_input}, {"text": text_question1}],
     }
-    assert history[1] == {"role": "model", "parts": [{"text": f"{text_answer1}"}]}
+    assert history[1] == {"role": "model", "parts": [{"text": text_answer1}]}


### PR DESCRIPTION
  - **Description:** added support for chat_history for Google GenerativeAI (to actually use the `chat` API) plus since Gemini currently doesn't have a support for SystemMessage, added support for it only if a user provides additional `convert_system_message_to_human` flag during model initialization (in this case, SystemMessage would be prepanded to the first HumanMessage)
  - **Issue:** #14710 
  - **Dependencies:** any dependencies required for this change,
  - **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below),
  - **Twitter handle:** lkuligin
