### PR TITLE
Catch type errors in dumps/dumpd

### DIFF
--- a/libs/core/langchain_core/load/dump.py
+++ b/libs/core/langchain_core/load/dump.py
@@ -17,11 +17,17 @@ def dumps(obj: Any, *, pretty: bool = False, **kwargs: Any) -> str:
     """Return a json string representation of an object."""
     if "default" in kwargs:
         raise ValueError("`default` should not be passed to dumps")
-    if pretty:
-        indent = kwargs.pop("indent", 2)
-        return json.dumps(obj, default=default, indent=indent, **kwargs)
-    else:
-        return json.dumps(obj, default=default, **kwargs)
+    try:
+        if pretty:
+            indent = kwargs.pop("indent", 2)
+            return json.dumps(obj, default=default, indent=indent, **kwargs)
+        else:
+            return json.dumps(obj, default=default, **kwargs)
+    except TypeError:
+        if pretty:
+            return json.dumps(to_json_not_implemented(obj), indent=indent, **kwargs)
+        else:
+            return json.dumps(to_json_not_implemented(obj), **kwargs)
 
 
 def dumpd(obj: Any) -> Dict[str, Any]:

--- a/libs/langchain/tests/unit_tests/load/test_dump.py
+++ b/libs/langchain/tests/unit_tests/load/test_dump.py
@@ -60,6 +60,13 @@ def test_person(snapshot: Any) -> None:
     assert Person.lc_id() == ["tests", "unit_tests", "load", "test_dump", "Person"]
 
 
+def test_typeerror() -> None:
+    assert (
+        dumps({(1, 2): 3})
+        == """{"lc": 1, "type": "not_implemented", "id": ["builtins", "dict"], "repr": "{(1, 2): 3}"}"""  # noqa: E501
+    )
+
+
 @pytest.mark.requires("openai")
 def test_serialize_openai_llm(snapshot: Any) -> None:
     llm = OpenAI(


### PR DESCRIPTION
These can happen for edge cases not covered by `default` handler (eg. "strange" keys in dicts)

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
