### PR TITLE
community: added support for handling parsing errors in SQL agent

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/sql/base.py
+++ b/libs/community/langchain_community/agent_toolkits/sql/base.py
@@ -61,6 +61,7 @@ def create_sql_agent(
     *,
     db: Optional[SQLDatabase] = None,
     prompt: Optional[BasePromptTemplate] = None,
+    handle_parsing_errors : bool = False,
     **kwargs: Any,
 ) -> AgentExecutor:
     """Construct a SQL agent from an LLM and toolkit or database.
@@ -93,6 +94,10 @@ def create_sql_agent(
             using 'db' and 'llm'. Must provide exactly one of 'db' or 'toolkit'.
         prompt: Complete agent prompt. prompt and {prefix, suffix, format_instructions,
             input_variables} are mutually exclusive.
+        handle_parsing_errors: Occasionally the LLM cannot determine what step to take
+            because its outputs are not correctly formatted to be handled by the output
+            parser. In this case, by default the agent errors.
+            You can set handle_parsing_errors to True to handle such parsing errors.
         **kwargs: DEPRECATED. Not used, kept for backwards compatibility.
 
     Returns:
@@ -228,5 +233,6 @@ def create_sql_agent(
         max_iterations=max_iterations,
         max_execution_time=max_execution_time,
         early_stopping_method=early_stopping_method,
+        handle_parsing_errors=handle_parsing_errors,
         **(agent_executor_kwargs or {}),
     )


### PR DESCRIPTION
**Added error handling for LLM output parsing errors**

This commit introduces the ability to handle errors when the output from the Language Learning Model (LLM) is not in the expected format for the output parser. Developers can now use the `handle_parsing_errors` parameter when creating an SQL agent to enable this feature. This parameter is optional and defaults to `False` to ensure backward compatibility with existing functionality.

Example usage:
agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True, **handle_parsing_errors=True**)

Dependencies: None