### PR TITLE
added interfaces as `core.schemas`

### DIFF
--- a/libs/core/langchain_core/schema/__init__.py
+++ b/libs/core/langchain_core/schema/__init__.py
@@ -1,0 +1,2 @@
+"""Interfaces for standard types.
+"""

--- a/libs/core/langchain_core/schema/cache.py
+++ b/libs/core/langchain_core/schema/cache.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Sequence
+
+from langchain_core.outputs import Generation
+
+RETURN_VAL_TYPE = Sequence[Generation]
+
+
+class CacheInterface(ABC):
+    """Interface for cache."""
+
+    @abstractmethod
+    def lookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
+        """Look up based on prompt and llm_string."""
+
+    @abstractmethod
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        """Update cache based on prompt and llm_string."""
+
+    @abstractmethod
+    def clear(self, **kwargs: Any) -> None:
+        """Clear cache that can take additional keyword arguments."""

--- a/libs/core/langchain_core/schema/chat_loader.py
+++ b/libs/core/langchain_core/schema/chat_loader.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Iterator, List
+
+if TYPE_CHECKING:
+    from langchain_core.chat_sessions import ChatSession
+
+
+class ChatLoaderInterface(ABC):
+    """Interface for chat loaders."""
+
+    @abstractmethod
+    def lazy_load(self) -> Iterator[ChatSession]:
+        """Lazy load the chat sessions."""
+
+    @abstractmethod
+    def load(self) -> List[ChatSession]:
+        """Eagerly load the chat sessions into memory."""

--- a/libs/core/langchain_core/schema/chat_loader.py
+++ b/libs/core/langchain_core/schema/chat_loader.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator, List
+from typing import Iterator, List
 
-if TYPE_CHECKING:
-    from langchain_core.chat_sessions import ChatSession
+from langchain_core.chat_sessions import ChatSession
 
 
 class ChatLoaderInterface(ABC):

--- a/libs/core/langchain_core/schema/chat_message_history.py
+++ b/libs/core/langchain_core/schema/chat_message_history.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, List, Union
+
+if TYPE_CHECKING:
+    from langchain_core.messages import (
+        AIMessage,
+        BaseMessage,
+        HumanMessage,
+    )
+
+
+class ChatMessageHistoryInterface(ABC):
+    """Interface for storing chat message history.
+
+    See `ChatMessageHistory` for default implementation.
+    The default implementation is the BaseChatMessageHistory class.
+
+    Example:
+        .. code-block:: python
+
+            class FileChatMessageHistory(BaseChatMessageHistory):
+                storage_path:  str
+                session_id: str
+
+               @property
+               def messages(self):
+                   with open(os.path.join(storage_path, session_id), 'r:utf-8') as f:
+                       messages = json.loads(f.read())
+                    return messages_from_dict(messages)
+
+               def add_message(self, message: BaseMessage) -> None:
+                   messages = self.messages.append(_message_to_dict(message))
+                   with open(os.path.join(storage_path, session_id), 'w') as f:
+                       json.dump(f, messages)
+
+               def clear(self):
+                   with open(os.path.join(storage_path, session_id), 'w') as f:
+                       f.write("[]")
+    """
+
+    messages: List[BaseMessage]
+    """A list of Messages stored in-memory."""
+
+    @abstractmethod
+    def add_user_message(self, message: Union[HumanMessage, str]) -> None:
+        """Convenience method for adding a human message string to the store.
+
+        Args:
+            message: The human message to add
+        """
+
+    @abstractmethod
+    def add_ai_message(self, message: Union[AIMessage, str]) -> None:
+        """Convenience method for adding an AI message string to the store.
+
+        Args:
+            message: The AI message to add.
+        """
+
+    @abstractmethod
+    def add_message(self, message: BaseMessage) -> None:
+        """Add a Message object to the store.
+
+        Args:
+            message: A BaseMessage object to store.
+        """
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all messages from the store"""

--- a/libs/core/langchain_core/schema/chat_message_history.py
+++ b/libs/core/langchain_core/schema/chat_message_history.py
@@ -1,12 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Union
+from typing import List, Union
 
-if TYPE_CHECKING:
-    from langchain_core.messages import (
-        AIMessage,
-        BaseMessage,
-        HumanMessage,
-    )
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+)
 
 
 class ChatMessageHistoryInterface(ABC):

--- a/libs/core/langchain_core/schema/chat_model.py
+++ b/libs/core/langchain_core/schema/chat_model.py
@@ -1,0 +1,48 @@
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+
+
+# TODO: this is a work in progress
+# TODO: do we need other methods from BaseChatModel or BaseLanguageModel?
+class ChatModelInterface(ABC):
+    """Interface for Chat Model.
+
+    The default implementation of this interface is :class:`BaseChatModel`.
+    """
+
+    @abstractmethod
+    def _call(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Simpler interface."""
+
+    @abstractmethod
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Simpler interface."""
+
+    @abstractmethod
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Simpler interface."""

--- a/libs/core/langchain_core/schema/docstore.py
+++ b/libs/core/langchain_core/schema/docstore.py
@@ -1,9 +1,8 @@
 """Interface to access to place that stores documents."""
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import Dict, List, Union
 
-if TYPE_CHECKING:
-    from langchain_core.documents import Document
+from langchain_core.documents import Document
 
 
 class DocstoreInterface(ABC):

--- a/libs/core/langchain_core/schema/docstore.py
+++ b/libs/core/langchain_core/schema/docstore.py
@@ -1,0 +1,30 @@
+"""Interface to access to place that stores documents."""
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Dict, List, Union
+
+if TYPE_CHECKING:
+    from langchain_core.documents import Document
+
+
+class DocstoreInterface(ABC):
+    """Interface to access to place that stores documents."""
+
+    @abstractmethod
+    def search(self, search: str) -> Union[str, Document]:
+        """Search for a document.
+
+        If page exists, return the page summary, and a Document object.
+        If the page does not exist, return similar entries.
+        """
+
+    @abstractmethod
+    def delete(self, ids: List) -> None:
+        """Deleting IDs from in memory dictionary."""
+
+
+class AddableMixin(ABC):
+    """Mixin class that supports adding texts."""
+
+    @abstractmethod
+    def add(self, texts: Dict[str, Document]) -> None:
+        """Add more documents."""

--- a/libs/core/langchain_core/schema/document_loader.py
+++ b/libs/core/langchain_core/schema/document_loader.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+if TYPE_CHECKING:
+    from langchain_core.documents import Document
+    from langchain_core.schema.text_splitter import TextSplitterInterface
+
+
+class DocumentLoaderInterface(ABC):
+    """Interface for Document Loader.
+
+    Implementations should implement the lazy-loading method using generators
+    to avoid loading all Documents into memory at once.
+
+    The `load` method will remain as is for backwards compatibility, but its
+    implementation should be just `list(self.lazy_load())`.
+    """
+
+    @abstractmethod
+    def load(self) -> List[Document]:
+        """Load data into Document objects.
+
+        Sub-classes should implement this method
+        as `return list(self.lazy_load())`
+        This method returns a List which is materialized in memory.
+        """
+
+    @abstractmethod
+    def load_and_split(
+        self, text_splitter: Optional[TextSplitterInterface] = None
+    ) -> List[Document]:
+        """Load Documents and split into chunks. Chunks are returned as Documents.
+
+        Args:
+            text_splitter: TextSplitter instance to use for splitting documents.
+              Defaults to RecursiveCharacterTextSplitter.
+
+        Returns:
+            List of Documents.
+        """
+
+    # Attention: This method will be upgraded into an abstractmethod once it's
+    #            implemented in all the existing subclasses.
+    @abstractmethod
+    def lazy_load(
+        self,
+    ) -> Iterator[Document]:
+        """A lazy loader for Documents."""

--- a/libs/core/langchain_core/schema/document_loader.py
+++ b/libs/core/langchain_core/schema/document_loader.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import Iterator, List, Optional
 
-if TYPE_CHECKING:
-    from langchain_core.documents import Document
-    from langchain_core.schema.text_splitter import TextSplitterInterface
+from langchain_core.documents import Document
+from langchain_core.schema.text_splitter import TextSplitterInterface
 
 
 class DocumentLoaderInterface(ABC):

--- a/libs/core/langchain_core/schema/document_transformer.py
+++ b/libs/core/langchain_core/schema/document_transformer.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import Any, Sequence
 
-if TYPE_CHECKING:
-    from langchain_core.documents import Document
+from langchain_core.documents import Document
 
 
 class DocumentTransformerInterface(ABC):

--- a/libs/core/langchain_core/schema/document_transformer.py
+++ b/libs/core/langchain_core/schema/document_transformer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Sequence
+
+if TYPE_CHECKING:
+    from langchain_core.documents import Document
+
+
+class DocumentTransformerInterface(ABC):
+    """Interface for document transformation systems.
+
+    The default implementation is the BaseDocumentTransformer.
+    A document transformation system takes a sequence of Documents and returns a
+    sequence of transformed Documents.
+
+    Example:
+        .. code-block:: python
+
+            class EmbeddingsRedundantFilter(BaseDocumentTransformer, BaseModel):
+                embeddings: Embeddings
+                similarity_fn: Callable = cosine_similarity
+                similarity_threshold: float = 0.95
+
+                class Config:
+                    arbitrary_types_allowed = True
+
+                def transform_documents(
+                    self, documents: Sequence[Document], **kwargs: Any
+                ) -> Sequence[Document]:
+                    stateful_documents = get_stateful_documents(documents)
+                    embedded_documents = _get_embeddings_from_stateful_docs(
+                        self.embeddings, stateful_documents
+                    )
+                    included_idxs = _filter_similar_embeddings(
+                        embedded_documents, self.similarity_fn, self.similarity_threshold
+                    )
+                    return [stateful_documents[i] for i in sorted(included_idxs)]
+
+                async def atransform_documents(
+                    self, documents: Sequence[Document], **kwargs: Any
+                ) -> Sequence[Document]:
+                    raise NotImplementedError
+
+    """  # noqa: E501
+
+    @abstractmethod
+    def transform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Transform a list of documents.
+
+        Args:
+            documents: A sequence of Documents to be transformed.
+
+        Returns:
+            A list of transformed Documents.
+        """
+
+    @abstractmethod
+    async def atransform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Asynchronously transform a list of documents.
+
+        Args:
+            documents: A sequence of Documents to be transformed.
+
+        Returns:
+            A list of transformed Documents.
+        """

--- a/libs/core/langchain_core/schema/embeddings.py
+++ b/libs/core/langchain_core/schema/embeddings.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class EmbeddingsInterface(ABC):
+    """Interface for embedding models."""
+
+    @abstractmethod
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Embed search docs."""
+
+    @abstractmethod
+    def embed_query(self, text: str) -> List[float]:
+        """Embed query text."""
+
+    @abstractmethod
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Asynchronous Embed search docs."""
+
+    @abstractmethod
+    async def aembed_query(self, text: str) -> List[float]:
+        """Asynchronous Embed query text."""

--- a/libs/core/langchain_core/schema/graph_store.py
+++ b/libs/core/langchain_core/schema/graph_store.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, List
+
+if TYPE_CHECKING:
+    from langchain_community.graphs.graph_document import GraphDocument
+
+
+class GraphStoreInterface(ABC):
+    """Interface for graph store."""
+
+    @property
+    @abstractmethod
+    def get_schema(self) -> str:
+        """Returns the schema of the Graph database"""
+        pass
+
+    @property
+    @abstractmethod
+    def get_structured_schema(self) -> Dict[str, Any]:
+        """Returns the schema of the Graph database"""
+        pass
+
+    @abstractmethod
+    def query(self, query: str, params: dict = {}) -> List[Dict[str, Any]]:
+        """Query the graph."""
+        pass
+
+    @abstractmethod
+    def refresh_schema(self) -> None:
+        """Refreshes the graph schema information."""
+        pass
+
+    @abstractmethod
+    def add_graph_documents(
+        self, graph_documents: List[GraphDocument], include_source: bool = False
+    ) -> None:
+        """Take GraphDocument as input as uses it to construct a graph."""
+        pass

--- a/libs/core/langchain_core/schema/graph_store.py
+++ b/libs/core/langchain_core/schema/graph_store.py
@@ -3,10 +3,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 if TYPE_CHECKING:
     from langchain_core.documents import Document
-    from langchain_core.pydantic_v1 import Field
-
 
 from langchain_core.load.serializable import Serializable
+from langchain_core.pydantic_v1 import Field
 
 
 class Node(Serializable):

--- a/libs/core/langchain_core/schema/graph_store.py
+++ b/libs/core/langchain_core/schema/graph_store.py
@@ -3,8 +3,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 if TYPE_CHECKING:
     from langchain_core.documents import Document
-    from langchain_core.load.serializable import Serializable
     from langchain_core.pydantic_v1 import Field
+
+
+from langchain_core.load.serializable import Serializable
 
 
 class Node(Serializable):

--- a/libs/core/langchain_core/schema/graph_store.py
+++ b/libs/core/langchain_core/schema/graph_store.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import Any, Dict, List, Union
 
-if TYPE_CHECKING:
-    from langchain_core.documents import Document
-
+from langchain_core.documents import Document
 from langchain_core.load.serializable import Serializable
 from langchain_core.pydantic_v1 import Field
 

--- a/libs/core/langchain_core/schema/graph_store.py
+++ b/libs/core/langchain_core/schema/graph_store.py
@@ -1,8 +1,54 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 if TYPE_CHECKING:
-    from langchain_community.graphs.graph_document import GraphDocument
+    from langchain_core.documents import Document
+    from langchain_core.load.serializable import Serializable
+    from langchain_core.pydantic_v1 import Field
+
+
+class Node(Serializable):
+    """Represents a node in a graph with associated properties.
+
+    Attributes:
+        id (Union[str, int]): A unique identifier for the node.
+        type (str): The type or label of the node, default is "Node".
+        properties (dict): Additional properties and metadata associated with the node.
+    """
+
+    id: Union[str, int]
+    type: str = "Node"
+    properties: dict = Field(default_factory=dict)
+
+
+class Relationship(Serializable):
+    """Represents a directed relationship between two nodes in a graph.
+
+    Attributes:
+        source (Node): The source node of the relationship.
+        target (Node): The target node of the relationship.
+        type (str): The type of the relationship.
+        properties (dict): Additional properties associated with the relationship.
+    """
+
+    source: Node
+    target: Node
+    type: str
+    properties: dict = Field(default_factory=dict)
+
+
+class GraphDocument(Serializable):
+    """Represents a graph document consisting of nodes and relationships.
+
+    Attributes:
+        nodes (List[Node]): A list of nodes in the graph.
+        relationships (List[Relationship]): A list of relationships in the graph.
+        source (Document): The document from which the graph information is derived.
+    """
+
+    nodes: List[Node]
+    relationships: List[Relationship]
+    source: Document
 
 
 class GraphStoreInterface(ABC):

--- a/libs/core/langchain_core/schema/llm.py
+++ b/libs/core/langchain_core/schema/llm.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.outputs import LLMResult
+
+
+# TODO: this is a work in progress
+# TODO: do we need other methods from BaseLLM or BaseLanguageModel?
+class LLMInterface(ABC):
+    """Interface for LLM.
+
+    The default implementation of this interface is :class:`BaseLLM`.
+    The purpose of this class is to expose a simpler interface for
+    LLMs, rather than expect the user to implement the full _generate method.
+    """
+
+    @abstractmethod
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Run the LLM on the given prompt and input."""
+
+    @abstractmethod
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Run the LLM on the given prompt and input."""
+
+    @abstractmethod
+    def _generate(
+        self,
+        prompts: List[str],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> LLMResult:
+        """Run the LLM on the given prompt and input."""
+
+    @abstractmethod
+    async def _agenerate(
+        self,
+        prompts: List[str],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> LLMResult:
+        """Run the LLM on the given prompt and input."""

--- a/libs/core/langchain_core/schema/retriever.py
+++ b/libs/core/langchain_core/schema/retriever.py
@@ -1,0 +1,80 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForRetrieverRun,
+    CallbackManagerForRetrieverRun,
+)
+from langchain_core.documents import Document
+
+
+# TODO: this is a work in progress
+# TODO: do we need `metadata` and `tags` in interface?
+# TODO: do we need other methods from BaseRetriever?
+class RetrieverInterface(ABC):
+    """Interface for a Document retrieval system.
+
+    The default implementation of this interface is :class:`BaseRetriever`.
+    A retrieval system is defined as something that can take string queries and return
+        the most 'relevant' Documents from some source.
+
+    Example:
+        .. code-block:: python
+
+            class TFIDFRetriever(BaseRetriever, BaseModel):
+                vectorizer: Any
+                docs: List[Document]
+                tfidf_array: Any
+                k: int = 4
+
+                class Config:
+                    arbitrary_types_allowed = True
+
+                def get_relevant_documents(self, query: str) -> List[Document]:
+                    from sklearn.metrics.pairwise import cosine_similarity
+
+                    # Ip -- (n_docs,x), Op -- (n_docs,n_Feats)
+                    query_vec = self.vectorizer.transform([query])
+                    # Op -- (n_docs,1) -- Cosine Sim with each doc
+                    results = cosine_similarity(self.tfidf_array, query_vec).reshape((-1,))
+                    return [self.docs[i] for i in results.argsort()[-self.k :][::-1]]
+    """  # noqa: E501
+
+    tags: Optional[List[str]] = None
+    """Optional list of tags associated with the retriever. Defaults to None
+    These tags will be associated with each call to this retriever,
+    and passed as arguments to the handlers defined in `callbacks`.
+    You can use these to eg identify a specific instance of a retriever with its 
+    use case.
+    """
+    metadata: Optional[Dict[str, Any]] = None
+    """Optional metadata associated with the retriever. Defaults to None
+    This metadata will be associated with each call to this retriever,
+    and passed as arguments to the handlers defined in `callbacks`.
+    You can use these to eg identify a specific instance of a retriever with its 
+    use case.
+    """
+
+    @abstractmethod
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+    ) -> List[Document]:
+        """Get documents relevant to a query.
+        Args:
+            query: String to find relevant documents for
+            run_manager: The callback handler to use
+        Returns:
+            List of relevant documents
+        """
+
+    @abstractmethod
+    async def _aget_relevant_documents(
+        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+    ) -> List[Document]:
+        """Asynchronously get documents relevant to a query.
+        Args:
+            query: String to find relevant documents for
+            run_manager: The callback handler to use
+        Returns:
+            List of relevant documents
+        """

--- a/libs/core/langchain_core/schema/text_splitter.py
+++ b/libs/core/langchain_core/schema/text_splitter.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.documents import BaseDocumentTransformer, Document
+
+
+class TextSplitterInterface(
+    BaseDocumentTransformer, ABC
+):  # TODO Do we need ABC since we have BaseDocumentTransformer?
+    """Interface for splitting text into chunks."""
+
+    @abstractmethod
+    def split_text(self, text: str) -> List[str]:
+        """Split text into multiple components."""
+
+    @abstractmethod
+    def create_documents(
+        self, texts: List[str], metadatas: Optional[List[dict]] = None
+    ) -> List[Document]:
+        """Create documents from a list of texts."""
+
+    @abstractmethod
+    def split_documents(self, documents: Iterable[Document]) -> List[Document]:
+        """Split documents."""
+
+    @abstractmethod
+    def transform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Transform sequence of documents by splitting them."""

--- a/libs/core/langchain_core/schema/text_splitter.py
+++ b/libs/core/langchain_core/schema/text_splitter.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import (
-    TYPE_CHECKING,
     Any,
     Iterable,
     List,
@@ -8,8 +7,7 @@ from typing import (
     Sequence,
 )
 
-if TYPE_CHECKING:
-    from langchain_core.documents import BaseDocumentTransformer, Document
+from langchain_core.documents import BaseDocumentTransformer, Document
 
 
 class TextSplitterInterface(

--- a/libs/core/langchain_core/schema/text_splitter.py
+++ b/libs/core/langchain_core/schema/text_splitter.py
@@ -1,18 +1,16 @@
 from abc import ABC, abstractmethod
 from typing import (
-    Any,
     Iterable,
     List,
     Optional,
-    Sequence,
 )
 
-from langchain_core.documents import BaseDocumentTransformer, Document
+from langchain_core.documents import Document
 
 
-class TextSplitterInterface(
-    BaseDocumentTransformer, ABC
-):  # TODO Do we need ABC since we have BaseDocumentTransformer?
+# TODO: this is a work in progress
+# TODO: do we need to derive from DocumentTransformer?
+class TextSplitterInterface(ABC):
     """Interface for splitting text into chunks."""
 
     @abstractmethod
@@ -28,9 +26,3 @@ class TextSplitterInterface(
     @abstractmethod
     def split_documents(self, documents: Iterable[Document]) -> List[Document]:
         """Split documents."""
-
-    @abstractmethod
-    def transform_documents(
-        self, documents: Sequence[Document], **kwargs: Any
-    ) -> Sequence[Document]:
-        """Transform sequence of documents by splitting them."""

--- a/libs/core/langchain_core/schema/tool.py
+++ b/libs/core/langchain_core/schema/tool.py
@@ -1,0 +1,175 @@
+from abc import ABC, abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import (
+        BaseCallbackManager,
+        Callbacks,
+    )
+    from langchain_core.pydantic_v1 import (
+        BaseModel,
+        Field,
+    )
+    from langchain_core.runnables import RunnableConfig
+    from langchain_core.tools import ToolException
+
+
+class BaseToolInterface(ABC):
+    """Interface LangChain tools must implement."""
+
+    name: str
+    """The unique name of the tool that clearly communicates its purpose."""
+    description: str
+    """Used to tell the model how/when/why to use the tool.
+
+    You can provide few-shot examples as a part of the description.
+    """
+    args_schema: Optional[Type[BaseModel]] = None
+    """Pydantic model class to validate and parse the tool's input arguments."""
+    return_direct: bool = False
+    """Whether to return the tool's output directly. Setting this to True means
+
+    that after the tool is called, the AgentExecutor will stop looping.
+    """
+    verbose: bool = False
+    """Whether to log the tool's progress."""
+
+    callbacks: Callbacks = Field(default=None, exclude=True)
+    """Callbacks to be called during tool execution."""
+    callback_manager: Optional[BaseCallbackManager] = Field(default=None, exclude=True)
+    """Deprecated. Please use callbacks instead."""
+    tags: Optional[List[str]] = None
+    """Optional list of tags associated with the tool. Defaults to None
+    These tags will be associated with each call to this tool,
+    and passed as arguments to the handlers defined in `callbacks`.
+    You can use these to eg identify a specific instance of a tool with its use case.
+    """
+    metadata: Optional[Dict[str, Any]] = None
+    """Optional metadata associated with the tool. Defaults to None
+    This metadata will be associated with each call to this tool,
+    and passed as arguments to the handlers defined in `callbacks`.
+    You can use these to eg identify a specific instance of a tool with its use case.
+    """
+
+    handle_tool_error: Optional[
+        Union[bool, str, Callable[[ToolException], str]]
+    ] = False
+    """Handle the content of the ToolException thrown."""
+
+    @property
+    @abstractmethod
+    def is_single_input(self) -> bool:
+        """Whether the tool only accepts a single input."""
+
+    @property
+    @abstractmethod
+    def args(self) -> dict:
+        """Arguments."""
+
+    @abstractmethod
+    def get_input_schema(
+        self, config: Optional[RunnableConfig] = None
+    ) -> Type[BaseModel]:
+        """The tool's input schema."""
+
+    @abstractmethod
+    def invoke(
+        self,
+        input: Union[str, Dict],
+        config: Optional[RunnableConfig] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the tool."""
+
+    @abstractmethod
+    async def ainvoke(
+        self,
+        input: Union[str, Dict],
+        config: Optional[RunnableConfig] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the tool asynchronously."""
+
+    @abstractmethod
+    def _parse_input(
+        self,
+        tool_input: Union[str, Dict],
+    ) -> Union[str, Dict[str, Any]]:
+        """Convert tool input to a pydantic model."""
+
+    @abstractmethod
+    def _run(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Use the tool.
+
+        Add run_manager: Optional[CallbackManagerForToolRun] = None
+        to child implementations to enable tracing.
+        """
+
+    @abstractmethod
+    async def _arun(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Use the tool asynchronously.
+
+        Add run_manager: Optional[AsyncCallbackManagerForToolRun] = None
+        to child implementations to enable tracing,
+        """
+
+    @abstractmethod
+    def _to_args_and_kwargs(self, tool_input: Union[str, Dict]) -> Tuple[Tuple, Dict]:
+        """
+        For backwards compatibility, if run_input is a string,
+        pass as a positional argument.
+        """
+
+    @abstractmethod
+    def run(
+        self,
+        tool_input: Union[str, Dict],
+        verbose: Optional[bool] = None,
+        start_color: Optional[str] = "green",
+        color: Optional[str] = "green",
+        callbacks: Callbacks = None,
+        *,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        run_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run the tool."""
+
+    @abstractmethod
+    async def arun(
+        self,
+        tool_input: Union[str, Dict],
+        verbose: Optional[bool] = None,
+        start_color: Optional[str] = "green",
+        color: Optional[str] = "green",
+        callbacks: Callbacks = None,
+        *,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        run_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run the tool asynchronously."""
+
+    @abstractmethod
+    def __call__(self, tool_input: str, callbacks: Callbacks = None) -> str:
+        """Make tool callable."""

--- a/libs/core/langchain_core/schema/tool.py
+++ b/libs/core/langchain_core/schema/tool.py
@@ -22,7 +22,9 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import ToolException
 
 
-class BaseToolInterface(ABC):
+# TODO: this is a work in progress
+# TODO: do we need only _run fun or other fields and funcs?
+class ToolInterface(ABC):
     """Interface LangChain tools must implement."""
 
     name: str
@@ -79,24 +81,6 @@ class BaseToolInterface(ABC):
         self, config: Optional[RunnableConfig] = None
     ) -> Type[BaseModel]:
         """The tool's input schema."""
-
-    @abstractmethod
-    def invoke(
-        self,
-        input: Union[str, Dict],
-        config: Optional[RunnableConfig] = None,
-        **kwargs: Any,
-    ) -> Any:
-        """Invoke the tool."""
-
-    @abstractmethod
-    async def ainvoke(
-        self,
-        input: Union[str, Dict],
-        config: Optional[RunnableConfig] = None,
-        **kwargs: Any,
-    ) -> Any:
-        """Invoke the tool asynchronously."""
 
     @abstractmethod
     def _parse_input(

--- a/libs/core/langchain_core/schema/tool.py
+++ b/libs/core/langchain_core/schema/tool.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -11,17 +10,16 @@ from typing import (
     Union,
 )
 
-if TYPE_CHECKING:
-    from langchain_core.callbacks import (
-        BaseCallbackManager,
-        Callbacks,
-    )
-    from langchain_core.pydantic_v1 import (
-        BaseModel,
-        Field,
-    )
-    from langchain_core.runnables import RunnableConfig
-    from langchain_core.tools import ToolException
+from langchain_core.callbacks import (
+    BaseCallbackManager,
+    Callbacks,
+)
+from langchain_core.pydantic_v1 import (
+    BaseModel,
+    Field,
+)
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import ToolException
 
 
 class BaseToolInterface(ABC):

--- a/libs/core/langchain_core/schema/toolkit.py
+++ b/libs/core/langchain_core/schema/toolkit.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from langchain_core.schema.tool import BaseToolInterface
+
+
+class ToolkitInterface(ABC):
+    """Toolkit Interface is a collection of related tools."""
+
+    @abstractmethod
+    def get_tools(self) -> List[BaseToolInterface]:
+        """Get the tools in the toolkit."""

--- a/libs/core/langchain_core/schema/toolkit.py
+++ b/libs/core/langchain_core/schema/toolkit.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from langchain_core.schema.tool import BaseToolInterface
+from langchain_core.schema.tool import ToolInterface
 
 
 class ToolkitInterface(ABC):
     """Toolkit Interface is a collection of related tools."""
 
     @abstractmethod
-    def get_tools(self) -> List[BaseToolInterface]:
+    def get_tools(self) -> List[ToolInterface]:
         """Get the tools in the toolkit."""

--- a/libs/core/langchain_core/schema/vectorstore.py
+++ b/libs/core/langchain_core/schema/vectorstore.py
@@ -1,0 +1,454 @@
+from abc import ABC, abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.documents import Document
+    from langchain_core.embeddings import Embeddings
+    from langchain_core.vectorstores import VectorStoreRetriever
+
+
+VST = TypeVar("VST", bound="VectorStoreInterface")
+
+
+class VectorStoreInterface(ABC):
+    """Interface for vector store."""
+
+    @abstractmethod
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Run more texts through the embeddings and add to the vectorstore.
+
+        Args:
+            texts: Iterable of strings to add to the vectorstore.
+            metadatas: Optional list of metadatas associated with the texts.
+            kwargs: vectorstore specific parameters
+
+        Returns:
+            List of ids from adding the texts into the vectorstore.
+        """
+
+    @property
+    @abstractmethod
+    def embeddings(self) -> Optional[Embeddings]:
+        """Access the query embedding object if available."""
+
+    @abstractmethod
+    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+        """Delete by vector ID or other criteria.
+
+        Args:
+            ids: List of ids to delete.
+            **kwargs: Other keyword arguments that subclasses might use.
+
+        Returns:
+            Optional[bool]: True if deletion is successful,
+            False otherwise, None if not implemented.
+        """
+
+        raise NotImplementedError("delete method must be implemented by subclass.")
+
+    async def adelete(
+        self, ids: Optional[List[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
+        """Delete by vector ID or other criteria.
+
+        Args:
+            ids: List of ids to delete.
+            **kwargs: Other keyword arguments that subclasses might use.
+
+        Returns:
+            Optional[bool]: True if deletion is successful,
+            False otherwise, None if not implemented.
+        """
+
+    @abstractmethod
+    async def aadd_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Run more texts through the embeddings and add to the vectorstore."""
+
+    @abstractmethod
+    def add_documents(self, documents: List[Document], **kwargs: Any) -> List[str]:
+        """Run more documents through the embeddings and add to the vectorstore.
+
+        Args:
+            documents (List[Document]: Documents to add to the vectorstore.
+
+        Returns:
+            List[str]: List of IDs of the added texts.
+        """
+        # TODO: Handle the case where the user doesn't provide ids on the Collection
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+        return self.add_texts(texts, metadatas, **kwargs)
+
+    @abstractmethod
+    async def aadd_documents(
+        self, documents: List[Document], **kwargs: Any
+    ) -> List[str]:
+        """Run more documents through the embeddings and add to the vectorstore.
+
+        Args:
+            documents (List[Document]: Documents to add to the vectorstore.
+
+        Returns:
+            List[str]: List of IDs of the added texts.
+        """
+
+    @abstractmethod
+    def search(self, query: str, search_type: str, **kwargs: Any) -> List[Document]:
+        """Return docs most similar to query using specified search type."""
+
+    @abstractmethod
+    async def asearch(
+        self, query: str, search_type: str, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to query using specified search type."""
+
+    @abstractmethod
+    def similarity_search(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to query."""
+
+    @abstractmethod
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        """
+        The 'correct' relevance function
+        may differ depending on a few things, including:
+        - the distance / similarity metric used by the VectorStore
+        - the scale of your embeddings (OpenAI's are unit normed. Many others are not!)
+        - embedding dimensionality
+        - etc.
+
+        Vectorstores should define their own selection based method of relevance.
+        """
+
+    @abstractmethod
+    def similarity_search_with_score(
+        self, *args: Any, **kwargs: Any
+    ) -> List[Tuple[Document, float]]:
+        """Run similarity search with distance."""
+
+    @abstractmethod
+    async def asimilarity_search_with_score(
+        self, *args: Any, **kwargs: Any
+    ) -> List[Tuple[Document, float]]:
+        """Run similarity search with distance asynchronously."""
+
+    @abstractmethod
+    def _similarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """
+        Default similarity search with relevance scores. Modify if necessary
+        in subclass.
+        Return docs and relevance scores in the range [0, 1].
+
+        0 is dissimilar, 1 is most similar.
+
+        Args:
+            query: input text
+            k: Number of Documents to return. Defaults to 4.
+            **kwargs: kwargs to be passed to similarity search. Should include:
+                score_threshold: Optional, a floating point value between 0 to 1 to
+                    filter the resulting set of retrieved docs
+
+        Returns:
+            List of Tuples of (doc, similarity_score)
+        """
+
+    @abstractmethod
+    async def _asimilarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """
+        Default async similarity search with relevance scores. Modify if necessary
+        in subclass.
+        Return docs and relevance scores in the range [0, 1].
+
+        0 is dissimilar, 1 is most similar.
+
+        Args:
+            query: input text
+            k: Number of Documents to return. Defaults to 4.
+            **kwargs: kwargs to be passed to similarity search. Should include:
+                score_threshold: Optional, a floating point value between 0 to 1 to
+                    filter the resulting set of retrieved docs
+
+        Returns:
+            List of Tuples of (doc, similarity_score)
+        """
+
+    @abstractmethod
+    def similarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Return docs and relevance scores in the range [0, 1].
+
+        0 is dissimilar, 1 is most similar.
+
+        Args:
+            query: input text
+            k: Number of Documents to return. Defaults to 4.
+            **kwargs: kwargs to be passed to similarity search. Should include:
+                score_threshold: Optional, a floating point value between 0 to 1 to
+                    filter the resulting set of retrieved docs
+
+        Returns:
+            List of Tuples of (doc, similarity_score)
+        """
+
+    @abstractmethod
+    async def asimilarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Return docs and relevance scores in the range [0, 1], asynchronously.
+
+        0 is dissimilar, 1 is most similar.
+
+        Args:
+            query: input text
+            k: Number of Documents to return. Defaults to 4.
+            **kwargs: kwargs to be passed to similarity search. Should include:
+                score_threshold: Optional, a floating point value between 0 to 1 to
+                    filter the resulting set of retrieved docs
+
+        Returns:
+            List of Tuples of (doc, similarity_score)
+        """
+
+    @abstractmethod
+    async def asimilarity_search(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to query."""
+
+        # This is a temporary workaround to make the similarity search
+        # asynchronous. The proper solution is to make the similarity search
+        # asynchronous in the vector store implementations.
+
+    @abstractmethod
+    def similarity_search_by_vector(
+        self, embedding: List[float], k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to embedding vector.
+
+        Args:
+            embedding: Embedding to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+
+        Returns:
+            List of Documents most similar to the query vector.
+        """
+
+    @abstractmethod
+    async def asimilarity_search_by_vector(
+        self, embedding: List[float], k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to embedding vector."""
+
+    @abstractmethod
+    def max_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs selected using the maximal marginal relevance.
+
+        Maximal marginal relevance optimizes for similarity to query AND diversity
+        among selected documents.
+
+        Args:
+            query: Text to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+            fetch_k: Number of Documents to fetch to pass to MMR algorithm.
+            lambda_mult: Number between 0 and 1 that determines the degree
+                        of diversity among the results with 0 corresponding
+                        to maximum diversity and 1 to minimum diversity.
+                        Defaults to 0.5.
+        Returns:
+            List of Documents selected by maximal marginal relevance.
+        """
+
+    @abstractmethod
+    async def amax_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs selected using the maximal marginal relevance."""
+
+    @abstractmethod
+    def max_marginal_relevance_search_by_vector(
+        self,
+        embedding: List[float],
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs selected using the maximal marginal relevance.
+
+        Maximal marginal relevance optimizes for similarity to query AND diversity
+        among selected documents.
+
+        Args:
+            embedding: Embedding to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+            fetch_k: Number of Documents to fetch to pass to MMR algorithm.
+            lambda_mult: Number between 0 and 1 that determines the degree
+                        of diversity among the results with 0 corresponding
+                        to maximum diversity and 1 to minimum diversity.
+                        Defaults to 0.5.
+        Returns:
+            List of Documents selected by maximal marginal relevance.
+        """
+
+    @abstractmethod
+    async def amax_marginal_relevance_search_by_vector(
+        self,
+        embedding: List[float],
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs selected using the maximal marginal relevance."""
+
+    @classmethod
+    @abstractmethod
+    def from_documents(
+        cls: Type[VST],
+        documents: List[Document],
+        embedding: Embeddings,
+        **kwargs: Any,
+    ) -> VST:
+        """Return VectorStore initialized from documents and embeddings."""
+
+    @classmethod
+    @abstractmethod
+    async def afrom_documents(
+        cls: Type[VST],
+        documents: List[Document],
+        embedding: Embeddings,
+        **kwargs: Any,
+    ) -> VST:
+        """Return VectorStore initialized from documents and embeddings."""
+
+    @classmethod
+    @abstractmethod
+    def from_texts(
+        cls: Type[VST],
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> VST:
+        """Return VectorStore initialized from texts and embeddings."""
+
+    @classmethod
+    @abstractmethod
+    async def afrom_texts(
+        cls: Type[VST],
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> VST:
+        """Return VectorStore initialized from texts and embeddings."""
+
+    @abstractmethod
+    def _get_retriever_tags(self) -> List[str]:
+        """Get tags for retriever."""
+
+    @abstractmethod
+    def as_retriever(self, **kwargs: Any) -> VectorStoreRetriever:
+        """Return VectorStoreRetriever initialized from this VectorStore.
+
+        Args:
+            search_type (Optional[str]): Defines the type of search that
+                the Retriever should perform.
+                Can be "similarity" (default), "mmr", or
+                "similarity_score_threshold".
+            search_kwargs (Optional[Dict]): Keyword arguments to pass to the
+                search function. Can include things like:
+                    k: Amount of documents to return (Default: 4)
+                    score_threshold: Minimum relevance threshold
+                        for similarity_score_threshold
+                    fetch_k: Amount of documents to pass to MMR algorithm (Default: 20)
+                    lambda_mult: Diversity of results returned by MMR;
+                        1 for minimum diversity and 0 for maximum. (Default: 0.5)
+                    filter: Filter by document metadata
+
+        Returns:
+            VectorStoreRetriever: Retriever class for VectorStore.
+
+        Examples:
+
+        .. code-block:: python
+
+            # Retrieve more documents with higher diversity
+            # Useful if your dataset has many similar documents
+            docsearch.as_retriever(
+                search_type="mmr",
+                search_kwargs={'k': 6, 'lambda_mult': 0.25}
+            )
+
+            # Fetch more documents for the MMR algorithm to consider
+            # But only return the top 5
+            docsearch.as_retriever(
+                search_type="mmr",
+                search_kwargs={'k': 5, 'fetch_k': 50}
+            )
+
+            # Only retrieve documents that have a relevance score
+            # Above a certain threshold
+            docsearch.as_retriever(
+                search_type="similarity_score_threshold",
+                search_kwargs={'score_threshold': 0.8}
+            )
+
+            # Only get the single most similar document from the dataset
+            docsearch.as_retriever(search_kwargs={'k': 1})
+
+            # Use a filter to only retrieve documents from a specific paper
+            docsearch.as_retriever(
+                search_kwargs={'filter': {'paper_title':'GPT-4 Technical Report'}}
+            )
+        """

--- a/libs/core/langchain_core/schema/vectorstore.py
+++ b/libs/core/langchain_core/schema/vectorstore.py
@@ -17,6 +17,8 @@ from langchain_core.vectorstores import VectorStoreRetriever
 VST = TypeVar("VST", bound="VectorStoreInterface")
 
 
+# TODO: this is a work in progress
+# TODO: there should be only essential methods and fields here.
 class VectorStoreInterface(ABC):
     """Interface for vector store."""
 
@@ -58,6 +60,7 @@ class VectorStoreInterface(ABC):
 
         raise NotImplementedError("delete method must be implemented by subclass.")
 
+    @abstractmethod
     async def adelete(
         self, ids: Optional[List[str]] = None, **kwargs: Any
     ) -> Optional[bool]:
@@ -92,9 +95,6 @@ class VectorStoreInterface(ABC):
             List[str]: List of IDs of the added texts.
         """
         # TODO: Handle the case where the user doesn't provide ids on the Collection
-        texts = [doc.page_content for doc in documents]
-        metadatas = [doc.metadata for doc in documents]
-        return self.add_texts(texts, metadatas, **kwargs)
 
     @abstractmethod
     async def aadd_documents(

--- a/libs/core/langchain_core/schema/vectorstore.py
+++ b/libs/core/langchain_core/schema/vectorstore.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Iterable,
@@ -11,11 +10,9 @@ from typing import (
     TypeVar,
 )
 
-if TYPE_CHECKING:
-    from langchain_core.documents import Document
-    from langchain_core.embeddings import Embeddings
-    from langchain_core.vectorstores import VectorStoreRetriever
-
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.vectorstores import VectorStoreRetriever
 
 VST = TypeVar("VST", bound="VectorStoreInterface")
 


### PR DESCRIPTION
Defined interfaces for base classes.
The idea is NOT to move Base classes at all. The idea is to extract pure interfaces and use them to help with integrations. The mandatory fields and functions should be clearly defined. The optional convenience functions should not be part of the Interface.
Some of the current Base classes are overloaded with helper functions, and it is not clear what is mandatory and what is optional without going deep into the implementations of Base classes. As time goes on, more and more convenience functions are added, and integration becomes more unnecessarily complex.
CC @baskaryan 
