### PR TITLE
core: absolute `EXAMPLE_DIR` path

### DIFF
--- a/libs/core/tests/unit_tests/prompts/test_loading.py
+++ b/libs/core/tests/unit_tests/prompts/test_loading.py
@@ -10,7 +10,7 @@ from langchain_core.prompts.few_shot import FewShotPromptTemplate
 from langchain_core.prompts.loading import load_prompt
 from langchain_core.prompts.prompt import PromptTemplate
 
-EXAMPLE_DIR = Path("tests/unit_tests/examples").absolute()
+EXAMPLE_DIR = (Path(__file__).parent.parent / "examples").absolute()
 
 
 @contextmanager


### PR DESCRIPTION
If you invoked testing from places besides `core/`, this `EXAMPLE_DIR` path won't work. This PR makes`EXAMPLE_DIR` robust against invocation location