### PR TITLE
core: fix repr handling of recursive object references

### DIFF
--- a/libs/core/langchain_core/load/safe_repr.py
+++ b/libs/core/langchain_core/load/safe_repr.py
@@ -1,0 +1,43 @@
+def safe_repr(obj, seen=None):
+    """A repr implementation that accounts for recursive object references."""
+
+    if seen is None:
+        seen = set()
+
+    obj_id = id(obj)
+    if obj_id in seen:
+        raise RecursionError("Found a recursive reference")
+
+    seen.add(obj_id)
+    result = []
+
+    if isinstance(obj, dict):
+        result.append("{")
+        for key, value in obj.items():
+            result.append(f"{safe_repr(key, seen=seen)}: {safe_repr(value, seen=seen)}, ")
+        result.append("}")
+    elif isinstance(obj, list):
+        result.append("[")
+        result.extend(f"{safe_repr(item, seen=seen)}, " for item in obj)
+        result.append("]")
+    elif isinstance(obj, tuple):
+        result.append("(")
+        result.extend(f"{safe_repr(item, seen=seen)}, " for item in obj)
+        result.append(")")
+    elif isinstance(obj, set):
+        result.append("{")
+        result.extend(f"{safe_repr(item, seen=seen)}, " for item in obj)
+        result.append("}")
+    else:
+        # Handle general class instances
+        if hasattr(obj, "__dict__"):
+            result.append(f"<{obj.__class__.__name__}: ")
+            for key, value in obj.__dict__.items():
+                result.append(f"{key}={safe_repr(value, seen=seen)}, ")
+            result.append(">")
+        else:
+            # Fallback for objects without __dict__ or non-container types
+            result.append(repr(obj))
+
+    seen.remove(obj_id)
+    return ''.join(result)

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -13,6 +13,7 @@ from typing import (
 from typing_extensions import NotRequired
 
 from langchain_core.pydantic_v1 import BaseModel, PrivateAttr
+from langchain_core.load.safe_repr import safe_repr
 
 
 class BaseSerialized(TypedDict):
@@ -232,7 +233,7 @@ def to_json_not_implemented(obj: object) -> SerializedNotImplemented:
         "repr": None,
     }
     try:
-        result["repr"] = repr(obj)
+        result["repr"] = safe_repr(obj)
     except Exception:
         pass
     return result


### PR DESCRIPTION
**Description:** Generic serialization of objects via `repr` does not account for recursive object references. This leads to issues when 3rd parties extend Langchain classes and add properties which contain circular references ([example](https://github.com/joaomdmoura/crewAI/blob/e51b8aadae20792882db152fee302378b99580c8/src/crewai/agents/executor.py#L19)). In these cases, a `RecursionError` will be thrown when the `sys.getrecursionlimit()` is reached. However a very difficult to debug `Segmentation Fault` assertion occurs if `sys.setrecursionlimit(...)` is set too high, and the process runs out of memory. Using a `safe_repr` implementation that throws an exception early upon finding a circular reference fixes this problem.

**Twitter handle:** @polywrap_io @dorgjelli @nerfzael