### PR TITLE
tools:docs: update google_search.ipynb - change tool name

### DIFF
--- a/docs/docs/integrations/tools/google_search.ipynb
+++ b/docs/docs/integrations/tools/google_search.ipynb
@@ -40,7 +40,7 @@
     "search = GoogleSearchAPIWrapper()\n",
     "\n",
     "tool = Tool(\n",
-    "    name=\"Google Search\",\n",
+    "    name=\"google_search\",\n",
     "    description=\"Search Google for recent results.\",\n",
     "    func=search.run,\n",
     ")"


### PR DESCRIPTION
according to https://youtu.be/rZus0JtRqXE?si=aFo1JTDnu5kSEiEN&t=678 by @efriis

  - **Description:** Seems the requirements for tool names have changed and spaces are no longer allowed. Changed the tool name from Google Search to google_search in the notebook
  - **Issue:** n/a
  - **Dependencies:** none
  - **Twitter handle:** @mesirii