### PR TITLE
community[patch]: Invoke callback prior to yielding token (openai)

### DIFF
--- a/libs/community/langchain_community/llms/openai.py
+++ b/libs/community/langchain_community/llms/openai.py
@@ -365,7 +365,6 @@ class BaseOpenAI(BaseLLM):
             if not isinstance(stream_resp, dict):
                 stream_resp = stream_resp.dict()
             chunk = _stream_response_to_generation_chunk(stream_resp)
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(
                     chunk.text,
@@ -375,6 +374,7 @@ class BaseOpenAI(BaseLLM):
                     if chunk.generation_info
                     else None,
                 )
+            yield chunk
 
     async def _astream(
         self,


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ method in llms/openai.
- Issue: #16913 
- Dependencies: None