### PR TITLE
community: update huggingface pipeline with  `pipeline_kwargs`  configuration

### DIFF
--- a/docs/docs/integrations/llms/openvino.ipynb
+++ b/docs/docs/integrations/llms/openvino.ipynb
@@ -218,6 +218,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7574c6f0",
+   "metadata": {},
+   "source": [
+    "### Streaming\n",
+    "\n",
+    "To get streaming of LLM output, you can create a Huggingface `TextIteratorStreamer` for `_forward_params`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "548c9489",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from threading import Thread\n",
+    "\n",
+    "from transformers import TextIteratorStreamer\n",
+    "\n",
+    "streamer = TextIteratorStreamer(\n",
+    "    ov_llm.pipeline.tokenizer,\n",
+    "    timeout=30.0,\n",
+    "    skip_prompt=True,\n",
+    "    skip_special_tokens=True,\n",
+    ")\n",
+    "ov_llm.pipeline._forward_params  = {\"streamer\": streamer, \"max_new_tokens\": 100}\n",
+    "\n",
+    "t1 = Thread(target=chain.invoke, args=({\"question\": question},))\n",
+    "t1.start()\n",
+    "\n",
+    "for new_text in streamer:\n",
+    "    print(new_text, end=\"\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "da9a9239",
    "metadata": {},
    "source": [

--- a/libs/community/langchain_community/llms/huggingface_pipeline.py
+++ b/libs/community/langchain_community/llms/huggingface_pipeline.py
@@ -110,7 +110,7 @@ class HuggingFacePipeline(BaseLLM):
                         raise ImportError(
                             "Could not import optimum-intel python package. "
                             "Please install it with: "
-                            "pip install 'optimum[openvino,nncf]' "
+                            "pip install `optimum[openvino,nncf]` "
                         )
                     try:
                         # use local model
@@ -136,7 +136,7 @@ class HuggingFacePipeline(BaseLLM):
                         raise ImportError(
                             "Could not import optimum-intel python package. "
                             "Please install it with: "
-                            "pip install 'optimum[openvino,nncf]' "
+                            "pip install `optimum[openvino,nncf]` "
                         )
                     try:
                         # use local model
@@ -206,7 +206,7 @@ class HuggingFacePipeline(BaseLLM):
                     cuda_device_count,
                 )
         if device is not None and device_map is not None and backend == "openvino":
-            logger.warning("Please set device for OpenVINO through: " "'model_kwargs'")
+            logger.warning("Please set device for OpenVINO through: `model_kwargs`")
         if "trust_remote_code" in _model_kwargs:
             _model_kwargs = {
                 k: v for k, v in _model_kwargs.items() if k != "trust_remote_code"


### PR DESCRIPTION
Since `pipeline_kwargs` cannot be updated through `chain.invoke` function, I added a new method to change `pipeline_kwargs` after model compiled. 

Now we can change the generation parameter without reloading/recompiling the model.