### PR TITLE
langchain_mistralai[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -317,9 +317,9 @@ class ChatMistralAI(BaseChatModel):
                 continue
             chunk = _convert_delta_to_message_chunk(delta, default_chunk_class)
             default_chunk_class = chunk.__class__
-            yield ChatGenerationChunk(message=chunk)
             if run_manager:
                 run_manager.on_llm_new_token(token=chunk.content, chunk=chunk)
+            yield ChatGenerationChunk(message=chunk)
 
     async def _astream(
         self,
@@ -342,9 +342,9 @@ class ChatMistralAI(BaseChatModel):
                 continue
             chunk = _convert_delta_to_message_chunk(delta, default_chunk_class)
             default_chunk_class = chunk.__class__
-            yield ChatGenerationChunk(message=chunk)
             if run_manager:
                 await run_manager.on_llm_new_token(token=chunk.content, chunk=chunk)
+            yield ChatGenerationChunk(message=chunk)
 
     async def _agenerate(
         self,

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -17,10 +17,8 @@ from langchain_core.messages import (
 from mistralai.models.chat_completion import (  # type: ignore[import]
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
-    DeltaMessage,
-)
-from mistralai.models.chat_completion import (
     ChatMessage as MistralChatMessage,
+    DeltaMessage,
 )
 
 from langchain_mistralai.chat_models import (  # type: ignore[import]

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -17,8 +17,10 @@ from langchain_core.messages import (
 from mistralai.models.chat_completion import (  # type: ignore[import]
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
-    ChatMessage as MistralChatMessage,
     DeltaMessage,
+)
+from mistralai.models.chat_completion import (
+    ChatMessage as MistralChatMessage,
 )
 
 from langchain_mistralai.chat_models import (  # type: ignore[import]

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -1,7 +1,9 @@
 """Test MistralAI Chat API wrapper."""
 import os
+from unittest.mock import patch
 
 import pytest
+from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -12,7 +14,10 @@ from langchain_core.messages import (
 
 # TODO: Remove 'type: ignore' once mistralai has stubs or py.typed marker.
 from mistralai.models.chat_completion import (  # type: ignore[import]
+    ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse,
     ChatMessage as MistralChatMessage,
+    DeltaMessage,
 )
 
 from langchain_mistralai.chat_models import (  # type: ignore[import]
@@ -63,3 +68,60 @@ def test_convert_message_to_mistral_chat_message(
 ) -> None:
     result = _convert_message_to_mistral_chat_message(message)
     assert result == expected
+
+
+def _make_completion_response_from_token(token: str) -> ChatCompletionStreamResponse:
+    return ChatCompletionStreamResponse(
+        id="abc123",
+        model="fake_model",
+        choices=[
+            ChatCompletionResponseStreamChoice(
+                index=0,
+                delta=DeltaMessage(content=token),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def mock_chat_stream(*args, **kwargs):
+    for token in ["Hello", " how", " can", " I", " help", "?"]:
+        yield _make_completion_response_from_token(token)
+
+
+async def mock_chat_astream():
+    for token in ["Hello", " how", " can", " I", " help", "?"]:
+        yield _make_completion_response_from_token(token)
+
+
+async def mock_acompletion(*args, **kwargs):
+    return mock_chat_astream()
+
+
+class MyCustomHandler(BaseCallbackHandler):
+    last_token: str = ""
+
+    def on_llm_new_token(self, token: str, **kwargs) -> None:
+        self.last_token = token
+
+
+@patch(
+    "langchain_mistralai.chat_models.ChatMistralAI.completion_with_retry",
+    new=mock_chat_stream,
+)
+def test_stream_with_callback() -> None:
+    callback = MyCustomHandler()
+    chat = ChatMistralAI(callbacks=[callback])
+    for token in chat.stream("Hello"):
+        assert callback.last_token == token.content
+
+
+@patch(
+    "langchain_mistralai.chat_models.acompletion_with_retry",
+    new=mock_acompletion,
+)
+async def test_astream_with_callback() -> None:
+    callback = MyCustomHandler()
+    chat = ChatMistralAI(callbacks=[callback])
+    async for token in chat.astream("Hello"):
+        assert callback.last_token == token.content

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -1,5 +1,6 @@
 """Test MistralAI Chat API wrapper."""
 import os
+from typing import Any, AsyncGenerator, Generator
 from unittest.mock import patch
 
 import pytest
@@ -16,8 +17,10 @@ from langchain_core.messages import (
 from mistralai.models.chat_completion import (  # type: ignore[import]
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
-    ChatMessage as MistralChatMessage,
     DeltaMessage,
+)
+from mistralai.models.chat_completion import (
+    ChatMessage as MistralChatMessage,
 )
 
 from langchain_mistralai.chat_models import (  # type: ignore[import]
@@ -84,24 +87,24 @@ def _make_completion_response_from_token(token: str) -> ChatCompletionStreamResp
     )
 
 
-def mock_chat_stream(*args, **kwargs):
+def mock_chat_stream(*args: Any, **kwargs: Any) -> Generator:
     for token in ["Hello", " how", " can", " I", " help", "?"]:
         yield _make_completion_response_from_token(token)
 
 
-async def mock_chat_astream():
+async def mock_chat_astream() -> AsyncGenerator:
     for token in ["Hello", " how", " can", " I", " help", "?"]:
         yield _make_completion_response_from_token(token)
 
 
-async def mock_acompletion(*args, **kwargs):
+async def mock_acompletion(*args: Any, **kwargs: Any) -> AsyncGenerator:
     return mock_chat_astream()
 
 
 class MyCustomHandler(BaseCallbackHandler):
     last_token: str = ""
 
-    def on_llm_new_token(self, token: str, **kwargs) -> None:
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         self.last_token = token
 
 

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -92,13 +92,9 @@ def mock_chat_stream(*args: Any, **kwargs: Any) -> Generator:
         yield _make_completion_response_from_token(token)
 
 
-async def mock_chat_astream() -> AsyncGenerator:
+async def mock_chat_astream(*args: Any, **kwargs: Any) -> AsyncGenerator:
     for token in ["Hello", " how", " can", " I", " help", "?"]:
         yield _make_completion_response_from_token(token)
-
-
-async def mock_acompletion(*args: Any, **kwargs: Any) -> AsyncGenerator:
-    return mock_chat_astream()
 
 
 class MyCustomHandler(BaseCallbackHandler):
@@ -108,10 +104,7 @@ class MyCustomHandler(BaseCallbackHandler):
         self.last_token = token
 
 
-@patch(
-    "langchain_mistralai.chat_models.ChatMistralAI.completion_with_retry",
-    new=mock_chat_stream,
-)
+@patch("mistralai.client.MistralClient.chat_stream", new=mock_chat_stream)
 def test_stream_with_callback() -> None:
     callback = MyCustomHandler()
     chat = ChatMistralAI(callbacks=[callback])
@@ -119,10 +112,7 @@ def test_stream_with_callback() -> None:
         assert callback.last_token == token.content
 
 
-@patch(
-    "langchain_mistralai.chat_models.acompletion_with_retry",
-    new=mock_acompletion,
-)
+@patch("mistralai.async_client.MistralAsyncClient.chat_stream", new=mock_chat_astream)
 async def test_astream_with_callback() -> None:
     callback = MyCustomHandler()
     chat = ChatMistralAI(callbacks=[callback])


### PR DESCRIPTION
- **Description:** Invoke callback prior to yielding token in stream and astream methods for ChatMistralAI.
- **Issue:** https://github.com/langchain-ai/langchain/issues/16913
