### PR TITLE
cli[patch]: Update migrations file manually

### DIFF
--- a/libs/cli/langchain_cli/namespaces/migrate/codemods/migrations/langchain_to_core.json
+++ b/libs/cli/langchain_cli/namespaces/migrate/codemods/migrations/langchain_to_core.json
@@ -1569,7 +1569,7 @@
   ],
   [
     "langchain.schema.runnable.RunnableMap",
-    "langchain_core.runnables.RunnableParallel"
+    "langchain_core.runnables.RunnableMap"
   ],
   [
     "langchain.schema.runnable.RunnableParallel",
@@ -1629,7 +1629,7 @@
   ],
   [
     "langchain.schema.runnable.base.RunnableMap",
-    "langchain_core.runnables.RunnableParallel"
+    "langchain_core.runnables.RunnableMap"
   ],
   [
     "langchain.schema.runnable.base.coerce_to_runnable",

--- a/libs/cli/langchain_cli/namespaces/migrate/generate/generic.py
+++ b/libs/cli/langchain_cli/namespaces/migrate/generate/generic.py
@@ -106,7 +106,7 @@ def generate_top_level_imports(pkg: str) -> List[Tuple[str, str]]:
 
     # Only iterate through top-level modules/packages
     for finder, modname, ispkg in pkgutil.iter_modules(
-            package.__path__, package.__name__ + "."
+        package.__path__, package.__name__ + "."
     ):
         if ispkg:
             try:

--- a/libs/cli/tests/unit_tests/migrate/cli_runner/cases/imports_with_alias_changes.py
+++ b/libs/cli/tests/unit_tests/migrate/cli_runner/cases/imports_with_alias_changes.py
@@ -1,0 +1,29 @@
+"""Handle a test case where the import is updated and may involve an alias change."""
+from tests.unit_tests.migrate.cli_runner.case import Case
+from tests.unit_tests.migrate.cli_runner.file import File
+
+# The test case right now make sure that if we update the import
+# of RunnableMap to RunnableParallel then the code that's using RunnableMap
+# should be updated as well (or else we keep importing RunnableMap.)
+cases = [
+    Case(
+        name="Imports",
+        source=File(
+            "app.py",
+            content=[
+                "from langchain.runnables import RunnableMap",
+                "",
+                "chain = RunnableMap({})",
+            ],
+        ),
+        expected=File(
+            "app.py",
+            content=[
+                "from langchain_core.runnables import RunnableMap",
+                "",
+                "chain = RunnableMap({})",
+            ],
+        ),
+    ),
+]
+""


### PR DESCRIPTION
We need to replace occurrences in the code of RunnableMap not just the import,
so for now, we don't replace RunnableMap.
