### PR TITLE
infra: remove path filter on check_diffs

### DIFF
--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -5,11 +5,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    paths:
-      - ".github/actions/**"
-      - ".github/tools/**"
-      - ".github/workflows/**"
-      - "libs/**"
 
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.


### PR DESCRIPTION
CI should run on https://github.com/langchain-ai/langchain/pull/15412

But github only checks first 300 files: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#git-diff-comparisons

> Diffs are limited to 300 files. If there are files changed that aren't matched in the first 300 files returned by the filter, the workflow will not run. You may need to create more specific filters so that the workflow will run automatically.