### PR TITLE
docs: Adding api documentation link at the end of each output parser class description page.

### DIFF
--- a/docs/docs/modules/model_io/output_parsers/types/csv.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/csv.ipynb
@@ -84,6 +84,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "af204787",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [CommaSeparatedListOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.list.CommaSeparatedListOutputParser.html#langchain_core.output_parsers.list.CommaSeparatedListOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "13cc7be2",

--- a/docs/docs/modules/model_io/output_parsers/types/datetime.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/datetime.ipynb
@@ -101,6 +101,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8a12b77a",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [DatetimeOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.datetime.DatetimeOutputParser.html#langchain.output_parsers.datetime.DatetimeOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ad1f7e8d",

--- a/docs/docs/modules/model_io/output_parsers/types/enum.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/enum.ipynb
@@ -88,6 +88,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b1adc71f",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [EnumOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.enum.EnumOutputParser.html#langchain.output_parsers.enum.EnumOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "8f0a5f80",

--- a/docs/docs/modules/model_io/output_parsers/types/json.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/json.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Keep in mind that large language models are leaky abstractions! You'll have to use an LLM with sufficient capacity to generate well-formed JSON. In the OpenAI family, DaVinci can do reliably but Curie's ability already drops off dramatically. \n",
     "\n",
-    "You can optionally use Pydantic to declare your data model."
+    "You can optionally use Pydantic to declare your data model. \n"
    ]
   },
   {
@@ -170,6 +170,14 @@
     "chain = prompt | model | parser\n",
     "\n",
     "chain.invoke({\"query\": joke_query})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d9b8f6c",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [JsonOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.json.JsonOutputParser.html#langchain_core.output_parsers.json.JsonOutputParser)."
    ]
   },
   {

--- a/docs/docs/modules/model_io/output_parsers/types/output_fixing.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/output_fixing.ipynb
@@ -127,6 +127,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "84498e02",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [OutputFixingParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.fix.OutputFixingParser.html#langchain.output_parsers.fix.OutputFixingParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "bc7af2a0",

--- a/docs/docs/modules/model_io/output_parsers/types/pandas_dataframe.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/pandas_dataframe.ipynb
@@ -204,6 +204,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [PandasDataFrameOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.pandas_dataframe.PandasDataFrameOutputParser.html#langchain.output_parsers.pandas_dataframe.PandasDataFrameOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/docs/modules/model_io/output_parsers/types/pydantic.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/pydantic.ipynb
@@ -126,6 +126,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e227d9a0",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [PydanticOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.pydantic.PydanticOutputParser.html#langchain_core.output_parsers.pydantic.PydanticOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2b11e014",

--- a/docs/docs/modules/model_io/output_parsers/types/retry.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/retry.ipynb
@@ -244,6 +244,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e3a2513a",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [RetryOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.retry.RetryOutputParser.html#langchain.output_parsers.retry.RetryOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a2f94fd8",

--- a/docs/docs/modules/model_io/output_parsers/types/structured.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/structured.ipynb
@@ -116,6 +116,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1f97aa07",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [StructuredOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.structured.StructuredOutputParser.html#langchain.output_parsers.structured.StructuredOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "c18e5dc7",

--- a/docs/docs/modules/model_io/output_parsers/types/xml.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/xml.ipynb
@@ -179,6 +179,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "09c711fb",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [XMLOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain_core.output_parsers.xml.XMLOutputParser.html#langchain_core.output_parsers.xml.XMLOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "efc073c6",

--- a/docs/docs/modules/model_io/output_parsers/types/yaml.ipynb
+++ b/docs/docs/modules/model_io/output_parsers/types/yaml.ipynb
@@ -87,6 +87,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f859ace0",
+   "metadata": {},
+   "source": [
+    "Find out api documentation for [YamlOutputParser](https://api.python.langchain.com/en/latest/output_parsers/langchain.output_parsers.yaml.YamlOutputParser.html#langchain.output_parsers.yaml.YamlOutputParser)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a4d12261",


### PR DESCRIPTION
  - **Description:** Added cross-links for easy access of api documentation of each output parser class from it's description page.
  - **Issue:** related to issue #19969 

