### PR TITLE
docs: Fixed the cross links for output_parsers docs for openai_tools and openai_functions

### DIFF
--- a/docs/docs/modules/model_io/output_parsers/types/openai_functions.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/openai_functions.ipynb
@@ -9,10 +9,10 @@
     "\n",
     "These output parsers use OpenAI function calling to structure its outputs. This means they are only usable with models that support function calling. There are a few different variants:\n",
     "\n",
-    "- JsonOutputFunctionsParser: Returns the arguments of the function call as JSON\n",
-    "- PydanticOutputFunctionsParser: Returns the arguments of the function call as a Pydantic Model\n",
-    "- JsonKeyOutputFunctionsParser: Returns the value of specific key in the function call as JSON\n",
-    "- PydanticAttrOutputFunctionsParser: Returns the value of specific key in the function call as a Pydantic Model\n"
+    "- [JsonOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.JsonOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.JsonOutputFunctionsParser): Returns the arguments of the function call as JSON\n",
+    "- [PydanticOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.PydanticOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.PydanticOutputFunctionsParser): Returns the arguments of the function call as a Pydantic Model\n",
+    "- [JsonKeyOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.JsonKeyOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.JsonKeyOutputFunctionsParser): Returns the value of specific key in the function call as JSON\n",
+    "- [PydanticAttrOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.PydanticAttrOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.PydanticAttrOutputFunctionsParser): Returns the value of specific key in the function call as a Pydantic Model\n"
    ]
   },
   {

--- a/docs/docs/modules/model_io/output_parsers/types/openai_tools.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/openai_tools.ipynb
@@ -11,9 +11,9 @@
     "\n",
     "There are a few different variants of output parsers:\n",
     "\n",
-    "- [JsonOutputToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.openai_tools.JsonOutputToolsParser.html#langchain.output_parsers.openai_tools.JsonOutputToolsParser): Returns the arguments of the function call as JSON\n",
-    "- [JsonOutputKeyToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.openai_tools.JsonOutputKeyToolsParser.html#langchain.output_parsers.openai_tools.JsonOutputKeyToolsParser): Returns the value of specific key in the function call as JSON\n",
-    "- [PydanticToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.openai_tools.PydanticToolsParser.html#langchain.output_parsers.openai_tools.PydanticToolsParser): Returns the arguments of the function call as a Pydantic Model"
+    "- [JsonOutputToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_tools.JsonOutputToolsParser.html#langchain_core.output_parsers.openai_tools.JsonOutputToolsParser): Returns the arguments of the function call as JSON\n",
+    "- [JsonOutputKeyToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_tools.JsonOutputKeyToolsParser.html#langchain_core.output_parsers.openai_tools.JsonOutputKeyToolsParser): Returns the value of specific key in the function call as JSON\n",
+    "- [PydanticToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_tools.PydanticToolsParser.html#langchain_core.output_parsers.openai_tools.PydanticToolsParser): Returns the arguments of the function call as a Pydantic Model"
    ]
   },
   {


### PR DESCRIPTION
  - **Description:** I fixed the links in the output parsers docs which references the API docs.  
  - **Issue:** the issue #19969 it fixes, if applicable
