### PR TITLE
Add missing comment char "#" before Load in chain.py for the rag-pinecone-rerank template

### DIFF
--- a/templates/rag-pinecone-rerank/rag_pinecone_rerank/chain.py
+++ b/templates/rag-pinecone-rerank/rag_pinecone_rerank/chain.py
@@ -19,7 +19,7 @@ if os.environ.get("PINECONE_ENVIRONMENT", None) is None:
 PINECONE_INDEX_NAME = os.environ.get("PINECONE_INDEX", "langchain-test")
 
 ### Ingest code - you may need to run this the first time
-# Load
+# # Load
 # from langchain.document_loaders import WebBaseLoader
 # loader = WebBaseLoader("https://lilianweng.github.io/posts/2023-06-23-agent/")
 # data = loader.load()


### PR DESCRIPTION
Without this additional `#`, one needs to add it manually after uncommenting the section.