### PR TITLE
docs: Remove Duplicate --quiet Flag in Installation Command in LangSmith Docs

### DIFF
--- a/docs/docs/langsmith/walkthrough.ipynb
+++ b/docs/docs/langsmith/walkthrough.ipynb
@@ -69,8 +69,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  langchain langsmith langchainhub --quiet\n",
-    "%pip install --upgrade --quiet  langchain-openai tiktoken pandas duckduckgo-search --quiet"
+    "%pip install --upgrade --quiet  langchain langsmith langchainhub\n",
+    "%pip install --upgrade --quiet  langchain-openai tiktoken pandas duckduckgo-search"
    ]
   },
   {


### PR DESCRIPTION
**Description:** This pull request removes a duplicated `--quiet` flag in the pip install command found in the LangSmith Walkthrough section of the documentation.

**Issue:** N/A

**Dependencies:** None
