### PR TITLE
Implement vector length definition at init time in PGVector for indexing

### DIFF
--- a/libs/community/langchain_community/vectorstores/pgvector.py
+++ b/libs/community/langchain_community/vectorstores/pgvector.py
@@ -151,6 +151,10 @@ class PGVector(VectorStore):
         connection_string: Postgres connection string.
         embedding_function: Any embedding function implementing
             `langchain.embeddings.base.Embeddings` interface.
+        embedding_length: The length of the embedding vector. (default: None)
+            NOTE: This is not mandatory. Defining it will prevent vectors of
+            any other size to be added to the embeddings table but, without it,
+            the embeddings can't be indexed.
         collection_name: The name of the collection to use. (default: langchain)
             NOTE: This is not the name of the table, but the name of the collection.
             The tables will be created when initializing the store (if not exists)


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** allow user to define tVector length in PGVector when creating the embedding store, this allows for later indexing
  - **Issue:** #16132
  - **Dependencies:** None
