### PR TITLE
core: fix .bind when used with RunnableLambda async methods

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -3416,6 +3416,7 @@ class RunnableLambda(Runnable[Input, Output]):
                     input: Input,
                     run_manager: AsyncCallbackManagerForChainRun,
                     config: RunnableConfig,
+                    **kwargs: Any,
                 ) -> Output:
                     output: Optional[Output] = None
                     for chunk in call_func_with_variable_args(

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -3440,6 +3440,7 @@ class RunnableLambda(Runnable[Input, Output]):
                     input: Input,
                     run_manager: AsyncCallbackManagerForChainRun,
                     config: RunnableConfig,
+                    **kwargs: Any,
                 ) -> Output:
                     return call_func_with_variable_args(
                         self.func, input, config, run_manager.get_sync(), **kwargs
@@ -3645,6 +3646,7 @@ class RunnableLambda(Runnable[Input, Output]):
                 input: Input,
                 run_manager: AsyncCallbackManagerForChainRun,
                 config: RunnableConfig,
+                **kwargs: Any,
             ) -> Output:
                 return call_func_with_variable_args(
                     self.func, input, config, run_manager.get_sync(), **kwargs

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3424,7 +3424,7 @@ def test_bind_bind() -> None:
     ) == dumpd(llm.bind(stop=["Observation:"], one="two", hello="world"))
 
 
-def test_bind_with_runnablelambda() -> None:
+def test_bind_with_lambda() -> None:
     def my_function(*args: Any, **kwargs: Any) -> int:
         return 3 + kwargs.get("n", 0)
 
@@ -3434,7 +3434,7 @@ def test_bind_with_runnablelambda() -> None:
     assert [4] == chunks
 
 
-async def test_bind_with_runnablelambda_async() -> None:
+async def test_bind_with_lambda_async() -> None:
     def my_function(*args: Any, **kwargs: Any) -> int:
         return 3 + kwargs.get("n", 0)
 

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3425,8 +3425,9 @@ def test_bind_bind() -> None:
 
 
 def test_bind_with_runnablelambda() -> None:
-    def my_function(*args, **kwargs):
+    def my_function(*args: Any, **kwargs: Any) -> int:
         return 3 + kwargs.get("n", 0)
+
     runnable = RunnableLambda(my_function).bind(n=1)
     assert 4 == runnable.invoke({})
     chunks = list(runnable.stream({}))
@@ -3434,8 +3435,9 @@ def test_bind_with_runnablelambda() -> None:
 
 
 async def test_bind_with_runnablelambda_async() -> None:
-    def my_function(*args, **kwargs):
+    def my_function(*args: Any, **kwargs: Any) -> int:
         return 3 + kwargs.get("n", 0)
+
     runnable = RunnableLambda(my_function).bind(n=1)
     assert 4 == await runnable.ainvoke({})
     chunks = [item async for item in runnable.astream({})]

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3424,6 +3424,15 @@ def test_bind_bind() -> None:
     ) == dumpd(llm.bind(stop=["Observation:"], one="two", hello="world"))
 
 
+def test_bind_with_runnablelambda() -> None:
+    def my_function(*args, **kwargs):
+        return 3 + kwargs.get("n", 0)
+    runnable = RunnableLambda(my_function).bind(n=1)
+    assert 4 == runnable.invoke({})
+    chunks = list(runnable.stream({}))
+    assert [4] == chunks
+
+
 def test_deep_stream() -> None:
     prompt = (
         SystemMessagePromptTemplate.from_template("You are a nice assistant.")

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3433,6 +3433,15 @@ def test_bind_with_runnablelambda() -> None:
     assert [4] == chunks
 
 
+async def test_bind_with_runnablelambda_async() -> None:
+    def my_function(*args, **kwargs):
+        return 3 + kwargs.get("n", 0)
+    runnable = RunnableLambda(my_function).bind(n=1)
+    assert 4 == await runnable.ainvoke({})
+    chunks = [item async for item in runnable.astream({})]
+    assert [4] == chunks
+
+
 def test_deep_stream() -> None:
     prompt = (
         SystemMessagePromptTemplate.from_template("You are a nice assistant.")


### PR DESCRIPTION
**Description:** Here is a minimal example to illustrate behavior:
```python
from langchain_core.runnables import RunnableLambda

def my_function(*args, **kwargs):
    return 3 + kwargs.get("n", 0)

runnable = RunnableLambda(my_function).bind(n=1)


assert 4 == runnable.invoke({})
assert [4] == list(runnable.stream({}))

assert 4 == await runnable.ainvoke({})
assert [4] == [item async for item in runnable.astream({})]
```
Here, `runnable.invoke({})` and `runnable.stream({})` work fine, but `runnable.ainvoke({})` raises
```
TypeError: RunnableLambda._ainvoke.<locals>.func() got an unexpected keyword argument 'n'
```
and similarly for `runnable.astream({})`:
```
TypeError: RunnableLambda._atransform.<locals>.func() got an unexpected keyword argument 'n'
```
Here we assume that this behavior is undesired and attempt to fix it.

**Issue:** https://github.com/langchain-ai/langchain/issues/17241, https://github.com/langchain-ai/langchain/discussions/16446
