### PR TITLE
infra: fail check_diffs if too many files changed

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -52,4 +52,5 @@ if __name__ == "__main__":
             dirs_to_run.update(LANGCHAIN_DIRS)
         else:
             pass
-    print(json.dumps(list(dirs_to_run)))
+    json_output = json.dumps(list(dirs_to_run))
+    print(f"dirs-to-run={json_output}")

--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -13,6 +13,10 @@ if __name__ == "__main__":
     files = sys.argv[1:]
     dirs_to_run = set()
 
+    if len(files) == 300:
+        # max diff length is 300 files - there are likely files missing
+        raise ValueError("Max diff reached. Please manually run CI on changed libs.")
+
     for file in files:
         if any(
             file.startswith(dir_)

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -27,7 +27,9 @@ jobs:
       - id: files
         uses: Ana06/get-changed-files@v2.2.0
       - id: set-matrix
-        run: echo "dirs-to-run=$(python .github/scripts/check_diff.py ${{ steps.files.outputs.all }})" >> $GITHUB_OUTPUT
+        run: |
+          set -e
+          echo "dirs-to-run=$(python .github/scripts/check_diff.py ${{ steps.files.outputs.all }})" >> $GITHUB_OUTPUT
     outputs:
       dirs-to-run: ${{ steps.set-matrix.outputs.dirs-to-run }}
   ci:

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -28,8 +28,7 @@ jobs:
         uses: Ana06/get-changed-files@v2.2.0
       - id: set-matrix
         run: |
-          set -e
-          echo "dirs-to-run=$(python .github/scripts/check_diff.py ${{ steps.files.outputs.all }})" >> $GITHUB_OUTPUT
+          python .github/scripts/check_diff.py ${{ steps.files.outputs.all }} >> $GITHUB_OUTPUT
     outputs:
       dirs-to-run: ${{ steps.set-matrix.outputs.dirs-to-run }}
   ci:


### PR DESCRIPTION
Jobs like https://github.com/langchain-ai/langchain/actions/runs/7389187843/job/20101494206 only receive the first 300 changed files. Because of the opportunity to miss packages, better to auto-fail and manually run.

Checking that it does what I expect in #15424