### PR TITLE
core, community: propagate context between threads

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -338,6 +338,7 @@ async def _ahandle_event_for_handler(
         if event_name == "on_chat_model_start":
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
+                executor,
                 handler,
                 "on_llm_start",
                 "ignore_llm",

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
+from contextvars import Context, copy_context
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -271,10 +272,23 @@ def handle_event(
                 # we end up in a deadlock, as we'd have gotten here from a
                 # running coroutine, which we cannot interrupt to run this one.
                 # The solution is to create a new loop in a new thread.
-                with ThreadPoolExecutor(1) as executor:
+                with _executor_w_context(1) as executor:
                     executor.submit(_run_coros, coros).result()
             else:
                 _run_coros(coros)
+
+
+def _set_context(context: Context):
+    for var, value in context.items():
+        var.set(value)
+
+
+def _executor_w_context(max_workers: Optional[int] = None) -> ThreadPoolExecutor:
+    return ThreadPoolExecutor(
+        max_workers=max_workers,
+        initializer=_set_context,
+        initargs=(copy_context(),),
+    )
 
 
 def _run_coros(coros: List[Coroutine[Any, Any, Any]]) -> None:
@@ -301,6 +315,7 @@ def _run_coros(coros: List[Coroutine[Any, Any, Any]]) -> None:
 
 
 async def _ahandle_event_for_handler(
+    executor: ThreadPoolExecutor,
     handler: BaseCallbackHandler,
     event_name: str,
     ignore_condition_name: Optional[str],
@@ -317,7 +332,7 @@ async def _ahandle_event_for_handler(
                     event(*args, **kwargs)
                 else:
                     await asyncio.get_event_loop().run_in_executor(
-                        None, functools.partial(event, *args, **kwargs)
+                        executor, functools.partial(event, *args, **kwargs)
                     )
     except NotImplementedError as e:
         if event_name == "on_chat_model_start":
@@ -364,19 +379,25 @@ async def ahandle_event(
         *args: The arguments to pass to the event handler
         **kwargs: The keyword arguments to pass to the event handler
     """
-    for handler in [h for h in handlers if h.run_inline]:
-        await _ahandle_event_for_handler(
-            handler, event_name, ignore_condition_name, *args, **kwargs
-        )
-    await asyncio.gather(
-        *(
-            _ahandle_event_for_handler(
-                handler, event_name, ignore_condition_name, *args, **kwargs
+    with _executor_w_context() as executor:
+        for handler in [h for h in handlers if h.run_inline]:
+            await _ahandle_event_for_handler(
+                executor, handler, event_name, ignore_condition_name, *args, **kwargs
             )
-            for handler in handlers
-            if not handler.run_inline
+        await asyncio.gather(
+            *(
+                _ahandle_event_for_handler(
+                    executor,
+                    handler,
+                    event_name,
+                    ignore_condition_name,
+                    *args,
+                    **kwargs,
+                )
+                for handler in handlers
+                if not handler.run_inline
+            )
         )
-    )
 
 
 BRM = TypeVar("BRM", bound="BaseRunManager")

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -278,7 +278,7 @@ def handle_event(
                 _run_coros(coros)
 
 
-def _set_context(context: Context):
+def _set_context(context: Context) -> None:
     for var, value in context.items():
         var.set(value)
 

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -260,7 +260,8 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         if type(self)._astream == BaseChatModel._astream:
             # model doesn't implement streaming, so use default implementation
             yield cast(
-                BaseMessageChunk, self.invoke(input, config=config, stop=stop, **kwargs)
+                BaseMessageChunk,
+                await self.ainvoke(input, config=config, stop=stop, **kwargs),
             )
         else:
             config = config or {}

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -424,9 +424,10 @@ class Runnable(Generic[Input, Output], ABC):
 
         Subclasses should override this method if they can run asynchronously.
         """
-        return await asyncio.get_running_loop().run_in_executor(
-            None, partial(self.invoke, **kwargs), input, config
-        )
+        with get_executor_for_config(config) as executor:
+            return await asyncio.get_running_loop().run_in_executor(
+                executor, partial(self.invoke, **kwargs), input, config
+            )
 
     def batch(
         self,
@@ -2699,9 +2700,10 @@ class RunnableLambda(Runnable[Input, Output]):
 
             @wraps(self.func)
             async def f(*args, **kwargs):  # type: ignore[no-untyped-def]
-                return await asyncio.get_running_loop().run_in_executor(
-                    None, partial(self.func, **kwargs), *args
-                )
+                with get_executor_for_config(config) as executor:
+                    return await asyncio.get_running_loop().run_in_executor(
+                        executor, partial(self.func, **kwargs), *args
+                    )
 
             afunc = f
 

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -394,7 +394,9 @@ def _set_context(context: Context) -> None:
 
 
 @contextmanager
-def get_executor_for_config(config: RunnableConfig) -> Generator[Executor, None, None]:
+def get_executor_for_config(
+    config: Optional[RunnableConfig]
+) -> Generator[Executor, None, None]:
     """Get an executor for a config.
 
     Args:
@@ -403,6 +405,7 @@ def get_executor_for_config(config: RunnableConfig) -> Generator[Executor, None,
     Yields:
         Generator[Executor, None, None]: The executor.
     """
+    config = config or {}
     with ThreadPoolExecutor(
         max_workers=config.get("max_concurrency"),
         initializer=_set_context,

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -388,7 +388,7 @@ def get_async_callback_manager_for_config(
     )
 
 
-def _set_context(context: Context):
+def _set_context(context: Context) -> None:
     for var, value in context.items():
         var.set(value)
 

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -388,7 +388,7 @@ def get_async_callback_manager_for_config(
     )
 
 
-def set_context(context: Context):
+def _set_context(context: Context):
     for var, value in context.items():
         var.set(value)
 
@@ -403,11 +403,9 @@ def get_executor_for_config(config: RunnableConfig) -> Generator[Executor, None,
     Yields:
         Generator[Executor, None, None]: The executor.
     """
-
-    context_copy = copy_context()
-
     with ThreadPoolExecutor(
         max_workers=config.get("max_concurrency"),
-        initializer=lambda: set_context(context_copy),
+        initializer=_set_context,
+        initargs=(copy_context(),),
     ) as executor:
         yield executor


### PR DESCRIPTION
While using `chain.batch`, the default implementation uses a `ThreadPoolExecutor` and run the chains in separate threads. An issue with this approach is that that [the token counting callback](https://python.langchain.com/docs/modules/callbacks/token_counting) fails to work as a consequence of the context not being propagated between threads. This PR adds context propagation to the new threads and adds some thread synchronization in the OpenAI callback. With this change, the token counting callback works as intended.

Having the context propagation change would be highly beneficial for those implementing custom callbacks for similar functionalities as well.
