### PR TITLE
Make Groq .stream robust to ToolMessage

### DIFF
--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -358,7 +358,7 @@ class ChatGroq(BaseChatModel):
                     "id": rtc.get("id"),
                     "index": rtc.get("index"),
                 }
-                for rtc in message.additional_kwargs["tool_calls"]
+                for rtc in message.additional_kwargs.get("tool_calls")
             ]
             chunk_ = ChatGenerationChunk(
                 message=AIMessageChunk(

--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -358,7 +358,7 @@ class ChatGroq(BaseChatModel):
                     "id": rtc.get("id"),
                     "index": rtc.get("index"),
                 }
-                for rtc in message.additional_kwargs.get("tool_calls")
+                for rtc in message.additional_kwargs.get("tool_calls", [])
             ]
             chunk_ = ChatGenerationChunk(
                 message=AIMessageChunk(

--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -287,7 +287,7 @@ class ChatGroq(BaseChatModel):
                     "id": rtc.get("id"),
                     "index": rtc.get("index"),
                 }
-                for rtc in message.additional_kwargs["tool_calls"]
+                for rtc in message.additional_kwargs.get("tool_calls", [])
             ]
             chunk_ = ChatGenerationChunk(
                 message=AIMessageChunk(


### PR DESCRIPTION
```python
from langchain.agents import AgentExecutor, create_tool_calling_agent, tool
from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
from langchain_groq import ChatGroq


prompt = ChatPromptTemplate.from_messages(
    [
        ("system", "You are a helpful assistant"),
        ("human", "{input}"),
        MessagesPlaceholder("agent_scratchpad"),
    ]
)

model = ChatGroq(model_name="mixtral-8x7b-32768", temperature=0)

@tool
def magic_function(input: int) -> int:
    """Applies a magic function to an input."""
    return input + 2

tools = [magic_function]


agent = create_tool_calling_agent(model, tools, prompt)
agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)

agent_executor.invoke({"input": "what is the value of magic_function(3)?"})
```
```
> Entering new AgentExecutor chain...

Invoking: `magic_function` with `{'input': 3}`


5The value of magic\_function(3) is 5.

> Finished chain.
{'input': 'what is the value of magic_function(3)?',
 'output': 'The value of magic\\_function(3) is 5.'}
```