### PR TITLE
core: improve type hints for `on_chain_start` for BaseCallbackHandler

### DIFF
--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -9,7 +9,7 @@ from tenacity import RetryCallState
 if TYPE_CHECKING:
     from langchain_core.agents import AgentAction, AgentFinish
     from langchain_core.documents import Document
-    from langchain_core.messages import BaseMessage
+    from langchain_core.messages import BaseMessage, AIMessage
     from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
 
 
@@ -211,7 +211,7 @@ class CallbackManagerMixin:
     def on_chain_start(
         self,
         serialized: Dict[str, Any],
-        inputs: Dict[str, Any],
+        inputs: Union[str, Dict[str, Any], AIMessage],
         *,
         run_id: UUID,
         parent_run_id: Optional[UUID] = None,

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -9,7 +9,7 @@ from tenacity import RetryCallState
 if TYPE_CHECKING:
     from langchain_core.agents import AgentAction, AgentFinish
     from langchain_core.documents import Document
-    from langchain_core.messages import BaseMessage, AIMessage
+    from langchain_core.messages import AIMessage, BaseMessage
     from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
 
 


### PR DESCRIPTION
- **Description:** a description of the change
    - **Issue:** The type of the actual value for `inputs` is inconsistant, and does not correspond to the type hint. I've added two more types (`str` and `AIMessage`) but there could be more. Is it a bug and should it always be `Dict[str, Any]`?
    - **Dependencies:** none
    - **Twitter handle:** @lunary_hq

Below is an example that shows the type are not consistent with the current type hint:

```python
from typing import Any, Dict, List
from uuid import UUID
from langchain_openai import ChatOpenAI
from langchain_core.runnables import RunnablePassthrough, RunnableConfig
from langchain_core.output_parsers import StrOutputParser
from langchain_core.prompts import ChatPromptTemplate
from langchain_core.callbacks.base import BaseCallbackHandler

class MyCallbackHandler(BaseCallbackHandler): 
  def on_chain_start(self, serialized: Dict[str, Any], inputs: Dict[str, Any], *, run_id: UUID, parent_run_id: UUID | None = None, tags: List[str] | None = None, metadata: Dict[str, Any] | None = None, **kwargs: Any) -> Any:
    print("[on_chain_start]")
    print(type(inputs))
    print(inputs)
    print('\n')

  def on_chain_end(self, outputs: Dict[str, Any], *, run_id: UUID, parent_run_id: UUID | None = None, **kwargs: Any) -> Any:
    print("[on_chain_end]")
    print(type(outputs))
    print(outputs)
    print('\n')

handler = MyCallbackHandler()

config = RunnableConfig({"callbacks": [handler]})

prompt = ChatPromptTemplate.from_template(
  "Tell me a short joke about {topic}"
)
output_parser = StrOutputParser()
model = ChatOpenAI(model="gpt-4")
chain = (
  {"topic": RunnablePassthrough()} 
  | prompt
  | model
  | output_parser
)

chain.invoke("ice cream", config=config)
```

```text
[on_chain_start]
<class 'str'>
ice cream


[on_chain_start]
<class 'str'>
ice cream


[on_chain_start]
<class 'str'>
ice cream


[on_chain_end]
<class 'str'>
ice cream


[on_chain_end]
<class 'dict'>
{'topic': 'ice cream'}


[on_chain_start]
<class 'dict'>
{'topic': 'ice cream'}


[on_chain_end]
<class 'dict'>
{'lc': 1, 'type': 'constructor', 'id': ['langchain', 'prompts', 'chat', 'ChatPromptValue'], 'kwargs': {'messages': [{'lc': 1, 'type': 'constructor', 'id': ['langchain', 'schema', 'messages', 'HumanMessage'], 'kwargs': {'content': 'Tell me a short joke about ice cream', 'additional_kwargs': {}}}]}}


[on_chain_start]
<class 'langchain_core.messages.ai.AIMessage'>
content="Why don't ice creams ever get into arguments?\n\nBecause they always stay cool!"


[on_chain_end]
<class 'str'>
Why don't ice creams ever get into arguments?

Because they always stay cool!


[on_chain_end]
<class 'str'>
Why don't ice creams ever get into arguments?

Because they always stay cool!
```
