### PR TITLE
langchain: Minor Fix: Enable Passing custom_headers for Authentication in GraphQL Agent/Tool

### DIFF
--- a/libs/langchain/langchain/agents/load_tools.py
+++ b/libs/langchain/langchain/agents/load_tools.py
@@ -353,9 +353,7 @@ def _get_scenexplain(**kwargs: Any) -> BaseTool:
 
 
 def _get_graphql_tool(**kwargs: Any) -> BaseTool:
-    graphql_endpoint = kwargs["graphql_endpoint"]
-    wrapper = GraphQLAPIWrapper(graphql_endpoint=graphql_endpoint)
-    return BaseGraphQLTool(graphql_wrapper=wrapper)
+    return BaseGraphQLTool(graphql_wrapper=GraphQLAPIWrapper(**kwargs))
 
 
 def _get_openweathermap(**kwargs: Any) -> BaseTool:
@@ -455,7 +453,7 @@ _EXTRA_OPTIONAL_TOOLS: Dict[str, Tuple[Callable[[KwArg(Any)], BaseTool], List[st
     ),
     "stackexchange": (_get_stackexchange, []),
     "sceneXplain": (_get_scenexplain, []),
-    "graphql": (_get_graphql_tool, ["graphql_endpoint"]),
+    "graphql": (_get_graphql_tool, ["graphql_endpoint", "custom_headers"]),
     "openweathermap-api": (_get_openweathermap, ["openweathermap_api_key"]),
     "dataforseo-api-search": (
         _get_dataforseo_api_search,


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
  - **Description:** 

This PR aims to enhance the `langchain` library by enabling the support for passing `custom_headers` in the `GraphQLAPIWrapper` usage within `langchain/agents/load_tools.py`. 

While the `GraphQLAPIWrapper` from the `langchain_community` module is inherently capable of handling `custom_headers`, its current invocation in `load_tools.py` does not facilitate this functionality. 
This limitation restricts the use of the `graphql` tool with databases or APIs that require token-based authentication.

The absence of support for `custom_headers` in this context also leads to a lack of error messages when attempting to interact with secured GraphQL endpoints, making debugging and troubleshooting more challenging.

This update modifies the `load_tools` function to correctly handle `custom_headers`, thereby allowing secure and authenticated access to GraphQL services requiring tokens. 

Example usage after the proposed change:
```python
tools = load_tools(
    ["graphql"],
    graphql_endpoint="https://your-graphql-endpoint.com/graphql",
    custom_headers={"Authorization": f"Token {api_token}"},
)
```
  - **Issue:** None,
  - **Dependencies:** None,
  - **Twitter handle:** None
