### PR TITLE
docs: Add typehints in both signature and description of API docs

### DIFF
--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -114,8 +114,8 @@ autodoc_pydantic_field_signature_prefix = "param"
 autodoc_member_order = "groupwise"
 autoclass_content = "both"
 autodoc_typehints_format = "short"
+autodoc_typehints = "both"
 
-# autodoc_typehints = "description"
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["templates"]
 


### PR DESCRIPTION
This way we can document APIs in methods signature only where they are checked by the typing system and we get them also in the param description without having to duplicate in the docstrings (where they are unchecked).

Twitter: @cbornet_