### PR TITLE
langchain[patch]: Upgrade prompts to optional imports

### DIFF
--- a/libs/langchain/langchain/prompts/__init__.py
+++ b/libs/langchain/langchain/prompts/__init__.py
@@ -27,9 +27,8 @@ from multiple components. Prompt classes and functions make constructing
                     ChatPromptValue
 
 """  # noqa: E501
-from langchain_community.example_selectors.ngram_overlap import (
-    NGramOverlapExampleSelector,
-)
+from typing import TYPE_CHECKING, Any
+
 from langchain_core.example_selectors import (
     LengthBasedExampleSelector,
     MaxMarginalRelevanceExampleSelector,
@@ -53,7 +52,28 @@ from langchain_core.prompts import (
     load_prompt,
 )
 
+from langchain._api import create_importer
 from langchain.prompts.prompt import Prompt
+
+if TYPE_CHECKING:
+    from langchain_community.example_selectors.ngram_overlap import (
+        NGramOverlapExampleSelector,
+    )
+
+# Create a way to dynamically look up deprecated imports.
+# Used to consolidate logic for raising deprecation warnings and
+# handling optional imports.
+MODULE_LOOKUP = {
+    "NGramOverlapExampleSelector": "langchain_community.example_selectors.ngram_overlap"
+}
+
+_import_attribute = create_importer(__file__, module_lookup=MODULE_LOOKUP)
+
+
+def __getattr__(name: str) -> Any:
+    """Look up attributes dynamically."""
+    return _import_attribute(name)
+
 
 __all__ = [
     "AIMessagePromptTemplate",

--- a/libs/langchain/langchain/prompts/example_selector/__init__.py
+++ b/libs/langchain/langchain/prompts/example_selector/__init__.py
@@ -1,7 +1,6 @@
 """Logic for selecting examples to include in prompts."""
-from langchain_community.example_selectors.ngram_overlap import (
-    NGramOverlapExampleSelector,
-)
+from typing import TYPE_CHECKING, Any
+
 from langchain_core.example_selectors.length_based import (
     LengthBasedExampleSelector,
 )
@@ -9,6 +8,28 @@ from langchain_core.example_selectors.semantic_similarity import (
     MaxMarginalRelevanceExampleSelector,
     SemanticSimilarityExampleSelector,
 )
+
+from langchain._api import create_importer
+
+if TYPE_CHECKING:
+    from langchain_community.example_selectors.ngram_overlap import (
+        NGramOverlapExampleSelector,
+    )
+
+# Create a way to dynamically look up deprecated imports.
+# Used to consolidate logic for raising deprecation warnings and
+# handling optional imports.
+MODULE_LOOKUP = {
+    "NGramOverlapExampleSelector": "langchain_community.example_selectors.ngram_overlap"
+}
+
+_import_attribute = create_importer(__file__, module_lookup=MODULE_LOOKUP)
+
+
+def __getattr__(name: str) -> Any:
+    """Look up attributes dynamically."""
+    return _import_attribute(name)
+
 
 __all__ = [
     "LengthBasedExampleSelector",

--- a/libs/langchain/langchain/prompts/example_selector/__init__.py
+++ b/libs/langchain/langchain/prompts/example_selector/__init__.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 # Create a way to dynamically look up deprecated imports.
 # Used to consolidate logic for raising deprecation warnings and
 # handling optional imports.
-MODULE_LOOKUP = {
+DEPRECATED_LOOKUPS = {
     "NGramOverlapExampleSelector": "langchain_community.example_selectors.ngram_overlap"
 }
 
-_import_attribute = create_importer(__file__, module_lookup=MODULE_LOOKUP)
+_import_attribute = create_importer(__file__, deprecated_lookups=DEPRECATED_LOOKUPS)
 
 
 def __getattr__(name: str) -> Any:

--- a/libs/langchain/langchain/prompts/example_selector/ngram_overlap.py
+++ b/libs/langchain/langchain/prompts/example_selector/ngram_overlap.py
@@ -18,7 +18,7 @@ MODULE_LOOKUP = {
     "ngram_overlap_score": "langchain_community.example_selectors.ngram_overlap",
 }
 
-_import_attribute = create_importer(__file__, module_lookup=MODULE_LOOKUP)
+_import_attribute = create_importer(__file__, deprecated_lookups=MODULE_LOOKUP)
 
 
 def __getattr__(name: str) -> Any:

--- a/libs/langchain/langchain/prompts/example_selector/ngram_overlap.py
+++ b/libs/langchain/langchain/prompts/example_selector/ngram_overlap.py
@@ -1,7 +1,28 @@
-from langchain_community.example_selectors.ngram_overlap import (
-    NGramOverlapExampleSelector,
-    ngram_overlap_score,
-)
+from typing import TYPE_CHECKING, Any
+
+from langchain._api import create_importer
+
+if TYPE_CHECKING:
+    from langchain_community.example_selectors.ngram_overlap import (
+        NGramOverlapExampleSelector,
+        ngram_overlap_score,
+    )
+
+# Create a way to dynamically look up deprecated imports.
+# Used to consolidate logic for raising deprecation warnings and
+# handling optional imports.
+MODULE_LOOKUP = {
+    "NGramOverlapExampleSelector": "langchain_community.example_selectors.ngram_overlap",
+    "ngram_overlap_score": "langchain_community.example_selectors.ngram_overlap",
+}
+
+_import_attribute = create_importer(__file__, module_lookup=MODULE_LOOKUP)
+
+
+def __getattr__(name: str) -> Any:
+    """Look up attributes dynamically."""
+    return _import_attribute(name)
+
 
 __all__ = [
     "NGramOverlapExampleSelector",

--- a/libs/langchain/langchain/prompts/example_selector/ngram_overlap.py
+++ b/libs/langchain/langchain/prompts/example_selector/ngram_overlap.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
 # Used to consolidate logic for raising deprecation warnings and
 # handling optional imports.
 MODULE_LOOKUP = {
-    "NGramOverlapExampleSelector": "langchain_community.example_selectors.ngram_overlap",
+    "NGramOverlapExampleSelector": (
+        "langchain_community.example_selectors.ngram_overlap"
+    ),
     "ngram_overlap_score": "langchain_community.example_selectors.ngram_overlap",
 }
 


### PR DESCRIPTION
Upgrades prompts module to use optional imports.

This code was generated with a migration script, but had to be adjusted manually a bit.

Testing in preparation for applying this code modification across the rest of the modules in langchain package to reverse the dependency
between langchain community and langchain.
