### PR TITLE
core: tracer: Support receiving child runs out of order

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -2010,6 +2010,10 @@ def _configure(
         if run_tree is not None:
             for handler in callback_manager.handlers:
                 if isinstance(handler, LangChainTracer):
+                    handler.order_map[run_tree.id] = (
+                        run_tree.trace_id,
+                        run_tree.dotted_order,
+                    )
                     handler.run_map[str(run_tree.id)] = cast(Run, run_tree)
     for var, inheritable, handler_class, env_var in _configure_hooks:
         create_one = (

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -67,6 +67,7 @@ def test_tracer_with_run_tree_parent() -> None:
     parent = RunTree(name="parent", inputs={"input": "foo"}, client=client)
     run_id = uuid.uuid4()
     tracer = LangChainTracer(client=client)
+    tracer.order_map[parent.id] = (parent.trace_id, parent.dotted_order)
     tracer.run_map[str(parent.id)] = parent  # type: ignore
     tracer.on_chain_start(
         {"name": "child"}, {"input": "bar"}, run_id=run_id, parent_run_id=parent.id


### PR DESCRIPTION
- previously child runs received after parent run ends (possible when using background threads/async code) would not have trace_id/dotted_order, resulting in incorrect run ingestion in langsmith
