### PR TITLE
docs: fix JsonOutputToolsParser import in use_cases/tool_use/quickstart

### DIFF
--- a/docs/docs/use_cases/tool_use/quickstart.ipynb
+++ b/docs/docs/use_cases/tool_use/quickstart.ipynb
@@ -255,7 +255,7 @@
     }
    ],
    "source": [
-    "from langchain.output_parsers import JsonOutputToolsParser\n",
+    "from langchain.output_parsers.openai_tools import JsonOutputToolsParser\n",
     "\n",
     "chain = model_with_tools | JsonOutputToolsParser()\n",
     "chain.invoke(\"What's four times 23\")"
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "from langchain.output_parsers import JsonOutputKeyToolsParser\n",
+    "from langchain.output_parsers.openai_tools import JsonOutputKeyToolsParser\n",
     "\n",
     "chain = model_with_tools | JsonOutputKeyToolsParser(\n",
     "    key_name=\"multiply\", first_tool_only=True\n",


### PR DESCRIPTION
 - **Description:** fixes incorrect import in the tools quickstart
 - **Dependencies:** none
 
Hey team, I was reading through the tool use quickstart and stumbled across some outdated
docs when it comes to creating your own tools and using the JsonOutputToolsParser.

This should fix it by referencing the right package.