### PR TITLE
core[patch]: Pull formatting of examples into standalone function

### DIFF
--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -28,11 +28,14 @@ def _example_to_text(example: Dict[str, str], input_keys: Optional[List[str]]) -
 class SemanticSimilarityExampleSelector(BaseExampleSelector, BaseModel):
     """Example selector that selects examples based on SemanticSimilarity.
 
-    The example select is able to retrieve examples from a vectorstore based on
-    semantic similarity of the example content to the
+    This selector is able to retrieve examples from a vectorstore based on
+    semantic similarity of the query to examples stored in the vectorstore.
 
-
-
+    Selecting examples dynamically based on semantic similarity can be useful
+    in situations where there is a large number of examples, and we want to
+    select a subset of examples that are most similar to the input query to
+    improve the performance of the model while keeping the prompt size
+    within the limits of the model.
     """
 
     vectorstore: VectorStore


### PR DESCRIPTION
1) Users may reasonable want to customize how the example is formatted into text.
2) I don't think we want users to implement behavior via overriding the private
method -- instead we can accept something in the initializer when someone wants
the feature (e.g., function format to text)

So for now pulling this into a standalone function to prevent users from overriding via
inheritance.
