### PR TITLE
core[patch]: handle some optional cases in tools

### DIFF
--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -49,7 +49,7 @@ def _create_subset_model(
             # this isn't perfect but should work for most functions
             field.outer_type_
             if field.required and not field.allow_none
-            else Union[field.outer_type_, None]
+            else Optional[field.outer_type_]
         )
         fields[field_name] = (t, field.field_info)
     rtn = create_model(name, **fields)  # type: ignore

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -39,14 +39,21 @@ class SchemaAnnotationError(TypeError):
 
 
 def _create_subset_model(
-    name: str, model: BaseModel, field_names: list
+    name: str, model: Type[BaseModel], field_names: list
 ) -> Type[BaseModel]:
     """Create a pydantic model with only a subset of model's fields."""
     fields = {}
     for field_name in field_names:
         field = model.__fields__[field_name]
-        fields[field_name] = (field.outer_type_, field.field_info)
-    return create_model(name, **fields)  # type: ignore
+        t = (
+            # this isn't perfect but should work for most functions
+            field.outer_type_
+            if field.required and not field.allow_none
+            else Union[field.outer_type_, None]
+        )
+        fields[field_name] = (t, field.field_info)
+    rtn = create_model(name, **fields)  # type: ignore
+    return rtn
 
 
 def _get_filtered_args(
@@ -764,7 +771,8 @@ class StructuredTool(BaseTool):
         description = f"{name}{sig} - {description.strip()}"
         _args_schema = args_schema
         if _args_schema is None and infer_schema:
-            _args_schema = create_schema_from_function(f"{name}Schema", source_function)
+            # schema name is appended within function
+            _args_schema = create_schema_from_function(name, source_function)
         return cls(
             name=name,
             func=func,

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -81,7 +81,7 @@ def test_function_optional_param() -> None:
         a: Optional[str],
         b: str,
         c: Optional[List[Optional[str]]],
-    ):
+    ) -> None:
         """A test function"""
         pass
 

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1,9 +1,9 @@
-from typing import Any, Callable, Literal, Type
+from typing import Any, Callable, List, Literal, Optional, Type
 
 import pytest
 
 from langchain_core.pydantic_v1 import BaseModel, Field
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool, tool
 from langchain_core.utils.function_calling import convert_to_openai_function
 
 
@@ -33,7 +33,7 @@ def function() -> Callable:
 
 
 @pytest.fixture()
-def tool() -> BaseTool:
+def dummy_tool() -> BaseTool:
     class Schema(BaseModel):
         arg1: int = Field(..., description="foo")
         arg2: Literal["bar", "baz"] = Field(..., description="one of 'bar', 'baz'")
@@ -50,7 +50,7 @@ def tool() -> BaseTool:
 
 
 def test_convert_to_openai_function(
-    pydantic: Type[BaseModel], function: Callable, tool: BaseTool
+    pydantic: Type[BaseModel], function: Callable, dummy_tool: BaseTool
 ) -> None:
     expected = {
         "name": "dummy_function",
@@ -69,6 +69,22 @@ def test_convert_to_openai_function(
         },
     }
 
-    for fn in (pydantic, function, tool, expected):
+    for fn in (pydantic, function, dummy_tool, expected):
         actual = convert_to_openai_function(fn)  # type: ignore
         assert actual == expected
+
+
+@pytest.mark.xfail(reason="Pydantic converts Optional[str] to str in .schema()")
+def test_function_optional_param() -> None:
+    @tool
+    def func5(
+        a: Optional[str],
+        b: str,
+        c: Optional[List[Optional[str]]],
+    ):
+        """A test function"""
+        pass
+
+    func = convert_to_openai_function(func5)
+    req = func["parameters"]["required"]
+    assert set(req) == {"b"}


### PR DESCRIPTION
primary problem in pydantic still exists, where `Optional[str]` gets turned to `string` in the jsonschema `.schema()`

Also fixes the `SchemaSchema` naming issue