### PR TITLE
feat(experimental): add support for modin in pandas agent

### DIFF
--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
@@ -162,6 +162,7 @@ def create_pandas_dataframe_agent(
     include_df_in_prompt: Optional[bool] = True,
     number_of_head_rows: int = 5,
     extra_tools: Sequence[BaseTool] = (),
+    use_modin: bool = False,
     **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Pandas agent from an LLM and dataframe(s).
@@ -189,6 +190,7 @@ def create_pandas_dataframe_agent(
         number_of_head_rows: Number of initial rows to include in prompt if
             include_df_in_prompt is True.
         extra_tools: Additional tools to give to agent on top of a PythonAstREPLTool.
+        use_modin: Whether to use `modin.pandas` instead of `pandas`
         **kwargs: DEPRECATED. Not used, kept for backwards compatibility.
 
     Returns:
@@ -213,10 +215,14 @@ def create_pandas_dataframe_agent(
 
     """  # noqa: E501
     try:
-        import pandas as pd
+        if use_modin:
+            import modin.pandas as pd
+        else:
+            import pandas as pd
     except ImportError as e:
+        pkg = "modin" if use_modin else "pandas"
         raise ImportError(
-            "pandas package not found, please install with `pip install pandas`"
+            f"`{pkg}` package not found, please install with `pip install {pkg}`"
         ) from e
 
     if is_interactive_env():

--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
@@ -162,7 +162,7 @@ def create_pandas_dataframe_agent(
     include_df_in_prompt: Optional[bool] = True,
     number_of_head_rows: int = 5,
     extra_tools: Sequence[BaseTool] = (),
-    use_modin: bool = False,
+    engine: Literal["pandas", "modin"] = "pandas",
     **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a Pandas agent from an LLM and dataframe(s).
@@ -190,7 +190,7 @@ def create_pandas_dataframe_agent(
         number_of_head_rows: Number of initial rows to include in prompt if
             include_df_in_prompt is True.
         extra_tools: Additional tools to give to agent on top of a PythonAstREPLTool.
-        use_modin: Whether to use `modin.pandas` instead of `pandas`
+        engine: One of "modin" or "pandas". Defaults to "pandas".
         **kwargs: DEPRECATED. Not used, kept for backwards compatibility.
 
     Returns:
@@ -215,14 +215,17 @@ def create_pandas_dataframe_agent(
 
     """  # noqa: E501
     try:
-        if use_modin:
+        if engine == "modin":
             import modin.pandas as pd
-        else:
+        elif engine == "pandas":
             import pandas as pd
+        else:
+            raise ValueError(
+                f"Unsupported engine {engine}. It must be one of 'modin' or 'pandas'."
+            )
     except ImportError as e:
-        pkg = "modin" if use_modin else "pandas"
         raise ImportError(
-            f"`{pkg}` package not found, please install with `pip install {pkg}`"
+            f"`{engine}` package not found, please install with `pip install {engine}`"
         ) from e
 
     if is_interactive_env():


### PR DESCRIPTION
Added support for Intel's [modin](https://github.com/modin-project/modin) in `create_pandas_dataframe_agent`. 
