### PR TITLE
langchain[patch]: Invoke chain prep_inputs and prep_outputs inside try block to catch validation errors

### DIFF
--- a/libs/langchain/tests/unit_tests/chains/test_base.py
+++ b/libs/langchain/tests/unit_tests/chains/test_base.py
@@ -162,3 +162,35 @@ def test_run_with_callback() -> None:
     assert handler.starts == 1
     assert handler.ends == 1
     assert handler.errors == 0
+
+
+def test_run_with_callback_and_input_error() -> None:
+    """Test callback manager catches run validation input error."""
+    handler = FakeCallbackHandler()
+    chain = FakeChain(
+        the_input_keys=["foo", "bar"],
+        callbacks=[handler],
+    )
+
+    with pytest.raises(ValueError):
+        chain({"bar": "foo"})
+
+    assert handler.starts == 1
+    assert handler.ends == 0
+    assert handler.errors == 1
+
+
+def test_run_with_callback_and_output_error() -> None:
+    """Test callback manager catches run validation output error."""
+    handler = FakeCallbackHandler()
+    chain = FakeChain(
+        the_output_keys=["foo", "bar"],
+        callbacks=[handler],
+    )
+
+    with pytest.raises(ValueError):
+        chain("foo")
+
+    assert handler.starts == 1
+    assert handler.ends == 0
+    assert handler.errors == 1


### PR DESCRIPTION
  - **Description:** Callback manager can't catch chain input or output validation errors because `prepare_input` and `prepare_output` are not part of the try/raise logic, this PR fixes that logic.
 
  - **Issue:** #15954 

