### PR TITLE
Update grobid.py

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/grobid.py
+++ b/libs/community/langchain_community/document_loaders/parsers/grobid.py
@@ -59,19 +59,20 @@ class GrobidParser(BaseBlobParser):
                     for i, sentence in enumerate(paragraph.find_all("s")):
                         paragraph_text.append(sentence.text)
                         sbboxes = []
-                        for bbox in sentence.get("coords").split(";"):
-                            box = bbox.split(",")
-                            sbboxes.append(
-                                {
-                                    "page": box[0],
-                                    "x": box[1],
-                                    "y": box[2],
-                                    "h": box[3],
-                                    "w": box[4],
-                                }
-                            )
+                        if sentence.get("coords") is not None:
+                            for bbox in sentence.get("coords").split(";"):
+                                box = bbox.split(",")
+                                sbboxes.append(
+                                    {
+                                        "page": box[0],
+                                        "x": box[1],
+                                        "y": box[2],
+                                        "h": box[3],
+                                        "w": box[4],
+                                    }
+                                )
                         chunk_bboxes.append(sbboxes)
-                        if segment_sentences is True:
+                        if (segment_sentences is True) and (len(sbboxes) > 0):
                             fpage, lpage = sbboxes[0]["page"], sbboxes[-1]["page"]
                             sentence_dict = {
                                 "text": sentence.text,

--- a/libs/community/langchain_community/document_loaders/parsers/grobid.py
+++ b/libs/community/langchain_community/document_loaders/parsers/grobid.py
@@ -71,7 +71,7 @@ class GrobidParser(BaseBlobParser):
                                         "w": box[4],
                                     }
                                 )
-                        chunk_bboxes.append(sbboxes)
+                            chunk_bboxes.append(sbboxes)
                         if (segment_sentences is True) and (len(sbboxes) > 0):
                             fpage, lpage = sbboxes[0]["page"], sbboxes[-1]["page"]
                             sentence_dict = {


### PR DESCRIPTION
there is a case where "coords" does not exist in the "sentence" therefore, the "split(";")" will lead to error. 

we can fix that by adding "if sentence.get("coords") is not None:" 

the resulting empty "sbboxes" from this scenario will raise error at "sbboxes[0]["page"]" because sbboxes are empty.

the PDF from https://pubmed.ncbi.nlm.nih.gov/23970373/ can replicate those errors.

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
