### PR TITLE
docs: add cohere to the list of partners

### DIFF
--- a/docs/docs/integrations/platforms/index.mdx
+++ b/docs/docs/integrations/platforms/index.mdx
@@ -15,6 +15,7 @@ These providers have standalone `langchain-{provider}` packages for improved ver
 - [Airbyte](/docs/integrations/providers/airbyte)
 - [Anthropic](/docs/integrations/platforms/anthropic)
 - [Astra DB](/docs/integrations/providers/astradb)
+- [Cohere](/docs/integrations/providers/cohere)
 - [Elasticsearch](/docs/integrations/providers/elasticsearch)
 - [Exa Search](/docs/integrations/providers/exa_search)
 - [Fireworks](/docs/integrations/providers/fireworks)


### PR DESCRIPTION
**Description:** Add Cohere to the list of LangChain partners
**Issue:** The Cohere partner package was recently added [#19049](https://github.com/langchain-ai/langchain/pull/19049)
**Dependencies:** None
