### PR TITLE
RFC: unpack .assign() arg

### DIFF
--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -325,10 +325,12 @@ class RunnableAssign(RunnableSerializable[Dict[str, Any], Dict[str, Any]]):
     A runnable that assigns key-value pairs to Dict[str, Any] inputs.
     """
 
-    mapper: Runnable[Dict[str, Any], Dict[str, Any]]
+    mapper: RunnableSerializable[Dict[str, Any], Dict[str, Any]]
 
     def __init__(
-        self, mapper: Runnable[Dict[str, Any], Dict[str, Any]], **kwargs: Any
+        self,
+        mapper: RunnableSerializable[Dict[str, Any], Dict[str, Any]],
+        **kwargs: Any,
     ) -> None:
         super().__init__(mapper=mapper, **kwargs)
 


### PR DESCRIPTION
suppose you have two chains that output dicts. second takes output of first as input. you want to return combined dict of their outputsr.

imagine second_chain outputs {"bar": ..., "baz": ...} and you want those to be in top level of output.
currently you'd do
```python
def unpack(x):
  foo = x.pop("foo")
  return {**x, **foo}

chain.assign(foo=second_chain) | unpack
```
i would like to do

```python
chain.assign(second_chain)
```