### PR TITLE
community: Fixing WARNING by providing embedding_function in collection creation

### DIFF
--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -125,7 +125,7 @@ class Chroma(VectorStore):
         self._embedding_function = embedding_function
         self._collection = self._client.get_or_create_collection(
             name=collection_name,
-            embedding_function=None,
+            embedding_function=embedding_function,
             metadata=collection_metadata,
         )
         self.override_relevance_score_fn = relevance_score_fn


### PR DESCRIPTION
**Description:** 
Resolved the WARNING message that occurred due to the absence of the embedding_function parameter during the creation of a collection. Updated the code to include the embedding_function parameter in the collection creation process.

**Issue:** #15400 

**Dependencies:** None
