### PR TITLE
core[patch]: Replace beta decorator with warning on init to avoid breaking type annotations

### DIFF
--- a/libs/core/langchain_core/beta/runnables/context.py
+++ b/libs/core/langchain_core/beta/runnables/context.py
@@ -18,7 +18,7 @@ from typing import (
     Union,
 )
 
-from langchain_core._api.beta_decorator import beta
+from langchain_core._api.beta_decorator import warn_beta
 from langchain_core.runnables.base import (
     Runnable,
     RunnableSerializable,
@@ -157,7 +157,6 @@ def config_with_context(
     return _config_with_context(config, steps, _setter, _getter, threading.Event)
 
 
-@beta()
 class ContextGet(RunnableSerializable):
     """Get a context value."""
 
@@ -221,7 +220,6 @@ def _coerce_set_value(value: SetValue) -> Runnable[Input, Output]:
     return coerce_to_runnable(value)
 
 
-@beta()
 class ContextSet(RunnableSerializable):
     """Set a context value."""
 
@@ -239,6 +237,13 @@ class ContextSet(RunnableSerializable):
         prefix: str = "",
         **kwargs: SetValue,
     ):
+        warn_beta(
+            message=(
+                "ContextSet and ContextGet are in beta. The API of these features "
+                "may change in the future."
+            ),
+        )
+
         if key is not None:
             kwargs[key] = value
         super().__init__(


### PR DESCRIPTION
Replace beta decorator with warning on init to avoid breaking type annotations