### PR TITLE
refactor `utils`

### DIFF
--- a/libs/community/langchain_community/utils/__init__.py
+++ b/libs/community/langchain_community/utils/__init__.py
@@ -1,0 +1,3 @@
+"""
+**Utility functions** for LangChain.
+"""

--- a/libs/community/langchain_community/utils/ernie_functions.py
+++ b/libs/community/langchain_community/utils/ernie_functions.py
@@ -1,0 +1,51 @@
+from typing import Literal, Optional, Type, TypedDict
+
+from langchain_core.pydantic_v1 import BaseModel
+from langchain_core.utils.json_schema import dereference_refs
+
+
+class FunctionDescription(TypedDict):
+    """Representation of a callable function to the Ernie API."""
+
+    name: str
+    """The name of the function."""
+    description: str
+    """A description of the function."""
+    parameters: dict
+    """The parameters of the function."""
+
+
+class ToolDescription(TypedDict):
+    """Representation of a callable function to the Ernie API."""
+
+    type: Literal["function"]
+    function: FunctionDescription
+
+
+def convert_pydantic_to_ernie_function(
+    model: Type[BaseModel],
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> FunctionDescription:
+    """Converts a Pydantic model to a function description for the Ernie API."""
+    schema = dereference_refs(model.schema())
+    schema.pop("definitions", None)
+    return {
+        "name": name or schema["title"],
+        "description": description or schema["description"],
+        "parameters": schema,
+    }
+
+
+def convert_pydantic_to_ernie_tool(
+    model: Type[BaseModel],
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> ToolDescription:
+    """Converts a Pydantic model to a function description for the Ernie API."""
+    function = convert_pydantic_to_ernie_function(
+        model, name=name, description=description
+    )
+    return {"type": "function", "function": function}

--- a/libs/langchain/langchain/utils/ernie_functions.py
+++ b/libs/langchain/langchain/utils/ernie_functions.py
@@ -1,51 +1,13 @@
-from typing import Literal, Optional, Type, TypedDict
+from langchain_community.utils.ernie_functions import (
+    FunctionDescription,
+    ToolDescription,
+    convert_pydantic_to_ernie_function,
+    convert_pydantic_to_ernie_tool,
+)
 
-from langchain.pydantic_v1 import BaseModel
-from langchain.utils.json_schema import dereference_refs
-
-
-class FunctionDescription(TypedDict):
-    """Representation of a callable function to the Ernie API."""
-
-    name: str
-    """The name of the function."""
-    description: str
-    """A description of the function."""
-    parameters: dict
-    """The parameters of the function."""
-
-
-class ToolDescription(TypedDict):
-    """Representation of a callable function to the Ernie API."""
-
-    type: Literal["function"]
-    function: FunctionDescription
-
-
-def convert_pydantic_to_ernie_function(
-    model: Type[BaseModel],
-    *,
-    name: Optional[str] = None,
-    description: Optional[str] = None,
-) -> FunctionDescription:
-    """Converts a Pydantic model to a function description for the Ernie API."""
-    schema = dereference_refs(model.schema())
-    schema.pop("definitions", None)
-    return {
-        "name": name or schema["title"],
-        "description": description or schema["description"],
-        "parameters": schema,
-    }
-
-
-def convert_pydantic_to_ernie_tool(
-    model: Type[BaseModel],
-    *,
-    name: Optional[str] = None,
-    description: Optional[str] = None,
-) -> ToolDescription:
-    """Converts a Pydantic model to a function description for the Ernie API."""
-    function = convert_pydantic_to_ernie_function(
-        model, name=name, description=description
-    )
-    return {"type": "function", "function": function}
+__all__ = [
+    "FunctionDescription",
+    "ToolDescription",
+    "convert_pydantic_to_ernie_function",
+    "convert_pydantic_to_ernie_tool",
+]


### PR DESCRIPTION
The `langchain` [still holds several artifacts](https://api.python.langchain.com/en/latest/langchain_api_reference.html#module-langchain.utils) that belongs to `community`. If they moved then `langchain.utils` namespace would be  removed completely.
- moved `ernie_functions` artifacts to `community`