### PR TITLE
docs: Updated integration docs structure for tools/arxiv (#16091)

### DIFF
--- a/docs/docs/integrations/tools/arxiv.ipynb
+++ b/docs/docs/integrations/tools/arxiv.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook goes over how to use the `arxiv` tool with an agent. \n",
     "\n",
-    "First, you need to install `arxiv` python package."
+    "First, you need to install the `arxiv` python package."
    ]
   },
   {
@@ -36,20 +36,18 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.agents import AgentType, initialize_agent, load_tools\n",
+    "from langchain import hub\n",
+    "from langchain.agents import AgentExecutor, create_react_agent, load_tools\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",
     "llm = ChatOpenAI(temperature=0.0)\n",
     "tools = load_tools(\n",
     "    [\"arxiv\"],\n",
     ")\n",
+    "prompt = hub.pull(\"hwchase17/react\")\n",
     "\n",
-    "agent_chain = initialize_agent(\n",
-    "    tools,\n",
-    "    llm,\n",
-    "    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,\n",
-    "    verbose=True,\n",
-    ")"
+    "agent = create_react_agent(llm, tools, prompt)\n",
+    "agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)"
    ]
   },
   {
@@ -67,10 +65,9 @@
       "\n",
       "\n",
       "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
-      "\u001b[32;1m\u001b[1;3mI need to use Arxiv to search for the paper.\n",
-      "Action: Arxiv\n",
-      "Action Input: \"1605.08386\"\u001b[0m\n",
-      "Observation: \u001b[36;1m\u001b[1;3mPublished: 2016-05-26\n",
+      "\u001b[32;1m\u001b[1;3mI should use the arxiv tool to search for the paper with the given identifier.\n",
+      "Action: arxiv\n",
+      "Action Input: 1605.08386\u001b[0m\u001b[36;1m\u001b[1;3mPublished: 2016-05-26\n",
       "Title: Heat-bath random walks with Markov bases\n",
       "Authors: Caprice Stanley, Tobias Windisch\n",
       "Summary: Graphs on lattice points are studied whose edges come from a finite set of\n",
@@ -79,18 +76,15 @@
       "then study the mixing behaviour of heat-bath random walks on these graphs. We\n",
       "also state explicit conditions on the set of moves so that the heat-bath random\n",
       "walk, a generalization of the Glauber dynamics, is an expander in fixed\n",
-      "dimension.\u001b[0m\n",
-      "Thought:\u001b[32;1m\u001b[1;3mThe paper is about heat-bath random walks with Markov bases on graphs of lattice points.\n",
-      "Final Answer: The paper 1605.08386 is about heat-bath random walks with Markov bases on graphs of lattice points.\u001b[0m\n",
+      "dimension.\u001b[0m\u001b[32;1m\u001b[1;3mThe paper \"1605.08386\" is titled \"Heat-bath random walks with Markov bases\" and is authored by Caprice Stanley and Tobias Windisch. It was published on May 26, 2016. The paper discusses the study of graphs on lattice points with edges coming from a finite set of allowed moves. It explores the diameter of these graphs and the mixing behavior of heat-bath random walks on them. The paper also discusses conditions for the heat-bath random walk to be an expander in fixed dimension.\n",
+      "Final Answer: The paper \"1605.08386\" is about heat-bath random walks with Markov bases.\u001b[0m\n",
       "\n",
       "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
      "data": {
-      "text/plain": [
-       "'The paper 1605.08386 is about heat-bath random walks with Markov bases on graphs of lattice points.'"
-      ]
+      "text/plain": "{'input': \"What's the paper 1605.08386 about?\",\n 'output': 'The paper \"1605.08386\" is about heat-bath random walks with Markov bases.'}"
      },
      "execution_count": 3,
      "metadata": {},
@@ -98,8 +92,10 @@
     }
    ],
    "source": [
-    "agent_chain.run(\n",
-    "    \"What's the paper 1605.08386 about?\",\n",
+    "agent_executor.invoke(\n",
+    "    {\n",
+    "        \"input\": \"What's the paper 1605.08386 about?\",\n",
+    "    }\n",
     ")"
    ]
   },
@@ -130,15 +126,15 @@
    "id": "c89c110c-96ac-4fe1-ba3e-6056543d1a59",
    "metadata": {},
    "source": [
-    "Run a query to get information about some `scientific article`/articles. The query text is limited to 300 characters.\n",
+    "You can use the ArxivAPIWrapper to get information about a scientific article or articles. The query text is limited to 300 characters.\n",
     "\n",
-    "It returns these article fields:\n",
+    "The ArxivAPIWrapper returns these article fields:\n",
     "- Publishing date\n",
     "- Title\n",
     "- Authors\n",
     "- Summary\n",
     "\n",
-    "Next query returns information about one article with arxiv Id equal \"1605.08386\". "
+    "The following query returns information about one article with the arxiv ID \"1605.08386\". "
    ]
   },
   {
@@ -151,9 +147,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "'Published: 2016-05-26\\nTitle: Heat-bath random walks with Markov bases\\nAuthors: Caprice Stanley, Tobias Windisch\\nSummary: Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.'"
-      ]
+      "text/plain": "'Published: 2016-05-26\\nTitle: Heat-bath random walks with Markov bases\\nAuthors: Caprice Stanley, Tobias Windisch\\nSummary: Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.'"
      },
      "execution_count": 5,
      "metadata": {},
@@ -186,9 +180,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "'Published: 2017-10-10\\nTitle: On Mixing Behavior of a Family of Random Walks Determined by a Linear Recurrence\\nAuthors: Caprice Stanley, Seth Sullivant\\nSummary: We study random walks on the integers mod $G_n$ that are determined by an\\ninteger sequence $\\\\{ G_n \\\\}_{n \\\\geq 1}$ generated by a linear recurrence\\nrelation. Fourier analysis provides explicit formulas to compute the\\neigenvalues of the transition matrices and we use this to bound the mixing time\\nof the random walks.\\n\\nPublished: 2016-05-26\\nTitle: Heat-bath random walks with Markov bases\\nAuthors: Caprice Stanley, Tobias Windisch\\nSummary: Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.\\n\\nPublished: 2003-03-18\\nTitle: Calculation of fluxes of charged particles and neutrinos from atmospheric showers\\nAuthors: V. Plyaskin\\nSummary: The results on the fluxes of charged particles and neutrinos from a\\n3-dimensional (3D) simulation of atmospheric showers are presented. An\\nagreement of calculated fluxes with data on charged particles from the AMS and\\nCAPRICE detectors is demonstrated. Predictions on neutrino fluxes at different\\nexperimental sites are compared with results from other calculations.'"
-      ]
+      "text/plain": "'Published: 2017-10-10\\nTitle: On Mixing Behavior of a Family of Random Walks Determined by a Linear Recurrence\\nAuthors: Caprice Stanley, Seth Sullivant\\nSummary: We study random walks on the integers mod $G_n$ that are determined by an\\ninteger sequence $\\\\{ G_n \\\\}_{n \\\\geq 1}$ generated by a linear recurrence\\nrelation. Fourier analysis provides explicit formulas to compute the\\neigenvalues of the transition matrices and we use this to bound the mixing time\\nof the random walks.\\n\\nPublished: 2016-05-26\\nTitle: Heat-bath random walks with Markov bases\\nAuthors: Caprice Stanley, Tobias Windisch\\nSummary: Graphs on lattice points are studied whose edges come from a finite set of\\nallowed moves of arbitrary length. We show that the diameter of these graphs on\\nfibers of a fixed integer matrix can be bounded from above by a constant. We\\nthen study the mixing behaviour of heat-bath random walks on these graphs. We\\nalso state explicit conditions on the set of moves so that the heat-bath random\\nwalk, a generalization of the Glauber dynamics, is an expander in fixed\\ndimension.\\n\\nPublished: 2003-03-18\\nTitle: Calculation of fluxes of charged particles and neutrinos from atmospheric showers\\nAuthors: V. Plyaskin\\nSummary: The results on the fluxes of charged particles and neutrinos from a\\n3-dimensional (3D) simulation of atmospheric showers are presented. An\\nagreement of calculated fluxes with data on charged particles from the AMS and\\nCAPRICE detectors is demonstrated. Predictions on neutrino fluxes at different\\nexperimental sites are compared with results from other calculations.'"
      },
      "execution_count": 6,
      "metadata": {},
@@ -218,9 +210,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "'No good Arxiv Result was found'"
-      ]
+      "text/plain": "'No good Arxiv Result was found'"
      },
      "execution_count": 7,
      "metadata": {},


### PR DESCRIPTION
  - **Description:** Updated docs for tools/arxiv to use `AgentExecutor` and `invoke`
  - **Issue:** #15664
  - **Dependencies:** None
  - **Twitter handle:** None