### PR TITLE
perf: update v4 client API initialization for weaveate vector db

### DIFF
--- a/docs/docs/integrations/retrievers/weaviate-hybrid.ipynb
+++ b/docs/docs/integrations/retrievers/weaviate-hybrid.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "WEAVIATE_URL = os.getenv(\"WEAVIATE_URL\")\n",
     "auth_client_secret = (weaviate.AuthApiKey(api_key=os.getenv(\"WEAVIATE_API_KEY\")),)\n",
-    "client = weaviate.Client(\n",
+    "client = weaviate.WeaviateClient(\n",
     "    url=WEAVIATE_URL,\n",
     "    additional_headers={\n",
     "        \"X-Openai-Api-Key\": os.getenv(\"OPENAI_API_KEY\"),\n",
@@ -295,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/libs/community/langchain_community/retrievers/weaviate_hybrid_search.py
+++ b/libs/community/langchain_community/retrievers/weaviate_hybrid_search.py
@@ -43,10 +43,10 @@ class WeaviateHybridSearchRetriever(BaseRetriever):
                 "Could not import weaviate python package. "
                 "Please install it with `pip install weaviate-client`."
             )
-        if not isinstance(values["client"], weaviate.Client):
+        if not isinstance(values["client"], weaviate.WeaviateClient):
             client = values["client"]
             raise ValueError(
-                f"client should be an instance of weaviate.Client, got {type(client)}"
+                f"client should be an instance of weaviate.WeaviateClient, got {type(client)}"
             )
         if values.get("attributes") is None:
             values["attributes"] = []

--- a/templates/hybrid-search-weaviate/hybrid_search_weaviate/chain.py
+++ b/templates/hybrid-search-weaviate/hybrid_search_weaviate/chain.py
@@ -24,7 +24,7 @@ if os.environ.get("OPENAI_API_KEY", None) is None:
 WEAVIATE_INDEX_NAME = os.environ.get("WEAVIATE_INDEX", "langchain-test")
 WEAVIATE_URL = os.getenv("WEAVIATE_URL")
 auth_client_secret = (weaviate.AuthApiKey(api_key=os.getenv("WEAVIATE_API_KEY")),)
-client = weaviate.Client(
+client = weaviate.WeaviateClient(
     url=WEAVIATE_URL,
     additional_headers={
         "X-Openai-Api-Key": os.getenv("OPENAI_API_KEY"),


### PR DESCRIPTION
**`weaviate.Client(url=url, auth=auth, **kwargs)` is a `v3` type of implementation of Weaviate client, which is a depreciated way of initialising a weaveate client. This leads to a `DeprecationWarning`. This PR handles to upgrade the client initialisation for `from langchain_community.vectorstores.weaviate import Weaviate` library**

**Issue:** #20442 
**Dependencies:** No dependency change requierd
**Twitter handle:** [@vardhaman722](https://twitter.com/vardhaman722) 

