### PR TITLE
community[patch]: Invoke callback prior to yielding token (titan_takeoff_pro)

### DIFF
--- a/libs/community/langchain_community/llms/titan_takeoff_pro.py
+++ b/libs/community/langchain_community/llms/titan_takeoff_pro.py
@@ -207,9 +207,9 @@ class TitanTakeoffPro(LLM):
         # Yield any remaining content in the buffer.
         if buffer:
             chunk = GenerationChunk(text=buffer.replace("</s>", ""))
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(token=chunk.text)
+            yield chunk
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ method in llms/titan_takeoff_pro.
- Issue: #16913 
- Dependencies: None