### PR TITLE
langchain-mongodb: Return DeleteResult object on clear

### DIFF
--- a/libs/partners/mongodb/langchain_mongodb/cache.py
+++ b/libs/partners/mongodb/langchain_mongodb/cache.py
@@ -21,6 +21,7 @@ from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.database import Database
 from pymongo.driver_info import DriverInfo
+from pymongo.results import DeleteResult
 
 from langchain_mongodb.vectorstores import MongoDBAtlasVectorSearch
 
@@ -201,7 +202,7 @@ class MongoDBCache(BaseCache):
         """Create keyed fields for local caching layer"""
         return f"{prompt}#{llm_string}"
 
-    def clear(self, **kwargs: Any) -> None:
+    def clear(self, **kwargs: Any) -> DeleteResult:  # type: ignore
         """Clear cache that can take additional keyword arguments.
         Any additional arguments will propagate as filtration criteria for
         what gets deleted.
@@ -210,7 +211,7 @@ class MongoDBCache(BaseCache):
             # Delete only entries that have llm_string as "fake-model"
             self.clear(llm_string="fake-model")
         """
-        self.collection.delete_many({**kwargs})
+        return self.collection.delete_many({**kwargs})
 
 
 class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
@@ -299,7 +300,7 @@ class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
         """Create keyed fields for local caching layer"""
         return f"{prompt}#{llm_string}"
 
-    def clear(self, **kwargs: Any) -> None:
+    def clear(self, **kwargs: Any) -> DeleteResult:  # type: ignore
         """Clear cache that can take additional keyword arguments.
         Any additional arguments will propagate as filtration criteria for
         what gets deleted. It will delete any locally cached content regardless
@@ -308,5 +309,4 @@ class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
             # Delete only entries that have llm_string as "fake-model"
             self.clear(llm_string="fake-model")
         """
-        self.collection.delete_many({**kwargs})
-        self._local_cache.clear()
+        return self.collection.delete_many({**kwargs})

--- a/libs/partners/mongodb/langchain_mongodb/cache.py
+++ b/libs/partners/mongodb/langchain_mongodb/cache.py
@@ -300,7 +300,18 @@ class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
         """Create keyed fields for local caching layer"""
         return f"{prompt}#{llm_string}"
 
-    def clear(self, **kwargs: Any) -> DeleteResult:  # type: ignore
+    def clear(self, **kwargs: Any) -> None:  # type: ignore
+        """Clear cache that can take additional keyword arguments.
+        Any additional arguments will propagate as filtration criteria for
+        what gets deleted. It will delete any locally cached content regardless
+
+        E.g.
+            # Delete only entries that have llm_string as "fake-model"
+            self.clear(llm_string="fake-model")
+        """
+        self.clear_and_return(**kwargs)
+
+    def clear_and_return(self, **kwargs: Any) -> DeleteResult:  # type: ignore
         """Clear cache that can take additional keyword arguments.
         Any additional arguments will propagate as filtration criteria for
         what gets deleted. It will delete any locally cached content regardless


### PR DESCRIPTION
## Description
MongoDB `delete_many` returns a `DeleteResult`. We'll override the `clear` function to provide the `DeleteResult` as a function response.

- [x] **Add tests and docs**: Passes current tests


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/