### PR TITLE
docs(ollama): Fix Documentation in `CallbackManager`, missing `])`

### DIFF
--- a/docs/docs/integrations/llms/ollama.ipynb
+++ b/docs/docs/integrations/llms/ollama.ipynb
@@ -72,8 +72,8 @@
     "\n",
     "```\n",
     "llm = Ollama(\n",
-    "    model=\"llama2\"\n",
-    "    callback_manager=CallbackManager([StreamingStdOutCallbackHandler()\n",
+    "    model=\"llama2\",\n",
+    "    callback_manager=CallbackManager([StreamingStdOutCallbackHandler()]),\n",
     ")\n",
     "```"
    ]


### PR DESCRIPTION
  - **Description:** This PR corrects a documentation error in the `ollama` usage tutorial. Specifically, it fixes a missing `])` in the `CallbackManager()` example, ensuring that the code snippet is syntactically correct and can be successfully executed.
  - **Issue:** N/A
  - **Dependencies:** No additional dependencies are required for this change.
  - **Twitter handle:** My twitter is @yhzhu99