### PR TITLE
docs: Fix the bug in MongoDBChatMessageHistory notebook

### DIFF
--- a/docs/docs/integrations/memory/mongodb_chat_message_history.ipynb
+++ b/docs/docs/integrations/memory/mongodb_chat_message_history.ipynb
@@ -180,7 +180,7 @@
     "chain_with_history = RunnableWithMessageHistory(\n",
     "    chain,\n",
     "    lambda session_id: MongoDBChatMessageHistory(\n",
-    "        session_id=\"test_session\",\n",
+    "        session_id=session_id,\n",
     "        connection_string=\"mongodb://mongo_user:password123@mongo:27017\",\n",
     "        database_name=\"my_db\",\n",
     "        collection_name=\"chat_histories\",\n",


### PR DESCRIPTION
I tried to configure MongoDBChatMessageHistory using the code from the original documentation to store messages based on the passed session_id in MongoDB. However, this configuration did not take effect, and the session id in the database remained as 'test_session'. To resolve this issue, I found that when configuring MongoDBChatMessageHistory, it is necessary to set session_id=session_id instead of session_id=test_session.

Issue: DOC: Ineffective Configuration of MongoDBChatMessageHistory for Custom session_id Storage

previous code：
```python
chain_with_history = RunnableWithMessageHistory(
    chain,
    lambda session_id: MongoDBChatMessageHistory(
        session_id="test_session",
        connection_string="mongodb://root:xxxxxcLj@12.56.14.2:27017",
        database_name="my_db",
        collection_name="chat_histories",
    ),
    input_messages_key="question",
    history_messages_key="history",
)
config = {"configurable": {"session_id": "mmm"}}
chain_with_history.invoke({"question": "Hi! I'm bob"}, config)
```
![image](https://github.com/langchain-ai/langchain/assets/83388493/c372f785-1ec1-43f5-8d01-b7cc07b806b7)


Modified code:
```python
chain_with_history = RunnableWithMessageHistory(
    chain,
    lambda session_id: MongoDBChatMessageHistory(
        session_id=session_id,   # here is my modify code
        connection_string="mongodb://root:xxxxxxxcLj@1.56.2.2:27017",
        database_name="my_db",
        collection_name="chat_histories",
    ),
    input_messages_key="question",
    history_messages_key="history",
)
config = {"configurable": {"session_id": "mmm"}}
chain_with_history.invoke({"question": "Hi! I'm bob"}, config)
```

Effect after modification (it works)：

![image](https://github.com/langchain-ai/langchain/assets/83388493/5776268c-9098-4da3-bf41-52825be5fafb)
