### PR TITLE
core,community,partners[minor]: add optional env var OPENAI_BASE_URL

### DIFF
--- a/libs/community/langchain_community/chat_models/azure_openai.py
+++ b/libs/community/langchain_community/chat_models/azure_openai.py
@@ -121,8 +121,10 @@ class AzureChatOpenAI(ChatOpenAI):
             or os.getenv("AZURE_OPENAI_API_KEY")
             or os.getenv("OPENAI_API_KEY")
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_api_version"] = values["openai_api_version"] or os.getenv(
             "OPENAI_API_VERSION"

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -290,8 +290,10 @@ class ChatOpenAI(BaseChatModel):
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,

--- a/libs/community/langchain_community/document_loaders/parsers/audio.py
+++ b/libs/community/langchain_community/document_loaders/parsers/audio.py
@@ -35,7 +35,11 @@ class OpenAIWhisperParser(BaseBlobParser):
         self.api_key = api_key
         self.chunk_duration_threshold = chunk_duration_threshold
         self.base_url = (
-            base_url if base_url is not None else os.environ.get("OPENAI_API_BASE")
+            base_url
+            if base_url is not None
+            else (
+                os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+            )
         )
 
     def lazy_parse(self, blob: Blob) -> Iterator[Document]:

--- a/libs/community/langchain_community/embeddings/azure_openai.py
+++ b/libs/community/langchain_community/embeddings/azure_openai.py
@@ -65,8 +65,10 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
             or os.getenv("AZURE_OPENAI_API_KEY")
             or os.getenv("OPENAI_API_KEY")
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_api_version"] = values["openai_api_version"] or os.getenv(
             "OPENAI_API_VERSION", default="2023-05-15"

--- a/libs/community/langchain_community/embeddings/localai.py
+++ b/libs/community/langchain_community/embeddings/localai.py
@@ -123,8 +123,8 @@ class LocalAIEmbeddings(BaseModel, Embeddings):
     uses the ``openai`` Python package's ``openai.Embedding`` as its client.
     Thus, you should have the ``openai`` python package installed, and defeat
     the environment variable ``OPENAI_API_KEY`` by setting to a random string.
-    You also need to specify ``OPENAI_API_BASE`` to point to your LocalAI
-    service endpoint.
+    You also need to specify ``OPENAI_API_BASE`` or ``OPENAI_BASE_URL``
+    to point to your LocalAI service endpoint.
 
     Example:
         .. code-block:: python
@@ -203,6 +203,7 @@ class LocalAIEmbeddings(BaseModel, Embeddings):
             values,
             "openai_api_base",
             "OPENAI_API_BASE",
+            "OPENAI_BASE_URL",
             default="",
         )
         values["openai_proxy"] = get_from_dict_or_env(

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -157,7 +157,8 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             openai = OpenAIEmbeddings(openai_api_key="my-api-key")
 
     In order to use the library with Microsoft Azure endpoints, you need to set
-    the OPENAI_API_TYPE, OPENAI_API_BASE, OPENAI_API_KEY and OPENAI_API_VERSION.
+    the OPENAI_API_TYPE, OPENAI_API_BASE or OPENAI_BASE_URL, OPENAI_API_KEY
+    and OPENAI_API_VERSION.
     The OPENAI_API_TYPE must be set to 'azure' and the others correspond to
     the properties of your endpoint.
     In addition, the deployment name must be passed as the model parameter.
@@ -288,8 +289,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         values["openai_api_key"] = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_api_type"] = get_from_dict_or_env(
             values,

--- a/libs/community/langchain_community/llms/openai.py
+++ b/libs/community/langchain_community/llms/openai.py
@@ -282,8 +282,10 @@ class BaseOpenAI(BaseLLM):
         values["openai_api_key"] = get_from_dict_or_env(
             values, "openai_api_key", "OPENAI_API_KEY"
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,
@@ -841,8 +843,10 @@ class AzureOpenAI(BaseOpenAI):
         values["azure_ad_token"] = values["azure_ad_token"] or os.getenv(
             "AZURE_OPENAI_AD_TOKEN"
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,
@@ -1033,6 +1037,7 @@ class OpenAIChat(BaseLLM):
             values,
             "openai_api_base",
             "OPENAI_API_BASE",
+            "OPENAI_BASE_URL",
             default="",
         )
         openai_proxy = get_from_dict_or_env(

--- a/libs/community/langchain_community/utilities/dalle_image_generator.py
+++ b/libs/community/langchain_community/utilities/dalle_image_generator.py
@@ -102,8 +102,10 @@ class DallEAPIWrapper(BaseModel):
             or os.getenv("OPENAI_ORGANIZATION")
             or None
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,

--- a/libs/community/tests/unit_tests/chat_models/test_azureopenai.py
+++ b/libs/community/tests/unit_tests/chat_models/test_azureopenai.py
@@ -53,3 +53,12 @@ def test_model_name_set_on_chat_result_when_present_in_response(
         chat_result.llm_output is not None
         and chat_result.llm_output["model_name"] == model_name
     )
+
+    os.environ["OPENAI_BASE_URL"] = os.environ["OPENAI_API_BASE"]
+    os.environ.pop("OPENAI_API_BASE", None)
+    mock_chat = AzureChatOpenAI()
+    chat_result = mock_chat._create_chat_result(sample_response)
+    assert (
+        chat_result.llm_output is not None
+        and chat_result.llm_output["model_name"] == model_name
+    )

--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -22,19 +22,30 @@ def env_var_is_set(env_var: str) -> bool:
 
 
 def get_from_dict_or_env(
-    data: Dict[str, Any], key: str, env_key: str, default: Optional[str] = None
+    data: Dict[str, Any],
+    key: str,
+    env_key: str,
+    env_key_alias: Optional[str] = None,
+    default: Optional[str] = None,
 ) -> str:
     """Get a value from a dictionary or an environment variable."""
     if key in data and data[key]:
         return data[key]
     else:
-        return get_from_env(key, env_key, default=default)
+        return get_from_env(key, env_key, env_key_alias=env_key_alias, default=default)
 
 
-def get_from_env(key: str, env_key: str, default: Optional[str] = None) -> str:
+def get_from_env(
+    key: str,
+    env_key: str,
+    env_key_alias: Optional[str] = None,
+    default: Optional[str] = None,
+) -> str:
     """Get a value from a dictionary or an environment variable."""
     if env_key in os.environ and os.environ[env_key]:
         return os.environ[env_key]
+    elif env_key_alias and os.environ.get(env_key_alias):
+        return os.environ[env_key_alias]
     elif default is not None:
         return default
     else:

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -119,8 +119,10 @@ class AzureChatOpenAI(ChatOpenAI):
         values["openai_api_key"] = (
             convert_to_secret_str(openai_api_key) if openai_api_key else None
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_api_version"] = values["openai_api_version"] or os.getenv(
             "OPENAI_API_VERSION"

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -394,8 +394,10 @@ class ChatOpenAI(BaseChatModel):
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -75,8 +75,10 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
         values["openai_api_key"] = (
             convert_to_secret_str(openai_api_key) if openai_api_key else None
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_api_version"] = values["openai_api_version"] or os.getenv(
             "OPENAI_API_VERSION", default="2023-05-15"

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -171,8 +171,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         values["openai_api_key"] = (
             convert_to_secret_str(openai_api_key) if openai_api_key else None
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_api_type"] = get_from_dict_or_env(
             values,

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -101,8 +101,10 @@ class AzureOpenAI(BaseOpenAI):
         values["azure_ad_token"] = (
             convert_to_secret_str(azure_ad_token) if azure_ad_token else None
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -187,8 +187,10 @@ class BaseOpenAI(BaseLLM):
         values["openai_api_key"] = (
             convert_to_secret_str(openai_api_key) if openai_api_key else None
         )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
+        values["openai_api_base"] = (
+            values["openai_api_base"]
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
         )
         values["openai_proxy"] = get_from_dict_or_env(
             values,


### PR DESCRIPTION
`OPENAI_BASE_URL`  as an alternative to `OPENAI_API_BASE`

*Why?* 
There is some confusion with this `env var`, so it is would not be bad to support original one
https://github.com/openai/openai-python/blob/main/src/openai/_client.py#L108

and it can also make life a little better for developers =)