### PR TITLE
docs: fix documentation broken link in integrations chroma

### DIFF
--- a/docs/docs/integrations/providers/chroma.mdx
+++ b/docs/docs/integrations/providers/chroma.mdx
@@ -22,7 +22,7 @@ For a more detailed walkthrough of the Chroma wrapper, see [this notebook](/docs
 
 ## Retriever
 
-See a [usage example](/docs/integrations/retrievers/self_query/chroma).
+See a [usage example](/docs/integrations/retrievers/self_query/chroma_self_query).
 
 ```python
 from langchain.retrievers import SelfQueryRetriever


### PR DESCRIPTION
  - **Description:** Fixed broken link in the documentation for Chroma., 
  - **Issue:** 
  - **Dependencies:** 