### PR TITLE
community[patch]: Update documentation to use  'model_id' rather than 'model_name' to match actual API

### DIFF
--- a/libs/community/langchain_community/embeddings/self_hosted_hugging_face.py
+++ b/libs/community/langchain_community/embeddings/self_hosted_hugging_face.py
@@ -71,9 +71,9 @@ class SelfHostedHuggingFaceEmbeddings(SelfHostedEmbeddings):
 
             from langchain_community.embeddings import SelfHostedHuggingFaceEmbeddings
             import runhouse as rh
-            model_name = "sentence-transformers/all-mpnet-base-v2"
+            model_id = "sentence-transformers/all-mpnet-base-v2"
             gpu = rh.cluster(name="rh-a10x", instance_type="A100:1")
-            hf = SelfHostedHuggingFaceEmbeddings(model_name=model_name, hardware=gpu)
+            hf = SelfHostedHuggingFaceEmbeddings(model_id=model_id, hardware=gpu)
     """
 
     client: Any  #: :meta private:


### PR DESCRIPTION

  - **Description:** Replace 'model_name' with 'model_id' for accuracy 
  - **Issue:** [link-to-issue](https://github.com/langchain-ai/langchain/issues/16577)
  - **Dependencies:** 
  - **Twitter handle:**




