### PR TITLE
community: changing the .dict() to .model_dump() since it is deprecated

### DIFF
--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -491,7 +491,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 **self._invocation_params,
             )
             if not isinstance(response, dict):
-                response = response.dict()
+                response = response.model_dump()
             batched_embeddings.extend(r["embedding"] for r in response["data"])
 
         results: List[List[List[float]]] = [[] for _ in range(len(texts))]
@@ -512,7 +512,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     **self._invocation_params,
                 )
                 if not isinstance(average_embedded, dict):
-                    average_embedded = average_embedded.dict()
+                    average_embedded = average_embedded.model_dump()
                 average = average_embedded["data"][0]["embedding"]
             else:
                 average = np.average(_result, axis=0, weights=num_tokens_in_batch[i])
@@ -616,7 +616,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             )
 
             if not isinstance(response, dict):
-                response = response.dict()
+                response = response.model_dump()
             batched_embeddings.extend(r["embedding"] for r in response["data"])
 
         results: List[List[List[float]]] = [[] for _ in range(len(texts))]


### PR DESCRIPTION
  - **Description:** The method `.dict()` was replaced by `.model_dump` since its deprecated in Pydantic V2 and will be removed in Pydantic V.3, 
  - **Issue:** None,
  - **Dependencies:** None,
  - **Twitter handle:** @hhvedoveli

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
