### PR TITLE
[community]: Elasticsearch chat history encoding

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/elasticsearch.py
+++ b/libs/community/langchain_community/chat_message_histories/elasticsearch.py
@@ -26,6 +26,7 @@ class ElasticsearchChatMessageHistory(BaseChatMessageHistory):
         es_password: Password to use when connecting to Elasticsearch.
         es_api_key: API key to use when connecting to Elasticsearch.
         es_connection: Optional pre-existing Elasticsearch connection.
+        esnsure_ascii: Used to escape ASCII symbols as `\uXXXX`. Enabled by default.
         index: Name of the index to use.
         session_id: Arbitrary key that is used to store the messages
             of a single chat session.
@@ -42,9 +43,11 @@ class ElasticsearchChatMessageHistory(BaseChatMessageHistory):
         es_user: Optional[str] = None,
         es_api_key: Optional[str] = None,
         es_password: Optional[str] = None,
+        esnsure_ascii: Optional[bool] = True,
     ):
         self.index: str = index
         self.session_id: str = session_id
+        self.ensure_ascii: bool = esnsure_ascii
 
         # Initialize Elasticsearch client from passed client arg or connection info
         if es_connection is not None:
@@ -172,7 +175,10 @@ class ElasticsearchChatMessageHistory(BaseChatMessageHistory):
                 document={
                     "session_id": self.session_id,
                     "created_at": round(time() * 1000),
-                    "history": json.dumps(message_to_dict(message)),
+                    "history": json.dumps(
+                        message_to_dict(message),
+                        ensure_ascii=self.ensure_ascii,
+                    ),
                 },
                 refresh=True,
             )

--- a/libs/community/langchain_community/chat_message_histories/elasticsearch.py
+++ b/libs/community/langchain_community/chat_message_histories/elasticsearch.py
@@ -26,7 +26,7 @@ class ElasticsearchChatMessageHistory(BaseChatMessageHistory):
         es_password: Password to use when connecting to Elasticsearch.
         es_api_key: API key to use when connecting to Elasticsearch.
         es_connection: Optional pre-existing Elasticsearch connection.
-        esnsure_ascii: Used to escape ASCII symbols as `\uXXXX`. Enabled by default.
+        esnsure_ascii: Used to escape ASCII symbols in json.dumps. Defaults to True.
         index: Name of the index to use.
         session_id: Arbitrary key that is used to store the messages
             of a single chat session.


### PR DESCRIPTION
- Added ensure_ascii property to ElasticsearchChatMessageHistory

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
