### PR TITLE
langchain: Import from langchain_core in langchain.smith to avoid deprecation warning

### DIFF
--- a/libs/langchain/langchain/smith/evaluation/progress.py
+++ b/libs/langchain/langchain/smith/evaluation/progress.py
@@ -4,10 +4,9 @@ import threading
 from typing import Any, Dict, Optional, Sequence
 from uuid import UUID
 
+from langchain_core.callbacks import base as base_callbacks
 from langchain_core.documents import Document
 from langchain_core.outputs import LLMResult
-
-from langchain.callbacks import base as base_callbacks
 
 
 class ProgressBarCallback(base_callbacks.BaseCallbackHandler):


### PR DESCRIPTION
Avoids deprecation warning that triggered at import time, e.g. with `python -c 'import langchain.smith'`

    /opt/venv/lib/python3.12/site-packages/langchain/callbacks/__init__.py:37: LangChainDeprecationWarning: Importing this callback from langchain is deprecated. Importing it from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

    `from langchain_community.callbacks import base`.

    To install langchain-community run `pip install -U langchain-community`.

