### PR TITLE
community: add fixes for AzureSearch after update to stable azure-search-documents library

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -91,10 +91,10 @@ def _get_search_client(
         SemanticField,
         SemanticPrioritizedFields,
         SemanticSearch,
+        VectorSearch,
         VectorSearchAlgorithmKind,
         VectorSearchAlgorithmMetric,
         VectorSearchProfile,
-        VectorSearch,
     )
 
     default_fields = default_fields or []

--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -94,6 +94,7 @@ def _get_search_client(
         VectorSearchAlgorithmKind,
         VectorSearchAlgorithmMetric,
         VectorSearchProfile,
+        VectorSearch,
     )
 
     default_fields = default_fields or []
@@ -255,7 +256,7 @@ class AzureSearch(VectorStore):
                 type=SearchFieldDataType.Collection(SearchFieldDataType.Single),
                 searchable=True,
                 vector_search_dimensions=len(self.embed_query("Text")),
-                vector_search_configuration="default",
+                vector_search_profile_name="myHnswProfile",
             ),
             SearchableField(
                 name=FIELDS_METADATA,


### PR DESCRIPTION
- **Description:** Addresses the bugs described in linked issue where an import was erroneously removed and the rename of a keyword argument was missed when migrating from beta --> stable of the azure-search-documents package 
- **Issue:** https://github.com/langchain-ai/langchain/issues/17598
- **Dependencies:** N/A
- **Twitter handle:** N/A