### PR TITLE
Documentation: Update playwright documentation for langchain version >= 0.0.351

### DIFF
--- a/docs/docs/integrations/toolkits/playwright.ipynb
+++ b/docs/docs/integrations/toolkits/playwright.ipynb
@@ -60,6 +60,8 @@
    "outputs": [],
    "source": [
     "from playwright.async_api import async_playwright\n",
+    "\n",
+    "\n",
     "async def create_async_playwright_browser():\n",
     "    browser_context = await async_playwright().start()\n",
     "    browser = await browser_context.chromium.launch(headless=True)\n",

--- a/docs/docs/integrations/toolkits/playwright.ipynb
+++ b/docs/docs/integrations/toolkits/playwright.ipynb
@@ -43,10 +43,27 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.agents.agent_toolkits import PlayWrightBrowserToolkit\n",
-    "from langchain.tools.playwright.utils import (\n",
-    "    create_async_playwright_browser,  # A synchronous browser is available, though it isn't compatible with jupyter.\n",
-    ")"
+    "from langchain.agents.agent_toolkits import PlayWrightBrowserToolkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Async function to create context and launch browser:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from playwright.async_api import async_playwright\n",
+    "async def create_async_playwright_browser():\n",
+    "    browser_context = await async_playwright().start()\n",
+    "    browser = await browser_context.chromium.launch(headless=True)\n",
+    "    return browser"
    ]
   },
   {

--- a/docs/docs/integrations/toolkits/playwright.ipynb
+++ b/docs/docs/integrations/toolkits/playwright.ipynb
@@ -37,13 +37,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from langchain.agents.agent_toolkits import PlayWrightBrowserToolkit"
+    "from langchain_community.agent_toolkits import PlayWrightBrowserToolkit"
    ]
   },
   {
@@ -55,17 +55,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from playwright.async_api import async_playwright\n",
-    "\n",
-    "\n",
-    "async def create_async_playwright_browser():\n",
-    "    browser_context = await async_playwright().start()\n",
-    "    browser = await browser_context.chromium.launch(headless=True)\n",
-    "    return browser"
+    "from langchain_community.tools.playwright.utils import (\n",
+    "    create_async_playwright_browser,  # A synchronous browser is available, though it isn't compatible with jupyter.\\n\",\t  },\n",
+    ")"
    ]
   },
   {
@@ -347,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
  - A documentation change in the example listed under: https://python.langchain.com/docs/integrations/toolkits/playwright
  - `create_async_playwright_browser` does not exist under the module: `langchain.tools.playwright.utils` post >= 0.0.351 version
  - No dependencies to be changed
