### PR TITLE
mistralai: update tool calling

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -83,7 +83,7 @@ def _convert_mistral_chat_message_to_message(
 
     additional_kwargs: Dict = {}
     if tool_calls := _message.get("tool_calls"):
-        additional_kwargs["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+        additional_kwargs["tool_calls"] = tool_calls
     return AIMessage(content=content, additional_kwargs=additional_kwargs)
 
 

--- a/libs/partners/mistralai/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/integration_tests/test_chat_models.py
@@ -67,7 +67,9 @@ def test_structred_output() -> None:
     llm = ChatMistralAI(model="mistral-large-latest", temperature=0)
     schema = {
         "title": "AnswerWithJustification",
-        "description": "An answer to the user question along with justification for the answer.",
+        "description": (
+            "An answer to the user question along with justification for the answer."
+        ),
         "type": "object",
         "properties": {
             "answer": {"title": "Answer", "type": "string"},

--- a/libs/partners/mistralai/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/integration_tests/test_chat_models.py
@@ -61,3 +61,22 @@ def test_invoke() -> None:
 
     result = llm.invoke("I'm Pickle Rick", config=dict(tags=["foo"]))
     assert isinstance(result.content, str)
+
+
+def test_structred_output() -> None:
+    llm = ChatMistralAI(model="mistral-large-latest", temperature=0)
+    schema = {
+        "title": "AnswerWithJustification",
+        "description": "An answer to the user question along with justification for the answer.",
+        "type": "object",
+        "properties": {
+            "answer": {"title": "Answer", "type": "string"},
+            "justification": {"title": "Justification", "type": "string"},
+        },
+        "required": ["answer", "justification"],
+    }
+    structured_llm = llm.with_structured_output(schema)
+    result = structured_llm.invoke(
+        "What weighs more a pound of bricks or a pound of feathers"
+    )
+    assert isinstance(result, dict)


### PR DESCRIPTION
```python
from langchain.agents import tool
from langchain_mistralai import ChatMistralAI


llm = ChatMistralAI(model="mistral-large-latest", temperature=0)

@tool
def get_word_length(word: str) -> int:
    """Returns the length of a word."""
    return len(word)


tools = [get_word_length]
llm_with_tools = llm.bind_tools(tools)

llm_with_tools.invoke("how long is the word chrysanthemum")
```
currently raises
```
AttributeError: 'dict' object has no attribute 'model_dump'
```

Same with `.with_structured_output`
```python
from langchain_mistralai import ChatMistralAI
from langchain_core.pydantic_v1 import BaseModel

class AnswerWithJustification(BaseModel):
    """An answer to the user question along with justification for the answer."""
    answer: str
    justification: str

llm = ChatMistralAI(model="mistral-large-latest", temperature=0)
structured_llm = llm.with_structured_output(AnswerWithJustification)

structured_llm.invoke("What weighs more a pound of bricks or a pound of feathers")
```

This appears to fix.