### PR TITLE
Docs: Use `invoke` instead of `__call__`

### DIFF
--- a/docs/docs/integrations/llms/llamacpp.ipynb
+++ b/docs/docs/integrations/llms/llamacpp.ipynb
@@ -316,7 +316,7 @@
     "prompt = \"\"\"\n",
     "Question: A rap battle between Stephen Colbert and John Oliver\n",
     "\"\"\"\n",
-    "llm(prompt)"
+    "llm.invoke(prompt)"
    ]
   },
   {
@@ -618,7 +618,7 @@
    ],
    "source": [
     "%%capture captured --no-stdout\n",
-    "result = llm(\"Describe a person in JSON format:\")"
+    "result = llm.invoke(\"Describe a person in JSON format:\")"
    ]
   },
   {
@@ -674,7 +674,7 @@
    ],
    "source": [
     "%%capture captured --no-stdout\n",
-    "result = llm(\"List of top-3 my favourite books:\")"
+    "result = llm.invoke(\"List of top-3 my favourite books:\")"
    ]
   }
  ],


### PR DESCRIPTION
The following warning information will be displayed when i use `llm(PROMPT)`:

```python
/Users/169/llama.cpp/venv/lib/python3.11/site-packages/langchain_core/_api/deprecation.py:117: LangChainDeprecationWarning: The function `__call__` was deprecated in LangChain 0.1.7 and will be removed in 0.2.0. Use invoke instead.
  warn_deprecated(
```

So I changed to standard usage.