### PR TITLE
community: import fix

### DIFF
--- a/libs/community/langchain_community/cache.py
+++ b/libs/community/langchain_community/cache.py
@@ -323,7 +323,7 @@ class UpstashRedisCache(BaseCache):
         try:
             from upstash_redis import Redis
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import upstash_redis python package. "
                 "Please install it with `pip install upstash_redis`."
             )
@@ -461,7 +461,7 @@ class RedisCache(_RedisCacheBase):
         try:
             from redis import Redis
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import `redis` python package. "
                 "Please install it with `pip install redis`."
             )
@@ -528,7 +528,7 @@ class AsyncRedisCache(_RedisCacheBase):
         try:
             from redis.asyncio import Redis
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import `redis.asyncio` python package. "
                 "Please install it with `pip install redis`."
             )
@@ -1069,7 +1069,7 @@ class CassandraCache(BaseCache):
         try:
             from cassio.table import ElasticCassandraTable
         except (ImportError, ModuleNotFoundError):
-            raise ValueError(
+            raise ImportError(
                 "Could not import cassio python package. "
                 "Please install it with `pip install cassio`."
             )
@@ -1192,7 +1192,7 @@ class CassandraSemanticCache(BaseCache):
         try:
             from cassio.table import MetadataVectorCassandraTable
         except (ImportError, ModuleNotFoundError):
-            raise ValueError(
+            raise ImportError(
                 "Could not import cassio python package. "
                 "Please install it with `pip install cassio`."
             )

--- a/libs/community/langchain_community/chat_message_histories/neo4j.py
+++ b/libs/community/langchain_community/chat_message_histories/neo4j.py
@@ -25,7 +25,7 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
         try:
             import neo4j
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import neo4j python package. "
                 "Please install it with `pip install neo4j`."
             )

--- a/libs/community/langchain_community/chat_message_histories/xata.py
+++ b/libs/community/langchain_community/chat_message_histories/xata.py
@@ -25,7 +25,7 @@ class XataChatMessageHistory(BaseChatMessageHistory):
         try:
             from xata.client import XataClient  # noqa: F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import xata python package. "
                 "Please install it with `pip install xata`."
             )

--- a/libs/community/langchain_community/chat_models/anyscale.py
+++ b/libs/community/langchain_community/chat_models/anyscale.py
@@ -127,7 +127,7 @@ class ChatAnyscale(ChatOpenAI):
             import openai
 
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 "Could not import openai python package. "
                 "Please install it with `pip install openai`.",
             ) from e

--- a/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
+++ b/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
@@ -164,7 +164,7 @@ class QianfanChatEndpoint(BaseChatModel):
 
             values["client"] = qianfan.ChatCompletion(**params)
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "qianfan package not found, please install it with "
                 "`pip install qianfan`"
             )

--- a/libs/community/langchain_community/chat_models/everlyai.py
+++ b/libs/community/langchain_community/chat_models/everlyai.py
@@ -89,7 +89,7 @@ class ChatEverlyAI(ChatOpenAI):
             import openai
 
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 "Could not import openai python package. "
                 "Please install it with `pip install openai`.",
             ) from e

--- a/libs/community/langchain_community/chat_models/jinachat.py
+++ b/libs/community/langchain_community/chat_models/jinachat.py
@@ -227,7 +227,7 @@ class JinaChat(BaseChatModel):
             import openai
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import openai python package. "
                 "Please install it with `pip install openai`."
             )

--- a/libs/community/langchain_community/chat_models/konko.py
+++ b/libs/community/langchain_community/chat_models/konko.py
@@ -94,7 +94,7 @@ class ChatKonko(ChatOpenAI):
             import konko
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import konko python package. "
                 "Please install it with `pip install konko`."
             )

--- a/libs/community/langchain_community/chat_models/mlx.py
+++ b/libs/community/langchain_community/chat_models/mlx.py
@@ -150,7 +150,7 @@ class ChatMLX(BaseChatModel):
             from mlx_lm.utils import generate_step
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import mlx_lm python package. "
                 "Please install it with `pip install mlx_lm`."
             )

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -67,7 +67,7 @@ def _import_tiktoken() -> Any:
     try:
         import tiktoken
     except ImportError:
-        raise ValueError(
+        raise ImportError(
             "Could not import tiktoken python package. "
             "This is needed in order to calculate get_token_ids. "
             "Please install it with `pip install tiktoken`."

--- a/libs/community/langchain_community/chat_models/yuan2.py
+++ b/libs/community/langchain_community/chat_models/yuan2.py
@@ -176,7 +176,7 @@ class ChatYuan2(BaseChatModel):
             import openai
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import openai python package. "
                 "Please install it with `pip install openai`."
             )

--- a/libs/community/langchain_community/document_compressors/openvino_rerank.py
+++ b/libs/community/langchain_community/document_compressors/openvino_rerank.py
@@ -38,7 +38,7 @@ class OpenVINOReranker(BaseDocumentCompressor):
         try:
             from optimum.intel.openvino import OVModelForSequenceClassification
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 "Could not import optimum-intel python package. "
                 "Please install it with: "
                 "pip install -U 'optimum[openvino,nncf]'"
@@ -47,7 +47,7 @@ class OpenVINOReranker(BaseDocumentCompressor):
         try:
             from huggingface_hub import HfApi
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 "Could not import huggingface_hub python package. "
                 "Please install it with: "
                 "`pip install -U huggingface_hub`."

--- a/libs/community/langchain_community/document_loaders/athena.py
+++ b/libs/community/langchain_community/document_loaders/athena.py
@@ -54,7 +54,7 @@ class AthenaLoader(BaseLoader):
         try:
             import boto3
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
@@ -115,7 +115,7 @@ class AthenaLoader(BaseLoader):
         try:
             import pandas as pd
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import pandas python package. "
                 "Please install it with `pip install pandas`."
             )

--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -634,7 +634,7 @@ class AmazonTextractPDFLoader(BasePDFLoader):
         try:
             import textractcaller as tc  # noqa: F401
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import amazon-textract-caller python package. "
                 "Please install it with `pip install amazon-textract-caller`."
             )
@@ -662,7 +662,7 @@ class AmazonTextractPDFLoader(BasePDFLoader):
                 client = session.client("textract", **client_params)
 
             except ImportError:
-                raise ModuleNotFoundError(
+                raise ImportError(
                     "Could not import boto3 python package. "
                     "Please install it with `pip install boto3`."
                 )
@@ -710,7 +710,7 @@ class AmazonTextractPDFLoader(BasePDFLoader):
             from PIL import Image, ImageSequence
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import pypdf or Pilloe python package. "
                 "Please install it with `pip install pypdf Pillow`."
             )

--- a/libs/community/langchain_community/document_loaders/unstructured.py
+++ b/libs/community/langchain_community/document_loaders/unstructured.py
@@ -48,7 +48,7 @@ class UnstructuredBaseLoader(BaseLoader, ABC):
         try:
             import unstructured  # noqa:F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "unstructured package not found, please install it with "
                 "`pip install unstructured`"
             )

--- a/libs/community/langchain_community/embeddings/aleph_alpha.py
+++ b/libs/community/langchain_community/embeddings/aleph_alpha.py
@@ -98,7 +98,7 @@ class AlephAlphaAsymmetricSemanticEmbedding(BaseModel, Embeddings):
                 nice=values["nice"],
             )
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import aleph_alpha_client python package. "
                 "Please install it with `pip install aleph_alpha_client`."
             )
@@ -121,7 +121,7 @@ class AlephAlphaAsymmetricSemanticEmbedding(BaseModel, Embeddings):
                 SemanticRepresentation,
             )
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import aleph_alpha_client python package. "
                 "Please install it with `pip install aleph_alpha_client`."
             )
@@ -161,7 +161,7 @@ class AlephAlphaAsymmetricSemanticEmbedding(BaseModel, Embeddings):
                 SemanticRepresentation,
             )
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import aleph_alpha_client python package. "
                 "Please install it with `pip install aleph_alpha_client`."
             )
@@ -209,7 +209,7 @@ class AlephAlphaSymmetricSemanticEmbedding(AlephAlphaAsymmetricSemanticEmbedding
                 SemanticRepresentation,
             )
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import aleph_alpha_client python package. "
                 "Please install it with `pip install aleph_alpha_client`."
             )

--- a/libs/community/langchain_community/embeddings/bedrock.py
+++ b/libs/community/langchain_community/embeddings/bedrock.py
@@ -99,7 +99,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
             values["client"] = session.client("bedrock-runtime", **client_params)
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )

--- a/libs/community/langchain_community/embeddings/cohere.py
+++ b/libs/community/langchain_community/embeddings/cohere.py
@@ -77,7 +77,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
                 client_name=client_name,
             )
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import cohere python package. "
                 "Please install it with `pip install cohere`."
             )

--- a/libs/community/langchain_community/embeddings/llamacpp.py
+++ b/libs/community/langchain_community/embeddings/llamacpp.py
@@ -88,7 +88,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
 
             values["client"] = Llama(model_path, embedding=True, **model_params)
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import llama-cpp-python library. "
                 "Please install the llama-cpp-python library to "
                 "use this embedding model: pip install llama-cpp-python"

--- a/libs/community/langchain_community/embeddings/oci_generative_ai.py
+++ b/libs/community/langchain_community/embeddings/oci_generative_ai.py
@@ -143,7 +143,7 @@ class OCIGenAIEmbeddings(BaseModel, Embeddings):
             )
 
         except ImportError as ex:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import oci python package. "
                 "Please make sure you have the oci package installed."
             ) from ex

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -424,7 +424,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             try:
                 from transformers import AutoTokenizer
             except ImportError:
-                raise ValueError(
+                raise ImportError(
                     "Could not import transformers python package. "
                     "This is needed in order to for OpenAIEmbeddings without "
                     "`tiktoken`. Please install it with `pip install transformers`. "
@@ -557,7 +557,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             try:
                 from transformers import AutoTokenizer
             except ImportError:
-                raise ValueError(
+                raise ImportError(
                     "Could not import transformers python package. "
                     "This is needed in order to for OpenAIEmbeddings without "
                     " `tiktoken`. Please install it with `pip install transformers`."

--- a/libs/community/langchain_community/embeddings/openvino.py
+++ b/libs/community/langchain_community/embeddings/openvino.py
@@ -51,7 +51,7 @@ class OpenVINOEmbeddings(BaseModel, Embeddings):
         try:
             from optimum.intel.openvino import OVModelForFeatureExtraction
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 "Could not import optimum-intel python package. "
                 "Please install it with: "
                 "pip install -U 'optimum[openvino,nncf]'"
@@ -60,7 +60,7 @@ class OpenVINOEmbeddings(BaseModel, Embeddings):
         try:
             from huggingface_hub import HfApi
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 "Could not import huggingface_hub python package. "
                 "Please install it with: "
                 "`pip install -U huggingface_hub`."

--- a/libs/community/langchain_community/graphs/age_graph.py
+++ b/libs/community/langchain_community/graphs/age_graph.py
@@ -76,7 +76,7 @@ class AGEGraph(GraphStore):
         try:
             import psycopg2
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import psycopg2 python package. "
                 "Please install it with `pip install psycopg2`."
             )

--- a/libs/community/langchain_community/graphs/gremlin_graph.py
+++ b/libs/community/langchain_community/graphs/gremlin_graph.py
@@ -55,7 +55,7 @@ class GremlinGraph(GraphStore):
             if sys.platform == "win32":
                 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Please install gremlin-python first: " "`pip3 install gremlinpython"
             )
 

--- a/libs/community/langchain_community/graphs/hugegraph.py
+++ b/libs/community/langchain_community/graphs/hugegraph.py
@@ -28,7 +28,7 @@ class HugeGraph:
         try:
             from hugegraph.connection import PyHugeGraph
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Please install HugeGraph Python client first: "
                 "`pip3 install hugegraph-python`"
             )

--- a/libs/community/langchain_community/graphs/nebula_graph.py
+++ b/libs/community/langchain_community/graphs/nebula_graph.py
@@ -47,7 +47,7 @@ class NebulaGraph:
             import nebula3  # noqa: F401
             import pandas  # noqa: F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Please install NebulaGraph Python client and pandas first: "
                 "`pip install nebula3-python pandas`"
             )

--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -181,7 +181,7 @@ class Neo4jGraph(GraphStore):
         try:
             import neo4j
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import neo4j python package. "
                 "Please install it with `pip install neo4j`."
             )

--- a/libs/community/langchain_community/graphs/neptune_graph.py
+++ b/libs/community/langchain_community/graphs/neptune_graph.py
@@ -196,13 +196,13 @@ class NeptuneAnalyticsGraph(BaseNeptuneGraph):
                     self.client = session.client("neptune-graph")
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
         except Exception as e:
             if type(e).__name__ == "UnknownServiceError":
-                raise ModuleNotFoundError(
+                raise ImportError(
                     "NeptuneGraph requires a boto3 version 1.34.40 or greater."
                     "Please install it with `pip install -U boto3`."
                 ) from e
@@ -345,13 +345,13 @@ class NeptuneGraph(BaseNeptuneGraph):
                     )
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
         except Exception as e:
             if type(e).__name__ == "UnknownServiceError":
-                raise ModuleNotFoundError(
+                raise ImportError(
                     "NeptuneGraph requires a boto3 version 1.28.38 or greater."
                     "Please install it with `pip install -U boto3`."
                 ) from e

--- a/libs/community/langchain_community/graphs/neptune_rdf_graph.py
+++ b/libs/community/langchain_community/graphs/neptune_rdf_graph.py
@@ -121,13 +121,13 @@ class NeptuneRdfGraph:
                     )
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
         except Exception as e:
             if type(e).__name__ == "UnknownServiceError":
-                raise ModuleNotFoundError(
+                raise ImportError(
                     "NeptuneGraph requires a boto3 version 1.28.38 or greater."
                     "Please install it with `pip install -U boto3`."
                 ) from e

--- a/libs/community/langchain_community/graphs/ontotext_graphdb_graph.py
+++ b/libs/community/langchain_community/graphs/ontotext_graphdb_graph.py
@@ -81,7 +81,7 @@ class OntotextGraphDBGraph:
             import rdflib
             from rdflib.plugins.stores import sparqlstore
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import rdflib python package. "
                 "Please install it with `pip install rdflib`."
             )

--- a/libs/community/langchain_community/graphs/rdf_graph.py
+++ b/libs/community/langchain_community/graphs/rdf_graph.py
@@ -146,7 +146,7 @@ class RdfGraph:
             import rdflib
             from rdflib.plugins.stores import sparqlstore
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import rdflib python package. "
                 "Please install it with `pip install rdflib`."
             )

--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -424,7 +424,7 @@ class BedrockBase(BaseModel, ABC):
             values["client"] = session.client("bedrock-runtime", **client_params)
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )

--- a/libs/community/langchain_community/llms/bigdl_llm.py
+++ b/libs/community/langchain_community/llms/bigdl_llm.py
@@ -53,7 +53,7 @@ class BigdlLLM(IpexLLM):
             from transformers import AutoTokenizer, LlamaTokenizer
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import bigdl-llm or transformers. "
                 "Please install it with `pip install --pre --upgrade bigdl-llm[all]`."
             )
@@ -136,7 +136,7 @@ class BigdlLLM(IpexLLM):
             from transformers import AutoTokenizer, LlamaTokenizer
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import bigdl-llm or transformers. "
                 "Please install it with `pip install --pre --upgrade bigdl-llm[all]`."
             )

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -88,7 +88,7 @@ class HuggingFaceHub(LLM):
                 )
             values["client"] = client
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import huggingface_hub python package. "
                 "Please install it with `pip install huggingface_hub`."
             )

--- a/libs/community/langchain_community/llms/huggingface_pipeline.py
+++ b/libs/community/langchain_community/llms/huggingface_pipeline.py
@@ -92,7 +92,7 @@ class HuggingFacePipeline(BaseLLM):
             from transformers import pipeline as hf_pipeline
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import transformers python package. "
                 "Please install it with `pip install transformers`."
             )
@@ -107,7 +107,7 @@ class HuggingFacePipeline(BaseLLM):
                         from optimum.intel.openvino import OVModelForCausalLM
 
                     except ImportError:
-                        raise ValueError(
+                        raise ImportError(
                             "Could not import optimum-intel python package. "
                             "Please install it with: "
                             "pip install 'optimum[openvino,nncf]' "
@@ -133,7 +133,7 @@ class HuggingFacePipeline(BaseLLM):
                         from optimum.intel.openvino import OVModelForSeq2SeqLM
 
                     except ImportError:
-                        raise ValueError(
+                        raise ImportError(
                             "Could not import optimum-intel python package. "
                             "Please install it with: "
                             "pip install 'optimum[openvino,nncf]' "
@@ -159,7 +159,7 @@ class HuggingFacePipeline(BaseLLM):
                     f"currently only {VALID_TASKS} are supported"
                 )
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 f"Could not load the {task} model due to missing dependencies."
             ) from e
 

--- a/libs/community/langchain_community/llms/ipex_llm.py
+++ b/libs/community/langchain_community/llms/ipex_llm.py
@@ -132,7 +132,7 @@ class IpexLLM(LLM):
             from transformers import AutoTokenizer, LlamaTokenizer
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import ipex-llm. "
                 "Please install `ipex-llm` properly following installation guides: "
                 "https://github.com/intel-analytics/ipex-llm?tab=readme-ov-file#install-ipex-llm."

--- a/libs/community/langchain_community/llms/konko.py
+++ b/libs/community/langchain_community/llms/konko.py
@@ -71,7 +71,7 @@ class Konko(LLM):
             import konko
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import konko python package. "
                 "Please install it with `pip install konko`."
             )

--- a/libs/community/langchain_community/llms/mlx_pipeline.py
+++ b/libs/community/langchain_community/llms/mlx_pipeline.py
@@ -81,7 +81,7 @@ class MLXPipeline(LLM):
             from mlx_lm import load
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import mlx_lm python package. "
                 "Please install it with `pip install mlx_lm`."
             )
@@ -130,7 +130,7 @@ class MLXPipeline(LLM):
             from mlx_lm import generate
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import mlx_lm python package. "
                 "Please install it with `pip install mlx_lm`."
             )
@@ -151,7 +151,7 @@ class MLXPipeline(LLM):
             from mlx_lm.utils import generate_step
 
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import mlx_lm python package. "
                 "Please install it with `pip install mlx_lm`."
             )

--- a/libs/community/langchain_community/llms/oci_generative_ai.py
+++ b/libs/community/langchain_community/llms/oci_generative_ai.py
@@ -128,7 +128,7 @@ class OCIGenAIBase(BaseModel, ABC):
             )
 
         except ImportError as ex:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import oci python package. "
                 "Please make sure you have the oci package installed."
             ) from ex

--- a/libs/community/langchain_community/llms/sambanova.py
+++ b/libs/community/langchain_community/llms/sambanova.py
@@ -63,7 +63,7 @@ class SVEndpointHandler:
         try:
             import sseclient
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "could not import sseclient library"
                 "Please install it with `pip install sseclient-py`."
             )
@@ -505,7 +505,7 @@ class SSEndpointHandler:
         try:
             import sseclient
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "could not import sseclient library"
                 "Please install it with `pip install sseclient-py`."
             )

--- a/libs/community/langchain_community/llms/self_hosted_hugging_face.py
+++ b/libs/community/langchain_community/llms/self_hosted_hugging_face.py
@@ -73,7 +73,7 @@ def _load_transformer(
                 f"currently only {VALID_TASKS} are supported"
             )
     except ImportError as e:
-        raise ValueError(
+        raise ImportError(
             f"Could not load the {task} model due to missing dependencies."
         ) from e
 

--- a/libs/community/langchain_community/llms/weight_only_quantization.py
+++ b/libs/community/langchain_community/llms/weight_only_quantization.py
@@ -108,7 +108,7 @@ class WeightOnlyQuantPipeline(LLM):
             from transformers import AutoTokenizer
             from transformers import pipeline as hf_pipeline
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import transformers python package. "
                 "Please install it with `pip install transformers` "
                 "and `pip install intel-extension-for-transformers`."
@@ -154,7 +154,7 @@ class WeightOnlyQuantPipeline(LLM):
                     f"currently only {VALID_TASKS} are supported"
                 )
         except ImportError as e:
-            raise ValueError(
+            raise ImportError(
                 f"Could not load the {task} model due to missing dependencies."
             ) from e
 

--- a/libs/community/langchain_community/retrievers/bedrock.py
+++ b/libs/community/langchain_community/retrievers/bedrock.py
@@ -88,12 +88,12 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
 
             return values
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
         except UnknownServiceError as e:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Ensure that you have installed the latest boto3 package "
                 "that contains the API for `bedrock-runtime-agent`."
             ) from e

--- a/libs/community/langchain_community/retrievers/elastic_search_bm25.py
+++ b/libs/community/langchain_community/retrievers/elastic_search_bm25.py
@@ -103,7 +103,7 @@ class ElasticSearchBM25Retriever(BaseRetriever):
         try:
             from elasticsearch.helpers import bulk
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import elasticsearch python package. "
                 "Please install it with `pip install elasticsearch`."
             )

--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -400,7 +400,7 @@ class AmazonKendraRetriever(BaseRetriever):
 
             return values
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )

--- a/libs/community/langchain_community/retrievers/thirdai_neuraldb.py
+++ b/libs/community/langchain_community/retrievers/thirdai_neuraldb.py
@@ -36,7 +36,7 @@ class NeuralDBRetriever(BaseRetriever):
 
             licensing.activate(thirdai_key or os.getenv("THIRDAI_KEY"))
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import thirdai python package and neuraldb dependencies. "
                 "Please install it with `pip install thirdai[neural_db]`."
             )

--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -69,7 +69,7 @@ class SerpAPIWrapper(BaseModel):
 
             values["search_engine"] = GoogleSearch
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import serpapi python package. "
                 "Please install it with `pip install google-search-results`."
             )

--- a/libs/community/langchain_community/utilities/spark_sql.py
+++ b/libs/community/langchain_community/utilities/spark_sql.py
@@ -82,7 +82,7 @@ class SparkSQL:
         try:
             from pyspark.sql import SparkSession
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "pyspark is not installed. Please install it with `pip install pyspark`"
             )
 

--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -189,7 +189,7 @@ class SQLDatabase:
         try:
             from databricks import sql  # noqa: F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "databricks-sql-connector package not found, please install with"
                 " `pip install databricks-sql-connector`"
             )
@@ -267,7 +267,7 @@ class SQLDatabase:
             uri = make_cnosdb_langchain_uri(url, user, password, tenant, database)
             return cls.from_uri(database_uri=uri)
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "cnos-connector package not found, please install with"
                 " `pip install cnos-connector`"
             )

--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -149,7 +149,7 @@ class Chroma(VectorStore):
         try:
             import chromadb  # noqa: F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import chromadb python package. "
                 "Please install it with `pip install chromadb`."
             )

--- a/libs/community/langchain_community/vectorstores/dashvector.py
+++ b/libs/community/langchain_community/vectorstores/dashvector.py
@@ -51,7 +51,7 @@ class DashVector(VectorStore):
         try:
             import dashvector
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import dashvector python package. "
                 "Please install it with `pip install dashvector`."
             )
@@ -366,7 +366,7 @@ class DashVector(VectorStore):
         try:
             import dashvector
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import dashvector python package. "
                 "Please install it with `pip install dashvector`."
             )

--- a/libs/community/langchain_community/vectorstores/deeplake.py
+++ b/libs/community/langchain_community/vectorstores/deeplake.py
@@ -913,7 +913,7 @@ class DeepLake(VectorStore):
         try:
             import deeplake
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import deeplake python package. "
                 "Please install it with `pip install deeplake`."
             )

--- a/libs/community/langchain_community/vectorstores/jaguar.py
+++ b/libs/community/langchain_community/vectorstores/jaguar.py
@@ -53,7 +53,7 @@ class Jaguar(VectorStore):
         try:
             from jaguardb_http_client.JaguarHttpClient import JaguarHttpClient
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import jaguardb-http-client python package. "
                 "Please install it with `pip install -U jaguardb-http-client`"
             )

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -139,7 +139,7 @@ class Milvus(VectorStore):
         try:
             from pymilvus import Collection, utility
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import pymilvus python package. "
                 "Please install it with `pip install pymilvus`."
             )

--- a/libs/community/langchain_community/vectorstores/nucliadb.py
+++ b/libs/community/langchain_community/vectorstores/nucliadb.py
@@ -36,7 +36,7 @@ class NucliaDB(VectorStore):
         try:
             from nuclia.sdk import NucliaAuth
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "nuclia python package not found. "
                 "Please install it with `pip install nuclia`."
             )

--- a/libs/community/langchain_community/vectorstores/qdrant.py
+++ b/libs/community/langchain_community/vectorstores/qdrant.py
@@ -1625,7 +1625,7 @@ class Qdrant(VectorStore):
         try:
             import qdrant_client  # noqa
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import qdrant-client python package. "
                 "Please install it with `pip install qdrant-client`."
             )
@@ -1790,7 +1790,7 @@ class Qdrant(VectorStore):
         try:
             import qdrant_client  # noqa
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import qdrant-client python package. "
                 "Please install it with `pip install qdrant-client`."
             )

--- a/libs/community/langchain_community/vectorstores/redis/base.py
+++ b/libs/community/langchain_community/vectorstores/redis/base.py
@@ -610,7 +610,7 @@ class Redis(VectorStore):
         try:
             import redis  # noqa: F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import redis python package. "
                 "Please install it with `pip install redis`."
             )
@@ -651,7 +651,7 @@ class Redis(VectorStore):
         try:
             import redis  # noqa: F401
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import redis python package. "
                 "Please install it with `pip install redis`."
             )

--- a/libs/community/langchain_community/vectorstores/tair.py
+++ b/libs/community/langchain_community/vectorstores/tair.py
@@ -173,7 +173,7 @@ class Tair(VectorStore):
         try:
             from tair import tairvector
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import tair python package. "
                 "Please install it with `pip install tair`."
             )
@@ -262,7 +262,7 @@ class Tair(VectorStore):
         try:
             from tair import Tair as TairClient
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import tair python package. "
                 "Please install it with `pip install tair`."
             )

--- a/libs/community/langchain_community/vectorstores/thirdai_neuraldb.py
+++ b/libs/community/langchain_community/vectorstores/thirdai_neuraldb.py
@@ -47,7 +47,7 @@ class NeuralDBVectorStore(VectorStore):
 
             licensing.activate(thirdai_key or os.getenv("THIRDAI_KEY"))
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import thirdai python package and neuraldb dependencies. "
                 "Please install it with `pip install thirdai[neural_db]`."
             )

--- a/libs/community/langchain_community/vectorstores/tiledb.py
+++ b/libs/community/langchain_community/vectorstores/tiledb.py
@@ -28,7 +28,7 @@ def dependable_tiledb_import() -> Any:
         import tiledb as tiledb
         import tiledb.vector_search as tiledb_vs
     except ImportError:
-        raise ValueError(
+        raise ImportError(
             "Could not import tiledb-vector-search python package. "
             "Please install it with `conda install -c tiledb tiledb-vector-search` "
             "or `pip install tiledb-vector-search`"

--- a/libs/community/langchain_community/vectorstores/typesense.py
+++ b/libs/community/langchain_community/vectorstores/typesense.py
@@ -227,7 +227,7 @@ class Typesense(VectorStore):
         try:
             from typesense import Client
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import typesense python package. "
                 "Please install it with `pip install typesense`."
             )

--- a/libs/community/langchain_community/vectorstores/vald.py
+++ b/libs/community/langchain_community/vectorstores/vald.py
@@ -58,7 +58,7 @@ class Vald(VectorStore):
         try:
             import grpc
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import grpcio python package. "
                 "Please install it with `pip install grpcio`."
             )
@@ -86,7 +86,7 @@ class Vald(VectorStore):
             from vald.v1.payload import payload_pb2
             from vald.v1.vald import upsert_pb2_grpc
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import vald-client-python python package. "
                 "Please install it with `pip install vald-client-python`."
             )
@@ -126,7 +126,7 @@ class Vald(VectorStore):
             from vald.v1.payload import payload_pb2
             from vald.v1.vald import remove_pb2_grpc
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import vald-client-python python package. "
                 "Please install it with `pip install vald-client-python`."
             )
@@ -221,7 +221,7 @@ class Vald(VectorStore):
             from vald.v1.payload import payload_pb2
             from vald.v1.vald import search_pb2_grpc
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import vald-client-python python package. "
                 "Please install it with `pip install vald-client-python`."
             )
@@ -289,7 +289,7 @@ class Vald(VectorStore):
             from vald.v1.payload import payload_pb2
             from vald.v1.vald import object_pb2_grpc
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import vald-client-python python package. "
                 "Please install it with `pip install vald-client-python`."
             )

--- a/libs/community/langchain_community/vectorstores/vearch.py
+++ b/libs/community/langchain_community/vectorstores/vearch.py
@@ -39,7 +39,7 @@ class Vearch(VectorStore):
             else:
                 import vearch
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import suitable python package. "
                 "Please install it with `pip install vearch or vearch_cluster`."
             )

--- a/libs/community/langchain_community/vectorstores/vikingdb.py
+++ b/libs/community/langchain_community/vectorstores/vikingdb.py
@@ -59,7 +59,7 @@ class VikingDB(VectorStore):
         try:
             from volcengine.viking_db import Collection, VikingDBService
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import volcengine python package. "
                 "Please install it with `pip install --upgrade volcengine`."
             )
@@ -104,7 +104,7 @@ class VikingDB(VectorStore):
         try:
             from volcengine.viking_db import Field, FieldType
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import volcengine python package. "
                 "Please install it with `pip install --upgrade volcengine`."
             )
@@ -139,7 +139,7 @@ class VikingDB(VectorStore):
         try:
             from volcengine.viking_db import VectorIndexParams
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import volcengine python package. "
                 "Please install it with `pip install --upgrade volcengine`."
             )
@@ -177,7 +177,7 @@ class VikingDB(VectorStore):
         try:
             from volcengine.viking_db import Data
         except ImportError:
-            raise ValueError(
+            raise ImportError(
                 "Could not import volcengine python package. "
                 "Please install it with `pip install --upgrade volcengine`."
             )

--- a/libs/community/tests/unit_tests/document_loaders/test_lakefs.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_lakefs.py
@@ -74,7 +74,7 @@ class TestLakeFSLoader(unittest.TestCase):
         loader.set_repo(self.repo)
         loader.set_ref(self.ref)
         loader.set_path(self.path)
-        with pytest.raises(ValueError):
+        with pytest.raises(ImportError):
             loader.load()
 
     @requests_mock.Mocker()


### PR DESCRIPTION
Issue: When the third-party package is not installed, whenever we need to `pip install <package>` the ImportError is raised.
But sometimes, the `ValueError` or `ModuleNotFoundError` is raised. It is bad for consistency.
Change: replaced the  `ValueError` or `ModuleNotFoundError` with `ImportError` when we raise an error with the `pip install <package>` message.
Note: Ideally, we replace all `try: import... except... raise ... `with helper functions like `import_aim` or just use the existing [langchain_core.utils.utils.guard_import](https://api.python.langchain.com/en/latest/utils/langchain_core.utils.utils.guard_import.html#langchain_core.utils.utils.guard_import) But it would be much bigger refactoring. @baskaryan Please, advice on this.