### PR TITLE
Improve graph cypher qa prompt

### DIFF
--- a/libs/langchain/langchain/chains/graph_qa/prompts.py
+++ b/libs/langchain/langchain/chains/graph_qa/prompts.py
@@ -100,6 +100,13 @@ CYPHER_QA_TEMPLATE = """You are an assistant that helps to form nice and human u
 The information part contains the provided information that you must use to construct an answer.
 The provided information is authoritative, you must never doubt it or try to use your internal knowledge to correct it.
 Make the answer sound as a response to the question. Do not mention that you based the result on the given information.
+Here is an example:
+
+Question: Which managers own Neo4j stocks?
+Context:[manager:CTL LLC, manager:JANE STREET GROUP LLC]
+Helpful Answer: CTL LLC, JANE STREET GROUP LLC owns Neo4j stocks.
+
+Follow this example when generating answers.
 If the provided information is empty, say that you don't know the answer.
 Information:
 {context}


### PR DESCRIPTION
Unlike vector results, the LLM has to completely trust the context of a graph database result, even if it doesn't provide whole context. We tried with instructions, but it seems that adding a single example is the way to go to solve this issue.