### PR TITLE
langchain:Fix streaming error of TongYi model

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -36,6 +36,8 @@ def merge_dicts(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
             merged[k] = merge_dicts(merged[k], v)
         elif isinstance(merged[k], list):
             merged[k] = merged[k] + v
+        elif isinstance(merged[k], int):
+            merged[k] = v
         else:
             raise TypeError(
                 f"Additional kwargs key {k} already exists in left dict and value has "


### PR DESCRIPTION
 - **Description:**
 Fix streaming error of TongYi model (make merge_dicts to replace int value)
  - **Issue:**
 When using Tongyi or ChatTongyi with streaming in the [use case](https://python.langchain.com/docs/use_cases/question_answering/streaming),the following error occured:
`TypeError: Additional kwargs key output_tokens already exists in left dict and value has unsupported type <class 'int'>`

These are values need to be merged when the error occurred:
```
k = 'output_tokens'
left = {'input_tokens': 530, 'output_tokens': 2, 'total_tokens': 532}
merged = {'input_tokens': 530, 'output_tokens': 2, 'total_tokens': 532}
right = {'input_tokens': 530, 'output_tokens': 13, 'total_tokens': 543}
v = 13
```
The first out put has 2 tokens, the second has eleven. Seems the int should be replaced with new value?
```
{'answer': 'Task decomposition'}
{'answer': ' is the process of breaking down a complex task into smaller'}
```
Original PR:
 #16580

  - **Dependencies:**
 libs/core/langchain_core/utils/_merge.py