### PR TITLE
Update Tongyi default model_name

### DIFF
--- a/libs/community/langchain_community/llms/tongyi.py
+++ b/libs/community/langchain_community/llms/tongyi.py
@@ -108,7 +108,7 @@ class Tongyi(LLM):
         return False
 
     client: Any  #: :meta private:
-    model_name: str = "qwen-plus-v1"
+    model_name: str = "qwen-plus"
 
     """Model name to use."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
<img width="1305" alt="Screenshot 2023-12-18 at 9 54 01 PM" src="https://github.com/langchain-ai/langchain/assets/10000925/c943fd81-cd48-46eb-8dff-4680424d9ba9">

The current model is no longer available.