### PR TITLE
langchain:Fix streaming error of TongYi model 

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -36,6 +36,8 @@ def merge_dicts(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
             merged[k] = merge_dicts(merged[k], v)
         elif isinstance(merged[k], list):
             merged[k] = merged[k] + v
+        elif isinstance(merged[k], int):
+            merged[k] = merged[k] + v
         else:
             raise TypeError(
                 f"Additional kwargs key {k} already exists in left dict and value has "


### PR DESCRIPTION
 - **Description:**
 Fix streaming error of TongYi model (Allow merge_dicts to merge int value)
  - **Issue:** the issue
 When using Tongyi or ChatTongyi with streaming in the [use case](https://python.langchain.com/docs/use_cases/question_answering/streaming),the following error occured:
`TypeError: Additional kwargs key output_tokens already exists in left dict and value has unsupported type <class 'int'>`
  - **Dependencies:**
 libs/core/langchain_core/utils/_merge.py
