### PR TITLE
community: fix openai streaming throws 'AIMessageChunk' object has no attribute 'text'

### DIFF
--- a/libs/community/langchain_community/chat_models/fireworks.py
+++ b/libs/community/langchain_community/chat_models/fireworks.py
@@ -223,7 +223,7 @@ class ChatFireworks(BaseChatModel):
                 message=chunk, generation_info=generation_info
             )
             if run_manager:
-                run_manager.on_llm_new_token(chunk.text, chunk=cg_chunk)
+                run_manager.on_llm_new_token(cg_chunk.text, chunk=cg_chunk)
             yield cg_chunk
 
     async def _astream(

--- a/libs/community/langchain_community/chat_models/konko.py
+++ b/libs/community/langchain_community/chat_models/konko.py
@@ -221,7 +221,7 @@ class ChatKonko(ChatOpenAI):
                 message=chunk, generation_info=generation_info
             )
             if run_manager:
-                run_manager.on_llm_new_token(chunk.text, chunk=cg_chunk)
+                run_manager.on_llm_new_token(cg_chunk.text, chunk=cg_chunk)
             yield cg_chunk
 
     def _generate(

--- a/libs/community/langchain_community/chat_models/llama_edge.py
+++ b/libs/community/langchain_community/chat_models/llama_edge.py
@@ -192,7 +192,7 @@ class LlamaEdgeChatService(BaseChatModel):
                     message=chunk, generation_info=generation_info
                 )
                 if run_manager:
-                    run_manager.on_llm_new_token(chunk.text, chunk=cg_chunk)
+                    run_manager.on_llm_new_token(cg_chunk.text, chunk=cg_chunk)
                 yield cg_chunk
 
     def _chat(self, messages: List[BaseMessage], **kwargs: Any) -> requests.Response:

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -415,7 +415,7 @@ class ChatOpenAI(BaseChatModel):
                 message=chunk, generation_info=generation_info
             )
             if run_manager:
-                run_manager.on_llm_new_token(chunk.text, chunk=cg_chunk)
+                run_manager.on_llm_new_token(cg_chunk.text, chunk=cg_chunk)
             yield cg_chunk
 
     def _generate(
@@ -507,7 +507,7 @@ class ChatOpenAI(BaseChatModel):
                 message=chunk, generation_info=generation_info
             )
             if run_manager:
-                await run_manager.on_llm_new_token(token=chunk.text, chunk=cg_chunk)
+                await run_manager.on_llm_new_token(token=cg_chunk.text, chunk=cg_chunk)
             yield cg_chunk
 
     async def _agenerate(


### PR DESCRIPTION
After upgrading  langchain-community to 0.0.22, it's not possible to use openai from the community package with streaming=True
```
  File "/home/runner/work/ragstack-ai/ragstack-ai/ragstack-e2e-tests/.tox/langchain/lib/python3.11/site-packages/langchain_community/chat_models/openai.py", line 434, in _generate
    return generate_from_stream(stream_iter)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ragstack-ai/ragstack-ai/ragstack-e2e-tests/.tox/langchain/lib/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 65, in generate_from_stream
    for chunk in stream:
  File "/home/runner/work/ragstack-ai/ragstack-ai/ragstack-e2e-tests/.tox/langchain/lib/python3.11/site-packages/langchain_community/chat_models/openai.py", line 418, in _stream
    run_manager.on_llm_new_token(chunk.text, chunk=cg_chunk)
                                 ^^^^^^^^^^
AttributeError: 'AIMessageChunk' object has no attribute 'text'
```

Fix regression of https://github.com/langchain-ai/langchain/pull/17907 
**Twitter handle:** @nicoloboschi
