### PR TITLE
community: Fixed bug of "system message check" in chat_models/tongyi.

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -383,8 +383,10 @@ class ChatTongyi(BaseChatModel):
         system_message_indices = [
             i for i, m in enumerate(message_dicts) if m["role"] == "system"
         ]
-        if len(system_message_indices) != 1 or system_message_indices[0] != 0:
+        if len(system_message_indices) == 1 and system_message_indices[0] != 0:
             raise ValueError("System message can only be the first message.")
+        elif len(system_message_indices) > 1:
+            raise ValueError("There can be only one system message at most.")
 
         params["messages"] = message_dicts
 


### PR DESCRIPTION
  - **Description:** This PR is to fix a bug of "system message check" in langchain_community/ chat_models/tongyi.py
  - **Issue:** In term of current logic, if there's no system message in the chat messages, an error of "System message can only be the first message." will be wrongly raised.
  - **Dependencies:** No.
  - **Twitter handle:** I don't have a Twitter account.