### PR TITLE
docs: Fix spelling typos in apache_kafka notebook

### DIFF
--- a/cookbook/apache_kafka_message_handling.ipynb
+++ b/cookbook/apache_kafka_message_handling.ipynb
@@ -14,9 +14,9 @@
     "\n",
     "This notebook shows you how to use LangChain's standard chat features while passing the chat messages back and forth via Apache Kafka.\n",
     "\n",
-    "This goal is to simulate an architecture where the chat front end and the LLM are running as separate services that need to communicate with one another over an internal nework.\n",
+    "This goal is to simulate an architecture where the chat front end and the LLM are running as separate services that need to communicate with one another over an internal network.\n",
     "\n",
-    "It's an alternative to typical pattern of requesting a reponse from the model via a REST API (there's more info on why you would want to do this at the end of the notebook)."
+    "It's an alternative to typical pattern of requesting a response from the model via a REST API (there's more info on why you would want to do this at the end of the notebook)."
    ]
   },
   {
@@ -261,7 +261,7 @@
     "\n",
     "Load Llama 2 and set the conversation buffer to 300 tokens using `ConversationTokenBufferMemory`. This value was used for running Llama in a CPU only container, so you can raise it if running in Google Colab. It prevents the container that is hosting the model from running out of memory.\n",
     "\n",
-    "Here, we're overiding the default system persona so that the chatbot has the personality of Marvin The Paranoid Android from the Hitchhiker's Guide to the Galaxy."
+    "Here, we're overriding the default system persona so that the chatbot has the personality of Marvin The Paranoid Android from the Hitchhiker's Guide to the Galaxy."
    ]
   },
   {
@@ -272,7 +272,7 @@
    },
    "outputs": [],
    "source": [
-    "# Load the model with the apporiate parameters:\n",
+    "# Load the model with the appropriate parameters:\n",
     "llm = LlamaCpp(\n",
     "    model_path=model_path,\n",
     "    max_tokens=250,\n",
@@ -551,7 +551,7 @@
     "\n",
     "  * **Scalability**: Apache Kafka is designed with parallel processing in mind, so many teams prefer to use it to more effectively distribute work to available workers (in this case the \"worker\" is a container running an LLM).\n",
     "\n",
-    "  * **Durability**: Kafka is designed to allow services to pick up where another service left off in the case where that service experienced a memory issue or went offline. This prevents data loss in highly complex, distribuited architectures where multiple systems are communicating with one another (LLMs being just one of many interdependent systems that also include vector databases and traditional databases).\n",
+    "  * **Durability**: Kafka is designed to allow services to pick up where another service left off in the case where that service experienced a memory issue or went offline. This prevents data loss in highly complex, distributed architectures where multiple systems are communicating with one another (LLMs being just one of many interdependent systems that also include vector databases and traditional databases).\n",
     "\n",
     "For more background on why event streaming is a good fit for Gen AI application architecture, see Kai Waehner's article [\"Apache Kafka + Vector Database + LLM = Real-Time GenAI\"](https://www.kai-waehner.de/blog/2023/11/08/apache-kafka-flink-vector-database-llm-real-time-genai/)."
    ]


### PR DESCRIPTION
This patch fixes some spelling typos in apache_kafka_message_handling.ipynb
