### PR TITLE
community: Add `top_k` parameter with default value 4 to enhance flexibility

### DIFF
--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -97,8 +97,15 @@ class BM25Retriever(BaseRetriever):
         )
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun,
+        k: Optional[int] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         processed_query = self.preprocess_func(query)
-        return_docs = self.vectorizer.get_top_n(processed_query, self.docs, n=self.k)
+        return_docs = self.vectorizer.get_top_n(
+            processed_query, self.docs, n=(k or self.k), **kwargs
+        )
         return return_docs

--- a/libs/community/tests/unit_tests/retrievers/test_bm25.py
+++ b/libs/community/tests/unit_tests/retrievers/test_bm25.py
@@ -52,7 +52,7 @@ def test_k() -> None:
         Document(page_content="Do you have a pen?"),
         Document(page_content="I have a bag."),
         Document(page_content="Do you have a dog?"),
-        Document(page_content="I have a cat.")
+        Document(page_content="I have a cat."),
     ]
     bm25_retriever = BM25Retriever.from_documents(documents=input_docs)
 

--- a/libs/community/tests/unit_tests/retrievers/test_bm25.py
+++ b/libs/community/tests/unit_tests/retrievers/test_bm25.py
@@ -43,3 +43,21 @@ def test_repr() -> None:
     ]
     bm25_retriever = BM25Retriever.from_documents(documents=input_docs)
     assert "I have a pen" not in repr(bm25_retriever)
+
+
+@pytest.mark.requires("rank_bm25")
+def test_k() -> None:
+    input_docs = [
+        Document(page_content="I have a pen."),
+        Document(page_content="Do you have a pen?"),
+        Document(page_content="I have a bag."),
+        Document(page_content="Do you have a dog?"),
+        Document(page_content="I have a cat.")
+    ]
+    bm25_retriever = BM25Retriever.from_documents(documents=input_docs)
+
+    documents = bm25_retriever.get_relevant_documents(query="I have a pen")
+    assert len(documents) == bm25_retriever.k
+
+    documents = bm25_retriever.get_relevant_documents(query="I have a pen", k=2)
+    assert len(documents) == 2


### PR DESCRIPTION
- [x] **PR message**: 
- [x] **Description**: The Retriever can use a different value than the one specified at creation time whenever desired.