### PR TITLE
Fixed issue Chain::ainvoke replaced sync prep_outputs call with  asyn…

### DIFF
--- a/libs/langchain/langchain/chains/base.py
+++ b/libs/langchain/langchain/chains/base.py
@@ -204,7 +204,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
                 if new_arg_supported
                 else await self._acall(inputs)
             )
-            final_outputs: Dict[str, Any] = self.prep_outputs(
+            final_outputs: Dict[str, Any] = await self.aprep_outputs(
                 inputs, outputs, return_only_outputs
             )
         except BaseException as e:
@@ -457,7 +457,33 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
             return outputs
         else:
             return {**inputs, **outputs}
+        
+    async def aprep_outputs(
+        self,
+        inputs: Dict[str, str],
+        outputs: Dict[str, str],
+        return_only_outputs: bool = False,
+    ) -> Dict[str, str]:
+        """Asynchronously Validate and  prepare chain outputs, and save info about this run to memory.
 
+        Args:
+            inputs: Dictionary of chain inputs, including any inputs added by chain
+                memory.
+            outputs: Dictionary of initial chain outputs.
+            return_only_outputs: Whether to only return the chain outputs. If False,
+                inputs are also added to the final outputs.
+
+        Returns:
+            A dict of the final chain outputs.
+        """
+        self._validate_outputs(outputs)
+        if self.memory is not None:
+            await self.memory.asave_context(inputs, outputs)
+        if return_only_outputs:
+            return outputs
+        else:
+            return {**inputs, **outputs}
+        
     def prep_inputs(self, inputs: Union[Dict[str, Any], Any]) -> Dict[str, str]:
         """Prepare chain inputs, including adding inputs from memory.
 


### PR DESCRIPTION
In class 'Chain', method 'ainvoke', at line 207, 'self.prep_outputs' has been called synchronously. However, this function should be called asynchronously due to memory dependency and the need to call 'asave_context' in a memory class context.


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
