### PR TITLE
<langchain>: tracing_enabled incompatibility issue between core 0.1.5 and langchain v0.0.353

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -12,7 +12,7 @@ langchain-server = "langchain.server:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = ">=0.1.4,<0.2"
+langchain-core = ">=0.1.4,<0.1.5"
 langchain-community = ">=0.0.2,<0.1"
 pydantic = ">=1,<3"
 SQLAlchemy = ">=1.4,<3"


### PR DESCRIPTION
https://github.com/langchain-ai/langchain/issues/15526

TLDR:

In commit [7eec8f2](https://github.com/langchain-ai/langchain/commit/7eec8f24876fd624573c09ff82270362031e6a5f#) the function [tracing_enabled](https://github.com/langchain-ai/langchain/commit/7eec8f24876fd624573c09ff82270362031e6a5f#diff-aa3d4ef71b404ecd0d1198ccf778a3ccc605d9b6e043057d0db3bd8f7d9c483dL46) was deleted.

the function deletion was included in langchain-core [0.1.5](https://github.com/langchain-ai/langchain/pull/15480), and is being referred to by v0.0.353, which didn't clean up the dependencies yet, not until v0.0.354

Causing the retrievers API of v0.0.353 and some earlier versions to raise ImportError after Jan 3rd, when langchain-core 0.1.5 was released.