### PR TITLE
langchain: pubmed tool path update in doc

### DIFF
--- a/docs/docs/integrations/tools/pubmed.ipynb
+++ b/docs/docs/integrations/tools/pubmed.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.tools import PubmedQueryRun"
+    "from langchain_community.tools.pubmed.tool import PubmedQueryRun"
    ]
   },
   {


### PR DESCRIPTION
  - **Description:** The current pubmed tool documentation is referencing the path to langchain core not the path to the tool in community.  The old tool redirects anyways, but for efficiency of using the more direct path, just adding this documentation so it references the new path
  - **Issue:** doesn't fix an issue
  - **Dependencies:** no dependencies
  - **Twitter handle:** rooftopzen

