### PR TITLE
Make packages optional

### DIFF
--- a/libs/cli/langchain_cli/project_template/Dockerfile
+++ b/libs/cli/langchain_cli/project_template/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /code
 
 COPY ./pyproject.toml ./README.md ./poetry.lock* ./
 
-COPY ./packages ./packages
+COPY ./package[s] ./packages
 
 RUN poetry install  --no-interaction --no-ansi --no-root
 


### PR DESCRIPTION
So we don't have to instruct people to modify the Dockerfile every time they delete the packages directory.


See: https://stackoverflow.com/questions/70096208/dockerfile-copy-folder-if-it-exists-conditional-copy/70096420#70096420

Tested on a new repo