### PR TITLE
core[patch]: preserve inspect.iscoroutinefunction with @deprecated decorator

### DIFF
--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -144,6 +144,15 @@ def deprecated(
                 emit_warning()
             return wrapped(*args, **kwargs)
 
+        async def awarning_emitting_wrapper(*args: Any, **kwargs: Any) -> Any:
+            """Same as warning_emitting_wrapper, but for async functions."""
+
+            nonlocal warned
+            if not warned and not is_caller_internal():
+                warned = True
+                emit_warning()
+            return await wrapped(*args, **kwargs)
+
         if isinstance(obj, type):
             if not _obj_type:
                 _obj_type = "class"
@@ -256,7 +265,10 @@ def deprecated(
             f"   {details}"
         )
 
-        return finalize(warning_emitting_wrapper, new_doc)
+        if inspect.iscoroutinefunction(obj):
+            return finalize(awarning_emitting_wrapper, new_doc)
+        else:
+            return finalize(warning_emitting_wrapper, new_doc)
 
     return deprecate
 

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -178,8 +178,7 @@ def test_deprecated_async_methond() -> None:
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         obj = ClassWithDeprecatedMethods()
-        assert obj.deprecated_async_method(
-        ) == "This is a deprecated async method."
+        assert obj.deprecated_async_method() == "This is a deprecated async method."
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 from typing import Any, Dict
 
@@ -74,6 +75,12 @@ def deprecated_function() -> str:
     return "This is a deprecated function."
 
 
+@deprecated(since="2.0.0", removal="3.0.0", pending=False)
+async def deprecated_async_function() -> str:
+    """original doc"""
+    return "This is a deprecated async function."
+
+
 class ClassWithDeprecatedMethods:
     def __init__(self) -> None:
         """original doc"""
@@ -83,6 +90,11 @@ class ClassWithDeprecatedMethods:
     def deprecated_method(self) -> str:
         """original doc"""
         return "This is a deprecated method."
+
+    @deprecated(since="2.0.0", removal="3.0.0")
+    async def deprecated_async_method(self) -> str:
+        """original doc"""
+        return "This is a deprecated async method."
 
     @classmethod
     @deprecated(since="2.0.0", removal="3.0.0")
@@ -112,12 +124,31 @@ def test_deprecated_function() -> None:
         warning = warning_list[0].message
         assert str(warning) == (
             "The function `deprecated_function` was deprecated in LangChain 2.0.0 "
-            "and will be removed in 3.0.0"
-        )
+            "and will be removed in 3.0.0")
 
         doc = deprecated_function.__doc__
         assert isinstance(doc, str)
         assert doc.startswith("[*Deprecated*]  original doc")
+
+    assert not inspect.iscoroutinefunction(deprecated_function)
+
+
+def test_deprecated_async_function() -> None:
+    """Test deprecated async function."""
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        assert deprecated_function() == "This is a deprecated async function."
+        assert len(warning_list) == 1
+        warning = warning_list[0].message
+        assert str(warning) == (
+            "The function `deprecated_async_function` was deprecated in LangChain 2.0.0 "
+            "and will be removed in 3.0.0")
+
+        doc = deprecated_function.__doc__
+        assert isinstance(doc, str)
+        assert doc.startswith("[*Deprecated*]  original doc")
+
+    assert inspect.iscoroutinefunction(deprecated_async_function)
 
 
 def test_deprecated_method() -> None:
@@ -130,12 +161,33 @@ def test_deprecated_method() -> None:
         warning = warning_list[0].message
         assert str(warning) == (
             "The function `deprecated_method` was deprecated in "
-            "LangChain 2.0.0 and will be removed in 3.0.0"
-        )
+            "LangChain 2.0.0 and will be removed in 3.0.0")
 
         doc = obj.deprecated_method.__doc__
         assert isinstance(doc, str)
         assert doc.startswith("[*Deprecated*]  original doc")
+
+    assert not inspect.iscoroutinefunction(obj.deprecated_async_method)
+
+
+def test_deprecated_async_methond() -> None:
+    """Test deprecated async method."""
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        obj = ClassWithDeprecatedMethods()
+        assert obj.deprecated_async_method(
+        ) == "This is a deprecated async method."
+        assert len(warning_list) == 1
+        warning = warning_list[0].message
+        assert str(warning) == (
+            "The function `deprecated_async_method` was deprecated in "
+            "LangChain 2.0.0 and will be removed in 3.0.0")
+
+        doc = obj.deprecated_method.__doc__
+        assert isinstance(doc, str)
+        assert doc.startswith("[*Deprecated*]  original doc")
+
+    assert inspect.iscoroutinefunction(obj.deprecated_async_method)
 
 
 def test_deprecated_classmethod() -> None:

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -142,8 +142,8 @@ def test_deprecated_async_function() -> None:
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (
-            "The function `deprecated_async_function` was deprecated in LangChain 2.0.0 "
-            "and will be removed in 3.0.0"
+            "The function `deprecated_async_function` was deprecated "
+            "in LangChain 2.0.0 and will be removed in 3.0.0"
         )
 
         doc = deprecated_function.__doc__

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -138,7 +138,7 @@ def test_deprecated_async_function() -> None:
     """Test deprecated async function."""
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
-        assert deprecated_function() == "This is a deprecated async function."
+        assert deprecated_async_function() == "This is a deprecated async function."
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -139,7 +139,8 @@ async def test_deprecated_async_function() -> None:
     """Test deprecated async function."""
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
-        assert await deprecated_async_function() == "This is a deprecated async function."
+        assert await deprecated_async_function() \
+            == "This is a deprecated async function."
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (
@@ -180,7 +181,8 @@ async def test_deprecated_async_method() -> None:
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         obj = ClassWithDeprecatedMethods()
-        assert await obj.deprecated_async_method() == "This is a deprecated async method."
+        assert await obj.deprecated_async_method() \
+            == "This is a deprecated async method."
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -139,8 +139,9 @@ async def test_deprecated_async_function() -> None:
     """Test deprecated async function."""
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
-        assert await deprecated_async_function() \
-            == "This is a deprecated async function."
+        assert (
+            await deprecated_async_function() == "This is a deprecated async function."
+        )
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (
@@ -181,8 +182,9 @@ async def test_deprecated_async_method() -> None:
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         obj = ClassWithDeprecatedMethods()
-        assert await obj.deprecated_async_method() \
-            == "This is a deprecated async method."
+        assert (
+            await obj.deprecated_async_method() == "This is a deprecated async method."
+        )
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -173,7 +173,7 @@ def test_deprecated_method() -> None:
         assert isinstance(doc, str)
         assert doc.startswith("[*Deprecated*]  original doc")
 
-    assert not inspect.iscoroutinefunction(obj.deprecated_async_method)
+    assert not inspect.iscoroutinefunction(obj.deprecated_method)
 
 
 @pytest.mark.asyncio

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -124,7 +124,8 @@ def test_deprecated_function() -> None:
         warning = warning_list[0].message
         assert str(warning) == (
             "The function `deprecated_function` was deprecated in LangChain 2.0.0 "
-            "and will be removed in 3.0.0")
+            "and will be removed in 3.0.0"
+        )
 
         doc = deprecated_function.__doc__
         assert isinstance(doc, str)
@@ -142,7 +143,8 @@ def test_deprecated_async_function() -> None:
         warning = warning_list[0].message
         assert str(warning) == (
             "The function `deprecated_async_function` was deprecated in LangChain 2.0.0 "
-            "and will be removed in 3.0.0")
+            "and will be removed in 3.0.0"
+        )
 
         doc = deprecated_function.__doc__
         assert isinstance(doc, str)
@@ -161,7 +163,8 @@ def test_deprecated_method() -> None:
         warning = warning_list[0].message
         assert str(warning) == (
             "The function `deprecated_method` was deprecated in "
-            "LangChain 2.0.0 and will be removed in 3.0.0")
+            "LangChain 2.0.0 and will be removed in 3.0.0"
+        )
 
         doc = obj.deprecated_method.__doc__
         assert isinstance(doc, str)
@@ -181,7 +184,8 @@ def test_deprecated_async_methond() -> None:
         warning = warning_list[0].message
         assert str(warning) == (
             "The function `deprecated_async_method` was deprecated in "
-            "LangChain 2.0.0 and will be removed in 3.0.0")
+            "LangChain 2.0.0 and will be removed in 3.0.0"
+        )
 
         doc = obj.deprecated_method.__doc__
         assert isinstance(doc, str)

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -134,11 +134,12 @@ def test_deprecated_function() -> None:
     assert not inspect.iscoroutinefunction(deprecated_function)
 
 
-def test_deprecated_async_function() -> None:
+@pytest.mark.asyncio
+async def test_deprecated_async_function() -> None:
     """Test deprecated async function."""
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
-        assert deprecated_async_function() == "This is a deprecated async function."
+        assert await deprecated_async_function() == "This is a deprecated async function."
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (
@@ -173,12 +174,13 @@ def test_deprecated_method() -> None:
     assert not inspect.iscoroutinefunction(obj.deprecated_async_method)
 
 
-def test_deprecated_async_methond() -> None:
+@pytest.mark.asyncio
+async def test_deprecated_async_methond() -> None:
     """Test deprecated async method."""
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         obj = ClassWithDeprecatedMethods()
-        assert obj.deprecated_async_method() == "This is a deprecated async method."
+        assert await obj.deprecated_async_method() == "This is a deprecated async method."
         assert len(warning_list) == 1
         warning = warning_list[0].message
         assert str(warning) == (

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -175,7 +175,7 @@ def test_deprecated_method() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deprecated_async_methond() -> None:
+async def test_deprecated_async_method() -> None:
     """Test deprecated async method."""
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")


### PR DESCRIPTION
Adjusted `deprecate` decorator to make sure decorated async functions are still recognized as "coroutinefunction" by `inspect`. 

Before change, functions such as `LLMChain.acall` which are decorated as deprecated are not recognized as coroutine functions. After the change, they are recognized:

```python
import inspect
from langchain import LLMChain

# Is false before change but true after.
inspect.iscoroutinefunction(LLMChain.acall)
```