### PR TITLE
Update character.py

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -36,10 +36,9 @@ def _split_text_with_regex(
         if keep_separator:
             # The parentheses in the pattern keep the delimiters in the result.
             _splits = re.split(f"({separator})", text)
-            splits = [_splits[i] + _splits[i + 1] for i in range(1, len(_splits), 2)]
-            if len(_splits) % 2 == 0:
-                splits += _splits[-1:]
-            splits = [_splits[0]] + splits
+            if len(_splits) % 2 != 0:
+                _splits.append("")
+            splits = [_splits[i] + _splits[i + 1] for i in range(0, len(_splits), 2)]
         else:
             splits = re.split(separator, text)
     else:


### PR DESCRIPTION
Fix: Inaccurate separator placement.

- [x] **PR title**: "langchain: Fix the inaccurate separator placement."
- [x] **PR message**: ***Fix: Inaccurate separator placement.***
    - **Description:** In the example below, if the `keep_separator` parameter is set to `True`, the separator's position will appear at the beginning of each chunk, whereas we would prefer it to appear at the end.
```python
from langchain_text_splitters import CharacterTextSplitter

content = "Hello world! Nice to meet you! Nice to meet you too!"
text_splitter = CharacterTextSplitter(separator="!", chunk_size=25, chunk_overlap=0, keep_separator=True)
chunks = text_splitter.create_documents([content])
for chunk in chunks:
    print(chunk.page_content)
```
```
# Output
Hello world
! Nice to meet you
! Nice to meet you too!
```
```
# Expected
Hello world!
Nice to meet you!
Nice to meet you too!
```
This was an issue with the splitting details, which I have fixed by modifying the code.
