### PR TITLE
langchain_community: Replace azure_cosmos_db_vector_search with azure_cosmos_db in Cosmos DB Documentation

### DIFF
--- a/docs/docs/integrations/vectorstores/azure_cosmos_db.ipynb
+++ b/docs/docs/integrations/vectorstores/azure_cosmos_db.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "from langchain.text_splitter import CharacterTextSplitter\n",
     "from langchain_community.document_loaders import TextLoader\n",
-    "from langchain_community.vectorstores.azure_cosmos_db_vector_search import (\n",
+    "from langchain_community.vectorstores.azure_cosmos_db import (\n",
     "    AzureCosmosDBVectorSearch,\n",
     "    CosmosDBSimilarityType,\n",
     ")\n",


### PR DESCRIPTION
**Description**: This PR fixes an error in the documentation for Azure Cosmos DB Integration. 
**Issue**: The correct way to import `AzureCosmosDBVectorSearch` is
```python
from langchain_community.vectorstores.azure_cosmos_db import (
    AzureCosmosDBVectorSearch,
)
```
While the [documentation](https://python.langchain.com/docs/integrations/vectorstores/azure_cosmos_db) states it to be
```python
from langchain_community.vectorstores.azure_cosmos_db_vector_search import (
    AzureCosmosDBVectorSearch,
    CosmosDBSimilarityType,
)
```
As you can see in [azure_cosmos_db.py](https://github.com/langchain-ai/langchain/blob/c323742f4fda30e8bef5381f41f66192afb2b9d2/libs/langchain/langchain/vectorstores/azure_cosmos_db.py#L1C45-L2)
**Dependencies:**: None
**Twitter handle**: None
