### PR TITLE
OPENAI_PROXY not working

### DIFF
--- a/docs/docs/integrations/llms/openai.ipynb
+++ b/docs/docs/integrations/llms/openai.ipynb
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "55142cec",
    "metadata": {},
    "outputs": [],

--- a/docs/docs/integrations/llms/openai.ipynb
+++ b/docs/docs/integrations/llms/openai.ipynb
@@ -163,6 +163,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "pip install httpx\n",
+    "\n",
     "import httpx\n",
     "\n",
     "openai = OpenAI(model_name=\"gpt-3.5-turbo-instruct\", http_client=httpx.Client(proxies=\"http://proxy.yourcompany.com:8080\"))"

--- a/docs/docs/integrations/llms/openai.ipynb
+++ b/docs/docs/integrations/llms/openai.ipynb
@@ -153,17 +153,19 @@
    "id": "58a9ddb1",
    "metadata": {},
    "source": [
-    "If you are behind an explicit proxy, you can use the OPENAI_PROXY environment variable to pass through"
+    "If you are behind an explicit proxy, you can specify the http_client to pass through"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "55142cec",
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ[\"OPENAI_PROXY\"] = \"http://proxy.yourcompany.com:8080\""
+    "import httpx\n",
+    "\n",
+    "openai = OpenAI(model_name=\"gpt-3.5-turbo-instruct\", http_client=httpx.Client(proxies=\"http://proxy.yourcompany.com:8080\"))"
    ]
   }
  ],


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** OPENAI_PROXY is not working for openai==1.3.9, The `proxies` argument is deprecated. The `http_client` argument should be passed instead,
  - **Issue:** OPENAI_PROXY is not working,
  - **Dependencies:** None,
  - **Tag maintainer:** @hwchase17 ,
  - **Twitter handle:** timothy66666
