### PR TITLE
community[patch]: Invoke callback prior to yielding token (replicate)

### DIFF
--- a/libs/community/langchain_community/llms/replicate.py
+++ b/libs/community/langchain_community/llms/replicate.py
@@ -177,12 +177,12 @@ class Replicate(LLM):
                     if not output:
                         break
             if output:
-                yield GenerationChunk(text=output)
                 if run_manager:
                     run_manager.on_llm_new_token(
                         output,
                         verbose=self.verbose,
                     )
+                yield GenerationChunk(text=output)
             if stop_condition_reached:
                 break
 


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ method in llms/replicate.
- Issue: #16913 
- Dependencies: None