### PR TITLE
<Community>: tidb vector support vector index

### DIFF
--- a/libs/community/langchain_community/vectorstores/tidb_vector.py
+++ b/libs/community/langchain_community/vectorstores/tidb_vector.py
@@ -5,7 +5,7 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
 
-DEFAULT_DISTANCE_STRATEGY = "cosine"  # or "l2", "inner_product"
+DEFAULT_DISTANCE_STRATEGY = "cosine"  # or "l2"
 DEFAULT_TiDB_VECTOR_TABLE_NAME = "langchain_vector"
 
 
@@ -45,7 +45,7 @@ class TiDBVectorStore(VectorStore):
                 store vector data. If you do not provide a table name,
                 a default table named `langchain_vector` will be created automatically.
             distance_strategy: The strategy used for similarity search,
-                defaults to "cosine", valid values: "l2", "cosine", "inner_product".
+                defaults to "cosine", valid values: "l2", "cosine".
             engine_args (Optional[Dict]): Additional arguments for the database engine,
                 defaults to None.
             drop_existing_table: Drop the existing TiDB table before initializing,
@@ -143,7 +143,7 @@ class TiDBVectorStore(VectorStore):
                 table_name (str, optional): The name of table used to store vector data,
                     defaults to "langchain_vector".
                 distance_strategy: The distance strategy used for similarity search,
-                    defaults to "cosine", allowed: "l2", "cosine", "inner_product".
+                    defaults to "cosine", allowed: "l2", "cosine".
                 ids (Optional[List[str]]): The list of IDs corresponding to each text,
                     defaults to None.
                 engine_args: Additional arguments for the underlying database engine,
@@ -205,7 +205,7 @@ class TiDBVectorStore(VectorStore):
             table_name (str, optional): The name of table used to store vector data,
                 defaults to "langchain_vector".
             distance_strategy: The distance strategy used for similarity search,
-                defaults to "cosine", allowed: "l2", "cosine", 'inner_product'.
+                defaults to "cosine", allowed: "l2", "cosine".
             engine_args: Additional arguments for the underlying database engine,
                 defaults to None.
             **kwargs (Any): Additional keyword arguments.

--- a/libs/community/tests/integration_tests/vectorstores/test_tidb_vector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_tidb_vector.py
@@ -1,4 +1,5 @@
 """Test TiDB Vector functionality."""
+
 import os
 from typing import List
 
@@ -276,7 +277,7 @@ def test_relevance_score() -> None:
     metadatas = [{"page": str(i)} for i in range(len(texts))]
     docsearch_consine = TiDBVectorStore.from_texts(
         texts=texts,
-        table_name="test_tidb_vectorstore_langchain",
+        table_name="test_tidb_vectorstore_langchain_cosine",
         embedding=FakeEmbeddingsWithAdaDimension(),
         connection_string=TiDB_CONNECT_URL,
         metadatas=metadatas,
@@ -293,11 +294,14 @@ def test_relevance_score() -> None:
         (Document(page_content="baz", metadata={"page": "2"}), 0.9953081577931554),
     ]
 
-    docsearch_l2 = TiDBVectorStore.from_existing_vector_table(
-        table_name="test_tidb_vectorstore_langchain",
+    docsearch_l2 = TiDBVectorStore.from_texts(
+        texts=texts,
+        table_name="test_tidb_vectorstore_langchain_cosine",
         embedding=FakeEmbeddingsWithAdaDimension(),
         connection_string=TiDB_CONNECT_URL,
+        metadatas=metadatas,
         distance_strategy="l2",
+        drop_existing_table=True,
     )
     output_l2 = docsearch_l2.similarity_search_with_relevance_scores("foo", k=3)
     assert output_l2 == [
@@ -309,7 +313,7 @@ def test_relevance_score() -> None:
     try:
         _ = TiDBVectorStore.from_texts(
             texts=texts,
-            table_name="test_tidb_vectorstore_langchain",
+            table_name="test_tidb_vectorstore_langchain_inner",
             embedding=FakeEmbeddingsWithAdaDimension(),
             connection_string=TiDB_CONNECT_URL,
             metadatas=metadatas,


### PR DESCRIPTION
This PR introduces adjustments to ensure compatibility with the recently released preview version of [TiDB Serverless Vector Search](https://tidb.cloud/ai), aiming to prevent user confusion.

- TiDB Vector now supports vector indexing with cosine and l2 distance strategies, although inner_product remains unsupported.
- Changing the distance strategy is currently not supported, so the test cased should be adjusted.