### PR TITLE
docs: use markdown cell instead of code block

### DIFF
--- a/docs/docs/expression_language/why.ipynb
+++ b/docs/docs/expression_language/why.ipynb
@@ -300,7 +300,10 @@
     "async def ainvoke_chain(topic: str) -> str:\n",
     "    prompt_value = prompt_template.format(topic=topic)\n",
     "    messages = [{\"role\": \"user\", \"content\": prompt_value}]\n",
-    "    return await acall_chat_model(messages)"
+    "    return await acall_chat_model(messages)\n",
+    "\n",
+    "\n",
+    "await ainvoke_chain(\"ice cream\")"
    ]
   },
   {
@@ -308,19 +311,22 @@
    "id": "2f209290-498c-4c17-839e-ee9002919846",
    "metadata": {},
    "source": [
-    "```python\n",
-    "await ainvoke_chain(\"ice cream\")\n",
-    "```\n",
-    "\n",
     "</Column>\n",
     "\n",
     "<Column>\n",
-    "\n",
+    "    \n",
     "#### LCEL\n",
-    "\n",
-    "```python\n",
-    "await chain.ainvoke(\"ice cream\")\n",
-    "```"
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d009781-7307-48a4-8439-f9d3dd015560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chain.ainvoke(\"ice cream\")"
    ]
   },
   {
@@ -347,12 +353,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import asyncio\n",
     "import openai\n",
     "\n",
     "\n",
     "async def abatch_chain(topics: list) -> list:\n",
     "    coros = map(ainvoke_chain, topics)\n",
-    "    return await asyncio.gather(*coros)\n"
+    "    return await asyncio.gather(*coros)\n",
+    "\n",
+    "\n",
+    "await abatch_chain([\"ice cream\", \"spaghetti\", \"dumplings\"])"
    ]
   },
   {
@@ -360,19 +370,22 @@
    "id": "90691048-17ae-479d-83c2-859e33ddf3eb",
    "metadata": {},
    "source": [
-    "```python\n",
-    "await abatch_chain([\"ice cream\", \"spaghetti\", \"dumplings\"])\n",
-    "```\n",
-    "\n",
     "</Column>\n",
     "\n",
     "<Column>\n",
     "\n",
     "#### LCEL\n",
-    "\n",
-    "```python\n",
-    "await chain.abatch([\"ice cream\", \"spaghetti\", \"dumplings\"])\n",
-    "```"
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "947dad23-3443-40eb-a03b-7840c261e261",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chain.abatch([\"ice cream\", \"spaghetti\", \"dumplings\"])"
    ]
   },
   {


### PR DESCRIPTION
I found that the code of async and async batch was divided into two blocks:

<img width="823" alt="Screenshot 2024-03-29 at 7 45 59 AM" src="https://github.com/langchain-ai/langchain/assets/10000925/0fa59d29-a692-4309-afb8-2260f03242ec">


so I changed it to unified.