### PR TITLE
langchain: pydantic entity extraction should support singular values alongside l…

### DIFF
--- a/libs/langchain/langchain/chains/openai_functions/extraction.py
+++ b/libs/langchain/langchain/chains/openai_functions/extraction.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import BasePromptTemplate, ChatPromptTemplate
@@ -99,7 +99,7 @@ def create_extraction_chain_pydantic(
     """
 
     class PydanticSchema(BaseModel):
-        info: List[pydantic_schema]  # type: ignore
+        info: Union[List[pydantic_schema], pydantic_schema]  # type: ignore
 
     openai_schema = pydantic_schema.schema()
     openai_schema = _resolve_schema_references(


### PR DESCRIPTION
…ists, otherwise entity extracts fails when expected cardinality is 1

  - **Description:** When testing entity extraction via pydantic, I noticed it works well when it's getting back multiple entities from a single extraction, but it fails when the expected cardinality is 1.  This extends the schema for validation to accept single entities too.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** (https://twitter.com/therealarrays)
