### PR TITLE
langchain: Passthrough batch_size on index()/aindex() calls

### DIFF
--- a/libs/langchain/langchain/indexes/_api.py
+++ b/libs/langchain/langchain/indexes/_api.py
@@ -330,7 +330,7 @@ def index(
         # Be pessimistic and assume that all vector store write will fail.
         # First write to vector store
         if docs_to_index:
-            vector_store.add_documents(docs_to_index, ids=uids)
+            vector_store.add_documents(docs_to_index, ids=uids, batch_size=batch_size)
             num_added += len(docs_to_index) - len(seen_docs)
             num_updated += len(seen_docs)
 
@@ -544,7 +544,9 @@ async def aindex(
         # Be pessimistic and assume that all vector store write will fail.
         # First write to vector store
         if docs_to_index:
-            await vector_store.aadd_documents(docs_to_index, ids=uids)
+            await vector_store.aadd_documents(
+                docs_to_index, ids=uids, batch_size=batch_size
+            )
             num_added += len(docs_to_index) - len(seen_docs)
             num_updated += len(seen_docs)
 


### PR DESCRIPTION
**Description:** This change passes through `batch_size` to `add_documents()`/`aadd_documents()` on calls to `index()` and `aindex()` such that the documents are processed in the expected batch size.
**Issue:** #19415
**Dependencies:** N/A
**Twitter handle:** N/A
