### PR TITLE
community: Add new fields in metadata for qdrant vector store

### DIFF
--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1943,6 +1943,7 @@ class Qdrant(VectorStore):
     ) -> Document:
         metadata = scored_point.payload.get(metadata_payload_key) or {}
         metadata["_id"] = scored_point.id
+        metadata["_collection_name"] = scored_point.collection_name
         return Document(
             page_content=scored_point.payload.get(content_payload_key),
             metadata=metadata,

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1941,9 +1941,11 @@ class Qdrant(VectorStore):
         content_payload_key: str,
         metadata_payload_key: str,
     ) -> Document:
+        metadata = scored_point.payload.get(metadata_payload_key) or {}
+        metadata["_id"] = scored_point.id
         return Document(
             page_content=scored_point.payload.get(content_payload_key),
-            metadata=scored_point.payload.get(metadata_payload_key) or {},
+            metadata=metadata,
         )
 
     def _build_condition(self, key: str, value: Any) -> List[rest.FieldCondition]:


### PR DESCRIPTION
## Description

The PR is to return the ID and collection name from qdrant client to metadata field in `Document` class.

## Issue

The motivation is almost same to [11592](https://github.com/langchain-ai/langchain/issues/11592)

Returning ID is useful to update existing records in a vector store, but we cannot know them if we use some retrievers.

In order to avoid any conflicts, breaking changes, the new fields in metadata have a prefix `_` 

## Dependencies

N/A

## Twitter handle

@kill_in_sun

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
