### PR TITLE
refactor `tools`

### DIFF
--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -1,4 +1,3 @@
-"""Base implementation for tools or skills."""
 from __future__ import annotations
 
 import inspect

--- a/libs/langchain/langchain/tools/render.py
+++ b/libs/langchain/langchain/tools/render.py
@@ -4,49 +4,20 @@ Depending on the LLM you are using and the prompting strategy you are using,
 you may want Tools to be rendered in a different way.
 This module contains various ways to render tools.
 """
-from typing import List
 
 # For backwards compatibility
 from langchain_community.tools.convert_to_openai import (
     format_tool_to_openai_function,
     format_tool_to_openai_tool,
 )
-from langchain_core.tools import BaseTool
+from langchain_core.tools import (
+    render_text_description,
+    render_text_description_and_args,
+)
 
 __all__ = [
+    "format_tool_to_openai_function",
+    "format_tool_to_openai_tool",
     "render_text_description",
     "render_text_description_and_args",
-    "format_tool_to_openai_tool",
-    "format_tool_to_openai_function",
 ]
-
-
-def render_text_description(tools: List[BaseTool]) -> str:
-    """Render the tool name and description in plain text.
-
-    Output will be in the format of:
-
-    .. code-block:: markdown
-
-        search: This tool is used for search
-        calculator: This tool is used for math
-    """
-    return "\n".join([f"{tool.name}: {tool.description}" for tool in tools])
-
-
-def render_text_description_and_args(tools: List[BaseTool]) -> str:
-    """Render the tool name, description, and args in plain text.
-
-    Output will be in the format of:
-
-    .. code-block:: markdown
-
-        search: This tool is used for search, args: {"query": {"type": "string"}}
-        calculator: This tool is used for math, \
-args: {"expression": {"type": "string"}}
-    """
-    tool_strings = []
-    for tool in tools:
-        args_schema = str(tool.args)
-        tool_strings.append(f"{tool.name}: {tool.description}, args: {args_schema}")
-    return "\n".join(tool_strings)

--- a/libs/langchain/langchain/tools/retriever.py
+++ b/libs/langchain/langchain/tools/retriever.py
@@ -1,34 +1,3 @@
-from langchain_core.pydantic_v1 import BaseModel, Field
-from langchain_core.retrievers import BaseRetriever
+from langchain_core.tools import RetrieverInput, create_retriever_tool
 
-from langchain.tools import Tool
-
-
-class RetrieverInput(BaseModel):
-    """Input to the retriever."""
-
-    query: str = Field(description="query to look up in retriever")
-
-
-def create_retriever_tool(
-    retriever: BaseRetriever, name: str, description: str
-) -> Tool:
-    """Create a tool to do retrieval of documents.
-
-    Args:
-        retriever: The retriever to use for the retrieval
-        name: The name for the tool. This will be passed to the language model,
-            so should be unique and somewhat descriptive.
-        description: The description for the tool. This will be passed to the language
-            model, so should be descriptive.
-
-    Returns:
-        Tool class to pass to an agent
-    """
-    return Tool(
-        name=name,
-        description=description,
-        func=retriever.get_relevant_documents,
-        coroutine=retriever.aget_relevant_documents,
-        args_schema=RetrieverInput,
-    )
+__all__ = ["RetrieverInput", "create_retriever_tool"]


### PR DESCRIPTION
The `langchain` [still holds several artifacts](https://api.python.langchain.com/en/latest/langchain_api_reference.html#module-langchain.tools) that belongs to `core`. If they moved then `langchain.tools` would be split between `core` and `community` (no `langchain` artifacts), which is nice. It effectively removes the `langchain.tools` namespace.
- moved a class and functions to `core`