### PR TITLE
community: Fix LlamaContentFormatter to match actual input/output formatting

### DIFF
--- a/libs/community/langchain_community/chat_models/azureml_endpoint.py
+++ b/libs/community/langchain_community/chat_models/azureml_endpoint.py
@@ -68,7 +68,7 @@ class LlamaContentFormatter(ContentFormatterBase):
             for message in messages
         ]
         prompt = json.dumps(
-            {"input_data": {"input_string": chat_messages, "parameters": model_kwargs}}
+            {"messages": chat_messages, **model_kwargs}
         )
         return self.format_request_payload(prompt=prompt, model_kwargs=model_kwargs)
 
@@ -78,7 +78,7 @@ class LlamaContentFormatter(ContentFormatterBase):
 
     def format_response_payload(self, output: bytes) -> str:
         """Formats response"""
-        return json.loads(output)["output"]
+        return json.loads(output)['choices'][0]["message"]['content']
 
 
 class AzureMLChatOnlineEndpoint(SimpleChatModel):


### PR DESCRIPTION
 **Description:** The `LlamaContentFormatter` in the `langchain_community.chat_models.azureml_endpoint` does not work because it doesn't actually comply to the output of Llama models. The input/output formats are documented here: 

[Deploy Llama2 Chat Models - Chat API](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-llama?tabs=azure-studio#chat-api)

This PR creates a LlamaContentFormatter that works with the documented API.

 **Issue:** N/A
 **Dependencies:** N/A
 **Twitter handle:** parkerdhancock


