### PR TITLE
text-splitters, infra: fix `libs/langchain/dev.Dockerfile` so that the `text-splitter` directory is copied before poetry installation

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -46,5 +46,8 @@ COPY libs/core ../core
 # Copy the community library for installation
 COPY libs/community/ ../community/
 
+# Copy the text-splitters library for installation
+COPY libs/text-splitters/ ../text-splitters/
+
 # Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)
 RUN poetry install --no-interaction --no-ansi --with dev,test,docs


### PR DESCRIPTION
## Description
This PR modifies the settings in `libs/langchain/dev.Dockerfile` to ensure that the `text-splitters` directory is copied before the poetry installation process begins.

Without this modification, the `docker build` command fails for `dev.Dockerfile`, preventing the setup of some development environments, including `.devcontainer`.

## Bug Details

### Repro
Run the following command:

```bash
docker build -f libs/langchain/dev.Dockerfile .
```

### Current Behavior
The docker build command fails, raising the following error:

```
...
 => [langchain-dev-dependencies 4/5] COPY libs/community/ ../community/                                                                                0.4s
 => ERROR [langchain-dev-dependencies 5/5] RUN poetry install --no-interaction --no-ansi --with dev,test,docs                                          1.1s
------                                                                                                                                                      
 > [langchain-dev-dependencies 5/5] RUN poetry install --no-interaction --no-ansi --with dev,test,docs:
#13 0.970 
#13 0.970 Directory ../text-splitters does not exist
------
executor failed running [/bin/sh -c poetry install --no-interaction --no-ansi --with dev,test,docs]: exit code: 1
```

### Expected Behavior
The `docker build` command successfully completes without the poetry error.

### Analysis
The error occurs because the `text-splitters` directory is not copied into the build environment, unlike the other packages under the `libs` directory. I suspect that the `COPY` setting was overlooked since `text-splitters` was separated in a recent PR.

## Fix
Add the following lines to the `libs/langchain/dev.Dockerfile`:

```dockerfile
# Copy the text-splitters library for installation
COPY libs/text-splitters/ ../text-splitters/
```