### PR TITLE
docs: update stale links in Together AI documentation

### DIFF
--- a/cookbook/together_ai.ipynb
+++ b/cookbook/together_ai.ipynb
@@ -9,7 +9,7 @@
     " \n",
     "[Together AI](https://python.langchain.com/docs/integrations/llms/together) has a broad set of OSS LLMs via inference API.\n",
     "\n",
-    "See [here](https://api.together.xyz/playground). We use `\"mistralai/Mixtral-8x7B-Instruct-v0.1` for RAG on the Mixtral paper.\n",
+    "See [here](https://docs.together.ai/docs/inference-models). We use `\"mistralai/Mixtral-8x7B-Instruct-v0.1` for RAG on the Mixtral paper.\n",
     "\n",
     "Download the paper:\n",
     "https://arxiv.org/pdf/2401.04088.pdf"
@@ -148,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/llms/together.ipynb
+++ b/docs/docs/integrations/llms/together.ipynb
@@ -13,7 +13,7 @@
     "https://api.together.xyz/settings/api-keys. This can be passed in as init param\n",
     "``together_api_key`` or set as environment variable ``TOGETHER_API_KEY``.\n",
     "\n",
-    "Together API reference: https://docs.together.ai/reference/inference"
+    "Together API reference: https://docs.together.ai/reference"
    ]
   },
   {

--- a/docs/docs/integrations/providers/together.ipynb
+++ b/docs/docs/integrations/providers/together.ipynb
@@ -12,7 +12,7 @@
     "https://api.together.xyz/settings/api-keys. This can be passed in as init param\n",
     "``together_api_key`` or set as environment variable ``TOGETHER_API_KEY``.\n",
     "\n",
-    "Together API reference: https://docs.together.ai/reference/inference\n",
+    "Together API reference: https://docs.together.ai/reference\n",
     "\n",
     "You will also need to install the `langchain-together` integration package:"
    ]


### PR DESCRIPTION
**Description:** Update stales link in Together AI documentation
**Issue:** Some links pointed to legacy webpages on the Together AI website
**Dependencies:** None
**Lint and test**: `make format`, `make lint` were run
