### PR TITLE
chat menu item as icon

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -254,7 +254,7 @@ const config = {
           },
           {
             href: "https://chat.langchain.com",
-            label: "Chat",
+            label: "💬",
             position: "right",
           },
           // Please keep GitHub link to the right for consistency.


### PR DESCRIPTION
Controversial and opinionated:
It replaces the "Chat" top-menu item with the 💬 icon.
Reasons: 
- Right part of the top-menu is composed of icons, so, another icon looks organic.
- "Chat" vs. 💬 It is not 100% clear for both, what they mean. So, parity there.
- 💬 can be more fun to click
- 💬 is more compact and more "phone-friendly"
- 💬 looks good with both themes (Day and Night).

It would be nice to try 💬 for a week and compare its "clickability" with the "Chat".
