### PR TITLE
docs: Update function "run" to "invoke"

### DIFF
--- a/cookbook/llm_checker.ipynb
+++ b/cookbook/llm_checker.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "checker_chain = LLMCheckerChain.from_llm(llm, verbose=True)\n",
     "\n",
-    "checker_chain.run(text)"
+    "checker_chain.invoke(text)"
    ]
   },
   {


### PR DESCRIPTION
Currently llm_checker.ipynb uses a function "run".
Update to "invoke" to avoid following warning.

LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 
and will be removed in 0.2.0. Use invoke instead.

