### PR TITLE
community: Replaced hardcoded "metadata" with FIELDS_METADATA variable in semantic_hybrid_search_with_score_and_rerank

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -653,7 +653,10 @@ class AzureSearch(VectorStore):
                             if result.get("@search.captions")
                             else {},
                             "answers": semantic_answers_dict.get(
-                                json.loads(result["metadata"]).get("key"), ""
+                                json.loads(result[FIELDS_METADATA]).get("key")
+                                if FIELDS_METADATA in result
+                                else "",
+                                "",
                             ),
                         },
                     },


### PR DESCRIPTION
 - **Description:** This PR is to fix a bug in semantic_hybrid_search_with_score_and_rerank() function in langchain_community/vectorstores/azuresearch.py. The hardcoded "metadata" name is replaced with FIELDS_METADATA variable with an if block to check if the metadata column exists or not.
- **Issue:** Fixed #15581
- **Dependencies:** No
- **Twitter handle:** None