### PR TITLE
core[patch]: Fix JsonOutputParser returns empty json when text ends with "\".

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -71,6 +71,7 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
             elif char == "\n" and not escaped:
                 char = "\\n"  # Replace the newline character with the escape sequence.
             elif char == "\\":
+                char = "\\\\"
                 escaped = not escaped
             else:
                 escaped = False

--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -72,7 +72,6 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
                 char = "\\n"  # Replace the newline character with the escape sequence.
             elif char == "\\":
                 char = "\\\\"
-                escaped = not escaped
             else:
                 escaped = False
         else:

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -235,13 +235,13 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar": "foo', '{"foo": "bar", "bar": "foo"}'),
     ('{"foo": "bar", "bar": "foo}', '{"foo": "bar", "bar": "foo}"}'),
     ('{"foo": "bar", "bar": "foo[', '{"foo": "bar", "bar": "foo["}'),
-    ('{"foo": "bar", "bar": "foo\\"', '''{"foo": "bar", "bar": "foo\\\\"}'''),
+    ('{"foo": "bar", "bar": "foo\\"', """{"foo": "bar", "bar": "foo\\\\"}"""),
     ('{"foo": "bar", "bar":', '{"foo": "bar"}'),
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
-    ('{"key":"val\\ue', '''{"key": "val\\\\ue"}'''),
-    ('{"key":"value\\', '''{"key": "value\\\\"}'''),
-    ('{"key":"\\value', '''{"key": "\\\\value"}'''),
+    ('{"key":"val\\ue', """{"key": "val\\\\ue"}"""),
+    ('{"key":"value\\', """{"key": "value\\\\"}"""),
+    ('{"key":"\\value', """{"key": "\\\\value"}"""),
 ]
 
 

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -239,7 +239,9 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar":', '{"foo": "bar"}'),
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
-    ('{"key":"val\\ue', '{"key":"value\\', '{"key":"\\value'),
+    ('{"key":"val\\ue', "{'key': 'val\\ue'}"),
+    ('{"key":"value\\', "{'key': 'value\\'}"),
+    ('{"key":"\\value', "{'key': '\\value'}"),
 ]
 
 

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -239,6 +239,7 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar":', '{"foo": "bar"}'),
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
+    ('{"key":"val\\ue', '{"key":"value\\', '{"key":"\\value'),
 ]
 
 

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -239,7 +239,6 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar":', '{"foo": "bar"}'),
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
-    ('{"key":"val\\ue', """{"key": "val\\\\ue"}"""),
     ('{"key":"value\\', """{"key": "value\\\\"}"""),
     ('{"key":"\\value', """{"key": "\\\\value"}"""),
 ]

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -235,13 +235,13 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar": "foo', '{"foo": "bar", "bar": "foo"}'),
     ('{"foo": "bar", "bar": "foo}', '{"foo": "bar", "bar": "foo}"}'),
     ('{"foo": "bar", "bar": "foo[', '{"foo": "bar", "bar": "foo["}'),
-    ('{"foo": "bar", "bar": "foo\\"', '{"foo": "bar", "bar": "foo\\""}'),
+    ('{"foo": "bar", "bar": "foo\\"', '''{"foo": "bar", "bar": "foo\\\\"}'''),
     ('{"foo": "bar", "bar":', '{"foo": "bar"}'),
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
-    ('{"key":"val\\ue', "{'key': 'val\\ue'}"),
-    ('{"key":"value\\', "{'key': 'value\\'}"),
-    ('{"key":"\\value', "{'key': '\\value'}"),
+    ('{"key":"val\\ue', '''{"key": "val\\\\ue"}'''),
+    ('{"key":"value\\', '''{"key": "value\\\\"}'''),
+    ('{"key":"\\value', '''{"key": "\\\\value"}'''),
 ]
 
 


### PR DESCRIPTION
- **Issue:** Close #20204
- @baskaryan, @efriis, @eyurtsev, @hwchase17.
