### PR TITLE
API References sorted `Partner libs` menu

### DIFF
--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -146,6 +146,7 @@ partners = [
     (p.name, p.name.replace("-", "_") + "_api_reference")
     for p in partners_dir.iterdir()
 ]
+partners = sorted(partners)
 
 html_context = {
     "display_github": True,  # Integrate GitHub


### PR DESCRIPTION
The `Partner libs` menu is not sorted. Now it is long enough, and items should be sorted to simplify a package search.
- Sorted items in the `Partner libs` menu