### PR TITLE
langchain[minor],community[minor]: Add async methods in BaseLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/base.py
+++ b/libs/community/langchain_community/document_loaders/base.py
@@ -59,10 +59,6 @@ class BaseLoader(ABC):
             f"{self.__class__.__name__} does not implement lazy_load()"
         )
 
-    async def aload(self) -> List[Document]:
-        """Load data into Document objects."""
-        return [doc async for doc in self.alazy_load()]
-
     async def alazy_load(self) -> AsyncIterator[Document]:
         """A lazy loader for Documents."""
         iterator = await run_in_executor(None, self.lazy_load)

--- a/libs/community/langchain_community/document_loaders/base.py
+++ b/libs/community/langchain_community/document_loaders/base.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, AsyncIterator, Iterator, List, Optional
 
 from langchain_core.documents import Document
+from langchain_core.runnables import run_in_executor
 
 from langchain_community.document_loaders.blob_loaders import Blob
 
@@ -52,13 +53,25 @@ class BaseLoader(ABC):
 
     # Attention: This method will be upgraded into an abstractmethod once it's
     #            implemented in all the existing subclasses.
-    def lazy_load(
-        self,
-    ) -> Iterator[Document]:
+    def lazy_load(self) -> Iterator[Document]:
         """A lazy loader for Documents."""
         raise NotImplementedError(
             f"{self.__class__.__name__} does not implement lazy_load()"
         )
+
+    async def aload(self) -> List[Document]:
+        """Load data into Document objects."""
+        return [doc async for doc in self.alazy_load()]
+
+    async def alazy_load(self) -> AsyncIterator[Document]:
+        """A lazy loader for Documents."""
+        iterator = await run_in_executor(None, self.lazy_load)
+        done = object()
+        while True:
+            doc = await run_in_executor(None, next, iterator, done)
+            if doc is done:
+                break
+            yield doc
 
 
 class BaseBlobParser(ABC):

--- a/libs/community/langchain_community/document_loaders/merge.py
+++ b/libs/community/langchain_community/document_loaders/merge.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List
+from typing import AsyncIterator, Iterator, List
 
 from langchain_core.documents import Document
 
@@ -26,3 +26,9 @@ class MergedDataLoader(BaseLoader):
     def load(self) -> List[Document]:
         """Load docs."""
         return list(self.lazy_load())
+
+    async def alazy_load(self) -> AsyncIterator[Document]:
+        """Lazy load docs from each individual loader."""
+        for loader in self.loaders:
+            async for document in loader.alazy_load():
+                yield document

--- a/libs/community/tests/unit_tests/document_loaders/test_base.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_base.py
@@ -29,14 +29,18 @@ def test_base_blob_parser() -> None:
     assert docs[0].page_content == "foo"
 
 
-async def test_default_aload():
+async def test_default_aload() -> None:
     class FakeLoader(BaseLoader):
         def load(self) -> List[Document]:
             return list(self.lazy_load())
 
         def lazy_load(self) -> Iterator[Document]:
-            yield Document(page_content="foo")
+            yield from [
+                Document(page_content="foo"),
+                Document(page_content="bar"),
+                ]
 
     loader = FakeLoader()
     docs = loader.load()
-    assert docs == [Document(page_content="foo")]
+    assert docs == [Document(page_content="foo"), Document(page_content="bar")]
+    assert docs == [doc async for doc in loader.alazy_load()]

--- a/libs/community/tests/unit_tests/document_loaders/test_base.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_base.py
@@ -1,9 +1,9 @@
 """Test Base Schema of documents."""
-from typing import Iterator
+from typing import Iterator, List
 
 from langchain_core.documents import Document
 
-from langchain_community.document_loaders.base import BaseBlobParser
+from langchain_community.document_loaders.base import BaseBlobParser, BaseLoader
 from langchain_community.document_loaders.blob_loaders import Blob
 
 
@@ -27,3 +27,16 @@ def test_base_blob_parser() -> None:
     docs = parser.parse(Blob(data="who?"))
     assert len(docs) == 1
     assert docs[0].page_content == "foo"
+
+
+async def test_default_aload():
+    class FakeLoader(BaseLoader):
+        def load(self) -> List[Document]:
+            return list(self.lazy_load())
+
+        def lazy_load(self) -> Iterator[Document]:
+            yield Document(page_content="foo")
+
+    loader = FakeLoader()
+    docs = loader.load()
+    assert docs == [Document(page_content="foo")]

--- a/libs/community/tests/unit_tests/document_loaders/test_base.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_base.py
@@ -38,7 +38,7 @@ async def test_default_aload() -> None:
             yield from [
                 Document(page_content="foo"),
                 Document(page_content="bar"),
-                ]
+            ]
 
     loader = FakeLoader()
     docs = loader.load()

--- a/libs/langchain/langchain/indexes/_api.py
+++ b/libs/langchain/langchain/indexes/_api.py
@@ -391,7 +391,7 @@ async def _to_async_iterator(iterator: Iterable[T]) -> AsyncIterator[T]:
 
 
 async def aindex(
-    docs_source: Union[Iterable[Document], AsyncIterator[Document]],
+    docs_source: Union[BaseLoader, Iterable[Document], AsyncIterator[Document]],
     record_manager: RecordManager,
     vector_store: VectorStore,
     *,
@@ -469,16 +469,17 @@ async def aindex(
         # implementation which just raises a NotImplementedError
         raise ValueError("Vectorstore has not implemented the delete method")
 
-    if isinstance(docs_source, BaseLoader):
-        raise NotImplementedError(
-            "Not supported yet. Please pass an async iterator of documents."
-        )
     async_doc_iterator: AsyncIterator[Document]
-
-    if hasattr(docs_source, "__aiter__"):
-        async_doc_iterator = docs_source  # type: ignore[assignment]
+    if isinstance(docs_source, BaseLoader):
+        try:
+            async_doc_iterator = docs_source.alazy_load()
+        except NotImplementedError:
+            async_doc_iterator = _to_async_iterator(await docs_source.aload())
     else:
-        async_doc_iterator = _to_async_iterator(docs_source)
+        if hasattr(docs_source, "__aiter__"):
+            async_doc_iterator = docs_source  # type: ignore[assignment]
+        else:
+            async_doc_iterator = _to_async_iterator(docs_source)
 
     source_id_assigner = _get_source_id_assigner(source_id_key)
 

--- a/libs/langchain/langchain/indexes/_api.py
+++ b/libs/langchain/langchain/indexes/_api.py
@@ -474,7 +474,12 @@ async def aindex(
         try:
             async_doc_iterator = docs_source.alazy_load()
         except NotImplementedError:
-            async_doc_iterator = _to_async_iterator(await docs_source.aload())
+            # Exception triggered when neither lazy_load nor alazy_load are implemented.
+            # * The default implementation of alazy_load uses lazy_load.
+            # * The default implementation of lazy_load raises NotImplementedError.
+            # In such a case, we use the load method and convert it to an async
+            # iterator.
+            async_doc_iterator = _to_async_iterator(docs_source.load())
     else:
         if hasattr(docs_source, "__aiter__"):
             async_doc_iterator = docs_source  # type: ignore[assignment]


### PR DESCRIPTION
Adds:
* methods `aload()` and `alazy_load()` to interface `BaseLoader`
* implementation for class `MergedDataLoader `
* support for class `BaseLoader` in async function `aindex()` with unit tests

Note: this is compatible with existing `aload()` methods that some loaders already had.

**Twitter handle:** @cbornet_
