### PR TITLE
mistralai[patch]: Use public attribute for eventsource.response

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -148,9 +148,7 @@ async def _aiter_sse(
 ) -> AsyncIterator[Dict]:
     """Iterate over the server-sent events."""
     async with event_source_mgr as event_source:
-        # TODO(Team): Remove after this is fixed in httpx dependency
-        # https://github.com/florimondmanca/httpx-sse/pull/25/files
-        await _araise_on_error(event_source._response)
+        await _araise_on_error(event_source.response)
         async for event in event_source.aiter_sse():
             if event.data == "[DONE]":
                 return
@@ -370,9 +368,7 @@ class ChatMistralAI(BaseChatModel):
                     with connect_sse(
                         self.client, "POST", "/chat/completions", json=kwargs
                     ) as event_source:
-                        # TODO(Team): Remove after this is fixed in httpx dependency
-                        # https://github.com/florimondmanca/httpx-sse/pull/25/files
-                        _raise_on_error(event_source._response)
+                        _raise_on_error(event_source.response)
                         for event in event_source.iter_sse():
                             if event.data == "[DONE]":
                                 return


### PR DESCRIPTION
Minor change, use the public attribute instead of the protected one.
