### PR TITLE
community[patch]: make metadata and text optional as expected in DocArray

### DIFF
--- a/libs/community/langchain_community/vectorstores/docarray/base.py
+++ b/libs/community/langchain_community/vectorstores/docarray/base.py
@@ -51,9 +51,9 @@ class DocArrayIndex(VectorStore, ABC):
         from docarray.typing import NdArray
 
         class DocArrayDoc(BaseDoc):
-            text: Optional[str]
+            text: Optional[str] = Field(default=None, required=False)
             embedding: Optional[NdArray] = Field(**embeddings_params)
-            metadata: Optional[dict]
+            metadata: Optional[dict] = Field(default=None, required=False)
 
         return DocArrayDoc
 


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: "community: make metadata and text optional as expected to fix Pydantic validation error"

- [ ] **PR message**:
    - **Description:** 
    - Solve the error when calling the official [sample code](https://python.langchain.com/docs/expression_language/get_started#rag-search-example), 

Error will be like:
```
File ~/anaconda3/envs/py310/lib/python3.10/site-packages/pydantic/main.py:164, in BaseModel.init(pydantic_self, **data)
162 # __tracebackhide__ tells pytest and some other tools to omit this function from tracebacks
163 tracebackhide = True
--> 164 pydantic_self.pydantic_validator.validate_python(data, self_instance=pydantic_self)

ValidationError: 2 validation errors for DocArrayDoc
text
Field required [type=missing, input_value={'embedding': [-0.0191128...9, 0.01005221541175212]}, input_type=dict]
For further information visit https://errors.pydantic.dev/2.5/v/missing
metadata
Field required [type=missing, input_value={'embedding': [-0.0191128...9, 0.01005221541175212]}, input_type=dict]
For further information visit https://errors.pydantic.dev/2.5/v/missing
```
In the `_get_doc_cls` method, the `DocArrayDoc` class is defined as follows:

```python
class DocArrayDoc(BaseDoc):
    text: Optional[str]
    embedding: Optional[NdArray] = Field(**embeddings_params)
    metadata: Optional[dict]
```

Even though `text` and `metadata` are declared as `Optional`, Pydantic treats them as required fields by default, which cause validation error above.

    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** No
    - **Twitter handle:** if your PR gets announced, and you'd like a mention, we'll gladly shout you out!


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
