### PR TITLE
fix: BigQueryVectorSearch JSON type unsupported for metadatas

### DIFF
--- a/libs/community/langchain_community/vectorstores/bigquery_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/bigquery_vector_search.py
@@ -404,9 +404,8 @@ class BigQueryVectorSearch(VectorStore):
             if self.metadata_field:
                 metadata = row[self.metadata_field]
             if metadata:
-                if isinstance(metadata, dict):
-                    metadata = json.dumps(metadata)
-                metadata = json.loads(metadata)
+                if not isinstance(metadata, dict):
+                    metadata = json.loads(metadata)
             else:
                 metadata = {}
             metadata["__id"] = row[self.doc_id_field]
@@ -546,9 +545,8 @@ class BigQueryVectorSearch(VectorStore):
         for row in job:
             metadata = row[self.metadata_field]
             if metadata:
-                if isinstance(metadata, dict):
-                    metadata = json.dumps(metadata)
-                metadata = json.loads(metadata)
+                if not isinstance(metadata, dict):
+                    metadata = json.loads(metadata)
             else:
                 metadata = {}
             metadata["__id"] = row[self.doc_id_field]

--- a/libs/community/langchain_community/vectorstores/bigquery_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/bigquery_vector_search.py
@@ -404,6 +404,8 @@ class BigQueryVectorSearch(VectorStore):
             if self.metadata_field:
                 metadata = row[self.metadata_field]
             if metadata:
+                if isinstance(metadata, dict):
+                    metadata = json.dumps(metadata)
                 metadata = json.loads(metadata)
             else:
                 metadata = {}
@@ -544,6 +546,8 @@ class BigQueryVectorSearch(VectorStore):
         for row in job:
             metadata = row[self.metadata_field]
             if metadata:
+                if isinstance(metadata, dict):
+                    metadata = json.dumps(metadata)
                 metadata = json.loads(metadata)
             else:
                 metadata = {}


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "community: fix error in BigQueryVectorSearch"

- [x] **PR message**: 
    - **Description:** Fixes the incorrect parsing of the metadata column
    - **Issue:** The metadata column can be of type JSON or STRING [1] but the code only works for the STRING type.

- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. An example notebook: [demo](https://github.com/ashleyxuu/langchain/blob/master/docs/docs/integrations/vectorstores/bigquery_vector_search.ipynb)

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
