### PR TITLE
langchain: fix pinecone upsert when async_req is set to False

### DIFF
--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -166,7 +166,8 @@ class PineconeVectorStore(VectorStore):
                     batch_size, zip(chunk_ids, embeddings, chunk_metadatas)
                 )
             ]
-            [res.get() for res in async_res]
+            if async_req:
+                [res.get() for res in async_res]
 
         return ids
 


### PR DESCRIPTION
Issue: 
When async_req is the default value True, pinecone client return the multiprocessing AsyncResult object.
When async_req is set to False, pinecone client return the result directly. `[{'upserted_count': 1}]` . Calling get() method will throw an error in this case.



