### PR TITLE
community: Enhance Github error prompt

### DIFF
--- a/libs/community/langchain_community/utilities/github.py
+++ b/libs/community/langchain_community/utilities/github.py
@@ -85,7 +85,13 @@ class GitHubAPIWrapper(BaseModel):
                 "https://docs.github.com/en/apps/using-"
                 "github-apps/installing-your-own-github-app"
             )
-        installation = installation[0]
+        try:
+            installation = installation[0]
+        except ValueError as e:
+            raise ValueError(
+                "Please make sure to give correct github parameters "
+                f"Error message: {e}"
+            )
         # create a GitHub instance:
         g = installation.get_github_for_installation()
         repo = g.get_repo(github_repository)


### PR DESCRIPTION
  - **Description:** The Github error prompt is confused because of JWT enctrypt to somebody not familiar with Github connection method. This PR is to add some useful error prompt to help users troubleshooting.
  - **Issue:** https://github.com/langchain-ai/langchain/issues/14550#issuecomment-1867445049
  - **Dependencies:** None,
  - **Twitter handle:** None