### PR TITLE
community: Allow including vectors with text missing for Pinecone

### DIFF
--- a/docs/docs/integrations/vectorstores/pinecone.ipynb
+++ b/docs/docs/integrations/vectorstores/pinecone.ipynb
@@ -212,6 +212,31 @@
     "for i, doc in enumerate(found_docs):\n",
     "    print(f\"{i + 1}.\", doc.page_content, \"\\n\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0716424c",
+   "metadata": {},
+   "source": [
+    "### Including Documents with Missing Text Key\n",
+    "\n",
+    "By default, Pinecone only returns documents that have page contents (i.e., there is a metadata field on the vector that matches the provided `text_key`). If you want to fetch the similarity scores for vectors that are missing the page contents, you can set `include_text_missing=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fba7e6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vectorstore = Pinecone.from_existing_index(\n",
+    "    index_name, embeddings, text_key=\"non-matching-text-key\", include_text_missing=True\n",
+    ")\n",
+    "query = \"What did the president tell the Chinese president?\"\n",
+    "docs_and_scores = vectorstore.similarity_search_with_score(query)\n",
+    "print(docs_and_scores[0][1])"
+   ]
   }
  ],
  "metadata": {
@@ -230,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
  - **Description:** 
  This PR adds the option to include vectors that don't have page content. Currently, any such vectors will be skipped. This change can be useful when you're only concerned about the similarity score and not the page content. I'm a contributor to [Rebuff](https://github.com/protectai/rebuff), and we are working on adding a standalone Python SDK. When we query Pinecone, we only need the vector scores. Currently with Langchain, if a Rebuff user sets up their Pinecone database without a metadata field named `"text"`, they will not receive any vector scores when querying Pinecone. With this PR, it won't matter the name of the metadata field used for page content.
For what it's worth, langchain-js does not skip vectors when the page content cannot be found: [pinecone.ts](https://github.com/langchain-ai/langchainjs/blob/8154c7829fc930a5b4060e830d06cbdd3e9484c4/libs/langchain-community/src/vectorstores/pinecone.ts#L230-L234).
I didn't update the Pinecone integration tests because I could not get the tests to pass (even before my changes). They were repeatedly failing because Pinecone is eventually consistent and the tests were assuming the changes would be applied immediately. 
  - **Issue:** N/A
  - **Dependencies:** No changes needed
