### PR TITLE
langchain: updates default json splitter chunk size and list conversion

### DIFF
--- a/docs/docs/modules/data_connection/document_transformers/recursive_json_splitter.ipynb
+++ b/docs/docs/modules/data_connection/document_transformers/recursive_json_splitter.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a504e1e7",
    "metadata": {},
    "outputs": [],
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3390ae1d",
    "metadata": {},
    "outputs": [],
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "7bfe2c1e",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "2833c409",
    "metadata": {
     "scrolled": true
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "f941aa56",
    "metadata": {
     "scrolled": false
@@ -73,19 +73,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "0839f4f0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"openapi\": \"3.0.2\", \"info\": {\"title\": \"LangChainPlus\", \"version\": \"0.1.0\"}, \"paths\": {\"/sessions/{session_id}\": {\"get\": {\"tags\": [\"tracer-sessions\"], \"summary\": \"Read Tracer Session\", \"description\": \"Get a specific session.\", \"operationId\": \"read_tracer_session_sessions__session_id__get\"}}}}\n",
-      "{\"paths\": {\"/sessions/{session_id}\": {\"get\": {\"parameters\": [{\"required\": true, \"schema\": {\"title\": \"Session Id\", \"type\": \"string\", \"format\": \"uuid\"}, \"name\": \"session_id\", \"in\": \"path\"}, {\"required\": false, \"schema\": {\"title\": \"Include Stats\", \"type\": \"boolean\", \"default\": false}, \"name\": \"include_stats\", \"in\": \"query\"}, {\"required\": false, \"schema\": {\"title\": \"Accept\", \"type\": \"string\"}, \"name\": \"accept\", \"in\": \"header\"}]}}}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The splitter can also output documents\n",
     "docs = splitter.create_documents(texts=[json_data])\n",
@@ -99,106 +90,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "c34b1f7f",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[293, 431, 203, 277, 230, 194, 162, 280, 223, 193]\n",
-      "{\"paths\": {\"/sessions/{session_id}\": {\"get\": {\"parameters\": [{\"required\": true, \"schema\": {\"title\": \"Session Id\", \"type\": \"string\", \"format\": \"uuid\"}, \"name\": \"session_id\", \"in\": \"path\"}, {\"required\": false, \"schema\": {\"title\": \"Include Stats\", \"type\": \"boolean\", \"default\": false}, \"name\": \"include_stats\", \"in\": \"query\"}, {\"required\": false, \"schema\": {\"title\": \"Accept\", \"type\": \"string\"}, \"name\": \"accept\", \"in\": \"header\"}]}}}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Let's look at the size of the chunks\n",
-    "print([len(text) for text in texts][:10])\n",
-    "\n",
-    "# Reviewing one of these chunks that was bigger we see there is a list object there\n",
-    "print(texts[1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "992477c2",
+   "execution_count": null,
+   "id": "96e27780",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The json splitter by default does not split lists\n",
-    "# the following will preprocess the json and convert list to dict with index:item as key:val pairs\n",
-    "texts = splitter.split_text(json_data=json_data, convert_lists=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "2d23b3aa",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[293, 431, 203, 277, 230, 194, 162, 280, 223, 193]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Let's look at the size of the chunks. Now they are all under the max\n",
-    "print([len(text) for text in texts][:10])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "d2c2773e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"paths\": {\"/sessions/{session_id}\": {\"get\": {\"parameters\": [{\"required\": true, \"schema\": {\"title\": \"Session Id\", \"type\": \"string\", \"format\": \"uuid\"}, \"name\": \"session_id\", \"in\": \"path\"}, {\"required\": false, \"schema\": {\"title\": \"Include Stats\", \"type\": \"boolean\", \"default\": false}, \"name\": \"include_stats\", \"in\": \"query\"}, {\"required\": false, \"schema\": {\"title\": \"Accept\", \"type\": \"string\"}, \"name\": \"accept\", \"in\": \"header\"}]}}}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# The list has been converted to a dict, but retains all the needed contextual information even if split into many chunks\n",
-    "print(texts[1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "8963b01a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Document(page_content='{\"paths\": {\"/sessions/{session_id}\": {\"get\": {\"parameters\": [{\"required\": true, \"schema\": {\"title\": \"Session Id\", \"type\": \"string\", \"format\": \"uuid\"}, \"name\": \"session_id\", \"in\": \"path\"}, {\"required\": false, \"schema\": {\"title\": \"Include Stats\", \"type\": \"boolean\", \"default\": false}, \"name\": \"include_stats\", \"in\": \"query\"}, {\"required\": false, \"schema\": {\"title\": \"Accept\", \"type\": \"string\"}, \"name\": \"accept\", \"in\": \"header\"}]}}}}')"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
     "# We can also look at the documents\n",
-    "docs[1]"
+    "docs[0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168da4f0",
+   "id": "c34b1f7f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Let's look at the size of the chunks\n",
+    "print([len(text) for text in texts][:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "992477c2",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# The json splitter by default splits lists\n",
+    "# it will preprocess the json and convert list to dict with index:item as key:val pairs\n",
+    "# If we don't want this for some reason it can be dissabled and lists will not be split\n",
+    "texts = splitter.split_text(json_data=json_data, convert_lists=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d23b3aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's look at the size of the chunks. Now we see one of them is bigger than the max\n",
+    "print([len(text) for text in texts][:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2c2773e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This includes a list, which has not been converted to a dict and so it doesn't get split\n",
+    "print(texts[1])"
+   ]
   }
  ],
  "metadata": {
@@ -217,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/libs/langchain/langchain/text_splitter.py
+++ b/libs/langchain/langchain/text_splitter.py
@@ -1493,9 +1493,7 @@ class LatexTextSplitter(RecursiveCharacterTextSplitter):
 
 
 class RecursiveJsonSplitter:
-    def __init__(
-        self, max_chunk_size: int = 2000, min_chunk_size: Optional[int] = None
-    ):
+    def __init__(self, max_chunk_size: int = 500, min_chunk_size: Optional[int] = None):
         super().__init__()
         self.max_chunk_size = max_chunk_size
         self.min_chunk_size = (
@@ -1564,7 +1562,7 @@ class RecursiveJsonSplitter:
     def split_json(
         self,
         json_data: Dict[str, Any],
-        convert_lists: bool = False,
+        convert_lists: bool = True,
     ) -> List[Dict]:
         """Splits JSON into a list of JSON chunks"""
 
@@ -1579,7 +1577,7 @@ class RecursiveJsonSplitter:
         return chunks
 
     def split_text(
-        self, json_data: Dict[str, Any], convert_lists: bool = False
+        self, json_data: Dict[str, Any], convert_lists: bool = True
     ) -> List[str]:
         """Splits JSON into a list of JSON formatted strings"""
 
@@ -1591,7 +1589,7 @@ class RecursiveJsonSplitter:
     def create_documents(
         self,
         texts: List[Dict],
-        convert_lists: bool = False,
+        convert_lists: bool = True,
         metadatas: Optional[List[dict]] = None,
     ) -> List[Document]:
         """Create documents from a list of json objects (Dict)."""


### PR DESCRIPTION
- **Description:** This changes the default value for max_chunk_size from 2000 to the more appropriate 500 characters. This also changes the default for convert_lists to True as I believe most users will want to split long lists by default. I have updated the ipynb to reflect this updated default behavior.
- **Issue:** None
- **Dependencies:** None
- **Twitter handle:** @joelsprunger
