### PR TITLE
community: Handle HuggingFaceInferenceAPI failure response of POST request

### DIFF
--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -329,6 +329,11 @@ class HuggingFaceInferenceAPIEmbeddings(BaseModel, Embeddings):
                 "options": {"wait_for_model": True, "use_cache": True},
             },
         )
+        if response.status_code != 200:
+            raise Exception(
+                f"HuggingFaceInferenceAPI returned an unexpected response with status "
+                f"{response.status_code}: {response.text}"
+            )
         return response.json()
 
     def embed_query(self, text: str) -> List[float]:


### PR DESCRIPTION
  - **Description:** 
 Currently the embed_documents() function of HuggingFaceInferenceAPIEmbeddings class posts a request to HuggingFaceInference API to generate text embeddings. The POST request may not always return successful response due to various technical glitches. This PR handles the event when the status code of the response returned by HuggingFaceInference API is not 200 and raises an exception for this event.

  - **Dependencies:** None
  - **Twitter handle:** None