### PR TITLE
Feat: support RunnableBranch constructed with `|`

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -395,7 +395,7 @@ def _set_context(context: Context) -> None:
 
 @contextmanager
 def get_executor_for_config(
-    config: Optional[RunnableConfig]
+    config: Optional[RunnableConfig],
 ) -> Generator[Executor, None, None]:
     """Get an executor for a config.
 


### PR DESCRIPTION
```python
from langchain_core.runnables import RunnableBranch

branch = RunnableBranch(
    (lambda x: isinstance(x, str), lambda x: x.upper()),
    (lambda x: isinstance(x, int), lambda x: x + 1),
    (lambda x: isinstance(x, float), lambda x: x * 2),
    lambda x: "goodbye",
  )

branch.invoke("hello") # "HELLO"
branch.invoke(None) # "goodbye"

# A RunnableBranch constructed using the `|` operator
branch = branch | (lambda x: isinstance(x, bool), lambda x: f'{x}')
branch.invoke(true) # "true"
```