### PR TITLE
Docs: Update import library for StreamlitCallbackHandler

### DIFF
--- a/docs/docs/integrations/callbacks/streamlit.md
+++ b/docs/docs/integrations/callbacks/streamlit.md
@@ -46,7 +46,7 @@ thoughts and actions live in your app.
 ```python
 from langchain_openai import OpenAI
 from langchain.agents import AgentType, initialize_agent, load_tools
-from langchain.callbacks import StreamlitCallbackHandler
+from langchain_community.callbacks import StreamlitCallbackHandler
 import streamlit as st
 
 llm = OpenAI(temperature=0, streaming=True)


### PR DESCRIPTION

  - **Description:** Some code sources have been moved from `langchain` to `langchain_community` and so the documentation is not yet up-to-date. This is specifically true for `StreamlitCallbackHandler` which returns a `warning` message if not loaded from `langchain_community`., 
  - **Issue:** I don't see a # issue that could address this problem but perhaps #10744,
  - **Dependencies:** Since it's a documentation change no dependencies are required