### PR TITLE
docs: API Reference builder bug fix

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -217,8 +217,8 @@ def _construct_doc(
 
     for module in namespaces:
         _members = members_by_namespace[module]
-        classes = _members["classes_"]
-        functions = _members["functions"]
+        classes = [el for el in _members["classes_"] if el["is_public"]]
+        functions = [el for el in _members["functions"] if el["is_public"]]
         if not (classes or functions):
             continue
         section = f":mod:`{package_namespace}.{module}`"
@@ -244,9 +244,6 @@ Classes
 """
 
             for class_ in sorted(classes, key=lambda c: c["qualified_name"]):
-                if not class_["is_public"]:
-                    continue
-
                 if class_["kind"] == "TypedDict":
                     template = "typeddict.rst"
                 elif class_["kind"] == "enum":
@@ -264,7 +261,7 @@ Classes
 """
 
         if functions:
-            _functions = [f["qualified_name"] for f in functions if f["is_public"]]
+            _functions = [f["qualified_name"] for f in functions]
             fstring = "\n    ".join(sorted(_functions))
             full_doc += f"""\
 Functions


### PR DESCRIPTION
Issue in the API Reference:
If the `Classes` of `Functions` section is empty, it still shown in API Reference. Here is an [example](https://api.python.langchain.com/en/latest/core_api_reference.html#module-langchain_core.agents) where `Functions` table is empty but still presented.
It happens only if this section has only the "private" members (with names started with '_'). Those members are not shown but the whole member section (empty) is shown.
