### PR TITLE
community: Include PDF ID in MathPix metadata

### DIFF
--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -512,7 +512,7 @@ class MathpixPDFLoader(BasePDFLoader):
         contents = self.get_processed_pdf(pdf_id)
         if self.should_clean_pdf:
             contents = self.clean_pdf(contents)
-        metadata = {"source": self.source, "file_path": self.source}
+        metadata = {"source": self.source, "file_path": self.source, "pdf_id": pdf_id}
         return [Document(page_content=contents, metadata=metadata)]
 
 


### PR DESCRIPTION
  - **Description:** Includes the PDF ID in the MathPix document metadata. This is useful in case you need to re-request a processed PDF from the MathPix API later.