### PR TITLE
langchain: add openai-tools mode to create_structured_output_runnable

### DIFF
--- a/libs/langchain/langchain/chains/structured_output/base.py
+++ b/libs/langchain/langchain/chains/structured_output/base.py
@@ -85,7 +85,7 @@ def create_openai_fn_runnable(
 
                 llm = ChatOpenAI(model="gpt-4", temperature=0)
                 structured_llm = create_openai_fn_runnable([RecordPerson, RecordDog], llm)
-                structured_llm.invoke("Harry was a chubby brown beagle who loved chicken)
+                structured_llm.invoke("Harry was a chubby brown beagle who loved chicken")
                 # -> RecordDog(name="Harry", color="brown", fav_food="chicken")
     """  # noqa: E501
     if not functions:
@@ -184,7 +184,7 @@ def create_structured_output_runnable(
                 structured_llm = create_structured_output_runnable(Dog, llm, mode="openai-functions")
                 system = '''Extract information about any dogs mentioned in the user input.'''
                 prompt = ChatPromptTemplate.from_messages(
-                    [("system", system), ("human", "{input}"),]
+                    [("system", system), ("human", "{input}")]
                 )
                 chain = prompt | structured_llm
                 chain.invoke({"input": "Harry was a chubby brown beagle who loved chicken"})
@@ -207,17 +207,16 @@ def create_structured_output_runnable(
                     fav_food: Optional[str] = Field(None, description="The dog's favorite food")
 
                 llm = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
-                structured_llm = create_structured_output_runnable(Dog, llm, mode="openai-json")
                 system = '''You are a world class assistant for extracting information in structured JSON formats. \
                 
                 Extract a valid JSON blob from the user input that matches the following JSON Schema:
                 
                 {output_schema}'''
                 prompt = ChatPromptTemplate.from_messages(
-                    [("system", system), ("human", "{input}"),]
+                    [("system", system), ("human", "{input}")]
                 )
-                chain = prompt | structured_llm
-                chain.invoke({"input": "Harry was a chubby brown beagle who loved chicken"})
+                structured_llm = create_structured_output_runnable(Dog, llm, mode="openai-json", prompt=prompt)
+                structured_llm.invoke({"input": "Harry was a chubby brown beagle who loved chicken"})
     """  # noqa: E501
     if mode == "openai-functions":
         return _create_openai_functions_structured_output_runnable(

--- a/libs/langchain/langchain/chains/structured_output/base.py
+++ b/libs/langchain/langchain/chains/structured_output/base.py
@@ -9,9 +9,16 @@ from langchain_core.output_parsers import (
 from langchain_core.prompts import BasePromptTemplate
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import Runnable
-from langchain_core.utils.function_calling import convert_to_openai_function, convert_to_openai_tool
+from langchain_core.utils.function_calling import (
+    convert_to_openai_function,
+    convert_to_openai_tool,
+)
 
-from langchain.output_parsers import JsonOutputToolsParser, PydanticOutputParser, PydanticToolsParser
+from langchain.output_parsers import (
+    JsonOutputToolsParser,
+    PydanticOutputParser,
+    PydanticToolsParser,
+)
 from langchain.output_parsers.openai_functions import (
     JsonOutputFunctionsParser,
     PydanticAttrOutputFunctionsParser,
@@ -129,7 +136,9 @@ def create_structured_output_runnable(
     prompt: Optional[BasePromptTemplate] = None,
     *,
     output_parser: Optional[Union[BaseOutputParser, BaseGenerationOutputParser]] = None,
-    mode: Literal["openai-functions", "openai-tools", "openai-json"] = "openai-functions",
+    mode: Literal[
+        "openai-functions", "openai-tools", "openai-json"
+    ] = "openai-functions",
     enforce_single_function_usage: bool = True,
     **kwargs: Any,
 ) -> Runnable:

--- a/libs/langchain/langchain/chains/structured_output/base.py
+++ b/libs/langchain/langchain/chains/structured_output/base.py
@@ -351,7 +351,9 @@ def get_openai_tool_output_parser(
             only the function arguments and not the function name.
     """
     if isinstance(tools[0], type) and issubclass(tools[0], BaseModel):
-        output_parser = PydanticToolsParser(tools=tools)
+        output_parser: Union[
+            BaseOutputParser, BaseGenerationOutputParser
+        ] = PydanticToolsParser(tools=tools)
     else:
         output_parser = JsonOutputToolsParser(args_only=len(tools) <= 1)
     return output_parser
@@ -436,7 +438,7 @@ def _create_openai_tools_structured_output_runnable(
                 "function": {
                     "name": "output_formatter",
                     "description": (
-                        "Output formatter. Should always be used to format your response to the"
+                        "Output formatter. Should always be used to format your response to the"  # noqa: E501
                         " user."
                     ),
                     "parameters": output_schema,

--- a/libs/langchain/langchain/output_parsers/openai_tools.py
+++ b/libs/langchain/langchain/output_parsers/openai_tools.py
@@ -99,3 +99,14 @@ class PydanticToolsParser(JsonOutputToolsParser):
         results = super().parse_result(result, partial=partial)
         name_dict = {tool.__name__: tool for tool in self.tools}
         return [name_dict[res["type"]](**res["args"]) for res in results]
+
+
+class PydanticAttrToolsParser(PydanticToolsParser):
+    """Parse an output as an attribute of a pydantic object."""
+
+    attr_name: str
+    """The name of the attribute to return."""
+
+    def parse_result(self, results: List[Generation], *, partial: bool = False) -> Any:
+        results = super().parse_result(results)
+        return [getattr(result, self.attr_name) for result in results]

--- a/libs/langchain/tests/unit_tests/chains/test_structured_output.py
+++ b/libs/langchain/tests/unit_tests/chains/test_structured_output.py
@@ -1,21 +1,44 @@
 from typing import Optional
 
-from langchain.chains import create_structured_output_runnable
 from langchain_community.chat_models.fake import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.pydantic_v1 import BaseModel, Field
 
+from langchain.chains import create_structured_output_runnable
 
-def test_structured_output_tools():
+
+def test_structured_output_tools() -> None:
     class Dog(BaseModel):
-        '''Identifying information about a dog.'''
+        """Identifying information about a dog."""
 
         name: str = Field(..., description="The dog's name")
         color: str = Field(..., description="The dog's color")
         fav_food: Optional[str] = Field(None, description="The dog's favorite food")
 
     responses = [
-        AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_qtDBDM46DpUsPA3BC0hucEUi', 'function': {'arguments': '{"output": {"name": "Harry", "color": "brown", "fav_food": "chicken"}}', 'name': '_OutputFormatter'}, 'type': 'function'}, {'id': 'call_kIPim7iMCL1Ekk61jCenP5Kd', 'function': {'arguments': '{"output": {"name": "Joe", "color": "black", "fav_food": "dog food"}}', 'name': '_OutputFormatter'}, 'type': 'function'}]})
+        AIMessage(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "call_qtDBDM46DpUsPA3BC0hucEUi",
+                        "function": {
+                            "arguments": '{"output": {"name": "Harry", "color": "brown", "fav_food": "chicken"}}',  # noqa: E501
+                            "name": "_OutputFormatter",
+                        },
+                        "type": "function",
+                    },
+                    {
+                        "id": "call_kIPim7iMCL1Ekk61jCenP5Kd",
+                        "function": {
+                            "arguments": '{"output": {"name": "Joe", "color": "black", "fav_food": "dog food"}}',  # noqa: E501
+                            "name": "_OutputFormatter",
+                        },
+                        "type": "function",
+                    },
+                ]
+            },
+        )
     ]
     llm = FakeMessagesListChatModel(responses=responses)
     structured_llm = create_structured_output_runnable(Dog, llm, mode="openai-tools")
@@ -23,4 +46,7 @@ def test_structured_output_tools():
         "Harry was a chubby brown beagle who loved chicken. "
         "Joe was a black lab who loved dog food."
     )
-    assert [Dog(name='Harry', color='brown', fav_food='chicken'), Dog(name='Joe', color='black', fav_food='dog food')] == result
+    assert [
+        Dog(name="Harry", color="brown", fav_food="chicken"),
+        Dog(name="Joe", color="black", fav_food="dog food"),
+    ] == result

--- a/libs/langchain/tests/unit_tests/chains/test_structured_output.py
+++ b/libs/langchain/tests/unit_tests/chains/test_structured_output.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from langchain.chains import create_structured_output_runnable
+from langchain_community.chat_models.fake import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.pydantic_v1 import BaseModel, Field
+
+
+def test_structured_output_tools():
+    class Dog(BaseModel):
+        '''Identifying information about a dog.'''
+
+        name: str = Field(..., description="The dog's name")
+        color: str = Field(..., description="The dog's color")
+        fav_food: Optional[str] = Field(None, description="The dog's favorite food")
+
+    responses = [
+        AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_qtDBDM46DpUsPA3BC0hucEUi', 'function': {'arguments': '{"output": {"name": "Harry", "color": "brown", "fav_food": "chicken"}}', 'name': '_OutputFormatter'}, 'type': 'function'}, {'id': 'call_kIPim7iMCL1Ekk61jCenP5Kd', 'function': {'arguments': '{"output": {"name": "Joe", "color": "black", "fav_food": "dog food"}}', 'name': '_OutputFormatter'}, 'type': 'function'}]})
+    ]
+    llm = FakeMessagesListChatModel(responses=responses)
+    structured_llm = create_structured_output_runnable(Dog, llm, mode="openai-tools")
+    result = structured_llm.invoke(
+        "Harry was a chubby brown beagle who loved chicken. "
+        "Joe was a black lab who loved dog food."
+    )
+    assert [Dog(name='Harry', color='brown', fav_food='chicken'), Dog(name='Joe', color='black', fav_food='dog food')] == result


### PR DESCRIPTION
Add `"openai-tools"` mode to `create_structured_output_runnable`.

Also fixes an example in the API reference for `"openai-json"` mode.
