### PR TITLE
openai[patch]: fix special token default behavior

### DIFF
--- a/libs/partners/openai/poetry.lock
+++ b/libs/partners/openai/poetry.lock
@@ -1286,4 +1286,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "f8a406a4ebd93e5c2ef3fcf4a3cebdd588ce09e288dc31b7b9b6b1560285575a"
+content-hash = "1d9cefc90178d94dee2a09afc14af160a7e35e4972ad4701d3bbbfdde14a81fa"

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -29,6 +29,7 @@ pytest-asyncio = "^0.21.1"
 langchain-core = { path = "../../core", develop = true }
 pytest-cov = "^4.1.0"
 langchain-standard-tests = { path = "../../standard-tests", develop = true }
+numpy = "^1.24"
 
 [tool.poetry.group.codespell]
 optional = true

--- a/libs/partners/openai/tests/integration_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/embeddings/test_base.py
@@ -1,4 +1,7 @@
 """Test OpenAI embeddings."""
+import numpy as np
+import openai
+
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 
 
@@ -26,3 +29,31 @@ def test_langchain_openai_embeddings_dimensions() -> None:
     output = embedding.embed_documents(documents)
     assert len(output) == 1
     assert len(output[0]) == 128
+
+
+def test_langchain_openai_embeddings_equivalent_to_raw() -> None:
+    documents = ["disallowed special token '<|endoftext|>'"]
+    embedding = OpenAIEmbeddings()
+
+    lc_output = embedding.embed_documents(documents)[0]
+    direct_output = (
+        openai.OpenAI()
+        .embeddings.create(input=documents, model=embedding.model)
+        .data[0]
+        .embedding
+    )
+    assert np.isclose(lc_output, direct_output).all()
+
+
+async def test_langchain_openai_embeddings_equivalent_to_raw_async() -> None:
+    documents = ["disallowed special token '<|endoftext|>'"]
+    embedding = OpenAIEmbeddings()
+
+    lc_output = (await embedding.aembed_documents(documents))[0]
+    client = openai.AsyncOpenAI()
+    direct_output = (
+        (await client.embeddings.create(input=documents, model=embedding.model))
+        .data[0]
+        .embedding
+    )
+    assert np.isclose(lc_output, direct_output).all()


### PR DESCRIPTION
By default handle special sequences as regular text