### PR TITLE
langchain: Fix for issue where .devcontainer doesnt build

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -46,5 +46,8 @@ COPY libs/core ../core
 # Copy the community library for installation
 COPY libs/community/ ../community/
 
+# Copy the text-splitter library for installation
+COPY libs/text-splitters/ ../text-splitters/
+
 # Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)
 RUN poetry install --no-interaction --no-ansi --with dev,test,docs


### PR DESCRIPTION
Bug similar to https://github.com/langchain-ai/langchain/pull/15251

- [x] **PR message**:
    - **Description:** Devcontainer does not build
    - **Issue:** #18465
