### PR TITLE
docs: TogetherAI as a drop-in replacement for OpenAI

### DIFF
--- a/docs/src/theme/ChatModelTabs.js
+++ b/docs/src/theme/ChatModelTabs.js
@@ -120,7 +120,7 @@ export default function ChatModelTabs(props) {
     {
       value: "TogetherAI",
       label: "TogetherAI",
-      text: `from langchain_openai import ChatOpenAI\n\n${llmVarName} = Together(${togetherParamsOrDefault})`,
+      text: `from langchain_openai import ChatOpenAI\n\n${llmVarName} = ChatOpenAI(${togetherParamsOrDefault})`,
       apiKeyName: "TOGETHER_API_KEY",
       packageName: "langchain-openai",
       default: false,


### PR DESCRIPTION
**Description:** TogetherAI as a drop-in replacement for OpenAI
**Issue:** None
**Dependencies:** None

@baskaryan apropos #20032