### PR TITLE
community: Updating Multi-modal in Ollama to match OpenAI API 

### DIFF
--- a/docs/docs/integrations/chat/ollama.ipynb
+++ b/docs/docs/integrations/chat/ollama.ipynb
@@ -421,7 +421,7 @@
     "\n",
     "    image_part = {\n",
     "        \"type\": \"image_url\",\n",
-    "        \"image_url\": f\"data:image/jpeg;base64,{image}\",\n",
+    "        \"image_url\": {\"url\": f\"data:image/jpeg;base64,{image}\"},\n",
     "    }\n",
     "\n",
     "    content_parts = []\n",

--- a/libs/community/langchain_community/chat_models/ollama.py
+++ b/libs/community/langchain_community/chat_models/ollama.py
@@ -120,8 +120,12 @@ class ChatOllama(BaseChatModel, _OllamaCommon):
                     if content_part.get("type") == "text":
                         content += f"\n{content_part['text']}"
                     elif content_part.get("type") == "image_url":
-                        if isinstance(content_part.get("image_url"), str):
-                            image_url_components = content_part["image_url"].split(",")
+                        if isinstance(
+                            content_part.get("image_url"), dict
+                            ) and isinstance(content_part.get("image_url").get("url"), str):
+                            image_url_components = content_part["image_url"][
+                                "url"
+                            ].split(",")
                             # Support data:image/jpeg;base64,<image> format
                             # and base64 strings
                             if len(image_url_components) > 1:

--- a/libs/community/langchain_community/chat_models/ollama.py
+++ b/libs/community/langchain_community/chat_models/ollama.py
@@ -120,6 +120,7 @@ class ChatOllama(BaseChatModel, _OllamaCommon):
                     if content_part.get("type") == "text":
                         content += f"\n{content_part['text']}"
                     elif content_part.get("type") == "image_url":
+                        image_url_part = content_part.get("image_url")
                         if isinstance(image_url_part, dict) and isinstance(
                             image_url_part.get("url"), str
                         ):

--- a/libs/community/langchain_community/chat_models/ollama.py
+++ b/libs/community/langchain_community/chat_models/ollama.py
@@ -120,9 +120,9 @@ class ChatOllama(BaseChatModel, _OllamaCommon):
                     if content_part.get("type") == "text":
                         content += f"\n{content_part['text']}"
                     elif content_part.get("type") == "image_url":
-                        if isinstance(
-                            content_part.get("image_url"), dict
-                            ) and isinstance(content_part.get("image_url").get("url"), str):
+                        if isinstance(image_url_part, dict) and isinstance(
+                            image_url_part.get("url"), str
+                        ):
                             image_url_components = content_part["image_url"][
                                 "url"
                             ].split(",")


### PR DESCRIPTION
# Description
[Ollama Multimodal](https://python.langchain.com/docs/integrations/chat/ollama/#multi-modal) is different from OpenAI API Format, which is used also by other providers like Fireworks, I changed it to match them

# Ollama Multimodal Before Changing
```python
def prompt_func(data):
    ...
    image_part = {
        "type": "image_url",
        "image_url": f"data:image/jpeg;base64,{image}",
    }

    content_parts = []

    text_part = {"type": "text", "text": text}
    ...
```
`image_url` contains the encoded image directly, however in [OpenAI API](https://platform.openai.com/docs/guides/vision/uploading-base-64-encoded-images) it's under `url` key:

# OpenAI API Vision Guide
```python
{
    "role": "user",
    "content": [
        {"type": "text", "text": "What’s in this image?"},
        {
            "type": "image_url",
            "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"},
        },
    ],
}
```

# Fireworks Multimodal
[Fireworks](https://readme.fireworks.ai/docs/querying-vision-language-models#chat-completions-api) Follows the same scheme as OpenAI
```python
{
    "role": "user",
    "content": [{
      "type": "text",
      "text": "Can you describe this image?",
    }, {
      "type": "image_url",
      "image_url": {
        "url": f "data:image/jpeg;base64,{image_base64}"
      },
    }, ],
  }
```

Twitter: @0ssamaak0