### PR TITLE
community: Support Pinecone synchronous processing for e.g. AWS Lambdas, backwards-compatible!

### DIFF
--- a/libs/community/langchain_community/vectorstores/pinecone.py
+++ b/libs/community/langchain_community/vectorstores/pinecone.py
@@ -145,8 +145,8 @@ class Pinecone(VectorStore):
             metadata[self._text_key] = text
 
         if async_req:
-            # For loops to avoid memory issues and optimize when using HTTP based embeddings
-            # The first loop runs the embeddings, it benefits when using OpenAI embeddings
+            # For loops to avoid memory issues when using HTTP-based embeddings
+            # First loop runs embeddings, benefits when using OpenAI embeddings
             # The second loops runs the pinecone upsert asynchronously.
             for i in range(0, len(texts), embedding_chunk_size):
                 chunk_texts = texts[i : i + embedding_chunk_size]

--- a/libs/community/tests/integration_tests/vectorstores/test_pinecone.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_pinecone.py
@@ -2,7 +2,7 @@ import importlib
 import os
 import time
 import uuid
-from typing import TYPE_CHECKING, List, Generator
+from typing import TYPE_CHECKING, Generator, List
 
 import numpy as np
 import pytest
@@ -36,13 +36,18 @@ def texts() -> Generator[List[str], None, None]:
 
     yield [doc.page_content for doc in documents]
 
+
 @pytest.fixture
 def mock_pool_not_supported(mocker):
     """
     This is the error thrown when multiprocessing is not supported.
     See https://github.com/langchain-ai/langchain/issues/11168
     """
-    mocker.patch('multiprocessing.synchronize.SemLock.__init__', side_effect=OSError('OSError: [Errno 38] Function not implemented'))
+    mocker.patch(
+        "multiprocessing.synchronize.SemLock.__init__",
+        side_effect=OSError("OSError: [Errno 38] Function not implemented"),
+    )
+
 
 def reset_pinecone() -> None:
     assert os.environ.get("PINECONE_API_KEY") is not None
@@ -311,9 +316,10 @@ class TestPinecone:
         query = "What did the president say about Ketanji Brown Jackson"
         _ = docsearch.similarity_search(query, k=1, namespace=namespace_name)
 
-
-    @pytest.mark.usefixtures('mock_pool_not_supported')
-    def test_that_async_freq_uses_multiprocessing(self, embedding_openai: OpenAIEmbeddings) -> None:
+    @pytest.mark.usefixtures("mock_pool_not_supported")
+    def test_that_async_freq_uses_multiprocessing(
+        self, embedding_openai: OpenAIEmbeddings
+    ) -> None:
         with pytest.raises(OSError):
             Pinecone.from_texts(
                 texts=["foo", "bar", "baz"] * 32,
@@ -321,12 +327,14 @@ class TestPinecone:
                 index_name=index_name,
                 async_req=True,
             )
-    
-    @pytest.mark.usefixtures('mock_pool_not_supported')
-    def test_that_async_freq_false_enabled_singlethreading(self, embedding_openai: OpenAIEmbeddings) -> None:
+
+    @pytest.mark.usefixtures("mock_pool_not_supported")
+    def test_that_async_freq_false_enabled_singlethreading(
+        self, embedding_openai: OpenAIEmbeddings
+    ) -> None:
         Pinecone.from_texts(
             texts=["foo", "bar", "baz"],
             embedding=embedding_openai,
             index_name=index_name,
-            async_req=False
+            async_req=False,
         )


### PR DESCRIPTION
  **Description:**
  
Currently, langchain forces the `async_req` (asynchronous required) argument to pinecone to `True`, even though the underlying native pinecone library supports synchronous (that is, non-asynchronous 😅 ) processing. This is only an issue when deploying to environments that don't support multithreading, like AWS lambda, and has lead to issue documented here: https://github.com/langchain-ai/langchain/issues/11168

This leads to potential customers abandoning langchain to roll their own using the native pinecone library

In general, if a community/vendor library supports an option, we should allow the user to pass that option through. This is not currently possible because by by hardcoding `async_req=True`, we cannot even pass `{async_req: False}` in the `**kwargs`, because then pinecone gets two keyword arguments with the same name and throws an error

While it looks like @efriis  is making a wholesale makeover to the pinecone interface in https://github.com/langchain-ai/langchain/pull/16556, I hope the maintainers can accept this small fix so that people can start using this version of langchain with AWS Lambda 
  
**Dependencies:** 

None, that I'm aware. 

**Twitter handle:** 
  
@nelsonauner, but I'd also take a sticker! :) 
