### PR TITLE
partners[anthropic]: update AnthropicLLM deprecation message

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/llms.py
+++ b/libs/partners/anthropic/langchain_anthropic/llms.py
@@ -175,7 +175,7 @@ class AnthropicLLM(LLM, _AnthropicCommon):
         """Raise warning that this class is deprecated."""
         warnings.warn(
             "This Anthropic LLM is deprecated. "
-            "Please use `from langchain_community.chat_models import ChatAnthropic` "
+            "Please use `from langchain_anthropic import ChatAnthropic` "
             "instead"
         )
         return values


### PR DESCRIPTION
**Description:** Update AnthropicLLM deprecation message import path for ChatAnthropic
**Issue:** Incorrect import path in deprecation message
**Dependencies:** None
**Lint and test**: `make format`, `make lint` and `make test` were run