### PR TITLE
docs: fix typo in contributing re installing integration test deps

### DIFF
--- a/docs/docs/contributing/code.mdx
+++ b/docs/docs/contributing/code.mdx
@@ -64,7 +64,7 @@ cd libs/community
 Install langchain-community development requirements (for running langchain, running examples, linting, formatting, tests, and coverage):
 
 ```bash
-poetry install --with lint,typing,test,integration_tests
+poetry install --with lint,typing,test,test_integration
 ```
 
 Then verify dependency installation:


### PR DESCRIPTION
**Description**

The contributing docs lists a poetry command to install community for dev work that includes a poetry group called `integration_tests`. This is a mistake: the poetry group for integration tests is called `test_integration`, not `integration_tests`. See here:
https://github.com/langchain-ai/langchain/blob/master/libs/community/pyproject.toml#L119