### PR TITLE
community: delete documents by index name on Redis Cluster

### DIFF
--- a/docs/docs/integrations/vectorstores/redis.ipynb
+++ b/docs/docs/integrations/vectorstores/redis.ipynb
@@ -351,8 +351,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m16:58:26\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
-      "\u001b[32m16:58:26\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. users\n"
+      "\u001B[32m16:58:26\u001B[0m \u001B[34m[RedisVL]\u001B[0m \u001B[1;30mINFO\u001B[0m   Indices:\n",
+      "\u001B[32m16:58:26\u001B[0m \u001B[34m[RedisVL]\u001B[0m \u001B[1;30mINFO\u001B[0m   1. users\n"
      ]
     }
    ],
@@ -1262,6 +1262,25 @@
     "    redis_url=\"redis://localhost:6379\",\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To remove documents from a specific index"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "Redis.delete_documents(index_name=\"users\",redis_url=\"red://localhost:6379\")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   }
  ],
  "metadata": {

--- a/libs/community/langchain_community/vectorstores/redis/base.py
+++ b/libs/community/langchain_community/vectorstores/redis/base.py
@@ -668,6 +668,49 @@ class Redis(VectorStore):
             # Index not exist
             return False
 
+    @staticmethod
+    def delete_documents(
+        index_name: str,
+        **kwargs: Any,
+    ) -> bool:
+        """
+        Delete documents in Redis Index.
+
+        Args:
+            index_name (str): Name of the index to delete documents.
+        Returns:
+            bool: Whether or not the deleting documents was successful.
+        """
+        redis_url = get_from_dict_or_env(kwargs, "redis_url", "REDIS_URL")
+        try:
+            import redis  # noqa: F401
+        except ImportError:
+            raise ValueError(
+                "Could not import redis python package. "
+                "Please install it with `pip install redis`."
+            )
+        try:
+            # We need to first remove redis_url from kwargs,
+            # otherwise passing it to Redis will result in an error.
+            if "redis_url" in kwargs:
+                kwargs.pop("redis_url")
+            client = get_client(redis_url=redis_url, **kwargs)
+        except ValueError as e:
+            raise ValueError(f"Your redis connected error: {e}")
+        # Check if index exists
+        try:
+            pipe = client.pipeline()
+
+            for key in redis.client.scan_iter(f"doc:{index_name}:*"):
+                pipe.delete(key)
+
+            pipe.execute()
+
+            logger.info("Documents removed")
+            return True
+        except:  # noqa: E722
+            return False
+
     def add_texts(
         self,
         texts: Iterable[str],

--- a/libs/community/tests/integration_tests/vectorstores/test_redis.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_redis.py
@@ -34,6 +34,12 @@ def drop(index_name: str) -> bool:
     )
 
 
+def delete_documents(index_name: str) -> bool:
+    return Redis.delete_documents(
+        index_name=index_name, redis_url=TEST_REDIS_URL
+    )
+
+
 def convert_bytes(data: Any) -> Any:
     if isinstance(data, bytes):
         return data.decode("ascii")
@@ -202,9 +208,9 @@ def test_custom_keys_from_docs(texts: List[str]) -> None:
     ],
 )
 def test_redis_filters_1(
-    filter_expr: RedisFilterExpression,
-    expected_length: int,
-    expected_nums: Optional[list],
+        filter_expr: RedisFilterExpression,
+        expected_length: int,
+        expected_nums: Optional[list],
 ) -> None:
     metadata = [
         {"name": "joe", "num": 1, "text": "foo", "category": ["a", "b"]},
@@ -227,13 +233,13 @@ def test_redis_filters_1(
     if expected_nums is not None:
         for out in sim_output:
             assert (
-                out.metadata["text"] in expected_nums
-                or int(out.metadata["num"]) in expected_nums
+                    out.metadata["text"] in expected_nums
+                    or int(out.metadata["num"]) in expected_nums
             )
         for out in mmr_output:
             assert (
-                out.metadata["text"] in expected_nums
-                or int(out.metadata["num"]) in expected_nums
+                    out.metadata["text"] in expected_nums
+                    or int(out.metadata["num"]) in expected_nums
             )
 
     assert drop(docsearch.index_name)


### PR DESCRIPTION
Description: The drop_index function operates effectively in Redis Sentinel but encounters issues within Redis Cluster. Specifically, when attempting to use drop_index with the delete_documents option set to true, the Redis Cluster drops the index without deleting all documents. To address this, I have developed a delete_documents function that executes the delete command without dropping the index.

Dependencies:
Twitter handle: 