### PR TITLE
infra: run CI on all PRs

### DIFF
--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -5,11 +5,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    paths:
-      - ".github/actions/**"
-      - ".github/tools/**"
-      - ".github/workflows/**"
-      - "libs/**"
 
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.


### PR DESCRIPTION
Somehow it looks like experimental linting didn't run properly on https://github.com/langchain-ai/langchain/pull/14842 before merging. Looks like it's because [check_diffs.yml](https://github.com/langchain-ai/langchain/blob/master/.github/workflows/check_diffs.yml#L8-L12) has some paths defined, and those paths are maybe only matched against the most recent commit, not the whole PR