### PR TITLE
core: Update messages/__init__.py to account for AIMessageChunk which breaks message history runnable.

### DIFF
--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -82,6 +82,8 @@ def _message_from_dict(message: dict) -> BaseMessage:
         return FunctionMessage(**message["data"])
     elif _type == "tool":
         return ToolMessage(**message["data"])
+    elif _type == "AIMessageChunk":
+        return AIMessageChunk(**message["data"])
     else:
         raise ValueError(f"Got unexpected message type: {_type}")
 

--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -84,6 +84,14 @@ def _message_from_dict(message: dict) -> BaseMessage:
         return ToolMessage(**message["data"])
     elif _type == "AIMessageChunk":
         return AIMessageChunk(**message["data"])
+    elif _type == "HumanMessageChunk":
+        return HumanMessageChunk(**message["data"])
+    elif _type == "FunctionMessageChunk":
+        return FunctionMessageChunk(**message["data"])
+    elif _type == "ToolMessageChunk":
+        return ToolMessageChunk(**message["data"])
+    elif _type == "SystemMessageChunk":
+        return SystemMessageChunk(**message["data"])
     else:
         raise ValueError(f"Got unexpected message type: {_type}")
 


### PR DESCRIPTION
  - **Description:** fix parse issue for AIMessageChunk when using 
  - **Issue:** https://github.com/langchain-ai/langchain/issues/14511
  - **Dependencies:** none
  - **Twitter handle:** none

Taken from this fix: https://github.com/gpt-engineer-org/gpt-engineer/issues/804#issuecomment-1769853850

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.

