### PR TITLE
feat(community): make Amadeus toolkit LLM-agnostic

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/amadeus/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/amadeus/toolkit.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
+from langchain_core.language_models import BaseLanguageModel
 from langchain_core.pydantic_v1 import Field
 
 from langchain_community.agent_toolkits.base import BaseToolkit
@@ -18,6 +19,7 @@ class AmadeusToolkit(BaseToolkit):
     """Toolkit for interacting with Amadeus which offers APIs for travel."""
 
     client: Client = Field(default_factory=authenticate)
+    llm: Optional[BaseLanguageModel] = Field(default=None)
 
     class Config:
         """Pydantic config."""
@@ -27,6 +29,6 @@ class AmadeusToolkit(BaseToolkit):
     def get_tools(self) -> List[BaseTool]:
         """Get the tools in the toolkit."""
         return [
-            AmadeusClosestAirport(),
+            AmadeusClosestAirport(llm=self.llm),
             AmadeusFlightSearch(),
         ]

--- a/libs/community/langchain_community/tools/amadeus/closest_airport.py
+++ b/libs/community/langchain_community/tools/amadeus/closest_airport.py
@@ -1,6 +1,5 @@
-from typing import Dict, Optional, Type
+from typing import Any, Dict, Optional, Type
 
-from black import Any
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.pydantic_v1 import BaseModel, Field, root_validator

--- a/libs/community/langchain_community/tools/amadeus/closest_airport.py
+++ b/libs/community/langchain_community/tools/amadeus/closest_airport.py
@@ -36,7 +36,9 @@ class AmadeusClosestAirport(AmadeusBaseTool):
         "Use this tool to find the closest airport to a particular location."
     )
     args_schema: Type[ClosestAirportSchema] = ClosestAirportSchema
+
     llm: Optional[BaseLanguageModel] = Field(default=None)
+    """Tool's llm used for calculating the closest airport. Defaults to `ChatOpenAI`."""
 
     @root_validator(pre=True)
     def set_llm(cls, values: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
 - **Description:** `AmadeusToolkit` and `AmadeusClosestAirport` contained a hardcoded call to `ChatOpenAI`. This PR makes it LLM-independent, while guaranteeing backward compatibility.
  - **Issue:** #15847 
  - **Dependencies:** None
   
@baskaryan 

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
