### PR TITLE
community: Fix pgvector deprecated filter clause usage with OR and AND conditions

### DIFF
--- a/libs/community/langchain_community/vectorstores/pgvector.py
+++ b/libs/community/langchain_community/vectorstores/pgvector.py
@@ -795,13 +795,13 @@ class PGVector(VectorStore):
             )
         elif OR in map(str.lower, value):
             or_clauses = [
-                self._create_filter_clause(key, sub_value)
+                self._create_filter_clause_deprecated(key, sub_value)
                 for sub_value in value_case_insensitive[OR]
             ]
             filter_by_metadata = sqlalchemy.or_(*or_clauses)
         elif AND in map(str.lower, value):
             and_clauses = [
-                self._create_filter_clause(key, sub_value)
+                self._create_filter_clause_deprecated(key, sub_value)
                 for sub_value in value_case_insensitive[AND]
             ]
             filter_by_metadata = sqlalchemy.and_(*and_clauses)

--- a/libs/community/tests/integration_tests/vectorstores/test_pgvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_pgvector.py
@@ -227,6 +227,45 @@ def test_pgvector_with_filter_nin_set() -> None:
     ]
 
 
+def test_pg_vector_with_or_filter():
+    """Test end to end construction and search with specific OR filter."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    docsearch = PGVector.from_texts(
+        texts=texts,
+        collection_name="test_collection_filter",
+        embedding=FakeEmbeddingsWithAdaDimension(),
+        metadatas=metadatas,
+        connection_string=CONNECTION_STRING,
+        pre_delete_collection=True,
+    )
+    output = docsearch.similarity_search_with_score(
+        "foo", k=3, filter={"page": {"OR": [{"EQ": "0"}, {"EQ": "2"}]}}
+    )
+    assert output == [
+        (Document(page_content="foo", metadata={"page": "0"}), 0.0),
+        (Document(page_content="baz", metadata={"page": "2"}), 0.0013003906671379406),
+    ]
+
+
+def test_pg_vector_with_and_filter():
+    """Test end to end construction and search with specific AND filter."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": str(i)} for i in range(len(texts))]
+    docsearch = PGVector.from_texts(
+        texts=texts,
+        collection_name="test_collection_filter",
+        embedding=FakeEmbeddingsWithAdaDimension(),
+        metadatas=metadatas,
+        connection_string=CONNECTION_STRING,
+        pre_delete_collection=True,
+    )
+    output = docsearch.similarity_search_with_score(
+        "foo", k=3, filter={"page": {"AND": [{"IN": ["0","1"]}, {"NIN": ["1"]}]}}
+    )
+    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 0.0)]
+
+
 def test_pgvector_delete_docs() -> None:
     """Add and delete documents."""
     texts = ["foo", "bar", "baz"]

--- a/libs/community/tests/integration_tests/vectorstores/test_pgvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_pgvector.py
@@ -227,7 +227,7 @@ def test_pgvector_with_filter_nin_set() -> None:
     ]
 
 
-def test_pg_vector_with_or_filter():
+def test_pg_vector_with_or_filter() -> None:
     """Test end to end construction and search with specific OR filter."""
     texts = ["foo", "bar", "baz"]
     metadatas = [{"page": str(i)} for i in range(len(texts))]
@@ -248,7 +248,7 @@ def test_pg_vector_with_or_filter():
     ]
 
 
-def test_pg_vector_with_and_filter():
+def test_pg_vector_with_and_filter() -> None:
     """Test end to end construction and search with specific AND filter."""
     texts = ["foo", "bar", "baz"]
     metadatas = [{"page": str(i)} for i in range(len(texts))]
@@ -261,7 +261,7 @@ def test_pg_vector_with_and_filter():
         pre_delete_collection=True,
     )
     output = docsearch.similarity_search_with_score(
-        "foo", k=3, filter={"page": {"AND": [{"IN": ["0","1"]}, {"NIN": ["1"]}]}}
+        "foo", k=3, filter={"page": {"AND": [{"IN": ["0", "1"]}, {"NIN": ["1"]}]}}
     )
     assert output == [(Document(page_content="foo", metadata={"page": "0"}), 0.0)]
 


### PR DESCRIPTION
**Description**: Support filter by OR and AND for deprecated PGVector version
**Issue**: #20445 
**Dependencies**: N/A
**Twitter** handle: @martinferenaz
