### PR TITLE
docs: Fix link to HF TEI in text_embeddings_inference.ipynb

### DIFF
--- a/docs/docs/integrations/text_embedding/text_embeddings_inference.ipynb
+++ b/docs/docs/integrations/text_embedding/text_embeddings_inference.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Text Embeddings Inference\n",
     "\n",
-    ">[Hugging Face Text Embeddings Inference (TEI)](https://huggingface.co/docs/text-generation-inference/index) is a toolkit for deploying and serving open-source\n",
+    ">[Hugging Face Text Embeddings Inference (TEI)](https://huggingface.co/docs/text-embeddings-inference/index) is a toolkit for deploying and serving open-source\n",
     "> text embeddings and sequence classification models. `TEI` enables high-performance extraction for the most popular models,\n",
     ">including `FlagEmbedding`, `Ember`, `GTE` and `E5`.\n",
     "\n",


### PR DESCRIPTION
 - [ ]  **PR title:** docs: Fix link to HF TEI in text_embeddings_inference.ipynb
 
- [ ] **PR message:**

   - **Description:** Fix the link to [Hugging Face Text Embeddings Inference (TEI)](https://huggingface.co/docs/text-embeddings-inference/index) in text_embeddings_inference.ipynb
   - **Issue:** Fix #18576


