### PR TITLE
langchain: `output_parser.py` in conversation_chat is customizable

### DIFF
--- a/libs/langchain/langchain/agents/conversational_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational_chat/output_parser.py
@@ -13,7 +13,7 @@ from langchain.output_parsers.json import parse_json_markdown
 # Define a class that parses output for conversational agents
 class ConvoOutputParser(AgentOutputParser):
     """Output parser for the conversational agent."""
-    
+
     format_instructions: str = FORMAT_INSTRUCTIONS
 
     def get_format_instructions(self) -> str:

--- a/libs/langchain/langchain/agents/conversational_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational_chat/output_parser.py
@@ -4,19 +4,21 @@ from typing import Union
 
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.exceptions import OutputParserException
-from langchain_core.output_parsers.json import parse_json_markdown
 
 from langchain.agents import AgentOutputParser
 from langchain.agents.conversational_chat.prompt import FORMAT_INSTRUCTIONS
+from langchain.output_parsers.json import parse_json_markdown
 
 
 # Define a class that parses output for conversational agents
 class ConvoOutputParser(AgentOutputParser):
     """Output parser for the conversational agent."""
+    
+    format_instructions: str = FORMAT_INSTRUCTIONS
 
     def get_format_instructions(self) -> str:
         """Returns formatting instructions for the given output parser."""
-        return FORMAT_INSTRUCTIONS
+        return self.format_instructions
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         """Attempts to parse the given text into an AgentAction or AgentFinish.


### PR DESCRIPTION
**Description:**
With this modification, users can customize the `FORMAT_INSTRUCTIONS` template, allowing them to create their own prompts

As it is happening in [this](https://github.com/langchain-ai/langchain/issues/10721) issue, the `FORMAT_INSTRUCTIONS` is not customizable for the output parser, unless you create your own class `ConvoOutputParser`. To avoid this, a modification was done, creating a `format_instruction` variable that users can customize with ease after initialize the agent.

For example:
```
agent = initialize_agent(
    agent = AgentType.CHAT_CONVERSATIONAL_REACT_DESCRIPTION,
    tools = tools,
    llm = llm_agent,
    verbose = True,
    max_iterations = 3,
    early_stopping_method = 'generate',
    memory = b_w_memory,
    handle_parsing_errors = True,
    agent_kwargs={
        'system_message':PREFIX,
        'human_message':SUFFIX,
        'template_tool_response':TEMPLATE_TOOL_RESPONSE,
        }
)
agent.agent.output_parser.format_instructions = "MY CUSTOM FORMAT INSTRUCTIONS"
print(agent.agent.output_parser.get_format_instructions())
MY CUSTOM FORMAT INSTRUCTIONS
```

Other parameters like `system_message`, `human_message`, or `template_tool_response` are already customizable and with this PR, the last parameter `FORMAT_INSTRUCTIONS` in `langchain.agents.conversational_chat.prompt` can be modified.


**Issue:**
https://github.com/langchain-ai/langchain/issues/10721

**Dependencies:**
No new dependencies required for this change

**Twitter handle:**
With my github user is enough. Thanks

I hope you accept my PR.