### PR TITLE
community: Invalidate sqlalchemy connection

### DIFF
--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -360,6 +360,8 @@ class SQLDatabase:
             # save the sample rows in string format
             sample_rows_str = "\n".join(["\t".join(row) for row in sample_rows])
 
+            connection.invalidate()
+
         # in some dialects when there are no rows in the table a
         # 'ProgrammingError' is returned
         except ProgrammingError:


### PR DESCRIPTION

  - **Description:** 
  _connection.close()_ restores the DBAPI connection back to the connection-holding pool but does not actually close it. 
  _connection.invalidate()_  closes the underlying DBAPI connection. It will prevent exceptions such as OperationalError.

  - **Issue:** Fixed #15687