### PR TITLE
community: Updated OpenAI pricing in mapping

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -16,6 +16,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-vision-preview": 0.01,
     "gpt-4-1106-preview": 0.01,
     "gpt-4-0125-preview": 0.01,
+    "gpt-4-turbo-preview": 0.01,  # Currently points to gpt-4-0125-preview
     # GPT-4 output
     "gpt-4-completion": 0.06,
     "gpt-4-0314-completion": 0.06,
@@ -26,6 +27,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-vision-preview-completion": 0.03,
     "gpt-4-1106-preview-completion": 0.03,
     "gpt-4-0125-preview-completion": 0.03,
+    "gpt-4-turbo-preview-completion": 0.03,  # Currently points to gpt-4-0125-preview
     # GPT-3.5 input
     # gpt-3.5-turbo points at gpt-3.5-turbo-0613 until Feb 16, 2024.
     # Switches to gpt-3.5-turbo-0125 after.

--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -15,6 +15,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-32k-0613": 0.06,
     "gpt-4-vision-preview": 0.01,
     "gpt-4-1106-preview": 0.01,
+    "gpt-4-0125-preview": 0.01,
     # GPT-4 output
     "gpt-4-completion": 0.06,
     "gpt-4-0314-completion": 0.06,
@@ -24,6 +25,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-32k-0613-completion": 0.12,
     "gpt-4-vision-preview-completion": 0.03,
     "gpt-4-1106-preview-completion": 0.03,
+    "gpt-4-0125-preview-completion": 0.03,
     # GPT-3.5 input
     # gpt-3.5-turbo points at gpt-3.5-turbo-0613 until Feb 16, 2024.
     # Switches to gpt-3.5-turbo-0125 after.


### PR DESCRIPTION
  - **Description:** There are updates on website on page [pricing](https://openai.com/pricing) for GPT-4 Turbo
<img width="763" alt="image" src="https://github.com/langchain-ai/langchain/assets/1635118/890e9666-427f-4b1e-83f2-955128012824">

  - **Issue:** https://github.com/langchain-ai/langchain/issues/17173,

