### PR TITLE
doc: fix typo in message_history.ipynb

### DIFF
--- a/docs/docs/expression_language/how_to/message_history.ipynb
+++ b/docs/docs/expression_language/how_to/message_history.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Add message history (memory)\n",
     "\n",
-    "The `RunnableWithMessageHistory` let's us add message history to certain types of chains.\n",
+    "The `RunnableWithMessageHistory` let us add message history to certain types of chains.\n",
     "\n",
     "Specifically, it can be used for any Runnable that takes as input one of\n",
     "\n",


### PR DESCRIPTION
  - **Description:** just fixed a small typo in the documentation in the `expression_language/how_to/message_history` session [here](https://python.langchain.com/docs/expression_language/how_to/message_history)