### PR TITLE
core: Add aformat_messages to FewShotChatMessagePromptTemplate and ChatPromptTemplate

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -38,6 +38,7 @@ from langchain_core.prompts.image import ImagePromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import StringPromptTemplate, get_template_variables
 from langchain_core.pydantic_v1 import Field, root_validator
+from langchain_core.runnables import run_in_executor
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.interactive_env import is_interactive_env
 
@@ -65,6 +66,17 @@ class BaseMessagePromptTemplate(Serializable, ABC):
         Returns:
             List of BaseMessages.
         """
+
+    async def aformat_messages(self, **kwargs: Any) -> List[BaseMessage]:
+        """Format messages from kwargs. Should return a list of BaseMessages.
+
+        Args:
+            **kwargs: Keyword arguments to use for formatting.
+
+        Returns:
+            List of BaseMessages.
+        """
+        return await run_in_executor(None, self.format_messages, **kwargs)
 
     @property
     @abstractmethod
@@ -594,6 +606,10 @@ class BaseChatPromptTemplate(BasePromptTemplate, ABC):
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format kwargs into a list of messages."""
 
+    async def aformat_messages(self, **kwargs: Any) -> List[BaseMessage]:
+        """Format kwargs into a list of messages."""
+        return await run_in_executor(None, self.format_messages, **kwargs)
+
     def pretty_repr(self, html: bool = False) -> str:
         """Human-readable representation."""
         raise NotImplementedError
@@ -901,18 +917,6 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
             partial_variables=partial_vars,
         )
 
-    def format(self, **kwargs: Any) -> str:
-        """Format the chat template into a string.
-
-        Args:
-            **kwargs: keyword arguments to use for filling in template variables
-                      in all the template messages in this chat template.
-
-        Returns:
-            formatted string
-        """
-        return self.format_prompt(**kwargs).to_string()
-
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format the chat template into a list of finalized messages.
 
@@ -932,6 +936,30 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
                 message_template, (BaseMessagePromptTemplate, BaseChatPromptTemplate)
             ):
                 message = message_template.format_messages(**kwargs)
+                result.extend(message)
+            else:
+                raise ValueError(f"Unexpected input: {message_template}")
+        return result
+
+    async def aformat_messages(self, **kwargs: Any) -> List[BaseMessage]:
+        """Format the chat template into a list of finalized messages.
+
+        Args:
+            **kwargs: keyword arguments to use for filling in template variables
+                      in all the template messages in this chat template.
+
+        Returns:
+            list of formatted messages
+        """
+        kwargs = self._merge_partial_and_user_variables(**kwargs)
+        result = []
+        for message_template in self.messages:
+            if isinstance(message_template, BaseMessage):
+                result.extend([message_template])
+            elif isinstance(
+                message_template, (BaseMessagePromptTemplate, BaseChatPromptTemplate)
+            ):
+                message = await message_template.aformat_messages(**kwargs)
                 result.extend(message)
             else:
                 raise ValueError(f"Unexpected input: {message_template}")

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -38,7 +38,6 @@ from langchain_core.prompts.image import ImagePromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import StringPromptTemplate, get_template_variables
 from langchain_core.pydantic_v1 import Field, root_validator
-from langchain_core.runnables import run_in_executor
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.interactive_env import is_interactive_env
 
@@ -76,7 +75,7 @@ class BaseMessagePromptTemplate(Serializable, ABC):
         Returns:
             List of BaseMessages.
         """
-        return await run_in_executor(None, self.format_messages, **kwargs)
+        return self.format_messages(**kwargs)
 
     @property
     @abstractmethod
@@ -608,7 +607,7 @@ class BaseChatPromptTemplate(BasePromptTemplate, ABC):
 
     async def aformat_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format kwargs into a list of messages."""
-        return await run_in_executor(None, self.format_messages, **kwargs)
+        return self.format_messages(**kwargs)
 
     def pretty_repr(self, html: bool = False) -> str:
         """Human-readable representation."""


### PR DESCRIPTION
Needed since the example selector may use a vector store.