### PR TITLE
community: fix a bug that mistakenly handle zip iterator in FAISS.from_embeddings

### DIFF
--- a/libs/community/langchain_community/vectorstores/faiss.py
+++ b/libs/community/langchain_community/vectorstores/faiss.py
@@ -986,8 +986,7 @@ class FAISS(VectorStore):
                 text_embedding_pairs = zip(texts, text_embeddings)
                 faiss = FAISS.from_embeddings(text_embedding_pairs, embeddings)
         """
-        texts = [t[0] for t in text_embeddings]
-        embeddings = [t[1] for t in text_embeddings]
+        texts, embeddings = zip(*text_embeddings)
         return cls.__from(
             texts,
             embeddings,

--- a/libs/community/langchain_community/vectorstores/faiss.py
+++ b/libs/community/langchain_community/vectorstores/faiss.py
@@ -988,8 +988,8 @@ class FAISS(VectorStore):
         """
         texts, embeddings = zip(*text_embeddings)
         return cls.__from(
-            texts,
-            embeddings,
+            list(texts),
+            list(embeddings),
             embedding,
             metadatas=metadatas,
             ids=ids,


### PR DESCRIPTION
**Description**: `zip` is iterator that will only produce result once, so the previous code will cause the `embeddings` to be an empty list. 

**Issue**: I could not find a related issue.

**Dependencies**: this PR does not introduce or affect dependencies.