### PR TITLE
community[patch]: Fix NotionDBLoader 400 Error by conditionally adding filter parameter

### DIFF
--- a/libs/community/langchain_community/document_loaders/notiondb.py
+++ b/libs/community/langchain_community/document_loaders/notiondb.py
@@ -207,11 +207,14 @@ class NotionDBLoader(BaseLoader):
         *,
         filter_object: Optional[Dict[str, Any]] = None,
     ) -> Any:
+        json_payload = query_dict.copy()
+        if filter_object:
+            json_payload["filter"] = filter_object
         res = requests.request(
             method,
             url,
             headers=self.headers,
-            json={**query_dict, "filter": filter_object or {}},
+            json=json_payload,
             timeout=self.request_timeout_sec,
         )
         res.raise_for_status()


### PR DESCRIPTION
- **Description:** This change fixes a bug where attempts to load data from Notion using the NotionDBLoader resulted in a 400 Bad Request error. The issue was traced to the unconditional addition of an empty 'filter' object in the request payload, which Notion's API does not accept. The modification ensures that the 'filter' object is only included in the payload when it is explicitly provided and not empty, thus preventing the 400 error from occurring.
- **Issue:** Fixes [#18009](https://github.com/langchain-ai/langchain/issues/18009)
- **Dependencies:** None
- **Twitter handle:** @gunnzolder

