### PR TITLE
Docs: Add missing import of 'ConfigurableField' in 'Full code comparison' example in LCEL

### DIFF
--- a/docs/docs/expression_language/why.ipynb
+++ b/docs/docs/expression_language/why.ipynb
@@ -1007,7 +1007,7 @@
     "from langchain_openai import OpenAI\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",
-    "from langchain_core.runnables import RunnablePassthrough\n",
+    "from langchain_core.runnables import RunnablePassthrough, ConfigurableField\n",
     "\n",
     "os.environ[\"LANGCHAIN_API_KEY\"] = \"...\"\n",
     "os.environ[\"LANGCHAIN_TRACING_V2\"] = \"true\"\n",


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** Add missing import of 'ConfigurableField' in 'Full code comparison' example in LCEL
  - **Issue:** Example code not running
  - **Dependencies:** None
  - **Twitter handle:** @heyyoshan