### PR TITLE
upgrade langchain-community version

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -13,7 +13,7 @@ langchain-server = "langchain.server:main"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 langchain-core = "^0.1"
-langchain-community = ">=0.0.2,<0.1"
+langchain-community = ">=0.0.6,<0.1"
 pydantic = ">=1,<3"
 SQLAlchemy = ">=1.4,<3"
 requests = "^2"


### PR DESCRIPTION
This pr enforce the latest version for some feature just like: change default openai model from davinci-003 to gpt-3.5.
