### PR TITLE
community[patch]: Fix HuggingFace LLM to not repeat the prompt as part of the result

### DIFF
--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,7 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {"return_full_text": False, **_model_kwargs, **kwargs, "return_full_text": False}
+        parameters = {"return_full_text": False, **_model_kwargs, **kwargs}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,7 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {"return_full_text": False, **_model_kwargs, **kwargs}
+        parameters = {**({"return_full_text":False} if self.task=="text-generation" else {}), **_model_kwargs, **kwargs}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,9 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {**({"return_full_text":False} if self.task=="text-generation" else {}), **_model_kwargs, **kwargs}
+        parameters = {**({"return_full_text":False} if self.task=="text-generation" else {}),
+                      **_model_kwargs,
+                      **kwargs}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,8 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {**({"return_full_text":False} if self.task=="text-generation" else {}),
+        parameters = {**({"return_full_text":False} 
+                         if self.task=="text-generation" else {}),
                       **_model_kwargs,
                       **kwargs}
 

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,7 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {"return_full_text": False**_model_kwargs, **kwargs, "return_full_text": False}
+        parameters = {"return_full_text": False, **_model_kwargs, **kwargs, "return_full_text": False}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,7 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {**_model_kwargs, **kwargs}
+        parameters = {**_model_kwargs, **kwargs, "return_full_text":False}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,7 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {**_model_kwargs, **kwargs, "return_full_text": False}
+        parameters = {"return_full_text": False**_model_kwargs, **kwargs, "return_full_text": False}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -127,7 +127,7 @@ class HuggingFaceHub(LLM):
                 response = hf("Tell me a joke.")
         """
         _model_kwargs = self.model_kwargs or {}
-        parameters = {**_model_kwargs, **kwargs, "return_full_text":False}
+        parameters = {**_model_kwargs, **kwargs, "return_full_text": False}
 
         response = self.client.post(
             json={"inputs": prompt, "parameters": parameters}, task=self.task


### PR DESCRIPTION
<!-- Thank you for contributing to LangChain!

Please title your PR "<package>: <description>", where <package> is whichever of langchain, community, core, experimental, etc. is being modified.

Replace this entire comment with:
  - **Description:** a description of the change, 
  - **Issue:** the issue # it fixes if applicable,
  - **Dependencies:** any dependencies required for this change,
  - **Twitter handle:** we announce bigger features on Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` from the root of the package you've modified to check this locally.

See contribution guidelines for more information on how to write/run tests, lint, etc: https://python.langchain.com/docs/contributing/

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
Description: Let huggingface llm don't repeat prompt
Issue: #16972 
Break changes: It changes the llm `Huggingface`'s behavior:
  - Before: Huggingface llm will repeat the prompt in its result
  - After:    Huggingface llm will not repeat the prompt in its result