### PR TITLE
community: Skip nested directories when using S3DirectoryLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/s3_directory.py
+++ b/libs/community/langchain_community/document_loaders/s3_directory.py
@@ -120,6 +120,9 @@ class S3DirectoryLoader(BaseLoader):
         bucket = s3.Bucket(self.bucket)
         docs = []
         for obj in bucket.objects.filter(Prefix=self.prefix):
+            # Skip directories
+            if obj.size == 0 and obj.key.endswith('/'):
+                continue
             loader = S3FileLoader(
                 self.bucket,
                 obj.key,

--- a/libs/community/langchain_community/document_loaders/s3_directory.py
+++ b/libs/community/langchain_community/document_loaders/s3_directory.py
@@ -121,7 +121,7 @@ class S3DirectoryLoader(BaseLoader):
         docs = []
         for obj in bucket.objects.filter(Prefix=self.prefix):
             # Skip directories
-            if obj.size == 0 and obj.key.endswith('/'):
+            if obj.size == 0 and obj.key.endswith("/"):
                 continue
             loader = S3FileLoader(
                 self.bucket,


### PR DESCRIPTION
- **Description:** `S3DirectoryLoader` is failing if prefix is a folder (ex: `my_folder/`) because `S3FileLoader` will try to load that folder and will fail. This PR skip nested directories so prefix can be set to folder instead of `my_folder/files_prefix`.
- **Issue:**
  - #11917
  - #6535
  - #4326
- **Dependencies:** none
- **Twitter handle:** @Falydoor


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/
