### PR TITLE
Feature request: Provide exception objects in fallback

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -133,6 +133,9 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         yield self.runnable
         yield from self.fallbacks
 
+    def _configurable(self, error) -> dict[str, Any]:
+        return {"exception": error} if error else {}
+
     def invoke(
         self, input: Input, config: Optional[RunnableConfig] = None, **kwargs: Any
     ) -> Output:
@@ -148,7 +151,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             try:
                 output = runnable.invoke(
                     input,
-                    patch_config(config, callbacks=run_manager.get_child()),
+                    patch_config(config, callbacks=run_manager.get_child(),
+                                 configurable=self._configurable(first_error)),
                     **kwargs,
                 )
             except self.exceptions_to_handle as e:
@@ -184,7 +188,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             try:
                 output = await runnable.ainvoke(
                     input,
-                    patch_config(config, callbacks=run_manager.get_child()),
+                    patch_config(config, callbacks=run_manager.get_child(),
+                                 configurable=self._configurable(first_error)),
                     **kwargs,
                 )
             except self.exceptions_to_handle as e:
@@ -248,7 +253,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     inputs,
                     [
                         # each step a child run of the corresponding root run
-                        patch_config(config, callbacks=rm.get_child())
+                        patch_config(config, callbacks=rm.get_child(),
+                                     configurable=self._configurable(first_error))
                         for rm, config in zip(run_managers, configs)
                     ],
                     return_exceptions=return_exceptions,
@@ -320,7 +326,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     inputs,
                     [
                         # each step a child run of the corresponding root run
-                        patch_config(config, callbacks=rm.get_child())
+                        patch_config(config, callbacks=rm.get_child(),
+                                     configurable=self._configurable(first_error))
                         for rm, config in zip(run_managers, configs)
                     ],
                     return_exceptions=return_exceptions,


### PR DESCRIPTION
## Motivation

I have an increasingly complex chain of LLM calls, and I would like to be able to continue it even if some intermediate requests fail. For example, if a prompt requires 10 requests as input and 1 of them fails, I might just use an empty string for it and continue with the remaining 9 as input. The [fallbacks](https://python.langchain.com/docs/guides/fallbacks) mechanism seems to work well for this:

```python
chain.with_fallbacks([RunnableLambda(lambda input: "")])
```

However, currently the exception objects are not exposed to the fallback runnable. You can only specify the exception *types* to catch by using the `exceptions_to_handle=` option.

For example, say one of the requests produces the following error:

```python
BadRequestError('Error code: 400 - {\'error\': {\'message\': "This model\'s maximum context length is 16385 tokens. However, your messages resulted in 17351 tokens. Please reduce the length of the messages.", \'type\': \'invalid_request_error\', \'param\': \'messages\', \'code\': \'context_length_exceeded\'}}')
```

I'd like to be able to surface this in the UI, so that I know *why* the request is failing, and that it's not just a transient server error – even though I want the chain to continue executing with missing data.

## Suggested implementation

One solution I can see is changing `RunnableWithFallbacks` so that it passes the exception object into the `configurable` dictionary in the [config](https://python.langchain.com/docs/expression_language/how_to/configure) of the fallback runnables. This way you can obtain the exception like this:

```python
from langchain_core.runnables import RunnableLambda, RunnableConfig

def handle_error(input, config: RunnableConfig):
    exception = config['configurable']['exception']
    # Store the `exception` object somewhere so it can be surfaced to the user
    return ''

chain = chain.with_fallbacks([RunnableLambda(handle_error)])
```

I'm attaching a patch that implements this in the Python library. I've only tested the `ainvoke` change in my code. In particular, I don't know if code for the `batch`/`abatch` case is correct.