### PR TITLE
langchain: Standardize `output_parser.py` across all agent types for custom `FORMAT_INSTRUCTIONS`

### DIFF
--- a/libs/langchain/langchain/agents/chat/output_parser.py
+++ b/libs/langchain/langchain/agents/chat/output_parser.py
@@ -14,11 +14,15 @@ FINAL_ANSWER_ACTION = "Final Answer:"
 class ChatOutputParser(AgentOutputParser):
     """Output parser for the chat agent."""
 
+    format_instructions: str = FORMAT_INSTRUCTIONS
+    """Default formatting instructions"""
+
     pattern = re.compile(r"^.*?`{3}(?:json)?\n(.*?)`{3}.*?$", re.DOTALL)
     """Regex pattern to parse the output."""
 
     def get_format_instructions(self) -> str:
-        return FORMAT_INSTRUCTIONS
+        """Returns formatting instructions for the given output parser."""
+        return self.format_instructions
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         includes_answer = FINAL_ANSWER_ACTION in text

--- a/libs/langchain/langchain/agents/conversational/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational/output_parser.py
@@ -14,8 +14,12 @@ class ConvoOutputParser(AgentOutputParser):
     ai_prefix: str = "AI"
     """Prefix to use before AI output."""
 
+    format_instructions: str = FORMAT_INSTRUCTIONS
+    """Default formatting instructions"""
+
     def get_format_instructions(self) -> str:
-        return FORMAT_INSTRUCTIONS
+        """Returns formatting instructions for the given output parser."""
+        return self.format_instructions
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         if f"{self.ai_prefix}:" in text:

--- a/libs/langchain/langchain/agents/conversational_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational_chat/output_parser.py
@@ -15,6 +15,7 @@ class ConvoOutputParser(AgentOutputParser):
     """Output parser for the conversational agent."""
 
     format_instructions: str = FORMAT_INSTRUCTIONS
+    """Default formatting instructions"""
 
     def get_format_instructions(self) -> str:
         """Returns formatting instructions for the given output parser."""

--- a/libs/langchain/langchain/agents/mrkl/output_parser.py
+++ b/libs/langchain/langchain/agents/mrkl/output_parser.py
@@ -22,8 +22,12 @@ FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE = (
 class MRKLOutputParser(AgentOutputParser):
     """MRKL Output parser for the chat agent."""
 
+    format_instructions: str = FORMAT_INSTRUCTIONS
+    """Default formatting instructions"""
+
     def get_format_instructions(self) -> str:
-        return FORMAT_INSTRUCTIONS
+        """Returns formatting instructions for the given output parser."""
+        return self.format_instructions
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         includes_answer = FINAL_ANSWER_ACTION in text

--- a/libs/langchain/langchain/agents/structured_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/structured_chat/output_parser.py
@@ -20,10 +20,15 @@ logger = logging.getLogger(__name__)
 class StructuredChatOutputParser(AgentOutputParser):
     """Output parser for the structured chat agent."""
 
+    format_instructions: str = FORMAT_INSTRUCTIONS
+    """Default formatting instructions"""
+
     pattern = re.compile(r"```(?:json\s+)?(\W.*?)```", re.DOTALL)
+    """Regex pattern to parse the output."""
 
     def get_format_instructions(self) -> str:
-        return FORMAT_INSTRUCTIONS
+        """Returns formatting instructions for the given output parser."""
+        return self.format_instructions
 
     def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
         try:


### PR DESCRIPTION
  - **Description:** 
This PR standardizes the `output_parser.py` file across all agent types to ensure a uniform parsing mechanism is implemented. It introduces a cohesive structure and common interface for output parsing, facilitating easier modifications and extensions by users. The standardized approach enhances maintainability and scalability of the codebase by providing a consistent pattern for output parsing, which can be easily understood and utilized across different agent types.

This PR builds upon the foundation set by a previously merged PR, which focused exclusively on standardizing the `output_parser.py` for the `conversational_agent` ([PR #16945](https://github.com/langchain-ai/langchain/pull/16945)). With this new update, I extend the standardization efforts to encompass `output_parser.py` files across all agent types. This enhancement not only unifies the parsing mechanism across the board but also introduces the flexibility for users to incorporate custom `FORMAT_INSTRUCTIONS`.

  - **Issue:** 
https://github.com/langchain-ai/langchain/issues/10721
https://github.com/langchain-ai/langchain/issues/4044

  - **Dependencies:**
No new dependencies required for this change

  - **Twitter handle:**
With my github user is enough. Thanks

I hope you accept my PR.
