### PR TITLE
Add support for parameters in neo4j retrieval query

### DIFF
--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -549,6 +549,7 @@ class Neo4jVector(VectorStore):
         self,
         query: str,
         k: int = 4,
+        params: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> List[Document]:
         """Run similarity search with Neo4jVector.
@@ -562,13 +563,14 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(text=query)
         return self.similarity_search_by_vector(
-            embedding=embedding, k=k, query=query, **kwargs
+            embedding=embedding, k=k, query=query, params=params, **kwargs
         )
 
     def similarity_search_with_score(
         self,
         query: str,
         k: int = 4,
+        params: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query.
@@ -582,12 +584,16 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(query)
         docs = self.similarity_search_with_score_by_vector(
-            embedding=embedding, k=k, query=query, **kwargs
+            embedding=embedding, k=k, query=query, params=params, **kwargs
         )
         return docs
 
     def similarity_search_with_score_by_vector(
-        self, embedding: List[float], k: int = 4, **kwargs: Any
+        self,
+        embedding: List[float],
+        k: int = 4,
+        params: Dict[str, Any] = {},
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """
         Perform a similarity search in the Neo4j database using a
@@ -623,8 +629,8 @@ class Neo4jVector(VectorStore):
             "k": k,
             "embedding": embedding,
             "keyword_index": self.keyword_index_name,
-            **kwargs,
             "query": remove_lucene_chars(kwargs["query"]),
+            **params,
         }
 
         results = self.query(read_query, params=parameters)

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -566,7 +566,10 @@ class Neo4jVector(VectorStore):
         )
 
     def similarity_search_with_score(
-        self, query: str, k: int = 4, **kwargs
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query.
 

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -562,13 +562,11 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(text=query)
         return self.similarity_search_by_vector(
-            embedding=embedding,
-            k=k,
-            query=query,
+            embedding=embedding, k=k, query=query, **kwargs
         )
 
     def similarity_search_with_score(
-        self, query: str, k: int = 4
+        self, query: str, k: int = 4, **kwargs
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query.
 
@@ -581,7 +579,7 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(query)
         docs = self.similarity_search_with_score_by_vector(
-            embedding=embedding, k=k, query=query
+            embedding=embedding, k=k, query=query, **kwargs
         )
         return docs
 
@@ -622,6 +620,7 @@ class Neo4jVector(VectorStore):
             "k": k,
             "embedding": embedding,
             "keyword_index": self.keyword_index_name,
+            **kwargs,
             "query": remove_lucene_chars(kwargs["query"]),
         }
 

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -562,7 +562,7 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(text=query)
         return self.similarity_search_by_vector(
-            embedding=embedding, k=k, query=query, **kwargs
+            embedding=embedding, k=k, query=query, **kwargs: Any
         )
 
     def similarity_search_with_score(
@@ -579,7 +579,7 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(query)
         docs = self.similarity_search_with_score_by_vector(
-            embedding=embedding, k=k, query=query, **kwargs
+            embedding=embedding, k=k, query=query, **kwargs: Any
         )
         return docs
 

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -562,7 +562,7 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(text=query)
         return self.similarity_search_by_vector(
-            embedding=embedding, k=k, query=query, **kwargs: Any
+            embedding=embedding, k=k, query=query, **kwargs
         )
 
     def similarity_search_with_score(
@@ -579,7 +579,7 @@ class Neo4jVector(VectorStore):
         """
         embedding = self.embedding.embed_query(query)
         docs = self.similarity_search_with_score_by_vector(
-            embedding=embedding, k=k, query=query, **kwargs: Any
+            embedding=embedding, k=k, query=query, **kwargs
         )
         return docs
 

--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -721,3 +721,21 @@ def test_index_fetching() -> None:
 
     index_0_store = fetch_store(index_0_str)
     assert index_0_store.index_name == index_0_str
+
+
+def test_retrieval_params() -> None:
+    """Test if we use parameters in retrieval query"""
+    docsearch = Neo4jVector.from_texts(
+        texts=texts,
+        embedding=FakeEmbeddings(),
+        pre_delete_collection=True,
+        retrieval_query="""
+        RETURN $test as text, score, {test: $test1} AS metadata
+        """,
+    )
+
+    output = docsearch.similarity_search("Foo", k=2, test="test", test1="test1")
+    assert output == [
+        Document(page_content="test", metadata={"test": "test1"}),
+        Document(page_content="test", metadata={"test": "test1"}),
+    ]

--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -734,7 +734,9 @@ def test_retrieval_params() -> None:
         """,
     )
 
-    output = docsearch.similarity_search("Foo", k=2, test="test", test1="test1")
+    output = docsearch.similarity_search(
+        "Foo", k=2, params={"test": "test", "test1": "test1"}
+    )
     assert output == [
         Document(page_content="test", metadata={"test": "test1"}),
         Document(page_content="test", metadata={"test": "test1"}),


### PR DESCRIPTION
Sometimes, you want to use various parameters in the retrieval query of Neo4j Vector to personalize/customize results. Before, when there were only predefined chains, it didn't really make sense. Now that it's all about custom chains and LCEL, it is worth adding since users can inject any params they wish at query time. Isn't prone to SQL injection-type attacks since we use parameters and not concatenating strings.