### PR TITLE
community[minor]: Fix pydantic ForwardRef error in BedrockBase

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -1,11 +1,8 @@
-from __future__ import annotations
-
 import asyncio
 import json
 import warnings
 from abc import ABC
 from typing import (
-    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     AsyncIterator,
@@ -30,9 +27,6 @@ from langchain_community.utilities.anthropic import (
     get_num_tokens_anthropic,
     get_token_ids_anthropic,
 )
-
-if TYPE_CHECKING:
-    from botocore.config import Config
 
 AMAZON_BEDROCK_TRACE_KEY = "amazon-bedrock-trace"
 GUARDRAILS_BODY_KEY = "amazon-bedrock-guardrailAssessment"
@@ -226,9 +220,6 @@ class BedrockBase(BaseModel, ABC):
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
     """
 
-    config: Optional[Config] = None
-    """An optional botocore.config.Config instance to pass to the client."""
-
     provider: Optional[str] = None
     """The model provider, e.g., amazon, cohere, ai21, etc. When not supplied, provider
     is extracted from the first part of the model_id e.g. 'amazon' in 
@@ -333,8 +324,6 @@ class BedrockBase(BaseModel, ABC):
                 client_params["region_name"] = values["region_name"]
             if values["endpoint_url"]:
                 client_params["endpoint_url"] = values["endpoint_url"]
-            if values["config"]:
-                client_params["config"] = values["config"]
 
             values["client"] = session.client("bedrock-runtime", **client_params)
 


### PR DESCRIPTION
## Description
Fixes a type annotation issue in the definition of BedrockBase. This issue was that the annotation for the `config` attribute includes a ForwardRef to `botocore.client.Config` which is only imported when `TYPE_CHECKING`, and thus can't be resolved at runtime. This can cause pydantic to raise an error like `pydantic.errors.ConfigError: field "config" not yet prepared so type is still a ForwardRef, ...`. 

This fix is a **breaking change** by removing the option to pass boto3 config. This is justified by the judgement that the minor convenience afforded by this feature does not justify the additional complexity in the implementation and interface.

An alternative non-breaking fix is proposed here: https://github.com/langchain-ai/langchain/pull/17416

## Issue
N/A

##Dependencies
N/A

##Twitter handle
`@__nat_n__`