### PR TITLE
Make input param optional for retrieval chain and history aware retriever chain

### DIFF
--- a/libs/langchain/langchain/chains/history_aware_retriever.py
+++ b/libs/langchain/langchain/chains/history_aware_retriever.py
@@ -48,10 +48,11 @@ def create_history_aware_retriever(
             chain.invoke({"input": "...", "chat_history": })
 
     """
-    if "input" not in prompt.input_variables:
+    input_vars = prompt.input_variables
+    if "input" not in input_vars and "chat_history" not in input_vars:
         raise ValueError(
-            "Expected `input` to be a prompt variable, "
-            f"but got {prompt.input_variables}"
+            "Expected either `input` or `chat_history` to be prompt variables, "
+            f"but got {input_vars}"
         )
 
     retrieve_documents: RetrieverOutputLike = RunnableBranch(

--- a/libs/langchain/langchain/chains/history_aware_retriever.py
+++ b/libs/langchain/langchain/chains/history_aware_retriever.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Dict
+
 from langchain_core.language_models import LanguageModelLike
+from langchain_core.messages import BaseMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import BasePromptTemplate
 from langchain_core.retrievers import RetrieverLike, RetrieverOutputLike
@@ -54,7 +57,7 @@ def create_history_aware_retriever(
             "Expected either `input` or `messages` to be prompt variables, "
             f"but got {input_vars}"
         )
-        
+
     def messages_param_is_message_list(x: Dict):
         return (
             isinstance(x.get("messages", []), list)
@@ -64,11 +67,13 @@ def create_history_aware_retriever(
 
     retrieve_documents: RetrieverOutputLike = RunnableBranch(
         (
-            lambda x: messages_param_is_message_list(x) and len(x.get("messages", [])) > 1,
-            prompt | llm | StrOutputParser() | retriever
+            lambda x: messages_param_is_message_list(x)
+            and len(x.get("messages", [])) > 1,
+            prompt | llm | StrOutputParser() | retriever,
         ),
         (
-            lambda x: messages_param_is_message_list(x) and len(x.get("messages", [])) == 1,
+            lambda x: messages_param_is_message_list(x)
+            and len(x.get("messages", [])) == 1,
             (lambda x: x["messages"][-1].content) | retriever,
         ),
         (

--- a/libs/langchain/langchain/chains/history_aware_retriever.py
+++ b/libs/langchain/langchain/chains/history_aware_retriever.py
@@ -58,7 +58,7 @@ def create_history_aware_retriever(
             f"but got {input_vars}"
         )
 
-    def messages_param_is_message_list(x: Dict):
+    def messages_param_is_message_list(x: Dict) -> bool:
         return (
             isinstance(x.get("messages", []), list)
             and len(x.get("messages", [])) > 0

--- a/libs/langchain/langchain/chains/retrieval.py
+++ b/libs/langchain/langchain/chains/retrieval.py
@@ -57,14 +57,14 @@ def create_retrieval_chain(
 
     """
 
-    def messages_param_is_message_list(x: Dict):
+    def messages_param_is_message_list(x: Dict) -> bool:
         return (
             isinstance(x.get("messages", []), list)
             and len(x.get("messages", [])) > 0
             and all(isinstance(i, BaseMessage) for i in x.get("messages", []))
         )
 
-    def extract_retriever_input_string(x: Dict):
+    def extract_retriever_input_string(x: Dict) -> str:
         if not x.get("input"):
             if messages_param_is_message_list(x):
                 return x["messages"][-1].content

--- a/libs/langchain/langchain/chains/retrieval.py
+++ b/libs/langchain/langchain/chains/retrieval.py
@@ -57,18 +57,18 @@ def create_retrieval_chain(
 
     """
 
-    def extract_retriever_input_string(x: Dict):
-        if x.get("input", None) is None or len(x.get("chat_history", [])) > 0:
-            return x["input"]
-        else:
-            return x["chat_history"][-1].content
-
     def input_chat_history_is_message_list(x: Dict):
         return (
             isinstance(x.get("chat_history", []), list)
             and len(x.get("chat_history", [])) > 0
             and all(isinstance(i, BaseMessage) for i in x.get("chat_history", []))
         )
+
+    def extract_retriever_input_string(x: Dict):
+        if x.get("input", None) is None and input_chat_history_is_message_list(x):
+            return x["chat_history"][-1].content
+        else:
+            return x["input"]
 
     if not isinstance(retriever, BaseRetriever):
         retrieval_docs: Runnable[dict, RetrieverOutput] = (

--- a/libs/langchain/langchain/chains/retrieval.py
+++ b/libs/langchain/langchain/chains/retrieval.py
@@ -65,7 +65,7 @@ def create_retrieval_chain(
         )
 
     def extract_retriever_input_string(x: Dict):
-        if x.get("input", None) is None and input_chat_history_is_message_list(x):
+        if not x.get("input") and input_chat_history_is_message_list(x):
             return x["chat_history"][-1].content
         else:
             return x["input"]

--- a/libs/langchain/langchain/chains/retrieval.py
+++ b/libs/langchain/langchain/chains/retrieval.py
@@ -7,7 +7,7 @@ from langchain_core.retrievers import (
     BaseRetriever,
     RetrieverOutput,
 )
-from langchain_core.runnables import Runnable, RunnableBranch, RunnablePassthrough
+from langchain_core.runnables import Runnable, RunnablePassthrough
 
 
 def create_retrieval_chain(
@@ -70,7 +70,8 @@ def create_retrieval_chain(
                 return x["messages"][-1].content
             else:
                 raise ValueError(
-                    'If `input` not provided, `messages` parameter must be a list of messages.'
+                    "If `input` not provided, ",
+                    "`messages` parameter must be a list of messages.",
                 )
         else:
             return x["input"]

--- a/libs/langchain/tests/unit_tests/chains/test_retrieval.py
+++ b/libs/langchain/tests/unit_tests/chains/test_retrieval.py
@@ -35,21 +35,21 @@ def test_create_with_chat_history_messages_only() -> None:
     retriever = FakeParrotRetriever()
     question_gen_prompt = ChatPromptTemplate.from_messages(
         [
-            MessagesPlaceholder(variable_name="chat_history"),
+            MessagesPlaceholder(variable_name="messages"),
         ]
     )
     chain = create_retrieval_chain(retriever, question_gen_prompt | llm)
 
     expected_output = {
         "answer": "I know the answer!",
-        "chat_history": [
+        "messages": [
             HumanMessage(content="What is the answer?"),
         ],
         "context": [Document(page_content="What is the answer?")],
     }
     output = chain.invoke(
         {
-            "chat_history": [
+            "messages": [
                 HumanMessage(content="What is the answer?"),
             ],
         }

--- a/libs/langchain/tests/unit_tests/chains/test_retrieval.py
+++ b/libs/langchain/tests/unit_tests/chains/test_retrieval.py
@@ -1,7 +1,12 @@
 """Test conversation chain and memory."""
 from langchain_community.llms.fake import FakeListLLM
 from langchain_core.documents import Document
-from langchain_core.prompts.prompt import PromptTemplate
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts.prompt import (
+    ChatPromptTemplate,
+    MessagesPlaceholder,
+    PromptTemplate,
+)
 
 from langchain.chains import create_retrieval_chain
 from tests.unit_tests.retrievers.parrot_retriever import FakeParrotRetriever
@@ -21,4 +26,33 @@ def test_create() -> None:
         "input": "What is the answer?",
     }
     output = chain.invoke({"input": "What is the answer?", "chat_history": "foo"})
+    assert output == expected_output
+
+
+def test_create_with_chat_history_messages_only() -> None:
+    answer = "I know the answer!"
+    llm = FakeListLLM(responses=[answer])
+    retriever = FakeParrotRetriever()
+    question_gen_prompt = ChatPromptTemplate.from_messages(
+        [
+            MessagesPlaceholder(variable_name="chat_history"),
+        ]
+    )
+    chain = create_retrieval_chain(retriever, question_gen_prompt | llm)
+
+    expected_output = {
+        "answer": "I know the answer!",
+        "chat_history": [
+            HumanMessage(content="What is the answer?"),
+        ],
+        "context": [Document(page_content="What is the answer?")],
+    }
+    output = chain.invoke(
+        {
+            "input": "What is the answer?",
+            "chat_history": [
+                HumanMessage(content="What is the answer?"),
+            ],
+        }
+    )
     assert output == expected_output

--- a/libs/langchain/tests/unit_tests/chains/test_retrieval.py
+++ b/libs/langchain/tests/unit_tests/chains/test_retrieval.py
@@ -2,7 +2,7 @@
 from langchain_community.llms.fake import FakeListLLM
 from langchain_core.documents import Document
 from langchain_core.messages import HumanMessage
-from langchain_core.prompts.prompt import (
+from langchain_core.prompts import (
     ChatPromptTemplate,
     MessagesPlaceholder,
     PromptTemplate,
@@ -49,7 +49,6 @@ def test_create_with_chat_history_messages_only() -> None:
     }
     output = chain.invoke(
         {
-            "input": "What is the answer?",
             "chat_history": [
                 HumanMessage(content="What is the answer?"),
             ],


### PR DESCRIPTION
If `chat_history` is a non-empty list of messages, we can extract the last message in the list as the input. This helps these chains be used in chatbot settings where we only want to pass a list of messages.

CC @baskaryan @hwchase17 