### PR TITLE
Community: Fix github search issues and PRs PaginatedList has no len() error

### DIFF
--- a/libs/community/langchain_community/utilities/github.py
+++ b/libs/community/langchain_community/utilities/github.py
@@ -734,7 +734,7 @@ class GitHubAPIWrapper(BaseModel):
             str: A string containing the first 5 issues and pull requests
         """
         search_result = self.github.search_issues(query, repo=self.github_repository)
-        max_items = min(5, len(search_result))
+        max_items = min(5, search_result.totalCount)
         results = [f"Top {max_items} results:"]
         for issue in search_result[:max_items]:
             results.append(

--- a/libs/community/tests/integration_tests/utilities/test_github.py
+++ b/libs/community/tests/integration_tests/utilities/test_github.py
@@ -19,3 +19,9 @@ def test_get_open_issues(api_client: GitHubAPIWrapper) -> None:
     """Basic test to fetch issues"""
     issues = api_client.get_issues()
     assert len(issues) != 0
+
+
+def test_search_issues_and_prs(api_client: GitHubAPIWrapper) -> None:
+    """Basic test to search issues and PRs"""
+    results = api_client.search_issues_and_prs("is:pr is:merged")
+    assert len(results) != 0


### PR DESCRIPTION
  **Description:** 
Bugfix: Langchain_community's GitHub Api wrapper throws a TypeError when searching for issues and/or PRs (the `search_issues_and_prs` method). This is because PyGithub's PageinatedList type does not support the len() method.  See https://github.com/PyGithub/PyGithub/issues/1476
![image](https://github.com/langchain-ai/langchain/assets/8849021/57390b11-ed41-4f48-ba50-f3028610789c)
  **Dependencies:** None 
  **Twitter handle**: @ChrisKeoghNZ
  
I haven't registered an issue as it would take me longer to fill the template out than to make the fix, but I'm happy to if that's deemed essential.

I've added a simple integration test to cover this as there were no existing unit tests and it was going to be tricky to set them up.
