### PR TITLE
Update parser

### DIFF
--- a/libs/langchain/langchain/agents/output_parsers/openai_tools.py
+++ b/libs/langchain/langchain/agents/output_parsers/openai_tools.py
@@ -36,7 +36,7 @@ def parse_ai_message_to_openai_tool_action(
         function = tool_call["function"]
         function_name = function["name"]
         try:
-            _tool_input = json.loads(function["arguments"])
+            _tool_input = json.loads(function["arguments"] or "{}")
         except JSONDecodeError:
             raise OutputParserException(
                 f"Could not parse tool input: {function} because "


### PR DESCRIPTION
Gpt-3.5 sometimes calls with empty string arguments instead of `{}`

I'd assume it's because the typescript representation on their backend makes it a bit ambiguous.
^ exaample