### PR TITLE
community: Improved notebook for vector store "HANA Cloud"

### DIFF
--- a/docs/docs/integrations/vectorstores/sap_hanavector.ipynb
+++ b/docs/docs/integrations/vectorstores/sap_hanavector.ipynb
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use `OpenAIEmbeddings` we use the OpenAI API Key."
+    "For `OpenAIEmbeddings` we use the OpenAI API key from the environment."
    ]
   },
   {
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a database connection to a HANA Cloud instance"
+    "Create a database connection to a HANA Cloud instance."
    ]
   },
   {
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Perform a query to get the two best-matching document chunks from the ones that we added in the previous step.\n",
+    "Perform a query to get the two best-matching document chunks from the ones that were added in the previous step.\n",
     "By default \"Cosine Similarity\" is used for the search."
    ]
   },
@@ -527,10 +527,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As default behaviour, the table for the embeddings is created with 3 columns\n",
-    "* A column `VEC_TEXT`, which contains the text of the Document\n",
-    "* A column `VEC_METADATA`, which contains the metadata of the Document\n",
-    "* A column `VEC_VECTOR`, which contains the embeddings-vector of the document's text"
+    "As default behaviour, the table for the embeddings is created with 3 columns:\n",
+    "\n",
+    "- A column `VEC_TEXT`, which contains the text of the Document\n",
+    "- A column `VEC_META`, which contains the metadata of the Document\n",
+    "- A column `VEC_VECTOR`, which contains the embeddings-vector of the Document's text"
    ]
   },
   {
@@ -609,9 +610,10 @@
    "metadata": {},
    "source": [
     "Custom tables must have at least three columns that match the semantics of a standard table\n",
-    "* A column with type `NCLOB` or `NVARCHAR` for the text/context of the embeddings\n",
-    "* A column with type `NCLOB` or `NVARCHAR` for the metadata \n",
-    "* A column with type REAL_VECTOR for the embedding vector\n",
+    "\n",
+    "- A column with type `NCLOB` or `NVARCHAR` for the text/context of the embeddings\n",
+    "- A column with type `NCLOB` or `NVARCHAR` for the metadata \n",
+    "- A column with type `REAL_VECTOR` for the embedding vector\n",
     "\n",
     "The table can contain additional columns. When new Documents are inserted into the table, these additional columns must allow NULL values."
    ]


### PR DESCRIPTION
  - **Description:**
This PR fixes some issues in the Jupyter notebook for the VectorStore "SAP HANA Cloud Vector Engine":
    * Slight textual adaptations
    * Fix of wrong column name VEC_META (was: VEC_METADATA)

  - **Issue:** N/A
  - **Dependencies:** no new dependecies added
  - **Twitter handle:** @sapopensource

path to notebook:
`docs/docs/integrations/vectorstores/hanavector.ipynb`


