### PR TITLE
community: Fix GenericRequestsWrapper _aget_resp_content must be async

### DIFF
--- a/libs/community/langchain_community/utilities/requests.py
+++ b/libs/community/langchain_community/utilities/requests.py
@@ -137,13 +137,13 @@ class GenericRequestsWrapper(BaseModel):
         else:
             raise ValueError(f"Invalid return type: {self.response_content_type}")
 
-    def _aget_resp_content(
+    async def _aget_resp_content(
         self, response: aiohttp.ClientResponse
     ) -> Union[str, Dict[str, Any]]:
         if self.response_content_type == "text":
-            return response.text()  # type: ignore[return-value]
+            return await response.text()
         elif self.response_content_type == "json":
-            return response.json()  # type: ignore[return-value]
+            return await response.json()
         else:
             raise ValueError(f"Invalid return type: {self.response_content_type}")
 
@@ -176,33 +176,33 @@ class GenericRequestsWrapper(BaseModel):
     async def aget(self, url: str, **kwargs: Any) -> Union[str, Dict[str, Any]]:
         """GET the URL and return the text asynchronously."""
         async with self.requests.aget(url, **kwargs) as response:
-            return await self._aget_resp_content(response)  # type: ignore[misc]
+            return await self._aget_resp_content(response)
 
     async def apost(
         self, url: str, data: Dict[str, Any], **kwargs: Any
     ) -> Union[str, Dict[str, Any]]:
         """POST to the URL and return the text asynchronously."""
         async with self.requests.apost(url, data, **kwargs) as response:
-            return await self._aget_resp_content(response)  # type: ignore[misc]
+            return await self._aget_resp_content(response)
 
     async def apatch(
         self, url: str, data: Dict[str, Any], **kwargs: Any
     ) -> Union[str, Dict[str, Any]]:
         """PATCH the URL and return the text asynchronously."""
         async with self.requests.apatch(url, data, **kwargs) as response:
-            return await self._aget_resp_content(response)  # type: ignore[misc]
+            return await self._aget_resp_content(response)
 
     async def aput(
         self, url: str, data: Dict[str, Any], **kwargs: Any
     ) -> Union[str, Dict[str, Any]]:
         """PUT the URL and return the text asynchronously."""
         async with self.requests.aput(url, data, **kwargs) as response:
-            return await self._aget_resp_content(response)  # type: ignore[misc]
+            return await self._aget_resp_content(response)
 
     async def adelete(self, url: str, **kwargs: Any) -> Union[str, Dict[str, Any]]:
         """DELETE the URL and return the text asynchronously."""
         async with self.requests.adelete(url, **kwargs) as response:
-            return await self._aget_resp_content(response)  # type: ignore[misc]
+            return await self._aget_resp_content(response)
 
 
 class JsonRequestsWrapper(GenericRequestsWrapper):


### PR DESCRIPTION
There are existing tests in `libs/community/tests/unit_tests/tools/requests/test_tool.py`