### PR TITLE
Pydantic replaced method schema with the model_json_schema

### DIFF
--- a/libs/langchain/langchain/chains/openai_functions/extraction.py
+++ b/libs/langchain/langchain/chains/openai_functions/extraction.py
@@ -101,7 +101,7 @@ def create_extraction_chain_pydantic(
     class PydanticSchema(BaseModel):
         info: List[pydantic_schema]  # type: ignore
 
-    openai_schema = pydantic_schema.schema()
+    openai_schema = pydantic_schema.model_json_schema()
     openai_schema = _resolve_schema_references(
         openai_schema, openai_schema.get("definitions", {})
     )

--- a/libs/langchain/langchain/chains/openai_functions/tagging.py
+++ b/libs/langchain/langchain/chains/openai_functions/tagging.py
@@ -75,7 +75,7 @@ def create_tagging_chain_pydantic(
     Returns:
         Chain (LLMChain) that can be used to extract information from a passage.
     """
-    openai_schema = pydantic_schema.schema()
+    openai_schema = pydantic_schema.model_json_schema()
     function = _get_tagging_function(openai_schema)
     prompt = prompt or ChatPromptTemplate.from_template(_TAGGING_TEMPLATE)
     output_parser = PydanticOutputFunctionsParser(pydantic_schema=pydantic_schema)


### PR DESCRIPTION
See: https://docs.pydantic.dev/2.4/migration/#changes-to-pydanticbasemodel