### PR TITLE
core[patch]: Release 0.1.35

### DIFF
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-core"
-version = "0.1.34"
+version = "0.1.35"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"


### PR DESCRIPTION
Release contains security related PR for https://github.com/langchain-ai/langchain/pull/19653

core[patch]: Patch XML vulnerability in XMLOutputParser (CVE-2024-1455)