### PR TITLE
WIP: Get rid of deprecated warnings originating from internal code

### DIFF
--- a/libs/core/langchain_core/_api/__init__.py
+++ b/libs/core/langchain_core/_api/__init__.py
@@ -16,6 +16,7 @@ from .beta_decorator import (
 )
 from .deprecation import (
     LangChainDeprecationWarning,
+    caller_aware_warn,
     deprecated,
     suppress_langchain_deprecation_warning,
     surface_langchain_deprecation_warnings,
@@ -35,4 +36,5 @@ __all__ = [
     "suppress_langchain_deprecation_warning",
     "surface_langchain_deprecation_warnings",
     "warn_deprecated",
+    "caller_aware_warn",
 ]

--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -13,6 +13,7 @@ https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/_api/deprecati
 import contextlib
 import functools
 import inspect
+import os
 import warnings
 from typing import Any, Callable, Generator, Type, TypeVar
 
@@ -25,6 +26,45 @@ class LangChainDeprecationWarning(DeprecationWarning):
 
 class LangChainPendingDeprecationWarning(PendingDeprecationWarning):
     """A class for issuing deprecation warnings for LangChain users."""
+
+
+def is_warning_internal() -> bool:
+    """Check if the warning is internal to LangChain libraries."""
+    # Get the current stack frame
+    try:
+        stack = inspect.stack(context=1)
+        for idx, frame in enumerate(stack):
+            if frame.filename.split("/")[-1] != "deprecation.py":
+                break
+
+        # Here we will be looking at the first frame which is not in deprecation.py
+        # This frame is the caller of the warning, and it will be the
+        # @deprecated decorator usually (i.e., the file that uses the decorator)
+        # We want to step another frame back to get the actual caller of the function
+        # that uses the decorator.
+        idx += 1
+
+        caller_frame = stack[idx].frame
+        # You can now use the frame object, for example, to get information about the code
+        if "__package__" not in caller_frame.f_globals:
+            return False
+        package = caller_frame.f_globals["__package__"]
+        # Most langchain libraries start with langchain.
+        # So this will suppress warnings from most langchain libraries.
+        # This does not have to be perfect
+        return package.startswith("langchain")
+    except Exception:
+        return False
+
+
+SURFACE_INTERNAL_WARNINGS = (
+    os.environ.get("SURFACE_INTERNAL_WARNINGS", "false").lower() == "true"
+)
+
+
+def _get_surface_internal_warnings() -> bool:
+    """Mocked for testing."""
+    return SURFACE_INTERNAL_WARNINGS
 
 
 # PUBLIC API
@@ -379,8 +419,11 @@ def warn_deprecated(
     warning_cls = (
         LangChainPendingDeprecationWarning if pending else LangChainDeprecationWarning
     )
-    warning = warning_cls(message)
-    warnings.warn(warning, category=LangChainDeprecationWarning, stacklevel=2)
+    caller_aware_warn(
+        message,
+        category=warning_cls,
+        surface_internal_warnings=_get_surface_internal_warnings(),
+    )
 
 
 def surface_langchain_deprecation_warnings() -> None:
@@ -394,3 +437,19 @@ def surface_langchain_deprecation_warnings() -> None:
         "default",
         category=LangChainDeprecationWarning,
     )
+
+
+def caller_aware_warn(
+    message: str,
+    *,
+    category: Type[Warning] = LangChainDeprecationWarning,
+    surface_internal_warnings: bool = False,
+) -> None:
+    """Warn deprecated"""
+    is_warning_internal()
+    if surface_internal_warnings:
+        warnings.warn(message, category=category, stacklevel=2)
+    else:
+        if is_warning_internal():
+            return
+        warnings.warn(message, category=category, stacklevel=2)

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -75,6 +75,17 @@ def test_warn_deprecated(kwargs: Dict[str, Any], expected_message: str) -> None:
             assert str(warning) == expected_message
 
 
+def test_internal_warnings_disabled() -> None:
+    """Test that internal warnings are disabled properly"""
+    with patch.object(deprecation, "_get_surface_internal_warnings") as func:
+        func.return_value = False
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            warn_deprecated("1.0.0", pending=True)
+            assert len(warning_list) == 0
+
+
+
 def test_undefined_deprecation_schedule() -> None:
     """This test is expected to fail until we defined a deprecation schedule."""
     with pytest.raises(NotImplementedError):

--- a/libs/core/tests/unit_tests/_api/test_imports.py
+++ b/libs/core/tests/unit_tests/_api/test_imports.py
@@ -12,6 +12,7 @@ EXPECTED_ALL = [
     "warn_deprecated",
     "as_import_path",
     "get_relative_path",
+    "caller_aware_warn",
 ]
 
 

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -246,15 +246,14 @@ def test_chat_valid_infer_variables() -> None:
 
 def test_chat_from_role_strings() -> None:
     """Test instantiation of chat template from role strings."""
-    with pytest.warns(LangChainPendingDeprecationWarning):
-        template = ChatPromptTemplate.from_role_strings(
-            [
-                ("system", "You are a bot."),
-                ("assistant", "hello!"),
-                ("human", "{question}"),
-                ("other", "{quack}"),
-            ]
-        )
+    template = ChatPromptTemplate.from_role_strings(
+        [
+            ("system", "You are a bot."),
+            ("assistant", "hello!"),
+            ("human", "{question}"),
+            ("other", "{quack}"),
+        ]
+    )
 
     messages = template.format_messages(question="How are you?", quack="duck")
     assert messages == [

--- a/libs/langchain/langchain/__init__.py
+++ b/libs/langchain/langchain/__init__.py
@@ -1,10 +1,12 @@
 # ruff: noqa: E402
 """Main entrypoint into package."""
-import warnings
 from importlib import metadata
 from typing import Any, Optional
 
-from langchain_core._api.deprecation import surface_langchain_deprecation_warnings
+from langchain_core._api.deprecation import (
+    caller_aware_warn,
+    surface_langchain_deprecation_warnings,
+)
 
 try:
     __version__ = metadata.version(__package__)
@@ -26,13 +28,13 @@ def _warn_on_import(name: str, replacement: Optional[str] = None) -> None:
         return
 
     if replacement:
-        warnings.warn(
+        caller_aware_warn(
             f"Importing {name} from langchain root module is no longer supported. "
-            f"Please use {replacement} instead."
+            f"Please use {replacement} instead.",
         )
     else:
-        warnings.warn(
-            f"Importing {name} from langchain root module is no longer supported."
+        caller_aware_warn(
+            f"Importing {name} from langchain root module is no longer supported.",
         )
 
 

--- a/libs/langchain/langchain/agents/agent_toolkits/__init__.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/__init__.py
@@ -17,7 +17,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 from langchain_core._api.path import as_import_path
 
 from langchain.agents.agent_toolkits.conversational_retrieval.openai_functions import (
@@ -61,13 +61,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing this agent toolkit from langchain is deprecated. Importing it "
             "from langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.agent_toolkits import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(agent_toolkits, name)

--- a/libs/langchain/langchain/agents/agent_toolkits/__init__.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/__init__.py
@@ -13,7 +13,6 @@ whether permissions of the given toolkit are appropriate for the application.
 
 See [Security](https://python.langchain.com/docs/security) for more information.
 """
-import warnings
 from pathlib import Path
 from typing import Any
 

--- a/libs/langchain/langchain/callbacks/__init__.py
+++ b/libs/langchain/langchain/callbacks/__init__.py
@@ -9,7 +9,7 @@
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 from langchain_core.callbacks import (
     StdOutCallbackHandler,
     StreamingStdOutCallbackHandler,
@@ -34,15 +34,13 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing this callback from langchain is deprecated. Importing it from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.callbacks import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
-
     return getattr(callbacks, name)
 
 

--- a/libs/langchain/langchain/callbacks/__init__.py
+++ b/libs/langchain/langchain/callbacks/__init__.py
@@ -6,7 +6,6 @@
 
     BaseCallbackHandler --> <name>CallbackHandler  # Example: AimCallbackHandler
 """
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/chat_models/__init__.py
+++ b/libs/langchain/langchain/chat_models/__init__.py
@@ -16,9 +16,8 @@ an interface where "chat messages" are the inputs and outputs.
 
     AIMessage, BaseMessage, HumanMessage
 """  # noqa: E501
-import warnings
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.utils.interactive_env import is_interactive_env
 
@@ -28,13 +27,12 @@ def __getattr__(name: str) -> None:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing chat models from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.chat_models import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(chat_models, name)

--- a/libs/langchain/langchain/docstore/__init__.py
+++ b/libs/langchain/langchain/docstore/__init__.py
@@ -17,7 +17,7 @@ The **Docstore** is a simplified version of the Document Loader.
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.utils.interactive_env import is_interactive_env
 
@@ -27,13 +27,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing docstores from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.docstore import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(docstore, name)

--- a/libs/langchain/langchain/docstore/__init__.py
+++ b/libs/langchain/langchain/docstore/__init__.py
@@ -14,7 +14,6 @@ The **Docstore** is a simplified version of the Document Loader.
 
     Document, AddableMixin
 """
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/document_loaders/__init__.py
+++ b/libs/langchain/langchain/document_loaders/__init__.py
@@ -17,7 +17,7 @@
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.utils.interactive_env import is_interactive_env
 
@@ -33,17 +33,16 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing document loaders from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.document_loaders import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     if name in _old_to_new_name:
-        warnings.warn(
+        caller_aware_warn(
             f"Using legacy class name {name}, use {_old_to_new_name[name]} instead."
         )
         name = _old_to_new_name[name]

--- a/libs/langchain/langchain/document_loaders/__init__.py
+++ b/libs/langchain/langchain/document_loaders/__init__.py
@@ -14,7 +14,6 @@
 
     Document, <name>TextSplitter
 """
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/document_transformers/__init__.py
+++ b/libs/langchain/langchain/document_transformers/__init__.py
@@ -14,10 +14,9 @@
 
     Document
 """  # noqa: E501
-import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.utils.interactive_env import is_interactive_env
 
@@ -27,13 +26,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing document transformers from langchain is deprecated. Importing "
             "from langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.document_transformers import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(document_transformers, name)

--- a/libs/langchain/langchain/embeddings/__init__.py
+++ b/libs/langchain/langchain/embeddings/__init__.py
@@ -15,7 +15,7 @@ import logging
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.embeddings.cache import CacheBackedEmbeddings
 from langchain.utils.interactive_env import is_interactive_env
@@ -26,13 +26,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing embeddings from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.embeddings import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(embeddings, name)

--- a/libs/langchain/langchain/embeddings/__init__.py
+++ b/libs/langchain/langchain/embeddings/__init__.py
@@ -12,7 +12,6 @@ from different APIs and services.
 
 
 import logging
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -20,7 +20,7 @@ access to the large language model (**LLM**) APIs and services.
 import warnings
 from typing import Any, Callable, Dict, Type
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 from langchain_core.language_models.llms import BaseLLM
 
 from langchain.utils.interactive_env import is_interactive_env
@@ -545,13 +545,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing LLMs from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.llms import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     if name == "type_to_cls_dict":

--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -17,7 +17,6 @@ access to the large language model (**LLM**) APIs and services.
     CallbackManager, AsyncCallbackManager,
     AIMessage, BaseMessage
 """  # noqa: E501
-import warnings
 from typing import Any, Callable, Dict, Type
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/memory/chat_message_histories/__init__.py
+++ b/libs/langchain/langchain/memory/chat_message_histories/__init__.py
@@ -1,7 +1,6 @@
-import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.utils.interactive_env import is_interactive_env
 
@@ -11,15 +10,13 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing chat message histories from langchain is deprecated. Importing "
             "from langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.chat_message_histories import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
-
     return getattr(chat_message_histories, name)
 
 

--- a/libs/langchain/langchain/retrievers/__init__.py
+++ b/libs/langchain/langchain/retrievers/__init__.py
@@ -20,7 +20,7 @@ the backbone of a retriever, but there are other types of retrievers as well.
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.retrievers.contextual_compression import ContextualCompressionRetriever
 from langchain.retrievers.ensemble import EnsembleRetriever
@@ -43,13 +43,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing this retriever from langchain is deprecated. Importing it from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.retrievers import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(retrievers, name)

--- a/libs/langchain/langchain/retrievers/__init__.py
+++ b/libs/langchain/langchain/retrievers/__init__.py
@@ -17,7 +17,6 @@ the backbone of a retriever, but there are other types of retrievers as well.
     Document, Serializable, Callbacks,
     CallbackManagerForRetrieverRun, AsyncCallbackManagerForRetrieverRun
 """
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/storage/__init__.py
+++ b/libs/langchain/langchain/storage/__init__.py
@@ -5,7 +5,6 @@ to a simple key-value interface.
 
 The primary goal of these storages is to support implementation of caching.
 """
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/storage/__init__.py
+++ b/libs/langchain/langchain/storage/__init__.py
@@ -8,7 +8,7 @@ The primary goal of these storages is to support implementation of caching.
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.storage._lc_store import create_kv_docstore, create_lc_store
 from langchain.storage.encoder_backed import EncoderBackedStore
@@ -22,13 +22,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing stores from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.storage import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(storage, name)

--- a/libs/langchain/langchain/tools/__init__.py
+++ b/libs/langchain/langchain/tools/__init__.py
@@ -19,7 +19,7 @@ tool for the job.
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 from langchain_core.tools import BaseTool, StructuredTool, Tool, tool
 
 from langchain.utils.interactive_env import is_interactive_env
@@ -60,14 +60,13 @@ def __getattr__(name: str) -> Any:
 
         # If not in interactive env, raise warning.
         if not is_interactive_env():
-            warnings.warn(
+            caller_aware_warn(
                 "Importing tools from langchain is deprecated. Importing from "
                 "langchain will no longer be supported as of langchain==0.2.0. "
                 "Please import from langchain-community instead:\n\n"
                 f"`from langchain_community.tools import {name}`.\n\n"
                 "To install langchain-community run "
                 "`pip install -U langchain-community`.",
-                category=LangChainDeprecationWarning,
             )
 
         return getattr(tools, name)

--- a/libs/langchain/langchain/tools/__init__.py
+++ b/libs/langchain/langchain/tools/__init__.py
@@ -16,7 +16,6 @@ tool for the job.
 
     CallbackManagerForToolRun, AsyncCallbackManagerForToolRun
 """
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn

--- a/libs/langchain/langchain/utilities/__init__.py
+++ b/libs/langchain/langchain/utilities/__init__.py
@@ -11,7 +11,7 @@ from langchain_community.utilities.requests import (
     RequestsWrapper,
     TextRequestsWrapper,
 )
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 
 from langchain.utils.interactive_env import is_interactive_env
 
@@ -21,13 +21,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing this utility from langchain is deprecated. Importing it from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.utilities import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(utilities, name)

--- a/libs/langchain/langchain/utilities/__init__.py
+++ b/libs/langchain/langchain/utilities/__init__.py
@@ -3,7 +3,6 @@
 Other LangChain classes use **Utilities** to interact with third-part systems
 and packages.
 """
-import warnings
 from typing import Any
 
 from langchain_community.utilities.requests import (

--- a/libs/langchain/langchain/vectorstores/__init__.py
+++ b/libs/langchain/langchain/vectorstores/__init__.py
@@ -21,7 +21,7 @@ and retrieve the data that are 'most similar' to the embedded query.
 import warnings
 from typing import Any
 
-from langchain_core._api import LangChainDeprecationWarning
+from langchain_core._api import caller_aware_warn
 from langchain_core.vectorstores import VectorStore
 
 from langchain.utils.interactive_env import is_interactive_env
@@ -32,13 +32,12 @@ def __getattr__(name: str) -> Any:
 
     # If not in interactive env, raise warning.
     if not is_interactive_env():
-        warnings.warn(
+        caller_aware_warn(
             "Importing vector stores from langchain is deprecated. Importing from "
             "langchain will no longer be supported as of langchain==0.2.0. "
             "Please import from langchain-community instead:\n\n"
             f"`from langchain_community.vectorstores import {name}`.\n\n"
             "To install langchain-community run `pip install -U langchain-community`.",
-            category=LangChainDeprecationWarning,
         )
 
     return getattr(vectorstores, name)

--- a/libs/langchain/langchain/vectorstores/__init__.py
+++ b/libs/langchain/langchain/vectorstores/__init__.py
@@ -18,7 +18,6 @@ and retrieve the data that are 'most similar' to the embedded query.
 
     Embeddings, Document
 """  # noqa: E501
-import warnings
 from typing import Any
 
 from langchain_core._api import caller_aware_warn


### PR DESCRIPTION
Users now see a lot of deprecation warnings that originate from internal code.

This PR proposes a solution for that. A lot of deprecation warnings = thousands of them.

This also makes it to hard to find out why our tests fail on CI since it
requires scrolling through a large wall of warnings before actually seeing the
failure.

What's going to happen is that users will effectively filter out all the
warnings in their code, so they won't be getting the deprecation warnings
anyway!

---

At least from a quick check it seems to result in desired behavior in user code

```bash
(langchain_3_11) ➜  libs git:(eugene/stackframe) ✗ time python -c "from langchain.chat_models import ChatOpenAI"
/home/eugene/src/langchain/libs/langchain/langchain/chat_models/__init__.py:30: LangChainDeprecationWarning: Importing chat models from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.chat_models import ChatOpenAI`.

To install langchain-community run `pip install -U langchain-community`.
  caller_aware_warn(
python -c "from langchain.chat_models import ChatOpenAI"  0.98s user 1.31s system 329% cpu 0.696 total
```