### PR TITLE
langchain-mongodb: Standardize mongodb collection/index names in tests

### DIFF
--- a/libs/partners/mongodb/tests/integration_tests/test_cache.py
+++ b/libs/partners/mongodb/tests/integration_tests/test_cache.py
@@ -13,8 +13,9 @@ from langchain_mongodb.cache import MongoDBAtlasSemanticCache, MongoDBCache
 from tests.utils import ConsistentFakeEmbeddings, FakeChatModel, FakeLLM
 
 CONN_STRING = os.environ.get("MONGODB_ATLAS_URI")
-COLLECTION = "default"
-DATABASE = "default"
+INDEX_NAME = "langchain-test-index-semantic-cache"
+DATABASE = "langchain_test_db"
+COLLECTION = "langchain_test_cache"
 
 
 def random_string() -> str:

--- a/libs/partners/mongodb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/partners/mongodb/tests/integration_tests/test_chat_message_histories.py
@@ -6,6 +6,9 @@ from langchain_core.messages import message_to_dict
 
 from langchain_mongodb.chat_message_histories import MongoDBChatMessageHistory
 
+DATABASE = "langchain_test_db"
+COLLECTION = "langchain_test_chat"
+
 # Replace these with your mongodb connection string
 connection_string = os.environ.get("MONGODB_ATLAS_URI", "")
 
@@ -14,7 +17,10 @@ def test_memory_with_message_store() -> None:
     """Test the memory with a message store."""
     # setup MongoDB as a message store
     message_history = MongoDBChatMessageHistory(
-        connection_string=connection_string, session_id="test-session"
+        connection_string=connection_string,
+        session_id="test-session",
+        database_name=DATABASE,
+        collection_name=COLLECTION,
     )
     memory = ConversationBufferMemory(
         memory_key="baz", chat_memory=message_history, return_messages=True

--- a/libs/partners/mongodb/tests/integration_tests/test_vectorstores.py
+++ b/libs/partners/mongodb/tests/integration_tests/test_vectorstores.py
@@ -15,8 +15,8 @@ from pymongo.collection import Collection
 from langchain_mongodb import MongoDBAtlasVectorSearch
 from tests.utils import ConsistentFakeEmbeddings
 
-INDEX_NAME = "langchain-test-index"
-NAMESPACE = "langchain_test_db.langchain_test_collection"
+INDEX_NAME = "langchain-test-index-vectorstores"
+NAMESPACE = "langchain_test_db.langchain_test_vectorstores"
 CONNECTION_STRING = os.environ.get("MONGODB_ATLAS_URI")
 DB_NAME, COLLECTION_NAME = NAMESPACE.split(".")
 DIMENSIONS = 1536


### PR DESCRIPTION
## **Description:**
MongoDB integration tests link to a provided Atlas Cluster. We have very stringent permissions set against the cluster provided. In order to make it easier to track and isolate the collections each test gets run against, we've updated the collection names to map the test file name. i.e. `langchain_{filename}` => `langchain_test_vectorstores` 

Fixes integration test results
![image](https://github.com/langchain-ai/langchain/assets/2887713/41f911b9-55f7-4fe4-9134-5514b82009f9)

## **Dependencies:** 
Provided MONGODB_ATLAS_URI

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

cc: @shaneharvey, @blink1073 , @NoahStapp , @caseyclements