### PR TITLE
community: add delete method to rocksetdb vectorstore to support recordmanager

### DIFF
--- a/docs/docs/modules/data_connection/indexing.ipynb
+++ b/docs/docs/modules/data_connection/indexing.ipynb
@@ -60,7 +60,7 @@
     "   * document addition by id (`add_documents` method with `ids` argument)\n",
     "   * delete by id (`delete` method with `ids` argument)\n",
     "\n",
-    "Compatible Vectorstores: `AnalyticDB`, `AstraDB`, `AwaDB`, `Bagel`, `Cassandra`, `Chroma`, `DashVector`, `DatabricksVectorSearch`, `DeepLake`, `Dingo`, `ElasticVectorSearch`, `ElasticsearchStore`, `FAISS`, `HanaDB`, `Milvus`, `MyScale`, `PGVector`, `Pinecone`, `Qdrant`, `Redis`, `ScaNN`, `SupabaseVectorStore`, `SurrealDBStore`, `TimescaleVector`, `Vald`, `Vearch`, `VespaStore`, `Weaviate`, `ZepVectorStore`.\n",
+    "Compatible Vectorstores: `AnalyticDB`, `AstraDB`, `AwaDB`, `Bagel`, `Cassandra`, `Chroma`, `DashVector`, `DatabricksVectorSearch`, `DeepLake`, `Dingo`, `ElasticVectorSearch`, `ElasticsearchStore`, `FAISS`, `HanaDB`, `Milvus`, `MyScale`, `PGVector`, `Pinecone`, `Qdrant`, `Redis`, `Rockset`, `ScaNN`, `SupabaseVectorStore`, `SurrealDBStore`, `TimescaleVector`, `Vald`, `Vearch`, `VespaStore`, `Weaviate`, `ZepVectorStore`.\n",
     "  \n",
     "## Caution\n",
     "\n",

--- a/libs/community/langchain_community/vectorstores/rocksetdb.py
+++ b/libs/community/langchain_community/vectorstores/rocksetdb.py
@@ -336,6 +336,8 @@ LIMIT {str(k)}
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
         try:
+            if ids is None:
+                ids = []
             self.delete_texts(ids)
         except Exception as e:
             logger.error("Exception when deleting docs from Rockset: %s\n", e)

--- a/libs/community/langchain_community/vectorstores/rocksetdb.py
+++ b/libs/community/langchain_community/vectorstores/rocksetdb.py
@@ -6,6 +6,7 @@ from typing import Any, Iterable, List, Optional, Tuple
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
+from langchain_core.runnables import run_in_executor
 from langchain_core.vectorstores import VectorStore
 
 logger = logging.getLogger(__name__)
@@ -332,3 +333,17 @@ LIMIT {str(k)}
             data=[DeleteDocumentsRequestData(id=i) for i in ids],
             workspace=self._workspace,
         )
+
+    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+        try:
+            self.delete_texts(ids)
+        except Exception as e:
+            logger.error("Exception when deleting docs from Rockset: %s\n", e)
+            return False
+
+        return True
+
+    async def adelete(
+        self, ids: Optional[List[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
+        return await run_in_executor(None, self.delete, ids, **kwargs)

--- a/libs/community/tests/integration_tests/vectorstores/test_rocksetdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_rocksetdb.py
@@ -155,3 +155,18 @@ ORDER BY dist DESC
 LIMIT 4
 """
         assert q_str == expected
+
+    def test_add_documents_and_delete(self) -> None:
+        """"add_documents" and "delete" are requirements to support use with RecordManager"""
+
+        texts = ["foo", "bar", "baz"]
+        metadatas = [{"metadata_index": i} for i in range(len(texts))]
+
+        _docs = zip(texts, metadatas)
+        docs = [Document(page_content=pc, metadata=i) for pc, i in _docs]
+
+        ids = self.rockset_vectorstore.add_documents(docs)
+        assert len(ids) == len(texts)
+
+        deleted = self.rockset_vectorstore.delete(ids)
+        assert deleted

--- a/libs/community/tests/integration_tests/vectorstores/test_rocksetdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_rocksetdb.py
@@ -157,7 +157,8 @@ LIMIT 4
         assert q_str == expected
 
     def test_add_documents_and_delete(self) -> None:
-        """"add_documents" and "delete" are requirements to support use with RecordManager"""
+        """ "add_documents" and "delete" are requirements to support use
+        with RecordManager"""
 
         texts = ["foo", "bar", "baz"]
         metadatas = [{"metadata_index": i} for i in range(len(texts))]

--- a/libs/community/tests/unit_tests/vectorstores/test_indexing_docs.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_indexing_docs.py
@@ -68,6 +68,7 @@ def test_compatible_vectorstore_documentation() -> None:
         "Pinecone",
         "Qdrant",
         "Redis",
+        "Rockset",
         "ScaNN",
         "SemaDB",
         "SupabaseVectorStore",


### PR DESCRIPTION
  - **Description:** This adds a delete method so that rocksetdb can be used with `RecordManager`.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** `@_morgan_adams_`
