### PR TITLE
Doc: Update `llamacpp.ipynb`

### DIFF
--- a/docs/docs/integrations/llms/llamacpp.ipynb
+++ b/docs/docs/integrations/llms/llamacpp.ipynb
@@ -10,17 +10,7 @@
     "\n",
     "It supports inference for [many LLMs](https://github.com/ggerganov/llama.cpp#description) models, which can be accessed on [Hugging Face](https://huggingface.co/TheBloke).\n",
     "\n",
-    "This notebook goes over how to run `llama-cpp-python` within LangChain.\n",
-    "\n",
-    "**Note: new versions of `llama-cpp-python` use GGUF model files (see [here](https://github.com/abetlen/llama-cpp-python/pull/633)).**\n",
-    "\n",
-    "This is a breaking change.\n",
-    " \n",
-    "To convert existing GGML models to GGUF you can run the following in [llama.cpp](https://github.com/ggerganov/llama.cpp):\n",
-    "\n",
-    "```\n",
-    "python ./convert-llama-ggmlv3-to-gguf.py --eps 1e-5 --input models/openorca-platypus2-13b.ggmlv3.q4_0.bin --output models/openorca-platypus2-13b.gguf.q4_0.bin\n",
-    "```"
+    "This notebook goes over how to run `llama-cpp-python` within LangChain."
    ]
   },
   {
@@ -45,7 +35,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  llama-cpp-python"
+    "%pip install --upgrade --quiet llama-cpp-python"
    ]
   },
   {
@@ -253,6 +243,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Download Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q huggingface-hub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone -q https://github.com/ggerganov/llama.cpp \n",
+    "!cd llama.cpp \n",
+    "!venv/bin/huggingface-cli download TheBloke/OpenOrca-Platypus2-13B-GGML openorca-platypus2-13b.ggmlv3.q4_0.bin --local-dir ./models --local-dir-use-symlinks False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note: new versions of `llama-cpp-python` use GGUF model files (see [here](https://github.com/abetlen/llama-cpp-python/pull/633)).**\n",
+    "\n",
+    "This is a breaking change. \n",
+    "To convert existing GGML models to GGUF you can run the following in [llama.cpp](https://github.com/ggerganov/llama.cpp):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you use a model file in `gguf` format, ignore this step\n",
+    "!python llama.cpp/convert-llama-ggml-to-gguf.py --eps 1e-5 --input llama.cpp/models/openorca-platypus2-13b.ggmlv3.q4_0.bin --output llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### CPU"
    ]
   },
@@ -271,7 +308,7 @@
    "source": [
     "# Make sure the model path is correct for your system!\n",
     "llm = LlamaCpp(\n",
-    "    model_path=\"/Users/rlm/Desktop/Code/llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
+    "    model_path=\"llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
     "    temperature=0.75,\n",
     "    max_tokens=2000,\n",
     "    top_p=1,\n",
@@ -339,80 +376,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Example using a LLaMA v1 model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Make sure the model path is correct for your system!\n",
-    "llm = LlamaCpp(\n",
-    "    model_path=\"./ggml-model-q4_0.bin\", callback_manager=callback_manager, verbose=True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "llm_chain = LLMChain(prompt=prompt, llm=llm)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "1. First, find out when Justin Bieber was born.\n",
-      "2. We know that Justin Bieber was born on March 1, 1994.\n",
-      "3. Next, we need to look up when the Super Bowl was played in that year.\n",
-      "4. The Super Bowl was played on January 28, 1995.\n",
-      "5. Finally, we can use this information to answer the question. The NFL team that won the Super Bowl in the year Justin Bieber was born is the San Francisco 49ers."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "llama_print_timings:        load time =   434.15 ms\n",
-      "llama_print_timings:      sample time =    41.81 ms /   121 runs   (    0.35 ms per token)\n",
-      "llama_print_timings: prompt eval time =  2523.78 ms /    48 tokens (   52.58 ms per token)\n",
-      "llama_print_timings:        eval time = 23971.57 ms /   121 runs   (  198.11 ms per token)\n",
-      "llama_print_timings:       total time = 28945.95 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'\\n\\n1. First, find out when Justin Bieber was born.\\n2. We know that Justin Bieber was born on March 1, 1994.\\n3. Next, we need to look up when the Super Bowl was played in that year.\\n4. The Super Bowl was played on January 28, 1995.\\n5. Finally, we can use this information to answer the question. The NFL team that won the Super Bowl in the year Justin Bieber was born is the San Francisco 49ers.'"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "question = \"What NFL team won the Super Bowl in the year Justin Bieber was born?\"\n",
-    "llm_chain.run(question)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### GPU\n",
     "\n",
     "If the installation with BLAS backend was correct, you will see a `BLAS = 1` indicator in model properties.\n",
@@ -423,25 +386,6 @@
     "- `n_batch` - how many tokens are processed in parallel. \n",
     "\n",
     "Setting these parameters correctly will dramatically improve the evaluation speed (see [wrapper code](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/llms/llamacpp.py) for more details)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n_gpu_layers = -1  # The number of layers to put on the GPU. The rest will be on the CPU. If you don't know how many layers there are, you can use -1 to move all to GPU.\n",
-    "n_batch = 512  # Should be between 1 and n_ctx, consider the amount of VRAM in your GPU.\n",
-    "\n",
-    "# Make sure the model path is correct for your system!\n",
-    "llm = LlamaCpp(\n",
-    "    model_path=\"/Users/rlm/Desktop/Code/llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
-    "    n_gpu_layers=n_gpu_layers,\n",
-    "    n_batch=n_batch,\n",
-    "    callback_manager=callback_manager,\n",
-    "    verbose=True,  # Verbose is required to pass to the callback manager\n",
-    ")"
    ]
   },
   {
@@ -513,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +465,7 @@
     "n_batch = 512  # Should be between 1 and n_ctx, consider the amount of RAM of your Apple Silicon Chip.\n",
     "# Make sure the model path is correct for your system!\n",
     "llm = LlamaCpp(\n",
-    "    model_path=\"/Users/rlm/Desktop/Code/llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
+    "    model_path=\"llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
     "    n_gpu_layers=n_gpu_layers,\n",
     "    n_batch=n_batch,\n",
     "    f16_kv=True,  # MUST set to True, otherwise you will run into problem after a couple of calls\n",
@@ -571,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,19 +523,19 @@
     "n_batch = 512  # Should be between 1 and n_ctx, consider the amount of RAM of your Apple Silicon Chip.\n",
     "# Make sure the model path is correct for your system!\n",
     "llm = LlamaCpp(\n",
-    "    model_path=\"/Users/rlm/Desktop/Code/llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
+    "    model_path=\"llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
     "    n_gpu_layers=n_gpu_layers,\n",
     "    n_batch=n_batch,\n",
     "    f16_kv=True,  # MUST set to True, otherwise you will run into problem after a couple of calls\n",
     "    callback_manager=callback_manager,\n",
     "    verbose=True,  # Verbose is required to pass to the callback manager\n",
-    "    grammar_path=\"/Users/rlm/Desktop/Code/langchain-main/langchain/libs/langchain/langchain/llms/grammars/json.gbnf\",\n",
+    "    grammar_path=\"../../../../libs/langchain/langchain/llms/grammars/json.gbnf\",\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -599,23 +543,17 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "  \"name\": \"John Doe\",\n",
-      "  \"age\": 34,\n",
-      "  \"\": {\n",
-      "    \"title\": \"Software Developer\",\n",
-      "    \"company\": \"Google\"\n",
+      "  \"name\": \"John Smith\",\n",
+      "  \"age\": 25,\n",
+      "  \"gender\": \"Male\",\n",
+      "  \"occupation\": {\n",
+      "    \"title\": \"Software Developer\"\n",
       "  },\n",
-      "  \"interests\": [\n",
-      "    \"Sports\",\n",
-      "    \"Music\",\n",
-      "    \"Cooking\"\n",
-      "  ],\n",
       "  \"address\": {\n",
-      "    \"street_number\": 123,\n",
-      "    \"street_name\": \"Oak Street\",\n",
-      "    \"city\": \"Mountain View\",\n",
-      "    \"state\": \"California\",\n",
-      "    \"postal_code\": 94040\n",
+      "    \"street_address\": \"123 Main St.\",\n",
+      "    \"city\": \"New York\",\n",
+      "    \"state\": \"NY\",\n",
+      "    \"zip_code\": 12345\n",
       "  }}"
      ]
     },
@@ -624,11 +562,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "llama_print_timings:        load time =   357.51 ms\n",
-      "llama_print_timings:      sample time =  1213.30 ms /   144 runs   (    8.43 ms per token,   118.68 tokens per second)\n",
-      "llama_print_timings: prompt eval time =   356.78 ms /     9 tokens (   39.64 ms per token,    25.23 tokens per second)\n",
-      "llama_print_timings:        eval time =  3947.16 ms /   143 runs   (   27.60 ms per token,    36.23 tokens per second)\n",
-      "llama_print_timings:       total time =  5846.21 ms\n"
+      "llama_print_timings:        load time =    3291.36 ms\n",
+      "llama_print_timings:      sample time =     483.18 ms /   104 runs   (    4.65 ms per token,   215.24 tokens per second)\n",
+      "llama_print_timings: prompt eval time =    3291.15 ms /     9 tokens (  365.68 ms per token,     2.73 tokens per second)\n",
+      "llama_print_timings:        eval time =   10581.66 ms /   103 runs   (  102.73 ms per token,     9.73 tokens per second)\n",
+      "llama_print_timings:       total time =   14633.86 ms /   112 tokens\n"
      ]
     }
    ],
@@ -646,33 +584,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "n_gpu_layers = 1\n",
     "n_batch = 512\n",
     "llm = LlamaCpp(\n",
-    "    model_path=\"/Users/rlm/Desktop/Code/llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
+    "    model_path=\"llama.cpp/models/openorca-platypus2-13b.gguf.q4_0.bin\",\n",
     "    n_gpu_layers=n_gpu_layers,\n",
     "    n_batch=n_batch,\n",
     "    f16_kv=True,  # MUST set to True, otherwise you will run into problem after a couple of calls\n",
     "    callback_manager=callback_manager,\n",
     "    verbose=True,\n",
-    "    grammar_path=\"/Users/rlm/Desktop/Code/langchain-main/langchain/libs/langchain/langchain/llms/grammars/list.gbnf\",\n",
+    "    grammar_path=\"../../../../libs/langchain/langchain/llms/grammars/list.gbnf\",\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[\"The Catcher in the Rye\", \"Wuthering Heights\", \"Anna Karenina\"]\n"
+      "[\"The Da Vinci Code\", \"Life of Pi\"]\n"
      ]
     },
     {
@@ -680,11 +618,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "llama_print_timings:        load time =   322.34 ms\n",
-      "llama_print_timings:      sample time =   232.60 ms /    26 runs   (    8.95 ms per token,   111.78 tokens per second)\n",
-      "llama_print_timings: prompt eval time =   321.90 ms /    11 tokens (   29.26 ms per token,    34.17 tokens per second)\n",
-      "llama_print_timings:        eval time =   680.82 ms /    25 runs   (   27.23 ms per token,    36.72 tokens per second)\n",
-      "llama_print_timings:       total time =  1295.27 ms\n"
+      "llama_print_timings:        load time =    1691.68 ms\n",
+      "llama_print_timings:      sample time =      73.35 ms /    15 runs   (    4.89 ms per token,   204.49 tokens per second)\n",
+      "llama_print_timings: prompt eval time =    1691.57 ms /    11 tokens (  153.78 ms per token,     6.50 tokens per second)\n",
+      "llama_print_timings:        eval time =    1877.38 ms /    14 runs   (  134.10 ms per token,     7.46 tokens per second)\n",
+      "llama_print_timings:       total time =    3681.26 ms /    25 tokens\n"
      ]
     }
    ],
@@ -710,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.0rc2"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
I found that some context was missing in the `Llama.cpp` document, such as how to download model files such as `openorca-platypus2-13b.gguf.q4_0.bin` and how to convert to `gguf` format model. Also, `model_path` is the user's directory. I changed it to relative to the model file path.