### PR TITLE
community: add authorization identities to GoogleDriveLoader

### DIFF
--- a/docs/docs/integrations/document_loaders/google_drive.ipynb
+++ b/docs/docs/integrations/document_loaders/google_drive.ipynb
@@ -206,11 +206,60 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "e312268a",
    "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading auth Identities\n",
+    "Authorized identities for each file ingested by Google Drive Loader can be loaded along with metadata per Document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "88edfbbb",
+   "metadata": {},
    "outputs": [],
+   "source": [
+    "from langchain_community.document_loaders import GoogleDriveLoader\n",
+    "\n",
+    "loader = GoogleDriveLoader(\n",
+    "    folder_id=\"1sd0RqMMJKidf9Pb4YRCI2-NH4Udj885k\",\n",
+    "    recursive=True,\n",
+    "    load_auth=True,\n",
+    "    # Optional: configure whether to load authorized identities for each Document.\n",
+    ")\n",
+    "\n",
+    "doc = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a717fa4f",
+   "metadata": {},
+   "source": [
+    "You can pass `load_auth=True`, to add Google Drive document access identities to metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41623c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc[0].metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83e3b626",
+   "metadata": {},
    "source": []
   },
   {
@@ -530,7 +579,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
    - **Description:** Add Google Drive document access identities to metadata
    - **Dependencies:** none
    - **Documentation:** GoogleDrive documentation update with `load_auth` usage 
