### PR TITLE
community[fix] - in FAISS vector store, support passing custom DocStore implementation when using from_xxx methods

### DIFF
--- a/libs/community/langchain_community/vectorstores/faiss.py
+++ b/libs/community/langchain_community/vectorstores/faiss.py
@@ -917,11 +917,13 @@ class FAISS(VectorStore):
         else:
             # Default to L2, currently other metric types not initialized.
             index = faiss.IndexFlatL2(len(embeddings[0]))
+        docstore = kwargs.pop("docstore", InMemoryDocstore())
+        index_to_docstore_id = kwargs.pop("index_to_docstore_id", {})
         vecstore = cls(
             embedding,
             index,
-            InMemoryDocstore(),
-            {},
+            docstore,
+            index_to_docstore_id,
             normalize_L2=normalize_L2,
             distance_strategy=distance_strategy,
             **kwargs,


### PR DESCRIPTION
  - **Description:** The from__xx methods of FAISS class have hardcoded InMemoryStore implementation and thereby not let users pass a custom DocStore implementation, 
  - **Issue:** no referenced issue,
  - **Dependencies:** none,
  - **Twitter handle:** ksachdeva


