### PR TITLE
core: improve None value processing in merge_dicts()

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -19,11 +19,9 @@ def merge_dicts(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
     for k, v in right.items():
         if k not in merged:
             merged[k] = v
-        elif merged[k] is None and v:
+        elif v is not None and merged[k] is None:
             merged[k] = v
-        elif v is None:
-            continue
-        elif merged[k] == v:
+        elif v is None or merged[k] == v:
             continue
         elif type(merged[k]) != type(v):
             raise TypeError(

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import AbstractContextManager, nullcontext
 from typing import Dict, Optional, Tuple, Type, Union
 from unittest.mock import patch
@@ -71,9 +72,9 @@ def test_check_package_version(
             {"a": "1"},
             pytest.raises(
                 TypeError,
-                match=(
-                    'additional_kwargs\["a"\] already exists in this message, '
-                    "but with a different type\."
+                match=re.escape(
+                    'additional_kwargs["a"] already exists in this message, '
+                    "but with a different type."
                 ),
             ),
         ),
@@ -84,7 +85,7 @@ def test_check_package_version(
                 TypeError,
                 match=(
                     "Additional kwargs key a already exists in left dict and value "
-                    "has unsupported type .+tuple.+\."
+                    "has unsupported type .+tuple.+."
                 ),
             ),
         ),

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -1,5 +1,5 @@
 from contextlib import AbstractContextManager, nullcontext
-from typing import Dict, Optional, Tuple, Type
+from typing import Dict, Optional, Tuple, Type, Union
 from unittest.mock import patch
 
 import pytest
@@ -91,7 +91,7 @@ def test_check_package_version(
     ),
 )
 def test_merge_dicts(
-    left: dict, right: dict, expected: dict | AbstractContextManager
+    left: dict, right: dict, expected: Union[dict, AbstractContextManager]
 ) -> None:
     if isinstance(expected, AbstractContextManager):
         err = expected


### PR DESCRIPTION
- **Description:** fix `None` and `0` merging in `merge_dicts()`, add tests.
```python
from langchain_core.utils._merge import merge_dicts
assert merge_dicts({"a": None}, {"a": 0}) == {"a": 0}
```

