### PR TITLE
Skip pydantic validation for llm graph transformer and fix JSON response where possible

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -315,6 +315,7 @@ class LLMGraphTransformer:
         """
         text = document.page_content
         raw_schema = self.chain.invoke({"input": text})
+        raw_schema = cast(Dict[Any, Any], raw_schema)
         nodes, relationships = _convert_to_graph_document(raw_schema)
 
         # Strict mode filtering

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -160,7 +160,7 @@ def map_to_base_relationship(rel: Any) -> Relationship:
 
 
 def _convert_to_graph_document(
-    raw_schema: Dict,
+    raw_schema: Dict[str, Any],
 ) -> Tuple[List[Node], Tuple[List[Relationship]]]:
     # If there are validation errors
     if not raw_schema["parsed"]:
@@ -226,7 +226,7 @@ def _convert_to_graph_document(
                     )
                 )
         except Exception:  # If we can't parse JSON
-            return [], []
+            return ([], [])
     else:  # If there are no validation errors use parsed pydantic object
         raw_schema = raw_schema["parsed"]
         nodes = (

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -172,12 +172,14 @@ def _convert_to_graph_document(
             )
             nodes = []
             for node in argument_json["nodes"]:
-                if not node.get("id"):  # Id is mandatory
+                if not node.get("id"):  # Id is mandatory, skip this node
                     continue
                 nodes.append(
                     Node(
                         id=node["id"].title(),
-                        type=node.get("type", "Node").capitalize(),
+                        type=node.get("type").capitalize()
+                        if node.get("type")
+                        else None,
                     )
                 )
             relationships = []
@@ -197,26 +199,26 @@ def _convert_to_graph_document(
                             el["type"]
                             for el in argument_json["nodes"]
                             if el["id"] == rel["source_node_id"]
-                        ][0]
+                        ][0].capitalize()
                     except IndexError:
-                        rel["source_node_type"] = "Node"
+                        rel["source_node_type"] = None
                 if not rel.get("target_node_type"):
                     try:
                         rel["target_node_type"] = [
                             el["type"]
                             for el in argument_json["nodes"]
                             if el["id"] == rel["target_node_id"]
-                        ][0]
+                        ][0].capitalize()
                     except IndexError:
-                        rel["target_node_type"] = "Node"
+                        rel["target_node_type"] = None
 
                 source_node = Node(
                     id=rel["source_node_id"].title(),
-                    type=rel["source_node_type"].capitalize(),
+                    type=rel["source_node_type"],
                 )
                 target_node = Node(
                     id=rel["target_node_id"].title(),
-                    type=rel["target_node_type"].capitalize(),
+                    type=rel["target_node_type"],
                 )
                 relationships.append(
                     Relationship(

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -225,7 +225,7 @@ def _convert_to_graph_document(
                         type=rel["type"].replace(" ", "_").upper(),
                     )
                 )
-        except Exception as e:  # If we can't parse JSON
+        except Exception:  # If we can't parse JSON
             return [], []
     else:  # If there are no validation errors use parsed pydantic object
         raw_schema = raw_schema["parsed"]

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -245,11 +245,17 @@ def _convert_to_graph_document(
     # If there are validation errors
     if not raw_schema["parsed"]:
         try:
-            argument_json = json.loads(
-                raw_schema["raw"].additional_kwargs["tool_calls"][0]["function"][
-                    "arguments"
-                ]
-            )
+            try: # OpenAI type response
+                argument_json = json.loads(
+                    raw_schema["raw"].additional_kwargs["tool_calls"][0]["function"][
+                        "arguments"
+                    ]
+                )
+            except Exception: # Google type response
+                argument_json = json.loads(
+                    raw_schema["raw"].additional_kwargs["function_call"]["arguments"]
+                )
+
             nodes, relationships = _parse_and_clean_json(argument_json)
         except Exception:  # If we can't parse JSON
             return ([], [])

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -347,18 +347,22 @@ class LLMGraphTransformer:
         # Strict mode filtering
         if self.strict_mode and (self.allowed_nodes or self.allowed_relationships):
             if self.allowed_nodes:
-                nodes = [node for node in nodes if node.type in self.allowed_nodes]
+                lower_allowed_nodes = [el.lower() for el in self.allowed_nodes]
+                nodes = [
+                    node for node in nodes if node.type.lower() in lower_allowed_nodes
+                ]
                 relationships = [
                     rel
                     for rel in relationships
-                    if rel.source.type in self.allowed_nodes
-                    and rel.target.type in self.allowed_nodes
+                    if rel.source.type.lower() in lower_allowed_nodes
+                    and rel.target.type.lower() in lower_allowed_nodes
                 ]
             if self.allowed_relationships:
                 relationships = [
                     rel
                     for rel in relationships
-                    if rel.type in self.allowed_relationships
+                    if rel.type.lower()
+                    in [el.lower() for el in self.allowed_relationships]
                 ]
 
         return GraphDocument(nodes=nodes, relationships=relationships, source=document)
@@ -389,18 +393,22 @@ class LLMGraphTransformer:
 
         if self.strict_mode and (self.allowed_nodes or self.allowed_relationships):
             if self.allowed_nodes:
-                nodes = [node for node in nodes if node.type in self.allowed_nodes]
+                lower_allowed_nodes = [el.lower() for el in self.allowed_nodes]
+                nodes = [
+                    node for node in nodes if node.type.lower() in lower_allowed_nodes
+                ]
                 relationships = [
                     rel
                     for rel in relationships
-                    if rel.source.type in self.allowed_nodes
-                    and rel.target.type in self.allowed_nodes
+                    if rel.source.type.lower() in lower_allowed_nodes
+                    and rel.target.type.lower() in lower_allowed_nodes
                 ]
             if self.allowed_relationships:
                 relationships = [
                     rel
                     for rel in relationships
-                    if rel.type in self.allowed_relationships
+                    if rel.type.lower()
+                    in [el.lower() for el in self.allowed_relationships]
                 ]
 
         return GraphDocument(nodes=nodes, relationships=relationships, source=document)

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -217,11 +217,11 @@ def _parse_and_clean_json(
                 type=rel["type"].replace(" ", "_").upper(),
             )
         )
-        return nodes, relationships
+    return nodes, relationships
 
 
 def _convert_to_graph_document(
-    raw_schema: Union[Dict[Any, Any], BaseModel],
+    raw_schema: Dict[Any, Any],
 ) -> Tuple[List[Node], List[Relationship]]:
     # If there are validation errors
     if not raw_schema["parsed"]:

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -230,16 +230,16 @@ def _convert_to_graph_document(
         except Exception:  # If we can't parse JSON
             return ([], [])
     else:  # If there are no validation errors use parsed pydantic object
-        raw_schema = raw_schema["parsed"]
+        parsed_schema: _Graph = raw_schema["parsed"]
         nodes = (
-            [map_to_base_node(node) for node in raw_schema.nodes]
-            if raw_schema.nodes
+            [map_to_base_node(node) for node in parsed_schema.nodes]
+            if parsed_schema.nodes
             else []
         )
 
         relationships = (
-            [map_to_base_relationship(rel) for rel in raw_schema.relationships]
-            if raw_schema.relationships
+            [map_to_base_relationship(rel) for rel in parsed_schema.relationships]
+            if parsed_schema.relationships
             else []
         )
     return nodes, relationships

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -160,7 +160,7 @@ def map_to_base_relationship(rel: Any) -> Relationship:
 
 
 def _convert_to_graph_document(
-    raw_schema: Dict[str, Any],
+    raw_schema: Dict[Any, Any],
 ) -> Tuple[List[Node], List[Relationship]]:
     # If there are validation errors
     if not raw_schema["parsed"]:

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -219,7 +219,13 @@ def _parse_and_clean_json(
 
 
 def _format_nodes(nodes: List[Node]) -> List[Node]:
-    return [Node(id=el.id.title(), type=el.type.capitalize()) for el in nodes]
+    return [
+        Node(
+            id=el.id.title() if isinstance(el.id, str) else el.id,
+            type=el.type.capitalize(),
+        )
+        for el in nodes
+    ]
 
 
 def _format_relationships(rels: List[Relationship]) -> List[Relationship]:

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, cast
 
 from langchain_community.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_core.documents import Document
@@ -357,6 +357,7 @@ class LLMGraphTransformer:
         """
         text = document.page_content
         raw_schema = await self.chain.ainvoke({"input": text})
+        raw_schema = cast(Dict[Any, Any], raw_schema)
         nodes, relationships = _convert_to_graph_document(raw_schema)
 
         if self.strict_mode and (self.allowed_nodes or self.allowed_relationships):

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -245,13 +245,13 @@ def _convert_to_graph_document(
     # If there are validation errors
     if not raw_schema["parsed"]:
         try:
-            try: # OpenAI type response
+            try:  # OpenAI type response
                 argument_json = json.loads(
                     raw_schema["raw"].additional_kwargs["tool_calls"][0]["function"][
                         "arguments"
                     ]
                 )
-            except Exception: # Google type response
+            except Exception:  # Google type response
                 argument_json = json.loads(
                     raw_schema["raw"].additional_kwargs["function_call"]["arguments"]
                 )

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -161,7 +161,7 @@ def map_to_base_relationship(rel: Any) -> Relationship:
 
 def _convert_to_graph_document(
     raw_schema: Dict[str, Any],
-) -> Tuple[List[Node], Tuple[List[Relationship]]]:
+) -> Tuple[List[Node], List[Relationship]]:
     # If there are validation errors
     if not raw_schema["parsed"]:
         try:

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 from langchain_community.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_core.documents import Document


### PR DESCRIPTION
LLMs might sometimes return invalid response for LLM graph transformer. Instead of failing due to pydantic validation, we skip it and manually check and optionally fix error where we can, so that more information gets extracted