### PR TITLE
elasticsearch: check for deployed models

### DIFF
--- a/libs/partners/elasticsearch/langchain_elasticsearch/_utilities.py
+++ b/libs/partners/elasticsearch/langchain_elasticsearch/_utilities.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Union
 
 import numpy as np
-from elasticsearch import Elasticsearch
+from elasticsearch import BadRequestError, ConflictError, Elasticsearch, NotFoundError
 from langchain_core import __version__ as langchain_version
 
 Matrix = Union[List[List[float]], List[np.ndarray], np.ndarray]
@@ -88,3 +88,21 @@ def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
             similarity = np.dot(X, Y.T) / np.outer(X_norm, Y_norm)
         similarity[np.isnan(similarity) | np.isinf(similarity)] = 0.0
         return similarity
+
+
+def check_if_model_deployed(client: Elasticsearch, model_id: str) -> None:
+    try:
+        dummy = {"x": "y"}
+        client.ml.infer_trained_model(model_id=model_id, docs=[dummy])
+    except NotFoundError as err:
+        raise err
+    except ConflictError as err:
+        raise NotFoundError(
+            f"model '{model_id}' not found, please deploy it first",
+            meta=err.meta,
+            body=err.body,
+        ) from err
+    except BadRequestError:
+        # This error is expected because we do not know the expected document
+        # shape and just use a dummy doc above.
+        pass

--- a/libs/partners/elasticsearch/tests/integration_tests/test_vectorstores.py
+++ b/libs/partners/elasticsearch/tests/integration_tests/test_vectorstores.py
@@ -40,7 +40,7 @@ Enable them by adding the model name to the modelsDeployed list below.
 """
 
 modelsDeployed: List[str] = [
-    # "elser",
+    # ".elser_model_1",
     # "sentence-transformers__all-minilm-l6-v2",
 ]
 
@@ -709,7 +709,7 @@ class TestElasticsearch:
         assert output == [Document(page_content="bar")]
 
     @pytest.mark.skipif(
-        "elser" not in modelsDeployed,
+        ".elser_model_1" not in modelsDeployed,
         reason="ELSER not deployed in ML Node, skipping test",
     )
     def test_similarity_search_with_sparse_infer_instack(


### PR DESCRIPTION
When creating a new index, if we use a retrieval strategy that expects a model to be deployed in Elasticsearch, check if a model with this name is indeed deployed before creating an index. This lowers the probability to get into a state in which an index was created with a faulty model ID, which cannot be overwritten any more (the index has to manually be deleted).
