### PR TITLE
community: fix azuresearch retriever

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -654,31 +654,6 @@ class AzureSearch(VectorStore):
         azure_search.add_texts(texts, metadatas, **kwargs)
         return azure_search
 
-    def as_retriever(self, **kwargs: Any) -> AzureSearchVectorStoreRetriever:  # type: ignore
-        """Return AzureSearchVectorStoreRetriever initialized from this VectorStore.
-
-        Args:
-            search_type (Optional[str]): Defines the type of search that
-                the Retriever should perform.
-                Can be "similarity" (default), "hybrid", or
-                    "semantic_hybrid".
-            search_kwargs (Optional[Dict]): Keyword arguments to pass to the
-                search function. Can include things like:
-                    k: Amount of documents to return (Default: 4)
-                    score_threshold: Minimum relevance threshold
-                        for similarity_score_threshold
-                    fetch_k: Amount of documents to pass to MMR algorithm (Default: 20)
-                    lambda_mult: Diversity of results returned by MMR;
-                        1 for minimum diversity and 0 for maximum. (Default: 0.5)
-                    filter: Filter by document metadata
-
-        Returns:
-            AzureSearchVectorStoreRetriever: Retriever class for VectorStore.
-        """
-        tags = kwargs.pop("tags", None) or []
-        tags.extend(self._get_retriever_tags())
-        return AzureSearchVectorStoreRetriever(vectorstore=self, **kwargs, tags=tags)
-
 
 class AzureSearchVectorStoreRetriever(BaseRetriever):
     """Retriever that uses `Azure Cognitive Search`."""


### PR DESCRIPTION
https://github.com/langchain-ai/langchain/pull/20601 introduced at least two regressions to `AzureSearchVectorStoreRetriever`:

1. Calls to async methods raise NotImplementedError (https://github.com/langchain-ai/langchain/issues/20787)
2. search_type `"similarity_score_threshold"` raises ValueError (https://github.com/langchain-ai/langchain/issues/20600#issuecomment-2072782405)