### PR TITLE
community[patch]: Invoke callback prior to yielding token for volcengine_maas

### DIFF
--- a/libs/community/langchain_community/llms/volcengine_maas.py
+++ b/libs/community/langchain_community/llms/volcengine_maas.py
@@ -175,6 +175,6 @@ class VolcEngineMaasLLM(LLM, VolcEngineMaasBase):
                 chunk = GenerationChunk(
                     text=res.get("choice", {}).get("message", {}).get("content", "")
                 )
-                yield chunk
                 if run_manager:
                     run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+                yield chunk


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding

PR message
Description: Invoke on_llm_new_token callback prior to yielding token in _stream and _astream methods.
Issue: https://github.com/langchain-ai/langchain/issues/16913
Dependencies: None
Twitter handle: None