### PR TITLE
community[patch]: OpenLLM Async Client Fixes and Timeout Parameter

### DIFF
--- a/libs/community/langchain_community/llms/openllm.py
+++ b/libs/community/langchain_community/llms/openllm.py
@@ -308,7 +308,7 @@ class OpenLLM(LLM):
             self._identifying_params["model_name"], **copied
         )
         if self._client:
-            async_client = openllm.client.AsyncHTTPClient(self.server_url)
+            async_client = openllm.client.AsyncHTTPClient(self.server_url, self.timeout)
             res = (
                 (await async_client.generate(prompt, **config.model_dump(flatten=True)))
                 .outputs[0]

--- a/libs/community/langchain_community/llms/openllm.py
+++ b/libs/community/langchain_community/llms/openllm.py
@@ -310,8 +310,10 @@ class OpenLLM(LLM):
         if self._client:
             async_client = openllm.client.AsyncHTTPClient(self.server_url)
             res = (
-                await async_client.generate(prompt, **config.model_dump(flatten=True))
-            ).responses[0]
+                (await async_client.generate(prompt, **config.model_dump(flatten=True)))
+                .outputs[0]
+                .text
+            )
         else:
             assert self._runner is not None
             (


### PR DESCRIPTION
Same changes as this merged [PR](https://github.com/langchain-ai/langchain/pull/17478) (https://github.com/langchain-ai/langchain/pull/17478), but for the async client, as the same issues persist.

- Replaced 'responses' attribute of OpenLLM's GenerationOutput schema to 'outputs'. 
reference: https://github.com/bentoml/OpenLLM/blob/66de54eae7e420a3740ddd77862fd7f7b7d8a222/openllm-core/src/openllm_core/_schemas.py#L135

- Added timeout parameter for the async client.