### PR TITLE
experimental[patch]: `prompts` import fix

### DIFF
--- a/libs/experimental/langchain_experimental/autonomous_agents/autogpt/prompt.py
+++ b/libs/experimental/langchain_experimental/autonomous_agents/autogpt/prompt.py
@@ -1,11 +1,11 @@
 import time
 from typing import Any, Callable, List, cast
 
-from langchain.prompts.chat import (
-    BaseChatPromptTemplate,
-)
 from langchain.tools.base import BaseTool
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.prompts.chat import (
+    BaseChatPromptTemplate,
+)
 from langchain_core.vectorstores import VectorStoreRetriever
 
 from langchain_experimental.autonomous_agents.autogpt.prompt_generator import get_prompt

--- a/libs/experimental/langchain_experimental/autonomous_agents/hugginggpt/task_planner.py
+++ b/libs/experimental/langchain_experimental/autonomous_agents/hugginggpt/task_planner.py
@@ -5,14 +5,14 @@ from typing import Any, Dict, List, Optional, Union
 
 from langchain.base_language import BaseLanguageModel
 from langchain.chains import LLMChain
-from langchain.prompts.chat import (
+from langchain.tools.base import BaseTool
+from langchain_core.callbacks.manager import Callbacks
+from langchain_core.prompts.chat import (
     AIMessagePromptTemplate,
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
     SystemMessagePromptTemplate,
 )
-from langchain.tools.base import BaseTool
-from langchain_core.callbacks.manager import Callbacks
 
 from langchain_experimental.pydantic_v1 import BaseModel
 

--- a/libs/experimental/langchain_experimental/cpal/base.py
+++ b/libs/experimental/langchain_experimental/cpal/base.py
@@ -10,8 +10,8 @@ from langchain.base_language import BaseLanguageModel
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
 from langchain.output_parsers import PydanticOutputParser
-from langchain.prompts.prompt import PromptTemplate
 from langchain_core.callbacks.manager import CallbackManagerForChainRun
+from langchain_core.prompts.prompt import PromptTemplate
 
 from langchain_experimental import pydantic_v1 as pydantic
 from langchain_experimental.cpal.constants import Constant

--- a/libs/experimental/langchain_experimental/fallacy_removal/prompts.py
+++ b/libs/experimental/langchain_experimental/fallacy_removal/prompts.py
@@ -1,5 +1,5 @@
-from langchain.prompts.few_shot import FewShotPromptTemplate
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.few_shot import FewShotPromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 fallacy_critique_example = PromptTemplate(
     template="""Human: {input_prompt}

--- a/libs/experimental/langchain_experimental/llm_bash/prompt.py
+++ b/libs/experimental/langchain_experimental/llm_bash/prompt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import List
 
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.output_parsers import BaseOutputParser
 from langchain_core.exceptions import OutputParserException
 

--- a/libs/experimental/langchain_experimental/llm_symbolic_math/base.py
+++ b/libs/experimental/langchain_experimental/llm_symbolic_math/base.py
@@ -7,11 +7,11 @@ from typing import Any, Dict, List, Optional
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
-from langchain.prompts.base import BasePromptTemplate
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForChainRun,
     CallbackManagerForChainRun,
 )
+from langchain_core.prompts.base import BasePromptTemplate
 
 from langchain_experimental.llm_symbolic_math.prompt import PROMPT
 from langchain_experimental.pydantic_v1 import Extra

--- a/libs/experimental/langchain_experimental/llm_symbolic_math/prompt.py
+++ b/libs/experimental/langchain_experimental/llm_symbolic_math/prompt.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 _PROMPT_TEMPLATE = """Translate a math problem into a expression that can be executed using Python's SymPy library. Use the output of running this code to answer the question.
 

--- a/libs/experimental/langchain_experimental/pal_chain/colored_object_prompt.py
+++ b/libs/experimental/langchain_experimental/pal_chain/colored_object_prompt.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 template = (
     """

--- a/libs/experimental/langchain_experimental/pal_chain/math_prompt.py
+++ b/libs/experimental/langchain_experimental/pal_chain/math_prompt.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 template = (
     '''

--- a/libs/experimental/langchain_experimental/plan_and_execute/planners/chat_planner.py
+++ b/libs/experimental/langchain_experimental/plan_and_execute/planners/chat_planner.py
@@ -1,9 +1,9 @@
 import re
 
 from langchain.chains import LLMChain
-from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.messages import SystemMessage
+from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 
 from langchain_experimental.plan_and_execute.planners.base import LLMPlanner
 from langchain_experimental.plan_and_execute.schema import (

--- a/libs/experimental/langchain_experimental/prompts/load.py
+++ b/libs/experimental/langchain_experimental/prompts/load.py
@@ -1,3 +1,3 @@
-from langchain.prompts.loading import load_prompt
+from langchain_core.prompts.loading import load_prompt
 
 __all__ = ["load_prompt"]

--- a/libs/experimental/langchain_experimental/recommenders/amazon_personalize_chain.py
+++ b/libs/experimental/langchain_experimental/recommenders/amazon_personalize_chain.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, List, Mapping, Optional, cast
 
 from langchain.chains import LLMChain
 from langchain.chains.base import Chain
-from langchain.prompts.prompt import PromptTemplate
 from langchain.schema.language_model import BaseLanguageModel
 from langchain_core.callbacks.manager import (
     CallbackManagerForChainRun,
 )
+from langchain_core.prompts.prompt import PromptTemplate
 
 from langchain_experimental.recommenders.amazon_personalize import AmazonPersonalize
 

--- a/libs/experimental/langchain_experimental/rl_chain/base.py
+++ b/libs/experimental/langchain_experimental/rl_chain/base.py
@@ -18,13 +18,13 @@ from typing import (
 
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
-from langchain.prompts import (
+from langchain_core.callbacks.manager import CallbackManagerForChainRun
+from langchain_core.prompts import (
     BasePromptTemplate,
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
     SystemMessagePromptTemplate,
 )
-from langchain_core.callbacks.manager import CallbackManagerForChainRun
 
 from langchain_experimental.pydantic_v1 import BaseModel, Extra, root_validator
 from langchain_experimental.rl_chain.metrics import (

--- a/libs/experimental/langchain_experimental/rl_chain/pick_best_chain.py
+++ b/libs/experimental/langchain_experimental/rl_chain/pick_best_chain.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.llm import LLMChain
-from langchain.prompts import BasePromptTemplate
 from langchain_core.callbacks.manager import CallbackManagerForChainRun
+from langchain_core.prompts import BasePromptTemplate
 
 import langchain_experimental.rl_chain.base as base
 

--- a/libs/experimental/langchain_experimental/smart_llm/base.py
+++ b/libs/experimental/langchain_experimental/smart_llm/base.py
@@ -4,15 +4,15 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 from langchain.base_language import BaseLanguageModel
 from langchain.chains.base import Chain
 from langchain.input import get_colored_text
-from langchain.prompts.base import BasePromptTemplate
-from langchain.prompts.chat import (
+from langchain.schema import LLMResult, PromptValue
+from langchain_core.callbacks.manager import CallbackManagerForChainRun
+from langchain_core.prompts.base import BasePromptTemplate
+from langchain_core.prompts.chat import (
     AIMessagePromptTemplate,
     BaseMessagePromptTemplate,
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
 )
-from langchain.schema import LLMResult, PromptValue
-from langchain_core.callbacks.manager import CallbackManagerForChainRun
 
 from langchain_experimental.pydantic_v1 import Extra, root_validator
 

--- a/libs/experimental/langchain_experimental/sql/base.py
+++ b/libs/experimental/langchain_experimental/sql/base.py
@@ -7,12 +7,12 @@ from typing import Any, Dict, List, Optional
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
 from langchain.chains.sql_database.prompt import DECIDER_PROMPT, PROMPT, SQL_PROMPTS
-from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import BasePromptTemplate
 from langchain_community.tools.sql_database.prompt import QUERY_CHECKER
 from langchain_community.utilities.sql_database import SQLDatabase
 from langchain_core.callbacks.manager import CallbackManagerForChainRun
 from langchain_core.language_models import BaseLanguageModel
+from langchain_core.prompts.prompt import PromptTemplate
 
 from langchain_experimental.pydantic_v1 import Extra, Field, root_validator
 

--- a/libs/experimental/langchain_experimental/sql/prompt.py
+++ b/libs/experimental/langchain_experimental/sql/prompt.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 
 PROMPT_SUFFIX = """Only use the following tables:

--- a/libs/experimental/langchain_experimental/sql/vector_sql.py
+++ b/libs/experimental/langchain_experimental/sql/vector_sql.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain.chains.llm import LLMChain
 from langchain.chains.sql_database.prompt import PROMPT, SQL_PROMPTS
-from langchain.prompts.prompt import PromptTemplate
 from langchain_community.tools.sql_database.prompt import QUERY_CHECKER
 from langchain_community.utilities.sql_database import SQLDatabase
 from langchain_core.callbacks.manager import CallbackManagerForChainRun
@@ -14,6 +13,7 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import BaseOutputParser
 from langchain_core.prompts import BasePromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 from langchain_experimental.sql.base import INTERMEDIATE_STEPS_KEY, SQLDatabaseChain
 

--- a/libs/experimental/langchain_experimental/synthetic_data/prompts.py
+++ b/libs/experimental/langchain_experimental/synthetic_data/prompts.py
@@ -1,4 +1,4 @@
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 sentence_template = """Given the following fields, create a sentence about them. 
 Make the sentence detailed and interesting. Use every given field.

--- a/libs/experimental/langchain_experimental/tabular_synthetic_data/base.py
+++ b/libs/experimental/langchain_experimental/tabular_synthetic_data/base.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Optional, Union
 
 from langchain.chains.base import Chain
 from langchain.chains.llm import LLMChain
-from langchain.prompts.few_shot import FewShotPromptTemplate
 from langchain.pydantic_v1 import BaseModel, root_validator
 from langchain_core.language_models import BaseLanguageModel
+from langchain_core.prompts.few_shot import FewShotPromptTemplate
 
 
 class SyntheticDataGenerator(BaseModel):

--- a/libs/experimental/langchain_experimental/tabular_synthetic_data/prompts.py
+++ b/libs/experimental/langchain_experimental/tabular_synthetic_data/prompts.py
@@ -1,4 +1,4 @@
-from langchain.prompts.prompt import PromptTemplate
+from langchain_core.prompts.prompt import PromptTemplate
 
 DEFAULT_INPUT_KEY = "example"
 DEFAULT_PROMPT = PromptTemplate(

--- a/libs/experimental/langchain_experimental/tot/thought_generation.py
+++ b/libs/experimental/langchain_experimental/tot/thought_generation.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 from typing import Any, Dict, List, Tuple
 
 from langchain.chains.llm import LLMChain
-from langchain.prompts.base import BasePromptTemplate
+from langchain_core.prompts.base import BasePromptTemplate
 
 from langchain_experimental.pydantic_v1 import Field
 from langchain_experimental.tot.prompts import get_cot_prompt, get_propose_prompt

--- a/libs/experimental/tests/integration_tests/chains/test_cpal.py
+++ b/libs/experimental/tests/integration_tests/chains/test_cpal.py
@@ -7,8 +7,8 @@ from unittest import mock
 
 import pytest
 from langchain.output_parsers import PydanticOutputParser
-from langchain.prompts.prompt import PromptTemplate
 from langchain_community.llms import OpenAI
+from langchain_core.prompts.prompt import PromptTemplate
 
 from langchain_experimental import pydantic_v1 as pydantic
 from langchain_experimental.cpal.base import (

--- a/libs/experimental/tests/integration_tests/chains/test_synthetic_data_openai.py
+++ b/libs/experimental/tests/integration_tests/chains/test_synthetic_data_openai.py
@@ -1,7 +1,7 @@
 import pytest
-from langchain.prompts.few_shot import FewShotPromptTemplate
 from langchain.pydantic_v1 import BaseModel
 from langchain_community.chat_models import ChatOpenAI
+from langchain_core.prompts.few_shot import FewShotPromptTemplate
 
 from langchain_experimental.tabular_synthetic_data.base import SyntheticDataGenerator
 from langchain_experimental.tabular_synthetic_data.openai import (

--- a/libs/experimental/tests/unit_tests/rl_chain/test_pick_best_chain_call.py
+++ b/libs/experimental/tests/unit_tests/rl_chain/test_pick_best_chain_call.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
 
 import pytest
-from langchain.prompts.prompt import PromptTemplate
 from langchain_community.chat_models import FakeListChatModel
+from langchain_core.prompts.prompt import PromptTemplate
 from test_utils import MockEncoder, MockEncoderReturnsList
 
 import langchain_experimental.rl_chain.base as rl_chain

--- a/libs/experimental/tests/unit_tests/test_smartllm.py
+++ b/libs/experimental/tests/unit_tests/test_smartllm.py
@@ -1,7 +1,7 @@
 """Test SmartLLM."""
-from langchain.prompts.prompt import PromptTemplate
 from langchain_community.chat_models import FakeListChatModel
 from langchain_community.llms import FakeListLLM
+from langchain_core.prompts.prompt import PromptTemplate
 
 from langchain_experimental.smart_llm import SmartLLMChain
 

--- a/libs/langchain/langchain/chains/ernie_functions/base.py
+++ b/libs/langchain/langchain/chains/ernie_functions/base.py
@@ -240,7 +240,7 @@ def create_ernie_fn_runnable(
 
                 from langchain.chains.ernie_functions import create_ernie_fn_chain
                 from langchain_community.chat_models import ErnieBotChat
-                from langchain.prompts import ChatPromptTemplate
+                from langchain_core.prompts import ChatPromptTemplate
                 from langchain.pydantic_v1 import BaseModel, Field
 
 
@@ -314,7 +314,7 @@ def create_structured_output_runnable(
 
             from langchain.chains.ernie_functions import create_structured_output_chain
             from langchain_community.chat_models import ErnieBotChat
-            from langchain.prompts import ChatPromptTemplate
+            from langchain_core.prompts import ChatPromptTemplate
             from langchain.pydantic_v1 import BaseModel, Field
 
             class Dog(BaseModel):
@@ -411,7 +411,7 @@ def create_ernie_fn_chain(
 
                 from langchain.chains.ernie_functions import create_ernie_fn_chain
                 from langchain_community.chat_models import ErnieBotChat
-                from langchain.prompts import ChatPromptTemplate
+                from langchain_core.prompts import ChatPromptTemplate
 
                 from langchain.pydantic_v1 import BaseModel, Field
 
@@ -498,7 +498,7 @@ def create_structured_output_chain(
 
                 from langchain.chains.ernie_functions import create_structured_output_chain
                 from langchain_community.chat_models import ErnieBotChat
-                from langchain.prompts import ChatPromptTemplate
+                from langchain_core.prompts import ChatPromptTemplate
 
                 from langchain.pydantic_v1 import BaseModel, Field
 

--- a/libs/langchain/tests/unit_tests/agents/test_agent.py
+++ b/libs/langchain/tests/unit_tests/agents/test_agent.py
@@ -19,7 +19,7 @@ from langchain_core.messages import (
     HumanMessage,
     ToolCall,
 )
-from langchain_core.prompts import MessagesPlaceholder
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.runnables.utils import add
 from langchain_core.tools import Tool
 from langchain_core.tracers import RunLog, RunLogPatch
@@ -33,7 +33,6 @@ from langchain.agents import (
     initialize_agent,
 )
 from langchain.agents.output_parsers.openai_tools import OpenAIToolAgentAction
-from langchain.prompts import ChatPromptTemplate
 from langchain.tools import tool
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 from tests.unit_tests.llms.fake_chat_model import GenericFakeChatModel


### PR DESCRIPTION
Replaced `from langchain.prompts` with `from langchain_core.prompts` where it is appropriate.
Most of the changes go to `langchain_experimental`
Similar to #20348 
