### PR TITLE
community: make `SET allow_experimental_[engine]_index` configurabe in vectorstores.clickhouse

### DIFF
--- a/libs/community/langchain_community/vectorstores/clickhouse.py
+++ b/libs/community/langchain_community/vectorstores/clickhouse.py
@@ -206,7 +206,7 @@ CREATE TABLE IF NOT EXISTS {self.config.database}.{self.config.table}(
         # Enable JSON type
         self.client.command("SET allow_experimental_object_type=1")
         # Enable Annoy index
-        self.client.command("SET allow_experimental_annoy_index=1")
+        self.client.command(f"SET allow_experimental_{self.config.index_type}_index=1")
         self.client.command(self.schema)
 
     @property

--- a/libs/community/langchain_community/vectorstores/clickhouse.py
+++ b/libs/community/langchain_community/vectorstores/clickhouse.py
@@ -205,7 +205,7 @@ CREATE TABLE IF NOT EXISTS {self.config.database}.{self.config.table}(
         )
         # Enable JSON type
         self.client.command("SET allow_experimental_object_type=1")
-        # Enable Annoy index
+        # Enable index
         self.client.command(f"SET allow_experimental_{self.config.index_type}_index=1")
         self.client.command(self.schema)
 


### PR DESCRIPTION
## Description & Issue
While following the official doc to use clickhouse as a vectorstore, I found only the default `annoy` index is properly supported. But I want to try another engine `usearch` for `annoy` is not properly supported on ARM platforms.
Here is the settings I prefer:

``` python
settings = ClickhouseSettings(
    table="wiki_Ethereum",
    index_type="usearch",  # annoy by default
    index_param=[],
)
```
The above settings do not work for the command `set allow_experimental_annoy_index=1` is hard-coded.
This PR will make sure the experimental feature follow the `index_type` which is also consistent with Clickhouse's naming conventions.