### PR TITLE
langchain[patch]: replace deprecated imports with imports from langchain_core

### DIFF
--- a/libs/langchain/langchain/agents/__init__.py
+++ b/libs/langchain/langchain/agents/__init__.py
@@ -40,6 +40,7 @@ from langchain_community.agent_toolkits import (
     create_sql_agent,
 )
 from langchain_core._api.path import as_import_path
+from langchain_core.tools import Tool, tool
 
 from langchain.agents.agent import (
     Agent,
@@ -83,7 +84,6 @@ from langchain.agents.structured_chat.base import (
     create_structured_chat_agent,
 )
 from langchain.agents.tool_calling_agent.base import create_tool_calling_agent
-from langchain.agents.tools import Tool, tool
 from langchain.agents.xml.base import XMLAgent, create_xml_agent
 
 DEPRECATED_CODE = [

--- a/libs/langchain/langchain/agents/agent_toolkits/conversational_retrieval/openai_functions.py
+++ b/libs/langchain/langchain/agents/agent_toolkits/conversational_retrieval/openai_functions.py
@@ -4,6 +4,7 @@ from langchain_core.language_models import BaseLanguageModel
 from langchain_core.memory import BaseMemory
 from langchain_core.messages import SystemMessage
 from langchain_core.prompts.chat import MessagesPlaceholder
+from langchain_core.tools import BaseTool
 
 from langchain.agents.agent import AgentExecutor
 from langchain.agents.openai_functions_agent.agent_token_buffer_memory import (
@@ -11,7 +12,6 @@ from langchain.agents.openai_functions_agent.agent_token_buffer_memory import (
 )
 from langchain.agents.openai_functions_agent.base import OpenAIFunctionsAgent
 from langchain.memory.token_buffer import ConversationTokenBufferMemory
-from langchain.tools.base import BaseTool
 
 
 def _get_default_system_message() -> SystemMessage:

--- a/libs/langchain/langchain/agents/conversational_chat/output_parser.py
+++ b/libs/langchain/langchain/agents/conversational_chat/output_parser.py
@@ -4,10 +4,10 @@ from typing import Union
 
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.exceptions import OutputParserException
+from langchain_core.utils.json import parse_json_markdown
 
 from langchain.agents import AgentOutputParser
 from langchain.agents.conversational_chat.prompt import FORMAT_INSTRUCTIONS
-from langchain.output_parsers.json import parse_json_markdown
 
 
 # Define a class that parses output for conversational agents

--- a/libs/langchain/langchain/agents/mrkl/base.py
+++ b/libs/langchain/langchain/agents/mrkl/base.py
@@ -8,13 +8,12 @@ from langchain_core.callbacks import BaseCallbackManager
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import PromptTemplate
 from langchain_core.pydantic_v1 import Field
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool, Tool
 
 from langchain.agents.agent import Agent, AgentExecutor, AgentOutputParser
 from langchain.agents.agent_types import AgentType
 from langchain.agents.mrkl.output_parser import MRKLOutputParser
 from langchain.agents.mrkl.prompt import FORMAT_INSTRUCTIONS, PREFIX, SUFFIX
-from langchain.agents.tools import Tool
 from langchain.agents.utils import validate_tools_single_input
 from langchain.chains import LLMChain
 from langchain.tools.render import render_text_description

--- a/libs/langchain/langchain/chains/openai_functions/__init__.py
+++ b/libs/langchain/langchain/chains/openai_functions/__init__.py
@@ -1,5 +1,6 @@
+from langchain_core.utils.function_calling import convert_to_openai_function
+
 from langchain.chains.openai_functions.base import (
-    convert_to_openai_function,
     create_openai_fn_chain,
     create_structured_output_chain,
 )

--- a/libs/langchain/langchain/chains/openai_tools/extraction.py
+++ b/libs/langchain/langchain/chains/openai_tools/extraction.py
@@ -2,12 +2,11 @@ from typing import List, Type, Union
 
 from langchain_core._api import deprecated
 from langchain_core.language_models import BaseLanguageModel
+from langchain_core.output_parsers.openai_tools import PydanticToolsParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import Runnable
 from langchain_core.utils.function_calling import convert_pydantic_to_openai_function
-
-from langchain.output_parsers import PydanticToolsParser
 
 _EXTRACTION_TEMPLATE = """Extract and save the relevant entities mentioned \
 in the following passage together with their properties.

--- a/libs/langchain/langchain/chains/router/llm_router.py
+++ b/libs/langchain/langchain/chains/router/llm_router.py
@@ -12,10 +12,10 @@ from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import BaseOutputParser
 from langchain_core.prompts import BasePromptTemplate
 from langchain_core.pydantic_v1 import root_validator
+from langchain_core.utils.json import parse_and_check_json_markdown
 
 from langchain.chains import LLMChain
 from langchain.chains.router.base import RouterChain
-from langchain.output_parsers.json import parse_and_check_json_markdown
 
 
 class LLMRouterChain(RouterChain):

--- a/libs/langchain/langchain/chains/structured_output/base.py
+++ b/libs/langchain/langchain/chains/structured_output/base.py
@@ -6,11 +6,16 @@ from langchain_core.output_parsers import (
     BaseGenerationOutputParser,
     BaseOutputParser,
     JsonOutputParser,
+    PydanticOutputParser,
 )
 from langchain_core.output_parsers.openai_functions import (
     JsonOutputFunctionsParser,
     PydanticAttrOutputFunctionsParser,
     PydanticOutputFunctionsParser,
+)
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser,
+    PydanticToolsParser,
 )
 from langchain_core.prompts import BasePromptTemplate
 from langchain_core.pydantic_v1 import BaseModel
@@ -18,12 +23,6 @@ from langchain_core.runnables import Runnable
 from langchain_core.utils.function_calling import (
     convert_to_openai_function,
     convert_to_openai_tool,
-)
-
-from langchain.output_parsers import (
-    JsonOutputKeyToolsParser,
-    PydanticOutputParser,
-    PydanticToolsParser,
 )
 
 

--- a/libs/langchain/langchain/document_loaders/base.py
+++ b/libs/langchain/langchain/document_loaders/base.py
@@ -1,3 +1,3 @@
-from langchain_community.document_loaders.base import BaseBlobParser, BaseLoader
+from langchain_core.document_loaders import BaseBlobParser, BaseLoader
 
 __all__ = ["BaseLoader", "BaseBlobParser"]

--- a/libs/langchain/langchain/document_loaders/blob_loaders/__init__.py
+++ b/libs/langchain/langchain/document_loaders/blob_loaders/__init__.py
@@ -1,9 +1,9 @@
 from langchain_community.document_loaders.blob_loaders.file_system import (
     FileSystemBlobLoader,
 )
-from langchain_community.document_loaders.blob_loaders.schema import Blob, BlobLoader
 from langchain_community.document_loaders.blob_loaders.youtube_audio import (
     YoutubeAudioLoader,
 )
+from langchain_core.document_loaders import Blob, BlobLoader
 
 __all__ = ["BlobLoader", "Blob", "FileSystemBlobLoader", "YoutubeAudioLoader"]

--- a/libs/langchain/langchain/document_loaders/blob_loaders/schema.py
+++ b/libs/langchain/langchain/document_loaders/blob_loaders/schema.py
@@ -1,7 +1,4 @@
-from langchain_community.document_loaders.blob_loaders.schema import (
-    Blob,
-    BlobLoader,
-    PathLike,
-)
+from langchain_community.document_loaders.blob_loaders.schema import PathLike
+from langchain_core.document_loaders import Blob, BlobLoader
 
 __all__ = ["PathLike", "Blob", "BlobLoader"]

--- a/libs/langchain/langchain/document_loaders/blob_loaders/schema.py
+++ b/libs/langchain/langchain/document_loaders/blob_loaders/schema.py
@@ -1,4 +1,3 @@
-from langchain_community.document_loaders.blob_loaders.schema import PathLike
-from langchain_core.document_loaders import Blob, BlobLoader
+from langchain_core.document_loaders import Blob, BlobLoader, PathLike
 
 __all__ = ["PathLike", "Blob", "BlobLoader"]

--- a/libs/langchain/langchain/evaluation/parsing/base.py
+++ b/libs/langchain/langchain/evaluation/parsing/base.py
@@ -3,8 +3,9 @@ import json
 from operator import eq
 from typing import Any, Callable, Optional, Union, cast
 
+from langchain_core.utils.json import parse_json_markdown
+
 from langchain.evaluation.schema import StringEvaluator
-from langchain.output_parsers.json import parse_json_markdown
 
 
 class JsonValidityEvaluator(StringEvaluator):

--- a/libs/langchain/langchain/evaluation/parsing/json_distance.py
+++ b/libs/langchain/langchain/evaluation/parsing/json_distance.py
@@ -1,8 +1,9 @@
 import json
 from typing import Any, Callable, Optional, Union
 
+from langchain_core.utils.json import parse_json_markdown
+
 from langchain.evaluation.schema import StringEvaluator
-from langchain.output_parsers.json import parse_json_markdown
 
 
 class JsonEditDistanceEvaluator(StringEvaluator):

--- a/libs/langchain/langchain/evaluation/parsing/json_schema.py
+++ b/libs/langchain/langchain/evaluation/parsing/json_schema.py
@@ -1,7 +1,8 @@
 from typing import Any, Union
 
+from langchain_core.utils.json import parse_json_markdown
+
 from langchain.evaluation.schema import StringEvaluator
-from langchain.output_parsers.json import parse_json_markdown
 
 
 class JsonSchemaEvaluator(StringEvaluator):

--- a/libs/langchain/langchain/indexes/vectorstore.py
+++ b/libs/langchain/langchain/indexes/vectorstore.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Type
 
-from langchain_community.document_loaders.base import BaseLoader
 from langchain_community.vectorstores.inmemory import InMemoryVectorStore
+from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import BaseLanguageModel

--- a/libs/langchain/langchain/output_parsers/__init__.py
+++ b/libs/langchain/langchain/output_parsers/__init__.py
@@ -12,30 +12,31 @@
 
     Serializable, Generation, PromptValue
 """  # noqa: E501
+from langchain_core.output_parsers import (
+    CommaSeparatedListOutputParser,
+    ListOutputParser,
+    MarkdownListOutputParser,
+    NumberedListOutputParser,
+    PydanticOutputParser,
+    XMLOutputParser,
+)
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser,
+    JsonOutputToolsParser,
+    PydanticToolsParser,
+)
+
 from langchain.output_parsers.boolean import BooleanOutputParser
 from langchain.output_parsers.combining import CombiningOutputParser
 from langchain.output_parsers.datetime import DatetimeOutputParser
 from langchain.output_parsers.enum import EnumOutputParser
 from langchain.output_parsers.fix import OutputFixingParser
-from langchain.output_parsers.list import (
-    CommaSeparatedListOutputParser,
-    ListOutputParser,
-    MarkdownListOutputParser,
-    NumberedListOutputParser,
-)
-from langchain.output_parsers.openai_tools import (
-    JsonOutputKeyToolsParser,
-    JsonOutputToolsParser,
-    PydanticToolsParser,
-)
 from langchain.output_parsers.pandas_dataframe import PandasDataFrameOutputParser
-from langchain.output_parsers.pydantic import PydanticOutputParser
 from langchain.output_parsers.rail_parser import GuardrailsOutputParser
 from langchain.output_parsers.regex import RegexParser
 from langchain.output_parsers.regex_dict import RegexDictParser
 from langchain.output_parsers.retry import RetryOutputParser, RetryWithErrorOutputParser
 from langchain.output_parsers.structured import ResponseSchema, StructuredOutputParser
-from langchain.output_parsers.xml import XMLOutputParser
 from langchain.output_parsers.yaml import YamlOutputParser
 
 __all__ = [

--- a/libs/langchain/langchain/retrievers/document_compressors/cohere_rerank.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/cohere_rerank.py
@@ -7,9 +7,9 @@ from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import Document
 from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.utils import get_from_dict_or_env
 
 from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
-from langchain.utils import get_from_dict_or_env
 
 
 @deprecated(

--- a/libs/langchain/langchain/utils/__init__.py
+++ b/libs/langchain/langchain/utils/__init__.py
@@ -4,6 +4,13 @@
 These functions do not depend on any other LangChain module.
 """
 
+from langchain_core.utils import (
+    comma_list,
+    get_from_dict_or_env,
+    get_from_env,
+    stringify_dict,
+    stringify_value,
+)
 from langchain_core.utils.formatting import StrictFormatter, formatter
 from langchain_core.utils.input import (
     get_bolded_text,
@@ -21,9 +28,7 @@ from langchain_core.utils.utils import (
     xor_args,
 )
 
-from langchain.utils.env import get_from_dict_or_env, get_from_env
 from langchain.utils.math import cosine_similarity, cosine_similarity_top_k
-from langchain.utils.strings import comma_list, stringify_dict, stringify_value
 
 __all__ = [
     "StrictFormatter",

--- a/libs/langchain/langchain/utils/openai_functions.py
+++ b/libs/langchain/langchain/utils/openai_functions.py
@@ -1,4 +1,4 @@
-from langchain_community.utils.openai_functions import (
+from langchain_core.utils.function_calling import (
     FunctionDescription,
     ToolDescription,
     convert_pydantic_to_openai_function,


### PR DESCRIPTION
* Output of running the migration script.
* Ran only against langchain code itself and not the unit tests.
