### PR TITLE
docs: API Ref navbar update

### DIFF
--- a/docs/api_reference/themes/scikit-learn-modern/layout.html
+++ b/docs/api_reference/themes/scikit-learn-modern/layout.html
@@ -80,7 +80,8 @@
                   <ul>
                     {% for inner_child in nav_item.children %}
                       <li class="sk-toctree-l3">
-                        <a href="{{ inner_child.url }}">{{ inner_child.title }}</a>
+                        {% set second_layer_ns = inner_child.title[inner_child.title.index(".")+1:] %}
+                        <a href="{{ inner_child.url }}">{{ second_layer_ns }}</a>
                       </li>
                     {% endfor %}
                   </ul>

--- a/docs/api_reference/themes/scikit-learn-modern/layout.html
+++ b/docs/api_reference/themes/scikit-learn-modern/layout.html
@@ -80,8 +80,8 @@
                   <ul>
                     {% for inner_child in nav_item.children %}
                       <li class="sk-toctree-l3">
-                        {% set second_layer_ns = inner_child.title[inner_child.title.index(".")+1:] %}
-                        <a href="{{ inner_child.url }}">{{ second_layer_ns }}</a>
+                        {% set last_url_part = inner_child.url.split(".")|last %}
+                        <a href="{{ inner_child.url }}">{{ last_url_part }}</a>
                       </li>
                     {% endfor %}
                   </ul>


### PR DESCRIPTION
Now the navbar items are too long and are not visible.
![image](https://github.com/langchain-ai/langchain/assets/2256422/8fb51f75-0ae2-43ec-a225-1dc69f16ce72)

I'm trying to cut the top-level part of the namespace in items.