### PR TITLE
community[patch]: Invoke callback prior to yielding token

### DIFF
--- a/libs/community/langchain_community/llms/anthropic.py
+++ b/libs/community/langchain_community/llms/anthropic.py
@@ -309,9 +309,9 @@ class Anthropic(LLM, _AnthropicCommon):
             prompt=self._wrap_prompt(prompt), stop_sequences=stop, stream=True, **params
         ):
             chunk = GenerationChunk(text=token.completion)
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+            yield chunk
 
     async def _astream(
         self,
@@ -345,9 +345,9 @@ class Anthropic(LLM, _AnthropicCommon):
             **params,
         ):
             chunk = GenerationChunk(text=token.completion)
-            yield chunk
             if run_manager:
                 await run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+            yield chunk
 
     def get_num_tokens(self, text: str) -> int:
         """Calculate number of tokens."""


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream and _astream methods in llms/anthropic.
- Issue: https://github.com/langchain-ai/langchain/issues/16913
- Dependencies: None