### PR TITLE
core: fix PydanticOutputParser typing in LCEL chains

### DIFF
--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -4,7 +4,8 @@ from typing import Generic, List, Type, TypeVar, Union
 import pydantic  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers.json import JsonOutputParser
+from langchain_core.output_parsers.transform import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import Generation
 from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
 
@@ -20,7 +21,7 @@ else:
 TBaseModel = TypeVar("TBaseModel", bound=PydanticBaseModel)
 
 
-class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
+class PydanticOutputParser(BaseCumulativeTransformOutputParser[TBaseModel]):
     """Parse an output using a pydantic model."""
 
     pydantic_object: Type[TBaseModel]  # type: ignore
@@ -61,7 +62,7 @@ class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
         return self._parse_obj(json_object)
 
     def parse(self, text: str) -> TBaseModel:
-        return super().parse(text)
+        return self.parse_result([Generation(text=text)])
 
     def get_format_instructions(self) -> str:
         # Copy schema to avoid altering original Pydantic schema.

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,5 +1,5 @@
 import json
-from typing import Generic, List, Type, TypeVar, Union
+from typing import List, Type, TypeVar, Union
 
 import pydantic  # pydantic: ignore
 
@@ -60,12 +60,7 @@ class PydanticOutputParser(BaseCumulativeTransformOutputParser[TBaseModel]):
     ) -> TBaseModel:
         json_parser = JsonOutputParser()
         json_object = json_parser.parse_result(result)
-        try:
-            return self._parse_obj(json_object)
-        except ValidationError as e:
-            name = self.pydantic_object.__name__
-            msg = f"Failed to parse {name} from completion {json_object}. Got: {e}"
-            raise OutputParserException(msg, llm_output=json.dumps(json_object))
+        return self._parse_obj(json_object)
 
     def parse(self, text: str) -> TBaseModel:
         return self.parse_result([Generation(text=text)])


### PR DESCRIPTION
By subclassing the `JsonOutputParser`, the `PydanticOutputParser` wasn't propagating the typing information from #18740 to the `BaseOutputParser`. This change removes `JsonOutputParser` as a subclass and instead directly subclasses `BaseCumulativeTransformOutputParser` so we get the correct typing when using LCEL.

Before:

<img width="527" alt="Screenshot 2024-03-12 at 4 34 23 PM" src="https://github.com/langchain-ai/langchain/assets/22690160/2c267480-dc53-4fb8-9364-dca4572908d4">

After:

<img width="533" alt="Screenshot 2024-03-12 at 4 35 41 PM" src="https://github.com/langchain-ai/langchain/assets/22690160/c34d9c19-0318-4ddf-b4a4-832178e9dae9">
