### PR TITLE
Added a function `from_existing_index` in `Qdrant` vector database.

### DIFF
--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1372,6 +1372,7 @@ class Qdrant(VectorStore):
     def from_existing_client(
         cls: Type[Qdrant],
         client: Optional[Any] = None,
+        async_client: Optional[Any] =None,
         path: Optional[str] = None,
         collection_name: str = None,
         embedding: Embeddings = None,
@@ -1385,22 +1386,21 @@ class Qdrant(VectorStore):
         
         if not (collection_name and embedding):
             raise ValueError("Both 'collection_name' and 'embedding' are necessary.")
-
-        if client and path:
-            raise QdrantException(
+         
+        if client is not None and path is not None:
+            raise ValueError(
                 "Both `client` and `path` are passed."
                 "Provide only one of them."
             )    
-        elif client is not None:
-            pass
-        elif path is not None:
-            sync_client, async_client = cls._generate_clients(path = path, **kwargs)
-            
+        elif client is None and path is not None:
+            client, async_client = cls._generate_clients(path = path, **kwargs)
+        elif client is not None and path is None:
+            client=client
         else:
             raise ValueError("Either 'client' or 'path' must be provided.")
         
         return cls(
-                    client = sync_client, 
+                    client = client, 
                     async_client = async_client,
                     collection_name = collection_name, 
                     embeddings = embedding, 

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1367,28 +1367,27 @@ class Qdrant(VectorStore):
         qdrant.add_texts(texts, metadatas, ids, batch_size)
         return qdrant
 
-
     @classmethod
     def from_existing_index(
         cls: Type[Qdrant],
         embedding: Embeddings,
         path: str,
         collection_name: str,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Qdrant:
         """
-        Get instance of an existing Qdrant vector database stored locally. 
+        Get instance of an existing Qdrant vector database stored locally.
         This method will return the instance of the store without inserting any new
         embeddings
         """
-        client, async_client = cls._generate_clients(path = path, **kwargs)
+        client, async_client = cls._generate_clients(path=path, **kwargs)
         return cls(
-                    client = client, 
-                    async_client = async_client,
-                    collection_name = collection_name, 
-                    embeddings = embedding, 
-                    **kwargs
-                )
+            client=client,
+            async_client=async_client,
+            collection_name=collection_name,
+            embeddings=embedding,
+            **kwargs,
+        )
 
     @classmethod
     @sync_call_fallback

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1374,7 +1374,8 @@ class Qdrant(VectorStore):
         client: Optional[Any] = None,
         path: Optional[str] = None,
         collection_name: str = None,
-        embedding: Embeddings = None, 
+        embedding: Embeddings = None,
+        **kwargs: Any
     ) -> Qdrant:
         """
         Get instance of an existing Qdrant store either locally or with client. 
@@ -1393,18 +1394,18 @@ class Qdrant(VectorStore):
         elif client is not None:
             pass
         elif path is not None:
-            try:
-                import qdrant_client
-            except ImportError:
-                raise ImportError(
-                    "Could not import qdrant-client python package. "
-                    "Please install it with `pip install qdrant-client`."
-                )
-            client = qdrant_client.QdrantClient(path = path)
+            client, async_client = cls._generate_clients(path = path, **kwargs)
+            
         else:
             raise ValueError("Either 'client' or 'path' must be provided.")
         
-        return cls(client, collection_name, embedding)
+        return cls(
+                    client = client, 
+                    collection_name = collection_name, 
+                    embedding = embedding, 
+                    async_client=async_client    
+                    **kwargs
+                )
 
     @classmethod
     @sync_call_fallback

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1394,16 +1394,16 @@ class Qdrant(VectorStore):
         elif client is not None:
             pass
         elif path is not None:
-            client, async_client = cls._generate_clients(path = path, **kwargs)
+            sync_client, async_client = cls._generate_clients(path = path, **kwargs)
             
         else:
             raise ValueError("Either 'client' or 'path' must be provided.")
         
         return cls(
-                    client = client, 
+                    client = sync_client, 
+                    async_client = async_client,
                     collection_name = collection_name, 
-                    embedding = embedding, 
-                    async_client=async_client    
+                    embeddings = embedding, 
                     **kwargs
                 )
 

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1369,36 +1369,19 @@ class Qdrant(VectorStore):
 
 
     @classmethod
-    def from_existing_client(
+    def from_existing_index(
         cls: Type[Qdrant],
-        client: Optional[Any] = None,
-        async_client: Optional[Any] =None,
-        path: Optional[str] = None,
-        collection_name: str = None,
-        embedding: Embeddings = None,
+        embedding: Embeddings,
+        path: str,
+        collection_name: str,
         **kwargs: Any
     ) -> Qdrant:
         """
-        Get instance of an existing Qdrant store either locally or with client. 
+        Get instance of an existing Qdrant vector database stored locally. 
         This method will return the instance of the store without inserting any new
         embeddings
         """
-        
-        if not (collection_name and embedding):
-            raise ValueError("Both 'collection_name' and 'embedding' are necessary.")
-         
-        if client is not None and path is not None:
-            raise ValueError(
-                "Both `client` and `path` are passed."
-                "Provide only one of them."
-            )    
-        elif client is None and path is not None:
-            client, async_client = cls._generate_clients(path = path, **kwargs)
-        elif client is not None and path is None:
-            client=client
-        else:
-            raise ValueError("Either 'client' or 'path' must be provided.")
-        
+        client, async_client = cls._generate_clients(path = path, **kwargs)
         return cls(
                     client = client, 
                     async_client = async_client,

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -80,7 +80,6 @@ class Qdrant(VectorStore):
             collection_name = "MyCollection"
             qdrant = Qdrant(client, collection_name, embedding_function)
     """
-    
 
     CONTENT_KEY = "page_content"
     METADATA_KEY = "metadata"
@@ -1373,7 +1372,7 @@ class Qdrant(VectorStore):
     def from_existing_client(
         cls: Type[Qdrant],
         client: Optional[Any] = None,
-        path: str = None,
+        path: Optional[str] = None,
         collection_name: str = None,
         embedding: Embeddings = None, 
     ) -> Qdrant:
@@ -1388,7 +1387,8 @@ class Qdrant(VectorStore):
 
         if client and path:
             raise QdrantException(
-                "Please provide `None` for either `client` or `path`."
+                "Both `client` and `path` are passed."
+                "Provide only one of them."
             )    
         elif client is not None:
             pass
@@ -1405,10 +1405,6 @@ class Qdrant(VectorStore):
             raise ValueError("Either 'client' or 'path' must be provided.")
         
         return cls(client, collection_name, embedding)
-
-        
-
-
 
     @classmethod
     @sync_call_fallback

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -80,6 +80,7 @@ class Qdrant(VectorStore):
             collection_name = "MyCollection"
             qdrant = Qdrant(client, collection_name, embedding_function)
     """
+    
 
     CONTENT_KEY = "page_content"
     METADATA_KEY = "metadata"
@@ -1366,6 +1367,48 @@ class Qdrant(VectorStore):
         )
         qdrant.add_texts(texts, metadatas, ids, batch_size)
         return qdrant
+
+
+    @classmethod
+    def from_existing_client(
+        cls: Type[Qdrant],
+        client: Optional[Any] = None,
+        path: str = None,
+        collection_name: str = None,
+        embedding: Embeddings = None, 
+    ) -> Qdrant:
+        """
+        Get instance of an existing Qdrant store either locally or with client. 
+        This method will return the instance of the store without inserting any new
+        embeddings
+        """
+        
+        if not (collection_name and embedding):
+            raise ValueError("Both 'collection_name' and 'embedding' are necessary.")
+
+        if client and path:
+            raise QdrantException(
+                "Please provide `None` for either `client` or `path`."
+            )    
+        elif client is not None:
+            pass
+        elif path is not None:
+            try:
+                import qdrant_client
+            except ImportError:
+                raise ImportError(
+                    "Could not import qdrant-client python package. "
+                    "Please install it with `pip install qdrant-client`."
+                )
+            client = qdrant_client.QdrantClient(path = path)
+        else:
+            raise ValueError("Either 'client' or 'path' must be provided.")
+        
+        return cls(client, collection_name, embedding)
+
+        
+
+
 
     @classmethod
     @sync_call_fallback

--- a/libs/community/tests/integration_tests/vectorstores/qdrant/test_from_existing_index.py
+++ b/libs/community/tests/integration_tests/vectorstores/qdrant/test_from_existing_index.py
@@ -1,44 +1,39 @@
 import tempfile
-import uuid
 from typing import Optional
 
 import pytest
-# from langchain_core.documents import Document
 
 from langchain_community.vectorstores import Qdrant
-from langchain_community.vectorstores.qdrant import QdrantException
 from tests.integration_tests.vectorstores.fake_embeddings import (
     ConsistentFakeEmbeddings,
 )
 
-# test_qdrant_from_existing_client_reuse_same_client
+
 @pytest.mark.parametrize("collection_name", ["custom-collection"])
-def test_qdrant_from_existing_index_uses_same_collection(collection_name: Optional[str]) -> None:
+def test_qdrant_from_existing_index_uses_same_collection(
+    collection_name: Optional[str],
+) -> None:
     """Test if the Qdrant.from_existing_client reuses the some client."""
     from qdrant_client import QdrantClient
-    
+
     # embeddings = ConsistentFakeEmbeddings()
     with tempfile.TemporaryDirectory() as tmpdir:
-        
         docs = ["foo"]
-        qdrant = Qdrant.from_texts(docs, embedding=ConsistentFakeEmbeddings(), path=str(tmpdir), collection_name=collection_name, )
-        del qdrant  
-        
-        
-        qdrant = Qdrant.from_existing_index(embedding=ConsistentFakeEmbeddings(), path=str(tmpdir), collection_name=collection_name)
-        qdrant.add_texts(["baz","bar"])
+        qdrant = Qdrant.from_texts(
+            docs,
+            embedding=ConsistentFakeEmbeddings(),
+            path=str(tmpdir),
+            collection_name=collection_name,
+        )
         del qdrant
-        
+
+        qdrant = Qdrant.from_existing_index(
+            embedding=ConsistentFakeEmbeddings(),
+            path=str(tmpdir),
+            collection_name=collection_name,
+        )
+        qdrant.add_texts(["baz", "bar"])
+        del qdrant
+
         client = QdrantClient(path=str(tmpdir))
         assert 3 == client.count(collection_name).count
-        
-        
-        
-        
-        
-        
-        
-    
-    
-
-

--- a/libs/community/tests/integration_tests/vectorstores/qdrant/test_from_existing_index.py
+++ b/libs/community/tests/integration_tests/vectorstores/qdrant/test_from_existing_index.py
@@ -11,7 +11,7 @@ from tests.integration_tests.vectorstores.fake_embeddings import (
 
 @pytest.mark.parametrize("collection_name", ["custom-collection"])
 def test_qdrant_from_existing_index_uses_same_collection(
-    collection_name: Optional[str],
+    collection_name: str,
 ) -> None:
     """Test if the Qdrant.from_existing_client reuses the some client."""
     from qdrant_client import QdrantClient

--- a/libs/community/tests/integration_tests/vectorstores/qdrant/test_from_existing_index.py
+++ b/libs/community/tests/integration_tests/vectorstores/qdrant/test_from_existing_index.py
@@ -1,0 +1,44 @@
+import tempfile
+import uuid
+from typing import Optional
+
+import pytest
+# from langchain_core.documents import Document
+
+from langchain_community.vectorstores import Qdrant
+from langchain_community.vectorstores.qdrant import QdrantException
+from tests.integration_tests.vectorstores.fake_embeddings import (
+    ConsistentFakeEmbeddings,
+)
+
+# test_qdrant_from_existing_client_reuse_same_client
+@pytest.mark.parametrize("collection_name", ["custom-collection"])
+def test_qdrant_from_existing_index_uses_same_collection(collection_name: Optional[str]) -> None:
+    """Test if the Qdrant.from_existing_client reuses the some client."""
+    from qdrant_client import QdrantClient
+    
+    # embeddings = ConsistentFakeEmbeddings()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        
+        docs = ["foo"]
+        qdrant = Qdrant.from_texts(docs, embedding=ConsistentFakeEmbeddings(), path=str(tmpdir), collection_name=collection_name, )
+        del qdrant  
+        
+        
+        qdrant = Qdrant.from_existing_index(embedding=ConsistentFakeEmbeddings(), path=str(tmpdir), collection_name=collection_name)
+        qdrant.add_texts(["baz","bar"])
+        del qdrant
+        
+        client = QdrantClient(path=str(tmpdir))
+        assert 3 == client.count(collection_name).count
+        
+        
+        
+        
+        
+        
+        
+    
+    
+
+


### PR DESCRIPTION
Issue: #20514 
The current implementation of `construct_instance` expects a `texts: List[str]` that will call the embedding function. This might not be needed when we already have a client with collection and `path,  you don't want to add any text.

This PR adds a class method that returns a qdrant instance with an existing client.

Here everytime https://github.com/langchain-ai/langchain/blob/cb6e5e56c29477c6da5824c17f1b70af11352685/libs/community/langchain_community/vectorstores/qdrant.py#L1592 `construct_instance` is called, this line sends some text for embedding generation.