### PR TITLE
[Core]: Relevance Score Scaling Issue

### DIFF
--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -198,21 +198,21 @@ class VectorStore(ABC):
         # This function converts the euclidean norm of normalized embeddings
         # (0 is most similar, sqrt(2) most dissimilar)
         # to a similarity function (0 to 1)
-        return max(1.0 - distance / math.sqrt(2),0)
+        return max(1.0 - distance / math.sqrt(2), 0)
 
     @staticmethod
     def _cosine_relevance_score_fn(distance: float) -> float:
         """Normalize the distance to a score on a scale [0, 1]."""
 
-        return max(1.0 - distance,0)
+        return max(1.0 - distance, 0)
 
     @staticmethod
     def _max_inner_product_relevance_score_fn(distance: float) -> float:
         """Normalize the distance to a score on a scale [0, 1]."""
         if distance > 0:
-            return max(1.0 - distance,0)
+            return max(1.0 - distance, 0)
 
-        return max(-1.0 * distance,0)
+        return max(-1.0 * distance, 0)
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         """

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -198,21 +198,21 @@ class VectorStore(ABC):
         # This function converts the euclidean norm of normalized embeddings
         # (0 is most similar, sqrt(2) most dissimilar)
         # to a similarity function (0 to 1)
-        return 1.0 - distance / math.sqrt(2)
+        return max(1.0 - distance / math.sqrt(2),0)
 
     @staticmethod
     def _cosine_relevance_score_fn(distance: float) -> float:
         """Normalize the distance to a score on a scale [0, 1]."""
 
-        return 1.0 - distance
+        return max(1.0 - distance,0)
 
     @staticmethod
     def _max_inner_product_relevance_score_fn(distance: float) -> float:
         """Normalize the distance to a score on a scale [0, 1]."""
         if distance > 0:
-            return 1.0 - distance
+            return max(1.0 - distance,0)
 
-        return -1.0 * distance
+        return max(-1.0 * distance,0)
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         """


### PR DESCRIPTION
Thank you for contributing to LangChain!

 **Description:**  
    - The normalization of scores for different Distance Strategies sometimes results in values less than 0, which raises the warning that relevance scores should be between 0 and 1. To address this issue, I have modified the relevance score normalization process to ensure that it never produces values less than zero for every Distance Strategy. I am uncertain about the reason behind the normalized score becoming less than zero, but it was observed to occur in the FIAAS Vector store, as highlighted in the reported issue.
   **Issue:**  #18709
    


