### PR TITLE
community: Fix Relevance Score Calculation in Chroma Class

### DIFF
--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -467,7 +467,7 @@ class Chroma(VectorStore):
         if distance == "cosine":
             return self._cosine_relevance_score_fn
         elif distance == "l2":
-            return self._euclidean_relevance_score_fn
+            return lambda distance: 1.0 - distance / 2
         elif distance == "ip":
             return self._max_inner_product_relevance_score_fn
         else:


### PR DESCRIPTION
 **Description:** Critical update to the relevance score calculation within the Chroma class. Previously, Chroma utilized the L2 distance (ranging from 0-2) for determining relevance scores. To convert these scores for Langchain's requirements, a Euclidean conversion function was employed. However, the conversion process inaccurately used sqrt(2) in the denominator, which does not correctly account for the squared nature of the L2 distance.

To address this inconsistency and ensure the relevance scores accurately reflect the intended range of 0-1, I propose updating the initialization of the Chroma class. This update involves modifying the relevance score conversion function. This adjustment ensures that the relevance scores are correctly scaled and directed, aligning with Langchain's expectations.

Changes:

Modify the default relevance score conversion function in the Chroma class initialization.
Ensure relevance scores are properly scaled between 0-1, correcting the direction based on the actual L2 distance.
This change is crucial for anyone utilizing the Chroma class in conjunction with Langchain, ensuring that the relevance scores are calculated accurately and effectively.

Twitter Handle:- @neerjd07