### PR TITLE
chore: revert #16608

### DIFF
--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1941,12 +1941,9 @@ class Qdrant(VectorStore):
         content_payload_key: str,
         metadata_payload_key: str,
     ) -> Document:
-        metadata = scored_point.payload.get(metadata_payload_key) or {}
-        metadata["_id"] = scored_point.id
-        metadata["_collection_name"] = scored_point.collection_name
         return Document(
             page_content=scored_point.payload.get(content_payload_key),
-            metadata=metadata,
+            metadata=scored_point.payload.get(metadata_payload_key) or {},
         )
 
     def _build_condition(self, key: str, value: Any) -> List[rest.FieldCondition]:


### PR DESCRIPTION
## Description

Reverts #16608 to resolve the`AttributeError: 'ScoredPoint' object has no attribute 'collection_name'` issue.
Fixes #16962.