### PR TITLE
docs: Fix typo and add KùzuDB to graphs docs

### DIFF
--- a/docs/docs/use_cases/graph/index.ipynb
+++ b/docs/docs/use_cases/graph/index.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# Graphs\n",
     "\n",
-    "One of the common types of databases that we can build Q&A systems for are graph databases. LangChain comes with a number of built-in chains and agents that are compatible with graph query language dialects like Cypher, SparQL, and others (e.g., Neo4j, MemGraph, Amazon Neptune, OntoText, Tigegraph). They enable use cases such as:\n",
+    "One of the common types of databases that we can build Q&A systems for are graph databases. LangChain comes with a number of built-in chains and agents that are compatible with graph query language dialects like Cypher, SparQL, and others (e.g., Neo4j, MemGraph, Amazon Neptune, Kùzu, OntoText, Tigergraph). They enable use cases such as:\n",
     "\n",
     "* Generating queries that will be run based on natural language questions,\n",
     "* Creating chatbots that can answer questions based on database data,\n",


### PR DESCRIPTION
 - **Description:** Adding Kùzu (an embedded graph DB that uses Cypher) to the graph docs, and fixing a typo
 - **Issue:** docs update
