### PR TITLE
fix for postgres schema change issue #17231

### DIFF
--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -437,8 +437,7 @@ class SQLDatabase:
                     pass
                 elif self.dialect == "postgresql":  # postgresql
                     connection.exec_driver_sql(
-                        "SET search_path TO %s",
-                        (self._schema,),
+                        f"SET search_path TO {self._schema}",
                         execution_options=execution_options,
                     )
 


### PR DESCRIPTION
<!-- 
Langchain-community: Fix for PostgreSQL search_path setting error

This PR addresses the issue where setting the PostgreSQL `search_path` using `exec_driver_sql` with parameter substitution resulted in a syntax error. The proposed fix removes parameter substitution and directly interpolates the schema name into the SQL command string.

- **Description:** Corrected the syntax error when setting the `search_path` for PostgreSQL in the `SQLDatabase` class by directly interpolating the schema name into the SQL command.
- **Issue:** Fixes issue #17231, where the use of parameter substitution with `exec_driver_sql` caused a syntax error in PostgreSQL.
- **Dependencies:** No new dependencies are required for this change.
- **Twitter handle:** https://x.com/zafershah247

-->
