### PR TITLE
docs: fix API link for BaseLoader

### DIFF
--- a/docs/docs/use_cases/question_answering/quickstart.mdx
+++ b/docs/docs/use_cases/question_answering/quickstart.mdx
@@ -253,7 +253,7 @@ In
 Detailed documentation on how to use `DocumentLoaders`. 
 - [Integrations](../../../docs/integrations/document_loaders/): 160+
 integrations to choose from. 
-- [Interface](https://api.python.langchain.com/en/latest/document_loaders/langchain_community.document_loaders.base.BaseLoader.html):
+- [Interface](https://api.python.langchain.com/en/latest/document_loaders/langchain_core.document_loaders.base.BaseLoader.html):
 API reference  for the base interface.
 
 ## 2. Indexing: Split {#indexing-split}


### PR DESCRIPTION
The link to the BaseLoader API requires an update as it has been moved into the `langchain_core` package.