### PR TITLE
docs: fix incorrect package name in the code snippet

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -281,7 +281,7 @@ Then we can build our index:
 
 ```python
 from langchain_community.vectorstores import FAISS
-from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 
 text_splitter = RecursiveCharacterTextSplitter()
@@ -531,7 +531,7 @@ from langchain_openai import ChatOpenAI
 from langchain_community.document_loaders import WebBaseLoader
 from langchain_openai import OpenAIEmbeddings
 from langchain_community.vectorstores import FAISS
-from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.tools.retriever import create_retriever_tool
 from langchain_community.tools.tavily_search import TavilySearchResults
 from langchain_openai import ChatOpenAI


### PR DESCRIPTION
- **Description:** The code snippets provided in the [Retrieval Chain](https://python.langchain.com/docs/get_started/quickstart#retrieval-chain) and [Serving with LangServe](https://python.langchain.com/docs/get_started/quickstart#serving-with-langserve) sections of the [QuickStart](https://python.langchain.com/docs/get_started/quickstart) guide contain incorrect package paths. This pull request addresses the discrepancy by rectifying the inaccuracies in the code examples.
- **Issue:** #18409
- **Twitter handle:** @ruddyscent

