### PR TITLE
Community: BedrockChat -> Support Titan express as chat model

### DIFF
--- a/libs/community/langchain_community/chat_models/bedrock.py
+++ b/libs/community/langchain_community/chat_models/bedrock.py
@@ -32,6 +32,12 @@ class ChatPromptAdapter:
             prompt = convert_messages_to_prompt_anthropic(messages=messages)
         elif provider == "meta":
             prompt = convert_messages_to_prompt_llama(messages=messages)
+        elif provider == "amazon":
+            prompt = convert_messages_to_prompt_anthropic(
+                messages=messages,
+                human_prompt="\n\nUser:",
+                ai_prompt="\n\nBot:",
+            )
         else:
             raise NotImplementedError(
                 f"Provider {provider} model does not support chat."

--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -272,10 +272,12 @@ class BedrockBase(BaseModel, ABC):
 
         try:
             response = self.client.invoke_model(
-                body=body, modelId=self.model_id, accept=accept, contentType=contentType
+                body=body,
+                modelId=self.model_id,
+                accept=accept,
+                contentType=contentType,
             )
             text = LLMInputOutputAdapter.prepare_output(provider, response)
-
         except Exception as e:
             raise ValueError(f"Error raised by bedrock service: {e}")
 


### PR DESCRIPTION
Titan Express model was not supported as a chat model because LangChain messages were not "translated" to a text prompt.
