### PR TITLE
community: Added add_images method to SingleStoreDB vector store

### DIFF
--- a/docs/docs/integrations/vectorstores/singlestoredb.ipynb
+++ b/docs/docs/integrations/vectorstores/singlestoredb.ipynb
@@ -115,12 +115,58 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "86efff90",
    "metadata": {},
+   "source": [
+    "## Multi-modal Example: Leveraging CLIP and OpenClip Embeddings\n",
+    "\n",
+    "In the realm of multi-modal data analysis, the integration of diverse information types like images and text has become increasingly crucial. One powerful tool facilitating such integration is [CLIP](https://openai.com/research/clip), a cutting-edge model capable of embedding both images and text into a shared semantic space. By doing so, CLIP enables the retrieval of relevant content across different modalities through similarity search.\n",
+    "\n",
+    "To illustrate, let's consider an application scenario where we aim to effectively analyze multi-modal data. In this example, we harness the capabilities of [OpenClip multimodal embeddings](https://python.langchain.com/docs/integrations/text_embedding/open_clip), which leverage CLIP's framework. With OpenClip, we can seamlessly embed textual descriptions alongside corresponding images, enabling comprehensive analysis and retrieval tasks. Whether it's identifying visually similar images based on textual queries or finding relevant text passages associated with specific visual content, OpenClip empowers users to explore and extract insights from multi-modal data with remarkable efficiency and accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c0bce88",
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "%pip install -U langchain openai singlestoredb langchain-experimental # (newest versions required for multi-modal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21a8c25c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from langchain_community.vectorstores import SingleStoreDB\n",
+    "from langchain_experimental.open_clip import OpenCLIPEmbeddings\n",
+    "\n",
+    "os.environ[\"SINGLESTOREDB_URL\"] = \"root:pass@localhost:3306/db\"\n",
+    "\n",
+    "TEST_IMAGES_DIR = \"../../modules/images\"\n",
+    "\n",
+    "docsearch = SingleStoreDB(\n",
+    "        OpenCLIPEmbeddings()\n",
+    "    )\n",
+    "    \n",
+    "image_uris = sorted(\n",
+    "    [\n",
+    "        os.path.join(TEST_IMAGES_DIR, image_name)\n",
+    "        for image_name in os.listdir(TEST_IMAGES_DIR)\n",
+    "        if image_name.endswith(\".jpg\")\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# Add images\n",
+    "docsearch.add_images(uris=image_uris)\n"
+   ]
   }
  ],
  "metadata": {

--- a/docs/docs/integrations/vectorstores/singlestoredb.ipynb
+++ b/docs/docs/integrations/vectorstores/singlestoredb.ipynb
@@ -152,10 +152,8 @@
     "\n",
     "TEST_IMAGES_DIR = \"../../modules/images\"\n",
     "\n",
-    "docsearch = SingleStoreDB(\n",
-    "        OpenCLIPEmbeddings()\n",
-    "    )\n",
-    "    \n",
+    "docsearch = SingleStoreDB(OpenCLIPEmbeddings())\n",
+    "\n",
     "image_uris = sorted(\n",
     "    [\n",
     "        os.path.join(TEST_IMAGES_DIR, image_name)\n",
@@ -165,7 +163,7 @@
     ")\n",
     "\n",
     "# Add images\n",
-    "docsearch.add_images(uris=image_uris)\n"
+    "docsearch.add_images(uris=image_uris)"
    ]
   }
  ],

--- a/libs/community/langchain_community/vectorstores/singlestoredb.py
+++ b/libs/community/langchain_community/vectorstores/singlestoredb.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 import re
 from typing import (
@@ -304,11 +303,6 @@ class SingleStoreDB(VectorStore):
         finally:
             conn.close()
 
-    def encode_image(self, uri: str) -> str:
-        """Get base64 string from image URI."""
-        with open(uri, "rb") as image_file:
-            return base64.b64encode(image_file.read()).decode("utf-8")
-
     def add_images(
         self,
         uris: List[str],
@@ -316,10 +310,11 @@ class SingleStoreDB(VectorStore):
         embeddings: Optional[List[List[float]]] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Run more images through the embeddings and add to the vectorstore.
+        """Run images through the embeddings and add to the vectorstore.
 
         Args:
             uris List[str]: File path to images.
+                Each URI will be added to the vectorstore as document content.
             metadatas (Optional[List[dict]], optional): Optional list of metadatas.
                 Defaults to None.
             embeddings (Optional[List[List[float]]], optional): Optional pre-generated
@@ -328,8 +323,6 @@ class SingleStoreDB(VectorStore):
         Returns:
             List[str]: empty list
         """
-        # Map from uris to b64 encoded strings
-        b64_texts = [self.encode_image(uri=uri) for uri in uris]
         # Set embeddings
         if (
             embeddings is None
@@ -337,7 +330,7 @@ class SingleStoreDB(VectorStore):
             and hasattr(self.embedding, "embed_image")
         ):
             embeddings = self.embedding.embed_image(uris=uris)
-        return self.add_texts(b64_texts, metadatas, embeddings, **kwargs)
+        return self.add_texts(uris, metadatas, embeddings, **kwargs)
 
     def add_texts(
         self,


### PR DESCRIPTION
In this pull request, we introduce the add_images method to the SingleStoreDB vector store class, expanding its capabilities to handle multi-modal embeddings seamlessly. This method facilitates the incorporation of image data into the vector store by associating each image's URI with corresponding document content, metadata, and either pre-generated embeddings or embeddings computed using the embed_image method of the provided embedding object.

the change includes integration tests, validating the behavior of the add_images. Additionally, we provide a notebook showcasing the usage of this new method.