### PR TITLE
CI: update poetry 1.6.1 -> 1.7.1

### DIFF
--- a/.github/workflows/_all_ci.yml
+++ b/.github/workflows/_all_ci.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   lint:

--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -9,7 +9,7 @@ on:
         description: "From which folder this pipeline executes"
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   build:

--- a/.github/workflows/_dependencies.yml
+++ b/.github/workflows/_dependencies.yml
@@ -13,7 +13,7 @@ on:
         description: "Relative path to the langchain library folder"
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   build:

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   build:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -13,7 +13,7 @@ on:
         description: "Relative path to the langchain library folder"
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
 
   # This env var allows us to get inline annotations when ruff has complaints.

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   build:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -13,7 +13,7 @@ on:
         description: "Relative path to the langchain library folder"
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   build:

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -9,7 +9,7 @@ on:
         description: "From which folder this pipeline executes"
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
   PYTHON_VERSION: "3.10"
 
 jobs:

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -6,7 +6,7 @@ on:
     - cron:  '0 13 * * *'
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
 
 jobs:
   build:

--- a/.github/workflows/templates_ci.yml
+++ b/.github/workflows/templates_ci.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  POETRY_VERSION: "1.6.1"
+  POETRY_VERSION: "1.7.1"
   WORKDIR: "templates"
 
 jobs:

--- a/docs/docs/contributing/code.mdx
+++ b/docs/docs/contributing/code.mdx
@@ -32,7 +32,7 @@ For a [development container](https://containers.dev/), see the [.devcontainer f
 
 ### Dependency Management: Poetry and other env/dependency managers
 
-This project utilizes [Poetry](https://python-poetry.org/) v1.6.1+ as a dependency manager.
+This project utilizes [Poetry](https://python-poetry.org/) v1.7.1+ as a dependency manager.
 
 ❗Note: *Before installing Poetry*, if you use `Conda`, create and activate a new Conda env (e.g. `conda create -n langchain python=3.9`)
 
@@ -75,7 +75,7 @@ make test
 
 If during installation you receive a `WheelFileValidationError` for `debugpy`, please make sure you are running
 Poetry v1.6.1+. This bug was present in older versions of Poetry (e.g. 1.4.1) and has been resolved in newer releases.
-If you are still seeing this bug on v1.6.1, you may also try disabling "modern installation"
+If you are still seeing this bug on v1.6.1+, you may also try disabling "modern installation"
 (`poetry config installer.modern-installation false`) and re-installing requirements.
 See [this `debugpy` issue](https://github.com/microsoft/debugpy/issues/1246) for more details.
 


### PR DESCRIPTION
CI: Update poetry version 1.6.1 -> 1.7.1 to bring many fixes and python 3.12 support
Changelog: [1.7.0](https://github.com/python-poetry/poetry/releases/tag/1.7.0), [1.7.1](https://github.com/python-poetry/poetry/releases/tag/1.7.1)
