### PR TITLE
Don't reassign chunk_type

### DIFF
--- a/libs/community/langchain_community/retrievers/google_vertex_ai_search.py
+++ b/libs/community/langchain_community/retrievers/google_vertex_ai_search.py
@@ -162,7 +162,6 @@ class _BaseGoogleVertexAISearchRetriever(BaseModel):
         from google.protobuf.json_format import MessageToDict
 
         documents: List[Document] = []
-        chunk_type = "extractive_answers"
 
         for result in results:
             document_dict = MessageToDict(


### PR DESCRIPTION
**Description**: The parameter chunk_type was being hard coded to "extractive_answers", so that when "snippet" was being passed, it was being ignored. This change simply doesn't do that.