### PR TITLE
docs: Update Robocorp Action Server installation instructions

### DIFF
--- a/docs/docs/integrations/providers/robocorp.mdx
+++ b/docs/docs/integrations/providers/robocorp.mdx
@@ -5,13 +5,15 @@
 
 ## Installation and Setup
 
-You need to install `langchain-robocorp` python package, as well as the `robocorp-action-server` package to run the action server locally.
+You need to install `langchain-robocorp` python package:
 
 ```bash
-pip install langchain-robocorp robocorp-action-server
+pip install langchain-robocorp
 ```
 
-You will need a running instance of Action Server to communicate with from your agent application. You can bootstrap a new project using Action Server `new` command.
+You will need a running instance of Action Server  to communicate with from your agent application. See the [Robocorp Quickstart](https://github.com/robocorp/robocorp#quickstart) on how to setup Action Server and create your Actions.
+
+You can bootstrap a new project using Action Server `new` command.
 
 ```bash
 action-server new

--- a/docs/docs/integrations/toolkits/robocorp.ipynb
+++ b/docs/docs/integrations/toolkits/robocorp.ipynb
@@ -7,9 +7,13 @@
    "source": [
     "# Robocorp\n",
     "\n",
-    "This notebook covers how to get started with [Robocorp Action Server](https://github.com/robocorp/robo/tree/master/action_server/docs) action toolkit and LangChain.\n",
+    "This notebook covers how to get started with [Robocorp Action Server](https://github.com/robocorp/robocorp) action toolkit and LangChain.\n",
     "\n",
-    "## Installation"
+    "## Installation\n",
+    "\n",
+    "First, see the [Robocorp Quickstart](https://github.com/robocorp/robocorp#quickstart) on how to setup Action Server and create your Actions.\n",
+    "\n",
+    "In your LangChain application, install the `langchain-robocorp` package: "
    ]
   },
   {
@@ -19,24 +23,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install package and Action Server\n",
-    "%pip install --upgrade --quiet langchain-robocorp robocorp-action-server"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8e2ca5c5",
-   "metadata": {},
-   "source": [
-    "## Action Server setup\n",
-    "\n",
-    "You will need a running instance of Action Server to communicate with from your agent application. You can bootstrap a new project using Action Server `new` command.\n",
-    "\n",
-    "```bash\n",
-    "!action-server new\n",
-    "cd ./your-project-name\n",
-    "action-server start\n",
-    "```\n"
+    "# Install package\n",
+    "%pip install --upgrade --quiet langchain-robocorp"
    ]
   },
   {


### PR DESCRIPTION
**Description:**

Remove section on how to install Action Server and direct the users t o the instructions on Robocorp repository.

**Reason:**

Robocorp Action Server has moved from a pip installation to a standalone cli application and is due for changes. Because of that, leaving only LangChain integration relevant part in the documentation.