### PR TITLE
langchain-mongodb: Added scoring threshold to caching

### DIFF
--- a/libs/partners/mongodb/pyproject.toml
+++ b/libs/partners/mongodb/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-mongodb"
-version = "0.1.2"
+version = "0.1.3"
 description = "An integration package connecting MongoDB and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/partners/mongodb/tests/integration_tests/test_cache.py
+++ b/libs/partners/mongodb/tests/integration_tests/test_cache.py
@@ -30,6 +30,7 @@ def llm_cache(cls: Any) -> BaseCache:
             collection_name=COLLECTION,
             database_name=DATABASE,
             index_name=INDEX_NAME,
+            score_threshold=0.5,
             wait_until_ready=True,
         )
     )
@@ -92,13 +93,17 @@ def _execute_test(
     ],
 )
 @pytest.mark.parametrize("cacher", [MongoDBCache, MongoDBAtlasSemanticCache])
+@pytest.mark.parametrize("remove_score", [True, False])
 def test_mongodb_cache(
+    remove_score: bool,
     cacher: Union[MongoDBCache, MongoDBAtlasSemanticCache],
     prompt: Union[str, List[BaseMessage]],
     llm: Union[str, FakeLLM, FakeChatModel],
     response: List[Generation],
 ) -> None:
     llm_cache(cacher)
+    if remove_score:
+        get_llm_cache().score_threshold = None  # type: ignore
     try:
         _execute_test(prompt, llm, response)
     finally:

--- a/libs/partners/mongodb/tests/unit_tests/test_cache.py
+++ b/libs/partners/mongodb/tests/unit_tests/test_cache.py
@@ -54,6 +54,7 @@ class PatchedMongoDBAtlasSemanticCache(MongoDBAtlasSemanticCache):
     ):
         self.collection = MockCollection()
         self._wait_until_ready = False
+        self.score_threshold = None
         MongoDBAtlasVectorSearch.__init__(
             self,
             self.collection,
@@ -144,13 +145,17 @@ def _execute_test(
 @pytest.mark.parametrize(
     "cacher", [PatchedMongoDBCache, PatchedMongoDBAtlasSemanticCache]
 )
+@pytest.mark.parametrize("remove_score", [True, False])
 def test_mongodb_cache(
+    remove_score: bool,
     cacher: Union[MongoDBCache, MongoDBAtlasSemanticCache],
     prompt: Union[str, List[BaseMessage]],
     llm: Union[str, FakeLLM, FakeChatModel],
     response: List[Generation],
 ) -> None:
     llm_cache(cacher)
+    if remove_score:
+        get_llm_cache().score_threshold = None  # type: ignore
     try:
         _execute_test(prompt, llm, response)
     finally:


### PR DESCRIPTION
## Description
Semantic Cache can retrieve noisy information if the score threshold for the value is too low. Adding the ability to set a `score_threshold` on cache construction can allow for less noisy scores to appear. 


- [x] **Add tests and docs**
  1. Added tests that confirm the `score_threshold` query is valid.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/