### PR TITLE
docs:Fix infinity.ipynb path error

### DIFF
--- a/docs/docs/integrations/providers/infinity.mdx
+++ b/docs/docs/integrations/providers/infinity.mdx
@@ -8,4 +8,4 @@ There exists an infinity Embedding model, which you can access with
 ```python
 from langchain_community.embeddings import InfinityEmbeddings
 ```
-For a more detailed walkthrough of this, see [this notebook](/docs/integrations/text_embedding/infinity)
+For a more detailed walkthrough of this, see [this notebook](/docs/docs/integrations/text_embedding/infinity.ipynb)


### PR DESCRIPTION
fix path error for ```infinity.ipynb```  in ```infinity.mdx```.