### PR TITLE
docs: Update local llms article to use invoke instead of deprecated __call__

### DIFF
--- a/docs/docs/guides/local_llms.ipynb
+++ b/docs/docs/guides/local_llms.ipynb
@@ -98,7 +98,7 @@
     "from langchain_community.llms import Ollama\n",
     "\n",
     "llm = Ollama(model=\"llama2\")\n",
-    "llm(\"The first man on the moon was ...\")"
+    "llm.invoke(\"The first man on the moon was ...\")"
    ]
   },
   {
@@ -140,7 +140,7 @@
     "llm = Ollama(\n",
     "    model=\"llama2\", callback_manager=CallbackManager([StreamingStdOutCallbackHandler()])\n",
     ")\n",
-    "llm(\"The first man on the moon was ...\")"
+    "llm.invoke(\"The first man on the moon was ...\")"
    ]
   },
   {
@@ -226,7 +226,7 @@
     "from langchain_community.llms import Ollama\n",
     "\n",
     "llm = Ollama(model=\"llama2:13b\")\n",
-    "llm(\"The first man on the moon was ... think step by step\")"
+    "llm.invoke(\"The first man on the moon was ... think step by step\")"
    ]
   },
   {
@@ -369,7 +369,7 @@
     }
    ],
    "source": [
-    "llm(\"The first man on the moon was ... Let's think step by step\")"
+    "llm.invoke(\"The first man on the moon was ... Let's think step by step\")"
    ]
   },
   {
@@ -426,7 +426,7 @@
     }
    ],
    "source": [
-    "llm(\"The first man on the moon was ... Let's think step by step\")"
+    "llm.invoke(\"The first man on the moon was ... Let's think step by step\")"
    ]
   },
   {


### PR DESCRIPTION
  - **Description:** Since the implicit `__call__` has been deprecated in favor of `invoke`, the local_llms article also needed to be updated. This article was my introduction to Lanchain, and as it was helpful in getting me setup with running LLMs locally, it is nice to not have any warnings when running the example code. With this change, the warnings go away when running the example code.
  - **Issue:** N/A
  - **Dependencies:** N/A
  - **Twitter handle:** clarkerican