### PR TITLE
langchain: creating assistants with file_ids

### DIFF
--- a/libs/langchain/langchain/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain/agents/openai_assistant/base.py
@@ -212,6 +212,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[Dict, OutputType]):
             instructions=instructions,
             tools=[convert_to_openai_tool(tool) for tool in tools],  # type: ignore
             model=model,
+            file_ids=kwargs.get("file_ids"),
         )
         return cls(assistant_id=assistant.id, client=client, **kwargs)
 
@@ -333,6 +334,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[Dict, OutputType]):
             instructions=instructions,
             tools=openai_tools,  # type: ignore
             model=model,
+            file_ids=kwargs.get("file_ids"),
         )
         return cls(assistant_id=assistant.id, async_client=async_client, **kwargs)
 


### PR DESCRIPTION
Changing OpenAIAssistantRunnable.create_assistant to send the `file_ids` parameter to openai.beta.assistants.create