### PR TITLE
community: fix: should flush after inserting data on milvus

### DIFF
--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -528,6 +528,7 @@ class Milvus(VectorStore):
                     "Failed to insert batch starting at entity: %s/%s", i, total_count
                 )
                 raise e
+        self.col.flush()
         return pks
 
     def similarity_search(


### PR DESCRIPTION
The inserted data cannot take effect immediately. We should flush after inserting data on milvus.