### PR TITLE
core[minor]: add name to basemessage

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, List, Literal
 
 from langchain_core.messages.base import (
     BaseMessage,
     BaseMessageChunk,
     merge_content,
 )
-from langchain_core.pydantic_v1 import root_validator
 
 
 class AIMessage(BaseMessage):
@@ -17,27 +16,6 @@ class AIMessage(BaseMessage):
     """
 
     type: Literal["ai"] = "ai"
-
-    name: Optional[str] = None
-
-    @root_validator
-    def sync_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Sync the name of the message with the name of the function."""
-        additional_kwargs = values.get("additional_kwargs", {})
-        if "name" in values and values["name"] is not None:
-            if (
-                "name" in additional_kwargs
-                and values["name"] != additional_kwargs["name"]
-            ):
-                raise ValueError(
-                    "Name is defined differently in name and the "
-                    'additional_kwargs["name"].'
-                )
-            additional_kwargs["name"] = values["name"]
-            values["additional_kwargs"] = additional_kwargs
-        elif "name" in additional_kwargs:
-            values["name"] = additional_kwargs["name"]
-        return values
 
     @classmethod
     def get_lc_namespace(cls) -> List[str]:

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -55,6 +55,8 @@ class BaseMessage(Serializable):
     def pretty_repr(self, html: bool = False) -> str:
         title = get_msg_title_repr(self.type.title() + " Message", bold=html)
         # TODO: handle non-string content.
+        if self.name is not None:
+            title += f"\nName: {self.name}"
         return f"{title}\n\n{self.content}"
 
     def pretty_print(self) -> None:

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.pydantic_v1 import Extra, Field
@@ -24,6 +24,8 @@ class BaseMessage(Serializable):
     """Any additional information."""
 
     type: str
+
+    name: Optional[str] = None
 
     class Config:
         extra = Extra.allow

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -1718,6 +1718,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -1760,6 +1764,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -1909,6 +1917,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'human',
             'enum': list([
@@ -1977,6 +1989,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -2019,6 +2035,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',
@@ -2116,6 +2136,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -2158,6 +2182,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -2307,6 +2335,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'human',
             'enum': list([
@@ -2375,6 +2407,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -2417,6 +2453,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',
@@ -2498,6 +2538,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -2540,6 +2584,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -2642,6 +2690,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'human',
             'enum': list([
@@ -2688,6 +2740,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -2730,6 +2786,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',
@@ -2799,6 +2859,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -2841,6 +2905,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -2990,6 +3058,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'human',
             'enum': list([
@@ -3058,6 +3130,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -3100,6 +3176,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',
@@ -3169,6 +3249,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -3211,6 +3295,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -3359,6 +3447,10 @@
             'default': False,
             'title': 'Example',
             'type': 'boolean',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'type': dict({
             'default': 'human',
@@ -3428,6 +3520,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -3470,6 +3566,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',
@@ -3531,6 +3631,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -3573,6 +3677,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -3721,6 +3829,10 @@
             'default': False,
             'title': 'Example',
             'type': 'boolean',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'type': dict({
             'default': 'human',
@@ -3801,6 +3913,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -3843,6 +3959,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',
@@ -3931,6 +4051,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'ai',
             'enum': list([
@@ -3973,6 +4097,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'role': dict({
             'title': 'Role',
@@ -4075,6 +4203,10 @@
             'title': 'Example',
             'type': 'boolean',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'human',
             'enum': list([
@@ -4121,6 +4253,10 @@
             ]),
             'title': 'Content',
           }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
           'type': dict({
             'default': 'system',
             'enum': list([
@@ -4163,6 +4299,10 @@
               }),
             ]),
             'title': 'Content',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
           }),
           'tool_call_id': dict({
             'title': 'Tool Call Id',

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -663,9 +663,7 @@ def test_lambda_schemas() -> None:
     }
 
     second_lambda = lambda x, y: (x["hello"], x["bye"], y["bah"])  # noqa: E731
-    assert RunnableLambda(
-        second_lambda
-    ).input_schema.schema() == {  # type: ignore[arg-type]
+    assert RunnableLambda(second_lambda).input_schema.schema() == {  # type: ignore[arg-type]
         "title": "RunnableLambdaInput",
         "type": "object",
         "properties": {"hello": {"title": "Hello"}, "bye": {"title": "Bye"}},
@@ -724,26 +722,27 @@ def test_lambda_schemas() -> None:
             "byebye": input["yo"],
         }
 
-    assert RunnableLambda(
-        aget_values_typed
-    ).input_schema.schema() == {  # type: ignore[arg-type]
-        "title": "aget_values_typed_input",
-        "$ref": "#/definitions/InputType",
-        "definitions": {
-            "InputType": {
-                "properties": {
-                    "variable_name": {
-                        "title": "Variable " "Name",
-                        "type": "string",
+    assert (
+        RunnableLambda(aget_values_typed).input_schema.schema()
+        == {  # type: ignore[arg-type]
+            "title": "aget_values_typed_input",
+            "$ref": "#/definitions/InputType",
+            "definitions": {
+                "InputType": {
+                    "properties": {
+                        "variable_name": {
+                            "title": "Variable " "Name",
+                            "type": "string",
+                        },
+                        "yo": {"title": "Yo", "type": "integer"},
                     },
-                    "yo": {"title": "Yo", "type": "integer"},
-                },
-                "required": ["variable_name", "yo"],
-                "title": "InputType",
-                "type": "object",
-            }
-        },
-    }
+                    "required": ["variable_name", "yo"],
+                    "title": "InputType",
+                    "type": "object",
+                }
+            },
+        }
+    )
 
     assert RunnableLambda(aget_values_typed).output_schema.schema() == {  # type: ignore[arg-type]
         "title": "aget_values_typed_output",

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -723,8 +723,10 @@ def test_lambda_schemas() -> None:
         }
 
     assert (
-        RunnableLambda(aget_values_typed).input_schema.schema()
-        == {  # type: ignore[arg-type]
+        RunnableLambda(
+            aget_values_typed  # type: ignore[arg-type]
+        ).input_schema.schema()
+        == {
             "title": "aget_values_typed_input",
             "$ref": "#/definitions/InputType",
             "definitions": {

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -116,9 +116,9 @@ class FakeTracer(BaseTracer):
         return run.copy(
             update={
                 "id": self._replace_uuid(run.id),
-                "parent_run_id": self.uuids_map[run.parent_run_id]
-                if run.parent_run_id
-                else None,
+                "parent_run_id": (
+                    self.uuids_map[run.parent_run_id] if run.parent_run_id else None
+                ),
                 "child_runs": [self._copy_run(child) for child in run.child_runs],
                 "execution_order": None,
                 "child_execution_order": None,
@@ -345,6 +345,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                         "enum": ["ai"],
                         "type": "string",
                     },
+                    "name": {"title": "Name", "type": "string"},
                     "example": {
                         "title": "Example",
                         "default": False,
@@ -380,6 +381,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                         "enum": ["human"],
                         "type": "string",
                     },
+                    "name": {"title": "Name", "type": "string"},
                     "example": {
                         "title": "Example",
                         "default": False,
@@ -390,7 +392,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
             },
             "ChatMessage": {
                 "title": "ChatMessage",
-                "description": "Message that can be assigned an arbitrary speaker (i.e. role).",  # noqa
+                "description": "Message that can be assigned an arbitrary speaker (i.e. role).",  # noqa: E501
                 "type": "object",
                 "properties": {
                     "content": {
@@ -415,13 +417,14 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                         "enum": ["chat"],
                         "type": "string",
                     },
+                    "name": {"title": "Name", "type": "string"},
                     "role": {"title": "Role", "type": "string"},
                 },
                 "required": ["content", "role"],
             },
             "SystemMessage": {
                 "title": "SystemMessage",
-                "description": "Message for priming AI behavior, usually passed in as the first of a sequence\nof input messages.",  # noqa
+                "description": "Message for priming AI behavior, usually passed in as the first of a sequence\nof input messages.",  # noqa: E501
                 "type": "object",
                 "properties": {
                     "content": {
@@ -446,12 +449,13 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                         "enum": ["system"],
                         "type": "string",
                     },
+                    "name": {"title": "Name", "type": "string"},
                 },
                 "required": ["content"],
             },
             "FunctionMessage": {
                 "title": "FunctionMessage",
-                "description": "Message for passing the result of executing a function back to a model.",  # noqa
+                "description": "Message for passing the result of executing a function back to a model.",  # noqa: E501
                 "type": "object",
                 "properties": {
                     "content": {
@@ -482,7 +486,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
             },
             "ToolMessage": {
                 "title": "ToolMessage",
-                "description": "Message for passing the result of executing a tool back to a model.",  # noqa
+                "description": "Message for passing the result of executing a tool back to a model.",  # noqa: E501
                 "type": "object",
                 "properties": {
                     "content": {
@@ -507,6 +511,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                         "enum": ["tool"],
                         "type": "string",
                     },
+                    "name": {"title": "Name", "type": "string"},
                     "tool_call_id": {"title": "Tool Call Id", "type": "string"},
                 },
                 "required": ["content", "tool_call_id"],
@@ -658,14 +663,13 @@ def test_lambda_schemas() -> None:
     }
 
     second_lambda = lambda x, y: (x["hello"], x["bye"], y["bah"])  # noqa: E731
-    assert (
-        RunnableLambda(second_lambda).input_schema.schema()  # type: ignore[arg-type]
-        == {
-            "title": "RunnableLambdaInput",
-            "type": "object",
-            "properties": {"hello": {"title": "Hello"}, "bye": {"title": "Bye"}},
-        }
-    )
+    assert RunnableLambda(
+        second_lambda
+    ).input_schema.schema() == {  # type: ignore[arg-type]
+        "title": "RunnableLambdaInput",
+        "type": "object",
+        "properties": {"hello": {"title": "Hello"}, "bye": {"title": "Bye"}},
+    }
 
     def get_value(input):  # type: ignore[no-untyped-def]
         return input["variable_name"]
@@ -720,27 +724,26 @@ def test_lambda_schemas() -> None:
             "byebye": input["yo"],
         }
 
-    assert (
-        RunnableLambda(aget_values_typed).input_schema.schema()  # type: ignore[arg-type]
-        == {
-            "title": "aget_values_typed_input",
-            "$ref": "#/definitions/InputType",
-            "definitions": {
-                "InputType": {
-                    "properties": {
-                        "variable_name": {
-                            "title": "Variable " "Name",
-                            "type": "string",
-                        },
-                        "yo": {"title": "Yo", "type": "integer"},
+    assert RunnableLambda(
+        aget_values_typed
+    ).input_schema.schema() == {  # type: ignore[arg-type]
+        "title": "aget_values_typed_input",
+        "$ref": "#/definitions/InputType",
+        "definitions": {
+            "InputType": {
+                "properties": {
+                    "variable_name": {
+                        "title": "Variable " "Name",
+                        "type": "string",
                     },
-                    "required": ["variable_name", "yo"],
-                    "title": "InputType",
-                    "type": "object",
-                }
-            },
-        }
-    )
+                    "yo": {"title": "Yo", "type": "integer"},
+                },
+                "required": ["variable_name", "yo"],
+                "title": "InputType",
+                "type": "object",
+            }
+        },
+    }
 
     assert RunnableLambda(aget_values_typed).output_schema.schema() == {  # type: ignore[arg-type]
         "title": "aget_values_typed_output",

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -505,10 +505,10 @@ def test_message_name(MessageClass: Type) -> None:
     assert msg.name == "bar"
 
     msg2 = MessageClass(content="foo", name=None)
-    assert msg2.name == None
+    assert msg2.name is None
 
     msg3 = MessageClass(content="foo")
-    assert msg3.name == None
+    assert msg3.name is None
 
 
 @pytest.mark.parametrize(
@@ -530,7 +530,7 @@ def test_message_name_chat(MessageClass: Type) -> None:
     assert msg.name == "bar"
 
     msg2 = MessageClass(content="foo", role="user", name=None)
-    assert msg2.name == None
+    assert msg2.name is None
 
     msg3 = MessageClass(content="foo", role="user")
-    assert msg3.name == None
+    assert msg3.name is None

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -29,42 +29,35 @@ def test_message_chunks() -> None:
         content="I am indeed."
     ), "MessageChunk + MessageChunk should be a MessageChunk"
 
-    assert (
-        AIMessageChunk(content="I am") + HumanMessageChunk(content=" indeed.")
-        == AIMessageChunk(content="I am indeed.")
+    assert AIMessageChunk(content="I am") + HumanMessageChunk(
+        content=" indeed."
+    ) == AIMessageChunk(
+        content="I am indeed."
     ), "MessageChunk + MessageChunk should be a MessageChunk of same class as the left side"  # noqa: E501
 
-    assert (
-        AIMessageChunk(content="", additional_kwargs={"foo": "bar"})
-        + AIMessageChunk(content="", additional_kwargs={"baz": "foo"})
-        == AIMessageChunk(content="", additional_kwargs={"foo": "bar", "baz": "foo"})
+    assert AIMessageChunk(
+        content="", additional_kwargs={"foo": "bar"}
+    ) + AIMessageChunk(content="", additional_kwargs={"baz": "foo"}) == AIMessageChunk(
+        content="", additional_kwargs={"foo": "bar", "baz": "foo"}
     ), "MessageChunk + MessageChunk should be a MessageChunk with merged additional_kwargs"  # noqa: E501
 
-    assert (
-        AIMessageChunk(
-            content="", additional_kwargs={"function_call": {"name": "web_search"}}
-        )
-        + AIMessageChunk(
-            content="", additional_kwargs={"function_call": {"arguments": None}}
-        )
-        + AIMessageChunk(
-            content="", additional_kwargs={"function_call": {"arguments": "{\n"}}
-        )
-        + AIMessageChunk(
-            content="",
-            additional_kwargs={
-                "function_call": {"arguments": '  "query": "turtles"\n}'}
-            },
-        )
-        == AIMessageChunk(
-            content="",
-            additional_kwargs={
-                "function_call": {
-                    "name": "web_search",
-                    "arguments": '{\n  "query": "turtles"\n}',
-                }
-            },
-        )
+    assert AIMessageChunk(
+        content="", additional_kwargs={"function_call": {"name": "web_search"}}
+    ) + AIMessageChunk(
+        content="", additional_kwargs={"function_call": {"arguments": None}}
+    ) + AIMessageChunk(
+        content="", additional_kwargs={"function_call": {"arguments": "{\n"}}
+    ) + AIMessageChunk(
+        content="",
+        additional_kwargs={"function_call": {"arguments": '  "query": "turtles"\n}'}},
+    ) == AIMessageChunk(
+        content="",
+        additional_kwargs={
+            "function_call": {
+                "name": "web_search",
+                "arguments": '{\n  "query": "turtles"\n}',
+            }
+        },
     ), "MessageChunk + MessageChunk should be a MessageChunk with merged additional_kwargs"  # noqa: E501
 
 
@@ -80,10 +73,10 @@ def test_chat_message_chunks() -> None:
             role="Assistant", content=" indeed."
         )
 
-    assert (
-        ChatMessageChunk(role="User", content="I am")
-        + AIMessageChunk(content=" indeed.")
-        == ChatMessageChunk(role="User", content="I am indeed.")
+    assert ChatMessageChunk(role="User", content="I am") + AIMessageChunk(
+        content=" indeed."
+    ) == ChatMessageChunk(
+        role="User", content="I am indeed."
     ), "ChatMessageChunk + other MessageChunk should be a ChatMessageChunk with the left side's role"  # noqa: E501
 
     assert AIMessageChunk(content="I am") + ChatMessageChunk(
@@ -480,3 +473,22 @@ def test_convert_to_messages() -> None:
         HumanMessage(content="Hello!"),
         AIMessage(content="Hi!"),
     ]
+
+
+def test_ai_message_name_sync() -> None:
+    msg = AIMessage(content="foo", name="bar")
+    assert msg.additional_kwargs == {"name": "bar"}
+    assert msg.name == "bar"
+
+    msg2 = AIMessage(content="foo", additional_kwargs={"name": "bar"})
+    assert msg2.additional_kwargs == {"name": "bar"}
+    assert msg2.name == "bar"
+
+    # should pass if names are same in both places
+    msg3 = AIMessage(content="foo", name="bar", additional_kwargs={"name": "bar"})
+    assert msg3.additional_kwargs == {"name": "bar"}
+    assert msg3.name == "bar"
+
+    # fail if different names
+    with pytest.raises(ValueError):
+        AIMessage(content="foo", name="bar", additional_kwargs={"name": "baz"})

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -29,35 +29,42 @@ def test_message_chunks() -> None:
         content="I am indeed."
     ), "MessageChunk + MessageChunk should be a MessageChunk"
 
-    assert AIMessageChunk(content="I am") + HumanMessageChunk(
-        content=" indeed."
-    ) == AIMessageChunk(
-        content="I am indeed."
+    assert (
+        AIMessageChunk(content="I am") + HumanMessageChunk(content=" indeed.")
+        == AIMessageChunk(content="I am indeed.")
     ), "MessageChunk + MessageChunk should be a MessageChunk of same class as the left side"  # noqa: E501
 
-    assert AIMessageChunk(
-        content="", additional_kwargs={"foo": "bar"}
-    ) + AIMessageChunk(content="", additional_kwargs={"baz": "foo"}) == AIMessageChunk(
-        content="", additional_kwargs={"foo": "bar", "baz": "foo"}
+    assert (
+        AIMessageChunk(content="", additional_kwargs={"foo": "bar"})
+        + AIMessageChunk(content="", additional_kwargs={"baz": "foo"})
+        == AIMessageChunk(content="", additional_kwargs={"foo": "bar", "baz": "foo"})
     ), "MessageChunk + MessageChunk should be a MessageChunk with merged additional_kwargs"  # noqa: E501
 
-    assert AIMessageChunk(
-        content="", additional_kwargs={"function_call": {"name": "web_search"}}
-    ) + AIMessageChunk(
-        content="", additional_kwargs={"function_call": {"arguments": None}}
-    ) + AIMessageChunk(
-        content="", additional_kwargs={"function_call": {"arguments": "{\n"}}
-    ) + AIMessageChunk(
-        content="",
-        additional_kwargs={"function_call": {"arguments": '  "query": "turtles"\n}'}},
-    ) == AIMessageChunk(
-        content="",
-        additional_kwargs={
-            "function_call": {
-                "name": "web_search",
-                "arguments": '{\n  "query": "turtles"\n}',
-            }
-        },
+    assert (
+        AIMessageChunk(
+            content="", additional_kwargs={"function_call": {"name": "web_search"}}
+        )
+        + AIMessageChunk(
+            content="", additional_kwargs={"function_call": {"arguments": None}}
+        )
+        + AIMessageChunk(
+            content="", additional_kwargs={"function_call": {"arguments": "{\n"}}
+        )
+        + AIMessageChunk(
+            content="",
+            additional_kwargs={
+                "function_call": {"arguments": '  "query": "turtles"\n}'}
+            },
+        )
+        == AIMessageChunk(
+            content="",
+            additional_kwargs={
+                "function_call": {
+                    "name": "web_search",
+                    "arguments": '{\n  "query": "turtles"\n}',
+                }
+            },
+        )
     ), "MessageChunk + MessageChunk should be a MessageChunk with merged additional_kwargs"  # noqa: E501
 
 
@@ -73,10 +80,10 @@ def test_chat_message_chunks() -> None:
             role="Assistant", content=" indeed."
         )
 
-    assert ChatMessageChunk(role="User", content="I am") + AIMessageChunk(
-        content=" indeed."
-    ) == ChatMessageChunk(
-        role="User", content="I am indeed."
+    assert (
+        ChatMessageChunk(role="User", content="I am")
+        + AIMessageChunk(content=" indeed.")
+        == ChatMessageChunk(role="User", content="I am indeed.")
     ), "ChatMessageChunk + other MessageChunk should be a ChatMessageChunk with the left side's role"  # noqa: E501
 
     assert AIMessageChunk(content="I am") + ChatMessageChunk(

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import List
+from typing import List, Type
 
 import pytest
 
@@ -176,6 +176,21 @@ def test_multiple_msg() -> None:
     human_msg = HumanMessage(content="human", additional_kwargs={"key": "value"})
     ai_msg = AIMessage(content="ai")
     sys_msg = SystemMessage(content="sys")
+
+    msgs = [
+        human_msg,
+        ai_msg,
+        sys_msg,
+    ]
+    assert messages_from_dict(messages_to_dict(msgs)) == msgs
+
+
+def test_multiple_msg_with_name() -> None:
+    human_msg = HumanMessage(
+        content="human", additional_kwargs={"key": "value"}, name="human erick"
+    )
+    ai_msg = AIMessage(content="ai", name="ai erick")
+    sys_msg = SystemMessage(content="sys", name="sys erick")
 
     msgs = [
         human_msg,
@@ -475,20 +490,23 @@ def test_convert_to_messages() -> None:
     ]
 
 
-def test_ai_message_name_sync() -> None:
-    msg = AIMessage(content="foo", name="bar")
-    assert msg.additional_kwargs == {"name": "bar"}
+@pytest.mark.parametrize(
+    "MessageClass",
+    [
+        AIMessage,
+        AIMessageChunk,
+        ChatMessage,
+        ChatMessageChunk,
+        FunctionMessage,
+        FunctionMessageChunk,
+        HumanMessage,
+        HumanMessageChunk,
+        SystemMessage,
+    ],
+)
+def test_message_name(MessageClass: Type) -> None:
+    msg = MessageClass(content="foo", name="bar")
     assert msg.name == "bar"
 
-    msg2 = AIMessage(content="foo", additional_kwargs={"name": "bar"})
-    assert msg2.additional_kwargs == {"name": "bar"}
+    msg2 = MessageClass(content="foo", additional_kwargs={"name": "bar"})
     assert msg2.name == "bar"
-
-    # should pass if names are same in both places
-    msg3 = AIMessage(content="foo", name="bar", additional_kwargs={"name": "bar"})
-    assert msg3.additional_kwargs == {"name": "bar"}
-    assert msg3.name == "bar"
-
-    # fail if different names
-    with pytest.raises(ValueError):
-        AIMessage(content="foo", name="bar", additional_kwargs={"name": "baz"})

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -495,10 +495,6 @@ def test_convert_to_messages() -> None:
     [
         AIMessage,
         AIMessageChunk,
-        ChatMessage,
-        ChatMessageChunk,
-        FunctionMessage,
-        FunctionMessageChunk,
         HumanMessage,
         HumanMessageChunk,
         SystemMessage,
@@ -508,5 +504,33 @@ def test_message_name(MessageClass: Type) -> None:
     msg = MessageClass(content="foo", name="bar")
     assert msg.name == "bar"
 
-    msg2 = MessageClass(content="foo", additional_kwargs={"name": "bar"})
-    assert msg2.name == "bar"
+    msg2 = MessageClass(content="foo", name=None)
+    assert msg2.name == None
+
+    msg3 = MessageClass(content="foo")
+    assert msg3.name == None
+
+
+@pytest.mark.parametrize(
+    "MessageClass",
+    [FunctionMessage, FunctionMessageChunk],
+)
+def test_message_name_function(MessageClass: Type) -> None:
+    # functionmessage doesn't support name=None
+    msg = MessageClass(name="foo", content="bar")
+    assert msg.name == "foo"
+
+
+@pytest.mark.parametrize(
+    "MessageClass",
+    [ChatMessage, ChatMessageChunk],
+)
+def test_message_name_chat(MessageClass: Type) -> None:
+    msg = MessageClass(content="foo", role="user", name="bar")
+    assert msg.name == "bar"
+
+    msg2 = MessageClass(content="foo", role="user", name=None)
+    assert msg2.name == None
+
+    msg3 = MessageClass(content="foo", role="user")
+    assert msg3.name == None


### PR DESCRIPTION
Adds an optional name param to our base message to support passing names into LLMs.

OpenAI supports having a name on anything except tool message now (system, ai, user/human).