### PR TITLE
langchain-pinecone: pinecone vectorstore does not work when async_req is set to False

### DIFF
--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -166,7 +166,8 @@ class PineconeVectorStore(VectorStore):
                     batch_size, zip(chunk_ids, embeddings, chunk_metadatas)
                 )
             ]
-            [res.get() for res in async_res]
+            if async_req:
+                [res.get() for res in async_res]
 
         return ids
 


### PR DESCRIPTION
When `async_req` is set to False, running `[res.get() for res in async_res]` produces an exception. We do no need to call `get()` at all, as it is already present, when `async_req` is set to False.

Fixes: {TypeError}TypeError("ModelNormal.get() missing 1 required positional argument: 'name'")