### PR TITLE
CLI: add chat playground option to langchain template serve

### DIFF
--- a/libs/cli/langchain_cli/dev_scripts.py
+++ b/libs/cli/langchain_cli/dev_scripts.py
@@ -13,6 +13,7 @@ from langchain_cli.utils.packages import get_langserve_export, get_package_root
 def create_demo_server(
     *,
     config_keys: Sequence[str] = (),
+    chat: bool = False,
 ):
     """
     Creates a demo server for the current template.
@@ -26,11 +27,20 @@ def create_demo_server(
         mod = __import__(package["module"], fromlist=[package["attr"]])
 
         chain = getattr(mod, package["attr"])
-        add_routes(
-            app,
-            chain,
-            config_keys=config_keys,
-        )
+
+        if chat:
+            add_routes(
+                app,
+                chain,
+                playground_type="chat",
+                config_keys=config_keys,
+            )
+        else:
+            add_routes(
+                app,
+                chain,
+                config_keys=config_keys,
+            )
     except KeyError as e:
         raise KeyError("Missing fields from pyproject.toml") from e
     except ImportError as e:
@@ -39,5 +49,13 @@ def create_demo_server(
     return app
 
 
+def create_demo_server_chat():
+    return create_demo_server(chat=True)
+
+
 def create_demo_server_configurable():
     return create_demo_server(config_keys=["configurable"])
+
+
+def create_demo_server_configurable_chat():
+    return create_demo_server(config_keys=["configurable"], chat=True)

--- a/libs/cli/langchain_cli/namespaces/template.py
+++ b/libs/cli/langchain_cli/namespaces/template.py
@@ -101,6 +101,13 @@ def serve(
             help="Whether to include a configurable route",
         ),
     ] = True,
+    chat: Annotated[
+        bool,
+        typer.Option(
+            "--chat/--no-chat",
+            help="Whether to use the chat playground",
+        ),
+    ] = False,
 ) -> None:
     """
     Starts a demo app for this template.
@@ -115,9 +122,13 @@ def serve(
     host_str = host if host is not None else "127.0.0.1"
 
     script = (
-        "langchain_cli.dev_scripts:create_demo_server"
+        ("langchain_cli.dev_scripts:create_demo_server" + "_chat" if chat else "")
         if not configurable
-        else "langchain_cli.dev_scripts:create_demo_server_configurable"
+        else (
+            "langchain_cli.dev_scripts:create_demo_server_configurable" + "_chat"
+            if chat
+            else ""
+        )
     )
 
     import uvicorn


### PR DESCRIPTION
Thank you for contributing to LangChain!

adds a `--chat` option to `langchain template serve` so you can use the chat playground while developing/testing a chat style template.