### PR TITLE
community[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/community/langchain_community/llms/vertexai.py
+++ b/libs/community/langchain_community/llms/vertexai.py
@@ -382,13 +382,13 @@ class VertexAI(_VertexAICommon, BaseLLM):
             **params,
         ):
             chunk = self._response_to_generation(stream_resp)
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(
                     chunk.text,
                     chunk=chunk,
                     verbose=self.verbose,
                 )
+            yield chunk
 
 
 @deprecated(


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
Description: Invoke callback prior to yielding token in _stream method in llms/vertexai.
Issue: https://github.com/langchain-ai/langchain/issues/16913
Dependencies: None