### PR TITLE
langchain: fix BaseChatMemory get output data error with extra key

### DIFF
--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -26,9 +26,12 @@ class BaseChatMemory(BaseMemory, ABC):
         else:
             prompt_input_key = self.input_key
         if self.output_key is None:
-            if len(outputs) != 1:
-                raise ValueError(f"One output key expected, got {outputs.keys()}")
-            output_key = list(outputs.keys())[0]
+            if len(outputs) == 1:
+                output_key = list(outputs.keys())[0]
+            elif "output" in outputs:
+                output_key = "output"
+            else:
+                raise ValueError("Could not determine output key.")
         else:
             output_key = self.output_key
         return inputs[prompt_input_key], outputs[output_key]

--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC
 from typing import Any, Dict, Optional, Tuple
 
@@ -30,8 +31,17 @@ class BaseChatMemory(BaseMemory, ABC):
                 output_key = list(outputs.keys())[0]
             elif "output" in outputs:
                 output_key = "output"
+                warnings.warn(
+                    f"'{self.__class__.__name__}' got multiple output keys:"
+                    f" {outputs.keys()}. The default 'output' key is being used."
+                    f" If this is not desired, please manually set 'output_key'."
+                )
             else:
-                raise ValueError("Could not determine output key.")
+                raise ValueError(
+                    f"Got multiple output keys: {outputs.keys()}, cannot "
+                    f"determine which to store in memory. Please set the "
+                    f"'output_key' explicitly."
+                )
         else:
             output_key = self.output_key
         return inputs[prompt_input_key], outputs[output_key]


### PR DESCRIPTION
**Description:** At times, BaseChatMemory._get_input_output may acquire some extra keys such as 'intermediate_steps' (agent_executor with return_intermediate_steps set to True) and 'messages' (agent_executor.iter with memory). In these instances, _get_input_output can raise an error due to the presence of multiple keys. The 'output' field should be used as the default field in these cases.
**Issue:** #16791