### PR TITLE
Docs: Updated callbacks/index.mdx 

### DIFF
--- a/docs/docs/modules/callbacks/index.mdx
+++ b/docs/docs/modules/callbacks/index.mdx
@@ -95,42 +95,40 @@ prompt = PromptTemplate.from_template("1 + {number} = ")
 
 # Constructor callback: First, let's explicitly set the StdOutCallbackHandler when initializing our chain
 chain = LLMChain(llm=llm, prompt=prompt, callbacks=[handler])
-chain.run(number=2)
+chain.invoke({"number":2})
 
 # Use verbose flag: Then, let's use the `verbose` flag to achieve the same result
 chain = LLMChain(llm=llm, prompt=prompt, verbose=True)
-chain.run(number=2)
+chain.invoke({"number":2})
 
 # Request callbacks: Finally, let's use the request `callbacks` to achieve the same result
 chain = LLMChain(llm=llm, prompt=prompt)
-chain.run(number=2, callbacks=[handler])
+chain.invoke({"number":2}, {"callbacks":[handler]})
+
 ```
 
 <CodeOutputBlock lang="python">
 
 ```
-    > Entering new LLMChain chain...
-    Prompt after formatting:
-    1 + 2 =
+> Entering new LLMChain chain...
+Prompt after formatting:
+1 + 2 = 
 
-    > Finished chain.
-
-
-    > Entering new LLMChain chain...
-    Prompt after formatting:
-    1 + 2 =
-
-    > Finished chain.
+> Finished chain.
 
 
-    > Entering new LLMChain chain...
-    Prompt after formatting:
-    1 + 2 =
+> Entering new LLMChain chain...
+Prompt after formatting:
+1 + 2 = 
 
-    > Finished chain.
+> Finished chain.
 
 
-    '\n\n3'
+> Entering new LLMChain chain...
+Prompt after formatting:
+1 + 2 = 
+
+> Finished chain.
 ```
 
 </CodeOutputBlock>


### PR DESCRIPTION
The callbacks get started demo code was updated , replacing the chain.run()  command ( which is now depricated) ,with the updated chain.invoke() command.
Solving the following issue : #16379
Twitter/X : @Hazxhx

