### PR TITLE
docs: quickstart retrieval chain for Cohere(API)

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -293,7 +293,7 @@ embeddings = OllamaEmbeddings()
 Make sure you have the `cohere` package installed and the appropriate environment variables set (these are the same as needed for the LLM).
 
 ```python
-from langchain_community.embeddings import CohereEmbeddings
+from langchain_cohere.embeddings import CohereEmbeddings
 
 embeddings = CohereEmbeddings()
 ```


### PR DESCRIPTION

    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change
    - **Twitter handle:** if your PR gets announced, and you'd like a mention, we'll gladly shout you out!


Description: fixes LangChainDeprecationWarning: The class `langchain_community.embeddings.cohere.CohereEmbeddings` was deprecated in langchain-community 0.0.30 and will be removed in 0.2.0. An updated version of the class exists in the langchain-cohere package and should be used instead. To use it run `pip install -U langchain-cohere` and import as `from langchain_cohere import CohereEmbeddings`.

![Screenshot 2024-04-15 200948](https://github.com/langchain-ai/langchain/assets/93511919/085b967d-a6fd-42c6-9404-faab8c5630ec)



Dependencies : langchain_cohere

Twitter handle: @Mo_Noumaan