### PR TITLE
Patch: improve openai functions call parser compatibility

### DIFF
--- a/libs/langchain/langchain/agents/openai_functions_multi_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_multi_agent/base.py
@@ -40,13 +40,20 @@ def _parse_ai_message(message: BaseMessage) -> Union[List[AgentAction], AgentFin
     function_call = message.additional_kwargs.get("function_call", {})
 
     if function_call:
-        try:
-            arguments = json.loads(function_call["arguments"])
-        except JSONDecodeError:
-            raise OutputParserException(
-                f"Could not parse tool input: {function_call} because "
-                f"the `arguments` is not valid JSON."
-            )
+        arguments = function_call["arguments"].strip()
+        if len(arguments) == 0:
+            arguments = {}
+        else:
+            try:
+                arguments = json.loads(function_call["arguments"])
+            except JSONDecodeError:
+                try:
+                    arguments = json.loads(arguments.replace("\n", "\\n"))
+                except JSONDecodeError:
+                    raise OutputParserException(
+                        f"Could not parse tool input: {function_call} because "
+                        f"the `arguments` is not valid JSON."
+                    )
 
         try:
             tools = arguments["actions"]

--- a/libs/langchain/langchain/agents/openai_functions_multi_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_multi_agent/base.py
@@ -40,20 +40,13 @@ def _parse_ai_message(message: BaseMessage) -> Union[List[AgentAction], AgentFin
     function_call = message.additional_kwargs.get("function_call", {})
 
     if function_call:
-        arguments = function_call["arguments"].strip()
-        if len(arguments) == 0:
-            arguments = {}
-        else:
-            try:
-                arguments = json.loads(function_call["arguments"])
-            except JSONDecodeError:
-                try:
-                    arguments = json.loads(arguments.replace("\n", "\\n"))
-                except JSONDecodeError:
-                    raise OutputParserException(
-                        f"Could not parse tool input: {function_call} because "
-                        f"the `arguments` is not valid JSON."
-                    )
+        try:
+            arguments = json.loads(function_call["arguments"], strict=False)
+        except JSONDecodeError:
+            raise OutputParserException(
+                f"Could not parse tool input: {function_call} because "
+                f"the `arguments` is not valid JSON."
+            )
 
         try:
             tools = arguments["actions"]

--- a/libs/langchain/langchain/agents/output_parsers/openai_functions.py
+++ b/libs/langchain/langchain/agents/output_parsers/openai_functions.py
@@ -40,21 +40,18 @@ class OpenAIFunctionsAgentOutputParser(AgentOutputParser):
 
         if function_call:
             function_name = function_call["name"]
-            arguments = function_call["arguments"].strip()
-            if len(arguments) == 0:
-                # OpenAI returns an empty string for functions containing no args
-                _tool_input = {}
-            else:
-                try:
-                    _tool_input = json.loads(arguments)
-                except JSONDecodeError:
-                    try:
-                        _tool_input = json.loads(arguments.replace("\n", "\\n"))
-                    except JSONDecodeError:
-                        raise OutputParserException(
-                            f"Could not parse tool input: {function_call} because "
-                            f"the `arguments` is not valid JSON."
-                        )
+            try:
+                if len(function_call["arguments"].strip()) == 0:
+                    # OpenAI returns an empty string for functions containing no args
+                    _tool_input = {}
+                else:
+                    # otherwise it returns a json object
+                    _tool_input = json.loads(function_call["arguments"], strict=False)
+            except JSONDecodeError:
+                raise OutputParserException(
+                    f"Could not parse tool input: {function_call} because "
+                    f"the `arguments` is not valid JSON."
+                )
 
             # HACK HACK HACK:
             # The code that encodes tool input into Open AI uses a special variable

--- a/libs/langchain/langchain/agents/output_parsers/openai_functions.py
+++ b/libs/langchain/langchain/agents/output_parsers/openai_functions.py
@@ -40,18 +40,21 @@ class OpenAIFunctionsAgentOutputParser(AgentOutputParser):
 
         if function_call:
             function_name = function_call["name"]
-            try:
-                if len(function_call["arguments"].strip()) == 0:
-                    # OpenAI returns an empty string for functions containing no args
-                    _tool_input = {}
-                else:
-                    # otherwise it returns a json object
-                    _tool_input = json.loads(function_call["arguments"])
-            except JSONDecodeError:
-                raise OutputParserException(
-                    f"Could not parse tool input: {function_call} because "
-                    f"the `arguments` is not valid JSON."
-                )
+            arguments = function_call["arguments"].strip()
+            if len(arguments) == 0:
+                # OpenAI returns an empty string for functions containing no args
+                _tool_input = {}
+            else:
+                try:
+                    _tool_input = json.loads(arguments)
+                except JSONDecodeError:
+                    try:
+                        _tool_input = json.loads(arguments.replace("\n", "\\n"))
+                    except JSONDecodeError:
+                        raise OutputParserException(
+                            f"Could not parse tool input: {function_call} because "
+                            f"the `arguments` is not valid JSON."
+                        )
 
             # HACK HACK HACK:
             # The code that encodes tool input into Open AI uses a special variable


### PR DESCRIPTION
```shell
Python 3.11.6 (main, Nov  2 2023, 04:39:43) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> s = {'name': 'gc', 'arguments': '{"prompt":"hi\nbob."}'}
>>> import json
>>> json.loads(s['arguments'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Invalid control character at: line 1 column 14 (char 13)
>>> json.loads(s['arguments'].replace('\n', '\\n'))
{'prompt': 'hi\nbob.'}
>>>
```