### PR TITLE
community: Invalidate sqlalchemy connection

### DIFF
--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -357,6 +357,8 @@ class SQLDatabase:
                     map(lambda ls: [str(i)[:100] for i in ls], sample_rows_result)
                 )
 
+            connection.invalidate()
+
             # save the sample rows in string format
             sample_rows_str = "\n".join(["\t".join(row) for row in sample_rows])
 


### PR DESCRIPTION

  - **Description:** 
 connection.close() restores the DBAPI connection back to the connection-holding pool but does not actually close it.connection.invalidate() closes the underlying DBAPI connection. It will prevent exceptions such as OperationalError.

  - **Issue:** Fixed #15687
  