### PR TITLE
docs:Update function "run" to "invoke" in llm_math.ipynb

### DIFF
--- a/cookbook/llm_math.ipynb
+++ b/cookbook/llm_math.ipynb
@@ -51,7 +51,7 @@
     "llm = OpenAI(temperature=0)\n",
     "llm_math = LLMMathChain.from_llm(llm, verbose=True)\n",
     "\n",
-    "llm_math.run(\"What is 13 raised to the .3432 power?\")"
+    "llm_math.invoke(\"What is 13 raised to the .3432 power?\")"
    ]
   },
   {


### PR DESCRIPTION
This patch updates function "run" to "invoke".
Without this patch you see following warning.

LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.
