### PR TITLE
docs `integraions/providers` nav fix

### DIFF
--- a/docs/docs/integrations/platforms/index.mdx
+++ b/docs/docs/integrations/platforms/index.mdx
@@ -1,3 +1,8 @@
+---
+sidebar_position: 0
+sidebar_class_name: hidden
+---
+
 # Providers
 
 LangChain integrates with many providers


### PR DESCRIPTION
Issue: `Provides` page is presented as the index page (on the `Providers` item) and as the `Providers/Providers` item. The latter should not be in the menu. See the picture.
![image](https://github.com/langchain-ai/langchain/assets/2256422/6894023f-f13a-4f0d-8fe2-ed5b0ae2bdd2)
This PR fixes this.
