### PR TITLE
docs: Update apify.ipynb for Document class import

### DIFF
--- a/docs/docs/integrations/tools/apify.ipynb
+++ b/docs/docs/integrations/tools/apify.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "from langchain.indexes import VectorstoreIndexCreator\n",
-    "from langchain_community.document_loaders.base import Document\n",
+    "from langchain_core.documents import Document\n",
     "from langchain_community.utilities import ApifyWrapper"
    ]
   },

--- a/docs/docs/integrations/tools/apify.ipynb
+++ b/docs/docs/integrations/tools/apify.ipynb
@@ -41,8 +41,8 @@
    "outputs": [],
    "source": [
     "from langchain.indexes import VectorstoreIndexCreator\n",
-    "from langchain_core.documents import Document\n",
-    "from langchain_community.utilities import ApifyWrapper"
+    "from langchain_community.utilities import ApifyWrapper\n",
+    "from langchain_core.documents import Document"
    ]
   },
   {


### PR DESCRIPTION
- **Description:**
Update to correctly import Document class -
from langchain_core.documents import Document

- **Issue:**
Fixes the notebook and the hosted documentation [here](https://python.langchain.com/docs/integrations/tools/apify)
