### PR TITLE
Community: Adds ability to pass a Config to the boto3 client used by Bedrock

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import warnings
 from abc import ABC
-from typing import Any, Dict, Iterator, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
@@ -14,6 +16,9 @@ from langchain_community.utilities.anthropic import (
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
 )
+
+if TYPE_CHECKING:
+    from botocore.config import Config
 
 HUMAN_PROMPT = "\n\nHuman:"
 ASSISTANT_PROMPT = "\n\nAssistant:"
@@ -163,6 +168,9 @@ class BedrockBase(BaseModel, ABC):
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
     """
 
+    config: Optional[Config] = None
+    """An optional botocore.config.Config instance to pass to the client."""
+
     model_id: str
     """Id of the model to call, e.g., amazon.titan-text-express-v1, this is
     equivalent to the modelId property in the list-foundation-models api"""
@@ -212,6 +220,8 @@ class BedrockBase(BaseModel, ABC):
                 client_params["region_name"] = values["region_name"]
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
+            if values["config"]:
+                client_params["config"] = values["config"]
 
             values["client"] = session.client("bedrock-runtime", **client_params)
 


### PR DESCRIPTION
# Description  
This PR adds the ability to pass a `botocore.config.Config` instance to the boto3 client instantiated by the Bedrock LLM.

Currently, the Bedrock LLM doesn't support a way to pass a Config, which means that some settings (e.g., timeouts and retry configuration) require instantiating a new boto3 client with a Config and then replacing the LLM's client:

```python
llm = Bedrock(
        region_name='us-west-2',
        model_id="anthropic.claude-v2",
        model_kwargs={'max_tokens_to_sample': 4096, 'temperature': 0},
)

llm.client = boto_client('bedrock-runtime', region_name='us-west-2', config=Config({'read_timeout': 300}))
```

# Issue
N/A

# Dependencies
N/A