### PR TITLE
community: Add support for translation in HuggingFacePipeline

### DIFF
--- a/libs/community/langchain_community/llms/huggingface_pipeline.py
+++ b/libs/community/langchain_community/llms/huggingface_pipeline.py
@@ -11,7 +11,12 @@ from langchain_core.pydantic_v1 import Extra
 
 DEFAULT_MODEL_ID = "gpt2"
 DEFAULT_TASK = "text-generation"
-VALID_TASKS = ("text2text-generation", "text-generation", "summarization")
+VALID_TASKS = (
+    "text2text-generation",
+    "text-generation",
+    "summarization",
+    "translation",
+)
 DEFAULT_BATCH_SIZE = 4
 
 logger = logging.getLogger(__name__)
@@ -121,7 +126,7 @@ class HuggingFacePipeline(BaseLLM):
                     model = AutoModelForCausalLM.from_pretrained(
                         model_id, **_model_kwargs
                     )
-            elif task in ("text2text-generation", "summarization"):
+            elif task in ("text2text-generation", "summarization", "translation"):
                 if backend == "openvino":
                     try:
                         from optimum.intel.openvino import OVModelForSeq2SeqLM
@@ -260,8 +265,6 @@ class HuggingFacePipeline(BaseLLM):
             # Process batch of prompts
             responses = self.pipeline(
                 batch_prompts,
-                stop_sequence=stop,
-                return_full_text=False,
                 **pipeline_kwargs,
             )
 
@@ -277,6 +280,8 @@ class HuggingFacePipeline(BaseLLM):
                     text = response["generated_text"]
                 elif self.pipeline.task == "summarization":
                     text = response["summary_text"]
+                elif self.pipeline.task in "translation":
+                    text = response["translation_text"]
                 else:
                     raise ValueError(
                         f"Got invalid task {self.pipeline.task}, "

--- a/libs/core/langchain_core/runnables/router.py
+++ b/libs/core/langchain_core/runnables/router.py
@@ -49,6 +49,19 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
     """
     Runnable that routes to a set of Runnables based on Input['key'].
     Returns the output of the selected Runnable.
+
+    For example,
+
+    .. code-block:: python
+
+        from langchain_core.runnables.router import RouterRunnable
+        from langchain_core.runnables import RunnableLambda
+
+        add = RunnableLambda(func=lambda x: x + 1)
+        square = RunnableLambda(func=lambda x: x**2)
+
+        router = RouterRunnable(runnables={"add": add, "square": square})
+        router.invoke({"key": "square", "input": 3})
     """
 
     runnables: Mapping[str, Runnable[Any, Output]]


### PR DESCRIPTION
- [x] **Support for translation**: "community: Add support for translation in `HuggingFacePipeline`"

- [x] **Add support for translation in `HuggingFacePipeline**:
    - **Description:** Added support for translation in `HuggingFacePipeline`, which earlier only support text generation and summarization.
    - **Issue:** N/A
    - **Dependencies:** N/A
    - **Twitter handle:** None


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/