### PR TITLE
partners[anthropic]: adding a default chat model for ChatAnthropic

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -154,7 +154,7 @@ class ChatAnthropic(BaseChatModel):
     _client: anthropic.Client = Field(default=None)
     _async_client: anthropic.AsyncClient = Field(default=None)
 
-    model: str = Field(alias="model_name")
+    model: str = Field(default="claude-3-sonnet-20240229", alias="model_name")
     """Model name to use."""
 
     max_tokens: int = Field(default=1024, alias="max_tokens_to_sample")


### PR DESCRIPTION
**Description:** Adding a default chat model for the ChatAnthropic class
**Issue:** No default model set for the ChatAnthropic class
**Dependencies:** None
**Lint and test**: `make format`, `make lint` and `make test` have been run

The chat model was set to `claude-3-sonnet-20240229`, the one with the cheapest cost among the current Claude-3 [models](https://docs.anthropic.com/claude/docs/models-overview#model-comparison).
