### PR TITLE
docs: Fix link for `partition_pdf` in Semi_Structured_RAG.ipynb cookbook

### DIFF
--- a/cookbook/Semi_Structured_RAG.ipynb
+++ b/cookbook/Semi_Structured_RAG.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "Apply to the [`LLaMA2`](https://arxiv.org/pdf/2307.09288.pdf) paper. \n",
     "\n",
-    "We use the Unstructured [`partition_pdf`](https://unstructured-io.github.io/unstructured/bricks/partition.html#partition-pdf), which segments a PDF document by using a layout model. \n",
+    "We use the Unstructured [`partition_pdf`](https://unstructured-io.github.io/unstructured/core/partition.html#partition-pdf), which segments a PDF document by using a layout model. \n",
     "\n",
     "This layout model makes it possible to extract elements, such as tables, from pdfs. \n",
     "\n",


### PR DESCRIPTION
docs: Fix link for `partition_pdf` in Semi_Structured_RAG.ipynb cookbook

  - **Description:** Fix incorrect link to unstructured-io `partition_pdf` section