### PR TITLE
langchain: fix syntax error in code comment for create_tool_calling_agent

### DIFF
--- a/libs/langchain/langchain/agents/tool_calling_agent/base.py
+++ b/libs/langchain/langchain/agents/tool_calling_agent/base.py
@@ -38,7 +38,7 @@ def create_tool_calling_agent(
             prompt = ChatPromptTemplate.from_messages(
                 [
                     ("system", "You are a helpful assistant"),
-                    ("placeholder", "{chat_history}",
+                    ("placeholder", "{chat_history}"),
                     ("human", "{input}"),
                     ("placeholder", "{agent_scratchpad}"),
                 ]


### PR DESCRIPTION
**PR message**:
- **Description:** Corrected a syntax error in the code comments within the `create_tool_calling_agent` function in the langchain package.
- **Issue:** N/A
- **Dependencies:** No additional dependencies required.
- **Twitter handle:** N/A
