### PR TITLE
langchain:Update the internal chat messages history

### DIFF
--- a/libs/langchain/langchain/memory/summary_buffer.py
+++ b/libs/langchain/langchain/memory/summary_buffer.py
@@ -71,6 +71,8 @@ class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin):
             self.moving_summary_buffer = self.predict_new_summary(
                 pruned_memory, self.moving_summary_buffer
             )
+            self.chat_memory.clear()
+            self.chat_memory.add_messages(buffer)
 
     def clear(self) -> None:
         """Clear memory contents."""


### PR DESCRIPTION
- **Description:** prune() just remove the messages in memory, but not the messages stored in the internal chat messages history object. This lead to the problem that load_memory_variables() return a dictionary with all the messages in the history item.
- **Issue:** add code to remove the old messages exceed token limit.
- **Dependencies:** none.
- **Twitter handle:** @meebox
