### PR TITLE
docs: Fix broken link in LLMs index.mdx

### DIFF
--- a/docs/docs/modules/model_io/llms/index.mdx
+++ b/docs/docs/modules/model_io/llms/index.mdx
@@ -26,4 +26,4 @@ This includes:
 - [How to write a custom LLM class](./custom_llm)
 - [How to cache LLM responses](./llm_caching)
 - [How to stream responses from an LLM](./streaming_llm)
-- [How to track token usage in an LLM call)(./token_usage_tracking)
+- [How to track token usage in an LLM call](./token_usage_tracking)


### PR DESCRIPTION
  - **Description:** The [LLMs](https://python.langchain.com/docs/modules/model_io/llms/) page has a broken link. This fixes the link.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** @sheilnaik