### PR TITLE
community: fix for surrealdb client 0.3.2 update + store and retrieve metadata

### DIFF
--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -103,13 +103,12 @@ class SurrealDBStore(VectorStore):
         embeddings = self.embedding_function.embed_documents(list(texts))
         ids = []
         for idx, text in enumerate(texts):
+            data = {"text": text, "embedding": embeddings[idx]}
+            if metadatas != None and idx < len(metadatas):
+                data["metadata"] = metadatas[idx]
             record = await self.sdb.create(
                 self.collection,
-                {
-                    "text": text,
-                    "embedding": embeddings[idx],
-                    "metadata": metadatas[idx],
-                },
+                data,
             )
             ids.append(record[0]["id"])
         return ids

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -211,7 +211,6 @@ class SurrealDBStore(VectorStore):
         if len(results) == 0:
             return []
 
-        print(results)
         return [
             (
                 Document(

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -104,7 +104,7 @@ class SurrealDBStore(VectorStore):
         ids = []
         for idx, text in enumerate(texts):
             data = {"text": text, "embedding": embeddings[idx]}
-            if metadatas != None and idx < len(metadatas):
+            if metadatas is not None and idx < len(metadatas):
                 data["metadata"] = metadatas[idx]
             record = await self.sdb.create(
                 self.collection,

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -127,7 +127,16 @@ class SurrealDBStore(VectorStore):
         Returns:
             List of ids for the newly inserted documents
         """
-        return asyncio.run(self.aadd_texts(texts, metadatas, **kwargs))
+
+        async def _add_texts(
+            texts: Iterable[str],
+            metadatas: Optional[List[dict]] = None,
+            **kwargs: Any,
+        ) -> List[str]:
+            await self.initialize()
+            return await self.aadd_texts(texts, metadatas, **kwargs)
+
+        return asyncio.run(_add_texts(texts, metadatas, **kwargs))
 
     async def adelete(
         self,
@@ -408,7 +417,7 @@ class SurrealDBStore(VectorStore):
 
         sdb = cls(embedding, **kwargs)
         await sdb.initialize()
-        await sdb.aadd_texts(texts)
+        await sdb.aadd_texts(texts, metadatas, **kwargs)
         return sdb
 
     @classmethod


### PR DESCRIPTION
Surrealdb client changes from 0.3.1 to 0.3.2 broke the surrealdb vectore integration.
This PR updates the code to work with the updated client. The change is backwards compatible with previous versions of surrealdb client.
Also expanded the vector store implementation to store and retrieve metadata that's included with the document object.