### PR TITLE
Docs[patch]: Add info admonitions to a few agents

### DIFF
--- a/docs/docs/modules/agents/agent_types/structured_chat.ipynb
+++ b/docs/docs/modules/agents/agent_types/structured_chat.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Structured chat\n",
     "\n",
-    "The structured chat agent is capable of using multi-input tools.\n"
+    "The structured chat agent is capable of using multi-input tools."
    ]
   },
   {
@@ -237,7 +237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/docs/modules/agents/agent_types/xml_agent.ipynb
+++ b/docs/docs/modules/agents/agent_types/xml_agent.ipynb
@@ -17,7 +17,14 @@
    "source": [
     "# XML Agent\n",
     "\n",
-    "Some language models (like Anthropic's Claude) are particularly good at reasoning/writing XML. This goes over how to use an agent that uses XML when prompting. "
+    "Some language models (like Anthropic's Claude) are particularly good at reasoning/writing XML. This goes over how to use an agent that uses XML when prompting. \n",
+    "\n",
+    ":::tip\n",
+    "\n",
+    "* Use with regular LLMs, not with chat models.\n",
+    "* Use only with unstructured tools; i.e., tools that accept a single string input.\n",
+    "* See [AgentTypes](../) documentation for more agent types.\n",
+    ":::"
    ]
   },
   {
@@ -217,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/docs/modules/agents/agent_types/xml_agent.ipynb
+++ b/docs/docs/modules/agents/agent_types/xml_agent.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "* Use with regular LLMs, not with chat models.\n",
     "* Use only with unstructured tools; i.e., tools that accept a single string input.\n",
-    "* See [AgentTypes](../) documentation for more agent types.\n",
+    "* See [AgentTypes](../index) documentation for more agent types.\n",
     ":::"
    ]
   },


### PR DESCRIPTION
Add admonitions directly in the agent page to explain constraints and include a
link to agent types.
