### PR TITLE
core: Fixes default asimilarity_search_with_relevance_scores call

### DIFF
--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -300,7 +300,6 @@ class VectorStore(ABC):
             List of Tuples of (doc, similarity_score)
         """
         score_threshold = kwargs.pop("score_threshold", None)
-
         docs_and_similarities = self._similarity_search_with_relevance_scores(
             query, k=k, **kwargs
         )
@@ -346,32 +345,11 @@ class VectorStore(ABC):
         Returns:
             List of Tuples of (doc, similarity_score)
         """
-        score_threshold = kwargs.pop("score_threshold", None)
+        # This is a temporary workaround to make the similarity search with relevance scores
+        # asynchronous. The proper solution is to make the similarity search
+        # asynchronous in the vector store implementations.
+        return await run_in_executor(None, self.similarity_search_with_relevance_scores, query, k=k, **kwargs)
 
-        docs_and_similarities = await self._asimilarity_search_with_relevance_scores(
-            query, k=k, **kwargs
-        )
-        if any(
-            similarity < 0.0 or similarity > 1.0
-            for _, similarity in docs_and_similarities
-        ):
-            warnings.warn(
-                "Relevance scores must be between"
-                f" 0 and 1, got {docs_and_similarities}"
-            )
-
-        if score_threshold is not None:
-            docs_and_similarities = [
-                (doc, similarity)
-                for doc, similarity in docs_and_similarities
-                if similarity >= score_threshold
-            ]
-            if len(docs_and_similarities) == 0:
-                warnings.warn(
-                    "No relevant docs were retrieved using the relevance score"
-                    f" threshold {score_threshold}"
-                )
-        return docs_and_similarities
 
     async def asimilarity_search(
         self, query: str, k: int = 4, **kwargs: Any

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -345,10 +345,12 @@ class VectorStore(ABC):
         Returns:
             List of Tuples of (doc, similarity_score)
         """
-        # This is a temporary workaround to make the similarity search with relevance scores
-        # asynchronous. The proper solution is to make the similarity search
-        # asynchronous in the vector store implementations.
-        return await run_in_executor(None, self.similarity_search_with_relevance_scores, query, k=k, **kwargs)
+        # This is a temporary workaround to make the similarity search with 
+        # relevance scores asynchronous. The proper solution is to make the 
+        # similarity search asynchronous in the vector store implementations.
+        return await run_in_executor(
+            None, self.similarity_search_with_relevance_scores, query, k=k, **kwargs
+        )
 
 
     async def asimilarity_search(


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->

 **Description:**
While using AzureSearch I realized that the `asimilarity_search_with_relevance_scores` is a direct copy of `similarity_search_with_relevance_scores`. When child class inherits `VectorStore` and overrides `similarity_search_with_relevance_scores` but without async version, then it refers to a private method that is not always defined and results with NotImplementedError.

Given that this is a problem affecting also others: #11539 ,  #3242 maybe it's okay to have a default implementation of async calls that wrap the non-async versions with `run_in_executor`. The child classes can amend it if needed.
Sorry I didn't find any unittests that cover that, but happy to add if suggested.

Details described in ⏬ 
 **Issue:** #17329
 **Dependencies:**Nope
 **Twitter handle:** dokatox