### PR TITLE
community: add new gpt-3.5-turbo-1106 finetuned for cost calculation

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -68,10 +68,12 @@ MODEL_COST_PER_1K_TOKENS = {
     "babbage-002-finetuned": 0.0016,
     "davinci-002-finetuned": 0.012,
     "gpt-3.5-turbo-0613-finetuned": 0.012,
+    "gpt-3.5-turbo-1106-finetuned": 0.012,
     # Fine Tuned output
     "babbage-002-finetuned-completion": 0.0016,
     "davinci-002-finetuned-completion": 0.012,
     "gpt-3.5-turbo-0613-finetuned-completion": 0.016,
+    "gpt-3.5-turbo-1106-finetuned-completion": 0.016,
     # Azure Fine Tuned input
     "babbage-002-azure-finetuned": 0.0004,
     "davinci-002-azure-finetuned": 0.002,


### PR DESCRIPTION
**Description:** Added the new gpt-3.5-turbo-1106 for **finetuned** cost calculation, 
**Issue:** no issue found open

By the information in OpenAI the pricing is the same as the older model (0613)