### PR TITLE
langchain: Updated OpenAIEmbeddings to latest version due to deprecation

### DIFF
--- a/libs/langchain/langchain/indexes/vectorstore.py
+++ b/libs/langchain/langchain/indexes/vectorstore.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Type
 
 from langchain_community.document_loaders.base import BaseLoader
-from langchain_community.embeddings.openai import OpenAIEmbeddings
+from langchain_openai import OpenAIEmbeddings
 from langchain_community.llms.openai import OpenAI
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_core.documents import Document


### PR DESCRIPTION
  - **Description:** Swapped OpenAIEmbeddings since ```from langchain_community.embeddings.openai import OpenAIEmbeddings``` got deprecated in v0.1.0, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** None,