### PR TITLE
community[patch]: Invoke callback prior to yielding token (pai_eas_endpoint)

### DIFF
--- a/libs/community/langchain_community/llms/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/llms/pai_eas_endpoint.py
@@ -231,9 +231,9 @@ class PaiEasEndpoint(LLM):
                     # yield text, if any
                     if text:
                         res = GenerationChunk(text=text)
-                        yield res
                         if run_manager:
                             run_manager.on_llm_new_token(res.text)
+                        yield res
 
                     # break if stop sequence found
                     if stop_seq_found:


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ method in llms/pai_eas_endpoint.
- Issue: #16913 
- Dependencies: None