### PR TITLE
docs: fix typo in google_cloud_sql_mysql.ipynb

### DIFF
--- a/docs/docs/integrations/document_loaders/google_cloud_sql_mysql.ipynb
+++ b/docs/docs/integrations/document_loaders/google_cloud_sql_mysql.ipynb
@@ -374,7 +374,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First we prepare an example table with non-default schema, and populate it with some arbitary data."
+    "First we prepare an example table with non-default schema, and populate it with some arbitrary data."
    ]
   },
   {


### PR DESCRIPTION
arbitary -> arbitrary