### PR TITLE
text-splitters: Add C language code splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -610,6 +610,48 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 " ",
                 "",
             ]
+        elif language == Language.C:
+            return [
+                # Split along type definition
+                "\ntypedef ",
+                # Split along struct definitions
+                "\nstruct ",
+                "\nenum ",
+                "\nunion ",
+                # Split along function definitions
+                "\nvoid ",
+                "\nint ",
+                "\nfloat ",
+                "\ndouble ",
+                "\nstatic ",
+                "\nchar ",
+                "\nconst ",
+                "\nsigned ",
+                "\nunsigned ",
+                "\nauto ",
+                "\nvolatile ",
+                "\nextern ",
+                "\nregister ",
+                "\nshort ",
+                "\nlong"
+                # Split along control flow statements
+                "\ndo ",
+                "\nif ",
+                "\nfor ",
+                "\nwhile ",
+                "\nswitch ",
+                "\ncase ",
+                "\ndefault:",
+                "\nbreak",
+                "\ngoto ",
+                "\ncontinue",
+                "\nelse ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         else:
             raise ValueError(
                 f"Language {language} is not supported! "

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1280,6 +1280,50 @@ def test_haskell_code_splitter() -> None:
     assert chunks == expected_chunks
 
 
+def test_c_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.C, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    code = """
+        #include <stdio.h>
+
+        union Data {
+            int intValue;
+            float floatValue;
+            char stringValue[20];
+        };
+
+        int main(int argc, char *argv[]) {
+            printf("Hello, world!\n");
+            return 0;
+        }
+    """
+    expected_chunks = [
+        "#include",
+        "<stdio.h>",
+        "union",
+        "Data {",
+        "int",
+        "intValue;",
+        "float",
+        "floatValue;",
+        "char",
+        "stringValue[20]",
+        ";",
+        "};",
+        "int",
+        "main(int argc,",
+        "char *argv[]) {",
+        'printf("Hello,',
+        "world!",
+        '");',
+        "return 0;",
+        "}",
+    ]
+    chunks = splitter.split_text(code)
+    assert chunks == expected_chunks
+
+
 @pytest.mark.requires("lxml")
 def test_html_header_text_splitter(tmp_path: Path) -> None:
     splitter = HTMLHeaderTextSplitter(


### PR DESCRIPTION

**Description:** Added code splitter for C language and the respective test. C language is already defined in `langchain_text_splitters.Language` enum class, but is missing its implementation in `get_separators_for_language`
**Issue:** https://github.com/langchain-ai/langchain/issues/5170
**Dependencies:** None
**Twitter handle:** @bolun_zhang

test output:
```
======================================================================================= test session starts =======================================================================================
platform darwin -- Python 3.9.6, pytest-7.4.4, pluggy-1.4.0 --...
cachedir: .pytest_cache
rootdir: ...
configfile: pyproject.toml
plugins: asyncio-0.21.1, mock-3.12.0, profiling-1.7.0
asyncio: mode=auto
collected 57 items                                                                                                                                                                                

tests/unit_tests/test_text_splitters.py::test_character_text_splitter PASSED                                                                                                                [  1%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_empty_doc PASSED                                                                                                      [  3%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_separtor_empty_doc PASSED                                                                                             [  5%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_long PASSED                                                                                                           [  7%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_short_words_first PASSED                                                                                              [  8%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_longer_words PASSED                                                                                                   [ 10%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_keep_separator_regex[\\.-True] PASSED                                                                                 [ 12%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_keep_separator_regex[.-False] PASSED                                                                                  [ 14%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_discard_separator_regex[\\.-True] PASSED                                                                              [ 15%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitter_discard_separator_regex[.-False] PASSED                                                                               [ 17%]
tests/unit_tests/test_text_splitters.py::test_character_text_splitting_args PASSED                                                                                                          [ 19%]
tests/unit_tests/test_text_splitters.py::test_merge_splits PASSED                                                                                                                           [ 21%]
tests/unit_tests/test_text_splitters.py::test_create_documents PASSED                                                                                                                       [ 22%]
tests/unit_tests/test_text_splitters.py::test_create_documents_with_metadata PASSED                                                                                                         [ 24%]
tests/unit_tests/test_text_splitters.py::test_create_documents_with_start_index[splitter0-foo bar baz 123-expected_docs0] PASSED                                                            [ 26%]
tests/unit_tests/test_text_splitters.py::test_create_documents_with_start_index[splitter1-w1 w1 w1 w1 w1 w1 w1 w1 w1-expected_docs1] PASSED                                                 [ 28%]
tests/unit_tests/test_text_splitters.py::test_metadata_not_shallow PASSED                                                                                                                   [ 29%]
tests/unit_tests/test_text_splitters.py::test_iterative_text_splitter_keep_separator PASSED                                                                                                 [ 31%]
tests/unit_tests/test_text_splitters.py::test_iterative_text_splitter_discard_separator PASSED                                                                                              [ 33%]
tests/unit_tests/test_text_splitters.py::test_iterative_text_splitter PASSED                                                                                                                [ 35%]
tests/unit_tests/test_text_splitters.py::test_split_documents PASSED                                                                                                                        [ 36%]
tests/unit_tests/test_text_splitters.py::test_python_text_splitter PASSED                                                                                                                   [ 38%]
tests/unit_tests/test_text_splitters.py::test_python_code_splitter PASSED                                                                                                                   [ 40%]
tests/unit_tests/test_text_splitters.py::test_golang_code_splitter PASSED                                                                                                                   [ 42%]
tests/unit_tests/test_text_splitters.py::test_rst_code_splitter PASSED                                                                                                                      [ 43%]
tests/unit_tests/test_text_splitters.py::test_proto_file_splitter PASSED                                                                                                                    [ 45%]
tests/unit_tests/test_text_splitters.py::test_javascript_code_splitter PASSED                                                                                                               [ 47%]
tests/unit_tests/test_text_splitters.py::test_cobol_code_splitter PASSED                                                                                                                    [ 49%]
tests/unit_tests/test_text_splitters.py::test_typescript_code_splitter PASSED                                                                                                               [ 50%]
tests/unit_tests/test_text_splitters.py::test_java_code_splitter PASSED                                                                                                                     [ 52%]
tests/unit_tests/test_text_splitters.py::test_kotlin_code_splitter PASSED                                                                                                                   [ 54%]
tests/unit_tests/test_text_splitters.py::test_csharp_code_splitter PASSED                                                                                                                   [ 56%]
tests/unit_tests/test_text_splitters.py::test_cpp_code_splitter PASSED                                                                                                                      [ 57%]
tests/unit_tests/test_text_splitters.py::test_scala_code_splitter PASSED                                                                                                                    [ 59%]
tests/unit_tests/test_text_splitters.py::test_ruby_code_splitter PASSED                                                                                                                     [ 61%]
tests/unit_tests/test_text_splitters.py::test_php_code_splitter PASSED                                                                                                                      [ 63%]
tests/unit_tests/test_text_splitters.py::test_swift_code_splitter PASSED                                                                                                                    [ 64%]
tests/unit_tests/test_text_splitters.py::test_rust_code_splitter PASSED                                                                                                                     [ 66%]
tests/unit_tests/test_text_splitters.py::test_markdown_code_splitter PASSED                                                                                                                 [ 68%]
tests/unit_tests/test_text_splitters.py::test_latex_code_splitter PASSED                                                                                                                    [ 70%]
tests/unit_tests/test_text_splitters.py::test_html_code_splitter PASSED                                                                                                                     [ 71%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_1 PASSED                                                                                                              [ 73%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_2 PASSED                                                                                                              [ 75%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_3 PASSED                                                                                                              [ 77%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_preserve_headers_1 PASSED                                                                                             [ 78%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_preserve_headers_2 PASSED                                                                                             [ 80%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_fenced_code_block[```] PASSED                                                                                         [ 82%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_fenced_code_block[~~~] PASSED                                                                                         [ 84%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_fenced_code_block_interleaved[```-~~~] PASSED                                                                         [ 85%]
tests/unit_tests/test_text_splitters.py::test_md_header_text_splitter_fenced_code_block_interleaved[~~~-```] PASSED                                                                         [ 87%]
tests/unit_tests/test_text_splitters.py::test_solidity_code_splitter PASSED                                                                                                                 [ 89%]
tests/unit_tests/test_text_splitters.py::test_haskell_code_splitter PASSED                                                                                                                  [ 91%]
tests/unit_tests/test_text_splitters.py::test_c_code_splitter PASSED                                                                                                                        [ 92%]
tests/unit_tests/test_text_splitters.py::test_html_header_text_splitter SKIPPED (Requires pkg: `lxml`)                                                                                      [ 94%]
tests/unit_tests/test_text_splitters.py::test_split_text_on_tokens PASSED                                                                                                                   [ 96%]
tests/unit_tests/test_text_splitters.py::test_split_json PASSED                                                                                                                             [ 98%]
tests/unit_tests/test_text_splitters.py::test_split_json_with_lists PASSED                                                                                                                  [100%]

======================================================================================== warnings summary =========================================================================================
...
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================= slowest 5 durations =======================================================================================
0.00s call     tests/unit_tests/test_text_splitters.py::test_split_json_with_lists
0.00s call     tests/unit_tests/test_text_splitters.py::test_split_json
0.00s call     tests/unit_tests/test_text_splitters.py::test_cobol_code_splitter
0.00s call     tests/unit_tests/test_text_splitters.py::test_haskell_code_splitter
0.00s call     tests/unit_tests/test_text_splitters.py::test_c_code_splitter
============================================================================ 56 passed, 1 skipped, 1 warning in 0.25s =============================================================================
```