### PR TITLE
<langchain_community.vectorstores>:<Fix pinecone.py __init__ docsrting instruction>

### DIFF
--- a/libs/community/langchain_community/vectorstores/pinecone.py
+++ b/libs/community/langchain_community/vectorstores/pinecone.py
@@ -58,7 +58,7 @@ class Pinecone(VectorStore):
             pinecone.init(api_key="***", environment="...")
             index = pinecone.Index("langchain-demo")
             embeddings = OpenAIEmbeddings()
-            vectorstore = Pinecone(index, embeddings.embed_query, "text")
+            vectorstore = Pinecone(index, embeddings, "text")
     """
 
     def __init__(


### PR DESCRIPTION
  - **Description:** The pinecone docstring instructs to pass the embedding query text causing the warning below. It should be the embeddings object.
 warning message: UserWarning: Passing in `embedding` as a Callable is deprecated. Please pass in an Embeddings object instead.
  - **Issue:** NA
  - **Dependencies:** None


@baskaryan


