### PR TITLE
community[patch]: add vector param to index query for pinecone vec store

### DIFF
--- a/libs/community/langchain_community/vectorstores/pinecone.py
+++ b/libs/community/langchain_community/vectorstores/pinecone.py
@@ -201,7 +201,7 @@ class Pinecone(VectorStore):
             namespace = self._namespace
         docs = []
         results = self._index.query(
-            [embedding],
+            vector=[embedding],
             top_k=k,
             include_metadata=True,
             namespace=namespace,
@@ -299,7 +299,7 @@ class Pinecone(VectorStore):
         if namespace is None:
             namespace = self._namespace
         results = self._index.query(
-            [embedding],
+            vector=[embedding],
             top_k=fetch_k,
             include_values=True,
             include_metadata=True,


### PR DESCRIPTION
 - **Description:** added `vector=` as it will become a required parameter from `pinecone-client 3.0.0.dev10` onwards, 
  - **Issue:** did not raise issue,
  - **Dependencies:** N/A,
  - **Twitter handle:** @jamescalam
