### PR TITLE
Community[patch]: Adjusted import to be compatible with SQLAlchemy<2

### DIFF
--- a/libs/community/langchain_community/tools/sql_database/tool.py
+++ b/libs/community/langchain_community/tools/sql_database/tool.py
@@ -2,7 +2,7 @@
 """Tools for interacting with a SQL database."""
 from typing import Any, Dict, Optional, Sequence, Type, Union
 
-from sqlalchemy import Result
+from sqlalchemy.engine import Result
 
 from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 


### PR DESCRIPTION
- **Description:** Adjusts an import to directly import `Result` from `sqlalchemy.engine`.
- **Issue:** #17519 
- **Dependencies:** N/A
- **Twitter handle:** @grafail
