### PR TITLE
community: Fix Tongyi streaming output, the token_usage keeps changing, leading to failure in merge_dicts

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -401,13 +401,14 @@ class ChatTongyi(BaseChatModel):
         resp: Any, is_chunk: bool = False
     ) -> Dict[str, Any]:
         choice = resp["output"]["choices"][0]
+        finish_reason = choice["finish_reason"]
         message = convert_dict_to_message(choice["message"], is_chunk=is_chunk)
         return dict(
             message=message,
             generation_info=dict(
-                finish_reason=choice["finish_reason"],
+                finish_reason=finish_reason,
                 request_id=resp["request_id"],
-                token_usage=dict(resp["usage"]),
+                token_usage=dict(resp["usage"]) if finish_reason == "stop" else None,
             ),
         )
 

--- a/libs/community/langchain_community/llms/tongyi.py
+++ b/libs/community/langchain_community/llms/tongyi.py
@@ -326,12 +326,13 @@ class Tongyi(BaseLLM):
 
     @staticmethod
     def _generation_from_qwen_resp(resp: Any) -> Dict[str, Any]:
+        finish_reason = resp["output"]["finish_reason"]
         return dict(
             text=resp["output"]["text"],
             generation_info=dict(
-                finish_reason=resp["output"]["finish_reason"],
+                finish_reason=finish_reason,
                 request_id=resp["request_id"],
-                token_usage=dict(resp["usage"]),
+                token_usage=dict(resp["usage"]) if finish_reason == "stop" else None,
             ),
         )
 


### PR DESCRIPTION
- **Description:** When Tongyi llm and chat model performing streaming output, the token_usage keeps changing, leading to failure in merging the dictionaries.

- **Tongyi Error:**
![image](https://github.com/langchain-ai/langchain/assets/2959046/957baa6f-7d90-4abf-be96-d056f8911696)

- **ChatTongyi Error:**
![image](https://github.com/langchain-ai/langchain/assets/2959046/2a7d0155-9ca1-4889-831b-bc9862a58ab8)


- **Test output:**
![image](https://github.com/langchain-ai/langchain/assets/2959046/4a8674f9-d4c9-4f8c-ab85-c5645c267783)



