### PR TITLE
docs: providers pinecone fix

### DIFF
--- a/docs/docs/integrations/providers/pinecone.mdx
+++ b/docs/docs/integrations/providers/pinecone.mdx
@@ -8,7 +8,7 @@
 Install the Python SDK:
 
 ```bash
-pip install pinecone-client
+pip install langchain-pinecone
 ```
 
 
@@ -22,3 +22,26 @@ from langchain_pinecone import PineconeVectorStore
 ```
 
 For a more detailed walkthrough of the Pinecone vectorstore, see [this notebook](/docs/integrations/vectorstores/pinecone)
+
+## Retrievers
+
+### Pinecone Hybrid Search
+
+```bash
+pip install pinecone-client pinecone-text
+```
+
+```python
+from langchain_community.retrievers import (
+    PineconeHybridSearchRetriever,
+)
+```
+
+For more detailed information, see [this notebook](/docs/integrations/retrievers/pinecone_hybrid_search).
+
+
+### Self Query retriever
+
+Pinecone vector store can be used as a retriever for self-querying.
+
+For more detailed information, see [this notebook](/docs/integrations/retrievers/self_query/pinecone).


### PR DESCRIPTION
Current providers page use link to the old package.
- Fixed installation instructions
- Added a reference to the Pinecone retriever