### PR TITLE
core: support pydantic V2 for JSONOutputParser, allow for other sources of JSON schemas

### DIFF
--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -210,7 +210,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
     pydantic_object: Optional[Type[TBaseModel]] = None  # type: ignore
     json_schema: Optional[dict[str, Any]] = None
 
-    @validator("json_schema", always=True)
+    @validator("json_schema", always=True, allow_reuse=True)
     def _validate_json_schema(
         cls, v: Optional[dict[str, Any]], values: dict
     ) -> Optional[dict[str, Any]]:

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from json import JSONDecodeError
-from typing import Any, Callable, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import jsonpatch  # type: ignore[import]
 import pydantic  # pydantic: ignore
@@ -208,7 +208,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
     """
 
     pydantic_object: Optional[Type[TBaseModel]] = None  # type: ignore
-    json_schema: Optional[dict[str, Any]] = None
+    json_schema: Optional[Dict[str, Any]] = None
 
     @validator("json_schema", always=True, allow_reuse=True)
     def _validate_json_schema(

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import re
-import warnings
 from json import JSONDecodeError
 from typing import Any, Callable, List, Optional, Type, TypeVar, Union
 
@@ -215,13 +214,9 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
     def _validate_json_schema(
         cls, v: Optional[dict[str, Any]], values: dict
     ) -> Optional[dict[str, Any]]:
-        try:
-            if v is None and values.get("pydantic_object") is not None:
-                return cls._get_schema(values["pydantic_object"])
-            return v
-        except Exception as e:
-            warnings.warn(f"Failed to get schema: {e}")
-            return None
+        if v is None and values.get("pydantic_object") is not None:
+            return cls._get_schema(values["pydantic_object"])
+        return v
 
     def _diff(self, prev: Optional[Any], next: Any) -> Any:
         return jsonpatch.make_patch(prev, next).patch

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -595,3 +595,13 @@ def test_base_model_schema_consistency() -> None:
 
     assert initial_joke_schema == retrieved_joke_schema
     assert openai_func.get("name", None) is not None
+
+
+def test_json_parser_just_schema() -> None:
+    class Joke(BaseModel):
+        setup: str
+        punchline: str
+
+    schema = {k: v for k, v in Joke.schema().items()}
+    parser = SimpleJsonOutputParser(json_schema=schema)
+    assert parser.json_schema == schema

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -595,13 +595,3 @@ def test_base_model_schema_consistency() -> None:
 
     assert initial_joke_schema == retrieved_joke_schema
     assert openai_func.get("name", None) is not None
-
-
-def test_json_parser_just_schema() -> None:
-    class Joke(BaseModel):
-        setup: str
-        punchline: str
-
-    schema = {k: v for k, v in Joke.schema().items()}
-    parser = SimpleJsonOutputParser(json_schema=schema)
-    assert parser.json_schema == schema

--- a/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -5,6 +5,7 @@ import pytest
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import ParrotFakeChatModel
+from langchain_core.output_parsers.json import JsonOutputParser
 from langchain_core.output_parsers.pydantic import PydanticOutputParser, TBaseModel
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
@@ -70,3 +71,29 @@ def test_pydantic_parser_validation(pydantic_object: TBaseModel) -> None:
     chain = bad_prompt | model | parser
     with pytest.raises(OutputParserException):
         chain.invoke({})
+
+
+# JSON output parser tests
+@pytest.mark.parametrize("pydantic_object", [ForecastV2, ForecastV1])
+def test_json_parser_chaining(
+    pydantic_object: TBaseModel,
+) -> None:
+    prompt = PromptTemplate(
+        template="""{{
+        "temperature": 20,
+        "f_or_c": "C",
+        "forecast": "Sunny"
+    }}""",
+        input_variables=[],
+    )
+
+    model = ParrotFakeChatModel()
+
+    parser = JsonOutputParser(pydantic_object=pydantic_object)  # type: ignore
+    assert parser.json_schema is not None
+    chain = prompt | model | parser
+
+    res = chain.invoke({})
+    assert res["f_or_c"] == "C"
+    assert res["temperature"] == 20
+    assert res["forecast"] == "Sunny"

--- a/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -90,7 +90,6 @@ def test_json_parser_chaining(
     model = ParrotFakeChatModel()
 
     parser = JsonOutputParser(pydantic_object=pydantic_object)  # type: ignore
-    assert parser.json_schema is not None
     chain = prompt | model | parser
 
     res = chain.invoke({})


### PR DESCRIPTION
This PR supports using Pydantic v2 objects to generate the schema for the JSONOutputParser (#19441). This also adds a `json_schema` parameter to allow users to pass any JSON schema to validate with, not just pydantic. 
