### PR TITLE
docs: API Ref generation update

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -194,9 +194,7 @@ def _load_package_modules(
             modules_by_namespace[top_namespace] = _module_members
 
         except (ImportError, AttributeError, TypeError) as e:
-            print(
-                f"Error: Unable to import module '{namespace}' with error: {e}"
-            )  # noqa: T201
+            print(f"Error: Unable to import module '{namespace}' with error: {e}")
     return modules_by_namespace
 
 

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -197,7 +197,6 @@ def _load_package_modules(
             print(
                 f"Error: Unable to import module '{namespace}' with error: {e}"
             )  # noqa: T201
-
     return modules_by_namespace
 
 


### PR DESCRIPTION
Using local and external paths for module parsing. Renamed the hidden functions; added logging; enhanced the error handling.
Now it can generate `API Reference` not only from the packages placed in the local monorepo but also from the external packages (such as `langchain-google-el-carro`).
Related PR: #19290 