### PR TITLE
community[patch]: deprecate community fireworks

### DIFF
--- a/libs/community/langchain_community/chat_models/fireworks.py
+++ b/libs/community/langchain_community/chat_models/fireworks.py
@@ -10,11 +10,11 @@ from typing import (
     Union,
 )
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
-from langchain_core._api.deprecation import deprecated
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.llms import create_base_retry_decorator
 from langchain_core.messages import (

--- a/libs/community/langchain_community/chat_models/fireworks.py
+++ b/libs/community/langchain_community/chat_models/fireworks.py
@@ -14,6 +14,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
+from langchain_core._api.deprecation import deprecated
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.llms import create_base_retry_decorator
 from langchain_core.messages import (
@@ -78,6 +79,11 @@ def convert_dict_to_message(_dict: Any) -> BaseMessage:
         return ChatMessage(content=content, role=role)
 
 
+@deprecated(
+    since="0.0.26",
+    removal="0.2",
+    alternative_import="langchain_fireworks.ChatFireworks",
+)
 class ChatFireworks(BaseChatModel):
     """Fireworks Chat models."""
 

--- a/libs/community/langchain_community/llms/fireworks.py
+++ b/libs/community/langchain_community/llms/fireworks.py
@@ -2,6 +2,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Optional, Union
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -26,6 +27,11 @@ def _stream_response_to_generation_chunk(
     )
 
 
+@deprecated(
+    since="0.0.26",
+    removal="0.2",
+    alternative_import="langchain_fireworks.Fireworks",
+)
 class Fireworks(BaseLLM):
     """Fireworks models."""
 


### PR DESCRIPTION
Deprecating as mentioned in #18543 in favor of langchain-fireworks package