### PR TITLE
langchain[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/langchain/tests/unit_tests/llms/fake_chat_model.py
+++ b/libs/langchain/tests/unit_tests/llms/fake_chat_model.py
@@ -120,9 +120,9 @@ class GenericFakeChatModel(BaseChatModel):
 
             for token in content_chunks:
                 chunk = ChatGenerationChunk(message=AIMessageChunk(content=token))
-                yield chunk
                 if run_manager:
                     run_manager.on_llm_new_token(token, chunk=chunk)
+                yield chunk
 
         if message.additional_kwargs:
             for key, value in message.additional_kwargs.items():
@@ -142,12 +142,12 @@ class GenericFakeChatModel(BaseChatModel):
                                         },
                                     )
                                 )
-                                yield chunk
                                 if run_manager:
                                     run_manager.on_llm_new_token(
                                         "",
                                         chunk=chunk,  # No token for function call
                                     )
+                                yield chunk
                         else:
                             chunk = ChatGenerationChunk(
                                 message=AIMessageChunk(
@@ -155,24 +155,24 @@ class GenericFakeChatModel(BaseChatModel):
                                     additional_kwargs={"function_call": {fkey: fvalue}},
                                 )
                             )
-                            yield chunk
                             if run_manager:
                                 run_manager.on_llm_new_token(
                                     "",
                                     chunk=chunk,  # No token for function call
                                 )
+                            yield chunk
                 else:
                     chunk = ChatGenerationChunk(
                         message=AIMessageChunk(
                             content="", additional_kwargs={key: value}
                         )
                     )
-                    yield chunk
                     if run_manager:
                         run_manager.on_llm_new_token(
                             "",
                             chunk=chunk,  # No token for function call
                         )
+                    yield chunk
 
     async def _astream(
         self,


### PR DESCRIPTION
## PR title
langchain[patch]: Invoke callback prior to yielding

## PR message
Description: Invoke on_llm_new_token callback prior to yielding token in _stream and _astream methods in langchain/tests/fake_chat_model.
Issue: https://github.com/langchain-ai/langchain/issues/16913
Dependencies: None
Twitter handle: None