### PR TITLE
docs: update astradb imports to in docs/sample notebook to import from partner package

### DIFF
--- a/docs/docs/integrations/providers/astradb.mdx
+++ b/docs/docs/integrations/providers/astradb.mdx
@@ -14,8 +14,8 @@ pip install "astrapy>=0.7.1"
 ## Vector Store
 
 ```python
-from langchain_community.vectorstores import AstraDB
-vector_store = AstraDB(
+from langchain_astradb import AstraDBVectorStore
+vector_store = AstraDBVectorStore(
     embedding=my_embedding,
     collection_name="my_store",
     api_endpoint="...",
@@ -82,10 +82,10 @@ Learn more in the [example notebook](/docs/integrations/document_loaders/astradb
 ## Self-querying retriever
 
 ```python
-from langchain_community.vectorstores import AstraDB
+from langchain_astradb import AstraDBVectorStore
 from langchain.retrievers.self_query.base import SelfQueryRetriever
 
-vector_store = AstraDB(
+vector_store = AstraDBVectorStore(
     embedding=my_embedding,
     collection_name="my_store",
     api_endpoint="...",

--- a/docs/docs/integrations/vectorstores/astradb.ipynb
+++ b/docs/docs/integrations/vectorstores/astradb.ipynb
@@ -39,7 +39,7 @@
    "id": "dbe7c156-0413-47e3-9237-4769c4248869",
    "metadata": {},
    "source": [
-    "Use of the integration requires the following Python package."
+    "Use of the integration requires the corresponding Python package:"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet \"astrapy>=0.7.1\""
+    "pip install --upgrade langchain-astradb"
    ]
   },
   {
@@ -57,8 +57,7 @@
    "id": "2453d83a-bc8f-41e1-a692-befe4dd90156",
    "metadata": {},
    "source": [
-    "_Note: depending on your LangChain setup, you may need to install/upgrade other dependencies needed for this demo_\n",
-    "_(specifically, recent versions of `datasets`, `langchain-openai` and `pypdf` are required, along with `langchain-community`)._"
+    "_**Note.** these are the packages required to run the full demo on this page. Depending on your LangChain setup, you may not have all of them already:_ `pip install langchain langchain-openai datasets pypdf`."
    ]
   },
   {
@@ -118,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_community.vectorstores import AstraDB"
+    "from langchain_astradb import AstraDBVectorStore"
    ]
   },
   {
@@ -167,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vstore = AstraDB(\n",
+    "vstore = AstraDBVectorStore(\n",
     "    embedding=embe,\n",
     "    collection_name=\"astra_vector_demo\",\n",
     "    api_endpoint=ASTRA_DB_API_ENDPOINT,\n",

--- a/docs/docs/integrations/vectorstores/astradb.ipynb
+++ b/docs/docs/integrations/vectorstores/astradb.ipynb
@@ -31,7 +31,7 @@
    "id": "bb9be7ce-8c70-4d46-9f11-71c42a36e928",
    "metadata": {},
    "source": [
-    "### Setup and general dependencies"
+    "## Setup and general dependencies"
    ]
   },
   {
@@ -57,7 +57,25 @@
    "id": "2453d83a-bc8f-41e1-a692-befe4dd90156",
    "metadata": {},
    "source": [
-    "_**Note.** these are the packages required to run the full demo on this page. Depending on your LangChain setup, you may not have all of them already:_ `pip install langchain langchain-openai datasets pypdf`."
+    "_**Note.** the following are all packages required to run the full demo on this page. Depending on your LangChain setup, some of them may need to be installed:_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56c1f86e-5921-4976-ac8f-1d62e5a512b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install langchain langchain-openai datasets pypdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2910035-e61f-48d9-a110-d68c401b62aa",
+   "metadata": {},
+   "source": [
+    "### Import dependencies"
    ]
   },
   {


### PR DESCRIPTION
This PR replaces the imports of the Astra DB vector store with the newly-released partner package, in compliance with the deprecation notice now attached to the community "legacy" store.
