### PR TITLE
core[minor]: Proposal run_type for RunnableLambdas

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -3634,6 +3634,8 @@ class RunnableLambda(Runnable[Input, Output]):
             ]
         ] = None,
         name: Optional[str] = None,
+        *,
+        run_type: Optional[str] = None,
     ) -> None:
         """Create a RunnableLambda from a callable, and async callable or both.
 
@@ -3643,6 +3645,8 @@ class RunnableLambda(Runnable[Input, Output]):
         Args:
             func: Either sync or async callable
             afunc: An async callable that takes an input and returns an output.
+            name: An optional name for the runnable.
+            run_type: An optional type for the runnable.
         """
         if afunc is not None:
             self.afunc = afunc
@@ -3673,6 +3677,8 @@ class RunnableLambda(Runnable[Input, Output]):
                 self.name = func_for_name.__name__
         except AttributeError:
             pass
+
+        self.run_type = run_type
 
     @property
     def InputType(self) -> Any:
@@ -3968,6 +3974,7 @@ class RunnableLambda(Runnable[Input, Output]):
                 self._invoke,
                 input,
                 self._config(config, self.func),
+                run_type=self.run_type,
                 **kwargs,
             )
         else:
@@ -3988,6 +3995,7 @@ class RunnableLambda(Runnable[Input, Output]):
             self._ainvoke,
             input,
             self._config(config, the_func),
+            run_type=self.run_type,
             **kwargs,
         )
 


### PR DESCRIPTION
Matches retriever abstraction for tracing. Potential alternative for users to implement retriever in less code?


```python
from langchain_core.runnables import RunnableLambda
from langchain_core.documents import Document

def foo(query: str, config):
    return [Document(page_content=query*2)]

foo = RunnableLambda(foo, run_type='retriever') | (lambda x: x)

foo.invoke('hello')
```

----

Current retriever abstraction doesn't work with `config` well (accepts only run_manager).

* This could be an alternatively to make it easier for users to create a retriever (or other chain types)
* Need to think about other ramifications (e.g., changing event types with astream event)
* Need to implement in remaining methods before landing if we decide to pursue