### PR TITLE
docs: Remove duplicated line in Get Started section

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -563,7 +563,6 @@ from langchain_community.vectorstores import FAISS
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain.tools.retriever import create_retriever_tool
 from langchain_community.tools.tavily_search import TavilySearchResults
-from langchain_openai import ChatOpenAI
 from langchain import hub
 from langchain.agents import create_openai_functions_agent
 from langchain.agents import AgentExecutor


### PR DESCRIPTION
Line `from langchain_openai import ChatOpenAI` is put twice in Get Started / Serving with LangServe section.
Imports on lines 559 and 566 are identical