### PR TITLE
docs: remove unnecessary args from the pip install

### DIFF
--- a/docs/docs/integrations/document_loaders/mediawikidump.ipynb
+++ b/docs/docs/integrations/document_loaders/mediawikidump.ipynb
@@ -24,10 +24,10 @@
    "outputs": [],
    "source": [
     "# mediawiki-utilities supports XML schema 0.11 in unmerged branches\n",
-    "%pip install --upgrade --quiet  U git+https://github.com/mediawiki-utilities/python-mwtypes@updates_schema_0.11\n",
+    "%pip install --upgrade --quiet git+https://github.com/mediawiki-utilities/python-mwtypes@updates_schema_0.11\n",
     "# mediawiki-utilities mwxml has a bug, fix PR pending\n",
-    "%pip install --upgrade --quiet  U git+https://github.com/gdedrouas/python-mwxml@xml_format_0.11\n",
-    "%pip install --upgrade --quiet  U mwparserfromhell"
+    "%pip install --upgrade --quiet git+https://github.com/gdedrouas/python-mwxml@xml_format_0.11\n",
+    "%pip install --upgrade --quiet mwparserfromhell"
    ]
   },
   {


### PR DESCRIPTION
**Description:** An additional `U` argument was added for the instructions to install the pip packages for the MediaWiki Dump Document loader which was leading to error in installing the package. Removing the argument fixed the command to install.

**Issue:** #19820 
**Dependencies:** No dependency change requierd
**Twitter handle:** [@vardhaman722](https://twitter.com/vardhaman722)
