### PR TITLE
infra: Resolve the endless dependency resolution during the build of `dev.Dockerfile` by copying `poetry.lock`

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -35,7 +35,7 @@ FROM langchain-dev-base AS langchain-dev-dependencies
 ARG PYTHON_VIRTUALENV_HOME
 
 # Copy only the dependency files for installation
-COPY libs/langchain/pyproject.toml libs/langchain/poetry.toml ./
+COPY libs/langchain/pyproject.toml libs/langchain/poetry.toml libs/langchain/poetry.lock ./
 
 # Copy the langchain library for installation
 COPY libs/langchain/ libs/langchain/


### PR DESCRIPTION
## Description
This PR proposes a modification to the `libs/langchain/dev.Dockerfile` configuration to copy the `libs/langchain/poetry.lock` into the working directory. The change aims to address the issue where the Poetry install command, the last command in the `dev.Dockerfile`, takes excessively long hours, and to ensure the reproducibility of the poetry environment in the devcontainer.

## Problem
The `dev.Dockerfile`, prepared for development environments such as `.devcontainer`, encounters an unending dependency resolution when attempting the Poetry installation.

### Steps to Reproduce
Execute the following build command: 

```bash
docker build -f libs/langchain/dev.Dockerfile .
```

### Current Behavior
The Docker build process gets stuck at the following step, which, in my experience, did not conclude even after an entire night:

```
 => [langchain-dev-dependencies 4/6] COPY libs/community/ ../community/                                                                                0.9s
 => [langchain-dev-dependencies 5/6] COPY libs/text-splitters/ ../text-splitters/                                                                      0.0s
 => [langchain-dev-dependencies 6/6] RUN poetry install --no-interaction --no-ansi --with dev,test,docs                                               12.3s
 => => # Updating dependencies                                                                                                                             
 => => # Resolving dependencies...  
```

### Expected Behavior
The Docker build completes in a realistic timeframe. By applying this PR, the build finishes within a few minutes.

### Analysis
The complexity of LangChain's dependencies has reached a point where Poetry is required to resolve dependencies akin to threading a needle. Consequently, poetry install fails to complete in a practical timeframe.

## Solution
The solution for dependency resolution is already recorded in `libs/langchain/poetry.lock`, so we can use it. When copying `project.toml` and `poetry.toml`, the `poetry.lock` located in the same directory should also be copied.

```diff
# Copy only the dependency files for installation
-COPY libs/langchain/pyproject.toml libs/langchain/poetry.toml ./
+COPY libs/langchain/pyproject.toml libs/langchain/poetry.toml libs/langchain/poetry.lock ./
```

## Note
I am not intimately familiar with the historical context of the `dev.Dockerfile` and thus do not know why `poetry.lock` has not been copied until now. It might have been an oversight, or perhaps dependency resolution used to complete quickly even without the `poetry.lock` file in the past. However, if there are deliberate reasons why copying `poetry.lock` is not advisable, please just close this PR.