### PR TITLE
langchain : Fix message type lookup in Anthropic Partners

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -16,7 +16,7 @@ from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResu
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str
 
-_message_type_lookups = {"human": "user", "assistant": "ai"}
+_message_type_lookups = {"human": "user", "ai": "assistant"}
 
 
 def _format_messages(messages: List[BaseMessage]) -> Tuple[Optional[str], List[Dict]]:


### PR DESCRIPTION
- **Description:** 

The parameters for user and assistant in Anthropic should be 'ai -> assistant,' but they are reversed to 'assistant -> ai.'
Below is error code.
```python
anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages: Unexpected role "ai". Allowed roles are "user" or "assistant"'}}
```
[anthropic](https://github.com/anthropics/anthropic-sdk-python/blob/7177f3a71f940d9f9842063a8198b7c3e92715dd/src/anthropic/types/beta/message_param.py#L13)

  - **Issue:** : #16561
  -  **Dependencies:** : None
   - **Twitter handle:** : None
