### PR TITLE
docs:Update function "run" to "invoke" in smart_llm.ipynb

### DIFF
--- a/cookbook/smart_llm.ipynb
+++ b/cookbook/smart_llm.ipynb
@@ -209,7 +209,7 @@
     }
    ],
    "source": [
-    "chain.run({})"
+    "chain.invoke({})"
    ]
   },
   {


### PR DESCRIPTION
This patch updates function "run" to "invoke" in smart_llm.ipynb.
Without this patch, you see following warning.

LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.

    Signed-off-by: Masanari Iida <standby24x7@gmail.com>

