### PR TITLE
docs: API Reference inherited members fix

### DIFF
--- a/docs/api_reference/templates/pydantic.rst
+++ b/docs/api_reference/templates/pydantic.rst
@@ -11,7 +11,7 @@
     :field-signature-prefix: param
     :members:
     :undoc-members:
-    :inherited-members:
+    :inherited-members: False
     :member-order: groupwise
     :show-inheritance: True
     :special-members: __call__


### PR DESCRIPTION
I'm trying to fix a bug in the API Ref generation when the members of the superclass go into the documentation. Here is an [example](https://api.python.langchain.com/en/latest/llms/langchain_community.llms.aleph_alpha.AlephAlpha.html#langchain_community.llms.aleph_alpha.AlephAlpha). Here the `abatch`, `agenerate` methods are not presented in the `AlephAlpha` class but inherited from -> LLM --> BaseLLM class. As the result, we have bloated, unreadable pages.
I'm following this [description](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). But it could not work. There were complaints about bugs in this part of the Sphinx generation.

@baskaryan Please, verify it, since I cannot verify it locally, nor can Vercel generate the PR API Ref for now.