### PR TITLE
Move optional dependencies to the top, fix formatting

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -94,7 +94,7 @@ dashvector = {version = "^1.0.1", optional = true}
 sqlite-vss = {version = "^0.1.2", optional = true}
 motor = {version = "^3.3.1", optional = true}
 timescale-vector = {version = "^0.0.1", optional = true}
-typer = {version= "^0.9.0", optional = true}
+typer = {version = "^0.9.0", optional = true}
 anthropic = {version = "^0.3.11", optional = true}
 aiosqlite = {version = "^0.19.0", optional = true}
 rspace_client = {version = "^2.5.0", optional = true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -43,7 +43,7 @@ huggingface_hub = {version = "^0", optional = true}
 sentence-transformers = {version = "^2", optional = true}
 arxiv = {version = "^1.4", optional = true}
 pypdf = {version = "^3.4.0", optional = true}
-aleph-alpha-client = {version="^2.15.0", optional = true}
+aleph-alpha-client = {version = "^2.15.0", optional = true}
 pgvector = {version = "^0.1.6", optional = true}
 azure-identity = {version = "^1.12.0", optional = true}
 atlassian-python-api = {version = "^3.36.0", optional = true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -47,9 +47,9 @@ aleph-alpha-client = {version="^2.15.0", optional = true}
 pgvector = {version = "^0.1.6", optional = true}
 azure-identity = {version = "^1.12.0", optional=true}
 atlassian-python-api = {version = "^3.36.0", optional=true}
-html2text = {version="^2020.1.16", optional=true}
-numexpr = {version="^2.8.6", optional=true}
-azure-cosmos = {version="^4.4.0b1", optional=true}
+html2text = {version = "^2020.1.16", optional=true}
+numexpr = {version = "^2.8.6", optional=true}
+azure-cosmos = {version = "^4.4.0b1", optional=true}
 jq = {version = "^1.4.1", optional = true}
 pdfminer-six = {version = "^20221105", optional = true}
 docarray = {version="^0.32.0", extras=["hnswlib"], optional=true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -22,6 +22,9 @@ numpy = "^1"
 aiohttp = "^3.8.3"
 tenacity = "^8.1.0"
 jsonpatch = "^1.33"
+dataclasses-json = ">= 0.5.7,<0.7"
+langsmith = "~0.0.77"
+async-timeout = {version = "^4.0.0", python = "<3.11"}
 azure-core = {version = "^1.26.4", optional=true}
 tqdm = {version = ">=4.48.0", optional = true}
 openapi-pydantic = {version = "^0.3.2", optional = true}
@@ -33,7 +36,6 @@ torch = {version = ">=1,<3", optional = true}
 jinja2 = {version = "^3", optional = true}
 tiktoken = {version = ">=0.3.2,<0.6.0", optional = true, python=">=3.9"}
 qdrant-client = {version = "^1.3.1", optional = true, python = ">=3.8.1,<3.12"}
-dataclasses-json = ">= 0.5.7, < 0.7"
 cohere = {version = "^4", optional = true}
 openai = {version = "<2", optional = true}
 nlpcloud = {version = "^1", optional = true}
@@ -43,7 +45,6 @@ arxiv = {version = "^1.4", optional = true}
 pypdf = {version = "^3.4.0", optional = true}
 aleph-alpha-client = {version="^2.15.0", optional = true}
 pgvector = {version = "^0.1.6", optional = true}
-async-timeout = {version = "^4.0.0", python = "<3.11"}
 azure-identity = {version = "^1.12.0", optional=true}
 atlassian-python-api = {version = "^3.36.0", optional=true}
 html2text = {version="^2020.1.16", optional=true}
@@ -80,7 +81,6 @@ cassio = {version = "^0.1.0", optional = true}
 sympy = {version = "^1.12", optional = true}
 rapidfuzz = {version = "^3.1.1", optional = true}
 jsonschema = {version = ">1", optional = true}
-langsmith = "~0.0.77"
 rank-bm25 = {version = "^0.2.2", optional = true}
 geopandas = {version = "^0.13.1", optional = true}
 gitpython = {version = "^3.1.32", optional = true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -60,7 +60,7 @@ pypdfium2 = {version = "^4.10.0", optional = true}
 gql = {version = "^3.4.1", optional = true}
 pandas = {version = "^2.0.1", optional = true}
 telethon = {version = "^1.28.5", optional = true}
-chardet = {version="^5.1.0", optional = true}
+chardet = {version = "^5.1.0", optional = true}
 requests-toolbelt = {version = "^1.0.0", optional = true}
 openlm = {version = "^0.0.5", optional = true}
 scikit-learn = {version = "^1.2.2", optional = true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -25,7 +25,7 @@ jsonpatch = "^1.33"
 dataclasses-json = ">= 0.5.7,<0.7"
 langsmith = "~0.0.77"
 async-timeout = {version = "^4.0.0", python = "<3.11"}
-azure-core = {version = "^1.26.4", optional=true}
+azure-core = {version = "^1.26.4", optional = true}
 tqdm = {version = ">=4.48.0", optional = true}
 openapi-pydantic = {version = "^0.3.2", optional = true}
 faiss-cpu = {version = "^1", optional = true}
@@ -45,14 +45,14 @@ arxiv = {version = "^1.4", optional = true}
 pypdf = {version = "^3.4.0", optional = true}
 aleph-alpha-client = {version="^2.15.0", optional = true}
 pgvector = {version = "^0.1.6", optional = true}
-azure-identity = {version = "^1.12.0", optional=true}
-atlassian-python-api = {version = "^3.36.0", optional=true}
-html2text = {version = "^2020.1.16", optional=true}
-numexpr = {version = "^2.8.6", optional=true}
-azure-cosmos = {version = "^4.4.0b1", optional=true}
+azure-identity = {version = "^1.12.0", optional = true}
+atlassian-python-api = {version = "^3.36.0", optional = true}
+html2text = {version = "^2020.1.16", optional = true}
+numexpr = {version = "^2.8.6", optional = true}
+azure-cosmos = {version = "^4.4.0b1", optional = true}
 jq = {version = "^1.4.1", optional = true}
 pdfminer-six = {version = "^20221105", optional = true}
-docarray = {version="^0.32.0", extras=["hnswlib"], optional=true}
+docarray = {version="^0.32.0", extras=["hnswlib"], optional = true}
 lxml = {version = "^4.9.2", optional = true}
 pymupdf = {version = "^1.22.3", optional = true}
 rapidocr-onnxruntime = {version = "^1.3.2", optional = true, python = ">=3.8.1,<3.12"}
@@ -60,7 +60,7 @@ pypdfium2 = {version = "^4.10.0", optional = true}
 gql = {version = "^3.4.1", optional = true}
 pandas = {version = "^2.0.1", optional = true}
 telethon = {version = "^1.28.5", optional = true}
-chardet = {version="^5.1.0", optional=true}
+chardet = {version="^5.1.0", optional = true}
 requests-toolbelt = {version = "^1.0.0", optional = true}
 openlm = {version = "^0.0.5", optional = true}
 scikit-learn = {version = "^1.2.2", optional = true}


### PR DESCRIPTION
This makes the pyproject.toml easier to read for repackaging like conda-forge.