### PR TITLE
community: fix bug in cohere that `async for` a coroutine in ChatCohere

### DIFF
--- a/libs/community/langchain_community/chat_models/cohere.py
+++ b/libs/community/langchain_community/chat_models/cohere.py
@@ -168,9 +168,9 @@ class ChatCohere(BaseChatModel, BaseCohere):
         request = get_cohere_chat_request(messages, **self._default_params, **kwargs)
 
         if hasattr(self.async_client, "chat_stream"):  # detect and support sdk v5
-            stream = self.async_client.chat_stream(**request)
+            stream = await self.async_client.chat_stream(**request)
         else:
-            stream = self.async_client.chat(**request, stream=True)
+            stream = await self.async_client.chat(**request, stream=True)
 
         async for data in stream:
             if data.event_type == "text-generation":


### PR DESCRIPTION
Without `await`, the `stream` returned from the `async_client` is actually a coroutine, which could not be used in `async for`.