### PR TITLE
[Bugfix] Ensure tool output is a str, for OAI Assistant

### DIFF
--- a/libs/langchain/langchain/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain/agents/openai_assistant/base.py
@@ -288,7 +288,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[Dict, OutputType]):
             tc.id for tc in run.required_action.submit_tool_outputs.tool_calls
         }
         tool_outputs = [
-            {"output": output, "tool_call_id": action.tool_call_id}
+            {"output": str(output), "tool_call_id": action.tool_call_id}
             for action, output in intermediate_steps
             if action.tool_call_id in required_tool_call_ids
         ]


### PR DESCRIPTION
Tool outputs have to be strings apparently. Ensure they are formatted correctly before passing as intermediate steps.
 

```
BadRequestError: Error code: 400 - {'error': {'message': '1 validation error for Request\nbody -> tool_outputs -> 0 -> output\n  str type expected (type=type_error.str)', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```