### PR TITLE
Core: Fix f-string formatting in error message for configurable_fields

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1646,7 +1646,7 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
             if key not in self.__fields__:
                 raise ValueError(
                     f"Configuration key {key} not found in {self}: "
-                    "available keys are {self.__fields__.keys()}"
+                    f"available keys are {self.__fields__.keys()}"
                 )
 
         return RunnableConfigurableFields(default=self, fields=kwargs)


### PR DESCRIPTION
  - **Description:** Simple fix to f-string formatting. Allows more informative ValueError output.
  - **Issue:** None needed.
  - **Dependencies:** None.
  - **Twitter handle:** @FlightP1an