### PR TITLE
langchain_cohere: make `preamble` configurable in ChatCohere

### DIFF
--- a/libs/partners/cohere/langchain_cohere/chat_models.py
+++ b/libs/partners/cohere/langchain_cohere/chat_models.py
@@ -146,6 +146,8 @@ class ChatCohere(BaseChatModel, BaseCohere):
             chat.invoke(messages)
     """
 
+    preamble: Optional[str] = None
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -163,6 +165,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
         base_params = {
             "model": self.model,
             "temperature": self.temperature,
+            "preamble": self.preamble,
         }
         return {k: v for k, v in base_params.items() if v is not None}
 


### PR DESCRIPTION
This PR make `preamble` configurable for ChatCohere.

Per doc https://docs.cohere.com/reference/chat, it would be a better idea to a place system prompt in `preamble` rather than in `chat_history`:
> The chat_history parameter should not be used for SYSTEM messages in most cases. Instead, to add a SYSTEM role message at the beginning of a conversation, the preamble parameter should be used.

Usage like simply specifying preamble when initialized `chat_model` is not list bellow, but the advanced usage like dynamically specifying preamble in runtime is here:
```python
from langserve import add_routes
# ...
cohere_chat_model = ChatCohere(
    model=COHERE_CHAT_MODEL,
    cohere_api_key=COHERE_API_KEY,
    verbose=True,
).configurable_fields(
    preamble=ConfigurableField(
        id="cohere_preamble",
        name="Cohere Preamble",
        description="The preamble of the cohere model",
    )
)

def cohere_preamble_router(input: ChatPromptValue):
    if isinstance(input.messages[0], SystemMessage):
        preamble = input.messages[0].content
        input.messages = input.messages[1:]
        return cohere_chat_model.with_config(
            RunnableConfig(configurable={"cohere_preamble": preamble})
        )
    return cohere_chat_model


add_routes(
    app=app,
    runnable=(
        ChatPromptTemplate.from_messages([MessagesPlaceholder("messages")])
        | RunnableLambda(cohere_preamble_router)
    ),
    path="/cohere",
)

# ...
if __name__ == "__main__":
    import uvicorn

    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="trace")

```