### PR TITLE
fix: add stronger contrast or labeling between notebook input and out…

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -36,6 +36,16 @@
   --ifm-color-primary-lightest: #4fddbf;
 }
 
+.theme-dark .input {
+  background-color: #333333; /* Darker background for input blocks in dark mode */
+  border: 1px solid #444444; /* Border to distinguish blocks */
+}
+
+.theme-dark .output {
+  background-color: #222222; /* Even darker background for output blocks in dark mode */
+  border: 1px solid #333333; /* Border to distinguish blocks */
+}
+
 .footer__links {
   margin-top: 1rem;
   margin-bottom: 3rem;


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

  - **Description:** Enhanced the contrast or add labels to distinguish between input and output blocks in the LangChain documentation by modifying the CSS styles for the code blocks in the `custom.css` file referenced in the `docusaurus.config.js` file, 
  - **Issue:** #14532 ,
  - **Dependencies:** N/A,
  - **Twitter handle:** [@vardhaman722](https://twitter.com/vardhaman722)