### PR TITLE
community watsonx[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/community/langchain_community/llms/watsonxllm.py
+++ b/libs/community/langchain_community/llms/watsonxllm.py
@@ -391,7 +391,7 @@ class WatsonxLLM(BaseLLM):
             prompt=prompt, raw_response=True, params=params
         ):
             chunk = self._stream_response_to_generation_chunk(stream_resp)
-            yield chunk
 
             if run_manager:
                 run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+            yield chunk


### PR DESCRIPTION
**Description:** Invoke callback prior to yielding token in stream method for watsonx.
**Issue:** [Callback for on_llm_new_token should be invoked before the token is yielded by the model #16913](https://github.com/langchain-ai/langchain/issues/16913)