### PR TITLE
community: fix the "page" mode in the AzureAIDocumentIntelligenceParser (bug)

### DIFF
--- a/libs/community/langchain_community/document_loaders/doc_intelligence.py
+++ b/libs/community/langchain_community/document_loaders/doc_intelligence.py
@@ -48,6 +48,8 @@ class AzureAIDocumentIntelligenceLoader(BaseLoader):
             the default value from SDK.
         api_model: str
             The model name or ID to be used for form recognition in Azure.
+        mode: Optional[str]
+            The type of content representation of the generated Documents.
 
         Examples:
         ---------
@@ -56,7 +58,8 @@ class AzureAIDocumentIntelligenceLoader(BaseLoader):
         ...     api_endpoint="https://endpoint.azure.com",
         ...     api_key="APIKEY",
         ...     api_version="2023-10-31-preview",
-        ...     model="prebuilt-document"
+        ...     model="prebuilt-document",
+        ...     mode="markdown"
         ... )
         """
 

--- a/libs/community/langchain_community/document_loaders/parsers/doc_intelligence.py
+++ b/libs/community/langchain_community/document_loaders/parsers/doc_intelligence.py
@@ -98,7 +98,7 @@ class AzureAIDocumentIntelligenceParser(BaseBlobParser):
 
             if self.mode in ["single", "markdown"]:
                 yield from self._generate_docs_single(result)
-            elif self.mode == ["page"]:
+            elif self.mode in ["page"]:
                 yield from self._generate_docs_page(result)
             else:
                 yield from self._generate_docs_object(result)
@@ -116,7 +116,7 @@ class AzureAIDocumentIntelligenceParser(BaseBlobParser):
 
         if self.mode in ["single", "markdown"]:
             yield from self._generate_docs_single(result)
-        elif self.mode == ["page"]:
+        elif self.mode in ["page"]:
             yield from self._generate_docs_page(result)
         else:
             yield from self._generate_docs_object(result)


### PR DESCRIPTION
**Description**: the "page" mode in the AzureAIDocumentIntelligenceParser is not accessible due to a wrong membership test. The mode argument can only be a string (also see the assertion in the `__init__`:  `assert self.mode in ["single", "page", "object", "markdown"]`, so the check `elif self.mode == ["page"]:` always fails. 
As a result, effectively the "object" mode is used when selecting the "page" mode, which may lead to errors.

The docstring of the `AzureAIDocumentIntelligenceLoader` also ommitted the `mode` parameter alltogether, so I added it.

**Issue**: I could not find a related issue (this class is only 3 weeks old anyways)

**Dependencies**: this PR does not introduce or affect dependencies.

The current demo notebook and examples are not affected because they all use the default markdown mode.
