### PR TITLE
community[patch]: Invoke callback prior to yielding token (sparkllm)

### DIFF
--- a/libs/community/langchain_community/llms/sparkllm.py
+++ b/libs/community/langchain_community/llms/sparkllm.py
@@ -169,9 +169,9 @@ class SparkLLM(LLM):
             if "data" not in content:
                 continue
             delta = content["data"]
-            yield GenerationChunk(text=delta["content"])
             if run_manager:
                 run_manager.on_llm_new_token(delta)
+            yield GenerationChunk(text=delta["content"])
 
 
 class _SparkLLMClient:


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ method in llms/sparkllm.
- Issue: #16913 
- Dependencies: None