### PR TITLE
Allow system message add to history

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -7,6 +7,7 @@ from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     HumanMessage,
+    SystemMessage,
     get_buffer_string,
 )
 

--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -43,7 +43,7 @@ class BaseChatMessageHistory(ABC):
     """A list of Messages stored in-memory."""
 
     def add_user_message(self, message: Union[HumanMessage, str]) -> None:
-        """Convenience method for adding a human message string to the store.
+        """Convenience method for adding a human message to the store.
 
         Args:
             message: The human message to add
@@ -54,7 +54,7 @@ class BaseChatMessageHistory(ABC):
             self.add_message(HumanMessage(content=message))
 
     def add_ai_message(self, message: Union[AIMessage, str]) -> None:
-        """Convenience method for adding an AI message string to the store.
+        """Convenience method for adding an AI message to the store.
 
         Args:
             message: The AI message to add.

--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -64,6 +64,17 @@ class BaseChatMessageHistory(ABC):
         else:
             self.add_message(AIMessage(content=message))
 
+    def add_system_message(self, message: Union[SystemMessage, str]) -> None:
+        """Convenience method for adding a system message to the store.
+
+        Args:
+            message: The system message to add.
+        """
+        if isinstance(message, SystemMessage):
+            self.add_message(message)
+        else:
+            self.add_message(SystemMessage(content=message))
+
     @abstractmethod
     def add_message(self, message: BaseMessage) -> None:
         """Add a Message object to the store.


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
## Description
This is a follow-up PR to https://github.com/langchain-ai/langchain/pull/14967 that added support for `AIMessage` and `HumanMessage` to `BaseChatMessageHistory.add_user_message` and `BaseChatMessageHistory.add_ai_message`. This extends that to include a `BaseChatMessageHistory.add_system_message` method with the same functionality. It also clarifies the docstrings of the other two methods.

## Dependencies
None

## Tag Maintainers
@hinthornw 
@eyurtsev 
@butlfrazp

## Note
I ran `make lint` and `make format` but `make test` results in `make: *** No rule to make target 'test'.  Stop.`.