### PR TITLE
docs: fix typo in inspect runnables docs

### DIFF
--- a/docs/docs/expression_language/how_to/inspect.ipynb
+++ b/docs/docs/expression_language/how_to/inspect.ipynb
@@ -177,7 +177,7 @@
    "source": [
     "## Get the prompts\n",
     "\n",
-    "An important part of every chain is the prompts that are used. You can get the graphs present in the chain:"
+    "An important part of every chain is the prompts that are used. You can get the prompts present in the chain:"
    ]
   },
   {


### PR DESCRIPTION
  - **Description:** Fixing a typo related to prompts in the inspecting runnables docs 