### PR TITLE
langchain_community.vectorstores: Issue #16146. Fix: Missing unpack operator for or_clause in pgvector document filter 

### DIFF
--- a/libs/community/langchain_community/vectorstores/pgvector.py
+++ b/libs/community/langchain_community/vectorstores/pgvector.py
@@ -545,13 +545,13 @@ class PGVector(VectorStore):
                 self._create_filter_clause(key, sub_value)
                 for sub_value in value_case_insensitive[OR]
             ]
-            filter_by_metadata = sqlalchemy.or_(or_clauses)
+            filter_by_metadata = sqlalchemy.or_(*or_clauses)
         elif AND in map(str.lower, value):
             and_clauses = [
                 self._create_filter_clause(key, sub_value)
                 for sub_value in value_case_insensitive[AND]
             ]
-            filter_by_metadata = sqlalchemy.and_(and_clauses)
+            filter_by_metadata = sqlalchemy.and_(*and_clauses)
 
         else:
             filter_by_metadata = None


### PR DESCRIPTION
- Fix for #16146 
- Adding unpack operation to "or" and "and" filter for pgvector retriever. #