### PR TITLE
docs: adding voyageai to the list of partner packages

### DIFF
--- a/docs/docs/integrations/platforms/index.mdx
+++ b/docs/docs/integrations/platforms/index.mdx
@@ -29,6 +29,7 @@ These providers have standalone `langchain-{provider}` packages for improved ver
 - [Pinecone](/docs/integrations/providers/pinecone)
 - [Robocorp](/docs/integrations/providers/robocorp)
 - [Together AI](/docs/integrations/providers/together)
+- [Voyage AI](/docs/integrations/providers/voyageai)
 
 
 ## Featured Community Providers


### PR DESCRIPTION
**Description:** Adding VoyageAI to the list of partners
**Issue:** A standalone langchain-voyageai package has been added
**Dependencies:** None
