### PR TITLE
docs: Fix URL typo in tigris.ipynb

### DIFF
--- a/docs/docs/integrations/vectorstores/tigris.ipynb
+++ b/docs/docs/integrations/vectorstores/tigris.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Tigris\n",
     "\n",
-    "> [Tigris](htttps://tigrisdata.com) is an open-source Serverless NoSQL Database and Search Platform designed to simplify building high-performance vector search applications.\n",
+    "> [Tigris](https://tigrisdata.com) is an open-source Serverless NoSQL Database and Search Platform designed to simplify building high-performance vector search applications.\n",
     "> `Tigris` eliminates the infrastructure complexity of managing, operating, and synchronizing multiple tools, allowing you to focus on building great applications instead."
    ]
   },


### PR DESCRIPTION
  - **Description:** The URL in the tigris tutorial was htttps instead of https, leading to a bad link.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** Speucey

