### PR TITLE
anthropic: support function messages

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -44,6 +44,7 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
 )
+from langchain_core.messages.tool import default_tool_parser
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.runnables import (
@@ -94,9 +95,6 @@ def _format_image(image_url: str) -> Dict:
         "media_type": match.group("media_type"),
         "data": match.group("data"),
     }
-
-
-from langchain_core.messages.tool import default_tool_parser
 
 
 def _process_ai_message(ai_message: AIMessage) -> AIMessage:

--- a/libs/partners/anthropic/tests/unit_tests/_utils.py
+++ b/libs/partners/anthropic/tests/unit_tests/_utils.py
@@ -253,3 +253,11 @@ class FakeCallbackHandler(BaseCallbackHandler, BaseFakeCallbackHandlerMixin):
 
     def __deepcopy__(self, memo: dict) -> "FakeCallbackHandler":
         return self
+
+
+class AnyStr(str):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, str)


### PR DESCRIPTION
This is a bit cumbersome:
- If an AIMessage has function calls in additional_kwargs, parse our using default parser and add an ID;
- Given a FunctionMessage, find the correct previous AIMessage (e.g., with the same function name) and assign it the same ID. This may not work right in a streaming context.