### PR TITLE
**PR title**: "community: Avoid cl100k_base encoding for Text embedding engines compatibility with LM Studio"

### DIFF
--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -219,7 +219,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Timeout for requests to OpenAI completion API. Can be float, httpx.Timeout or 
         None."""
     headers: Any = None
-    tiktoken_enabled: bool = True
+    tiktoken_enabled: Optional[bool] = Field(default=True)
     """Set this to False for non-OpenAI implementations of the embeddings API, e.g.
     the `--extensions openai` extension for `text-generation-webui`"""
     tiktoken_model_name: Optional[str] = None

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -219,7 +219,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Timeout for requests to OpenAI completion API. Can be float, httpx.Timeout or 
         None."""
     headers: Any = None
-    tiktoken_enabled: Optional[bool] = Field(default=True)
+    tiktoken_enabled: bool = Field(default=True)
     """Set this to False for non-OpenAI implementations of the embeddings API, e.g.
     the `--extensions openai` extension for `text-generation-webui`"""
     tiktoken_model_name: Optional[str] = None


### PR DESCRIPTION

    - **Description:** With this update, users can set as False tiktoken_enabled when they ned it. By default, the value is set to True (so, not changing current behavior).
    - **Issue:** LM studio provide, by default, nomic-ai/nomic-embed-text-v1.5-GGUF for embedding. When calling the exposed API, with tiktoken_enabled=True, the client sends integers as embedding requests. The API expects Strings and it returns errors: [ERROR] 'input' field must be a string or an array of strings
    - **Dependencies:** 
    - **Twitter handle:** 


- [x] **Add tests and docs**: 
[test.txt](https://github.com/langchain-ai/langchain/files/15153763/test.txt)
