### PR TITLE
langchain_google_vertexai: VertexAI model overrides not working unless they are truthy

### DIFF
--- a/libs/partners/google-vertexai/langchain_google_vertexai/llms.py
+++ b/libs/partners/google-vertexai/langchain_google_vertexai/llms.py
@@ -217,7 +217,7 @@ class _VertexAICommon(_VertexAIBase):
         for param_name, param_value in params.items():
             default_value = default_params.get(param_name)
             if param_value is not None:
-                updated_params[param_name] = param_value 
+                updated_params[param_name] = param_value
             elif default_value is not None:
                 updated_params[param_name] = default_value
         return updated_params

--- a/libs/partners/google-vertexai/langchain_google_vertexai/llms.py
+++ b/libs/partners/google-vertexai/langchain_google_vertexai/llms.py
@@ -216,10 +216,10 @@ class _VertexAICommon(_VertexAIBase):
         updated_params = {}
         for param_name, param_value in params.items():
             default_value = default_params.get(param_name)
-            if param_value or default_value:
-                updated_params[param_name] = (
-                    param_value if param_value else default_value
-                )
+            if param_value is not None:
+                updated_params[param_name] = param_value 
+            elif default_value is not None:
+                updated_params[param_name] = default_value
         return updated_params
 
     @classmethod

--- a/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
@@ -66,25 +66,31 @@ class StubTextChatResponse:
 
     text: str
 
-@pytest.mark.parametrize("prompt_params", [
-    {
-        "max_output_tokens": 1,
-        "temperature": 10000.0,
-        "top_k": 10,
-        "top_p": 0.5,
-    },
-    # test that non-truthy values work
-    {
-        "max_output_tokens": 0,
-        "temperature": 0.0,
-        "top_k": 0,
-        "top_p": 0.0,
-    }
-    ])
+
+@pytest.mark.parametrize(
+    "prompt_params",
+    [
+        {
+            "max_output_tokens": 1,
+            "temperature": 10000.0,
+            "top_k": 10,
+            "top_p": 0.5,
+        },
+        # test that non-truthy values work
+        {
+            "max_output_tokens": 0,
+            "temperature": 0.0,
+            "top_k": 0,
+            "top_p": 0.0,
+        },
+    ],
+)
 @pytest.mark.parametrize("stop", [None, "stop1"])
-def test_vertexai_args_passed(stop: Optional[str], prompt_params: Dict[str, Any]) -> None:
+def test_vertexai_args_passed(
+    stop: Optional[str], prompt_params: Dict[str, Any]
+) -> None:
     response_text = "Goodbye"
-    user_prompt = "Hello" 
+    user_prompt = "Hello"
 
     # Mock the library to ensure the args are passed correctly
     with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:

--- a/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_chat_models.py
@@ -66,17 +66,25 @@ class StubTextChatResponse:
 
     text: str
 
-
-@pytest.mark.parametrize("stop", [None, "stop1"])
-def test_vertexai_args_passed(stop: Optional[str]) -> None:
-    response_text = "Goodbye"
-    user_prompt = "Hello"
-    prompt_params: Dict[str, Any] = {
+@pytest.mark.parametrize("prompt_params", [
+    {
         "max_output_tokens": 1,
         "temperature": 10000.0,
         "top_k": 10,
         "top_p": 0.5,
+    },
+    # test that non-truthy values work
+    {
+        "max_output_tokens": 0,
+        "temperature": 0.0,
+        "top_k": 0,
+        "top_p": 0.0,
     }
+    ])
+@pytest.mark.parametrize("stop", [None, "stop1"])
+def test_vertexai_args_passed(stop: Optional[str], prompt_params: Dict[str, Any]) -> None:
+    response_text = "Goodbye"
+    user_prompt = "Hello" 
 
     # Mock the library to ensure the args are passed correctly
     with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
@@ -174,6 +182,7 @@ def test_default_params_palm() -> None:
         mock_start_chat.assert_called_once_with(
             context=None,
             message_history=[],
+            temperature=0.0,
             max_output_tokens=128,
             top_k=40,
             top_p=0.95,

--- a/libs/partners/google-vertexai/tests/unit_tests/test_llms.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_llms.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_google_vertexai.llms import VertexAI
+
+@pytest.mark.parametrize("params", [
+    {
+        "temperature": 0.8,
+        "max_output_tokens": 128,
+        "candidate_count": 1, 
+        "top_k": 30,
+        "top_p": 0.9
+    },
+    {
+        "temperature": 0.0,
+        "max_output_tokens": 0,
+        "candidate_count": 1, 
+        "top_k": 0,
+        "top_p": 0.0
+    }
+])
+def test_set_params_palm_model(params):
+    with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
+        model = VertexAI(model_name='text-bison', **params)
+        assert model._default_params == params
+
+@pytest.mark.parametrize("params", [
+    {
+        "temperature": 0.8,
+        "max_output_tokens": 128,
+        "candidate_count": 1, 
+    },
+    {
+        "temperature": 0.0,
+        "max_output_tokens": 0,
+        "candidate_count": 1, 
+    }
+])
+def test_set_params_codey_model(params):
+    with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
+        model = VertexAI(model_name='code-bison', **params)
+        assert model._default_params == params
+
+@pytest.mark.parametrize("params", [
+    {
+        "temperature": 0.8,
+        "max_output_tokens": 128,
+        "candidate_count": 1, 
+        "top_k": 30,
+        "top_p": 0.9
+    },
+    {
+        "temperature": 0.0,
+        "max_output_tokens": 0,
+        "candidate_count": 1, 
+        "top_k": 0,
+        "top_p": 0.0
+    }
+])
+def test_set_params_gemini_model(params):
+    with patch("langchain_google_vertexai.llms.GenerativeModel") as _:
+        model = VertexAI(model_name='gemini-pro', **params)
+
+        assert model._default_params == params

--- a/libs/partners/google-vertexai/tests/unit_tests/test_llms.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_llms.py
@@ -4,62 +4,74 @@ import pytest
 
 from langchain_google_vertexai.llms import VertexAI
 
-@pytest.mark.parametrize("params", [
-    {
-        "temperature": 0.8,
-        "max_output_tokens": 128,
-        "candidate_count": 1, 
-        "top_k": 30,
-        "top_p": 0.9
-    },
-    {
-        "temperature": 0.0,
-        "max_output_tokens": 0,
-        "candidate_count": 1, 
-        "top_k": 0,
-        "top_p": 0.0
-    }
-])
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "temperature": 0.8,
+            "max_output_tokens": 128,
+            "candidate_count": 1,
+            "top_k": 30,
+            "top_p": 0.9,
+        },
+        {
+            "temperature": 0.0,
+            "max_output_tokens": 0,
+            "candidate_count": 1,
+            "top_k": 0,
+            "top_p": 0.0,
+        },
+    ],
+)
 def test_set_params_palm_model(params):
     with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
-        model = VertexAI(model_name='text-bison', **params)
+        model = VertexAI(model_name="text-bison", **params)
         assert model._default_params == params
 
-@pytest.mark.parametrize("params", [
-    {
-        "temperature": 0.8,
-        "max_output_tokens": 128,
-        "candidate_count": 1, 
-    },
-    {
-        "temperature": 0.0,
-        "max_output_tokens": 0,
-        "candidate_count": 1, 
-    }
-])
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "temperature": 0.8,
+            "max_output_tokens": 128,
+            "candidate_count": 1,
+        },
+        {
+            "temperature": 0.0,
+            "max_output_tokens": 0,
+            "candidate_count": 1,
+        },
+    ],
+)
 def test_set_params_codey_model(params):
     with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
-        model = VertexAI(model_name='code-bison', **params)
+        model = VertexAI(model_name="code-bison", **params)
         assert model._default_params == params
 
-@pytest.mark.parametrize("params", [
-    {
-        "temperature": 0.8,
-        "max_output_tokens": 128,
-        "candidate_count": 1, 
-        "top_k": 30,
-        "top_p": 0.9
-    },
-    {
-        "temperature": 0.0,
-        "max_output_tokens": 0,
-        "candidate_count": 1, 
-        "top_k": 0,
-        "top_p": 0.0
-    }
-])
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "temperature": 0.8,
+            "max_output_tokens": 128,
+            "candidate_count": 1,
+            "top_k": 30,
+            "top_p": 0.9,
+        },
+        {
+            "temperature": 0.0,
+            "max_output_tokens": 0,
+            "candidate_count": 1,
+            "top_k": 0,
+            "top_p": 0.0,
+        },
+    ],
+)
 def test_set_params_gemini_model(params):
     with patch("langchain_google_vertexai.llms.GenerativeModel") as _:
-        model = VertexAI(model_name='gemini-pro', **params)
+        model = VertexAI(model_name="gemini-pro", **params)
 
         assert model._default_params == params

--- a/libs/partners/google-vertexai/tests/unit_tests/test_llms.py
+++ b/libs/partners/google-vertexai/tests/unit_tests/test_llms.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -25,7 +25,7 @@ from langchain_google_vertexai.llms import VertexAI
     ],
 )
 def test_set_params_palm_model(params):
-    with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
+    with patch("vertexai._model_garden._model_garden_models._from_pretrained") as _:
         model = VertexAI(model_name="text-bison", **params)
         assert model._default_params == params
 
@@ -46,7 +46,7 @@ def test_set_params_palm_model(params):
     ],
 )
 def test_set_params_codey_model(params):
-    with patch("vertexai._model_garden._model_garden_models._from_pretrained") as mg:
+    with patch("vertexai._model_garden._model_garden_models._from_pretrained") as _:
         model = VertexAI(model_name="code-bison", **params)
         assert model._default_params == params
 


### PR DESCRIPTION
**Description:**
Make VertexAI models accept overrides if they are not truthy (e.g. a temperature of 0.0).

**Issue:**
https://github.com/langchain-ai/langchain/issues/17658

**Dependencies:**
None

**Twitter handle:**
@steven__smit
