### PR TITLE
Use `ruff check` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,12 @@ spell_fix:
 
 ## lint: Run linting on the project.
 lint lint_package lint_tests:
-	poetry run ruff docs templates cookbook
+	poetry run ruff check docs templates cookbook
 	poetry run ruff format docs templates cookbook --diff
-	poetry run ruff --select I docs templates cookbook
+	poetry run ruff check --select I docs templates cookbook
 	git grep 'from langchain import' docs/docs templates cookbook | grep -vE 'from langchain import (hub)' && exit 1 || exit 0
 
 ## format: Format the project files.
 format format_diff:
 	poetry run ruff format docs templates cookbook
-	poetry run ruff --select I --fix docs templates cookbook
+	poetry run ruff check --select I --fix docs templates cookbook


### PR DESCRIPTION
## Summary

`ruff /path/to/file.py` works but is deprecated, and we now recommend `ruff check /path/to/file.py` (to match `ruff format /path/to/file.py`).
