### PR TITLE
docs [patch] : fix import to use community path for handler in fiddler notebook

### DIFF
--- a/docs/docs/integrations/callbacks/fiddler.ipynb
+++ b/docs/docs/integrations/callbacks/fiddler.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# langchain>=0.1.7 langchain-openai fiddler-client"
+    "# langchain langchain-community langchain-openai fiddler-client"
    ]
   },
   {
@@ -81,14 +81,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.callbacks.fiddler_callback import FiddlerCallback\n",
+    "from langchain_community.callbacks.fiddler_callback import FiddlerCallbackHandler\n",
     "\n",
-    "fiddler_handler = FiddlerCallback(\n",
+    "fiddler_handler = FiddlerCallbackHandler(\n",
     "    url=URL,\n",
-    "    org_name=ORG_NAME,\n",
-    "    project_name=PROJECT_NAME,\n",
-    "    model_name=MODEL_NAME,\n",
-    "    auth_token=AUTH_TOKEN,\n",
+    "    org=ORG_NAME,\n",
+    "    project=PROJECT_NAME,\n",
+    "    model=MODEL_NAME,\n",
+    "    api_key=AUTH_TOKEN,\n",
     ")"
    ]
   },
@@ -207,7 +207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Description:** Update the example fiddler notebook to use community path, instead of langchain.callback
**Dependencies:** None
**Twitter handle:** @bhalder 

