### PR TITLE
[langchain_core]: Change the `rm_title` default in convert_pydantic_to_openai_function

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -73,7 +73,7 @@ def convert_pydantic_to_openai_function(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    rm_titles: bool = True,
+    rm_titles: bool = False,
 ) -> FunctionDescription:
     """Converts a Pydantic model to a function description for the OpenAI API."""
     schema = dereference_refs(model.schema())


### PR DESCRIPTION
Fixes the issues #18319. Also it makes sense not to remove the titles parameter by default because user might want to use the argument `title`  as it is in their tools parameter.

