### PR TITLE
Docs reference for XataVectorStore constructor

### DIFF
--- a/docs/docs/integrations/vectorstores/xata.ipynb
+++ b/docs/docs/integrations/vectorstores/xata.ipynb
@@ -167,7 +167,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After running the above command, if you go to the Xata UI, you should see the documents loaded together with their embeddings."
+    "After running the above command, if you go to the Xata UI, you should see the documents loaded together with their embeddings.\n",
+    "To use an existing Xata table that already contains vector contents, initialize the XataVectorStore constructor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vector_store = XataVectorStore(\n",
+    "    api_key=api_key, db_url=db_url, embedding=embeddings, table_name=\"vectors\"\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
Adds doc reference to the XataVectorStore constructor for use with existing Xata table contents.

@tsg @philkra 