### PR TITLE
core: Convert SimSIMD back to NumPy

### DIFF
--- a/libs/community/langchain_community/utils/math.py
+++ b/libs/community/langchain_community/utils/math.py
@@ -29,7 +29,7 @@ def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
         Z = 1 - simd.cdist(X, Y, metric="cosine")
         if isinstance(Z, float):
             return np.array([Z])
-        return Z
+        return np.array(Z)
     except ImportError:
         logger.info(
             "Unable to import simsimd, defaulting to NumPy implementation. If you want "

--- a/libs/partners/elasticsearch/langchain_elasticsearch/_utilities.py
+++ b/libs/partners/elasticsearch/langchain_elasticsearch/_utilities.py
@@ -79,7 +79,7 @@ def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
         Z = 1 - simd.cdist(X, Y, metric="cosine")
         if isinstance(Z, float):
             return np.array([Z])
-        return Z
+        return np.array(Z)
     except ImportError:
         X_norm = np.linalg.norm(X, axis=1)
         Y_norm = np.linalg.norm(Y, axis=1)

--- a/libs/partners/mongodb/langchain_mongodb/utils.py
+++ b/libs/partners/mongodb/langchain_mongodb/utils.py
@@ -38,7 +38,7 @@ def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
         Z = 1 - simd.cdist(X, Y, metric="cosine")
         if isinstance(Z, float):
             return np.array([Z])
-        return Z
+        return np.array(Z)
     except ImportError:
         logger.info(
             "Unable to import simsimd, defaulting to NumPy implementation. If you want "

--- a/libs/partners/pinecone/langchain_pinecone/_utilities.py
+++ b/libs/partners/pinecone/langchain_pinecone/_utilities.py
@@ -69,7 +69,7 @@ def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
         Z = 1 - simd.cdist(X, Y, metric="cosine")
         if isinstance(Z, float):
             return np.array([Z])
-        return Z
+        return np.array(Z)
     except ImportError:
         X_norm = np.linalg.norm(X, axis=1)
         Y_norm = np.linalg.norm(Y, axis=1)


### PR DESCRIPTION
This patch fixes the #18022 issue, converting the SimSIMD internal zero-copy outputs to NumPy. 

I've also noticed, that oftentimes `dtype=np.float32` conversion is used before passing to SimSIMD. Which numeric types do LangChain users generally care about? We support `float64`, `float32`, `float16`, and `int8` for cosine distances and `float16` seems reasonable for practically any kind of embeddings and any modern piece of hardware, so we can change that part as well 🤗 