### PR TITLE
Adjusted get_num_tokens_from_messages method

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -283,7 +283,7 @@ class BaseLanguageModel(
         Returns:
             The sum of the number of tokens across the messages.
         """
-        return sum([self.get_num_tokens(get_buffer_string([m])) for m in messages])
+        return self.get_num_tokens(get_buffer_string(messages))
 
     @classmethod
     def _all_required_field_names(cls) -> Set:


### PR DESCRIPTION
added a small adjustment so that's a single call of `get_num_tokens` instead of multiple calls since results are summed up anyways