### PR TITLE
partners: replace deprecated .dict() with .model_dump() in openai base.py

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -407,7 +407,7 @@ class ChatOpenAI(BaseChatModel):
         default_chunk_class = AIMessageChunk
         for chunk in self.client.create(messages=message_dicts, **params):
             if not isinstance(chunk, dict):
-                chunk = chunk.dict()
+                chunk = chunk.model_dump()
             if len(chunk["choices"]) == 0:
                 continue
             choice = chunk["choices"][0]

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -24,7 +24,6 @@ from typing import (
 )
 
 import openai
-import pydantic
 import tiktoken
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
@@ -409,9 +408,9 @@ class ChatOpenAI(BaseChatModel):
         for chunk in self.client.create(messages=message_dicts, **params):
             if not isinstance(chunk, dict):
                 chunk = (
-                    chunk.dict()
-                    if pydantic.__version__.startswith("1")
-                    else chunk.model_dump()
+                    getattr(chunk, "model_dump")()
+                    if hasattr(chunk, "model_dump")
+                    else chunk.dict()
                 )
             if len(chunk["choices"]) == 0:
                 continue
@@ -471,9 +470,9 @@ class ChatOpenAI(BaseChatModel):
         generations = []
         if not isinstance(response, dict):
             response = (
-                response.dict()
-                if pydantic.__version__.startswith("1")
-                else response.model_dump()
+                getattr(response, "model_dump")()
+                if hasattr(response, "model_dump")
+                else response.dict()
             )
         for res in response["choices"]:
             message = _convert_dict_to_message(res["message"])
@@ -509,9 +508,9 @@ class ChatOpenAI(BaseChatModel):
         ):
             if not isinstance(chunk, dict):
                 chunk = (
-                    chunk.dict()
-                    if pydantic.__version__.startswith("1")
-                    else chunk.model_dump()
+                    getattr(chunk, "model_dump")()
+                    if hasattr(chunk, "model_dump")
+                    else chunk.dict()
                 )
             if len(chunk["choices"]) == 0:
                 continue

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -465,7 +465,7 @@ class ChatOpenAI(BaseChatModel):
     def _create_chat_result(self, response: Union[dict, BaseModel]) -> ChatResult:
         generations = []
         if not isinstance(response, dict):
-            response = response.dict()
+            response = response.model_dump()
         for res in response["choices"]:
             message = _convert_dict_to_message(res["message"])
             generation_info = dict(finish_reason=res.get("finish_reason"))
@@ -499,7 +499,7 @@ class ChatOpenAI(BaseChatModel):
             messages=message_dicts, **params
         ):
             if not isinstance(chunk, dict):
-                chunk = chunk.dict()
+                chunk = chunk.model_dump()
             if len(chunk["choices"]) == 0:
                 continue
             choice = chunk["choices"][0]

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 import openai
+import pydantic
 import tiktoken
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
@@ -407,7 +408,11 @@ class ChatOpenAI(BaseChatModel):
         default_chunk_class = AIMessageChunk
         for chunk in self.client.create(messages=message_dicts, **params):
             if not isinstance(chunk, dict):
-                chunk = chunk.model_dump()
+                chunk = (
+                    chunk.dict()
+                    if pydantic.__version__.startswith("1")
+                    else chunk.model_dump()
+                )
             if len(chunk["choices"]) == 0:
                 continue
             choice = chunk["choices"][0]
@@ -465,7 +470,11 @@ class ChatOpenAI(BaseChatModel):
     def _create_chat_result(self, response: Union[dict, BaseModel]) -> ChatResult:
         generations = []
         if not isinstance(response, dict):
-            response = response.model_dump()
+            response = (
+                response.dict()
+                if pydantic.__version__.startswith("1")
+                else response.model_dump()
+            )
         for res in response["choices"]:
             message = _convert_dict_to_message(res["message"])
             generation_info = dict(finish_reason=res.get("finish_reason"))
@@ -499,7 +508,11 @@ class ChatOpenAI(BaseChatModel):
             messages=message_dicts, **params
         ):
             if not isinstance(chunk, dict):
-                chunk = chunk.model_dump()
+                chunk = (
+                    chunk.dict()
+                    if pydantic.__version__.startswith("1")
+                    else chunk.model_dump()
+                )
             if len(chunk["choices"]) == 0:
                 continue
             choice = chunk["choices"][0]


### PR DESCRIPTION
  - **Description:** Same as #15489 but under the correct package this time. Using pydantic's new `.model_dump()` function. It produces the same result as `.dict()` without throwing a deprecation warning message, 
  - **Issue:** #15997 ,
  - **Dependencies:** None,
  - **Twitter handle:** @mantzouranidis

Thanks :) 