### PR TITLE
The predict_and_parse is deprecated, instead pass an output parser directly to LLMChain.

### DIFF
--- a/libs/langchain/langchain/retrievers/document_compressors/chain_extract.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/chain_extract.py
@@ -64,7 +64,9 @@ class LLMChainExtractor(BaseDocumentCompressor):
         compressed_docs = []
         for doc in documents:
             _input = self.get_input(query, doc)
-            output = self.llm_chain.predict_and_parse(**_input, callbacks=callbacks)
+            output = self.llm_chain.predict(**_input, callbacks=callbacks)
+            if self.llm_chain.prompt.output_parser is not None:
+                output = self.llm_chain.prompt.output_parser.parse(output)
             if len(output) == 0:
                 continue
             compressed_docs.append(

--- a/libs/langchain/langchain/retrievers/document_compressors/chain_extract.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/chain_extract.py
@@ -64,7 +64,8 @@ class LLMChainExtractor(BaseDocumentCompressor):
         compressed_docs = []
         for doc in documents:
             _input = self.get_input(query, doc)
-            output = self.llm_chain.predict(**_input, callbacks=callbacks)
+            output_dict = self.llm_chain.invoke(_input, config={"callbacks": callbacks})
+            output = output_dict[self.llm_chain.output_key]
             if self.llm_chain.prompt.output_parser is not None:
                 output = self.llm_chain.prompt.output_parser.parse(output)
             if len(output) == 0:


### PR DESCRIPTION
The `predict_and_parse` method is deprecated, instead pass an output parser directly to LLMChain.

- [x] **PR title**: "langchain: update chain_extract.py"

![image](https://github.com/langchain-ai/langchain/assets/40889019/e950d79f-5a0f-4086-86e9-89f627990fe5)

