### PR TITLE
docs: Link to Brave Website added

### DIFF
--- a/docs/docs/integrations/tools/brave_search.ipynb
+++ b/docs/docs/integrations/tools/brave_search.ipynb
@@ -7,7 +7,8 @@
    "source": [
     "# Brave Search\n",
     "\n",
-    "This notebook goes over how to use the Brave Search tool."
+    "This notebook goes over how to use the Brave Search tool.\n",
+    "Go to the [Brave Website](https://brave.com/search/api/) to sign up for a free account and get an API key."
    ]
   },
   {


### PR DESCRIPTION
**Description:** Link to the Brave Website added to the `brave-search.ipynb` notebook.
This notebook is shown in the docs as an example for the brave tool.

**Issue:** There was to reference on where / how to get an api key
 
**Dependencies:** none
 
**Twitter handle:** not for this one :)
