### PR TITLE
community: add args_schema to GmailSendMessage

### DIFF
--- a/libs/community/langchain_community/tools/gmail/send_message.py
+++ b/libs/community/langchain_community/tools/gmail/send_message.py
@@ -2,7 +2,7 @@
 import base64
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.pydantic_v1 import BaseModel, Field
@@ -42,6 +42,7 @@ class GmailSendMessage(GmailBaseTool):
     description: str = (
         "Use this tool to send email messages." " The input is the message, recipients"
     )
+    args_schema: Type[SendMessageSchema] = SendMessageSchema
 
     def _prepare_message(
         self,

--- a/libs/community/tests/unit_tests/tools/gmail/test_send.py
+++ b/libs/community/tests/unit_tests/tools/gmail/test_send.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+
+from langchain_community.tools.gmail.send_message import GmailSendMessage
+
+
+def test_send() -> None:
+    """Test gmail send."""
+    mock_api_resource = MagicMock()
+    # bypass pydantic validation as google-api-python-client is not a package dependency
+    tool = GmailSendMessage.construct(api_resource=mock_api_resource)
+    tool_input = {
+        "to": "fake123@email.com",
+        "subject": "subject line",
+        "message": "message body",
+    }
+    result = tool.run(tool_input)
+    assert result.startswith("Message sent. Message Id:")
+    assert tool.args_schema is not None


### PR DESCRIPTION
  - **Description:** `tools.gmail.send_message` implements a `SendMessageSchema` that is not used anywhere. `GmailSendMessage` also does not have an `args_schema` attribute (this led to issues when invoking the tool with an OpenAI functions agent, at least for me). Here we add the missing attribute and a minimal test for the tool.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** N/A