### PR TITLE
nvidia-trt: no stop request, stop response for decoupled model

### DIFF
--- a/libs/partners/nvidia-trt/langchain_nvidia_trt/llms.py
+++ b/libs/partners/nvidia-trt/langchain_nvidia_trt/llms.py
@@ -383,7 +383,7 @@ class StreamingResponseGenerator(queue.Queue):
         self,
         llm: TritonTensorRTLLM,
         request_id: str,
-        force_batch: bool,
+        signal_stop: bool,
         stop_words: Sequence[str],
     ) -> None:
         """Instantiate the generator class."""

--- a/libs/partners/nvidia-trt/langchain_nvidia_trt/llms.py
+++ b/libs/partners/nvidia-trt/langchain_nvidia_trt/llms.py
@@ -238,7 +238,9 @@ class TritonTensorRTLLM(BaseLLM):
             inputs=inputs,
             outputs=outputs,
             request_id=request_id,
-            enable_empty_final_response=self.client.get_model_config(model_name).config.model_transaction_policy.decoupled
+            enable_empty_final_response=self.client.get_model_config(
+                model_name
+            ).config.model_transaction_policy.decoupled,
         )
 
         return result_queue


### PR DESCRIPTION

- **Description:**  
    - suppress explicit stop request since Triton doesn't support it. https://github.com/triton-inference-server/server/issues/4818
    - detect decoupled model and ask for explicit stop response 
 
- **Issue:** now it sends `stop:True` as an input, and triton rejects it; then without `triton_enable_empty_final_response=True` stream hangs forever 




- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/


If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
