### PR TITLE
community[mini]: Add stop_reason and stop_sequence to Bedrock Anthropic model output

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -144,6 +144,7 @@ class LLMInputOutputAdapter:
     @classmethod
     def prepare_output(cls, provider: str, response: Any) -> dict:
         text = ""
+        metadata = {}
         if provider == "anthropic":
             response_body = json.loads(response.get("body").read().decode())
             if "completion" in response_body:
@@ -151,6 +152,10 @@ class LLMInputOutputAdapter:
             elif "content" in response_body:
                 content = response_body.get("content")
                 text = content[0].get("text")
+            if "stop_reason" in response_body:
+                metadata["stop_reason"] = response_body.get("stop_reason")
+            if "stop_sequence" in response_body:
+                metadata["stop_sequence"] = response_body.get("stop_sequence")
         else:
             response_body = json.loads(response.get("body").read())
 
@@ -176,6 +181,7 @@ class LLMInputOutputAdapter:
                 "completion_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
             },
+            "metadata": metadata,
         }
 
     @classmethod


### PR DESCRIPTION
**Description:**
Currently, the output of Amazon Bedrock llms will ignore the `stop_reason` and `stop_sequence` fields in the output of Anthropic models, making it hard for users to rely on these fields to build agents.

Description of these two fields are described here:
https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html

This PR adds these two fields in the "metadata" output field  if Bedrock returns them in the response so the downstream users could read and use the accordingly.

**Dependencies:**
n/a