### PR TITLE
core: Add docs for RouterRunnable

### DIFF
--- a/libs/core/langchain_core/runnables/router.py
+++ b/libs/core/langchain_core/runnables/router.py
@@ -49,6 +49,19 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
     """
     Runnable that routes to a set of Runnables based on Input['key'].
     Returns the output of the selected Runnable.
+
+    For example,
+
+    .. code-block:: python
+
+        from langchain_core.runnables.router import RouterRunnable
+        from langchain_core.runnables import RunnableLambda
+
+        add = RunnableLambda(func=lambda x: x + 1)
+        square = RunnableLambda(func=lambda x: x**2)
+
+        router = RouterRunnable(runnables={"add": add, "square": square})
+        router.invoke({"key": "square", "input": 3})
     """
 
     runnables: Mapping[str, Runnable[Any, Output]]


### PR DESCRIPTION
- [x] **Docs for `RouterRunnable`**: core: Add docs for `RouterRunnable`

- [x] **Add docs for `RouterRunnable`**:
    - **Description:** Add docs for `RouterRunnable`, which was previously missing documentation
    - **Issue:** #18803 
    - **Dependencies:** N/A
    - **Twitter handle:** None