### PR TITLE
community[patch]: Fix pwd import that is not available on windows

### DIFF
--- a/libs/community/langchain_community/document_loaders/pebblo.py
+++ b/libs/community/langchain_community/document_loaders/pebblo.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import pwd
 import uuid
 from http import HTTPStatus
 from typing import Any, Dict, Iterator, List
@@ -260,6 +259,8 @@ class PebbloSafeLoader(BaseLoader):
             str: Name of owner.
         """
         try:
+            import pwd
+
             file_owner_uid = os.stat(file_path).st_uid
             file_owner_name = pwd.getpwuid(file_owner_uid).pw_name
         except Exception:


### PR DESCRIPTION
  - **Description:** Resolving problem in `langchain_community\document_loaders\pebblo.py` with `import pwd`. `pwd` is not available on windows. import moved to try catch block
  - **Issue:** #17514 