### PR TITLE
community[patch]: `tools` imports

### DIFF
--- a/libs/community/langchain_community/tools/gmail/utils.py
+++ b/libs/community/langchain_community/tools/gmail/utils.py
@@ -1,9 +1,12 @@
 """Gmail tool utils."""
+
 from __future__ import annotations
 
 import logging
 import os
 from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from langchain_core.utils import guard_import
 
 if TYPE_CHECKING:
     from google.auth.transport.requests import Request
@@ -21,16 +24,15 @@ def import_google() -> Tuple[Request, Credentials]:
     Returns:
         Tuple[Request, Credentials]: Request and Credentials classes.
     """
-    # google-auth-httplib2
-    try:
-        from google.auth.transport.requests import Request
-        from google.oauth2.credentials import Credentials
-    except ImportError:
-        raise ImportError(
-            "You need to install google-auth-httplib2 to use this toolkit. "
-            "Try running pip install --upgrade google-auth-httplib2"
-        )
-    return Request, Credentials
+    return (
+        guard_import(
+            module_name="google.auth.transport.requests",
+            pip_name="google-auth-httplib2",
+        ).Request,
+        guard_import(
+            module_name="google.oauth2.credentials", pip_name="google-auth-httplib2"
+        ).Credentials,
+    )
 
 
 def import_installed_app_flow() -> InstalledAppFlow:
@@ -39,14 +41,9 @@ def import_installed_app_flow() -> InstalledAppFlow:
     Returns:
         InstalledAppFlow: InstalledAppFlow class.
     """
-    try:
-        from google_auth_oauthlib.flow import InstalledAppFlow
-    except ImportError:
-        raise ImportError(
-            "You need to install google-auth-oauthlib to use this toolkit. "
-            "Try running pip install --upgrade google-auth-oauthlib"
-        )
-    return InstalledAppFlow
+    return guard_import(
+        module_name="google_auth_oauthlib.flow", pip_name="google-auth-oauthlib"
+    ).InstalledAppFlow
 
 
 def import_googleapiclient_resource_builder() -> build_resource:
@@ -55,14 +52,9 @@ def import_googleapiclient_resource_builder() -> build_resource:
     Returns:
         build_resource: googleapiclient.discovery.build function.
     """
-    try:
-        from googleapiclient.discovery import build
-    except ImportError:
-        raise ImportError(
-            "You need to install googleapiclient to use this toolkit. "
-            "Try running pip install --upgrade google-api-python-client"
-        )
-    return build
+    return guard_import(
+        module_name="googleapiclient.discovery", pip_name="google-api-python-client"
+    ).build
 
 
 DEFAULT_SCOPES = ["https://mail.google.com/"]
@@ -77,8 +69,19 @@ def get_gmail_credentials(
 ) -> Credentials:
     """Get credentials."""
     # From https://developers.google.com/gmail/api/quickstart/python
-    Request, Credentials = import_google()
-    InstalledAppFlow = import_installed_app_flow()
+    Request, Credentials = (
+        guard_import(
+            module_name="google.auth.transport.requests",
+            pip_name="google-auth-httplib2",
+        ).Request,
+        guard_import(
+            module_name="google.oauth2.credentials", pip_name="google-auth-httplib2"
+        ).Credentials,
+    )
+
+    InstalledAppFlow = guard_import(
+        module_name="google_auth_oauthlib.flow", pip_name="google-auth-oauthlib"
+    ).InstalledAppFlow
     creds = None
     scopes = scopes or DEFAULT_SCOPES
     token_file = token_file or DEFAULT_CREDS_TOKEN_FILE
@@ -111,7 +114,9 @@ def build_resource_service(
 ) -> Resource:
     """Build a Gmail service."""
     credentials = credentials or get_gmail_credentials()
-    builder = import_googleapiclient_resource_builder()
+    builder = guard_import(
+        module_name="googleapiclient.discovery", pip_name="google-api-python-client"
+    ).build
     return builder(service_name, service_version, credentials=credentials)
 
 

--- a/libs/community/langchain_community/tools/playwright/base.py
+++ b/libs/community/langchain_community/tools/playwright/base.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Type
 
 from langchain_core.pydantic_v1 import root_validator
 from langchain_core.tools import BaseTool
+from langchain_core.utils import guard_import
 
 if TYPE_CHECKING:
     from playwright.async_api import Browser as AsyncBrowser
@@ -25,15 +26,10 @@ def lazy_import_playwright_browsers() -> Tuple[Type[AsyncBrowser], Type[SyncBrow
         Tuple[Type[AsyncBrowser], Type[SyncBrowser]]:
             AsyncBrowser and SyncBrowser classes.
     """
-    try:
-        from playwright.async_api import Browser as AsyncBrowser
-        from playwright.sync_api import Browser as SyncBrowser
-    except ImportError:
-        raise ImportError(
-            "The 'playwright' package is required to use the playwright tools."
-            " Please install it with 'pip install playwright'."
-        )
-    return AsyncBrowser, SyncBrowser
+    return (
+        guard_import(module_name="playwright.async_api").AsyncBrowser,
+        guard_import(module_name="playwright.sync_api").SyncBrowser,
+    )
 
 
 class BaseBrowserTool(BaseTool):
@@ -45,7 +41,8 @@ class BaseBrowserTool(BaseTool):
     @root_validator
     def validate_browser_provided(cls, values: dict) -> dict:
         """Check that the arguments are valid."""
-        lazy_import_playwright_browsers()
+        guard_import(module_name="playwright.async_api").AsyncBrowser
+        guard_import(module_name="playwright.sync_api").SyncBrowser
         if values.get("async_browser") is None and values.get("sync_browser") is None:
             raise ValueError("Either async_browser or sync_browser must be specified.")
         return values
@@ -57,5 +54,6 @@ class BaseBrowserTool(BaseTool):
         async_browser: Optional[AsyncBrowser] = None,
     ) -> BaseBrowserTool:
         """Instantiate the tool."""
-        lazy_import_playwright_browsers()
+        guard_import(module_name="playwright.async_api").AsyncBrowser
+        guard_import(module_name="playwright.sync_api").SyncBrowser
         return cls(sync_browser=sync_browser, async_browser=async_browser)


### PR DESCRIPTION
Issue: we have several helper functions to import third-party libraries like tools.gmail.utils.import_google in [community.tools](https://api.python.langchain.com/en/latest/community_api_reference.html#id37). And we have core.utils.utils.guard_import that works exactly for this purpose.
The import_<package> functions work inconsistently and rather be private functions.
Change: replaced these functions with the guard_import function.

Related to #21133 