### PR TITLE
cohere: support kwargs in with_structured_output

### DIFF
--- a/libs/partners/cohere/langchain_cohere/chat_models.py
+++ b/libs/partners/cohere/langchain_cohere/chat_models.py
@@ -191,10 +191,8 @@ class ChatCohere(BaseChatModel, BaseCohere):
             A Runnable that takes any ChatModel input and returns either a dict or
             Pydantic class as output.
         """
-        if kwargs:
-            raise ValueError(f"Received unsupported arguments {kwargs}")
         is_pydantic_schema = isinstance(schema, type) and issubclass(schema, BaseModel)
-        llm = self.bind_tools([schema])
+        llm = self.bind_tools([schema], **kwargs)
         if is_pydantic_schema:
             output_parser: OutputParserLike = PydanticToolsParser(
                 tools=[schema], first_tool_only=True


### PR DESCRIPTION
**Description:** We'd like to support passing additional kwargs in `with_structured_output`. I believe this is the accepted approach to enable additional arguments on API calls.