### PR TITLE
community: Ollama - Pass headers to post request in async method

### DIFF
--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -284,7 +284,10 @@ class _OllamaCommon(BaseLanguageModel):
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 url=api_url,
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    **(self.headers if isinstance(self.headers, dict) else {}),
+                },
                 json=request_payload,
                 timeout=self.timeout,
             ) as response:


### PR DESCRIPTION
# Description
A previous PR (https://github.com/langchain-ai/langchain/pull/15881) added option to pass headers to ollama endpoint, but headers are not pass to the async method.