### PR TITLE
chage _merge_splits total count

### DIFF
--- a/libs/langchain/langchain/text_splitter.py
+++ b/libs/langchain/langchain/text_splitter.py
@@ -177,6 +177,8 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         current_doc: List[str] = []
         total = 0
         for d in splits:
+            current_text = self._join_docs(current_doc, separator)
+            total = self._length_function(current_text)
             _len = self._length_function(d)
             if (
                 total + _len + (separator_len if len(current_doc) > 0 else 0)


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->




Description: Modified the _merge_splits function within langchain.text_splitter to ensure accurate length calculation of text chunks when using CharacterTextSplitter with from_huggingface_tokenizer and a custom length function. Previously, the function was generating shorter text chunks than expected, especially noticeable when working with Korean text documents. This discrepancy was due to the total variable in _merge_splits accumulating lengths of individual documents, which could differ significantly from the tokenizer's calculated length (in some cases with Korean text, the difference was over two-fold). To ensure the accuracy of chunk lengths, the function was modified to recalculate the total length using _length_function for each addition of a new chunk, despite the additional computational time required.