### PR TITLE
langchain[patch]: Update unit test

### DIFF
--- a/libs/langchain/tests/unit_tests/load/test_load.py
+++ b/libs/langchain/tests/unit_tests/load/test_load.py
@@ -29,7 +29,7 @@ def test_loads_openai_llm() -> None:
 
 @pytest.mark.requires("openai", "langchain_openai")
 def test_loads_llmchain() -> None:
-    from langchain_openai import OpenAI, ChatOpenAI
+    from langchain_openai import ChatOpenAI, OpenAI
 
     llm = CommunityOpenAI(model="davinci", temperature=0.5, openai_api_key="hello")  # type: ignore[call-arg]
     prompt = PromptTemplate.from_template("hello {name}!")
@@ -149,7 +149,7 @@ def test_load_llmchain_with_non_serializable_arg() -> None:
         model="davinci",
         temperature=0.5,
         openai_api_key="hello",
-        model_kwargs={"a": NotSerializable},
+        http_client=NotSerializable,
     )
     prompt = PromptTemplate.from_template("hello {name}!")
     chain = LLMChain(llm=llm, prompt=prompt)

--- a/libs/langchain/tests/unit_tests/load/test_load.py
+++ b/libs/langchain/tests/unit_tests/load/test_load.py
@@ -29,7 +29,7 @@ def test_loads_openai_llm() -> None:
 
 @pytest.mark.requires("openai", "langchain_openai")
 def test_loads_llmchain() -> None:
-    from langchain_openai import ChatOpenAI, OpenAI
+    from langchain_openai import OpenAI
 
     llm = CommunityOpenAI(model="davinci", temperature=0.5, openai_api_key="hello")  # type: ignore[call-arg]
     prompt = PromptTemplate.from_template("hello {name}!")
@@ -72,8 +72,6 @@ def test_loads_llmchain_env() -> None:
 
 @pytest.mark.requires("openai")
 def test_loads_llmchain_with_non_serializable_arg() -> None:
-    from langchain_community import __version__
-
     llm = CommunityOpenAI(  # type: ignore[call-arg]
         model="davinci",
         temperature=0.5,

--- a/libs/langchain/tests/unit_tests/load/test_load.py
+++ b/libs/langchain/tests/unit_tests/load/test_load.py
@@ -29,7 +29,7 @@ def test_loads_openai_llm() -> None:
 
 @pytest.mark.requires("openai", "langchain_openai")
 def test_loads_llmchain() -> None:
-    from langchain_openai import OpenAI
+    from langchain_openai import OpenAI, ChatOpenAI
 
     llm = CommunityOpenAI(model="davinci", temperature=0.5, openai_api_key="hello")  # type: ignore[call-arg]
     prompt = PromptTemplate.from_template("hello {name}!")
@@ -72,11 +72,13 @@ def test_loads_llmchain_env() -> None:
 
 @pytest.mark.requires("openai")
 def test_loads_llmchain_with_non_serializable_arg() -> None:
+    from langchain_community import __version__
+
     llm = CommunityOpenAI(  # type: ignore[call-arg]
         model="davinci",
         temperature=0.5,
         openai_api_key="hello",
-        http_client=NotSerializable,
+        model_kwargs={"a": NotSerializable},
     )
     prompt = PromptTemplate.from_template("hello {name}!")
     chain = LLMChain(llm=llm, prompt=prompt)
@@ -147,7 +149,7 @@ def test_load_llmchain_with_non_serializable_arg() -> None:
         model="davinci",
         temperature=0.5,
         openai_api_key="hello",
-        http_client=NotSerializable,
+        model_kwargs={"a": NotSerializable},
     )
     prompt = PromptTemplate.from_template("hello {name}!")
     chain = LLMChain(llm=llm, prompt=prompt)


### PR DESCRIPTION
This unit test fails likely validation by the openai client.

Newer openai library seems to be doing more validation so the existing test fails since http_client needs to be of httpx instance
