### PR TITLE
community: Add Documentation to enable authorized access identities in GoogleDriveLoader.

### DIFF
--- a/docs/docs/integrations/document_loaders/google_drive.ipynb
+++ b/docs/docs/integrations/document_loaders/google_drive.ipynb
@@ -324,6 +324,52 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7bde486a",
+   "metadata": {},
+   "source": [
+    "### Loading auth Identities\n",
+    "\n",
+    "Authorized identities for each file ingested by Google Drive Loader can be loaded along with metadata per Document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1d91045",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.document_loaders import GoogleDriveLoader\n",
+    "\n",
+    "loader = GoogleDriveLoader(\n",
+    "    folder_id=folder_id,\n",
+    "    load_auth=True,\n",
+    "    # Optional: configure whether to load authorized identities for each Document.\n",
+    ")\n",
+    "\n",
+    "doc = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83557b75",
+   "metadata": {},
+   "source": [
+    "You can pass load_auth=True, to add Google Drive document access identities to metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ac1a43b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc[0].metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cd13d7d1-db7a-498d-ac98-76ccd9ad9019",
    "metadata": {},
    "source": [
@@ -530,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Description: Document update.

GoogleDriveLoader: Added documentation for `load_auth` a new argument in document_loaders/GoogleDriveLoader.

Dependencies: None
Documentation: https://python.langchain.com/docs/integrations/document_loaders/google_drive/

Associated PR: https://github.com/langchain-ai/langchain-google/pull/110

Twitter handle: @rahul_tripathi2