### PR TITLE
docs: fixing typo in argument name

### DIFF
--- a/docs/docs/integrations/text_embedding/fireworks.ipynb
+++ b/docs/docs/integrations/text_embedding/fireworks.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedding = FireworksEmbeddings(mode=\"nomic-ai/nomic-embed-text-v1.5\")"
+    "embedding = FireworksEmbeddings(model=\"nomic-ai/nomic-embed-text-v1.5\")"
    ]
   },
   {


### PR DESCRIPTION
it's "mode" instead of "model", I fixed it