### PR TITLE
langchain: enable chat-memory to save compound types

### DIFF
--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -39,7 +39,7 @@ class BaseMemory(Serializable, ABC):
                 def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, str]:
                     return self.memories
 
-                def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+                def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, Any]) -> None:
                     pass
 
                 def clear(self) -> None:
@@ -65,11 +65,11 @@ class BaseMemory(Serializable, ABC):
         return await run_in_executor(None, self.load_memory_variables, inputs)
 
     @abstractmethod
-    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, Any]) -> None:
         """Save the context of this chain run to memory."""
 
     async def asave_context(
-        self, inputs: Dict[str, Any], outputs: Dict[str, str]
+        self, inputs: Dict[str, Any], outputs: Dict[str, Any]
     ) -> None:
         """Save the context of this chain run to memory."""
         await run_in_executor(None, self.save_context, inputs, outputs)

--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -24,7 +24,7 @@ class BaseChatMemory(BaseMemory, ABC):
     return_messages: bool = False
 
     def _get_input_output(
-        self, inputs: Dict[str, Any], outputs: Dict[str, str]
+        self, inputs: Dict[str, Any], outputs: Dict[str, Any]
     ) -> Tuple[str, str]:
         if self.input_key is None:
             prompt_input_key = get_prompt_input_key(inputs, self.memory_variables)
@@ -48,9 +48,12 @@ class BaseChatMemory(BaseMemory, ABC):
                 )
         else:
             output_key = self.output_key
-        return inputs[prompt_input_key], outputs[output_key]
+        output_value = outputs[output_key]
+        if not isinstance(output_value, str):
+            output_value = str(output_value)
+        return inputs[prompt_input_key], output_value
 
-    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, Any]) -> None:
         """Save context from this conversation to buffer."""
         input_str, output_str = self._get_input_output(inputs, outputs)
         self.chat_memory.add_messages(
@@ -58,7 +61,7 @@ class BaseChatMemory(BaseMemory, ABC):
         )
 
     async def asave_context(
-        self, inputs: Dict[str, Any], outputs: Dict[str, str]
+        self, inputs: Dict[str, Any], outputs: Dict[str, Any]
     ) -> None:
         """Save context from this conversation to buffer."""
         input_str, output_str = self._get_input_output(inputs, outputs)

--- a/libs/langchain/tests/unit_tests/memory/test_memory_save.py
+++ b/libs/langchain/tests/unit_tests/memory/test_memory_save.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import pytest
+from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.human import HumanMessage
+
+from langchain.chains.conversation.memory import (
+    ConversationBufferMemory,
+    ConversationBufferWindowMemory,
+    ConversationSummaryMemory,
+)
+from langchain.memory.chat_memory import BaseChatMemory
+from tests.unit_tests.llms.fake_llm import FakeLLM
+
+
+@pytest.mark.parametrize(
+    "memory, output_obj",
+    [
+        (ConversationBufferMemory(memory_key="baz"), "bar"),
+        (ConversationBufferMemory(memory_key="baz"), {"bar": "qux"}),
+        (ConversationBufferMemory(memory_key="baz"), ["bar", "qux"]),
+        (ConversationSummaryMemory(llm=FakeLLM(), memory_key="baz"), "bar"),
+        (ConversationSummaryMemory(llm=FakeLLM(), memory_key="baz"), {"bar": "qux"}),
+        (ConversationSummaryMemory(llm=FakeLLM(), memory_key="baz"), ["bar", "qux"]),
+        (ConversationBufferWindowMemory(memory_key="baz"), "bar"),
+        (ConversationBufferWindowMemory(memory_key="baz"), {"bar": "qux"}),
+        (ConversationBufferWindowMemory(memory_key="baz"), ["bar", "qux"]),
+    ],
+)
+def test_memory_save_context(memory: BaseChatMemory, output_obj: Any) -> None:
+    # all message content must be strings
+    memory.save_context({"input": "foo"}, {"output": output_obj})
+    assert len(memory.chat_memory.messages) == 2
+    assert memory.chat_memory.messages[0] == HumanMessage(content="foo")
+    assert memory.chat_memory.messages[1] == AIMessage(content=str(output_obj))


### PR DESCRIPTION
**Description:** Saving ChatMemory requires Message(content) to be a string. 
When using output parsers (eg: Json/Pydantic), the output returns as a dictionary and throws exception.  
This change allows saving of any output using any subtype of BaseChatMemory.  Adjusted related type-hints.
**Issue:** 6761
**Dependencies:** None
**Twitter handle:** None
