### PR TITLE
Use dotenv in langchain-community's integration tests

### DIFF
--- a/libs/community/tests/integration_tests/.env.example
+++ b/libs/community/tests/integration_tests/.env.example
@@ -1,0 +1,45 @@
+# openai
+# your api key from https://platform.openai.com/account/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+
+
+# searchapi
+# your api key from https://www.searchapi.io/
+SEARCHAPI_API_KEY=your_searchapi_api_key_here
+
+
+# astra db
+ASTRA_DB_API_ENDPOINT=https://your_astra_db_id-your_region.apps.astra.datastax.com
+ASTRA_DB_APPLICATION_TOKEN=AstraCS:your_astra_db_application_token
+# ASTRA_DB_KEYSPACE=your_astra_db_namespace
+
+
+# pinecone
+# your api key from left menu "API Keys" in https://app.pinecone.io
+PINECONE_API_KEY=your_pinecone_api_key_here
+# your pinecone environment from left menu "API Keys" in https://app.pinecone.io
+PINECONE_ENVIRONMENT=us-west4-gcp
+
+
+# jira
+# your api token from https://id.atlassian.com/manage-profile/security/api-tokens
+# more details here: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
+# JIRA_API_TOKEN=your_jira_api_token_here
+# JIRA_USERNAME=your_jira_username_here
+# JIRA_INSTANCE_URL=your_jira_instance_url_here
+
+
+# clickup
+CLICKUP_ACCESS_TOKEN=your_clickup_access_token
+
+
+# power bi
+# sign in to azure in order to authenticate with DefaultAzureCredentials
+# details here https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet
+POWERBI_DATASET_ID=_powerbi_dataset_id_here
+POWERBI_TABLE_NAME=_test_table_name_here
+POWERBI_NUMROWS=_num_rows_in_your_test_table
+
+
+# MongoDB Atlas Vector Search
+MONGODB_ATLAS_URI=your_mongodb_atlas_connection_string

--- a/libs/community/tests/integration_tests/conftest.py
+++ b/libs/community/tests/integration_tests/conftest.py
@@ -1,0 +1,19 @@
+# Getting the absolute path of the current file's directory
+import os
+
+ABS_PATH = os.path.dirname(os.path.abspath(__file__))
+
+# Getting the absolute path of the project's root directory
+PROJECT_DIR = os.path.abspath(os.path.join(ABS_PATH, os.pardir, os.pardir))
+
+
+# Loading the .env file if it exists
+def _load_env() -> None:
+    dotenv_path = os.path.join(PROJECT_DIR, "tests", "integration_tests", ".env")
+    if os.path.exists(dotenv_path):
+        from dotenv import load_dotenv
+
+        load_dotenv(dotenv_path)
+
+
+_load_env()

--- a/libs/langchain/tests/integration_tests/.env.example
+++ b/libs/langchain/tests/integration_tests/.env.example
@@ -8,23 +8,6 @@ OPENAI_API_KEY=your_openai_api_key_here
 SEARCHAPI_API_KEY=your_searchapi_api_key_here
 
 
-# pinecone
-# your api key from left menu "API Keys" in https://app.pinecone.io
-PINECONE_API_KEY=your_pinecone_api_key_here
-# your pinecone environment from left menu "API Keys" in https://app.pinecone.io
-PINECONE_ENVIRONMENT=us-west4-gcp
-
-
-# jira
-# your api token from https://id.atlassian.com/manage-profile/security/api-tokens
-# more details here: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
-# JIRA_API_TOKEN=your_jira_api_token_here
-# JIRA_USERNAME=your_jira_username_here
-# JIRA_INSTANCE_URL=your_jira_instance_url_here
-
-# clickup
-CLICKUP_ACCESS_TOKEN=your_clickup_access_token
-
 # power bi
 # sign in to azure in order to authenticate with DefaultAzureCredentials
 # details here https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet
@@ -33,5 +16,7 @@ POWERBI_TABLE_NAME=_test_table_name_here
 POWERBI_NUMROWS=_num_rows_in_your_test_table
 
 
-# MongoDB Atlas Vector Search
-MONGODB_ATLAS_URI=your_mongodb_atlas_connection_string
+# astra db
+ASTRA_DB_API_ENDPOINT=https://your_astra_db_id-your_region.apps.astra.datastax.com
+ASTRA_DB_APPLICATION_TOKEN=AstraCS:your_astra_db_application_token
+# ASTRA_DB_KEYSPACE=your_astra_db_namespace


### PR DESCRIPTION
* Removed some env vars not used in langchain package IT
* Added Astra DB env vars in langchain package, used for cache tests
* Added conftest.py to load env vars in langchain_community IT
* Added .env.example in  langchain_community IT
