### PR TITLE
community: fix myscale delete function bug

### DIFF
--- a/libs/community/langchain_community/vectorstores/myscale.py
+++ b/libs/community/langchain_community/vectorstores/myscale.py
@@ -470,7 +470,7 @@ class MyScale(VectorStore):
             ids is None and where_str is None
         ), "You need to specify where to be deleted! Either with `ids` or `where_str`"
         conds = []
-        if ids:
+        if ids and len(ids) > 0:
             id_list = ", ".join([f"'{id}'" for id in ids])
             conds.append(f"{self.config.column_map['id']} IN ({id_list})")
         if where_str:

--- a/libs/community/langchain_community/vectorstores/myscale.py
+++ b/libs/community/langchain_community/vectorstores/myscale.py
@@ -471,7 +471,8 @@ class MyScale(VectorStore):
         ), "You need to specify where to be deleted! Either with `ids` or `where_str`"
         conds = []
         if ids:
-            conds.extend([f"{self.config.column_map['id']} = '{id}'" for id in ids])
+            id_list = ", ".join([f"'{id}'" for id in ids])
+            conds.append(f"{self.config.column_map['id']} IN ({id_list})")
         if where_str:
             conds.append(where_str)
         assert len(conds) > 0


### PR DESCRIPTION
Now the SQL used to delete vector doc from myscale is as follow:
```sql
DELETE FROM collection WHERE id = '1' AND id = '2' AND id = '3'
```

But the expected one should be 

```sql
DELETE FROM collection WHERE id IN ('1', '2', '3')
```