### PR TITLE
langchain[patch]: make BooleanOutputParser check words not substrings

### DIFF
--- a/libs/langchain/langchain/output_parsers/boolean.py
+++ b/libs/langchain/langchain/output_parsers/boolean.py
@@ -1,3 +1,5 @@
+import re
+
 from langchain_core.output_parsers import BaseOutputParser
 
 
@@ -19,24 +21,26 @@ class BooleanOutputParser(BaseOutputParser[bool]):
             boolean
 
         """
-        cleaned_upper_text = text.strip().upper()
-        if (
-            self.true_val.upper() in cleaned_upper_text
-            and self.false_val.upper() in cleaned_upper_text
-        ):
-            raise ValueError(
-                f"Ambiguous response. Both {self.true_val} and {self.false_val} in "
-                f"received: {text}."
+        truthy = {
+            val.upper() for val in re.findall(
+                rf"\b({self.true_val}|{self.false_val})\b",
+                text,
+                flags=re.IGNORECASE | re.MULTILINE
             )
-        elif self.true_val.upper() in cleaned_upper_text:
+        }
+        if self.true_val.upper() in truthy:
+            if self.false_val.upper() in truthy:
+                raise ValueError(
+                    f"Ambiguous response. Both {self.true_val} and {self.false_val} "
+                    f"in received: {text}."
+                )
             return True
-        elif self.false_val.upper() in cleaned_upper_text:
+        elif self.false_val.upper() in truthy:
             return False
-        else:
-            raise ValueError(
-                f"BooleanOutputParser expected output value to include either "
-                f"{self.true_val} or {self.false_val}. Received {text}."
-            )
+        raise ValueError(
+            f"BooleanOutputParser expected output value to include either "
+            f"{self.true_val} or {self.false_val}. Received {text}."
+        )
 
     @property
     def _type(self) -> str:

--- a/libs/langchain/langchain/output_parsers/boolean.py
+++ b/libs/langchain/langchain/output_parsers/boolean.py
@@ -19,14 +19,12 @@ class BooleanOutputParser(BaseOutputParser[bool]):
 
         Returns:
             boolean
-
         """
+        regexp = rf"\b({self.true_val}|{self.false_val})\b"
+
         truthy = {
-            val.upper() for val in re.findall(
-                rf"\b({self.true_val}|{self.false_val})\b",
-                text,
-                flags=re.IGNORECASE | re.MULTILINE
-            )
+            val.upper()
+            for val in re.findall(regexp, text, flags=re.IGNORECASE | re.MULTILINE)
         }
         if self.true_val.upper() in truthy:
             if self.false_val.upper() in truthy:
@@ -36,6 +34,11 @@ class BooleanOutputParser(BaseOutputParser[bool]):
                 )
             return True
         elif self.false_val.upper() in truthy:
+            if self.true_val.upper() in truthy:
+                raise ValueError(
+                    f"Ambiguous response. Both {self.true_val} and {self.false_val} "
+                    f"in received: {text}."
+                )
             return False
         raise ValueError(
             f"BooleanOutputParser expected output value to include either "

--- a/libs/langchain/tests/unit_tests/output_parsers/test_boolean_parser.py
+++ b/libs/langchain/tests/unit_tests/output_parsers/test_boolean_parser.py
@@ -24,6 +24,10 @@ def test_boolean_output_parser_parse() -> None:
     result = parser.parse("Not relevant (NO)")
     assert result is False
 
+    # Test valid input
+    result = parser.parse("NOW this is relevant (YES)")
+    assert result is True
+
     # Test ambiguous input
     try:
         parser.parse("yes and no")

--- a/libs/langchain/tests/unit_tests/output_parsers/test_boolean_parser.py
+++ b/libs/langchain/tests/unit_tests/output_parsers/test_boolean_parser.py
@@ -1,3 +1,5 @@
+import pytest
+
 from langchain.output_parsers.boolean import BooleanOutputParser
 
 
@@ -29,15 +31,11 @@ def test_boolean_output_parser_parse() -> None:
     assert result is True
 
     # Test ambiguous input
-    try:
-        parser.parse("yes and no")
-        assert False, "Should have raised ValueError"
-    except ValueError:
-        pass
+    with pytest.raises(ValueError):
+        parser.parse("YES NO")
 
-    # Test invalid input
-    try:
-        parser.parse("INVALID")
-        assert False, "Should have raised ValueError"
-    except ValueError:
-        pass
+    with pytest.raises(ValueError):
+        parser.parse("NO YES")
+    # Bad input
+    with pytest.raises(ValueError):
+        parser.parse("BOOM")


### PR DESCRIPTION
- **Description**: fixes BooleanOutputParser detecting sub-words ("NOW this is likely (YES)" -> `True`, not `AmbiguousError`)
- **Issue(s)**: fixes #11408 (follow-up to #17810)
- **Dependencies**: None
- **GitHub handle**: @casperdcl

<!-- if unreviewd after a few days, @-mention one of baskaryan, efriis, eyurtsev, hwchase17 -->

- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.
- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/
