### PR TITLE
Report which file was errored on in DirectoryLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/directory.py
+++ b/libs/community/langchain_community/document_loaders/directory.py
@@ -103,6 +103,7 @@ class DirectoryLoader(BaseLoader):
                     if self.silent_errors:
                         logger.warning(f"Error loading file {str(item)}: {e}")
                     else:
+                        logger.error(f"Error loading file {str(item)}")
                         raise e
                 finally:
                     if pbar:


### PR DESCRIPTION
The current implementation leaves it up to the particular file loader implementation to report the file on which an error was encountered - in my case pdfminer was simply saying it could not parse a file as a PDF, but I didn't know which of my hundreds of files it was failing on.

No reason not to log the particular item on which an error was encountered, and it should be an immense debugging assistant.

<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
