### PR TITLE
partners/google-vertexai:fix _parse_response_candidate issue

### DIFF
--- a/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
@@ -30,8 +30,8 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import root_validator
-from proto.marshal.collections.maps import MapComposite
-from proto.marshal.collections.repeated import RepeatedComposite
+from proto.marshal.collections.maps import MapComposite  # type: ignore
+from proto.marshal.collections.repeated import RepeatedComposite  # type: ignore
 from vertexai.language_models import (  # type: ignore
     ChatMessage,
     ChatModel,

--- a/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
 from urllib.parse import urlparse
 
-import proto
+import proto  # type: ignore
 import requests
 from google.cloud.aiplatform_v1beta1.types.content import Part as GapicPart
 from google.cloud.aiplatform_v1beta1.types.tool import FunctionCall

--- a/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
 from urllib.parse import urlparse
 
-import proto  # type: ignore
+import proto  # type: ignore[import-untyped]
 import requests
 from google.cloud.aiplatform_v1beta1.types.content import Part as GapicPart
 from google.cloud.aiplatform_v1beta1.types.tool import FunctionCall

--- a/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/partners/google-vertexai/langchain_google_vertexai/chat_models.py
@@ -307,7 +307,10 @@ def _convert_mapcomposite(mapcomposite: MapComposite):
 def _convert_repeatedcomposite(repeated_composite: RepeatedComposite):
     _ = []
     for composite in repeated_composite:
-        if isinstance(composite, MapComposite):
+        if isinstance(composite, RepeatedComposite):
+            obj_list = _convert_repeatedcomposite(composite)
+            _.append(obj_list)
+        elif isinstance(composite, MapComposite):
             map = _convert_mapcomposite(composite)
             _.append(map)
         else:

--- a/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
@@ -11,12 +11,18 @@ from google.cloud.aiplatform_v1beta1.types import (
     FunctionCall,
     Part,
 )
+from google.cloud.aiplatform_v1beta1.types import (
+    content as gapic_content_types,
+)
 from langchain_core.messages import (
     AIMessage,
     HumanMessage,
     SystemMessage,
 )
 from vertexai.language_models import ChatMessage, InputOutputTextPair  # type: ignore
+from vertexai.preview.generative_models import (  # type: ignore
+    Candidate,
+)
 
 from langchain_google_vertexai.chat_models import (
     ChatVertexAI,
@@ -212,20 +218,21 @@ def test_default_params_gemini() -> None:
 
 
 @pytest.mark.parametrize(
-    "content, expected",
+    "raw_candidate, expected",
     [
         (
-            Content(
-                role="model",
-                parts=[
-                    Part(
-                        text="",
-                        function_call=FunctionCall(
-                            name="Information",
-                            args={"name": "Ben"},
-                        ),
-                    )
-                ],
+            gapic_content_types.Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            function_call=FunctionCall(
+                                name="Information",
+                                args={"name": "Ben"},
+                            ),
+                        )
+                    ],
+                )
             ),
             {
                 "name": "Information",
@@ -233,17 +240,18 @@ def test_default_params_gemini() -> None:
             },
         ),
         (
-            Content(
-                role="model",
-                parts=[
-                    Part(
-                        text="",
-                        function_call=FunctionCall(
-                            name="Information",
-                            args={"info": ["A", "B", "C"]},
-                        ),
-                    )
-                ],
+            gapic_content_types.Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            function_call=FunctionCall(
+                                name="Information",
+                                args={"info": ["A", "B", "C"]},
+                            ),
+                        )
+                    ],
+                )
             ),
             {
                 "name": "Information",
@@ -251,22 +259,23 @@ def test_default_params_gemini() -> None:
             },
         ),
         (
-            Content(
-                role="model",
-                parts=[
-                    Part(
-                        text="",
-                        function_call=FunctionCall(
-                            name="Information",
-                            args={
-                                "people": [
-                                    {"name": "Joe", "age": 30},
-                                    {"name": "Martha"},
-                                ]
-                            },
-                        ),
-                    )
-                ],
+            gapic_content_types.Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            function_call=FunctionCall(
+                                name="Information",
+                                args={
+                                    "people": [
+                                        {"name": "Joe", "age": 30},
+                                        {"name": "Martha"},
+                                    ]
+                                },
+                            ),
+                        )
+                    ],
+                )
             ),
             {
                 "name": "Information",
@@ -279,17 +288,18 @@ def test_default_params_gemini() -> None:
             },
         ),
         (
-            Content(
-                role="model",
-                parts=[
-                    Part(
-                        text="",
-                        function_call=FunctionCall(
-                            name="Information",
-                            args={"info": [[1, 2, 3], [4, 5, 6]]},
-                        ),
-                    )
-                ],
+            gapic_content_types.Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            function_call=FunctionCall(
+                                name="Information",
+                                args={"info": [[1, 2, 3], [4, 5, 6]]},
+                            ),
+                        )
+                    ],
+                )
             ),
             {
                 "name": "Information",
@@ -298,11 +308,8 @@ def test_default_params_gemini() -> None:
         ),
     ],
 )
-def test_parse_response_candidate(content, expected) -> None:
-    response_candidate = StubGeminiResponse(
-        text="", content=content, citation_metadata=Mock()
-    )
-
+def test_parse_response_candidate(raw_candidate, expected) -> None:
+    response_candidate = Candidate._from_gapic(raw_candidate)
     result = _parse_response_candidate(response_candidate)
     result_arguments = json.loads(
         result.additional_kwargs["function_call"]["arguments"]

--- a/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
@@ -278,6 +278,24 @@ def test_default_params_gemini() -> None:
                 },
             },
         ),
+        (
+            Content(
+                role="model",
+                parts=[
+                    Part(
+                        text="",
+                        function_call=FunctionCall(
+                            name="Information",
+                            args={"info": [[1, 2, 3], [4, 5, 6]]},
+                        ),
+                    )
+                ],
+            ),
+            {
+                "name": "Information",
+                "arguments": {"info": [[1, 2, 3], [4, 5, 6]]},
+            },
+        ),
     ],
 )
 def test_parse_response_candidate(content, expected) -> None:


### PR DESCRIPTION

  **Description:**  enable _parse_response_candidate to support complex structure format. 
  **Issue:** 
  currently, if Gemini response complex args format, people will get "TypeError: Object of type RepeatedComposite is not JSON serializable" error from _parse_response_candidate. 
  
 response candidate example
```
content {
  role: "model"
  parts {
    function_call {
      name: "Information"
      args {
        fields {
          key: "people"
          value {
            list_value {
              values {
                string_value: "Joe is 30, his mom is Martha"
              }
            }
          }
        }
      }
    }
  }
}
finish_reason: STOP
safety_ratings {
  category: HARM_CATEGORY_HARASSMENT
  probability: NEGLIGIBLE
}
safety_ratings {
  category: HARM_CATEGORY_HATE_SPEECH
  probability: NEGLIGIBLE
}
safety_ratings {
  category: HARM_CATEGORY_SEXUALLY_EXPLICIT
  probability: NEGLIGIBLE
}
safety_ratings {
  category: HARM_CATEGORY_DANGEROUS_CONTENT
  probability: NEGLIGIBLE
}
```
 
error msg:
```
Traceback (most recent call last):
  File "/home/jupyter/user/abehsu/gemini_langchain_tools/example2.py", line 36, in <module>
    print(tagging_chain.invoke({"input": "Joe is 30, his mom is Martha"}))
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/runnables/base.py", line 2053, in invoke
    input = step.invoke(
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/runnables/base.py", line 3887, in invoke
    return self.bound.invoke(
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 165, in invoke
    self.generate_prompt(
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 543, in generate_prompt
    return self.generate(prompt_messages, stop=stop, callbacks=callbacks, **kwargs)
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 407, in generate
    raise e
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 397, in generate
    self._generate_with_cache(
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_core/language_models/chat_models.py", line 576, in _generate_with_cache
    return self._generate(
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_google_vertexai/chat_models.py", line 406, in _generate
    generations = [
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_google_vertexai/chat_models.py", line 408, in <listcomp>
    message=_parse_response_candidate(c),
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/site-packages/langchain_google_vertexai/chat_models.py", line 280, in _parse_response_candidate
    function_call["arguments"] = json.dumps(
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/opt/conda/envs/gemini_langchain_tools/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type RepeatedComposite is not JSON serializable
```
  

  **Twitter handle:**  @abehsu1992626
