### PR TITLE
packaging: fix format for python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://www.github.com/langchain-ai/langchain"
 
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.8,<4.0"
 
 [tool.poetry.group.docs.dependencies]
 langchain = { path = "libs/langchain/", develop = true }


### PR DESCRIPTION
Hello,

could you adjust the version format? I am running into issues where it's not understood by some tools.

The python version format is only major.minor. It's one of the edge cases of python packaging.

You can see examples in setuptools, both the required python version for the package and the required python version for dependencies. It's not documented well but the format is only meant to be two digits.
https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html

```
# setup.cfg
[options]
zip_safe = False
include_package_data = True
packages = find:
python_requires = >=3.7
install_requires =
    requests
    importlib-metadata; python_version<"3.8"
```
