### PR TITLE
removed deprecated openai model 

### DIFF
--- a/docs/docs/integrations/text_embedding/openai.ipynb
+++ b/docs/docs/integrations/text_embedding/openai.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = OpenAIEmbeddings(model=\"text-search-ada-doc-001\")"
+    "embeddings = OpenAIEmbeddings(model=\"text-embedding-ada-002\")"
    ]
   },
   {


### PR DESCRIPTION
removed the deprecated model from text embedding page of openai notebook and added the suggested model from openai page 


<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
