### PR TITLE
community[minor]: added missed class to __all__

### DIFF
--- a/libs/community/langchain_community/document_loaders/__init__.py
+++ b/libs/community/langchain_community/document_loaders/__init__.py
@@ -171,6 +171,7 @@ _module_lookup = {
     "TwitterTweetLoader": "langchain_community.document_loaders.twitter",
     "UnstructuredAPIFileIOLoader": "langchain_community.document_loaders.unstructured",
     "UnstructuredAPIFileLoader": "langchain_community.document_loaders.unstructured",
+    "UnstructuredCHMLoader": "langchain_community.document_loaders.chm",
     "UnstructuredCSVLoader": "langchain_community.document_loaders.csv_loader",
     "UnstructuredEPubLoader": "langchain_community.document_loaders.epub",
     "UnstructuredEmailLoader": "langchain_community.document_loaders.email",

--- a/libs/community/tests/unit_tests/document_loaders/test_imports.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_imports.py
@@ -156,6 +156,7 @@ EXPECTED_ALL = [
     "TwitterTweetLoader",
     "UnstructuredAPIFileIOLoader",
     "UnstructuredAPIFileLoader",
+    "UnstructuredCHMLoader",
     "UnstructuredCSVLoader",
     "UnstructuredEPubLoader",
     "UnstructuredEmailLoader",


### PR DESCRIPTION
nit
Added missed `UnstructuredCHMLoader` class to the document_loader.\_\_init\_\_.py \_\_all\_\_