### PR TITLE
The Voyage reranker is not working 

### DIFF
--- a/libs/partners/voyageai/langchain_voyageai/__init__.py
+++ b/libs/partners/voyageai/langchain_voyageai/__init__.py
@@ -3,5 +3,5 @@ from langchain_voyageai.rerank import  VoyageAIRerank
 
 __all__ = [
     "VoyageAIEmbeddings",
-    " VoyageAIRerank"
+    "VoyageAIRerank"
 ]

--- a/libs/partners/voyageai/langchain_voyageai/__init__.py
+++ b/libs/partners/voyageai/langchain_voyageai/__init__.py
@@ -1,7 +1,4 @@
 from langchain_voyageai.embeddings import VoyageAIEmbeddings
-from langchain_voyageai.rerank import  VoyageAIRerank
+from langchain_voyageai.rerank import VoyageAIRerank
 
-__all__ = [
-    "VoyageAIEmbeddings",
-    "VoyageAIRerank"
-]
+__all__ = ["VoyageAIEmbeddings", "VoyageAIRerank"]

--- a/libs/partners/voyageai/langchain_voyageai/__init__.py
+++ b/libs/partners/voyageai/langchain_voyageai/__init__.py
@@ -1,5 +1,7 @@
 from langchain_voyageai.embeddings import VoyageAIEmbeddings
+from langchain_voyageai.rerank import  VoyageAIRerank
 
 __all__ = [
     "VoyageAIEmbeddings",
+    " VoyageAIRerank"
 ]

--- a/libs/partners/voyageai/tests/unit_tests/test_imports.py
+++ b/libs/partners/voyageai/tests/unit_tests/test_imports.py
@@ -2,6 +2,7 @@ from langchain_voyageai import __all__
 
 EXPECTED_ALL = [
     "VoyageAIEmbeddings",
+    "VoyageAIRerank",
 ]
 
 


### PR DESCRIPTION
The previous version didn't had  Voyage rerank in the init file


- [ ] **PR title**: langchain_voyageai reranker is not working
 


- [ ] **PR message**: 
    - **Description:** This fix let you run reranker from voyage
    - **Issue:** Was not able to run reranker from voyage
  






 @efriis
