### PR TITLE
core[patch]: Remove `print` statement on missing `grandalf` dependency in favor of more explicit ImportError

### DIFF
--- a/libs/core/langchain_core/runnables/graph_draw.py
+++ b/libs/core/langchain_core/runnables/graph_draw.py
@@ -165,9 +165,11 @@ def _build_sugiyama_layout(
             EdgeViewer,
             route_with_lines,
         )
-    except ImportError:
-        print("Install grandalf to draw graphs. `pip install grandalf`")
-        raise
+    except ImportError as exc:
+        raise ImportError(
+            "Install grandalf to draw graphs: `pip install grandalf`."
+        ) from exc
+
     #
     # Just a reminder about naming conventions:
     # +------------X


### PR DESCRIPTION
After this PR an ImportError will be raised without a print if grandalf is missing when using grandalf related code for printing runnable graphs.