### PR TITLE
community: apply embedding functions during query if defined

### DIFF
--- a/libs/community/langchain_community/vectorstores/bageldb.py
+++ b/libs/community/langchain_community/vectorstores/bageldb.py
@@ -110,8 +110,8 @@ class Bagel(VectorStore):
         except ImportError:
             raise ImportError("Please install bagel `pip install betabageldb`.")
 
-        texts = list(query_texts)
-        if self._embedding_function and query_embeddings is None and texts:
+        if self._embedding_function and query_embeddings is None and query_texts:
+            texts = list(query_texts)
             query_embeddings = self._embedding_function.embed_documents(texts)
             query_texts = None
 

--- a/libs/community/langchain_community/vectorstores/bageldb.py
+++ b/libs/community/langchain_community/vectorstores/bageldb.py
@@ -109,6 +109,12 @@ class Bagel(VectorStore):
             import bagel  # noqa: F401
         except ImportError:
             raise ImportError("Please install bagel `pip install betabageldb`.")
+
+        texts = list(query_texts)
+        if self._embedding_function and query_embeddings is None and texts:
+            query_embeddings = self._embedding_function.embed_documents(texts)
+            query_texts = None
+
         return self._cluster.find(
             query_texts=query_texts,
             query_embeddings=query_embeddings,


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Replace this entire comment with:
  
Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

  **Description:** This update ensures that the user-defined embedding function specified during vector store creation is applied during queries. Previously, even if a custom embedding function was defined at the time of store creation, Bagel DB would default to using the standard embedding function during query execution. This pull request addresses this issue by consistently using the user-defined embedding function for queries if one has been specified earlier.


