### PR TITLE
community: implement adelete from VectorStore in Qdrant

### DIFF
--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1138,8 +1138,7 @@ class Qdrant(VectorStore):
             **kwargs: Other keyword arguments that subclasses might use.
 
         Returns:
-            Optional[bool]: True if deletion is successful,
-            False otherwise, None if not implemented.
+            True if deletion is successful, False otherwise.
         """
         from qdrant_client.http import models as rest
 
@@ -1147,6 +1146,35 @@ class Qdrant(VectorStore):
             collection_name=self.collection_name,
             points_selector=ids,
         )
+        return result.status == rest.UpdateStatus.COMPLETED
+    
+    @sync_call_fallback
+    async def adelete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+        """Delete by vector ID or other criteria.
+
+        Args:
+            ids: List of ids to delete.
+            **kwargs: Other keyword arguments that subclasses might use.
+
+        Returns:
+            True if deletion is successful, False otherwise.
+        """
+        from qdrant_client.local.async_qdrant_local import AsyncQdrantLocal
+
+        if self.async_client is None or isinstance(
+            self.async_client._client, AsyncQdrantLocal
+        ):
+            raise NotImplementedError(
+                "QdrantLocal cannot interoperate with sync and async clients"
+            )
+
+        from qdrant_client.http import models as rest
+
+        result = await self.async_client.delete(
+            collection_name=self.collection_name,
+            points_selector=ids,
+        )
+
         return result.status == rest.UpdateStatus.COMPLETED
 
     @classmethod

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1147,9 +1147,11 @@ class Qdrant(VectorStore):
             points_selector=ids,
         )
         return result.status == rest.UpdateStatus.COMPLETED
-    
+
     @sync_call_fallback
-    async def adelete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+    async def adelete(
+        self, ids: Optional[List[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
         """Delete by vector ID or other criteria.
 
         Args:


### PR DESCRIPTION
**Description:**
Implement `adelete` function from `VectorStore` in `Qdrant` to support other asynchronous flows such as async indexing (`aindex`) which requires `adelete` to be implemented. Since `Qdrant` can be passed an async qdrant client, this can be supported easily.

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
