### PR TITLE
docs: Fix bug that caused the word "Beta" to appear twice in doc-strings

### DIFF
--- a/libs/core/langchain_core/_api/beta_decorator.py
+++ b/libs/core/langchain_core/_api/beta_decorator.py
@@ -206,10 +206,9 @@ def beta(
 
         old_doc = inspect.cleandoc(old_doc or "").strip("\n")
 
+        # old_doc can be None
         if not old_doc:
-            new_doc = "[*Beta*]"
-        else:
-            new_doc = f"[*Beta*]  {old_doc}"
+            old_doc = ""
 
         # Modify the docstring to include a beta notice.
         notes_header = "\nNotes\n-----"
@@ -218,7 +217,7 @@ def beta(
             addendum,
         ]
         details = " ".join([component.strip() for component in components if component])
-        new_doc += (
+        new_doc = (
             f"[*Beta*] {old_doc}\n"
             f"{notes_header if notes_header not in old_doc else ''}\n"
             f".. beta::\n"


### PR DESCRIPTION
The current issue:
Several beta descriptions in the API Reference are duplicated. For example:
`[Beta]  Get a context value.[Beta] Get a context value.` for the [ContextGet class](https://api.python.langchain.com/en/latest/core_api_reference.html#module-langchain_core.beta) description.

NOTE: I've tested it only with a new ut! I cannot build API Reference locally :(
This PR related to #17615