### PR TITLE
Fixed typo on  quickstart.ipynb

### DIFF
--- a/docs/docs/use_cases/sql/quickstart.ipynb
+++ b/docs/docs/use_cases/sql/quickstart.ipynb
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can look at the [LangSmith trace](https://smith.langchain.com/public/c8fa52ea-be46-4829-bde2-52894970b830/r) to get a better understanding of what this chain is doing. We can also inpect the chain directly for its prompts. Looking at the prompt (below), we can see that it is:\n",
+    "We can look at the [LangSmith trace](https://smith.langchain.com/public/c8fa52ea-be46-4829-bde2-52894970b830/r) to get a better understanding of what this chain is doing. We can also inspect the chain directly for its prompts. Looking at the prompt (below), we can see that it is:\n",
     "\n",
     "* Dialect-specific. In this case it references SQLite explicitly.\n",
     "* Has definitions for all the available tables.\n",


### PR DESCRIPTION
  - **Description:** Quick typo fix: `inpect` >> `inspect`
  - **Issue:** N/A
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** @geoffdudgeon