### PR TITLE
docs: Update function "run" to "invoke" in llm_symbolic_math.ipynb

### DIFF
--- a/cookbook/llm_symbolic_math.ipynb
+++ b/cookbook/llm_symbolic_math.ipynb
@@ -45,7 +45,7 @@
     }
    ],
    "source": [
-    "llm_symbolic_math.run(\"What is the derivative of sin(x)*exp(x) with respect to x?\")"
+    "llm_symbolic_math.invoke(\"What is the derivative of sin(x)*exp(x) with respect to x?\")"
    ]
   },
   {
@@ -65,7 +65,7 @@
     }
    ],
    "source": [
-    "llm_symbolic_math.run(\n",
+    "llm_symbolic_math.invoke(\n",
     "    \"What is the integral of exp(x)*sin(x) + exp(x)*cos(x) with respect to x?\"\n",
     ")"
    ]
@@ -94,7 +94,7 @@
     }
    ],
    "source": [
-    "llm_symbolic_math.run('Solve the differential equation y\" - y = e^t')"
+    "llm_symbolic_math.invoke('Solve the differential equation y\" - y = e^t')"
    ]
   },
   {
@@ -114,7 +114,7 @@
     }
    ],
    "source": [
-    "llm_symbolic_math.run(\"What are the solutions to this equation y^3 + 1/3y?\")"
+    "llm_symbolic_math.invoke(\"What are the solutions to this equation y^3 + 1/3y?\")"
    ]
   },
   {
@@ -134,7 +134,7 @@
     }
    ],
    "source": [
-    "llm_symbolic_math.run(\"x = y + 5, y = z - 3, z = x * y. Solve for x, y, z\")"
+    "llm_symbolic_math.invoke(\"x = y + 5, y = z - 3, z = x * y. Solve for x, y, z\")"
    ]
   }
  ],


### PR DESCRIPTION
This patch updates multiple function "run" to "invoke" in llm_symbolic_math.ipynb.

Without this patch, you see following message.
The function `run` was deprecated in LangChain 0.1.0
 and will be removed in 0.2.0. Use invoke instead.
