### PR TITLE
feat: add kwargs the the function

### DIFF
--- a/libs/langchain/langchain/retrievers/parent_document_retriever.py
+++ b/libs/langchain/langchain/retrievers/parent_document_retriever.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Any
 
 from langchain_core.documents import Document
 
@@ -74,6 +74,7 @@ class ParentDocumentRetriever(MultiVectorRetriever):
         documents: List[Document],
         ids: Optional[List[str]] = None,
         add_to_docstore: bool = True,
+        **kwargs: Any
     ) -> None:
         """Adds documents to the docstore and vectorstores.
 
@@ -119,6 +120,6 @@ class ParentDocumentRetriever(MultiVectorRetriever):
                 _doc.metadata[self.id_key] = _id
             docs.extend(sub_docs)
             full_docs.append((_id, doc))
-        self.vectorstore.add_documents(docs)
+        self.vectorstore.add_documents(docs, **kwargs)
         if add_to_docstore:
             self.docstore.mset(full_docs)


### PR DESCRIPTION
add kwargs the the function: ParentDocumentRetriever.add_documents()

For the scenario of the following example:
```python
retriever = ParentDocumentRetriever(
        vectorstore=vectorstore,
        docstore=store,
        child_splitter=child_splitter,
        parent_splitter=parent_splitter,
    )
retriever.add_documents(docs, batch_size=10)
```