### PR TITLE
docs: Bump cassio min version in docs

### DIFF
--- a/docs/docs/integrations/providers/cassandra.mdx
+++ b/docs/docs/integrations/providers/cassandra.mdx
@@ -12,7 +12,7 @@ i.e. those using the `Cassandra Query Language` protocol.
 Install the following Python package:
 
 ```bash
-pip install "cassio>=0.1.4"
+pip install "cassio>=0.1.6"
 ```
 
 ## Vector Store


### PR DESCRIPTION
Cassio 0.6+ is recommended for async vector store (not blocking on getting the embedding dimension) and for hybrid search support.