### PR TITLE
community: Fix the stop sequence key name for Mistral in Bedrock

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -339,7 +339,7 @@ class BedrockBase(BaseModel, ABC):
         "amazon": "stopSequences",
         "ai21": "stop_sequences",
         "cohere": "stop_sequences",
-        "mistral": "stop_sequences",
+        "mistral": "stop",
     }
 
     guardrails: Optional[Mapping[str, Any]] = {


### PR DESCRIPTION
Fixing the wrong stop sequence key name that causes an error on AWS Bedrock. 
You can check the MistralAI bedrock parameters [here](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral.html)
This change fixes this [issue](https://github.com/langchain-ai/langchain/issues/20095)

