### PR TITLE
langchain: adding object title when converting schema before doing the openai function call

### DIFF
--- a/libs/langchain/langchain/chains/openai_functions/utils.py
+++ b/libs/langchain/langchain/chains/openai_functions/utils.py
@@ -21,11 +21,14 @@ def _resolve_schema_references(schema: Any, definitions: Dict[str, Any]) -> Any:
 
 def _convert_schema(schema: dict) -> dict:
     props = {k: {"title": k, **v} for k, v in schema["properties"].items()}
-    return {
+    converted_schema = {
         "type": "object",
         "properties": props,
         "required": schema.get("required", []),
     }
+    if schema.get("title"):
+        converted_schema["title"] = schema.get("title")
+    return converted_schema
 
 
 def get_llm_kwargs(function: dict) -> dict:

--- a/libs/langchain/tests/unit_tests/chains/test_openai_functions.py
+++ b/libs/langchain/tests/unit_tests/chains/test_openai_functions.py
@@ -1,0 +1,41 @@
+"""Test OpenAI Function chain."""
+import pytest
+
+from langchain.chains.openai_functions.utils import _convert_schema
+
+
+@pytest.mark.parametrize("input_schema,expected_schema", [
+    # In this case we ensure that the title of the main object is preserved in the 
+    # schema convertion
+    (
+        {
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "title": "Product that can be purchased",
+            "type": "object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "title": "Product that can be purchased"
+        }
+    ),
+])
+def test_convert_schema(input_schema, expected_schema) -> None:
+    """Checks that the schemas are converted as expected"""
+    assert _convert_schema(input_schema) == expected_schema


### PR DESCRIPTION
- [x] **PR message**:
    - **Description:** adding the property "title" (if present) when converting the schema before sending it to the openai function call. This can help to improve the response provided by the openai LLM.