### PR TITLE
community: Add `SQLDatabaseLoader` document loader

### DIFF
--- a/docs/docs/integrations/document_loaders/example_data/mlb_teams_2012.sql
+++ b/docs/docs/integrations/document_loaders/example_data/mlb_teams_2012.sql
@@ -1,0 +1,40 @@
+-- Provisioning table "mlb_teams_2012".
+--
+-- psql postgresql://postgres@localhost < mlb_teams_2012.sql
+
+DROP TABLE IF EXISTS mlb_teams_2012;
+CREATE TABLE mlb_teams_2012 ("Team" VARCHAR, "Payroll (millions)" FLOAT, "Wins" BIGINT);
+INSERT INTO mlb_teams_2012
+    ("Team", "Payroll (millions)", "Wins")
+VALUES
+    ('Nationals', 81.34, 98),
+    ('Reds', 82.20, 97),
+    ('Yankees', 197.96, 95),
+    ('Giants',       117.62, 94),
+    ('Braves',        83.31, 94),
+    ('Athletics',     55.37, 94),
+    ('Rangers',      120.51, 93),
+    ('Orioles',       81.43, 93),
+    ('Rays',          64.17, 90),
+    ('Angels',       154.49, 89),
+    ('Tigers',       132.30, 88),
+    ('Cardinals',    110.30, 88),
+    ('Dodgers',       95.14, 86),
+    ('White Sox',     96.92, 85),
+    ('Brewers',       97.65, 83),
+    ('Phillies',     174.54, 81),
+    ('Diamondbacks',  74.28, 81),
+    ('Pirates',       63.43, 79),
+    ('Padres',        55.24, 76),
+    ('Mariners',      81.97, 75),
+    ('Mets',          93.35, 74),
+    ('Blue Jays',     75.48, 73),
+    ('Royals',        60.91, 72),
+    ('Marlins',      118.07, 69),
+    ('Red Sox',      173.18, 69),
+    ('Indians',       78.43, 68),
+    ('Twins',         94.08, 66),
+    ('Rockies',       78.06, 64),
+    ('Cubs',          88.19, 61),
+    ('Astros',        60.65, 55)
+;

--- a/libs/community/langchain_community/document_loaders/__init__.py
+++ b/libs/community/langchain_community/document_loaders/__init__.py
@@ -182,6 +182,7 @@ from langchain_community.document_loaders.sitemap import SitemapLoader
 from langchain_community.document_loaders.slack_directory import SlackDirectoryLoader
 from langchain_community.document_loaders.snowflake_loader import SnowflakeLoader
 from langchain_community.document_loaders.spreedly import SpreedlyLoader
+from langchain_community.document_loaders.sql_database import SQLDatabaseLoader
 from langchain_community.document_loaders.srt import SRTLoader
 from langchain_community.document_loaders.stripe import StripeLoader
 from langchain_community.document_loaders.surrealdb import SurrealDBLoader
@@ -367,6 +368,7 @@ __all__ = [
     "SlackDirectoryLoader",
     "SnowflakeLoader",
     "SpreedlyLoader",
+    "SQLDatabaseLoader",
     "StripeLoader",
     "SurrealDBLoader",
     "TelegramChatApiLoader",

--- a/libs/community/langchain_community/document_loaders/sql_database.py
+++ b/libs/community/langchain_community/document_loaders/sql_database.py
@@ -1,0 +1,138 @@
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+
+import sqlalchemy as sa
+
+from langchain_community.docstore.document import Document
+from langchain_community.document_loaders.base import BaseLoader
+from langchain_community.utilities.sql_database import SQLDatabase
+
+
+class SQLDatabaseLoader(BaseLoader):
+    """
+    Load documents by querying database tables supported by SQLAlchemy.
+
+    For talking to the database, the document loader uses the `SQLDatabase`
+    utility from the LangChain integration toolkit.
+
+    Each document represents one row of the result.
+    """
+
+    def __init__(
+        self,
+        query: Union[str, sa.Select],
+        db: SQLDatabase,
+        parameters: Optional[Dict[str, Any]] = None,
+        page_content_mapper: Optional[Callable[..., str]] = None,
+        metadata_mapper: Optional[Callable[..., Dict[str, Any]]] = None,
+        source_columns: Optional[List[str]] = None,
+        include_rownum_into_metadata: bool = False,
+        include_query_into_metadata: bool = False,
+    ):
+        """
+        Args:
+            query: The query to execute.
+            db: A LangChain `SQLDatabase`, wrapping an SQLAlchemy engine.
+            sqlalchemy_kwargs: More keyword arguments for SQLAlchemy's `create_engine`.
+            parameters: Optional. Parameters to pass to the query.
+            page_content_mapper: Optional. Function to convert a row into a string
+              to use as the `page_content` of the document. By default, the loader
+              serializes the whole row into a string, including all columns.
+            metadata_mapper: Optional. Function to convert a row into a dictionary
+              to use as the `metadata` of the document. By default, no columns are
+              selected into the metadata dictionary.
+            source_columns: Optional. The names of the columns to use as the `source`
+              within the metadata dictionary.
+            include_rownum_into_metadata: Optional. Whether to include the row number
+              into the metadata dictionary. Default: False.
+            include_query_into_metadata: Optional. Whether to include the query
+              expression into the metadata dictionary. Default: False.
+        """
+        self.query = query
+        self.db: SQLDatabase = db
+        self.parameters = parameters or {}
+        self.page_content_mapper = (
+            page_content_mapper or self.page_content_default_mapper
+        )
+        self.metadata_mapper = metadata_mapper or self.metadata_default_mapper
+        self.source_columns = source_columns
+        self.include_rownum_into_metadata = include_rownum_into_metadata
+        self.include_query_into_metadata = include_query_into_metadata
+
+    def lazy_load(self) -> Iterator[Document]:
+        try:
+            import sqlalchemy as sa
+        except ImportError:
+            raise ImportError(
+                "Could not import sqlalchemy python package. "
+                "Please install it with `pip install sqlalchemy`."
+            )
+
+        # Querying in `cursor` fetch mode will return an SQLAlchemy `Result` instance.
+        result: sa.Result[Any]
+
+        # Invoke the database query.
+        if isinstance(self.query, sa.SelectBase):
+            result = self.db._execute(  # type: ignore[assignment]
+                self.query, fetch="cursor", parameters=self.parameters
+            )
+            query_sql = str(self.query.compile(bind=self.db._engine))
+        elif isinstance(self.query, str):
+            result = self.db._execute(  # type: ignore[assignment]
+                sa.text(self.query), fetch="cursor", parameters=self.parameters
+            )
+            query_sql = self.query
+        else:
+            raise TypeError(f"Unable to process query of unknown type: {self.query}")
+
+        # Iterate database result rows and generate list of documents.
+        for i, row in enumerate(result.mappings()):
+            page_content = self.page_content_mapper(row)
+            metadata = self.metadata_mapper(row)
+
+            if self.include_rownum_into_metadata:
+                metadata["row"] = i
+            if self.include_query_into_metadata:
+                metadata["query"] = query_sql
+
+            source_values = []
+            for column, value in row.items():
+                if self.source_columns and column in self.source_columns:
+                    source_values.append(value)
+            if source_values:
+                metadata["source"] = ",".join(source_values)
+
+            yield Document(page_content=page_content, metadata=metadata)
+
+    def load(self) -> List[Document]:
+        return list(self.lazy_load())
+
+    @staticmethod
+    def page_content_default_mapper(
+        row: sa.RowMapping, column_names: Optional[List[str]] = None
+    ) -> str:
+        """
+        A reasonable default function to convert a record into a "page content" string.
+        """
+        if column_names is None:
+            column_names = list(row.keys())
+        return "\n".join(
+            f"{column}: {value}"
+            for column, value in row.items()
+            if column in column_names
+        )
+
+    @staticmethod
+    def metadata_default_mapper(
+        row: sa.RowMapping, column_names: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """
+        A reasonable default function to convert a record into a "metadata" dictionary.
+        """
+        if column_names is None:
+            return {}
+
+        metadata: Dict[str, Any] = {}
+        for column, value in row.items():
+            if column in column_names:
+                metadata[column] = value
+        return metadata

--- a/libs/community/poetry.lock
+++ b/libs/community/poetry.lock
@@ -3140,6 +3140,7 @@ files = [
     {file = "jq-1.6.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:227b178b22a7f91ae88525810441791b1ca1fc71c86f03190911793be15cec3d"},
     {file = "jq-1.6.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:780eb6383fbae12afa819ef676fc93e1548ae4b076c004a393af26a04b460742"},
     {file = "jq-1.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:08ded6467f4ef89fec35b2bf310f210f8cd13fbd9d80e521500889edf8d22441"},
+    {file = "jq-1.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49e44ed677713f4115bd5bf2dbae23baa4cd503be350e12a1c1f506b0687848f"},
     {file = "jq-1.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:984f33862af285ad3e41e23179ac4795f1701822473e1a26bf87ff023e5a89ea"},
     {file = "jq-1.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f42264fafc6166efb5611b5d4cb01058887d050a6c19334f6a3f8a13bb369df5"},
     {file = "jq-1.6.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a67154f150aaf76cc1294032ed588436eb002097dd4fd1e283824bf753a05080"},
@@ -5457,8 +5458,6 @@ files = [
     {file = "psycopg2-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:426f9f29bde126913a20a96ff8ce7d73fd8a216cfb323b1f04da402d452853c3"},
     {file = "psycopg2-2.9.9-cp311-cp311-win32.whl", hash = "sha256:ade01303ccf7ae12c356a5e10911c9e1c51136003a9a1d92f7aa9d010fb98372"},
     {file = "psycopg2-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981"},
-    {file = "psycopg2-2.9.9-cp312-cp312-win32.whl", hash = "sha256:d735786acc7dd25815e89cc4ad529a43af779db2e25aa7c626de864127e5a024"},
-    {file = "psycopg2-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:a7653d00b732afb6fc597e29c50ad28087dcb4fbfb28e86092277a559ae4e693"},
     {file = "psycopg2-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:5e0d98cade4f0e0304d7d6f25bbfbc5bd186e07b38eac65379309c4ca3193efa"},
     {file = "psycopg2-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:7e2dacf8b009a1c1e843b5213a87f7c544b2b042476ed7755be813eaf4e8347a"},
     {file = "psycopg2-2.9.9-cp38-cp38-win32.whl", hash = "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"},
@@ -5501,7 +5500,6 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win32.whl", hash = "sha256:dc4926288b2a3e9fd7b50dc6a1909a13bbdadfc67d93f3374d984e56f885579d"},
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:b76bedd166805480ab069612119ea636f5ab8f8771e640ae103e05a4aae3e417"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8532fd6e6e2dc57bcb3bc90b079c60de896d2128c5d9d6f24a63875a95a088cf"},
-    {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0605eaed3eb239e87df0d5e3c6489daae3f7388d455d0c0b4df899519c6a38d"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f8544b092a29a6ddd72f3556a9fcf249ec412e10ad28be6a0c0d948924f2212"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d423c8d8a3c82d08fe8af900ad5b613ce3632a1249fd6a223941d0735fce493"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e5afae772c00980525f6d6ecf7cbca55676296b580c0e6abb407f15f3706996"},
@@ -5510,8 +5508,6 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:cb16c65dcb648d0a43a2521f2f0a2300f40639f6f8c1ecbc662141e4e3e1ee07"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:911dda9c487075abd54e644ccdf5e5c16773470a6a5d3826fda76699410066fb"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:57fede879f08d23c85140a360c6a77709113efd1c993923c59fde17aa27599fe"},
-    {file = "psycopg2_binary-2.9.9-cp312-cp312-win32.whl", hash = "sha256:64cf30263844fa208851ebb13b0732ce674d8ec6a0c86a4e160495d299ba3c93"},
-    {file = "psycopg2_binary-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:81ff62668af011f9a48787564ab7eded4e9fb17a4a6a74af5ffa6a457400d2ab"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2293b001e319ab0d869d660a704942c9e2cce19745262a8aba2115ef41a0a42a"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9"},
     {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a602ea5aff39bb9fac6308e9c9d82b9a35c2bf288e184a816002c9fae930b77"},
@@ -6508,7 +6504,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -7614,7 +7609,7 @@ test = ["pytest"]
 name = "sqlparse"
 version = "0.4.4"
 description = "A non-validating SQL parser."
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sqlparse-0.4.4-py3-none-any.whl", hash = "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3"},
@@ -9003,4 +8998,4 @@ extended-testing = ["aiosqlite", "aleph-alpha-client", "anthropic", "arxiv", "as
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "fe633ab7d246239420a26bebf8bcf857edcf0778f75b3eb2a4b1314cb13645c8"
+content-hash = "1f1c3f7e6759e7299f70788a8f5b712cb39d3ac7c41335282378cf6dd69c7eaf"

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -115,6 +115,7 @@ pytest-socket = "^0.6.0"
 syrupy = "^4.0.2"
 requests-mock = "^1.11.0"
 langchain-core = {path = "../core", develop = true}
+sqlparse = "^0.4.4"
 
 [tool.poetry.group.codespell]
 optional = true

--- a/libs/community/tests/data.py
+++ b/libs/community/tests/data.py
@@ -1,0 +1,10 @@
+"""Module defines common test data."""
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).parent
+
+_EXAMPLES_DIR = _THIS_DIR / "examples"
+
+# Paths to data files
+MLB_TEAMS_2012_CSV = _EXAMPLES_DIR / "mlb_teams_2012.csv"
+MLB_TEAMS_2012_SQL = _EXAMPLES_DIR / "mlb_teams_2012.sql"

--- a/libs/community/tests/examples/mlb_teams_2012.csv
+++ b/libs/community/tests/examples/mlb_teams_2012.csv
@@ -1,0 +1,32 @@
+"Team", "Payroll (millions)", "Wins"
+"Nationals",     81.34, 98
+"Reds",          82.20, 97
+"Yankees",      197.96, 95
+"Giants",       117.62, 94
+"Braves",        83.31, 94
+"Athletics",     55.37, 94
+"Rangers",      120.51, 93
+"Orioles",       81.43, 93
+"Rays",          64.17, 90
+"Angels",       154.49, 89
+"Tigers",       132.30, 88
+"Cardinals",    110.30, 88
+"Dodgers",       95.14, 86
+"White Sox",     96.92, 85
+"Brewers",       97.65, 83
+"Phillies",     174.54, 81
+"Diamondbacks",  74.28, 81
+"Pirates",       63.43, 79
+"Padres",        55.24, 76
+"Mariners",      81.97, 75
+"Mets",          93.35, 74
+"Blue Jays",     75.48, 73
+"Royals",        60.91, 72
+"Marlins",      118.07, 69
+"Red Sox",      173.18, 69
+"Indians",       78.43, 68
+"Twins",         94.08, 66
+"Rockies",       78.06, 64
+"Cubs",          88.19, 61
+"Astros",        60.65, 55
+

--- a/libs/community/tests/examples/mlb_teams_2012.sql
+++ b/libs/community/tests/examples/mlb_teams_2012.sql
@@ -1,0 +1,40 @@
+-- Provisioning table "mlb_teams_2012".
+--
+-- psql postgresql://postgres@localhost < mlb_teams_2012.sql
+
+DROP TABLE IF EXISTS mlb_teams_2012;
+CREATE TABLE mlb_teams_2012 ("Team" VARCHAR, "Payroll (millions)" FLOAT, "Wins" BIGINT);
+INSERT INTO mlb_teams_2012
+    ("Team", "Payroll (millions)", "Wins")
+VALUES
+    ('Nationals', 81.34, 98),
+    ('Reds', 82.20, 97),
+    ('Yankees', 197.96, 95),
+    ('Giants',       117.62, 94),
+    ('Braves',        83.31, 94),
+    ('Athletics',     55.37, 94),
+    ('Rangers',      120.51, 93),
+    ('Orioles',       81.43, 93),
+    ('Rays',          64.17, 90),
+    ('Angels',       154.49, 89),
+    ('Tigers',       132.30, 88),
+    ('Cardinals',    110.30, 88),
+    ('Dodgers',       95.14, 86),
+    ('White Sox',     96.92, 85),
+    ('Brewers',       97.65, 83),
+    ('Phillies',     174.54, 81),
+    ('Diamondbacks',  74.28, 81),
+    ('Pirates',       63.43, 79),
+    ('Padres',        55.24, 76),
+    ('Mariners',      81.97, 75),
+    ('Mets',          93.35, 74),
+    ('Blue Jays',     75.48, 73),
+    ('Royals',        60.91, 72),
+    ('Marlins',      118.07, 69),
+    ('Red Sox',      173.18, 69),
+    ('Indians',       78.43, 68),
+    ('Twins',         94.08, 66),
+    ('Rockies',       78.06, 64),
+    ('Cubs',          88.19, 61),
+    ('Astros',        60.65, 55)
+;

--- a/libs/community/tests/integration_tests/document_loaders/docker-compose/postgresql.yml
+++ b/libs/community/tests/integration_tests/document_loaders/docker-compose/postgresql.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+  postgresql:
+    image: postgres:16
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    ports:
+      - "5432:5432"
+    command: |
+      postgres -c log_statement=all
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "psql postgresql://postgres@localhost --command 'SELECT 1;' || exit 1",
+        ]
+      interval: 5s
+      retries: 60

--- a/libs/community/tests/integration_tests/document_loaders/test_sql_database.py
+++ b/libs/community/tests/integration_tests/document_loaders/test_sql_database.py
@@ -1,0 +1,233 @@
+"""
+Test SQLAlchemy document loader functionality on behalf of SQLite and PostgreSQL.
+"""
+import functools
+import logging
+import typing
+import warnings
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+import sqlalchemy as sa
+import sqlparse
+
+from langchain_community.utilities.sql_database import SQLDatabase
+
+if typing.TYPE_CHECKING:
+    from _pytest.python import Metafunc
+
+from langchain_community.document_loaders.sql_database import SQLDatabaseLoader
+from tests.data import MLB_TEAMS_2012_SQL
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+try:
+    import sqlite3  # noqa: F401
+
+    sqlite3_installed = True
+except ImportError:
+    warnings.warn("sqlite3 not installed, skipping corresponding tests", UserWarning)
+    sqlite3_installed = False
+
+try:
+    import psycopg2  # noqa: F401
+
+    psycopg2_installed = True
+except ImportError:
+    warnings.warn("psycopg2 not installed, skipping corresponding tests", UserWarning)
+    psycopg2_installed = False
+
+
+@pytest.fixture()
+def engine(db_uri: str) -> sa.Engine:
+    """
+    Return an SQLAlchemy engine object.
+    """
+    return sa.create_engine(db_uri, echo=False)
+
+
+@pytest.fixture()
+def db(engine: sa.Engine) -> SQLDatabase:
+    return SQLDatabase(engine=engine)
+
+
+@pytest.fixture()
+def provision_database(engine: sa.Engine) -> None:
+    """
+    Provision database with table schema and data.
+    """
+    sql_statements = MLB_TEAMS_2012_SQL.read_text()
+    with engine.connect() as connection:
+        connection.execute(sa.text("DROP TABLE IF EXISTS mlb_teams_2012;"))
+        for statement in sqlparse.split(sql_statements):
+            connection.execute(sa.text(statement))
+            connection.commit()
+
+
+tmpdir = TemporaryDirectory()
+
+
+def pytest_generate_tests(metafunc: "Metafunc") -> None:
+    """
+    Dynamically parameterize test cases to verify both SQLite and PostgreSQL.
+    """
+    if "db_uri" in metafunc.fixturenames:
+        urls = []
+        ids = []
+        if sqlite3_installed:
+            db_path = Path(tmpdir.name).joinpath("testdrive.sqlite")
+            urls.append(f"sqlite:///{db_path}")
+            ids.append("sqlite")
+        if psycopg2_installed:
+            urls.append("postgresql+psycopg2://postgres@localhost:5432/")
+            ids.append("postgresql")
+
+        metafunc.parametrize("db_uri", urls, ids=ids)
+
+
+def test_sqldatabase_loader_no_options(db: SQLDatabase) -> None:
+    """Test SQLAlchemy loader basics."""
+
+    loader = SQLDatabaseLoader("SELECT 1 AS a, 2 AS b", db=db)
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "a: 1\nb: 2"
+    assert docs[0].metadata == {}
+
+
+def test_sqldatabase_loader_include_rownum_into_metadata(db: SQLDatabase) -> None:
+    """Test SQLAlchemy loader with row number in metadata."""
+
+    loader = SQLDatabaseLoader(
+        "SELECT 1 AS a, 2 AS b",
+        db=db,
+        include_rownum_into_metadata=True,
+    )
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "a: 1\nb: 2"
+    assert docs[0].metadata == {"row": 0}
+
+
+def test_sqldatabase_loader_include_query_into_metadata(db: SQLDatabase) -> None:
+    """Test SQLAlchemy loader with query in metadata."""
+
+    loader = SQLDatabaseLoader(
+        "SELECT 1 AS a, 2 AS b", db=db, include_query_into_metadata=True
+    )
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "a: 1\nb: 2"
+    assert docs[0].metadata == {"query": "SELECT 1 AS a, 2 AS b"}
+
+
+def test_sqldatabase_loader_page_content_columns(db: SQLDatabase) -> None:
+    """Test SQLAlchemy loader with defined page content columns."""
+
+    # Define a custom callback function to convert a row into a "page content" string.
+    row_to_content = functools.partial(
+        SQLDatabaseLoader.page_content_default_mapper, column_names=["a"]
+    )
+
+    loader = SQLDatabaseLoader(
+        "SELECT 1 AS a, 2 AS b UNION SELECT 3 AS a, 4 AS b",
+        db=db,
+        page_content_mapper=row_to_content,
+    )
+    docs = loader.load()
+
+    assert len(docs) == 2
+    assert docs[0].page_content == "a: 1"
+    assert docs[0].metadata == {}
+
+    assert docs[1].page_content == "a: 3"
+    assert docs[1].metadata == {}
+
+
+def test_sqldatabase_loader_metadata_columns(db: SQLDatabase) -> None:
+    """Test SQLAlchemy loader with defined metadata columns."""
+
+    # Define a custom callback function to convert a row into a "metadata" dictionary.
+    row_to_metadata = functools.partial(
+        SQLDatabaseLoader.metadata_default_mapper, column_names=["b"]
+    )
+
+    loader = SQLDatabaseLoader(
+        "SELECT 1 AS a, 2 AS b",
+        db=db,
+        metadata_mapper=row_to_metadata,
+    )
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert docs[0].metadata == {"b": 2}
+
+
+def test_sqldatabase_loader_real_data_with_sql_no_parameters(
+    db: SQLDatabase, provision_database: None
+) -> None:
+    """Test SQLAlchemy loader with real data, querying by SQL statement."""
+
+    loader = SQLDatabaseLoader(
+        query='SELECT * FROM mlb_teams_2012 ORDER BY "Team";',
+        db=db,
+    )
+    docs = loader.load()
+
+    assert len(docs) == 30
+    assert docs[0].page_content == "Team: Angels\nPayroll (millions): 154.49\nWins: 89"
+    assert docs[0].metadata == {}
+
+
+def test_sqldatabase_loader_real_data_with_sql_and_parameters(
+    db: SQLDatabase, provision_database: None
+) -> None:
+    """Test SQLAlchemy loader, querying by SQL statement and parameters."""
+
+    loader = SQLDatabaseLoader(
+        query='SELECT * FROM mlb_teams_2012 WHERE "Team" LIKE :search ORDER BY "Team";',
+        parameters={"search": "R%"},
+        db=db,
+    )
+    docs = loader.load()
+
+    assert len(docs) == 6
+    assert docs[0].page_content == "Team: Rangers\nPayroll (millions): 120.51\nWins: 93"
+    assert docs[0].metadata == {}
+
+
+def test_sqldatabase_loader_real_data_with_selectable(
+    db: SQLDatabase, provision_database: None
+) -> None:
+    """Test SQLAlchemy loader with real data, querying by SQLAlchemy selectable."""
+
+    # Define an SQLAlchemy table.
+    mlb_teams_2012 = sa.Table(
+        "mlb_teams_2012",
+        sa.MetaData(),
+        sa.Column("Team", sa.VARCHAR),
+        sa.Column("Payroll (millions)", sa.FLOAT),
+        sa.Column("Wins", sa.BIGINT),
+    )
+
+    # Query the database table using an SQLAlchemy selectable.
+    select = sa.select(mlb_teams_2012).order_by(mlb_teams_2012.c.Team)
+    loader = SQLDatabaseLoader(
+        query=select,
+        db=db,
+        include_query_into_metadata=True,
+    )
+    docs = loader.load()
+
+    assert len(docs) == 30
+    assert docs[0].page_content == "Team: Angels\nPayroll (millions): 154.49\nWins: 89"
+    assert docs[0].metadata == {
+        "query": 'SELECT mlb_teams_2012."Team", mlb_teams_2012."Payroll (millions)", '
+        'mlb_teams_2012."Wins" \nFROM mlb_teams_2012 '
+        'ORDER BY mlb_teams_2012."Team"'
+    }

--- a/libs/community/tests/unit_tests/document_loaders/test_imports.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_imports.py
@@ -126,6 +126,7 @@ EXPECTED_ALL = [
     "RocksetLoader",
     "S3DirectoryLoader",
     "S3FileLoader",
+    "SQLDatabaseLoader",
     "SRTLoader",
     "SeleniumURLLoader",
     "SharePointLoader",

--- a/libs/community/tests/unit_tests/test_dependencies.py
+++ b/libs/community/tests/unit_tests/test_dependencies.py
@@ -83,6 +83,7 @@ def test_test_group_dependencies(poetry_conf: Mapping[str, Any]) -> None:
             "pytest-socket",
             "pytest-watcher",
             "responses",
+            "sqlparse",
             "syrupy",
             "requests-mock",
         ]


### PR DESCRIPTION
  - **Description:** A generic document loader adapter for SQLAlchemy on top of LangChain's `SQLDatabaseLoader`.
  - **Needed by:** https://github.com/crate-workbench/langchain/pull/1
  - **Depends on:** GH-16655
  - **Addressed to:** @baskaryan, @cbornet, @eyurtsev

Hi from CrateDB again,

in the same spirit like GH-16243 and GH-16244, this patch breaks out another commit from https://github.com/crate-workbench/langchain/pull/1, in order to reduce the size of this patch before submitting it, and to separate concerns.

To accompany the SQLAlchemy adapter implementation, the patch includes integration tests for both SQLite and PostgreSQL. Let me know if corresponding utility resources should be added at different spots.

With kind regards,
Andreas.


### Software Tests

```console
docker compose --file libs/community/tests/integration_tests/document_loaders/docker-compose/postgresql.yml up
```

```console
cd libs/community
pip install psycopg2-binary
pytest -vvv tests/integration_tests -k sqldatabase
```

```
14 passed
```


![image](https://github.com/langchain-ai/langchain/assets/453543/42be233c-eb37-4c76-a830-474276e01436)

