### PR TITLE
Update google_cloud_storage_directory.ipynb

### DIFF
--- a/docs/docs/integrations/document_loaders/google_cloud_storage_directory.ipynb
+++ b/docs/docs/integrations/document_loaders/google_cloud_storage_directory.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "source": [
     "## Specifying a prefix\n",
-    "You can also specify a prefix for more finegrained control over what files to load."
+    "You can also specify a prefix for more finegrained control over what files to load -including loading all files from a specific folder-."
    ]
   },
   {


### PR DESCRIPTION
  - Description: Just a minor add to the documentation to clarify how to load all files from a folder. I assumed and try to do it specifying it in the bucket (BUCKET/FOLDER), instead of using the prefix.


