### PR TITLE
langchain: Exclude non-utf8 file from loader since it causes an error in the code_understanding example

### DIFF
--- a/docs/docs/use_cases/question_answering/code_understanding.ipynb
+++ b/docs/docs/use_cases/question_answering/code_understanding.ipynb
@@ -128,6 +128,7 @@
     "    repo_path + \"/libs/langchain/langchain\",\n",
     "    glob=\"**/*\",\n",
     "    suffixes=[\".py\"],\n",
+    "    exclude=[\"**/non-utf8-encoding.py\"],\n",
     "    parser=LanguageParser(language=Language.PYTHON, parser_threshold=500),\n",
     ")\n",
     "documents = loader.load()\n",


### PR DESCRIPTION
  - **Description:** in the code_understanding.ipynb example, the loader errors out on the langchain/libs/community/tests/examples/non-utf8-encoding.py file, so I updated the loader to exclude that file. Excluding that file allows the example to run.
  - **Issue:** not applicable
  - **Dependencies:** none
