### PR TITLE
[docs] custom instructions

### DIFF
--- a/docs/docs/modules/data_connection/retrievers/index.mdx
+++ b/docs/docs/modules/data_connection/retrievers/index.mdx
@@ -76,3 +76,26 @@ chain = (
 chain.invoke("What did the president say about technology?")
 
 ```
+
+## Custom Retriever
+
+Since the retriever interface is so simple, it's pretty easy to write a custom one.
+
+```python
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from typing import List
+
+
+class CustomRetriever(BaseRetriever):
+    
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+    ) -> List[Document]:
+        return [Document(page_content=query)]
+
+retriever = CustomRetriever()
+
+retriever.get_relevant_documents("bar")
+```

--- a/docs/docs/modules/model_io/llms/custom_llm.ipynb
+++ b/docs/docs/modules/model_io/llms/custom_llm.ipynb
@@ -9,9 +9,10 @@
     "\n",
     "This notebook goes over how to create a custom LLM wrapper, in case you want to use your own LLM or a different wrapper than one that is supported in LangChain.\n",
     "\n",
-    "There is only one required thing that a custom LLM needs to implement:\n",
+    "There are only two required things that a custom LLM needs to implement:\n",
     "\n",
-    "- A `_call` method that takes in a string, some optional stop words, and returns a string\n",
+    "- A `_call` method that takes in a string, some optional stop words, and returns a string.\n",
+    "- A `_llm_type` property that returns a string. Used for logging purposes only.\n",
     "\n",
     "There is a second optional thing it can implement:\n",
     "\n",
@@ -22,20 +23,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "a65696a0",
    "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Any, List, Mapping, Optional\n",
     "\n",
-    "from langchain.callbacks.manager import CallbackManagerForLLMRun\n",
+    "from langchain_core.callbacks.manager import CallbackManagerForLLMRun\n",
     "from langchain_core.language_models.llms import LLM"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "d5ceff02",
    "metadata": {},
    "outputs": [],
@@ -74,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "10e5ece6",
    "metadata": {},
    "outputs": [],
@@ -84,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "id": "8cd49199",
    "metadata": {},
    "outputs": [
@@ -94,7 +95,7 @@
        "'This is a '"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -113,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "id": "9c33fa19",
    "metadata": {},
    "outputs": [
@@ -155,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,

--- a/docs/docs/modules/model_io/llms/custom_llm.ipynb
+++ b/docs/docs/modules/model_io/llms/custom_llm.ipynb
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "id": "8cd49199",
    "metadata": {},
    "outputs": [
@@ -95,13 +95,13 @@
        "'This is a '"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "llm(\"This is a foobar thing\")"
+    "llm.invoke(\"This is a foobar thing\")"
    ]
   },
   {


### PR DESCRIPTION
We now have custom instructions for:
LLM
ChatModels
Retrievers
Agents
Tools

I held off adding for vectorstore since its a bit more involved and we dont have a good base and i think its more likely people write custom retrievers than vectorstores?