### PR TITLE
docs:Update function "run" to "invoke" in llm_bash.ipynb

### DIFF
--- a/cookbook/llm_bash.ipynb
+++ b/cookbook/llm_bash.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "bash_chain = LLMBashChain.from_llm(llm, verbose=True)\n",
     "\n",
-    "bash_chain.run(text)"
+    "bash_chain.invoke(text)"
    ]
   },
   {
@@ -135,7 +135,7 @@
     "\n",
     "text = \"Please write a bash script that prints 'Hello World' to the console.\"\n",
     "\n",
-    "bash_chain.run(text)"
+    "bash_chain.invoke(text)"
    ]
   },
   {
@@ -190,7 +190,7 @@
     "\n",
     "text = \"List the current directory then move up a level.\"\n",
     "\n",
-    "bash_chain.run(text)"
+    "bash_chain.invoke(text)"
    ]
   },
   {
@@ -231,7 +231,7 @@
    ],
    "source": [
     "# Run the same command again and see that the state is maintained between calls\n",
-    "bash_chain.run(text)"
+    "bash_chain.invoke(text)"
    ]
   }
  ],


### PR DESCRIPTION
This path updates function "run" to "invoke" in llm_bash.ipynb. 
Without this path, you see following warning.

LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 
and will be removed in 0.2.0. Use invoke instead.


