### PR TITLE
docs: Set cross-link for class descriptions to api docs

### DIFF
--- a/docs/docs/modules/model_io/output_parsers/types/csv.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/csv.ipynb
@@ -5,7 +5,7 @@
    "id": "e3fbf5c7",
    "metadata": {},
    "source": [
-    "# CSV parser\n",
+    "# [CSV parser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.list.CommaSeparatedListOutputParser.html#langchain_core.output_parsers.list.CommaSeparatedListOutputParser)\n",
     "\n",
     "This output parser can be used when you want to return a list of comma-separated items."
    ]

--- a/docs/docs/modules/model_io/output_parsers/types/datetime.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/datetime.ipynb
@@ -5,7 +5,7 @@
    "id": "07311335",
    "metadata": {},
    "source": [
-    "# Datetime parser\n",
+    "# [Datetime parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.datetime.DatetimeOutputParser.html#langchain.output_parsers.datetime.DatetimeOutputParser)\n",
     "\n",
     "This OutputParser can be used to parse LLM output into datetime format."
    ]

--- a/docs/docs/modules/model_io/output_parsers/types/enum.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/enum.ipynb
@@ -5,7 +5,7 @@
    "id": "0360be02",
    "metadata": {},
    "source": [
-    "# Enum parser\n",
+    "# [Enum parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.enum.EnumOutputParser.html#langchain.output_parsers.enum.EnumOutputParser)\n",
     "\n",
     "This notebook shows how to use an Enum output parser."
    ]

--- a/docs/docs/modules/model_io/output_parsers/types/json.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/json.ipynb
@@ -5,7 +5,7 @@
    "id": "72b1b316",
    "metadata": {},
    "source": [
-    "# JSON parser\n",
+    "# [JSON parser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.json.JsonOutputParser.html#langchain_core.output_parsers.json.JsonOutputParser)\n",
     "This output parser allows users to specify an arbitrary JSON schema and query LLMs for outputs that conform to that schema.\n",
     "\n",
     "Keep in mind that large language models are leaky abstractions! You'll have to use an LLM with sufficient capacity to generate well-formed JSON. In the OpenAI family, DaVinci can do reliably but Curie's ability already drops off dramatically. \n",

--- a/docs/docs/modules/model_io/output_parsers/types/openai_functions.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/openai_functions.ipynb
@@ -9,10 +9,10 @@
     "\n",
     "These output parsers use OpenAI function calling to structure its outputs. This means they are only usable with models that support function calling. There are a few different variants:\n",
     "\n",
-    "- JsonOutputFunctionsParser: Returns the arguments of the function call as JSON\n",
-    "- PydanticOutputFunctionsParser: Returns the arguments of the function call as a Pydantic Model\n",
-    "- JsonKeyOutputFunctionsParser: Returns the value of specific key in the function call as JSON\n",
-    "- PydanticAttrOutputFunctionsParser: Returns the value of specific key in the function call as a Pydantic Model\n"
+    "- [JsonOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.JsonOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.JsonOutputFunctionsParser): Returns the arguments of the function call as JSON\n",
+    "- [PydanticOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.PydanticOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.PydanticOutputFunctionsParser): Returns the arguments of the function call as a Pydantic Model\n",
+    "- [JsonKeyOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.JsonKeyOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.JsonKeyOutputFunctionsParser): Returns the value of specific key in the function call as JSON\n",
+    "- [PydanticAttrOutputFunctionsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_functions.PydanticAttrOutputFunctionsParser.html#langchain_core.output_parsers.openai_functions.PydanticAttrOutputFunctionsParser): Returns the value of specific key in the function call as a Pydantic Model\n"
    ]
   },
   {

--- a/docs/docs/modules/model_io/output_parsers/types/openai_tools.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/openai_tools.ipynb
@@ -11,9 +11,9 @@
     "\n",
     "There are a few different variants of output parsers:\n",
     "\n",
-    "- [JsonOutputToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.openai_tools.JsonOutputToolsParser.html#langchain.output_parsers.openai_tools.JsonOutputToolsParser): Returns the arguments of the function call as JSON\n",
-    "- [JsonOutputKeyToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.openai_tools.JsonOutputKeyToolsParser.html#langchain.output_parsers.openai_tools.JsonOutputKeyToolsParser): Returns the value of specific key in the function call as JSON\n",
-    "- [PydanticToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.openai_tools.PydanticToolsParser.html#langchain.output_parsers.openai_tools.PydanticToolsParser): Returns the arguments of the function call as a Pydantic Model"
+    "- [JsonOutputToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_tools.JsonOutputToolsParser.html#langchain_core.output_parsers.openai_tools.JsonOutputToolsParser): Returns the arguments of the function call as JSON\n",
+    "- [JsonOutputKeyToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_tools.JsonOutputKeyToolsParser.html#langchain_core.output_parsers.openai_tools.JsonOutputKeyToolsParser): Returns the value of specific key in the function call as JSON\n",
+    "- [PydanticToolsParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.openai_tools.PydanticToolsParser.html#langchain_core.output_parsers.openai_tools.PydanticToolsParser): Returns the arguments of the function call as a Pydantic Model"
    ]
   },
   {

--- a/docs/docs/modules/model_io/output_parsers/types/output_fixing.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/output_fixing.ipynb
@@ -5,7 +5,7 @@
    "id": "0fee7096",
    "metadata": {},
    "source": [
-    "# Output-fixing parser\n",
+    "# [Output-fixing parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.fix.OutputFixingParser.html#langchain.output_parsers.fix.OutputFixingParser)\n",
     "\n",
     "This output parser wraps another output parser, and in the event that the first one fails it calls out to another LLM to fix any errors.\n",
     "\n",

--- a/docs/docs/modules/model_io/output_parsers/types/pandas_dataframe.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/pandas_dataframe.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pandas DataFrame Parser\n",
+    "# [Pandas DataFrame Parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.pandas_dataframe.PandasDataFrameOutputParser.html#langchain.output_parsers.pandas_dataframe.PandasDataFrameOutputParser)\n",
     "\n",
     "A Pandas DataFrame is a popular data structure in the Python programming language, commonly used for data manipulation and analysis. It provides a comprehensive set of tools for working with structured data, making it a versatile option for tasks such as data cleaning, transformation, and analysis.\n",
     "\n",

--- a/docs/docs/modules/model_io/output_parsers/types/pydantic.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/pydantic.ipynb
@@ -5,7 +5,7 @@
    "id": "a1ae632a",
    "metadata": {},
    "source": [
-    "# Pydantic parser\n",
+    "# [Pydantic parser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.pydantic.PydanticOutputParser.html#langchain_core.output_parsers.pydantic.PydanticOutputParser)\n",
     "This output parser allows users to specify an arbitrary Pydantic Model and query LLMs for outputs that conform to that schema.\n",
     "\n",
     "Keep in mind that large language models are leaky abstractions! You'll have to use an LLM with sufficient capacity to generate well-formed JSON. In the OpenAI family, DaVinci can do reliably but [Curie](https://wiprotechblogs.medium.com/davinci-vs-curie-a-comparison-between-gpt-3-engines-for-extractive-summarization-b568d4633b3b)'s ability already drops off dramatically. \n",

--- a/docs/docs/modules/model_io/output_parsers/types/retry.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/retry.ipynb
@@ -5,7 +5,7 @@
    "id": "4d6c0c86",
    "metadata": {},
    "source": [
-    "# Retry parser\n",
+    "# [Retry parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.retry.RetryOutputParser.html#langchain.output_parsers.retry.RetryOutputParser)\n",
     "\n",
     "While in some cases it is possible to fix any parsing mistakes by only looking at the output, in other cases it isn't. An example of this is when the output is not just in the incorrect format, but is partially complete. Consider the below example."
    ]

--- a/docs/docs/modules/model_io/output_parsers/types/structured.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/structured.ipynb
@@ -5,7 +5,7 @@
    "id": "7460ca08",
    "metadata": {},
    "source": [
-    "# Structured output parser\n",
+    "# [Structured output parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.structured.StructuredOutputParser.html#langchain.output_parsers.structured.StructuredOutputParser)\n",
     "\n",
     "This output parser can be used when you want to return multiple fields. While the Pydantic/JSON parser is more powerful, this is useful for less powerful models."
    ]

--- a/docs/docs/modules/model_io/output_parsers/types/xml.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/xml.ipynb
@@ -5,7 +5,7 @@
    "id": "181b5b6d",
    "metadata": {},
    "source": [
-    "# XML parser\n",
+    "# [XML parser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.xml.XMLOutputParser.html#langchain_core.output_parsers.xml.XMLOutputParser)\n",
     "This output parser allows users to obtain results from LLM in the popular XML format. \n",
     "\n",
     "Keep in mind that large language models are leaky abstractions! You'll have to use an LLM with sufficient capacity to generate well-formed XML. \n",

--- a/docs/docs/modules/model_io/output_parsers/types/yaml.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/yaml.ipynb
@@ -5,7 +5,7 @@
    "id": "72b1b316",
    "metadata": {},
    "source": [
-    "# YAML parser\n",
+    "# [YAML parser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.yaml.YamlOutputParser.html#langchain.output_parsers.yaml.YamlOutputParser)\n",
     "This output parser allows users to specify an arbitrary schema and query LLMs for outputs that conform to that schema, using YAML to format their response.\n",
     "\n",
     "Keep in mind that large language models are leaky abstractions! You'll have to use an LLM with sufficient capacity to generate well-formed YAML. In the OpenAI family, DaVinci can do reliably but Curie's ability already drops off dramatically. \n",


### PR DESCRIPTION
  - **Description:** In this PR I am fixing the documentation of output parsers. It fixes the links in main descriptions page and points to the API docs.
  - **Issue:** Fixes the issue #19969
