### PR TITLE
Core: Support .yml extension for YAML

### DIFF
--- a/libs/community/langchain_community/llms/loading.py
+++ b/libs/community/langchain_community/llms/loading.py
@@ -35,7 +35,7 @@ def load_llm(file: Union[str, Path]) -> BaseLLM:
     if file_path.suffix == ".json":
         with open(file_path) as f:
             config = json.load(f)
-    elif file_path.suffix == ".yaml":
+    elif file_path.suffix.endswith((".yaml", ".yml")):
         with open(file_path, "r") as f:
             config = yaml.safe_load(f)
     else:

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -1082,7 +1082,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
         if save_path.suffix == ".json":
             with open(file_path, "w") as f:
                 json.dump(prompt_dict, f, indent=4)
-        elif save_path.suffix == ".yaml":
+        elif save_path.suffix.endswith((".yaml", ".yml")):
             with open(file_path, "w") as f:
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -210,7 +210,7 @@ class BasePromptTemplate(
         if save_path.suffix == ".json":
             with open(file_path, "w") as f:
                 json.dump(prompt_dict, f, indent=4)
-        elif save_path.suffix == ".yaml":
+        elif save_path.suffix.endswith((".yaml", ".yml")):
             with open(file_path, "w") as f:
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:

--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -146,7 +146,7 @@ def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
     if file_path.suffix == ".json":
         with open(file_path) as f:
             config = json.load(f)
-    elif file_path.suffix == ".yaml":
+    elif file_path.suffix.endswith((".yaml", ".yml")):
         with open(file_path, "r") as f:
             config = yaml.safe_load(f)
     else:

--- a/libs/experimental/langchain_experimental/data_anonymizer/presidio.py
+++ b/libs/experimental/langchain_experimental/data_anonymizer/presidio.py
@@ -428,7 +428,7 @@ class PresidioReversibleAnonymizer(PresidioAnonymizerBase, ReversibleAnonymizerB
         if save_path.suffix == ".json":
             with open(save_path, "w") as f:
                 json.dump(self.deanonymizer_mapping, f, indent=2)
-        elif save_path.suffix == ".yaml":
+        elif save_path.suffix.endswith((".yaml", ".yml")):
             with open(save_path, "w") as f:
                 yaml.dump(self.deanonymizer_mapping, f, default_flow_style=False)
 
@@ -452,7 +452,7 @@ class PresidioReversibleAnonymizer(PresidioAnonymizerBase, ReversibleAnonymizerB
         if load_path.suffix == ".json":
             with open(load_path, "r") as f:
                 loaded_mapping = json.load(f)
-        elif load_path.suffix == ".yaml":
+        elif load_path.suffix.endswith((".yaml", ".yml")):
             with open(load_path, "r") as f:
                 loaded_mapping = yaml.load(f, Loader=yaml.FullLoader)
 

--- a/libs/experimental/langchain_experimental/prompts/load.py
+++ b/libs/experimental/langchain_experimental/prompts/load.py
@@ -30,7 +30,7 @@ def _load_prompt_from_file(file: Union[str, Path]) -> BasePromptTemplate:
     if file_path.suffix == ".json":
         with open(file_path) as f:
             config = json.load(f)
-    elif file_path.suffix == ".yaml":
+    elif file_path.suffix.endswith((".yaml", ".yml")):
         with open(file_path, "r") as f:
             config = yaml.safe_load(f)
     elif file_path.suffix == ".py":

--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -397,7 +397,10 @@ class RunnableAgent(BaseSingleActionAgent):
         intermediate_steps: List[Tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[AgentAction, AgentFinish,]:
+    ) -> Union[
+        AgentAction,
+        AgentFinish,
+    ]:
         """Based on past history and current inputs, decide what to do.
 
         Args:
@@ -458,7 +461,10 @@ class RunnableMultiActionAgent(BaseMultiActionAgent):
         intermediate_steps: List[Tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[List[AgentAction], AgentFinish,]:
+    ) -> Union[
+        List[AgentAction],
+        AgentFinish,
+    ]:
         """Based on past history and current inputs, decide what to do.
 
         Args:
@@ -490,7 +496,10 @@ class RunnableMultiActionAgent(BaseMultiActionAgent):
         intermediate_steps: List[Tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[List[AgentAction], AgentFinish,]:
+    ) -> Union[
+        List[AgentAction],
+        AgentFinish,
+    ]:
         """Based on past history and current inputs, decide what to do.
 
         Args:

--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -185,7 +185,7 @@ class BaseSingleActionAgent(BaseModel):
         if save_path.suffix == ".json":
             with open(file_path, "w") as f:
                 json.dump(agent_dict, f, indent=4)
-        elif save_path.suffix == ".yaml":
+        elif save_path.suffix.endswith((".yaml", ".yml")):
             with open(file_path, "w") as f:
                 yaml.dump(agent_dict, f, default_flow_style=False)
         else:
@@ -310,7 +310,7 @@ class BaseMultiActionAgent(BaseModel):
         if save_path.suffix == ".json":
             with open(file_path, "w") as f:
                 json.dump(agent_dict, f, indent=4)
-        elif save_path.suffix == ".yaml":
+        elif save_path.suffix.endswith((".yaml", ".yml")):
             with open(file_path, "w") as f:
                 yaml.dump(agent_dict, f, default_flow_style=False)
         else:
@@ -397,10 +397,7 @@ class RunnableAgent(BaseSingleActionAgent):
         intermediate_steps: List[Tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[
-        AgentAction,
-        AgentFinish,
-    ]:
+    ) -> Union[AgentAction, AgentFinish,]:
         """Based on past history and current inputs, decide what to do.
 
         Args:
@@ -461,10 +458,7 @@ class RunnableMultiActionAgent(BaseMultiActionAgent):
         intermediate_steps: List[Tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[
-        List[AgentAction],
-        AgentFinish,
-    ]:
+    ) -> Union[List[AgentAction], AgentFinish,]:
         """Based on past history and current inputs, decide what to do.
 
         Args:
@@ -496,10 +490,7 @@ class RunnableMultiActionAgent(BaseMultiActionAgent):
         intermediate_steps: List[Tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[
-        List[AgentAction],
-        AgentFinish,
-    ]:
+    ) -> Union[List[AgentAction], AgentFinish,]:
         """Based on past history and current inputs, decide what to do.
 
         Args:

--- a/libs/langchain/langchain/chains/base.py
+++ b/libs/langchain/langchain/chains/base.py
@@ -687,7 +687,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
         if save_path.suffix == ".json":
             with open(file_path, "w") as f:
                 json.dump(chain_dict, f, indent=4)
-        elif save_path.suffix == ".yaml":
+        elif save_path.suffix.endswith((".yaml", ".yml")):
             with open(file_path, "w") as f:
                 yaml.dump(chain_dict, f, default_flow_style=False)
         else:

--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -607,7 +607,7 @@ def _load_chain_from_file(file: Union[str, Path], **kwargs: Any) -> Chain:
     if file_path.suffix == ".json":
         with open(file_path) as f:
             config = json.load(f)
-    elif file_path.suffix == ".yaml":
+    elif file_path.suffix.endswith((".yaml", ".yml")):
         with open(file_path, "r") as f:
             config = yaml.safe_load(f)
     else:


### PR DESCRIPTION
  - **Description:**

[AS-IS] When dealing with a yaml file, the extension must be .yaml.  

[TO-BE] In the absence of extension length constraints in the OS, the extension of the YAML file is yaml, but control over the yml extension must still be made.  

It's as if it's an error because it's a .jpg extension in jpeg support.

  - **Issue:** - 

  - **Dependencies:**
no dependencies required for this change,