### PR TITLE
community[patch]: Fix typo in milvus vectorstore

### DIFF
--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -569,7 +569,7 @@ class Milvus(VectorStore):
                             if self.auto_id
                             else [x for x in self.fields]
                         )
-                        for key in keys:
+                        if key in keys:
                             insert_dict.setdefault(key, []).append(value)
 
         # Total insert count


### PR DESCRIPTION
Problem from #17095

This error wasn't in the v1.4.0