### PR TITLE
allow optional newline in the action responses of JSON Agent parser

### DIFF
--- a/libs/langchain/langchain/agents/output_parsers/react_json_single_input.py
+++ b/libs/langchain/langchain/agents/output_parsers/react_json_single_input.py
@@ -42,7 +42,7 @@ class ReActJsonSingleInputOutputParser(AgentOutputParser):
 
     """
 
-    pattern = re.compile(r"^.*?`{3}(?:json)?\n(.*?)`{3}.*?$", re.DOTALL)
+    pattern = re.compile(r"^.*?`{3}(?:json)?\n?(.*?)`{3}.*?$", re.DOTALL)
     """Regex pattern to parse the output."""
 
     def get_format_instructions(self) -> str:


### PR DESCRIPTION
Based on my experiments, the newline isn't always there, so we can make the regex slightly more robust by allowing an optional newline after the bacticks