### PR TITLE
deprecate community docugami loader

### DIFF
--- a/docs/docs/integrations/document_loaders/docugami.ipynb
+++ b/docs/docs/integrations/document_loaders/docugami.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "# You need the dgml-utils package to use the DocugamiLoader (run pip install directly without \"poetry run\" if you are not using poetry)\n",
-    "!poetry run pip install dgml-utils==0.3.0 --upgrade --quiet"
+    "!poetry run pip install docugami-langchain dgml-utils==0.3.0 --upgrade --quiet"
    ]
   },
   {
@@ -56,7 +56,7 @@
    "source": [
     "import os\n",
     "\n",
-    "from langchain_community.document_loaders import DocugamiLoader"
+    "from docugami_langchain.document_loaders import DocugamiLoader"
    ]
   },
   {
@@ -470,7 +470,7 @@
    "source": [
     "from typing import Dict, List\n",
     "\n",
-    "from langchain_community.document_loaders import DocugamiLoader\n",
+    "from docugami_langchain.document_loaders import DocugamiLoader\n",
     "from langchain_core.documents import Document\n",
     "\n",
     "loader = DocugamiLoader(docset_id=\"zo954yqy53wp\")\n",
@@ -655,7 +655,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/providers/docugami.mdx
+++ b/docs/docs/integrations/providers/docugami.mdx
@@ -9,6 +9,7 @@
 
 ```bash
 pip install dgml-utils
+pip install docugami-langchain
 ```
 
 ## Document Loader
@@ -16,5 +17,5 @@ pip install dgml-utils
 See a [usage example](/docs/integrations/document_loaders/docugami).
 
 ```python
-from langchain_community.document_loaders import DocugamiLoader
+from docugami_langchain.document_loaders import DocugamiLoader
 ```

--- a/libs/community/langchain_community/document_loaders/docugami.py
+++ b/libs/community/langchain_community/document_loaders/docugami.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import requests
+from langchain_core._api.deprecation import deprecated
 from langchain_core.documents import Document
 from langchain_core.pydantic_v1 import BaseModel, root_validator
 
@@ -25,7 +26,11 @@ DEFAULT_API_ENDPOINT = "https://api.docugami.com/v1preview1"
 
 logger = logging.getLogger(__name__)
 
-
+@deprecated(
+    since="0.0.24",
+    removal="0.2.0",
+    alternative_import="docugami_langchain.DocugamiLoader",
+)
 class DocugamiLoader(BaseLoader, BaseModel):
     """Load from `Docugami`.
 

--- a/libs/community/langchain_community/document_loaders/docugami.py
+++ b/libs/community/langchain_community/document_loaders/docugami.py
@@ -26,6 +26,7 @@ DEFAULT_API_ENDPOINT = "https://api.docugami.com/v1preview1"
 
 logger = logging.getLogger(__name__)
 
+
 @deprecated(
     since="0.0.24",
     removal="0.2.0",

--- a/libs/community/tests/unit_tests/document_loaders/loaders/vendors/test_docugami.py
+++ b/libs/community/tests/unit_tests/document_loaders/loaders/vendors/test_docugami.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from langchain_community.document_loaders import DocugamiLoader
-
+from docugami_langchain.document_loaders import DocugamiLoader
 DOCUGAMI_XML_PATH = Path(__file__).parent / "test_data" / "docugami-example.xml"
 
 

--- a/libs/community/tests/unit_tests/document_loaders/loaders/vendors/test_docugami.py
+++ b/libs/community/tests/unit_tests/document_loaders/loaders/vendors/test_docugami.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pytest
 
-from docugami_langchain.document_loaders import DocugamiLoader
+from langchain_community.document_loaders import DocugamiLoader
+
 DOCUGAMI_XML_PATH = Path(__file__).parent / "test_data" / "docugami-example.xml"
 
 


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "community: deprecate DocugamiLoader"

- [x] **PR message**: Deprecate the langchain_community and use the docugami_langchain DocugamiLoader