### PR TITLE
community: fix create_sql_agent prefix

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/sql/base.py
+++ b/libs/community/langchain_community/agent_toolkits/sql/base.py
@@ -160,10 +160,10 @@ def create_sql_agent(
             )
             template = "\n\n".join(
                 [
-                    react_prompt.PREFIX,
+                    prefix or react_prompt.PREFIX,
                     "{tools}",
                     format_instructions,
-                    react_prompt.SUFFIX,
+                    suffix or react_prompt.SUFFIX,
                 ]
             )
             prompt = PromptTemplate.from_template(template)


### PR DESCRIPTION
  - **Description:** fix create_sql_agent prefix and suffix when `prefix` & `suffix` arguments are nor None.
  - **Issue:** 
  - **Dependencies:** 
  - **Twitter handle:** @dalssoft