### PR TITLE
community: Fix String-List Comparison Bug in AzureAIDocumentIntelligenceParser

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/doc_intelligence.py
+++ b/libs/community/langchain_community/document_loaders/parsers/doc_intelligence.py
@@ -98,7 +98,7 @@ class AzureAIDocumentIntelligenceParser(BaseBlobParser):
 
             if self.mode in ["single", "markdown"]:
                 yield from self._generate_docs_single(result)
-            elif self.mode == ["page"]:
+            elif self.mode == "page":
                 yield from self._generate_docs_page(result)
             else:
                 yield from self._generate_docs_object(result)
@@ -116,7 +116,7 @@ class AzureAIDocumentIntelligenceParser(BaseBlobParser):
 
         if self.mode in ["single", "markdown"]:
             yield from self._generate_docs_single(result)
-        elif self.mode == ["page"]:
+        elif self.mode == "page":
             yield from self._generate_docs_page(result)
         else:
             yield from self._generate_docs_object(result)


### PR DESCRIPTION
This pull request addresses a bug found in `AzureAIDocumentIntelligenceParser` where a string was incorrectly being compared to a list. 

The code currently uses the expression `self.mode == ["page"]` to check which mode the user has selected. In Python, this comparison is always `False` (self.mode is asserted to be str in line 35), thus the if-statement would always result in the execution of `_generate_docs_object` instead of `_generate_docs_page`.

The fix is to remove the brackets resulting in a correct comparison.
