### PR TITLE
core: make exit_history async in RunnableWithMessageHistory

### DIFF
--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -12,11 +12,13 @@ from typing import (
     Type,
     Union,
 )
+from uuid import UUID
 
+from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.chat_history import BaseChatMessageHistory
-from langchain_core.load.load import load
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableBindingBase, RunnableLambda
+from langchain_core.runnables.config import RunnableConfig
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (
     ConfigurableFieldSpec,
@@ -26,12 +28,72 @@ from langchain_core.runnables.utils import (
 
 if TYPE_CHECKING:
     from langchain_core.messages import BaseMessage
-    from langchain_core.runnables.config import RunnableConfig
-    from langchain_core.tracers.schemas import Run
 
 
 MessagesOrDictWithMessages = Union[Sequence["BaseMessage"], Dict[str, Any]]
 GetSessionHistoryCallable = Callable[..., BaseChatMessageHistory]
+
+
+class AsyncExitHistoryCallback(AsyncCallbackHandler):
+    """Callback that persist input_messages and output_messages."""
+
+    input_messages: List[BaseMessage]
+    output_messages: List[BaseMessage]
+
+    history_messages_key: Optional[str] = None
+    _get_input_messages: Callable[..., List[BaseMessage]]
+    _get_output_messages: Callable[..., List[BaseMessage]]
+    message_history: BaseChatMessageHistory
+
+    def __init__(
+        self,
+        get_input_messages: Callable[..., List[BaseMessage]],
+        get_output_messages: Callable[..., List[BaseMessage]],
+        history_messages_key: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self._get_input_messages = get_input_messages
+        self._get_output_messages = get_output_messages
+        self.history_messages_key = history_messages_key
+
+    async def on_chain_start(
+        self,
+        serialized: Dict[str, Any],
+        inputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: List[str] | None = None,
+        metadata: Dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Get the input messages
+        self.input_messages = self._get_input_messages(inputs)
+
+        # If historic messages were prepended to the input messages, remove them to
+        # avoid adding duplicate messages to history.
+        if not self.history_messages_key:
+            historic_messages = self.message_history.messages
+            self.input_messages = self.input_messages[len(historic_messages) :]
+
+        return
+
+    async def on_chain_end(
+        self,
+        outputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: List[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Get the output messages
+        self.output_messages = self._get_output_messages(outputs)
+
+        await self.message_history.aadd_messages(
+            self.input_messages + self.output_messages
+        )
+        return
 
 
 class RunnableWithMessageHistory(RunnableBindingBase):
@@ -220,6 +282,8 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     output_messages_key: Optional[str] = None
     history_messages_key: Optional[str] = None
     history_factory_config: Sequence[ConfigurableFieldSpec]
+    message_history: Optional[BaseChatMessageHistory] = None  #: :meta private:
+    exit_history_callback: Optional[AsyncExitHistoryCallback] = None  #: :meta private:
 
     @classmethod
     def get_lc_namespace(cls) -> List[str]:
@@ -302,8 +366,17 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             history_chain = RunnablePassthrough.assign(
                 **{messages_key: history_chain}
             ).with_config(run_name="insert_history")
+
+        exit_history_callback = AsyncExitHistoryCallback(
+            get_input_messages=self._get_input_messages,
+            get_output_messages=self._get_output_messages,
+            history_messages_key=history_messages_key,
+        )
         bound = (
-            history_chain | runnable.with_listeners(on_end=self._exit_history)
+            history_chain
+            | runnable.with_config(
+                config=RunnableConfig(callbacks=[exit_history_callback])
+            )
         ).with_config(run_name="RunnableWithMessageHistory")
 
         if history_factory_config:
@@ -328,6 +401,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             bound=bound,
             history_messages_key=history_messages_key,
             history_factory_config=_config_specs,
+            exit_history_callback=exit_history_callback,
             **kwargs,
         )
 
@@ -368,6 +442,9 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     ) -> List[BaseMessage]:
         from langchain_core.messages import BaseMessage
 
+        if isinstance(input_val, dict):
+            input_val = input_val[self.input_messages_key or "input"]
+
         if isinstance(input_val, str):
             from langchain_core.messages import HumanMessage
 
@@ -402,8 +479,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             raise ValueError()
 
     def _enter_history(self, input: Any, config: RunnableConfig) -> List[BaseMessage]:
-        hist: BaseChatMessageHistory = config["configurable"]["message_history"]
-        messages = hist.messages.copy()
+        messages = self.message_history.messages.copy()
 
         if not self.history_messages_key:
             # return all messages
@@ -416,8 +492,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     async def _aenter_history(
         self, input: Dict[str, Any], config: RunnableConfig
     ) -> List[BaseMessage]:
-        hist: BaseChatMessageHistory = config["configurable"]["message_history"]
-        messages = (await hist.aget_messages()).copy()
+        messages = (await self.message_history.aget_messages()).copy()
 
         if not self.history_messages_key:
             # return all messages
@@ -426,25 +501,6 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             )
             messages += self._get_input_messages(input_val)
         return messages
-
-    def _exit_history(self, run: Run, config: RunnableConfig) -> None:
-        hist: BaseChatMessageHistory = config["configurable"]["message_history"]
-
-        # Get the input messages
-        inputs = load(run.inputs)
-        input_val = inputs[self.input_messages_key or "input"]
-        input_messages = self._get_input_messages(input_val)
-
-        # If historic messages were prepended to the input messages, remove them to
-        # avoid adding duplicate messages to history.
-        if not self.history_messages_key:
-            historic_messages = config["configurable"]["message_history"].messages
-            input_messages = input_messages[len(historic_messages) :]
-
-        # Get the output messages
-        output_val = load(run.outputs)
-        output_messages = self._get_output_messages(output_val)
-        hist.add_messages(input_messages + output_messages)
 
     def _merge_configs(self, *configs: Optional[RunnableConfig]) -> RunnableConfig:
         config = super()._merge_configs(*configs)
@@ -483,7 +539,8 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             message_history = self.get_session_history(
                 **{key: configurable[key] for key in expected_keys}
             )
-        config["configurable"]["message_history"] = message_history
+        self.message_history = message_history
+        self.exit_history_callback.message_history = message_history
         return config
 
 

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -438,7 +438,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             return super_schema
 
     def _get_input_messages(
-        self, input_val: Union[str, BaseMessage, Sequence[BaseMessage]]
+        self, input_val: Union[str, BaseMessage, Sequence[BaseMessage], dict]
     ) -> List[BaseMessage]:
         from langchain_core.messages import BaseMessage
 
@@ -479,6 +479,8 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             raise ValueError()
 
     def _enter_history(self, input: Any, config: RunnableConfig) -> List[BaseMessage]:
+        if self.message_history is None:
+            raise AssertionError("unreachable: message_history is not set")
         messages = self.message_history.messages.copy()
 
         if not self.history_messages_key:
@@ -492,6 +494,8 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     async def _aenter_history(
         self, input: Dict[str, Any], config: RunnableConfig
     ) -> List[BaseMessage]:
+        if self.message_history is None:
+            raise AssertionError("unreachable: message_history is not set")
         messages = (await self.message_history.aget_messages()).copy()
 
         if not self.history_messages_key:
@@ -540,6 +544,8 @@ class RunnableWithMessageHistory(RunnableBindingBase):
                 **{key: configurable[key] for key in expected_keys}
             )
         self.message_history = message_history
+        if self.exit_history_callback is None:
+            raise AssertionError("unreachable: exit_history_callback is not set")
         self.exit_history_callback.message_history = message_history
         return config
 

--- a/libs/core/tests/unit_tests/fake/memory.py
+++ b/libs/core/tests/unit_tests/fake/memory.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Sequence
 
 from langchain_core.chat_history import (
     BaseChatMessageHistory,
@@ -18,6 +18,9 @@ class ChatMessageHistory(BaseChatMessageHistory, BaseModel):
     def add_message(self, message: BaseMessage) -> None:
         """Add a self-created message to the store"""
         self.messages.append(message)
+
+    async def aadd_messages(self, messages: Sequence[BaseMessage]) -> None:
+        self.messages.extend(messages)
 
     def clear(self) -> None:
         self.messages = []

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -400,9 +400,9 @@ def test_using_custom_config_specs() -> None:
 
 def test_chain_runnable_input_messages() -> None:
     """Test that runnable that is a chain can work with history."""
-    from langchain_core.runnables import RunnablePassthrough
+    from langchain_core.runnables import Runnable, RunnablePassthrough
 
-    runnable = {"input": RunnablePassthrough()} | RunnableLambda(
+    runnable: Runnable = {"input": RunnablePassthrough()} | RunnableLambda(
         lambda input: "you said: "
         + "\n".join(
             str(m.content) for m in input["input"] if isinstance(m, HumanMessage)

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -378,7 +378,7 @@ def test_non_chain_runnable_input_messages() -> None:
             )
 
         def invoke(
-            self, input: Sequence[BaseMessage], config: RunnableConfig | None = None
+            self, input: Sequence[BaseMessage], config: Optional[RunnableConfig] = None
         ) -> str:
             return self._call_with_config(func=self._invoke, input=input, config=config)
 


### PR DESCRIPTION
As `add_messages` almost always make API calls to remote store, it would be better to make this procedure `async`. This PR makes `_exit_history` `async` via `AsyncCallbackHandler`.