### PR TITLE
community: add gpt-4 pricing in callback

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -17,6 +17,8 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-1106-preview": 0.01,
     "gpt-4-0125-preview": 0.01,
     "gpt-4-turbo-preview": 0.01,
+    "gpt-4-turbo": 0.01,
+    "gpt-4-turbo-2024-04-09": 0.01,
     # GPT-4 output
     "gpt-4-completion": 0.06,
     "gpt-4-0314-completion": 0.06,
@@ -28,6 +30,8 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-1106-preview-completion": 0.03,
     "gpt-4-0125-preview-completion": 0.03,
     "gpt-4-turbo-preview-completion": 0.03,
+    "gpt-4-turbo-completion": 0.03,
+    "gpt-4-turbo-2024-04-09-completion": 0.03,
     # GPT-3.5 input
     # gpt-3.5-turbo points at gpt-3.5-turbo-0613 until Feb 16, 2024.
     # Switches to gpt-3.5-turbo-0125 after.


### PR DESCRIPTION
Added the pricing for `gpt-4-turbo` and `gpt-4-turbo-2024-04-09` in the callback method.
related to issue #17173 

https://openai.com/pricing#language-models
