### PR TITLE
Langchain: Allow AgentAction to take in a list as input.

### DIFF
--- a/libs/core/langchain_core/agents.py
+++ b/libs/core/langchain_core/agents.py
@@ -17,7 +17,7 @@ class AgentAction(Serializable):
 
     tool: str
     """The name of the Tool to execute."""
-    tool_input: Union[str, dict]
+    tool_input: Union[str, list, dict]
     """The input to pass in to the Tool."""
     log: str
     """Additional information to log about the action.


### PR DESCRIPTION
- **Description** Add `list` to the accepted types of the `tool_input` field in the `AgentAction` class