### PR TITLE
[community][vectorstores][SurrealDBStore] feat: provide functions for MMR (Maximal Marginal Relevance)

### DIFF
--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -1,5 +1,4 @@
 import asyncio
-import numpy as np
 from typing import (
     Any,
     Dict,
@@ -9,9 +8,11 @@ from typing import (
     Tuple,
 )
 
+import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
+
 from langchain_community.vectorstores.utils import maximal_marginal_relevance
 
 DEFAULT_K = 4  # Number of Documents to return.
@@ -380,11 +381,9 @@ class SurrealDBStore(VectorStore):
             List of Documents most similar along with relevance distance scores
         """
 
-        async def _similarity_search_with_score() -> (List[Tuple[Document, float]]):
+        async def _similarity_search_with_score() -> List[Tuple[Document, float]]:
             await self.initialize()
-            return await self.asimilarity_search_with_score(
-                query, k, filter, **kwargs
-            )
+            return await self.asimilarity_search_with_score(query, k, filter, **kwargs)
 
         return asyncio.run(_similarity_search_with_score())
 
@@ -521,13 +520,9 @@ class SurrealDBStore(VectorStore):
         ]
 
         # extract only document from result
-        results = [
-            sub[0] for sub in result
-        ]
+        results = [sub[0] for sub in result]
         # extract only embedding from result
-        embeddings = [
-            sub[-1] for sub in result
-        ]
+        embeddings = [sub[-1] for sub in result]
 
         mmr_selected = maximal_marginal_relevance(
             np.array(embedding, dtype=np.float32),

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -207,7 +207,11 @@ class SurrealDBStore(VectorStore):
         return asyncio.run(_delete(ids, **kwargs))
 
     async def _asimilarity_search_by_vector_with_score(
-        self, embedding: List[float], k: int = DEFAULT_K, **kwargs: Any
+        self,
+        embedding: List[float],
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Run similarity search for query embedding asynchronously
         and return documents and scores
@@ -215,6 +219,7 @@ class SurrealDBStore(VectorStore):
         Args:
             embedding (List[float]): Query embedding.
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar along with scores
@@ -225,6 +230,19 @@ class SurrealDBStore(VectorStore):
             "k": k,
             "score_threshold": kwargs.get("score_threshold", 0),
         }
+
+        # build additional filter criteria
+        custom_filter = ""
+        if filter:
+            for key in filter:
+                # check value type
+                if type(filter[key]) in [str, bool]:
+                    filter_value = f"'{filter[key]}'"
+                else:
+                    filter_value = f"{filter[key]}"
+
+                custom_filter += f"and metadata.{key} = {filter_value} "
+
         query = f"""
         select
             id,
@@ -234,6 +252,7 @@ class SurrealDBStore(VectorStore):
             vector::similarity::cosine(embedding, $embedding) as similarity
         from ⟨{args["collection"]}⟩
         where vector::similarity::cosine(embedding, $embedding) >= $score_threshold
+          {custom_filter}
         order by similarity desc LIMIT $k;
         """
         results = await self.sdb.query(query, args)
@@ -256,19 +275,24 @@ class SurrealDBStore(VectorStore):
                     metadata={"id": doc["id"], **(doc.get("metadata", None) or {})},
                 ),
                 doc["similarity"],
-                doc["embedding"]
+                doc["embedding"],
             )
             for doc in result["result"]
         ]
 
     async def asimilarity_search_with_relevance_scores(
-        self, query: str, k: int = DEFAULT_K, **kwargs: Any
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Run similarity search asynchronously and return relevance scores
 
         Args:
             query (str): Query
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar along with relevance scores
@@ -278,19 +302,24 @@ class SurrealDBStore(VectorStore):
             (document, similarity)
             for document, similarity, _ in (
                 await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, **kwargs
+                    query_embedding, k, filter, **kwargs
                 )
             )
         ]
 
     def similarity_search_with_relevance_scores(
-        self, query: str, k: int = DEFAULT_K, **kwargs: Any
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Run similarity search synchronously and return relevance scores
 
         Args:
             query (str): Query
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar along with relevance scores
@@ -301,19 +330,24 @@ class SurrealDBStore(VectorStore):
         ):
             await self.initialize()
             return await self.asimilarity_search_with_relevance_scores(
-                query, k, **kwargs
+                query, k, filter, **kwargs
             )
 
         return asyncio.run(_similarity_search_with_relevance_scores())
 
     async def asimilarity_search_with_score(
-        self, query: str, k: int = DEFAULT_K, **kwargs: Any
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Run similarity search asynchronously and return distance scores
 
         Args:
             query (str): Query
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar along with relevance distance scores
@@ -323,19 +357,24 @@ class SurrealDBStore(VectorStore):
             (document, similarity)
             for document, similarity, _ in (
                 await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, **kwargs
+                    query_embedding, k, filter, **kwargs
                 )
             )
         ]
 
     def similarity_search_with_score(
-        self, query: str, k: int = DEFAULT_K, **kwargs: Any
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Run similarity search synchronously and return distance scores
 
         Args:
             query (str): Query
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar along with relevance distance scores
@@ -343,37 +382,49 @@ class SurrealDBStore(VectorStore):
 
         async def _similarity_search_with_score() -> (List[Tuple[Document, float]]):
             await self.initialize()
-            return await self.asimilarity_search_with_score(query, k, **kwargs)
+            return await self.asimilarity_search_with_score(
+                query, k, filter, **kwargs
+            )
 
         return asyncio.run(_similarity_search_with_score())
 
     async def asimilarity_search_by_vector(
-        self, embedding: List[float], k: int = DEFAULT_K, **kwargs: Any
+        self,
+        embedding: List[float],
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Run similarity search on query embedding asynchronously
 
         Args:
             embedding (List[float]): Query embedding
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar to the query
         """
         return [
             document
-            for document, _ in await self._asimilarity_search_by_vector_with_score(
-                embedding, k, **kwargs
+            for document, _, _ in await self._asimilarity_search_by_vector_with_score(
+                embedding, k, filter, **kwargs
             )
         ]
 
     def similarity_search_by_vector(
-        self, embedding: List[float], k: int = DEFAULT_K, **kwargs: Any
+        self,
+        embedding: List[float],
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Run similarity search on query embedding
 
         Args:
             embedding (List[float]): Query embedding
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar to the query
@@ -381,33 +432,47 @@ class SurrealDBStore(VectorStore):
 
         async def _similarity_search_by_vector() -> List[Document]:
             await self.initialize()
-            return await self.asimilarity_search_by_vector(embedding, k, **kwargs)
+            return await self.asimilarity_search_by_vector(
+                embedding, k, filter, **kwargs
+            )
 
         return asyncio.run(_similarity_search_by_vector())
 
     async def asimilarity_search(
-        self, query: str, k: int = DEFAULT_K, **kwargs: Any
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Run similarity search on query asynchronously
 
         Args:
             query (str): Query
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar to the query
         """
         query_embedding = self.embedding_function.embed_query(query)
-        return await self.asimilarity_search_by_vector(query_embedding, k, **kwargs)
+        return await self.asimilarity_search_by_vector(
+            query_embedding, k, filter, **kwargs
+        )
 
     def similarity_search(
-        self, query: str, k: int = DEFAULT_K, **kwargs: Any
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[Document]:
         """Run similarity search on query
 
         Args:
             query (str): Query
             k (int): Number of results to return. Defaults to 4.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar to the query
@@ -415,7 +480,7 @@ class SurrealDBStore(VectorStore):
 
         async def _similarity_search() -> List[Document]:
             await self.initialize()
-            return await self.asimilarity_search(query, k, **kwargs)
+            return await self.asimilarity_search(query, k, filter, **kwargs)
 
         return asyncio.run(_similarity_search())
 
@@ -426,7 +491,6 @@ class SurrealDBStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         filter: Optional[Dict[str, str]] = None,
-        where_document: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
         """Return docs selected using the maximal marginal relevance.
@@ -451,29 +515,36 @@ class SurrealDBStore(VectorStore):
             (document, similarity, embedding)
             for document, similarity, embedding in (
                 await self._asimilarity_search_by_vector_with_score(
-                    embedding, fetch_k, **kwargs
+                    embedding, fetch_k, filter, **kwargs
                 )
             )
         ]
 
-        results = [(sub[0], sub[1]) for sub in result]  # extract only (document, similarity) from result
-        embeddings = [sub[-1] for sub in result]  # extract only embedding from result
+        # extract only document from result
+        results = [
+            sub[0] for sub in result
+        ]
+        # extract only embedding from result
+        embeddings = [
+            sub[-1] for sub in result
+        ]
 
         mmr_selected = maximal_marginal_relevance(
             np.array(embedding, dtype=np.float32),
             embeddings,
             k=k,
-            lambda_mult=lambda_mult
+            lambda_mult=lambda_mult,
         )
 
         return [results[i] for i in mmr_selected]
-        
+
     def max_marginal_relevance_search_by_vector(
         self,
         embedding: List[float],
         k: int = DEFAULT_K,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
+        filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
         """Return docs selected using the maximal marginal relevance.
@@ -489,6 +560,8 @@ class SurrealDBStore(VectorStore):
                         of diversity among the results with 0 corresponding
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+
         Returns:
             List of Documents selected by maximal marginal relevance.
         """
@@ -496,11 +569,7 @@ class SurrealDBStore(VectorStore):
         async def _max_marginal_relevance_search_by_vector() -> List[Document]:
             await self.initialize()
             return await self.amax_marginal_relevance_search_by_vector(
-                self,
-                embedding,
-                k,
-                fetch_k,
-                lambda_mult
+                self, embedding, k, fetch_k, lambda_mult, filter
             )
 
         return asyncio.run(_max_marginal_relevance_search_by_vector())
@@ -511,6 +580,7 @@ class SurrealDBStore(VectorStore):
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
+        filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
         """Return docs selected using the maximal marginal relevance.
@@ -526,16 +596,15 @@ class SurrealDBStore(VectorStore):
                         of diversity among the results with 0 corresponding
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+
         Returns:
             List of Documents selected by maximal marginal relevance.
         """
 
         embedding = self.embedding_function.embed_query(query)
         docs = await self.amax_marginal_relevance_search_by_vector(
-            embedding,
-            k,
-            fetch_k,
-            lambda_mult=lambda_mult
+            embedding, k, fetch_k, lambda_mult, filter, **kwargs
         )
         return docs
 
@@ -546,7 +615,6 @@ class SurrealDBStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         filter: Optional[Dict[str, str]] = None,
-        where_document: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
         """Return docs selected using the maximal marginal relevance.
@@ -570,11 +638,7 @@ class SurrealDBStore(VectorStore):
         async def _max_marginal_relevance_search() -> List[Document]:
             await self.initialize()
             return await self.amax_marginal_relevance_search(
-                query,
-                k,
-                fetch_k,
-                lambda_mult,
-                **kwargs
+                query, k, fetch_k, lambda_mult, filter, **kwargs
             )
 
         return asyncio.run(_max_marginal_relevance_search())

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -211,6 +211,7 @@ class SurrealDBStore(VectorStore):
         self,
         embedding: List[float],
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float, Any]]:
@@ -285,6 +286,7 @@ class SurrealDBStore(VectorStore):
         self,
         query: str,
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
@@ -303,7 +305,7 @@ class SurrealDBStore(VectorStore):
             (document, similarity)
             for document, similarity, _ in (
                 await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, filter, **kwargs
+                    query_embedding, k, filter=filter, **kwargs
                 )
             )
         ]
@@ -312,6 +314,7 @@ class SurrealDBStore(VectorStore):
         self,
         query: str,
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
@@ -331,7 +334,7 @@ class SurrealDBStore(VectorStore):
         ):
             await self.initialize()
             return await self.asimilarity_search_with_relevance_scores(
-                query, k, filter, **kwargs
+                query, k, filter=filter, **kwargs
             )
 
         return asyncio.run(_similarity_search_with_relevance_scores())
@@ -340,6 +343,7 @@ class SurrealDBStore(VectorStore):
         self,
         query: str,
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
@@ -358,7 +362,7 @@ class SurrealDBStore(VectorStore):
             (document, similarity)
             for document, similarity, _ in (
                 await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, filter, **kwargs
+                    query_embedding, k, filter=filter, **kwargs
                 )
             )
         ]
@@ -367,6 +371,7 @@ class SurrealDBStore(VectorStore):
         self,
         query: str,
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
@@ -383,7 +388,9 @@ class SurrealDBStore(VectorStore):
 
         async def _similarity_search_with_score() -> List[Tuple[Document, float]]:
             await self.initialize()
-            return await self.asimilarity_search_with_score(query, k, filter, **kwargs)
+            return await self.asimilarity_search_with_score(
+                query, k, filter=filter, **kwargs
+            )
 
         return asyncio.run(_similarity_search_with_score())
 
@@ -391,6 +398,7 @@ class SurrealDBStore(VectorStore):
         self,
         embedding: List[float],
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -407,7 +415,7 @@ class SurrealDBStore(VectorStore):
         return [
             document
             for document, _, _ in await self._asimilarity_search_by_vector_with_score(
-                embedding, k, filter, **kwargs
+                embedding, k, filter=filter, **kwargs
             )
         ]
 
@@ -415,6 +423,7 @@ class SurrealDBStore(VectorStore):
         self,
         embedding: List[float],
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -432,7 +441,7 @@ class SurrealDBStore(VectorStore):
         async def _similarity_search_by_vector() -> List[Document]:
             await self.initialize()
             return await self.asimilarity_search_by_vector(
-                embedding, k, filter, **kwargs
+                embedding, k, filter=filter, **kwargs
             )
 
         return asyncio.run(_similarity_search_by_vector())
@@ -441,6 +450,7 @@ class SurrealDBStore(VectorStore):
         self,
         query: str,
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -456,13 +466,14 @@ class SurrealDBStore(VectorStore):
         """
         query_embedding = self.embedding_function.embed_query(query)
         return await self.asimilarity_search_by_vector(
-            query_embedding, k, filter, **kwargs
+            query_embedding, k, filter=filter, **kwargs
         )
 
     def similarity_search(
         self,
         query: str,
         k: int = DEFAULT_K,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -479,7 +490,7 @@ class SurrealDBStore(VectorStore):
 
         async def _similarity_search() -> List[Document]:
             await self.initialize()
-            return await self.asimilarity_search(query, k, filter, **kwargs)
+            return await self.asimilarity_search(query, k, filter=filter, **kwargs)
 
         return asyncio.run(_similarity_search())
 
@@ -489,6 +500,7 @@ class SurrealDBStore(VectorStore):
         k: int = DEFAULT_K,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -511,7 +523,7 @@ class SurrealDBStore(VectorStore):
         """
 
         result = await self._asimilarity_search_by_vector_with_score(
-            embedding, fetch_k, filter, **kwargs
+            embedding, fetch_k, filter=filter, **kwargs
         )
 
         # extract only document from result
@@ -534,6 +546,7 @@ class SurrealDBStore(VectorStore):
         k: int = DEFAULT_K,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -559,7 +572,7 @@ class SurrealDBStore(VectorStore):
         async def _max_marginal_relevance_search_by_vector() -> List[Document]:
             await self.initialize()
             return await self.amax_marginal_relevance_search_by_vector(
-                embedding, k, fetch_k, lambda_mult, filter
+                embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
             )
 
         return asyncio.run(_max_marginal_relevance_search_by_vector())
@@ -570,6 +583,7 @@ class SurrealDBStore(VectorStore):
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -594,7 +608,7 @@ class SurrealDBStore(VectorStore):
 
         embedding = self.embedding_function.embed_query(query)
         docs = await self.amax_marginal_relevance_search_by_vector(
-            embedding, k, fetch_k, lambda_mult, filter, **kwargs
+            embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
         )
         return docs
 
@@ -604,6 +618,7 @@ class SurrealDBStore(VectorStore):
         k: int = DEFAULT_K,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
+        *,
         filter: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> List[Document]:
@@ -628,7 +643,7 @@ class SurrealDBStore(VectorStore):
         async def _max_marginal_relevance_search() -> List[Document]:
             await self.initialize()
             return await self.amax_marginal_relevance_search(
-                query, k, fetch_k, lambda_mult, filter, **kwargs
+                query, k, fetch_k, lambda_mult, filter=filter, **kwargs
             )
 
         return asyncio.run(_max_marginal_relevance_search())


### PR DESCRIPTION
This PR contains 4 added functions:

- max_marginal_relevance_search_by_vector
- amax_marginal_relevance_search_by_vector
- max_marginal_relevance_search
- amax_marginal_relevance_search

I'm no langchain expert, but tried do inspect other vectorstore sources like chroma, to build these functions for SurrealDB. If someone has some changes for me, please let me know. Otherwise I would be happy, if these changes are added to the repository, so that I can use the orignal repo and not my local monkey patched version.