### PR TITLE
docs: Fix minor typo in data_connection/document_loaders/custom

### DIFF
--- a/docs/docs/modules/data_connection/document_loaders/custom.ipynb
+++ b/docs/docs/modules/data_connection/document_loaders/custom.ipynb
@@ -33,7 +33,7 @@
     "|----------------|--------------------------------|\n",
     "| Document       | Contains `text` and `metadata` |\n",
     "| BaseLoader     | Use to convert raw data into `Documents`  |\n",
-    "| Blob           | A representation of binary data thta's located either in a file or in memory |\n",
+    "| Blob           | A representation of binary data that's located either in a file or in memory |\n",
     "| BaseBlobParser | Logic to parse a `Blob` to yield `Document` objects |\n",
     "\n",
     "This guide will demonstrate how to write custom document loading and file parsing logic; specifically, we'll see how to:\n",


### PR DESCRIPTION
**Description:**
Minor documentation typo fix in `data_connection/document_loaders/custom`: `thta's` -> `that's`