### PR TITLE
docs: fix a dead link

### DIFF
--- a/docs/docs/integrations/callbacks/argilla.ipynb
+++ b/docs/docs/integrations/callbacks/argilla.ipynb
@@ -12,7 +12,7 @@
     "> using both human and machine feedback. We provide support for each step in the MLOps cycle, \n",
     "> from data labeling to model monitoring.\n",
     "\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/hwchase17/langchain/blob/master/docs/integrations/callbacks/argilla\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/integrations/callbacks/argilla.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]


### PR DESCRIPTION
**Description**

Google Colab returned 404 when trying to click an "Open In Colab" button from document. This PR corrected the link.