### PR TITLE
community: Implement lazy_load() for TextLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/text.py
+++ b/libs/community/langchain_community/document_loaders/text.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Iterator, Optional
 
 from langchain_core.documents import Document
 
@@ -34,7 +34,7 @@ class TextLoader(BaseLoader):
         self.encoding = encoding
         self.autodetect_encoding = autodetect_encoding
 
-    def load(self) -> List[Document]:
+    def lazy_load(self) -> Iterator[Document]:
         """Load from file path."""
         text = ""
         try:
@@ -57,4 +57,4 @@ class TextLoader(BaseLoader):
             raise RuntimeError(f"Error loading {self.file_path}") from e
 
         metadata = {"source": self.file_path}
-        return [Document(page_content=text, metadata=metadata)]
+        yield Document(page_content=text, metadata=metadata)


### PR DESCRIPTION
Integration test: `tests/integration_tests/document_loaders/test_python.py`