### PR TITLE
Add neo4j timeout and value sanitization option

### DIFF
--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -33,8 +33,11 @@ RETURN {start: label, type: property, end: toString(other_node)} AS output
 
 def value_sanitize(d: Dict[str, Any]) -> Dict[str, Any]:
     """
-    The idea is to remove all internal properties which
-    are irrelevant for generating answers
+    Sanitizes the input dictionary by removing embedding-like values,
+    lists with more than 128 elements, that are mostly irrelevant for
+    generating answers in a LLM context. These properties, if left in
+    results, can occupy significant context space and detract from
+    the LLM's performance by introducing unnecessary noise and cost.
     """
     LIST_LIMIT = 128
     # Create a new dictionary to avoid changing size during iteration
@@ -60,7 +63,18 @@ def value_sanitize(d: Dict[str, Any]) -> Dict[str, Any]:
 
 
 class Neo4jGraph(GraphStore):
-    """Neo4j wrapper for graph operations.
+    """Provides a connection to a Neo4j database for various graph operations.
+    Parameters:
+    url (Optional[str]): The URL of the Neo4j database server.
+    username (Optional[str]): The username for database authentication.
+    password (Optional[str]): The password for database authentication.
+    database (str): The name of the database to connect to. Default is 'neo4j'.
+    timeout (Optional[float]): The timeout for transactions in seconds.
+            Useful for terminating long-running queries.
+            By default, there is no timeout set.
+    sanitize (bool): A flag to indicate whether to remove lists with
+            more than 128 elements from results. Useful for removing
+            embedding-like properties from database responses. Default is False.
 
     *Security note*: Make sure that the database connection uses credentials
         that are narrowly-scoped to only include necessary permissions.

--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -33,7 +33,8 @@ RETURN {start: label, type: property, end: toString(other_node)} AS output
 
 def value_sanitize(d: Dict[str, Any]) -> Dict[str, Any]:
     """
-    The idea is to remove all internal properties which are irrelevant for generating answers
+    The idea is to remove all internal properties which 
+    are irrelevant for generating answers
     """
     LIST_LIMIT = 128
     # Create a new dictionary to avoid changing size during iteration

--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -33,7 +33,7 @@ RETURN {start: label, type: property, end: toString(other_node)} AS output
 
 def value_sanitize(d: Dict[str, Any]) -> Dict[str, Any]:
     """
-    The idea is to remove all internal properties which 
+    The idea is to remove all internal properties which
     are irrelevant for generating answers
     """
     LIST_LIMIT = 128

--- a/libs/community/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/community/tests/integration_tests/graphs/test_neo4j.py
@@ -69,3 +69,22 @@ def test_cypher_return_correct_schema() -> None:
         sorted(relationships, key=lambda x: x["output"]["end"])
         == expected_relationships
     )
+
+
+def test_neo4j_timeout() -> None:
+    """Test that neo4j uses the timeout correctly."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    graph = Neo4jGraph(url=url, username=username, password=password, timeout=0.1)
+    try:
+        graph.query("UNWIND range(0,100000,1) AS i MERGE (:Foo {id:i})")
+    except Exception as e:
+        assert (
+            e.code
+            == "Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration"
+        )

--- a/libs/community/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/community/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -1,0 +1,32 @@
+from langchain_community.graphs.neo4j_graph import value_sanitize
+
+
+def test_value_sanitize_with_small_list():
+    small_list = list(range(15))  # list size > LIST_LIMIT
+    input_dict = {"key1": "value1", "small_list": small_list}
+    expected_output = {"key1": "value1", "small_list": small_list}
+    assert value_sanitize(input_dict) == expected_output
+
+
+def test_value_sanitize_with_oversized_list():
+    oversized_list = list(range(150))  # list size > LIST_LIMIT
+    input_dict = {"key1": "value1", "oversized_list": oversized_list}
+    expected_output = {
+        "key1": "value1"
+        # oversized_list should not be included
+    }
+    assert value_sanitize(input_dict) == expected_output
+
+
+def test_value_sanitize_with_nested_oversized_list():
+    oversized_list = list(range(150))  # list size > LIST_LIMIT
+    input_dict = {"key1": "value1", "oversized_list": {"key": oversized_list}}
+    expected_output = {"key1": "value1", "oversized_list": {}}
+    assert value_sanitize(input_dict) == expected_output
+
+
+def test_value_sanitize_with_dict_in_list():
+    oversized_list = list(range(150))  # list size > LIST_LIMIT
+    input_dict = {"key1": "value1", "oversized_list": [1, 2, {"key": oversized_list}]}
+    expected_output = {"key1": "value1", "oversized_list": [1, 2, {}]}
+    assert value_sanitize(input_dict) == expected_output


### PR DESCRIPTION
The timeout function comes in handy when you want to kill longrunning queries.
The value sanitization removes all lists that are larger than 128 elements. The idea here is to remove embedding properties from results.