### PR TITLE
[add] upsert texts to the Milvus vectorstore

### DIFF
--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -505,7 +505,7 @@ class Milvus(VectorStore):
 
     def add_texts(
         self,
-        texts: Iterable[str],
+        texts: List[str],
         metadatas: Optional[List[dict]] = None,
         timeout: Optional[float] = None,
         batch_size: int = 1000,

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -933,7 +933,8 @@ class Milvus(VectorStore):
         return ret
 
     def delete(  # type: ignore[no-untyped-def]
-            self, ids: Optional[List[str]] = None, expr: Optional[str] = None, **kwargs: str
+            self, ids: Optional[List[str]] = None,
+            expr: Optional[str] = None, **kwargs: str
     ):
         """Delete by vector ID or boolean expression.
         Refer to [Milvus documentation](https://milvus.io/docs/delete_data.md)

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1129,7 +1129,8 @@ class Milvus(VectorStore):
                 pass
         try:
             return self.add_texts(texts=texts, metadatas=metadatas,
-                                  timeout=timeout, batch_size=batch_size, ids=ids, **kwargs)
+                                  timeout=timeout, batch_size=batch_size,
+                                  ids=ids, **kwargs)
         except MilvusException as exc:
             logger.error(
                 "Failed to upsert texts entities: %s error: %s",

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1083,14 +1083,14 @@ class Milvus(VectorStore):
             raise exc
 
     def upsert_texts(
-            self,
-            texts: Iterable[str],
-            metadatas: Optional[List[dict]] = None,
-            timeout: Optional[float] = None,
-            batch_size: int = 1000,
-            *,
-            ids: Optional[List[str]] = None,
-            **kwargs: Any,
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        timeout: Optional[float] = None,
+        batch_size: int = 1000,
+        *,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> List[str] | None:
         """upsert texts to the Milvus vectorstore.
         This is based on upsert data based on add_text functionality
@@ -1128,12 +1128,17 @@ class Milvus(VectorStore):
             except MilvusException:
                 pass
         try:
-            return self.add_texts(texts=texts, metadatas=metadatas,
-                                  timeout=timeout, batch_size=batch_size,
-                                  ids=ids, **kwargs)
+            return self.add_texts(
+                texts=texts,
+                metadatas=metadatas,
+                timeout=timeout,
+                batch_size=batch_size,
+                ids=ids,
+                **kwargs)
         except MilvusException as exc:
             logger.error(
                 "Failed to upsert texts entities: %s error: %s",
-                self.collection_name, exc
+                self.collection_name,
+                exc
             )
             raise exc

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1134,11 +1134,12 @@ class Milvus(VectorStore):
                 timeout=timeout,
                 batch_size=batch_size,
                 ids=ids,
-                **kwargs)
+                **kwargs,
+            )
         except MilvusException as exc:
             logger.error(
                 "Failed to upsert texts entities: %s error: %s",
                 self.collection_name,
-                exc
+                exc,
             )
             raise exc

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -113,27 +113,27 @@ class Milvus(VectorStore):
     """
 
     def __init__(
-            self,
-            embedding_function: Embeddings,
-            collection_name: str = "LangChainCollection",
-            collection_description: str = "",
-            collection_properties: Optional[dict[str, Any]] = None,
-            connection_args: Optional[dict[str, Any]] = None,
-            consistency_level: str = "Session",
-            index_params: Optional[dict] = None,
-            search_params: Optional[dict] = None,
-            drop_old: Optional[bool] = False,
-            auto_id: bool = False,
-            *,
-            primary_field: str = "pk",
-            text_field: str = "text",
-            vector_field: str = "vector",
-            metadata_field: Optional[str] = None,
-            partition_key_field: Optional[str] = None,
-            partition_names: Optional[list] = None,
-            replica_number: int = 1,
-            timeout: Optional[float] = None,
-            num_shards: Optional[int] = None,
+        self,
+        embedding_function: Embeddings,
+        collection_name: str = "LangChainCollection",
+        collection_description: str = "",
+        collection_properties: Optional[dict[str, Any]] = None,
+        connection_args: Optional[dict[str, Any]] = None,
+        consistency_level: str = "Session",
+        index_params: Optional[dict] = None,
+        search_params: Optional[dict] = None,
+        drop_old: Optional[bool] = False,
+        auto_id: bool = False,
+        *,
+        primary_field: str = "pk",
+        text_field: str = "text",
+        vector_field: str = "vector",
+        metadata_field: Optional[str] = None,
+        partition_key_field: Optional[str] = None,
+        partition_names: Optional[list] = None,
+        replica_number: int = 1,
+        timeout: Optional[float] = None,
+        num_shards: Optional[int] = None,
     ):
         """Initialize the Milvus vector store."""
         try:
@@ -263,11 +263,11 @@ class Milvus(VectorStore):
             for con in connections.list_connections():
                 addr = connections.get_connection_addr(con[0])
                 if (
-                        con[1]
-                        and ("address" in addr)
-                        and (addr["address"] == given_address)
-                        and ("user" in addr)
-                        and (addr["user"] == tmp_user)
+                    con[1]
+                    and ("address" in addr)
+                    and (addr["address"] == given_address)
+                    and ("user" in addr)
+                    and (addr["user"] == tmp_user)
                 ):
                     logger.debug("Using previous connection: %s", con[0])
                     return con[0]
@@ -283,12 +283,12 @@ class Milvus(VectorStore):
             raise e
 
     def _init(
-            self,
-            embeddings: Optional[list] = None,
-            metadatas: Optional[list[dict]] = None,
-            partition_names: Optional[list] = None,
-            replica_number: int = 1,
-            timeout: Optional[float] = None,
+        self,
+        embeddings: Optional[list] = None,
+        metadatas: Optional[list[dict]] = None,
+        partition_names: Optional[list] = None,
+        replica_number: int = 1,
+        timeout: Optional[float] = None,
     ) -> None:
         if embeddings is not None:
             self._create_collection(embeddings, metadatas)
@@ -302,7 +302,7 @@ class Milvus(VectorStore):
         )
 
     def _create_collection(
-            self, embeddings: list, metadatas: Optional[list[dict]] = None
+        self, embeddings: list, metadatas: Optional[list[dict]] = None
     ) -> None:
         from pymilvus import (
             Collection,
@@ -481,10 +481,10 @@ class Milvus(VectorStore):
                 self.search_params["metric_type"] = metric_type
 
     def _load(
-            self,
-            partition_names: Optional[list] = None,
-            replica_number: int = 1,
-            timeout: Optional[float] = None,
+        self,
+        partition_names: Optional[list] = None,
+        replica_number: int = 1,
+        timeout: Optional[float] = None,
     ) -> None:
         """Load the collection if available."""
         from pymilvus import Collection, utility
@@ -492,10 +492,10 @@ class Milvus(VectorStore):
 
         timeout = self.timeout or timeout
         if (
-                isinstance(self.col, Collection)
-                and self._get_index() is not None
-                and utility.load_state(self.collection_name, using=self.alias)
-                == LoadState.NotLoad
+            isinstance(self.col, Collection)
+            and self._get_index() is not None
+            and utility.load_state(self.collection_name, using=self.alias)
+            == LoadState.NotLoad
         ):
             self.col.load(
                 partition_names=partition_names,
@@ -504,14 +504,14 @@ class Milvus(VectorStore):
             )
 
     def add_texts(
-            self,
-            texts: Iterable[str],
-            metadatas: Optional[List[dict]] = None,
-            timeout: Optional[float] = None,
-            batch_size: int = 1000,
-            *,
-            ids: Optional[List[str]] = None,
-            **kwargs: Any,
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        timeout: Optional[float] = None,
+        batch_size: int = 1000,
+        *,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> List[str]:
         """Insert text data into Milvus.
 
@@ -627,13 +627,13 @@ class Milvus(VectorStore):
         return pks
 
     def similarity_search(
-            self,
-            query: str,
-            k: int = 4,
-            param: Optional[dict] = None,
-            expr: Optional[str] = None,
-            timeout: Optional[float] = None,
-            **kwargs: Any,
+        self,
+        query: str,
+        k: int = 4,
+        param: Optional[dict] = None,
+        expr: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Perform a similarity search against the query string.
 
@@ -660,13 +660,13 @@ class Milvus(VectorStore):
         return [doc for doc, _ in res]
 
     def similarity_search_by_vector(
-            self,
-            embedding: List[float],
-            k: int = 4,
-            param: Optional[dict] = None,
-            expr: Optional[str] = None,
-            timeout: Optional[float] = None,
-            **kwargs: Any,
+        self,
+        embedding: List[float],
+        k: int = 4,
+        param: Optional[dict] = None,
+        expr: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Perform a similarity search against the query string.
 
@@ -693,13 +693,13 @@ class Milvus(VectorStore):
         return [doc for doc, _ in res]
 
     def similarity_search_with_score(
-            self,
-            query: str,
-            k: int = 4,
-            param: Optional[dict] = None,
-            expr: Optional[str] = None,
-            timeout: Optional[float] = None,
-            **kwargs: Any,
+        self,
+        query: str,
+        k: int = 4,
+        param: Optional[dict] = None,
+        expr: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Perform a search on a query string and return results with score.
 
@@ -733,13 +733,13 @@ class Milvus(VectorStore):
         return res
 
     def similarity_search_with_score_by_vector(
-            self,
-            embedding: List[float],
-            k: int = 4,
-            param: Optional[dict] = None,
-            expr: Optional[str] = None,
-            timeout: Optional[float] = None,
-            **kwargs: Any,
+        self,
+        embedding: List[float],
+        k: int = 4,
+        param: Optional[dict] = None,
+        expr: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Perform a search on a query string and return results with score.
 
@@ -793,15 +793,15 @@ class Milvus(VectorStore):
         return ret
 
     def max_marginal_relevance_search(
-            self,
-            query: str,
-            k: int = 4,
-            fetch_k: int = 20,
-            lambda_mult: float = 0.5,
-            param: Optional[dict] = None,
-            expr: Optional[str] = None,
-            timeout: Optional[float] = None,
-            **kwargs: Any,
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        param: Optional[dict] = None,
+        expr: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Perform a search and return results that are reordered by MMR.
 
@@ -843,15 +843,15 @@ class Milvus(VectorStore):
         )
 
     def max_marginal_relevance_search_by_vector(
-            self,
-            embedding: list[float],
-            k: int = 4,
-            fetch_k: int = 20,
-            lambda_mult: float = 0.5,
-            param: Optional[dict] = None,
-            expr: Optional[str] = None,
-            timeout: Optional[float] = None,
-            **kwargs: Any,
+        self,
+        embedding: list[float],
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        param: Optional[dict] = None,
+        expr: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Perform a search and return results that are reordered by MMR.
 
@@ -933,8 +933,7 @@ class Milvus(VectorStore):
         return ret
 
     def delete(  # type: ignore[no-untyped-def]
-            self, ids: Optional[List[str]] = None,
-            expr: Optional[str] = None, **kwargs: str
+        self, ids: Optional[List[str]] = None, expr: Optional[str] = None, **kwargs: str
     ):
         """Delete by vector ID or boolean expression.
         Refer to [Milvus documentation](https://milvus.io/docs/delete_data.md)
@@ -959,19 +958,19 @@ class Milvus(VectorStore):
 
     @classmethod
     def from_texts(
-            cls,
-            texts: List[str],
-            embedding: Embeddings,
-            metadatas: Optional[List[dict]] = None,
-            collection_name: str = "LangChainCollection",
-            connection_args: dict[str, Any] = DEFAULT_MILVUS_CONNECTION,
-            consistency_level: str = "Session",
-            index_params: Optional[dict] = None,
-            search_params: Optional[dict] = None,
-            drop_old: bool = False,
-            *,
-            ids: Optional[List[str]] = None,
-            **kwargs: Any,
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        collection_name: str = "LangChainCollection",
+        connection_args: dict[str, Any] = DEFAULT_MILVUS_CONNECTION,
+        consistency_level: str = "Session",
+        index_params: Optional[dict] = None,
+        search_params: Optional[dict] = None,
+        drop_old: bool = False,
+        *,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> Milvus:
         """Create a Milvus collection, indexes it with HNSW, and insert data.
 
@@ -1049,10 +1048,10 @@ class Milvus(VectorStore):
         return pks
 
     def upsert(
-            self,
-            ids: Optional[List[str]] = None,
-            documents: List[Document] | None = None,
-            **kwargs: Any,
+        self,
+        ids: Optional[List[str]] = None,
+        documents: List[Document] | None = None,
+        **kwargs: Any,
     ) -> List[str] | None:
         """Update/Insert documents to the vectorstore.
 

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -505,7 +505,7 @@ class Milvus(VectorStore):
 
     def add_texts(
         self,
-        texts: List[str],
+        texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
         timeout: Optional[float] = None,
         batch_size: int = 1000,
@@ -1084,7 +1084,7 @@ class Milvus(VectorStore):
 
     def upsert_texts(
         self,
-        texts: Iterable[str],
+        texts: List[str],
         metadatas: Optional[List[dict]] = None,
         timeout: Optional[float] = None,
         batch_size: int = 1000,

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1082,7 +1082,7 @@ class Milvus(VectorStore):
             )
             raise exc
 
-    def upsert_text(
+    def upsert_texts(
         self,
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -113,27 +113,27 @@ class Milvus(VectorStore):
     """
 
     def __init__(
-        self,
-        embedding_function: Embeddings,
-        collection_name: str = "LangChainCollection",
-        collection_description: str = "",
-        collection_properties: Optional[dict[str, Any]] = None,
-        connection_args: Optional[dict[str, Any]] = None,
-        consistency_level: str = "Session",
-        index_params: Optional[dict] = None,
-        search_params: Optional[dict] = None,
-        drop_old: Optional[bool] = False,
-        auto_id: bool = False,
-        *,
-        primary_field: str = "pk",
-        text_field: str = "text",
-        vector_field: str = "vector",
-        metadata_field: Optional[str] = None,
-        partition_key_field: Optional[str] = None,
-        partition_names: Optional[list] = None,
-        replica_number: int = 1,
-        timeout: Optional[float] = None,
-        num_shards: Optional[int] = None,
+            self,
+            embedding_function: Embeddings,
+            collection_name: str = "LangChainCollection",
+            collection_description: str = "",
+            collection_properties: Optional[dict[str, Any]] = None,
+            connection_args: Optional[dict[str, Any]] = None,
+            consistency_level: str = "Session",
+            index_params: Optional[dict] = None,
+            search_params: Optional[dict] = None,
+            drop_old: Optional[bool] = False,
+            auto_id: bool = False,
+            *,
+            primary_field: str = "pk",
+            text_field: str = "text",
+            vector_field: str = "vector",
+            metadata_field: Optional[str] = None,
+            partition_key_field: Optional[str] = None,
+            partition_names: Optional[list] = None,
+            replica_number: int = 1,
+            timeout: Optional[float] = None,
+            num_shards: Optional[int] = None,
     ):
         """Initialize the Milvus vector store."""
         try:
@@ -263,11 +263,11 @@ class Milvus(VectorStore):
             for con in connections.list_connections():
                 addr = connections.get_connection_addr(con[0])
                 if (
-                    con[1]
-                    and ("address" in addr)
-                    and (addr["address"] == given_address)
-                    and ("user" in addr)
-                    and (addr["user"] == tmp_user)
+                        con[1]
+                        and ("address" in addr)
+                        and (addr["address"] == given_address)
+                        and ("user" in addr)
+                        and (addr["user"] == tmp_user)
                 ):
                     logger.debug("Using previous connection: %s", con[0])
                     return con[0]
@@ -283,12 +283,12 @@ class Milvus(VectorStore):
             raise e
 
     def _init(
-        self,
-        embeddings: Optional[list] = None,
-        metadatas: Optional[list[dict]] = None,
-        partition_names: Optional[list] = None,
-        replica_number: int = 1,
-        timeout: Optional[float] = None,
+            self,
+            embeddings: Optional[list] = None,
+            metadatas: Optional[list[dict]] = None,
+            partition_names: Optional[list] = None,
+            replica_number: int = 1,
+            timeout: Optional[float] = None,
     ) -> None:
         if embeddings is not None:
             self._create_collection(embeddings, metadatas)
@@ -302,7 +302,7 @@ class Milvus(VectorStore):
         )
 
     def _create_collection(
-        self, embeddings: list, metadatas: Optional[list[dict]] = None
+            self, embeddings: list, metadatas: Optional[list[dict]] = None
     ) -> None:
         from pymilvus import (
             Collection,
@@ -481,10 +481,10 @@ class Milvus(VectorStore):
                 self.search_params["metric_type"] = metric_type
 
     def _load(
-        self,
-        partition_names: Optional[list] = None,
-        replica_number: int = 1,
-        timeout: Optional[float] = None,
+            self,
+            partition_names: Optional[list] = None,
+            replica_number: int = 1,
+            timeout: Optional[float] = None,
     ) -> None:
         """Load the collection if available."""
         from pymilvus import Collection, utility
@@ -492,10 +492,10 @@ class Milvus(VectorStore):
 
         timeout = self.timeout or timeout
         if (
-            isinstance(self.col, Collection)
-            and self._get_index() is not None
-            and utility.load_state(self.collection_name, using=self.alias)
-            == LoadState.NotLoad
+                isinstance(self.col, Collection)
+                and self._get_index() is not None
+                and utility.load_state(self.collection_name, using=self.alias)
+                == LoadState.NotLoad
         ):
             self.col.load(
                 partition_names=partition_names,
@@ -504,14 +504,14 @@ class Milvus(VectorStore):
             )
 
     def add_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        timeout: Optional[float] = None,
-        batch_size: int = 1000,
-        *,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
+            self,
+            texts: Iterable[str],
+            metadatas: Optional[List[dict]] = None,
+            timeout: Optional[float] = None,
+            batch_size: int = 1000,
+            *,
+            ids: Optional[List[str]] = None,
+            **kwargs: Any,
     ) -> List[str]:
         """Insert text data into Milvus.
 
@@ -627,13 +627,13 @@ class Milvus(VectorStore):
         return pks
 
     def similarity_search(
-        self,
-        query: str,
-        k: int = 4,
-        param: Optional[dict] = None,
-        expr: Optional[str] = None,
-        timeout: Optional[float] = None,
-        **kwargs: Any,
+            self,
+            query: str,
+            k: int = 4,
+            param: Optional[dict] = None,
+            expr: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
     ) -> List[Document]:
         """Perform a similarity search against the query string.
 
@@ -660,13 +660,13 @@ class Milvus(VectorStore):
         return [doc for doc, _ in res]
 
     def similarity_search_by_vector(
-        self,
-        embedding: List[float],
-        k: int = 4,
-        param: Optional[dict] = None,
-        expr: Optional[str] = None,
-        timeout: Optional[float] = None,
-        **kwargs: Any,
+            self,
+            embedding: List[float],
+            k: int = 4,
+            param: Optional[dict] = None,
+            expr: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
     ) -> List[Document]:
         """Perform a similarity search against the query string.
 
@@ -693,13 +693,13 @@ class Milvus(VectorStore):
         return [doc for doc, _ in res]
 
     def similarity_search_with_score(
-        self,
-        query: str,
-        k: int = 4,
-        param: Optional[dict] = None,
-        expr: Optional[str] = None,
-        timeout: Optional[float] = None,
-        **kwargs: Any,
+            self,
+            query: str,
+            k: int = 4,
+            param: Optional[dict] = None,
+            expr: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Perform a search on a query string and return results with score.
 
@@ -733,13 +733,13 @@ class Milvus(VectorStore):
         return res
 
     def similarity_search_with_score_by_vector(
-        self,
-        embedding: List[float],
-        k: int = 4,
-        param: Optional[dict] = None,
-        expr: Optional[str] = None,
-        timeout: Optional[float] = None,
-        **kwargs: Any,
+            self,
+            embedding: List[float],
+            k: int = 4,
+            param: Optional[dict] = None,
+            expr: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Perform a search on a query string and return results with score.
 
@@ -793,15 +793,15 @@ class Milvus(VectorStore):
         return ret
 
     def max_marginal_relevance_search(
-        self,
-        query: str,
-        k: int = 4,
-        fetch_k: int = 20,
-        lambda_mult: float = 0.5,
-        param: Optional[dict] = None,
-        expr: Optional[str] = None,
-        timeout: Optional[float] = None,
-        **kwargs: Any,
+            self,
+            query: str,
+            k: int = 4,
+            fetch_k: int = 20,
+            lambda_mult: float = 0.5,
+            param: Optional[dict] = None,
+            expr: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
     ) -> List[Document]:
         """Perform a search and return results that are reordered by MMR.
 
@@ -843,15 +843,15 @@ class Milvus(VectorStore):
         )
 
     def max_marginal_relevance_search_by_vector(
-        self,
-        embedding: list[float],
-        k: int = 4,
-        fetch_k: int = 20,
-        lambda_mult: float = 0.5,
-        param: Optional[dict] = None,
-        expr: Optional[str] = None,
-        timeout: Optional[float] = None,
-        **kwargs: Any,
+            self,
+            embedding: list[float],
+            k: int = 4,
+            fetch_k: int = 20,
+            lambda_mult: float = 0.5,
+            param: Optional[dict] = None,
+            expr: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
     ) -> List[Document]:
         """Perform a search and return results that are reordered by MMR.
 
@@ -933,7 +933,7 @@ class Milvus(VectorStore):
         return ret
 
     def delete(  # type: ignore[no-untyped-def]
-        self, ids: Optional[List[str]] = None, expr: Optional[str] = None, **kwargs: str
+            self, ids: Optional[List[str]] = None, expr: Optional[str] = None, **kwargs: str
     ):
         """Delete by vector ID or boolean expression.
         Refer to [Milvus documentation](https://milvus.io/docs/delete_data.md)
@@ -958,19 +958,19 @@ class Milvus(VectorStore):
 
     @classmethod
     def from_texts(
-        cls,
-        texts: List[str],
-        embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
-        collection_name: str = "LangChainCollection",
-        connection_args: dict[str, Any] = DEFAULT_MILVUS_CONNECTION,
-        consistency_level: str = "Session",
-        index_params: Optional[dict] = None,
-        search_params: Optional[dict] = None,
-        drop_old: bool = False,
-        *,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
+            cls,
+            texts: List[str],
+            embedding: Embeddings,
+            metadatas: Optional[List[dict]] = None,
+            collection_name: str = "LangChainCollection",
+            connection_args: dict[str, Any] = DEFAULT_MILVUS_CONNECTION,
+            consistency_level: str = "Session",
+            index_params: Optional[dict] = None,
+            search_params: Optional[dict] = None,
+            drop_old: bool = False,
+            *,
+            ids: Optional[List[str]] = None,
+            **kwargs: Any,
     ) -> Milvus:
         """Create a Milvus collection, indexes it with HNSW, and insert data.
 
@@ -1048,10 +1048,10 @@ class Milvus(VectorStore):
         return pks
 
     def upsert(
-        self,
-        ids: Optional[List[str]] = None,
-        documents: List[Document] | None = None,
-        **kwargs: Any,
+            self,
+            ids: Optional[List[str]] = None,
+            documents: List[Document] | None = None,
+            **kwargs: Any,
     ) -> List[str] | None:
         """Update/Insert documents to the vectorstore.
 
@@ -1083,14 +1083,14 @@ class Milvus(VectorStore):
             raise exc
 
     def upsert_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        timeout: Optional[float] = None,
-        batch_size: int = 1000,
-        *,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
+            self,
+            texts: Iterable[str],
+            metadatas: Optional[List[dict]] = None,
+            timeout: Optional[float] = None,
+            batch_size: int = 1000,
+            *,
+            ids: Optional[List[str]] = None,
+            **kwargs: Any,
     ) -> List[str] | None:
         """upsert texts to the Milvus vectorstore.
         This is based on upsert data based on add_text functionality
@@ -1132,6 +1132,7 @@ class Milvus(VectorStore):
                                   timeout=timeout, batch_size=batch_size, ids=ids, **kwargs)
         except MilvusException as exc:
             logger.error(
-                "Failed to upsert texts entities: %s error: %s", self.collection_name, exc
+                "Failed to upsert texts entities: %s error: %s",
+                self.collection_name, exc
             )
             raise exc

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1092,7 +1092,7 @@ class Milvus(VectorStore):
         ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> List[str] | None:
-        """Update/Insert texts to the Milvus vectorstore.
+        """upsert texts to the Milvus vectorstore.
         This is based on upsert data based on add_text functionality
         In case metadata need to upsert in milvus,
         Metadata keys will need to be present for all inserted values. At


### PR DESCRIPTION
Upsert texts to the Milvus vectorstore.
        This is based on upsert data based on add_text functionality
        In case metadata need to upsert in milvus,
        Metadata keys will need to be present for all inserted values. At
        the moment there is no None equivalent in Milvus.

