### PR TITLE
fix(minor): added missing **kwargs parameter to chroma query function

### DIFF
--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -345,7 +345,9 @@ class Chroma(VectorStore):
         Returns:
             List[Document]: List of documents most similar to the query text.
         """
-        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter, **kwargs)
+        docs_and_scores = self.similarity_search_with_score(
+            query, k, filter=filter, **kwargs
+        )
         return [doc for doc, _ in docs_and_scores]
 
     def similarity_search_by_vector(

--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -345,7 +345,7 @@ class Chroma(VectorStore):
         Returns:
             List[Document]: List of documents most similar to the query text.
         """
-        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter)
+        docs_and_scores = self.similarity_search_with_score(query, k, filter=filter, **kwargs)
         return [doc for doc, _ in docs_and_scores]
 
     def similarity_search_by_vector(
@@ -369,6 +369,7 @@ class Chroma(VectorStore):
             n_results=k,
             where=filter,
             where_document=where_document,
+            **kwargs,
         )
         return _results_to_docs(results)
 
@@ -398,6 +399,7 @@ class Chroma(VectorStore):
             n_results=k,
             where=filter,
             where_document=where_document,
+            **kwargs,
         )
         return _results_to_docs_and_scores(results)
 
@@ -427,6 +429,7 @@ class Chroma(VectorStore):
                 n_results=k,
                 where=filter,
                 where_document=where_document,
+                **kwargs,
             )
         else:
             query_embedding = self._embedding_function.embed_query(query)
@@ -435,6 +438,7 @@ class Chroma(VectorStore):
                 n_results=k,
                 where=filter,
                 where_document=where_document,
+                **kwargs,
             )
 
         return _results_to_docs_and_scores(results)
@@ -505,6 +509,7 @@ class Chroma(VectorStore):
             where=filter,
             where_document=where_document,
             include=["metadatas", "documents", "distances", "embeddings"],
+            **kwargs,
         )
         mmr_selected = maximal_marginal_relevance(
             np.array(embedding, dtype=np.float32),


### PR DESCRIPTION
**Description:**

This PR adds the `**kwargs` parameter to six calls in the `chroma.py` package. All functions already were able to receive `kwargs` but they were discarded before.

**Issue:**

When passing `kwargs` to functions in the `chroma.py` package they are being ignored.

For example:

```
chroma_instance.similarity_search_with_score(
    query,
    k=100,
    include=["metadatas", "documents", "distances", "embeddings"],  # this parameter gets ignored
)
```
The `include` parameter does not get passed on to the next function and does not have any effect.

**Dependencies:**

None
