### PR TITLE
PR: "docs: Remove accidental extra ``` in QuickStart doc."

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -184,7 +184,6 @@ A Retriever can be backed by anything - a SQL table, the internet, etc - but in 
 
 First, we need to load the data that we want to index. In order to do this, we will use the WebBaseLoader. This requires installing [BeautifulSoup](https://beautiful-soup-4.readthedocs.io/en/latest/):
 
-```
 ```shell
 pip install beautifulsoup4
 ```


### PR DESCRIPTION
Description: One too many set of triple-ticks in a sample code block in the QuickStart doc was causing "\`\`\`shell" to appear in the shell command that was being demonstrated. I just deleted the extra "```".
Issue: Didn't see one
Dependencies: None