### PR TITLE
community: Handle FunctionMessage type in ChatOllama

### DIFF
--- a/libs/community/langchain_community/chat_models/ollama.py
+++ b/libs/community/langchain_community/chat_models/ollama.py
@@ -12,6 +12,7 @@ from langchain_core.messages import (
     AIMessageChunk,
     BaseMessage,
     ChatMessage,
+    FunctionMessage,
     HumanMessage,
     SystemMessage,
 )
@@ -108,6 +109,8 @@ class ChatOllama(BaseChatModel, _OllamaCommon):
                 role = "assistant"
             elif isinstance(message, SystemMessage):
                 role = "system"
+            elif isinstance(message, FunctionMessage):
+                role = "assistant"
             else:
                 raise ValueError("Received unsupported message type for Ollama.")
 


### PR DESCRIPTION
**Description:** When using functional calling with OllamaFunctions, it  raises an error on encountering a FunctionMessage: "Received unsupported message type for Ollama."

**Issue:**  https://github.com/langchain-ai/langchain/discussions/18450

