### PR TITLE
docs: Fix typo in citations example

### DIFF
--- a/docs/docs/use_cases/question_answering/citations.ipynb
+++ b/docs/docs/use_cases/question_answering/citations.ipynb
@@ -184,7 +184,7 @@
     "## Function-calling\n",
     "\n",
     "### Cite documents\n",
-    "Let's try using [OpenAI function-calling](/docs/modules/model_io/chat/function_calling) to make the model specify which of the provided documents it's actually referencing when answering. LangChain has some utils for converting Pydantic ojbects to the JSONSchema format expected by OpenAI, so we'll use that to define our functions:"
+    "Let's try using [OpenAI function-calling](/docs/modules/model_io/chat/function_calling) to make the model specify which of the provided documents it's actually referencing when answering. LangChain has some utils for converting Pydantic objects to the JSONSchema format expected by OpenAI, so we'll use that to define our functions:"
    ]
   },
   {


### PR DESCRIPTION
Small typo in the citations notebook "ojbects" changed to "objects"
