### PR TITLE
docs: Change module import path for SQLDatabase in the documentation

### DIFF
--- a/docs/docs/integrations/toolkits/sql_database.ipynb
+++ b/docs/docs/integrations/toolkits/sql_database.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.sql_database import SQLDatabase\n",
+    "from langchain_community.utilities.sql_database import SQLDatabase\n",
     "\n",
     "db = SQLDatabase.from_uri(\"sqlite:///Chinook.db\")"
    ]


### PR DESCRIPTION
**Description:** This PR changes the module import path for SQLDatabase in the documentation
**Issue:** Updates the documentation to reflect the move of integrations to langchain-community
