### PR TITLE
langchain: Indexing with `ParentDocumentRetriever`

### DIFF
--- a/docs/docs/modules/data_connection/retrievers/parent_document_retriever.ipynb
+++ b/docs/docs/modules/data_connection/retrievers/parent_document_retriever.ipynb
@@ -216,6 +216,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7cd73544",
+   "metadata": {},
+   "source": [
+    "You may use different text splitting strategies per document, rather than just using one for all documents. In that case, you can instead provide a list of text splitters when adding documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34608183",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.text_splitter import MarkdownHeaderTextSplitter\n",
+    "\n",
+    "splitters = [RecursiveCharacterTextSplitter(chunk_size=400), MarkdownHeaderTextSplitter(\"#\", \"##\", \"###\")]\n",
+    "retriever.add_documents(docs, ids=None, child_splitters=splitters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "14f813a5",
    "metadata": {},
    "source": [
@@ -405,6 +426,49 @@
    ],
    "source": [
     "print(retrieved_docs[0].page_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad8be1b8",
+   "metadata": {},
+   "source": [
+    "## Usage with indexing\n",
+    "\n",
+    "You may want to use [indexing](../indexing.ipynb) along with `ParentDocumentRetriever`, but since `ParentDocumentRetriver` handles storage to the vector store for you, you don't have an opportunity to call `index` instead of `vectorstore.add_documents`.\n",
+    "\n",
+    "Instead, you can provide the arguments you *would* provide to `index` in the `index_args` argument when constructing a `ParentDocumentRetriver`. This does two things:\n",
+    "\n",
+    "1. Ensures that `index` is used when persisting to the vector store.\n",
+    "2. Injects those arguments into the call to `index`.\n",
+    "\n",
+    "Note that you don't need to provide arguments for `docs_source` and `vector_store`; these injected automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1faed43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.indexes import SQLRecordManager\n",
+    "\n",
+    "record_manager = SQLRecordManager(\n",
+    "    \"text_index\", db_url=\"sqlite:///record_manager_cache.sql\"\n",
+    ")\n",
+    "\n",
+    "retriver = ParentDocumentRetriever(\n",
+    "    vectorstore=vectorstore,\n",
+    "    docstore=store,\n",
+    "    child_splitter=child_splitter,\n",
+    "    parent_splitter=parent_splitter,\n",
+    "    index_args=dict(\n",
+    "        record_manager=record_manager,\n",
+    "        cleanup=\"incremental\",\n",
+    "        source_id_key=\"source\",\n",
+    "    ),\n",
+    ")"
    ]
   }
  ],

--- a/libs/langchain/tests/unit_tests/retrievers/test_parent_document.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_parent_document.py
@@ -1,7 +1,9 @@
+import unittest
 from typing import Any, List, Sequence
 
 from langchain_core.documents import Document
 
+from langchain.indexes import SQLRecordManager
 from langchain.retrievers import ParentDocumentRetriever
 from langchain.storage import InMemoryStore
 from langchain.text_splitter import CharacterTextSplitter
@@ -24,17 +26,73 @@ class InMemoryVectorstoreWithSearch(InMemoryVectorStore):
         )
 
 
-def test_parent_document_retriever_initialization() -> None:
-    vectorstore = InMemoryVectorstoreWithSearch()
-    store = InMemoryStore()
-    child_splitter = CharacterTextSplitter(chunk_size=400)
-    documents = [Document(page_content="test document")]
-    retriever = ParentDocumentRetriever(
-        vectorstore=vectorstore,
-        docstore=store,
-        child_splitter=child_splitter,
-    )
-    retriever.add_documents(documents)
-    results = retriever.invoke("0")
-    assert len(results) > 0
-    assert results[0].page_content == "test document"
+class ParentDocumentRetrieverTests(unittest.TestCase):
+    def test_initialization(self) -> None:
+        vectorstore = InMemoryVectorstoreWithSearch()
+        store = InMemoryStore()
+        child_splitter = CharacterTextSplitter(chunk_size=400)
+        documents = [Document(page_content="test document")]
+        retriever = ParentDocumentRetriever(
+            vectorstore=vectorstore,
+            docstore=store,
+            child_splitter=child_splitter,
+        )
+        retriever.add_documents(documents)
+        results = retriever.invoke("0")
+        assert len(results) > 0
+        assert results[0].page_content == "test document"
+
+    def test_initialization_child_splitter_list(self) -> None:
+        vectorstore = InMemoryVectorstoreWithSearch()
+        store = InMemoryStore()
+        child_splitter = CharacterTextSplitter(chunk_size=400)
+        documents = [Document(page_content="test document")]
+        retriever = ParentDocumentRetriever(
+            vectorstore=vectorstore,
+            docstore=store,
+        )
+        retriever.add_documents(documents, child_splitters=[child_splitter])
+        results = retriever.invoke("0")
+        assert len(results) > 0
+        assert results[0].page_content == "test document"
+
+    def test_initialization_no_child_splitter(self) -> None:
+        vectorstore = InMemoryVectorstoreWithSearch()
+        store = InMemoryStore()
+        documents = [Document(page_content="test document")]
+        retriever = ParentDocumentRetriever(
+            vectorstore=vectorstore,
+            docstore=store,
+        )
+
+        with self.assertRaises(ValueError):
+            retriever.add_documents(documents)
+
+    def test_indexing_not_used(self) -> None:
+        vectorstore = InMemoryVectorstoreWithSearch()
+        store = InMemoryStore()
+        child_splitter = CharacterTextSplitter(chunk_size=400)
+        retriever = ParentDocumentRetriever(
+            vectorstore=vectorstore,
+            docstore=store,
+            child_splitter=child_splitter,
+        )
+
+        add_func = retriever._add_documents  # pylint: disable=W0212
+        assert add_func.__name__ != "_index"
+
+    def test_indexing_is_used(self) -> None:
+        vectorstore = InMemoryVectorstoreWithSearch()
+        store = InMemoryStore()
+        child_splitter = CharacterTextSplitter(chunk_size=400)
+        record_manager = SQLRecordManager("test", db_url="sqlite:///:memory:")
+        record_manager.create_schema()
+        retriever = ParentDocumentRetriever(
+            vectorstore=vectorstore,
+            docstore=store,
+            child_splitter=child_splitter,
+            index_args=dict(record_manager=record_manager, cleanup=None),
+        )
+
+        add_func = retriever._add_documents  # pylint: disable=W0212
+        assert add_func.__name__ == "_index"


### PR DESCRIPTION
  - **Description:** Support using indexing along with `ParentDocumentRetriever`. In short, when you create a `ParentDocumentRetriever`, you can provide the arguments you would have provided to `index`. Then when you call `.add_documents`, `index` will be called with the provided arguments instead of directly persisting to the vector store.

This change also allows you to optionally provide a list of text splitters to `.add_documents` (being the same length as the list of documents), in case a single text splitter type for all docs that go through the receiver isn't appropriate.