### PR TITLE
Update arxiv.py with Entry ID as a return value

### DIFF
--- a/libs/community/langchain_community/utilities/arxiv.py
+++ b/libs/community/langchain_community/utilities/arxiv.py
@@ -118,6 +118,7 @@ class ArxivAPIWrapper(BaseModel):
             Document(
                 page_content=result.summary,
                 metadata={
+                    "Entry ID": result.entry_id,
                     "Published": result.updated.date(),
                     "Title": result.title,
                     "Authors": ", ".join(a.name for a in result.authors),


### PR DESCRIPTION
Added Entry ID as a return value inside get_summaries_as_docs

  - **Description:** Added the Entry ID as a return, so it's easier to track the IDs of the papers that are being returned.


With the addition return of the entry ID in functions like ArxivRetriever, it will be easier to reference the ID of the paper itself.

