### PR TITLE
Fix fireworks chat async streaming

### DIFF
--- a/libs/community/langchain_community/chat_models/fireworks.py
+++ b/libs/community/langchain_community/chat_models/fireworks.py
@@ -223,7 +223,7 @@ class ChatFireworks(BaseChatModel):
                 message=chunk, generation_info=generation_info
             )
             if run_manager:
-                run_manager.on_llm_new_token(cg_chunk.text, chunk=cg_chunk)
+                run_manager.on_llm_new_token(token=cg_chunk.text, chunk=cg_chunk)
             yield cg_chunk
 
     async def _astream(
@@ -256,7 +256,7 @@ class ChatFireworks(BaseChatModel):
                 message=chunk, generation_info=generation_info
             )
             if run_manager:
-                await run_manager.on_llm_new_token(token=chunk.text, chunk=cg_chunk)
+                await run_manager.on_llm_new_token(token=cg_chunk.text, chunk=cg_chunk)
             yield cg_chunk
 
 

--- a/libs/community/tests/integration_tests/chat_models/test_fireworks.py
+++ b/libs/community/tests/integration_tests/chat_models/test_fireworks.py
@@ -1,4 +1,5 @@
 """Test ChatFireworks wrapper."""
+
 import sys
 from typing import cast
 
@@ -86,7 +87,8 @@ def test_fireworks_invoke(chat: ChatFireworks) -> None:
     """Tests chat completion with invoke"""
     result = chat.invoke("How is the weather in New York today?", stop=[","])
     assert isinstance(result.content, str)
-    assert result.content[-1] == ","
+    assert "," not in result.content
+    assert "new" in result.content.lower()  # check answer contents
 
 
 @pytest.mark.scheduled
@@ -94,7 +96,8 @@ async def test_fireworks_ainvoke(chat: ChatFireworks) -> None:
     """Tests chat completion with invoke"""
     result = await chat.ainvoke("How is the weather in New York today?", stop=[","])
     assert isinstance(result.content, str)
-    assert result.content[-1] == ","
+    assert "," not in result.content  # check for stop words enforcement
+    assert "new" in result.content.lower()  # check answer contents
 
 
 @pytest.mark.scheduled
@@ -111,7 +114,8 @@ def test_fireworks_batch(chat: ChatFireworks) -> None:
     )
     for token in result:
         assert isinstance(token.content, str)
-        assert token.content[-1] == ",", token.content
+        assert "," not in token.content  # check for stop words enforcement
+        assert "redwood" in token.content.lower()  # check answer contents
 
 
 @pytest.mark.scheduled
@@ -127,7 +131,8 @@ async def test_fireworks_abatch(chat: ChatFireworks) -> None:
     )
     for token in result:
         assert isinstance(token.content, str)
-        assert token.content[-1] == ","
+        assert "," not in token.content  # check for stop words enforcement
+        assert "redwood" in token.content.lower()  # check answer contents
 
 
 @pytest.mark.scheduled
@@ -146,7 +151,7 @@ def test_fireworks_streaming_stop_words(chat: ChatFireworks) -> None:
     for token in chat.stream("I'm Pickle Rick", stop=[","]):
         last_token = cast(str, token.content)
         assert isinstance(token.content, str)
-    assert last_token[-1] == ","
+    assert "," not in token.content  # check for stop words enforcement
 
 
 @pytest.mark.scheduled
@@ -169,10 +174,12 @@ async def test_chat_fireworks_agenerate() -> None:
 async def test_fireworks_astream(chat: ChatFireworks) -> None:
     """Test streaming tokens from Fireworks."""
 
-    last_token = ""
+    response = ""
     async for token in chat.astream(
         "Who's the best quarterback in the NFL?", stop=[","]
     ):
-        last_token = cast(str, token.content)
+        response += cast(str, token.content)
         assert isinstance(token.content, str)
-    assert last_token[-1] == ","
+
+    assert "," not in response  # check for stop words enforcement
+    assert "quarterback" in response.lower()  # check answer contents


### PR DESCRIPTION
Async streaming for fireworks chat seemed to have a typo, fixed in this PR (L259 of fireworks.py)

As part of this, I realized that a lot of integration tests for fireworks were failing... probably not being run regularly? This particular issue was causing one of those tests to fail too and that issue is resolved.

The other tests were failing due to incorrectly expecting stop words to be included in the output as the last char... this is not the right expectation and the tests are now all passing.