### PR TITLE
community[patch]: invoke callback prior to yielding token (fireworks)

### DIFF
--- a/libs/community/langchain_community/llms/fireworks.py
+++ b/libs/community/langchain_community/llms/fireworks.py
@@ -186,9 +186,9 @@ class Fireworks(BaseLLM):
             self, self.use_retry, run_manager=run_manager, stop=stop, **params
         ):
             chunk = _stream_response_to_generation_chunk(stream_resp)
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+            yield chunk
 
     async def _astream(
         self,
@@ -207,9 +207,9 @@ class Fireworks(BaseLLM):
             self, self.use_retry, run_manager=run_manager, stop=stop, **params
         ):
             chunk = _stream_response_to_generation_chunk(stream_resp)
-            yield chunk
             if run_manager:
                 await run_manager.on_llm_new_token(chunk.text, chunk=chunk)
+            yield chunk
 
 
 def conditional_decorator(


### PR DESCRIPTION
**Description:** Invoke callback prior to yielding token for Fireworks
**Issue:**  [Callback for on_llm_new_token should be invoked before the token is yielded by the model #16913](https://github.com/langchain-ai/langchain/issues/16913)
**Dependencies:** None
