### PR TITLE
community: Fix Bedrock Mistral stop sequence request key

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -338,7 +338,7 @@ class BedrockBase(BaseModel, ABC):
         "amazon": "stopSequences",
         "ai21": "stop_sequences",
         "cohere": "stop_sequences",
-        "mistral": "stop_sequences",
+        "mistral": "stop",
     }
 
     guardrails: Optional[Mapping[str, Any]] = {


### PR DESCRIPTION
- **Description:** Change Bedrock's Mistral stop sequence key mapping to "stop" rather than "stop_sequences" which is the correct key [Bedrock docs link](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral.html) `{
    "prompt": string,
    "max_tokens" : int,
    "stop" : [string],    
    "temperature": float,
    "top_p": float,
    "top_k": int
}`
- **Issue:** #20053 
- **Dependencies:** N/A
- **Twitter handle:** N/a