### PR TITLE
community: `tigergraph` fixes

### DIFF
--- a/docs/docs/integrations/graphs/tigergraph.mdx
+++ b/docs/docs/integrations/graphs/tigergraph.mdx
@@ -1,0 +1,37 @@
+# TigerGraph
+
+>[TigerGraph](https://www.tigergraph.com/tigergraph-db/) is a natively distributed and high-performance graph database.
+> The storage of data in a graph format of vertices and edges leads to rich relationships, 
+> ideal for grouding LLM responses.
+ 
+A big example of the `TigerGraph` and `LangChain` integration [presented here](https://github.com/tigergraph/graph-ml-notebooks/blob/main/applications/large_language_models/TigerGraph_LangChain_Demo.ipynb).
+
+## Installation and Setup
+
+Follow instructions [how to connect to the `TigerGraph` database](https://docs.tigergraph.com/pytigergraph/current/getting-started/connection).
+
+Install the Python SDK:
+
+```bash
+pip install pyTigerGraph
+```
+
+## Example
+
+To utilize the `TigerGraph InquiryAI` functionality, you can import `TigerGraph` from `langchain_community.graphs`.
+
+```python
+import pyTigerGraph as tg
+
+conn = tg.TigerGraphConnection(host="DATABASE_HOST_HERE", graphname="GRAPH_NAME_HERE", username="USERNAME_HERE", password="PASSWORD_HERE")
+
+### ==== CONFIGURE INQUIRYAI HOST ====
+conn.ai.configureInquiryAIHost("INQUIRYAI_HOST_HERE")
+
+from langchain_community.graphs import TigerGraph
+
+graph = TigerGraph(conn)
+result = graph.query("How many servers are there?")
+print(result)
+```
+

--- a/docs/docs/integrations/providers/tigergraph.mdx
+++ b/docs/docs/integrations/providers/tigergraph.mdx
@@ -1,14 +1,12 @@
 # TigerGraph
 
-What is `TigerGraph`?
-
-**TigerGraph in a nutshell:**
-
-- `TigerGraph` is a natively distributed and high-performance graph database.
-- The storage of data in a graph format of vertices and edges leads to rich relationships, ideal for grouding LLM responses.
-- Get started quickly with `TigerGraph` by visiting [their website](https://tigergraph.com/).
+>[TigerGraph](https://www.tigergraph.com/tigergraph-db/) is a natively distributed and high-performance graph database.
+> The storage of data in a graph format of vertices and edges leads to rich relationships, 
+> ideal for grouding LLM responses.
 
 ## Installation and Setup
+
+Follow instructions [how to connect to the `TigerGraph` database](https://docs.tigergraph.com/pytigergraph/current/getting-started/connection).
 
 Install the Python SDK:
 
@@ -18,22 +16,10 @@ pip install pyTigerGraph
 
 ## Graph store
 
-### TigerGraph Store
+### TigerGraph
 
-To utilize the `TigerGraph InquiryAI` functionality, you can import `TigerGraph` from `langchain_community.graphs`.
+See a [usage example](/docs/integrations/graphs/tigergraph).
 
 ```python
-import pyTigerGraph as tg
-
-conn = tg.TigerGraphConnection(host="DATABASE_HOST_HERE", graphname="GRAPH_NAME_HERE", username="USERNAME_HERE", password="PASSWORD_HERE")
-
-### ==== CONFIGURE INQUIRYAI HOST ====
-conn.ai.configureInquiryAIHost("INQUIRYAI_HOST_HERE")
-
 from langchain_community.graphs import TigerGraph
-
-graph = TigerGraph(conn)
-result = graph.query("How many servers are there?")
-print(result)
 ```
-

--- a/libs/community/langchain_community/graphs/tigergraph_graph.py
+++ b/libs/community/langchain_community/graphs/tigergraph_graph.py
@@ -39,7 +39,13 @@ class TigerGraph(GraphStore):
             return str(self._schema)
 
     def set_connection(self, conn: Any) -> None:
-        from pyTigerGraph import TigerGraphConnection
+        try:
+            from pyTigerGraph import TigerGraphConnection
+        except ImportError:
+            raise ImportError(
+                "Could not import pyTigerGraph python package. "
+                "Please install it with `pip install pyTigerGraph`."
+            )
 
         if not isinstance(conn, TigerGraphConnection):
             msg = "**conn** parameter must inherit from TigerGraphConnection"


### PR DESCRIPTION
- added guard on the `pyTigerGraph` import
- added a missed example page in the `docs/integrations/graphs/`
- formatted the `docs/integrations/providers/` page to the consistent format. Added links.