### PR TITLE
community[patch]: Invoke callback prior to yielding token (titan_takeoff)

### DIFF
--- a/libs/community/langchain_community/llms/titan_takeoff.py
+++ b/libs/community/langchain_community/llms/titan_takeoff.py
@@ -151,9 +151,9 @@ class TitanTakeoff(LLM):
         for text in response.iter_content(chunk_size=1, decode_unicode=True):
             if text:
                 chunk = GenerationChunk(text=text)
-                yield chunk
                 if run_manager:
                     run_manager.on_llm_new_token(token=chunk.text)
+                yield chunk
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ method in llms/titan_takeoff.
- Issue: #16913 
- Dependencies: None