### PR TITLE
community: Fix KeyError 'embedding' (MongoDBAtlasVectorSearch)

### DIFF
--- a/libs/community/langchain_community/vectorstores/mongodb_atlas.py
+++ b/libs/community/langchain_community/vectorstores/mongodb_atlas.py
@@ -209,7 +209,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
         for res in cursor:
             text = res.pop(self._text_key)
             score = res.pop("score")
-            del res["embedding"]
+            del res[self._embedding_key]
             docs.append((Document(page_content=text, metadata=res), score))
         return docs
 


### PR DESCRIPTION
  - **Description:**
Embedding field name was hard-coded named "embedding".
So I suggest that change `res["embedding"]` into `res[self._embedding_key]`.
  - **Issue:** #17177,
  - **Twitter handle:** [@bagcheoljun17](https://twitter.com/bagcheoljun17)
