### PR TITLE
docs sorting `Examples using ...` section

### DIFF
--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -49,7 +49,7 @@ class ExampleLinksDirective(SphinxDirective):
         class_or_func_name = self.arguments[0]
         links = imported_classes.get(class_or_func_name, {})
         list_node = nodes.bullet_list()
-        for doc_name, link in links.items():
+        for doc_name, link in sorted(links.items()):
             item_node = nodes.list_item()
             para_node = nodes.paragraph()
             link_node = nodes.reference()


### PR DESCRIPTION
The API Reference docs. If the class has a long list of the examples that works with this class, then the `Examples using` list is [hard to comprehend](https://api.python.langchain.com/en/latest/llms/langchain_community.llms.openai.OpenAI.html#langchain-community-llms-openai-openai). If this list is sorted it would be much easier.
- sorting the `Examples using <ClassName>` list