### PR TITLE
Fix link typo to `/docs/integrations/text_embedding/nvidia_ai_endpoints`

### DIFF
--- a/docs/docs/integrations/providers/nvidia.mdx
+++ b/docs/docs/integrations/providers/nvidia.mdx
@@ -35,4 +35,4 @@ The active models which are supported can be found [in NGC](https://catalog.ngc.
 
 **The following may be useful examples to help you get started:**
 - **[`ChatNVIDIA` Model](/docs/integrations/chat/nvidia_ai_endpoints).**
-- **[`NVIDIAEmbeddings` Model for RAG Workflows](/docs/integrations/text_embeddings/nvidia_ai_endpoints).**
+- **[`NVIDIAEmbeddings` Model for RAG Workflows](/docs/integrations/text_embedding/nvidia_ai_endpoints).**


### PR DESCRIPTION
This page doesn't exist:
- https://python.langchain.com/docs/integrations/text_embeddings/nvidia_ai_endpoints

but this one does:
- https://python.langchain.com/docs/integrations/text_embedding/nvidia_ai_endpoints