### PR TITLE
community: use jq schema for content_key in json_loader

### DIFF
--- a/docs/docs/modules/data_connection/document_loaders/json.mdx
+++ b/docs/docs/modules/data_connection/document_loaders/json.mdx
@@ -199,6 +199,58 @@ pprint(data)
 
 </CodeOutputBlock>
 
+### JSON file with jq schema `content_key`
+
+To load documents from a JSON file using the content_key within the jq schema, set is_content_key_jq_parsable=True. 
+Ensure that content_key is compatible and can be parsed using the jq schema.
+
+```python
+file_path = './sample.json'
+pprint(Path(file_path).read_text())
+```
+
+<CodeOutputBlock lang="python">
+
+```json
+    {"data": [
+        {"attributes": {
+            "message": "message1",
+            "tags": [
+            "tag1"]},
+        "id": "1"},
+        {"attributes": {
+            "message": "message2",
+            "tags": [
+            "tag2"]},
+        "id": "2"}]}
+```
+
+</CodeOutputBlock>
+
+
+```python
+loader = JSONLoader(
+    file_path=file_path,
+    jq_schema=".data[]",
+    content_key=".attributes.message",
+    is_content_key_jq_parsable=True,
+)
+
+data = loader.load()
+```
+
+```python
+pprint(data)
+```
+
+<CodeOutputBlock lang="python">
+
+```
+    [Document(page_content='message1', metadata={'source': '/path/to/sample.json', 'seq_num': 1}),
+     Document(page_content='message2', metadata={'source': '/path/to/sample.json', 'seq_num': 2})]
+```
+
+</CodeOutputBlock>
 
 ## Extracting metadata
 

--- a/libs/community/tests/unit_tests/document_loaders/test_json_loader.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_json_loader.py
@@ -319,3 +319,123 @@ def test_json_meta_02(
     result = loader.load()
 
     assert result == expected_docs
+
+
+@pytest.mark.parametrize(
+    "params",
+    (
+        {"jq_schema": ".[].text"},
+        {"jq_schema": ".[]", "content_key": "text"},
+        {
+            "jq_schema": ".[]",
+            "content_key": ".text",
+            "is_content_key_jq_parsable": True,
+        },
+    ),
+)
+def test_load_json_with_jq_parsable_content_key(
+    params: Dict, mocker: MockerFixture
+) -> None:
+    file_path = "/workspaces/langchain/test.json"
+    expected_docs = [
+        Document(
+            page_content="value1",
+            metadata={"source": file_path, "seq_num": 1},
+        ),
+        Document(
+            page_content="value2",
+            metadata={"source": file_path, "seq_num": 2},
+        ),
+    ]
+
+    mocker.patch(
+        "pathlib.Path.open",
+        return_value=io.StringIO(
+            """
+            [{"text": "value1"}, {"text": "value2"}]
+            """
+        ),
+    )
+
+    loader = JSONLoader(file_path=file_path, json_lines=True, **params)
+    result = loader.load()
+
+    assert result == expected_docs
+
+
+def test_load_json_with_nested_jq_parsable_content_key(mocker: MockerFixture) -> None:
+    file_path = "/workspaces/langchain/test.json"
+    expected_docs = [
+        Document(
+            page_content="message1",
+            metadata={"source": file_path, "seq_num": 1},
+        ),
+        Document(
+            page_content="message2",
+            metadata={"source": file_path, "seq_num": 2},
+        ),
+    ]
+
+    mocker.patch(
+        "pathlib.Path.open",
+        return_value=io.StringIO(
+            """
+            {"data": [
+                    {"attributes": {"message": "message1","tags": ["tag1"]},"id": "1"},
+                    {"attributes": {"message": "message2","tags": ["tag2"]},"id": "2"}]}
+            """
+        ),
+    )
+
+    loader = JSONLoader(
+        file_path=file_path,
+        jq_schema=".data[]",
+        content_key=".attributes.message",
+        is_content_key_jq_parsable=True,
+    )
+    result = loader.load()
+
+    assert result == expected_docs
+
+
+def test_load_json_with_nested_jq_parsable_content_key_with_metadata(
+    mocker: MockerFixture,
+) -> None:
+    file_path = "/workspaces/langchain/test.json"
+    expected_docs = [
+        Document(
+            page_content="message1",
+            metadata={"source": file_path, "seq_num": 1, "id": "1", "tags": ["tag1"]},
+        ),
+        Document(
+            page_content="message2",
+            metadata={"source": file_path, "seq_num": 2, "id": "2", "tags": ["tag2"]},
+        ),
+    ]
+
+    mocker.patch(
+        "pathlib.Path.open",
+        return_value=io.StringIO(
+            """
+            {"data": [
+                    {"attributes": {"message": "message1","tags": ["tag1"]},"id": "1"},
+                    {"attributes": {"message": "message2","tags": ["tag2"]},"id": "2"}]}
+            """
+        ),
+    )
+
+    def _metadata_func(record: dict, metadata: dict) -> dict:
+        metadata["id"] = record.get("id")
+        metadata["tags"] = record["attributes"].get("tags")
+        return metadata
+
+    loader = JSONLoader(
+        file_path=file_path,
+        jq_schema=".data[]",
+        content_key=".attributes.message",
+        is_content_key_jq_parsable=True,
+        metadata_func=_metadata_func,
+    )
+    result = loader.load()
+
+    assert result == expected_docs


### PR DESCRIPTION
<!-- 
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"


- [x] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change
    - **Twitter handle:** if your PR gets announced, and you'd like a mention, we'll gladly shout you out!


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
 -->

### Description
Changed the value specified for `content_key` in JSONLoader from a single key to a value based on jq schema.
I created [similar PR](https://github.com/langchain-ai/langchain/pull/11255) before, but it has several conflicts because of the architectural change associated stable version release, so I re-create this PR to fit new architecture.

### Why
For json data like the following, specify `.data[].attributes.message` for page_content and `.data[].attributes.id` or `.data[].attributes.attributes. tags`, etc., the `content_key` must also parse the json structure.

<details>
<summary>sample json data</summary>

```json
{
  "data": [
    {
      "attributes": {
        "message": "message1",
        "tags": [
          "tag1"
        ]
      },
      "id": "1"
    },
    {
      "attributes": {
        "message": "message2",
        "tags": [
          "tag2"
        ]
      },
      "id": "2"
    }
  ]
}
```

</details>

<details>
<summary>sample code</summary>

```python
def metadata_func(record: dict, metadata: dict) -> dict:

    metadata["source"] = None
    metadata["id"] = record.get("id")
    metadata["tags"] = record["attributes"].get("tags")

    return metadata

sample_file = "sample1.json"
loader = JSONLoader(
    file_path=sample_file,
    jq_schema=".data[]",
    content_key=".attributes.message", ## content_key is parsable into jq schema
    is_content_key_jq_parsable=True, ## this is added parameter
    metadata_func=metadata_func
)

data = loader.load()
data
```

</details>

### Dependencies
none

### Twitter handle
[kzk_maeda](https://twitter.com/kzk_maeda)