### PR TITLE
langchain: fix EmbeddingsFilter compress_documents return type to Sequence[Document] instead of Sequence[_DocumentWithState]

### DIFF
--- a/libs/langchain/langchain/retrievers/document_compressors/embeddings_filter.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/embeddings_filter.py
@@ -69,4 +69,4 @@ class EmbeddingsFilter(BaseDocumentCompressor):
             included_idxs = included_idxs[similar_enough]
         for i in included_idxs:
             stateful_documents[i].state["query_similarity_score"] = similarity[i]
-        return [stateful_documents[i] for i in included_idxs]
+        return [stateful_documents[i].to_document() for i in included_idxs]


### PR DESCRIPTION
- **Description:** This PR solves a typing problem encountered using EmbeddingsFilter.compress_documents method with langchain. The returned Sequence of _DocumentWithState was not meeting the typing expectation of Sequence[Document]. This could cause a problem of json parsing because of embeddings field in _DocumentWithState.
- **Issue:** #17875
- **Twitter handle:** @maximeperrin_