### PR TITLE
core[patch]: fix duplicated kwargs in `_load_sql_databse_chain`

### DIFF
--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -383,7 +383,7 @@ def _load_sql_database_chain(config: dict, **kwargs: Any) -> Any:
         raise ValueError("`database` must be present.")
     if "llm_chain" in config:
         llm_chain_config = config.pop("llm_chain")
-        chain = load_chain_from_config(llm_chain_config, **kwargs, **kwargs)
+        chain = load_chain_from_config(llm_chain_config, **kwargs)
         return SQLDatabaseChain(llm_chain=chain, database=database, **config)
     if "llm" in config:
         llm_config = config.pop("llm")


### PR DESCRIPTION
`kwargs` is specified twice in [this line](https://github.com/langchain-ai/langchain/blame/3218463f6a3d841905648971735949a14a16e191/libs/langchain/langchain/chains/loading.py#L386), causing runtime error when passing any keyword arguments.
