### PR TITLE
docs: api docs for external repos

### DIFF
--- a/.github/workflows/api_doc_build.yml
+++ b/.github/workflows/api_doc_build.yml
@@ -15,6 +15,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: bagatur/api_docs_build
+          path: langchain
+      - uses: actions/checkout@v4
+        with:
+          repository: langchain-ai/langchain-google
+          path: langchain-google
+      - name: Move google libs
+        run: |
+          mv langchain-google/libs/genai langchain/libs/partners/google-genai
+          mv langchain-google/libs/vertexai langchain/libs/partners/google-vertexai
 
       - name: Set Git config
         run: |
@@ -22,6 +31,7 @@ jobs:
           git config --local user.name "Github Actions"
 
       - name: Merge master
+        working-directory: langchain
         run: | 
           git fetch origin master
           git merge origin/master -m "Merge master" --allow-unrelated-histories -X theirs
@@ -34,6 +44,7 @@ jobs:
           cache-key: api-docs
 
       - name: Install dependencies
+        working-directory: langchain
         run: |
           poetry run python -m pip install --upgrade --no-cache-dir pip setuptools
           poetry run python -m pip install --upgrade --no-cache-dir sphinx readthedocs-sphinx-ext
@@ -41,6 +52,7 @@ jobs:
           poetry run python -m pip install --exists-action=w --no-cache-dir -r docs/api_reference/requirements.txt
 
       - name: Build docs
+        working-directory: langchain
         run: |
           poetry run python -m pip install --upgrade --no-cache-dir pip setuptools
           poetry run python docs/api_reference/create_api_rst.py
@@ -49,4 +61,5 @@ jobs:
       # https://github.com/marketplace/actions/add-commit
       - uses: EndBug/add-and-commit@v9
         with:
+          cwd: langchain
           message: 'Update API docs build'


### PR DESCRIPTION
Stacked on google removal PR. Will make google continue to show up in API docs even from external repo