### PR TITLE
docs: fix variable name typo in example code

### DIFF
--- a/libs/langchain/langchain/chains/structured_output/base.py
+++ b/libs/langchain/langchain/chains/structured_output/base.py
@@ -268,7 +268,7 @@ def create_structured_output_runnable(
 
                 llm = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
                 structured_llm = create_structured_output_runnable(
-                    doc_schema, 
+                    dog_schema, 
                     llm, 
                     mode="openai-tools", 
                     enforce_function_usage=True, 


### PR DESCRIPTION
This pull request corrects a mistake in the variable name within the example code. The variable doc_schema has been changed to dog_schema to fix the error.

