### PR TITLE
langchain_google_genai : Add missing _identifying_params property.

### DIFF
--- a/libs/partners/google-genai/langchain_google_genai/llms.py
+++ b/libs/partners/google-genai/langchain_google_genai/llms.py
@@ -151,6 +151,18 @@ Supported examples:
     def _model_family(self) -> str:
         return GoogleModelFamily(self.model)
 
+    @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        """Get the identifying parameters."""
+        return {
+            "model": self.model,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            "max_output_tokens": self.max_output_tokens,
+            "candidate_count": self.n,
+        }
+
 
 class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
     """Google GenerativeAI models.


### PR DESCRIPTION
Description: Missing  _identifying_params create issues when dealing with callbacks to get current run model parameters.
All other model partners implementation provide this property and also provide _default_params. I'm not sure about the default values to include or if we can re-use the same as for _VertexAICommon(), this change allows you to access the model parameters correctly.
Issue: Not exactly this issue but could be related https://github.com/langchain-ai/langchain/issues/14711
Twitter handle:@musicaoriginal2

