### PR TITLE
langchain: fix OutputParserException (#15914)

### DIFF
--- a/libs/langchain/langchain/chains/query_constructor/base.py
+++ b/libs/langchain/langchain/chains/query_constructor/base.py
@@ -48,7 +48,7 @@ class StructuredQueryOutputParser(BaseOutputParser[StructuredQuery]):
             expected_keys = ["query", "filter"]
             allowed_keys = ["query", "filter", "limit"]
             parsed = parse_and_check_json_markdown(text, expected_keys)
-            if len(parsed["query"]) == 0:
+            if parsed["query"] is None or len(parsed["query"]) == 0:
                 parsed["query"] = " "
             if parsed["filter"] == "NO_FILTER" or not parsed["filter"]:
                 parsed["filter"] = None


### PR DESCRIPTION
**Description:**

Fixes OutputParserException thrown by the output_parser when 'query' is 'Null'.

Replace this entire comment with:
  - **Description:** Current implentation of output_parser throws OutputParserException if the response from the LLM contains `query: null`. This unfortunately happens for my use case. And since there is no way to modify the prompt used in SelfQueryRetriever, then we have to fix it here, so it doesn't crash. 
  - **Issue:** https://github.com/langchain-ai/langchain/issues/15914

Didn't run tests. `make test` is not working. There is no `test` rule in the `Makefile`.