### PR TITLE
docs: Update function "run" to "invoke" in fake_llm.ipynb

### DIFF
--- a/cookbook/fake_llm.ipynb
+++ b/cookbook/fake_llm.ipynb
@@ -100,7 +100,7 @@
     }
    ],
    "source": [
-    "agent.run(\"whats 2 + 2\")"
+    "agent.invoke(\"whats 2 + 2\")"
    ]
   },
   {


### PR DESCRIPTION
This patch updates function "run" to "invoke" in fake_llm.ipynb. Without this patch, you see following warning.

LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.


