### PR TITLE
community: set litellm max_tokens=None

### DIFF
--- a/libs/community/langchain_community/chat_models/litellm.py
+++ b/libs/community/langchain_community/chat_models/litellm.py
@@ -191,7 +191,7 @@ class ChatLiteLLM(BaseChatModel):
     n: int = 1
     """Number of chat completions to generate for each prompt. Note that the API may
        not return the full n completions if duplicates are generated."""
-    max_tokens: int = 256
+    max_tokens: Optional[int] = None
 
     max_retries: int = 6
 


### PR DESCRIPTION
Description: The default value of the max_tokens for litellm is 256. It should be increased to avoid truncation of replies.

resovle conflicts for #10812