### PR TITLE
docs: Clarify section title on filtering proper nouns

### DIFF
--- a/docs/docs/use_cases/sql/agents.ipynb
+++ b/docs/docs/use_cases/sql/agents.ipynb
@@ -626,7 +626,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Dealing with high-cardinality columns\n",
+    "## Filtering on Proper Nouns\n",
     "\n",
     "In order to filter columns that contain proper nouns such as addresses, song names or artists, we first need to double-check the spelling in order to filter the data correctly. \n",
     "\n",

--- a/docs/docs/use_cases/sql/agents.ipynb
+++ b/docs/docs/use_cases/sql/agents.ipynb
@@ -626,7 +626,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Filtering on Proper Nouns\n",
+    "## Filtering on Proper Text\n",
     "\n",
     "In order to filter columns that contain proper nouns such as addresses, song names or artists, we first need to double-check the spelling in order to filter the data correctly. \n",
     "\n",


### PR DESCRIPTION
- [x] **PR title**: "docs: Clarify section title on filtering proper nouns"

- [x] **PR message**: 
- **Description:** The current title "Dealing with high-cardinality columns" for the section discussing how to filter on proper nouns in the SQL agent documentation is not quite accurate and may cause confusion.
While high cardinality (having many distinct values) is a characteristic of columns containing proper nouns like names or addresses, the section's focus is more on the challenges of handling inexact string matches for such values and the solution of using a vector store for disambiguation.
To better align the title with the content and avoid misinterpretation around the meaning of "high cardinality", this PR proposes changing the section title to:
"Filtering on Proper Nouns"
This shorter, more targeted title captures the key subject matter while keeping things concise. The technical details of the disambiguation approach using vector stores can be left to the section body.
This change should help readers quickly grasp the section's purpose and find the information they need more easily.

- **Issue:** N/A 

- **Dependencies:** None

- **Twitter handle:** N/A

- [ ] **Add tests and docs**: N/A - this is a documentation update

- [x] **Lint and test**: N/A - no code changes