### PR TITLE
langchain: Allow OpenSearch Query Translator to correctly work with Date types

### DIFF
--- a/libs/langchain/tests/unit_tests/retrievers/self_query/test_opensearch.py
+++ b/libs/langchain/tests/unit_tests/retrievers/self_query/test_opensearch.py
@@ -85,3 +85,89 @@ def test_visit_structured_query() -> None:
     )
     actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
     assert expected == actual
+
+
+def test_visit_structured_query_with_date_range() -> None:
+    query = "Who was the president of France in 1995?"
+    operation = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.EQ, attribute="foo", value="20"),
+            Operation(
+                operator=Operator.AND,
+                arguments=[
+                    Comparison(
+                        comparator=Comparator.GTE,
+                        attribute="timestamp",
+                        value={"date": "1995-01-01", "type": "date"},
+                    ),
+                    Comparison(
+                        comparator=Comparator.LT,
+                        attribute="timestamp",
+                        value={"date": "1996-01-01", "type": "date"},
+                    ),
+                ],
+            ),
+        ],
+    )
+    structured_query = StructuredQuery(query=query, filter=operation, limit=None)
+    expected = (
+        query,
+        {
+            "filter": {
+                "bool": {
+                    "must": [
+                        {"term": {"metadata.foo.keyword": "20"}},
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "range": {
+                                            "metadata.timestamp": {"gte": "1995-01-01"}
+                                        }
+                                    },
+                                    {
+                                        "range": {
+                                            "metadata.timestamp": {"lt": "1996-01-01"}
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+def test_visit_structured_query_with_date() -> None:
+    query = "Who was the president of France on 1st of January 1995?"
+    operation = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.EQ, attribute="foo", value="20"),
+            Comparison(
+                comparator=Comparator.EQ,
+                attribute="timestamp",
+                value={"date": "1995-01-01", "type": "date"},
+            ),
+        ],
+    )
+    structured_query = StructuredQuery(query=query, filter=operation, limit=None)
+    expected = (
+        query,
+        {
+            "filter": {
+                "bool": {
+                    "must": [
+                        {"term": {"metadata.foo.keyword": "20"}},
+                        {"term": {"metadata.timestamp": "1995-01-01"}},
+                    ]
+                }
+            }
+        },
+    )
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual

--- a/libs/langchain/tests/unit_tests/retrievers/self_query/test_opensearch.py
+++ b/libs/langchain/tests/unit_tests/retrievers/self_query/test_opensearch.py
@@ -142,6 +142,7 @@ def test_visit_structured_query_with_date_range() -> None:
     actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
     assert expected == actual
 
+
 def test_visit_structured_query_with_date() -> None:
     query = "Who was the president of France on 1st of January 1995?"
     operation = Operation(


### PR DESCRIPTION
**Description:**

Fixes an issue where the Date type in an OpenSearch Self Querying Retriever would fail to generate a valid query

**Issue:**
https://github.com/langchain-ai/langchain/issues/14225
