### PR TITLE
langchain, community: Fixes in the Ontotext GraphDB Graph and QA Chain

### DIFF
--- a/docs/docs/use_cases/graph/graph_ontotext_graphdb_qa.ipynb
+++ b/docs/docs/use_cases/graph/graph_ontotext_graphdb_qa.ipynb
@@ -69,7 +69,7 @@
     "pip install openai==1.6.1\n",
     "pip install rdflib==7.0.0\n",
     "pip install langchain-openai==0.0.2\n",
-    "pip install langchain\n",
+    "pip install langchain>=0.1.5\n",
     "```\n",
     "\n",
     "Run Jupyter with\n",

--- a/libs/community/langchain_community/graphs/ontotext_graphdb_graph.py
+++ b/libs/community/langchain_community/graphs/ontotext_graphdb_graph.py
@@ -204,11 +204,7 @@ class OntotextGraphDBGraph:
         """
         Query the graph.
         """
-        from rdflib.exceptions import ParserError
         from rdflib.query import ResultRow
 
-        try:
-            res = self.graph.query(query)
-        except ParserError as e:
-            raise ValueError(f"Generated SPARQL statement is invalid\n{e}")
+        res = self.graph.query(query)
         return [r for r in res if isinstance(r, ResultRow)]


### PR DESCRIPTION
  - **Description:** Fixes in the Ontotext GraphDB Graph and QA Chain related to the error handling in case of invalid SPARQL queries, for which `prepareQuery` doesn't throw an exception, but the server returns 400 and the query is indeed invalid
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** @OntotextGraphDB