### PR TITLE
community : Fixed 'coroutine' object is not subscriptable error

### DIFF
--- a/libs/community/langchain_community/embeddings/huggingface_hub.py
+++ b/libs/community/langchain_community/embeddings/huggingface_hub.py
@@ -144,5 +144,5 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
         Returns:
             Embeddings for the text.
         """
-        response = await self.aembed_documents([text])[0]
+        response = (await self.aembed_documents([text]))[0]
         return response


### PR DESCRIPTION

  - **Description:** Added parenthesis in return statement of aembed_query() funtion to fix 'coroutine' object is not subscriptable error.
  - **Dependencies:** NA
