### PR TITLE
docs: Change saved/configured chain variable name

### DIFF
--- a/docs/docs/expression_language/how_to/configure.ipynb
+++ b/docs/docs/expression_language/how_to/configure.ipynb
@@ -557,7 +557,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "openai_poem = chain.with_config(configurable={\"llm\": \"openai\"})"
+    "openai_joke = chain.with_config(configurable={\"llm\": \"openai\"})"
    ]
   },
   {
@@ -578,7 +578,7 @@
     }
    ],
    "source": [
-    "openai_poem.invoke({\"topic\": \"bears\"})"
+    "openai_joke.invoke({\"topic\": \"bears\"})"
    ]
   },
   {


### PR DESCRIPTION
**Description:**
Variable name was `openai_poem` but it didn't pass in the `"prompt": "poem"` config, so the examples were showing a joke being returned from a variable called `*_poem`.

We could have gone one of two ways:

1. Updating the config line and the output line, or
2. Updating the variable name

The latter seemed simpler, so that's what I went with. But I'd be glad to re-do this PR if you prefer the former.

Thanks for everything, y'all. You rock 🤘

**Issue:** N/A

**Dependencies:** N/A

**Twitter handle:** `conroywhitney`