### PR TITLE
[langchain] fix OpenAIAssistantRunnable.create_assistant

### DIFF
--- a/libs/langchain/langchain/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain/agents/openai_assistant/base.py
@@ -89,7 +89,7 @@ def _get_openai_async_client() -> openai.AsyncOpenAI:
 
 def _is_assistants_builtin_tool(
     tool: Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool],
-) -> Dict[str, Any]:
+) -> bool:
     """Determine if tool corresponds to OpenAI Assistants built-in."""
     assistants_builtin_tools = ("code_interpreter", "retrieval")
     return (
@@ -108,7 +108,7 @@ def _get_assistants_tool(
     such as "code_interpreter" and "retrieval."
     """
     if _is_assistants_builtin_tool(tool):
-        return tool
+        return tool  # type: ignore
     else:
         return convert_to_openai_tool(tool)
 

--- a/libs/langchain/langchain/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain/agents/openai_assistant/base.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 import json
 from json import JSONDecodeError
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.callbacks import CallbackManager
@@ -77,8 +88,8 @@ def _get_openai_async_client() -> openai.AsyncOpenAI:
 
 
 def _get_assistants_tool(
-        tool: Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool],
-    ) -> Dict[str, Any]:
+    tool: Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool],
+) -> Dict[str, Any]:
     """Convert a raw function/class to an OpenAI tool.
 
     Note that OpenAI assistants supports several built-in tools,

--- a/libs/langchain/langchain/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain/agents/openai_assistant/base.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import json
 from json import JSONDecodeError
 from time import sleep
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.callbacks import CallbackManager
 from langchain_core.load import dumpd
-from langchain_core.pydantic_v1 import Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.runnables import RunnableConfig, RunnableSerializable, ensure_config
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
@@ -74,6 +74,20 @@ def _get_openai_async_client() -> openai.AsyncOpenAI:
             "Please make sure you are using a v1.1-compatible version of openai. You "
             'can install with `pip install "openai>=1.1"`.'
         ) from e
+
+
+def _get_assistants_tool(
+        tool: Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool],
+    ) -> Dict[str, Any]:
+    """Convert a raw function/class to an OpenAI tool.
+
+    Note that OpenAI assistants supports several built-in tools,
+    such as "code_interpreter" and "retrieval."
+    """
+    if isinstance(tool, dict) and "type" in tool:
+        return tool
+    else:
+        return convert_to_openai_tool(tool)
 
 
 OutputType = Union[
@@ -210,7 +224,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[Dict, OutputType]):
         assistant = client.beta.assistants.create(
             name=name,
             instructions=instructions,
-            tools=[convert_to_openai_tool(tool) for tool in tools],  # type: ignore
+            tools=[_get_assistants_tool(tool) for tool in tools],  # type: ignore
             model=model,
         )
         return cls(assistant_id=assistant.id, client=client, **kwargs)

--- a/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
+++ b/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
@@ -1,6 +1,15 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from langchain.agents.openai_assistant import OpenAIAssistantRunnable
+
+
+def _create_mock_client(*args, **kwargs) -> Any:
+    client = MagicMock()
+    client.beta.assistants.create().id = "abc123"
+    return client
 
 
 @pytest.mark.requires("openai")
@@ -19,3 +28,18 @@ def test_user_supplied_client() -> None:
     )
 
     assert assistant.client == client
+
+
+@patch(
+    "langchain.agents.openai_assistant.base._get_openai_client",
+    new=_create_mock_client,
+)
+def test_create_assistant() -> None:
+
+    assistant = OpenAIAssistantRunnable.create_assistant(
+        name="name",
+        instructions="instructions",
+        tools=[{"type": "code_interpreter"}],
+        model="",
+    )
+    assert isinstance(assistant, OpenAIAssistantRunnable)

--- a/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
+++ b/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
@@ -1,7 +1,7 @@
+from functools import partial
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from functools import partial
 import pytest
 
 from langchain.agents.openai_assistant import OpenAIAssistantRunnable
@@ -11,7 +11,7 @@ def _create_mock_client(*args: Any, use_async: bool = False, **kwargs: Any) -> A
     client = AsyncMock() if use_async else MagicMock()
     mock_assistant = MagicMock()
     mock_assistant.id = "abc123"
-    client.beta.assistants.create.return_value = mock_assistant
+    client.beta.assistants.create.return_value = mock_assistant  # type: ignore
     return client
 
 

--- a/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
+++ b/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
@@ -35,7 +35,6 @@ def test_user_supplied_client() -> None:
     new=_create_mock_client,
 )
 def test_create_assistant() -> None:
-
     assistant = OpenAIAssistantRunnable.create_assistant(
         name="name",
         instructions="instructions",

--- a/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
+++ b/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
@@ -6,7 +6,7 @@ import pytest
 from langchain.agents.openai_assistant import OpenAIAssistantRunnable
 
 
-def _create_mock_client(*args, **kwargs) -> Any:
+def _create_mock_client(*args: Any, **kwargs: Any) -> Any:
     client = MagicMock()
     client.beta.assistants.create().id = "abc123"
     return client

--- a/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
+++ b/libs/langchain/tests/unit_tests/agents/test_openai_assistant.py
@@ -30,6 +30,7 @@ def test_user_supplied_client() -> None:
     assert assistant.client == client
 
 
+@pytest.mark.requires("openai")
 @patch(
     "langchain.agents.openai_assistant.base._get_openai_client",
     new=_create_mock_client,


### PR DESCRIPTION
- **Description:** OpenAI assistants support some pre-built tools (e.g., `"retrieval"` and `"code_interpreter"`) and expect these as `{"type": "code_interpreter"}`. This may have been upset by https://github.com/langchain-ai/langchain/pull/18935
- **Issue:** https://github.com/langchain-ai/langchain/issues/19057