### PR TITLE
docs : quickstart example returns 404

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -193,7 +193,7 @@ After that, we can import and use WebBaseLoader.
 
 ```python
 from langchain_community.document_loaders import WebBaseLoader
-loader = WebBaseLoader("https://docs.smith.langchain.com/overview")
+loader = WebBaseLoader("https://docs.smith.langchain.com")
 
 docs = loader.load()
 ```


### PR DESCRIPTION
**Description:** 
Appears a legacy URL in the quickstart returns a 404. Updated to use Langchain homepage and ran through tutorial to confirm results.

