### PR TITLE
Fix source column xata.ipynb

### DIFF
--- a/docs/docs/integrations/vectorstores/xata.ipynb
+++ b/docs/docs/integrations/vectorstores/xata.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "* `content` of type \"Text\". This is used to store the `Document.pageContent` values.\n",
     "* `embedding` of type \"Vector\". Use the dimension used by the model you plan to use. In this notebook we use OpenAI embeddings, which have 1536 dimensions.\n",
-    "* `search` of type \"Text\". This is used as a metadata column by this example.\n",
+    "* `source` of type \"Text\". This is used as a metadata column by this example.\n",
     "* any other columns you want to use as metadata. They are populated from the `Document.metadata` object. For example, if in the `Document.metadata` object you have a `title` property, you can create a `title` column in the table and it will be populated.\n"
    ]
   },


### PR DESCRIPTION
Docs fix: replace column name search with source.

The Xata integration expects metadata column named "source".

The docs suggest the name "search", which if used, yields the following error:

```
File "/usr/local/lib/python3.11/site-packages/langchain_community/vectorstores/xata.py", line 95, in _add_vectors
    raise Exception(f"Error adding vectors to Xata: {r.status_code} {r}")
Exception: Error adding vectors to Xata: 400 {'errors': [{'status': 400, 'message': 'invalid record: column [source]: column not found'}]}
```