### PR TITLE
core: Rename parameter signature in BaseOutputParser.parse_with_prompt method

### DIFF
--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -259,8 +259,7 @@ class BaseOutputParser(
         """
         return await run_in_executor(None, self.parse, text)
 
-    # TODO: rename 'completion' -> 'text'.
-    def parse_with_prompt(self, completion: str, prompt: PromptValue) -> Any:
+    def parse_with_prompt(self, text: str, prompt_value: PromptValue) -> Any:
         """Parse the output of an LLM call with the input prompt for context.
 
         The prompt is largely provided in the event the OutputParser wants
@@ -268,13 +267,13 @@ class BaseOutputParser(
         the prompt to do so.
 
         Args:
-            completion: String output of a language model.
-            prompt: Input PromptValue.
+            text: String output of a language model.
+            prompt_value: Input PromptValue.
 
         Returns:
             Structured output
         """
-        return self.parse(completion)
+        return self.parse(text)
 
     def get_format_instructions(self) -> str:
         """Instructions on how the LLM output should be formatted."""

--- a/libs/langchain/langchain/output_parsers/fix.py
+++ b/libs/langchain/langchain/output_parsers/fix.py
@@ -51,7 +51,8 @@ class OutputFixingParser(BaseOutputParser[T]):
         chain = LLMChain(llm=llm, prompt=prompt)
         return cls(parser=parser, retry_chain=chain, max_retries=max_retries)
 
-    def parse(self, completion: str) -> T:
+    def parse(self, text: str) -> T:
+        completion = text
         retries = 0
 
         while retries <= self.max_retries:
@@ -68,9 +69,10 @@ class OutputFixingParser(BaseOutputParser[T]):
                         error=repr(e),
                     )
 
-        raise OutputParserException("Failed to parse")
+        raise OutputParserException(f"Failed to parse {text}", llm_output=text)
 
-    async def aparse(self, completion: str) -> T:
+    async def aparse(self, text: str) -> T:
+        completion = text
         retries = 0
 
         while retries <= self.max_retries:
@@ -87,7 +89,7 @@ class OutputFixingParser(BaseOutputParser[T]):
                         error=repr(e),
                     )
 
-        raise OutputParserException("Failed to parse")
+        raise OutputParserException(f"Failed to parse {text}", llm_output=text)
 
     def get_format_instructions(self) -> str:
         return self.parser.get_format_instructions()

--- a/libs/langchain/langchain/output_parsers/retry.py
+++ b/libs/langchain/langchain/output_parsers/retry.py
@@ -72,16 +72,17 @@ class RetryOutputParser(BaseOutputParser[T]):
         chain = LLMChain(llm=llm, prompt=prompt)
         return cls(parser=parser, retry_chain=chain, max_retries=max_retries)
 
-    def parse_with_prompt(self, completion: str, prompt_value: PromptValue) -> T:
+    def parse_with_prompt(self, text: str, prompt_value: PromptValue) -> T:
         """Parse the output of an LLM call using a wrapped parser.
 
         Args:
-            completion: The chain completion to parse.
+            text: The chain completion to parse.
             prompt_value: The prompt to use to parse the completion.
 
         Returns:
             The parsed completion.
         """
+        completion = text
         retries = 0
 
         while retries <= self.max_retries:
@@ -96,18 +97,19 @@ class RetryOutputParser(BaseOutputParser[T]):
                         prompt=prompt_value.to_string(), completion=completion
                     )
 
-        raise OutputParserException("Failed to parse")
+        raise OutputParserException(f"Failed to parse {text}", llm_output=text)
 
-    async def aparse_with_prompt(self, completion: str, prompt_value: PromptValue) -> T:
+    async def aparse_with_prompt(self, text: str, prompt_value: PromptValue) -> T:
         """Parse the output of an LLM call using a wrapped parser.
 
         Args:
-            completion: The chain completion to parse.
+            text: The chain completion to parse.
             prompt_value: The prompt to use to parse the completion.
 
         Returns:
             The parsed completion.
         """
+        completion = text
         retries = 0
 
         while retries <= self.max_retries:
@@ -122,9 +124,9 @@ class RetryOutputParser(BaseOutputParser[T]):
                         prompt=prompt_value.to_string(), completion=completion
                     )
 
-        raise OutputParserException("Failed to parse")
+        raise OutputParserException(f"Failed to parse {text}", llm_output=text)
 
-    def parse(self, completion: str) -> T:
+    def parse(self, text: str) -> T:
         raise NotImplementedError(
             "This OutputParser can only be called by the `parse_with_prompt` method."
         )
@@ -179,7 +181,8 @@ class RetryWithErrorOutputParser(BaseOutputParser[T]):
         chain = LLMChain(llm=llm, prompt=prompt)
         return cls(parser=parser, retry_chain=chain, max_retries=max_retries)
 
-    def parse_with_prompt(self, completion: str, prompt_value: PromptValue) -> T:
+    def parse_with_prompt(self, text: str, prompt_value: PromptValue) -> T:
+        completion = text
         retries = 0
 
         while retries <= self.max_retries:
@@ -196,9 +199,10 @@ class RetryWithErrorOutputParser(BaseOutputParser[T]):
                         error=repr(e),
                     )
 
-        raise OutputParserException("Failed to parse")
+        raise OutputParserException(f"Failed to parse {text}", llm_output=text)
 
-    async def aparse_with_prompt(self, completion: str, prompt_value: PromptValue) -> T:
+    async def aparse_with_prompt(self, text: str, prompt_value: PromptValue) -> T:
+        completion = text
         retries = 0
 
         while retries <= self.max_retries:
@@ -215,9 +219,9 @@ class RetryWithErrorOutputParser(BaseOutputParser[T]):
                         error=repr(e),
                     )
 
-        raise OutputParserException("Failed to parse")
+        raise OutputParserException(f"Failed to parse {text}", llm_output=text)
 
-    def parse(self, completion: str) -> T:
+    def parse(self, text: str) -> T:
         raise NotImplementedError(
             "This OutputParser can only be called by the `parse_with_prompt` method."
         )


### PR DESCRIPTION
### Description 

I've renamed the parameter signature of OutputParsers, which use llm for fixing on completions, to follow a consistent format `(text: str, prompt_value: PromptValue)`

It's anticipated that the `BaseOutputParser.parse_with_prompt` method will have minimal side-effects, as it's only overridden by `RetryOutputParser` and `RetryWithErrorOutputParser` in `output_parsers/retry.py`.

- AS-IS:
```python
# libs/core/langchain_core/output_parsers/base.py

    # TODO: rename 'completion' -> 'text'.
    def parse_with_prompt(self, completion: str, prompt: PromptValue) -> Any:
```
- TO-BE: 

```python
# libs/core/langchain_core/output_parsers/base.py

    def parse_with_prompt(self, text: str, prompt_value: PromptValue) -> Any:
```
```python
# libs/langchain/langchain/output_parsers/fix.py

    def parse(self, text: str) -> T:
        completion = text
        retries = 0

        while retries <= self.max_retries:
        # ...
```

```python
# libs/langchain/langchain/output_parsers/retry.py

    def parse_with_prompt(self, text: str, prompt_value: PromptValue) -> T:
        completion = text
        retries = 0

        while retries <= self.max_retries:
        # ...

```