### PR TITLE
WebBaseLoader: Add Cookie Support to Fetch Method

### DIFF
--- a/libs/community/langchain_community/document_loaders/web_base.py
+++ b/libs/community/langchain_community/document_loaders/web_base.py
@@ -132,6 +132,7 @@ class WebBaseLoader(BaseLoader):
                         url,
                         headers=self.session.headers,
                         ssl=None if self.session.verify else False,
+                        cookies=self.session.cookies.get_dict(),
                     ) as response:
                         return await response.text()
                 except aiohttp.ClientConnectionError as e:


### PR DESCRIPTION
- **Description:** This change allows the `_fetch` method in the `WebBaseLoader` class to utilize cookies from an existing `requests.Session`. It ensures that when the `fetch` method is used, any cookies in the provided session are included in the request. This enhancement maintains compatibility with existing functionality while extending the utility of the `fetch` method for scenarios where cookie persistence is necessary.
- **Issue:** Not applicable (new feature),
- **Dependencies:** Requires `aiohttp` and `requests` libraries (no new dependencies introduced),
- **Twitter handle:** N/A