### PR TITLE
experimental: patch content of AIMessage generated by OllamaFunctions

### DIFF
--- a/libs/experimental/langchain_experimental/llms/ollama_functions.py
+++ b/libs/experimental/langchain_experimental/llms/ollama_functions.py
@@ -121,7 +121,10 @@ output: {chat_generation_content}"
             )
 
         response_message_with_functions = AIMessage(
-            content="",
+            # fill raw response into content instead of leaving it empty
+            # since ChatOllama doesn't include additional_kwargs
+            # when the AIMessage is sent to LLMs
+            content=response_message,
             additional_kwargs={
                 "function_call": {
                     "name": called_tool_name,


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

OllamaFunctions generates an AIMessage with function call info stored in `additional_kwargs` field, which will be dropped by the underlying ChatOllama if we send the message back (to get further response like OpenAI though more tweaking is needed).

So a temporary and minimal patch would be to fill the raw response into `content` field since downstream using hardly depends on it, i.e. typically we use `if "function_call" in msg.additional_kwargs` to tell if there is a fucntion call involved.