### PR TITLE
core: add serialize path for ChatMistralAI

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -263,6 +263,11 @@ SERIALIZABLE_MAPPING: Dict[Tuple[str, ...], Tuple[str, ...]] = {
         "chat_models",
         "ChatVertexAI",
     ),
+    ("langchain", "chat_models", "mistralai", "ChatMistralAI"): (
+        "langchain_mistralai",
+        "chat_models",
+        "ChatMistralAI",
+    ),
     ("langchain", "schema", "output", "ChatGenerationChunk"): (
         "langchain_core",
         "outputs",


### PR DESCRIPTION
**Description:** Include a serialize path for ChatMistralAI so that the chat model can be loaded by `langchain_core.load`

**Issue:** n/a

**Dependencies:** none
