### PR TITLE
[community][vectorstores][surrealdb] bug fix - add empty metadata when metadata not provided

### DIFF
--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -117,7 +117,7 @@ class SurrealDBStore(VectorStore):
             if metadatas is not None and idx < len(metadatas):
                 data["metadata"] = metadatas[idx]  # type: ignore[assignment]
             else:
-                data["metadata"] = {}
+                data["metadata"] = []
             record = await self.sdb.create(
                 self.collection,
                 data,

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -116,6 +116,8 @@ class SurrealDBStore(VectorStore):
             data = {"text": text, "embedding": embeddings[idx]}
             if metadatas is not None and idx < len(metadatas):
                 data["metadata"] = metadatas[idx]  # type: ignore[assignment]
+            else:
+                data["metadata"] = {}
             record = await self.sdb.create(
                 self.collection,
                 data,


### PR DESCRIPTION
Code fix to include empty medata dictionary to aadd_texts if metadata is not provided.