### PR TITLE
[community] ElasticsearchStore: preserve user headers

### DIFF
--- a/libs/community/langchain_community/vectorstores/elasticsearch.py
+++ b/libs/community/langchain_community/vectorstores/elasticsearch.py
@@ -529,7 +529,7 @@ class ElasticsearchStore(VectorStore):
 
         if es_connection is not None:
             self.client = es_connection.options(
-                headers={"user-agent": self.get_user_agent()}
+                headers=dict(es_connection._headers) | {"user-agent": self.get_user_agent()}
             )
         elif es_url is not None or es_cloud_id is not None:
             self.client = ElasticsearchStore.connect_to_elasticsearch(

--- a/libs/community/langchain_community/vectorstores/elasticsearch.py
+++ b/libs/community/langchain_community/vectorstores/elasticsearch.py
@@ -528,9 +528,9 @@ class ElasticsearchStore(VectorStore):
         self.strategy = strategy
 
         if es_connection is not None:
-            self.client = es_connection.options(
-                headers=dict(es_connection._headers) | {"user-agent": self.get_user_agent()}
-            )
+            headers = dict(es_connection._headers)
+            headers.update({"user-agent": self.get_user_agent()})
+            self.client = es_connection.options(headers=headers)
         elif es_url is not None or es_cloud_id is not None:
             self.client = ElasticsearchStore.connect_to_elasticsearch(
                 es_url=es_url,


### PR DESCRIPTION
Users can provide an Elasticsearch connection with custom headers. This PR makes sure these headers are preserved when adding the langchain user agent header.
