### PR TITLE
community[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/community/langchain_community/llms/tongyi.py
+++ b/libs/community/langchain_community/llms/tongyi.py
@@ -285,13 +285,13 @@ class Tongyi(BaseLLM):
         )
         for stream_resp in stream_generate_with_retry(self, prompt=prompt, **params):
             chunk = GenerationChunk(**self._generation_from_qwen_resp(stream_resp))
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(
                     chunk.text,
                     chunk=chunk,
                     verbose=self.verbose,
                 )
+            yield chunk
 
     async def _astream(
         self,
@@ -307,13 +307,13 @@ class Tongyi(BaseLLM):
             self, prompt=prompt, **params
         ):
             chunk = GenerationChunk(**self._generation_from_qwen_resp(stream_resp))
-            yield chunk
             if run_manager:
                 await run_manager.on_llm_new_token(
                     chunk.text,
                     chunk=chunk,
                     verbose=self.verbose,
                 )
+            yield chunk
 
     def _invocation_params(self, stop: Any, **kwargs: Any) -> Dict[str, Any]:
         params = {


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream method in llms/tongyi.
- Issue: https://github.com/langchain-ai/langchain/issues/16913
- Dependencies: None