### PR TITLE
Update Docs for TFIDFRetriever Import Path

### DIFF
--- a/docs/docs/integrations/retrievers/tf_idf.ipynb
+++ b/docs/docs/integrations/retrievers/tf_idf.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.retrievers import TFIDFRetriever"
+    "from langchain_community.retrievers import TFIDFRetriever"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the `TF-IDF.ipynb` documentation to reflect the new import path for TFIDFRetriever in the langchain-community package. The previous path, `from langchain.retrievers import TFIDFRetriever`, has been updated to `from langchain_community.retrievers import TFIDFRetriever` to align with the latest changes in the langchain library.