### PR TITLE
community: Fix import path for StreamingStdOutCallbackHandler example

### DIFF
--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -46,9 +46,9 @@ class HuggingFaceEndpoint(LLM):
             print(llm("What is Deep Learning?"))
 
             # Streaming response example
-            from langchain_community.callbacks import streaming_stdout
+            from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
-            callbacks = [streaming_stdout.StreamingStdOutCallbackHandler()]
+            callbacks = [StreamingStdOutCallbackHandler()]
             llm = HuggingFaceEndpoint(
                 endpoint_url="http://localhost:8010/",
                 max_new_tokens=512,

--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -63,7 +63,7 @@ class HuggingFaceEndpoint(LLM):
             )
             print(llm("What is Deep Learning?"))
 
-    """
+    """  # noqa: E501
 
     endpoint_url: Optional[str] = None
     """Endpoint URL to use."""


### PR DESCRIPTION
- Description:
  - Updated the import path for `StreamingStdOutCallbackHandler` in the streaming response example within `huggingface_endpoint.py`. This change corrects the import statement to reflect the actual location of `StreamingStdOutCallbackHandler` in `langchain_core.callbacks.streaming_stdout`.
- Issue:
  - None
- Dependencies:
  - No additional dependencies are required for this change.
- Twitter handle:
  - None

## Note:
I have tested this change locally and confirmed that the `StreamingStdOutCallbackHandler` works as expected with the updated import path. This PR does not require the addition of new tests since it is a correction to documentation/examples rather than functional code.
