### PR TITLE
community[patch]: compatibility with SQLAlchemy 1.4.x

### DIFF
--- a/libs/community/langchain_community/tools/sql_database/tool.py
+++ b/libs/community/langchain_community/tools/sql_database/tool.py
@@ -44,7 +44,7 @@ class QuerySQLDataBaseTool(BaseSQLDatabaseTool, BaseTool):
         self,
         query: str,
         run_manager: Optional[CallbackManagerForToolRun] = None,
-    ) -> Union[str, Sequence[Dict[str, Any]], Result[Any]]:
+    ) -> Union[str, Sequence[Dict[str, Any]], Result]:
         """Execute the query, return the results or an error message."""
         return self.db.run_no_throw(query)
 


### PR DESCRIPTION
**Description:**
Change type hint on `QuerySQLDataBaseTool` to be compatible with SQLAlchemy v1.4.x.

**Issue:**
Users locked to `SQLAlchemy < 2.x` are unable to import `QuerySQLDataBaseTool`.

closes https://github.com/langchain-ai/langchain/issues/17819

**Dependencies:**
None
