### PR TITLE
Docs: Fix typo in XML agent documentation

### DIFF
--- a/docs/docs/modules/agents/agent_types/xml_agent.ipynb
+++ b/docs/docs/modules/agents/agent_types/xml_agent.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "* Use with regular LLMs, not with chat models.\n",
     "* Use only with unstructured tools; i.e., tools that accept a single string input.\n",
-    "* See [AgentTypes](/docs/moduels/agents/agent_types/) documentation for more agent types.\n",
+    "* See [AgentTypes](/docs/modules/agents/agent_types/) documentation for more agent types.\n",
     ":::"
    ]
   },


### PR DESCRIPTION
This is a tiny PR that just replacer "moduels" with "modules" in the documentation for XML agents.
