### PR TITLE
langchain: support PineconeVectorStore in self query retriever

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -124,11 +124,11 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
                 return ElasticsearchTranslator()
 
         try:
-            from langchain_pinecone import Pinecone
+            from langchain_pinecone import PineconeVectorStore
         except ImportError:
             pass
         else:
-            if isinstance(vectorstore, Pinecone):
+            if isinstance(vectorstore, PineconeVectorStore):
                 return PineconeTranslator()
 
         raise ValueError(


### PR DESCRIPTION
`langchain_pinecone.Pinecone` is deprecated in favor of `PineconeVectorStore`, and is currently a subclass of `PineconeVectorStore`.
```python
@deprecated(since="0.0.3", removal="0.2.0", alternative="PineconeVectorStore")
class Pinecone(PineconeVectorStore):
    """Deprecated. Use PineconeVectorStore instead."""

    pass
```