### PR TITLE
docs: quickstart.mdx

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -310,7 +310,7 @@ Then we can build our index:
 
 ```python
 from langchain_community.vectorstores import FAISS
-from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain.text_splitters import RecursiveCharacterTextSplitter
 
 
 text_splitter = RecursiveCharacterTextSplitter()


### PR DESCRIPTION
fix a small bug in quickstart.mdx.

As a beginner, reading the official documentation can help me quickly understand how to use langchain. However, a minor issue in the quick start document has troubled me for a long time.