### PR TITLE
Correct tool_call method to use model_dump_json in notebook

### DIFF
--- a/docs/docs/use_cases/extraction/how_to/examples.ipynb
+++ b/docs/docs/use_cases/extraction/how_to/examples.ipynb
@@ -215,7 +215,7 @@
     "                    # This is implicit in the API right now,\n",
     "                    # and will be improved over time.\n",
     "                    \"name\": tool_call.__class__.__name__,\n",
-    "                    \"arguments\": tool_call.json(),\n",
+    "                    \"arguments\": tool_call.model_dump_json(),\n",
     "                },\n",
     "            }\n",
     "        )\n",


### PR DESCRIPTION
**Description:** This PR updates the deprecated method `tool_call.json()` to the new method `tool_call.model_dump_json()` in an example notebook to align with the latest version of LangChain.

**Issue:** N/A (Since this change is due to a version update and not linked to an open issue)

**Dependencies:** None


