### PR TITLE
[Warning Fixed] HuggingFace Hub LLM Integration

### DIFF
--- a/docs/docs/integrations/llms/huggingface_hub.ipynb
+++ b/docs/docs/integrations/llms/huggingface_hub.ipynb
@@ -167,7 +167,7 @@
    ],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_length\": 64}\n",
+    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_new_tokens\": 64}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "\n",
@@ -215,7 +215,7 @@
    ],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_length\": 64}\n",
+    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_new_tokens\": 64}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"
@@ -251,7 +251,7 @@
    "outputs": [],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_length\": 64}\n",
+    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_new_tokens\": 64}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"
@@ -285,7 +285,7 @@
    "outputs": [],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_length\": 64}\n",
+    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_new_tokens\": 64}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"
@@ -319,7 +319,7 @@
    "outputs": [],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_length\": 64}\n",
+    "    repo_id=repo_id, model_kwargs={\"temperature\": 0.5, \"max_new_tokens\": 64}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"
@@ -353,7 +353,7 @@
    "outputs": [],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"max_length\": 128, \"temperature\": 0.8}\n",
+    "    repo_id=repo_id, model_kwargs={\"max_new_tokens\": 128, \"temperature\": 0.8}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"
@@ -391,7 +391,7 @@
    "outputs": [],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"max_length\": 128, \"temperature\": 0.5}\n",
+    "    repo_id=repo_id, model_kwargs={\"max_new_tokens\": 128, \"temperature\": 0.5}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"
@@ -427,7 +427,7 @@
    "outputs": [],
    "source": [
     "llm = HuggingFaceHub(\n",
-    "    repo_id=repo_id, model_kwargs={\"max_length\": 128, \"temperature\": 0.5}\n",
+    "    repo_id=repo_id, model_kwargs={\"max_new_tokens\": 128, \"temperature\": 0.5}\n",
     ")\n",
     "llm_chain = LLMChain(prompt=prompt, llm=llm)\n",
     "print(llm_chain.run(question))"

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -24,7 +24,7 @@ class HuggingFaceHub(LLM):
         .. code-block:: python
 
             from langchain_community.llms import HuggingFaceHub
-            hf = HuggingFaceHub(repo_id="gpt2", huggingfacehub_api_token="my-api-key")
+            hf = HuggingFaceHub(repo_id="huggingfaceh4/zephyr-7b-alpha", huggingfacehub_api_token="my-api-key")
     """
 
     client: Any  #: :meta private:
@@ -50,7 +50,7 @@ class HuggingFaceHub(LLM):
             values, "huggingfacehub_api_token", "HUGGINGFACEHUB_API_TOKEN"
         )
         try:
-            from huggingface_hub.inference_api import InferenceApi
+            from huggingface_hub.inference_api import InferenceClient
 
             repo_id = values["repo_id"]
             client = InferenceApi(


### PR DESCRIPTION
 This PR fixes the following warning
```
/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_deprecation.py:131: FutureWarning: 'InferenceApi' (from 'huggingface_hub.inference_api') is deprecated and will be removed from version '1.0'. `InferenceApi` client is deprecated in favor of the more feature-complete `InferenceClient`. Check out this guide to learn how to convert your script to use it: https://huggingface.co/docs/huggingface_hub/guides/inference#legacy-inferenceapi-client.
  warnings.warn(warning_message, FutureWarning)
```

Fixes made:
- Replace `InferenceAPI` with `InferenceClient`
- Replace `max_length` to `max_new_tokens` as per new HuggingFace docs