### PR TITLE
nvidia-trt[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/partners/nvidia-trt/langchain_nvidia_trt/llms.py
+++ b/libs/partners/nvidia-trt/langchain_nvidia_trt/llms.py
@@ -176,9 +176,9 @@ class TritonTensorRTLLM(BaseLLM):
         result_queue = self._invoke_triton(self.model_name, inputs, outputs, stop_words)
 
         for token in result_queue:
-            yield GenerationChunk(text=token)
             if run_manager:
                 run_manager.on_llm_new_token(token)
+            yield GenerationChunk(text=token)
 
         self.client.stop_stream()
 


### PR DESCRIPTION
## PR title
nvidia-trt[patch]: Invoke callback prior to yielding

## PR message
- Description: Invoke on_llm_new_token callback prior to yielding token in
_stream method.
- Issue: https://github.com/langchain-ai/langchain/issues/16913
- Dependencies: None