### PR TITLE
core(minor): Add a way to print out system information for debugging purposes.

### DIFF
--- a/libs/core/langchain_core/__init__.py
+++ b/libs/core/langchain_core/__init__.py
@@ -1,5 +1,4 @@
 from importlib import metadata
-from typing import Sequence
 
 from langchain_core._api import (
     surface_langchain_beta_warnings,
@@ -14,54 +13,3 @@ except metadata.PackageNotFoundError:
 
 surface_langchain_deprecation_warnings()
 surface_langchain_beta_warnings()
-
-
-def print_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
-    """Print information about the environment for debugging purposes."""
-    import importlib
-    import platform
-    import sys
-
-    packages = [
-        "langchain_core",
-        "langchain",
-        "langchain_community",
-    ] + list(additional_pkgs)
-
-    system_info = {
-        "OS": platform.system(),
-        "OS Version": platform.version(),
-        "Python Version": sys.version,
-    }
-
-    print("System Information")
-    print("------------------")
-    print("OS: ", system_info["OS"])
-    print("OS Version: ", system_info["OS Version"])
-    print("Python Version: ", system_info["Python Version"])
-
-    # Print out only langchain packages
-    print()
-    print("Package Information")
-    print("-------------------")
-
-    for pkg in packages:
-        try:
-            found_package = importlib.util.find_spec(pkg)
-        except Exception:
-            found_package = None
-        if found_package is None:
-            print(f"{pkg}: Not Found")
-            continue
-
-        # Package version
-        try:
-            package_version = importlib.metadata.version(pkg)
-        except Exception:
-            package_version = None
-
-        # Print package with version
-        if package_version is not None:
-            print(f"{pkg}: {package_version}")
-        else:
-            print(f"{pkg}: Found")

--- a/libs/core/langchain_core/sys_info.py
+++ b/libs/core/langchain_core/sys_info.py
@@ -1,22 +1,8 @@
-from importlib import metadata
+"""Print information about the system and langchain packages for debugging purposes."""
 from typing import Sequence
 
-from langchain_core._api import (
-    surface_langchain_beta_warnings,
-    surface_langchain_deprecation_warnings,
-)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-
-surface_langchain_deprecation_warnings()
-surface_langchain_beta_warnings()
-
-
-def print_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
+def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
     """Print information about the environment for debugging purposes."""
     import importlib
     import platform
@@ -33,12 +19,12 @@ def print_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
         "OS Version": platform.version(),
         "Python Version": sys.version,
     }
-
+    print()
     print("System Information")
     print("------------------")
-    print("OS: ", system_info["OS"])
-    print("OS Version: ", system_info["OS Version"])
-    print("Python Version: ", system_info["Python Version"])
+    print("> OS: ", system_info["OS"])
+    print("> OS Version: ", system_info["OS Version"])
+    print("> Python Version: ", system_info["Python Version"])
 
     # Print out only langchain packages
     print()
@@ -51,7 +37,7 @@ def print_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
         except Exception:
             found_package = None
         if found_package is None:
-            print(f"{pkg}: Not Found")
+            print(f"> {pkg}: Not Found")
             continue
 
         # Package version
@@ -62,6 +48,10 @@ def print_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
 
         # Print package with version
         if package_version is not None:
-            print(f"{pkg}: {package_version}")
+            print(f"> {pkg}: {package_version}")
         else:
-            print(f"{pkg}: Found")
+            print(f"> {pkg}: Found")
+
+
+if __name__ == "__main__":
+    print_sys_info()

--- a/libs/core/langchain_core/sys_info.py
+++ b/libs/core/langchain_core/sys_info.py
@@ -4,9 +4,9 @@ from typing import Sequence
 
 def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
     """Print information about the environment for debugging purposes."""
-    import importlib
     import platform
     import sys
+    from importlib import metadata, util
 
     packages = [
         "langchain_core",
@@ -34,7 +34,7 @@ def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
 
     for pkg in packages:
         try:
-            found_package = importlib.util.find_spec(pkg)
+            found_package = util.find_spec(pkg)
         except Exception:
             found_package = None
         if found_package is None:
@@ -43,7 +43,7 @@ def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
 
         # Package version
         try:
-            package_version = importlib.metadata.version(pkg)
+            package_version = metadata.version(pkg)
         except Exception:
             package_version = None
 

--- a/libs/core/langchain_core/sys_info.py
+++ b/libs/core/langchain_core/sys_info.py
@@ -12,6 +12,7 @@ def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
         "langchain_core",
         "langchain",
         "langchain_community",
+        "langserve",
     ] + list(additional_pkgs)
 
     system_info = {

--- a/libs/core/tests/unit_tests/test_sys_info.py
+++ b/libs/core/tests/unit_tests/test_sys_info.py
@@ -1,0 +1,6 @@
+from langchain_core.sys_info import print_sys_info
+
+
+def test_print_sys_info() -> None:
+    """Super simple test to that no exceptions are triggered when calling code."""
+    print_sys_info()


### PR DESCRIPTION
To use: 

```bash
python -m langchain_core.sys_info
```