### PR TITLE
community[patch]: Invoke callback prior to yielding token (ollama)

### DIFF
--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -462,12 +462,12 @@ class Ollama(BaseLLM, _OllamaCommon):
         for stream_resp in self._create_generate_stream(prompt, stop, **kwargs):
             if stream_resp:
                 chunk = _stream_response_to_generation_chunk(stream_resp)
-                yield chunk
                 if run_manager:
                     run_manager.on_llm_new_token(
                         chunk.text,
                         verbose=self.verbose,
                     )
+                yield chunk
 
     async def _astream(
         self,
@@ -479,9 +479,9 @@ class Ollama(BaseLLM, _OllamaCommon):
         async for stream_resp in self._acreate_generate_stream(prompt, stop, **kwargs):
             if stream_resp:
                 chunk = _stream_response_to_generation_chunk(stream_resp)
-                yield chunk
                 if run_manager:
                     await run_manager.on_llm_new_token(
                         chunk.text,
                         verbose=self.verbose,
                     )
+                yield chunk


### PR DESCRIPTION
## PR title
community[patch]: Invoke callback prior to yielding token

## PR message
- Description: Invoke callback prior to yielding token in _stream_ & _astream_ methods in llms/ollama.
- Issue: #16913 
- Dependencies: None