### PR TITLE
(all): update removal in deprecation warnings from 0.2 to 0.3

### DIFF
--- a/libs/community/langchain_community/cache.py
+++ b/libs/community/langchain_community/cache.py
@@ -1526,7 +1526,7 @@ ASTRA_DB_CACHE_DEFAULT_COLLECTION_NAME = "langchain_astradb_cache"
 
 @deprecated(
     since="0.0.28",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBCache",
 )
 class AstraDBCache(BaseCache):
@@ -1731,7 +1731,7 @@ def _async_lru_cache(maxsize: int = 128, typed: bool = False) -> Callable:
 
 @deprecated(
     since="0.0.28",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBSemanticCache",
 )
 class AstraDBSemanticCache(BaseCache):

--- a/libs/community/langchain_community/chat_loaders/gmail.py
+++ b/libs/community/langchain_community/chat_loaders/gmail.py
@@ -65,7 +65,7 @@ def _get_message_data(service: Any, message: Any) -> ChatSession:
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GMailLoader",
 )
 class GMailLoader(BaseChatLoader):

--- a/libs/community/langchain_community/chat_message_histories/astradb.py
+++ b/libs/community/langchain_community/chat_message_histories/astradb.py
@@ -26,7 +26,7 @@ DEFAULT_COLLECTION_NAME = "langchain_message_store"
 
 @deprecated(
     since="0.0.25",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBChatMessageHistory",
 )
 class AstraDBChatMessageHistory(BaseChatMessageHistory):

--- a/libs/community/langchain_community/chat_message_histories/mongodb.py
+++ b/libs/community/langchain_community/chat_message_histories/mongodb.py
@@ -18,7 +18,7 @@ DEFAULT_COLLECTION_NAME = "message_store"
 
 @deprecated(
     since="0.0.25",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_mongodb.MongoDBChatMessageHistory",
 )
 class MongoDBChatMessageHistory(BaseChatMessageHistory):

--- a/libs/community/langchain_community/chat_models/anthropic.py
+++ b/libs/community/langchain_community/chat_models/anthropic.py
@@ -73,7 +73,7 @@ def convert_messages_to_prompt_anthropic(
 
 @deprecated(
     since="0.0.28",
-    removal="0.2",
+    removal="0.3",
     alternative_import="langchain_anthropic.ChatAnthropic",
 )
 class ChatAnthropic(BaseChatModel, _AnthropicCommon):

--- a/libs/community/langchain_community/chat_models/azure_openai.py
+++ b/libs/community/langchain_community/chat_models/azure_openai.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.0.10",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_openai.AzureChatOpenAI",
 )
 class AzureChatOpenAI(ChatOpenAI):

--- a/libs/community/langchain_community/chat_models/cohere.py
+++ b/libs/community/langchain_community/chat_models/cohere.py
@@ -96,7 +96,7 @@ def get_cohere_chat_request(
 
 
 @deprecated(
-    since="0.0.30", removal="0.2.0", alternative_import="langchain_cohere.ChatCohere"
+    since="0.0.30", removal="0.3.0", alternative_import="langchain_cohere.ChatCohere"
 )
 class ChatCohere(BaseChatModel, BaseCohere):
     """`Cohere` chat large language models.

--- a/libs/community/langchain_community/chat_models/fireworks.py
+++ b/libs/community/langchain_community/chat_models/fireworks.py
@@ -81,7 +81,7 @@ def convert_dict_to_message(_dict: Any) -> BaseMessage:
 
 @deprecated(
     since="0.0.26",
-    removal="0.2",
+    removal="0.3",
     alternative_import="langchain_fireworks.ChatFireworks",
 )
 class ChatFireworks(BaseChatModel):

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -145,7 +145,7 @@ def _convert_delta_to_message_chunk(
 
 
 @deprecated(
-    since="0.0.10", removal="0.2.0", alternative_import="langchain_openai.ChatOpenAI"
+    since="0.0.10", removal="0.3.0", alternative_import="langchain_openai.ChatOpenAI"
 )
 class ChatOpenAI(BaseChatModel):
     """`OpenAI` Chat large language models API.

--- a/libs/community/langchain_community/chat_models/solar.py
+++ b/libs/community/langchain_community/chat_models/solar.py
@@ -11,7 +11,7 @@ from langchain_community.llms.solar import SOLAR_SERVICE_URL_BASE, SolarCommon
 
 
 @deprecated(
-    since="0.0.34", removal="0.2.0", alternative_import="langchain_upstage.ChatUpstage"
+    since="0.0.34", removal="0.3.0", alternative_import="langchain_upstage.ChatUpstage"
 )
 class SolarChat(SolarCommon, ChatOpenAI):
     """Wrapper around Solar large language models.

--- a/libs/community/langchain_community/chat_models/vertexai.py
+++ b/libs/community/langchain_community/chat_models/vertexai.py
@@ -205,7 +205,7 @@ def _get_question(messages: List[BaseMessage]) -> HumanMessage:
 
 @deprecated(
     since="0.0.12",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_vertexai.ChatVertexAI",
 )
 class ChatVertexAI(_VertexAICommon, BaseChatModel):

--- a/libs/community/langchain_community/document_loaders/astradb.py
+++ b/libs/community/langchain_community/document_loaders/astradb.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.0.29",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBLoader",
 )
 class AstraDBLoader(BaseLoader):

--- a/libs/community/langchain_community/document_loaders/bigquery.py
+++ b/libs/community/langchain_community/document_loaders/bigquery.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.BigQueryLoader",
 )
 class BigQueryLoader(BaseLoader):

--- a/libs/community/langchain_community/document_loaders/docugami.py
+++ b/libs/community/langchain_community/document_loaders/docugami.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.0.24",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="docugami_langchain.DocugamiLoader",
 )
 class DocugamiLoader(BaseLoader, BaseModel):

--- a/libs/community/langchain_community/document_loaders/gcs_directory.py
+++ b/libs/community/langchain_community/document_loaders/gcs_directory.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GCSDirectoryLoader",
 )
 class GCSDirectoryLoader(BaseLoader):

--- a/libs/community/langchain_community/document_loaders/gcs_file.py
+++ b/libs/community/langchain_community/document_loaders/gcs_file.py
@@ -12,7 +12,7 @@ from langchain_community.utilities.vertexai import get_client_info
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GCSFileLoader",
 )
 class GCSFileLoader(BaseLoader):

--- a/libs/community/langchain_community/document_loaders/google_speech_to_text.py
+++ b/libs/community/langchain_community/document_loaders/google_speech_to_text.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.SpeechToTextLoader",
 )
 class GoogleSpeechToTextLoader(BaseLoader):

--- a/libs/community/langchain_community/document_loaders/googledrive.py
+++ b/libs/community/langchain_community/document_loaders/googledrive.py
@@ -22,7 +22,7 @@ SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GoogleDriveLoader",
 )
 class GoogleDriveLoader(BaseLoader, BaseModel):

--- a/libs/community/langchain_community/document_loaders/parsers/docai.py
+++ b/libs/community/langchain_community/document_loaders/parsers/docai.py
@@ -36,7 +36,7 @@ class DocAIParsingResults:
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.DocAIParser",
 )
 class DocAIParser(BaseBlobParser):

--- a/libs/community/langchain_community/document_transformers/google_translate.py
+++ b/libs/community/langchain_community/document_transformers/google_translate.py
@@ -8,7 +8,7 @@ from langchain_community.utilities.vertexai import get_client_info
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.DocAIParser",
 )
 class GoogleTranslateTransformer(BaseDocumentTransformer):

--- a/libs/community/langchain_community/embeddings/azure_openai.py
+++ b/libs/community/langchain_community/embeddings/azure_openai.py
@@ -16,7 +16,7 @@ from langchain_community.utils.openai import is_openai_v1
 
 @deprecated(
     since="0.0.9",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_openai.AzureOpenAIEmbeddings",
 )
 class AzureOpenAIEmbeddings(OpenAIEmbeddings):

--- a/libs/community/langchain_community/embeddings/cohere.py
+++ b/libs/community/langchain_community/embeddings/cohere.py
@@ -10,7 +10,7 @@ from langchain_community.llms.cohere import _create_retry_decorator
 
 @deprecated(
     since="0.0.30",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_cohere.CohereEmbeddings",
 )
 class CohereEmbeddings(BaseModel, Embeddings):

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -140,7 +140,7 @@ async def async_embed_with_retry(embeddings: OpenAIEmbeddings, **kwargs: Any) ->
 
 @deprecated(
     since="0.0.9",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_openai.OpenAIEmbeddings",
 )
 class OpenAIEmbeddings(BaseModel, Embeddings):

--- a/libs/community/langchain_community/embeddings/solar.py
+++ b/libs/community/langchain_community/embeddings/solar.py
@@ -46,7 +46,7 @@ def embed_with_retry(embeddings: SolarEmbeddings, *args: Any, **kwargs: Any) -> 
 
 
 @deprecated(
-    since="0.0.34", removal="0.2.0", alternative_import="langchain_upstage.ChatUpstage"
+    since="0.0.34", removal="0.3.0", alternative_import="langchain_upstage.ChatUpstage"
 )
 class SolarEmbeddings(BaseModel, Embeddings):
     """Solar's embedding service.

--- a/libs/community/langchain_community/embeddings/vertexai.py
+++ b/libs/community/langchain_community/embeddings/vertexai.py
@@ -22,7 +22,7 @@ _MIN_BATCH_SIZE = 5
 
 @deprecated(
     since="0.0.12",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_vertexai.VertexAIEmbeddings",
 )
 class VertexAIEmbeddings(_VertexAICommon, Embeddings):

--- a/libs/community/langchain_community/embeddings/voyageai.py
+++ b/libs/community/langchain_community/embeddings/voyageai.py
@@ -61,7 +61,7 @@ def embed_with_retry(embeddings: VoyageEmbeddings, **kwargs: Any) -> Any:
 
 @deprecated(
     since="0.0.29",
-    removal="0.2",
+    removal="0.3",
     alternative_import="langchain_voyageai.VoyageAIEmbeddings",
 )
 class VoyageEmbeddings(BaseModel, Embeddings):

--- a/libs/community/langchain_community/llms/__init__.py
+++ b/libs/community/langchain_community/llms/__init__.py
@@ -172,7 +172,7 @@ def _import_databricks() -> Type[BaseLLM]:
 def _import_databricks_chat() -> Any:
     warn_deprecated(
         since="0.0.22",
-        removal="0.2",
+        removal="0.3",
         alternative_import="langchain_community.chat_models.ChatDatabricks",
     )
     from langchain_community.chat_models.databricks import ChatDatabricks
@@ -342,7 +342,7 @@ def _import_mlflow() -> Type[BaseLLM]:
 def _import_mlflow_chat() -> Any:
     warn_deprecated(
         since="0.0.22",
-        removal="0.2",
+        removal="0.3",
         alternative_import="langchain_community.chat_models.ChatMlflow",
     )
     from langchain_community.chat_models.mlflow import ChatMlflow

--- a/libs/community/langchain_community/llms/anthropic.py
+++ b/libs/community/langchain_community/llms/anthropic.py
@@ -150,7 +150,7 @@ class _AnthropicCommon(BaseLanguageModel):
 
 @deprecated(
     since="0.0.28",
-    removal="0.2",
+    removal="0.3",
     alternative_import="langchain_anthropic.AnthropicLLM",
 )
 class Anthropic(LLM, _AnthropicCommon):

--- a/libs/community/langchain_community/llms/cohere.py
+++ b/libs/community/langchain_community/llms/cohere.py
@@ -71,7 +71,7 @@ def acompletion_with_retry(llm: Cohere, **kwargs: Any) -> Any:
 
 
 @deprecated(
-    since="0.0.30", removal="0.2.0", alternative_import="langchain_cohere.BaseCohere"
+    since="0.0.30", removal="0.3.0", alternative_import="langchain_cohere.BaseCohere"
 )
 class BaseCohere(Serializable):
     """Base class for Cohere models."""
@@ -122,7 +122,7 @@ class BaseCohere(Serializable):
 
 
 @deprecated(
-    since="0.1.14", removal="0.2.0", alternative_import="langchain_cohere.Cohere"
+    since="0.1.14", removal="0.3.0", alternative_import="langchain_cohere.Cohere"
 )
 class Cohere(LLM, BaseCohere):
     """Cohere large language models.

--- a/libs/community/langchain_community/llms/fireworks.py
+++ b/libs/community/langchain_community/llms/fireworks.py
@@ -29,7 +29,7 @@ def _stream_response_to_generation_chunk(
 
 @deprecated(
     since="0.0.26",
-    removal="0.2",
+    removal="0.3",
     alternative_import="langchain_fireworks.Fireworks",
 )
 class Fireworks(BaseLLM):

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -20,7 +20,7 @@ VALID_TASKS_DICT = {
 }
 
 
-@deprecated("0.0.21", removal="0.2.0", alternative="HuggingFaceEndpoint")
+@deprecated("0.0.21", removal="0.3.0", alternative="HuggingFaceEndpoint")
 class HuggingFaceHub(LLM):
     """HuggingFaceHub  models.
     ! This class is deprecated, you should use HuggingFaceEndpoint instead.

--- a/libs/community/langchain_community/llms/huggingface_text_gen_inference.py
+++ b/libs/community/langchain_community/llms/huggingface_text_gen_inference.py
@@ -14,7 +14,7 @@ from langchain_core.utils import get_pydantic_field_names
 logger = logging.getLogger(__name__)
 
 
-@deprecated("0.0.21", removal="0.2.0", alternative="HuggingFaceEndpoint")
+@deprecated("0.0.21", removal="0.3.0", alternative="HuggingFaceEndpoint")
 class HuggingFaceTextGenInference(LLM):
     """
     HuggingFace text generation API.

--- a/libs/community/langchain_community/llms/openai.py
+++ b/libs/community/langchain_community/llms/openai.py
@@ -726,7 +726,7 @@ class BaseOpenAI(BaseLLM):
 
 
 @deprecated(
-    since="0.0.10", removal="0.2.0", alternative_import="langchain_openai.OpenAI"
+    since="0.0.10", removal="0.3.0", alternative_import="langchain_openai.OpenAI"
 )
 class OpenAI(BaseOpenAI):
     """OpenAI large language models.
@@ -755,7 +755,7 @@ class OpenAI(BaseOpenAI):
 
 
 @deprecated(
-    since="0.0.10", removal="0.2.0", alternative_import="langchain_openai.AzureOpenAI"
+    since="0.0.10", removal="0.3.0", alternative_import="langchain_openai.AzureOpenAI"
 )
 class AzureOpenAI(BaseOpenAI):
     """Azure-specific OpenAI large language models.
@@ -963,7 +963,7 @@ class AzureOpenAI(BaseOpenAI):
 
 @deprecated(
     since="0.0.1",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_openai.ChatOpenAI",
 )
 class OpenAIChat(BaseLLM):

--- a/libs/community/langchain_community/llms/together.py
+++ b/libs/community/langchain_community/llms/together.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    since="0.0.12", removal="0.2", alternative_import="langchain_together.Together"
+    since="0.0.12", removal="0.3", alternative_import="langchain_together.Together"
 )
 class Together(LLM):
     """LLM models from `Together`.

--- a/libs/community/langchain_community/llms/vertexai.py
+++ b/libs/community/langchain_community/llms/vertexai.py
@@ -203,7 +203,7 @@ class _VertexAICommon(_VertexAIBase):
 
 @deprecated(
     since="0.0.12",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_vertexai.VertexAI",
 )
 class VertexAI(_VertexAICommon, BaseLLM):
@@ -393,7 +393,7 @@ class VertexAI(_VertexAICommon, BaseLLM):
 
 @deprecated(
     since="0.0.12",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_vertexai.VertexAIModelGarden",
 )
 class VertexAIModelGarden(_VertexAIBase, BaseLLM):

--- a/libs/community/langchain_community/llms/watsonxllm.py
+++ b/libs/community/langchain_community/llms/watsonxllm.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    since="0.0.18", removal="0.2", alternative_import="langchain_ibm.WatsonxLLM"
+    since="0.0.18", removal="0.3", alternative_import="langchain_ibm.WatsonxLLM"
 )
 class WatsonxLLM(BaseLLM):
     """

--- a/libs/community/langchain_community/retrievers/cohere_rag_retriever.py
+++ b/libs/community/langchain_community/retrievers/cohere_rag_retriever.py
@@ -43,7 +43,7 @@ def _get_docs(response: Any) -> List[Document]:
 
 @deprecated(
     since="0.0.30",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_cohere.CohereRagRetriever",
 )
 class CohereRagRetriever(BaseRetriever):

--- a/libs/community/langchain_community/retrievers/google_cloud_documentai_warehouse.py
+++ b/libs/community/langchain_community/retrievers/google_cloud_documentai_warehouse.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 @deprecated(
     since="0.0.32",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.DocumentAIWarehouseRetriever",
 )
 class GoogleDocumentAIWarehouseRetriever(BaseRetriever):

--- a/libs/community/langchain_community/retrievers/google_vertex_ai_search.py
+++ b/libs/community/langchain_community/retrievers/google_vertex_ai_search.py
@@ -198,7 +198,7 @@ class _BaseGoogleVertexAISearchRetriever(BaseModel):
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.VertexAISearchRetriever",
 )
 class GoogleVertexAISearchRetriever(BaseRetriever, _BaseGoogleVertexAISearchRetriever):
@@ -398,7 +398,7 @@ class GoogleVertexAISearchRetriever(BaseRetriever, _BaseGoogleVertexAISearchRetr
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.VertexAIMultiTurnSearchRetriever",
 )
 class GoogleVertexAIMultiTurnSearchRetriever(

--- a/libs/community/langchain_community/storage/astradb.py
+++ b/libs/community/langchain_community/storage/astradb.py
@@ -99,7 +99,7 @@ class AstraDBBaseStore(Generic[V], BaseStore[str, V], ABC):
 
 @deprecated(
     since="0.0.22",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBStore",
 )
 class AstraDBStore(AstraDBBaseStore[Any]):
@@ -167,7 +167,7 @@ class AstraDBStore(AstraDBBaseStore[Any]):
 
 @deprecated(
     since="0.0.22",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBByteStore",
 )
 class AstraDBByteStore(AstraDBBaseStore[bytes], ByteStore):

--- a/libs/community/langchain_community/tools/google_cloud/texttospeech.py
+++ b/libs/community/langchain_community/tools/google_cloud/texttospeech.py
@@ -39,7 +39,7 @@ def _encoding_file_extension_map(encoding: texttospeech.AudioEncoding) -> Option
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.TextToSpeechTool",
 )
 class GoogleCloudTextToSpeechTool(BaseTool):

--- a/libs/community/langchain_community/tools/google_places/tool.py
+++ b/libs/community/langchain_community/tools/google_places/tool.py
@@ -18,7 +18,7 @@ class GooglePlacesSchema(BaseModel):
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GooglePlacesTool",
 )
 class GooglePlacesTool(BaseTool):

--- a/libs/community/langchain_community/tools/google_search/tool.py
+++ b/libs/community/langchain_community/tools/google_search/tool.py
@@ -11,7 +11,7 @@ from langchain_community.utilities.google_search import GoogleSearchAPIWrapper
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GoogleSearchRun",
 )
 class GoogleSearchRun(BaseTool):
@@ -36,7 +36,7 @@ class GoogleSearchRun(BaseTool):
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GoogleSearchResults",
 )
 class GoogleSearchResults(BaseTool):

--- a/libs/community/langchain_community/tools/metaphor_search/tool.py
+++ b/libs/community/langchain_community/tools/metaphor_search/tool.py
@@ -14,7 +14,7 @@ from langchain_community.utilities.metaphor_search import MetaphorSearchAPIWrapp
 
 @deprecated(
     since="0.0.15",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative="langchain_exa.ExaSearchResults",
 )
 class MetaphorSearchResults(BaseTool):

--- a/libs/community/langchain_community/utilities/google_places_api.py
+++ b/libs/community/langchain_community/utilities/google_places_api.py
@@ -10,7 +10,7 @@ from langchain_core.utils import get_from_dict_or_env
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GooglePlacesAPIWrapper",
 )
 class GooglePlacesAPIWrapper(BaseModel):

--- a/libs/community/langchain_community/utilities/google_search.py
+++ b/libs/community/langchain_community/utilities/google_search.py
@@ -9,7 +9,7 @@ from langchain_core.utils import get_from_dict_or_env
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.GoogleSearchAPIWrapper",
 )
 class GoogleSearchAPIWrapper(BaseModel):

--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -283,7 +283,7 @@ class SQLDatabase:
             return sorted(self._include_tables)
         return sorted(self._all_tables - self._ignore_tables)
 
-    @deprecated("0.0.1", alternative="get_usable_table_names", removal="0.2.0")
+    @deprecated("0.0.1", alternative="get_usable_table_names", removal="0.3.0")
     def get_table_names(self) -> Iterable[str]:
         """Get names of tables available."""
         return self.get_usable_table_names()

--- a/libs/community/langchain_community/vectorstores/astradb.py
+++ b/libs/community/langchain_community/vectorstores/astradb.py
@@ -67,7 +67,7 @@ def _unique_list(lst: List[T], key: Callable[[T], U]) -> List[T]:
 
 @deprecated(
     since="0.0.21",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_astradb.AstraDBVectorStore",
 )
 class AstraDB(VectorStore):

--- a/libs/community/langchain_community/vectorstores/bigquery_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/bigquery_vector_search.py
@@ -38,7 +38,7 @@ _vector_table_lock = Lock()  # process-wide BigQueryVectorSearch table lock
 
 @deprecated(
     since="0.0.33",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_community.BigQueryVectorSearch",
 )
 class BigQueryVectorSearch(VectorStore):

--- a/libs/community/langchain_community/vectorstores/matching_engine.py
+++ b/libs/community/langchain_community/vectorstores/matching_engine.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.0.12",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_google_vertexai.VectorSearchVectorStore",
 )
 class MatchingEngine(VectorStore):

--- a/libs/community/langchain_community/vectorstores/mongodb_atlas.py
+++ b/libs/community/langchain_community/vectorstores/mongodb_atlas.py
@@ -35,7 +35,7 @@ DEFAULT_INSERT_BATCH_SIZE = 100
 
 @deprecated(
     since="0.0.25",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_mongodb.MongoDBAtlasVectorSearch",
 )
 class MongoDBAtlasVectorSearch(VectorStore):

--- a/libs/community/langchain_community/vectorstores/pinecone.py
+++ b/libs/community/langchain_community/vectorstores/pinecone.py
@@ -43,7 +43,7 @@ def _is_pinecone_v3() -> bool:
 
 
 @deprecated(
-    since="0.0.18", removal="0.2.0", alternative_import="langchain_pinecone.Pinecone"
+    since="0.0.18", removal="0.3.0", alternative_import="langchain_pinecone.Pinecone"
 )
 class Pinecone(VectorStore):
     """`Pinecone` vector store.

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -207,7 +207,7 @@ class BaseLanguageModel(
         """Implement this if there is a way of steering the model to generate responses that match a given schema."""  # noqa: E501
         raise NotImplementedError()
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     @abstractmethod
     def predict(
         self, text: str, *, stop: Optional[Sequence[str]] = None, **kwargs: Any
@@ -228,7 +228,7 @@ class BaseLanguageModel(
             Top model prediction as a string.
         """
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     @abstractmethod
     def predict_messages(
         self,
@@ -253,7 +253,7 @@ class BaseLanguageModel(
             Top model prediction as a message.
         """
 
-    @deprecated("0.1.7", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="ainvoke", removal="0.3.0")
     @abstractmethod
     async def apredict(
         self, text: str, *, stop: Optional[Sequence[str]] = None, **kwargs: Any
@@ -274,7 +274,7 @@ class BaseLanguageModel(
             Top model prediction as a string.
         """
 
-    @deprecated("0.1.7", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="ainvoke", removal="0.3.0")
     @abstractmethod
     async def apredict_messages(
         self,

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -797,7 +797,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 break
             yield item  # type: ignore[misc]
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def __call__(
         self,
         messages: List[BaseMessage],
@@ -829,13 +829,13 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         else:
             raise ValueError("Unexpected generation type")
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def call_as_llm(
         self, message: str, stop: Optional[List[str]] = None, **kwargs: Any
     ) -> str:
         return self.predict(message, stop=stop, **kwargs)
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def predict(
         self, text: str, *, stop: Optional[Sequence[str]] = None, **kwargs: Any
     ) -> str:
@@ -849,7 +849,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         else:
             raise ValueError("Cannot use predict when output is not a string.")
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def predict_messages(
         self,
         messages: List[BaseMessage],
@@ -863,7 +863,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
             _stop = list(stop)
         return self(messages, stop=_stop, **kwargs)
 
-    @deprecated("0.1.7", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="ainvoke", removal="0.3.0")
     async def apredict(
         self, text: str, *, stop: Optional[Sequence[str]] = None, **kwargs: Any
     ) -> str:
@@ -879,7 +879,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         else:
             raise ValueError("Cannot use predict when output is not a string.")
 
-    @deprecated("0.1.7", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="ainvoke", removal="0.3.0")
     async def apredict_messages(
         self,
         messages: List[BaseMessage],

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -1064,7 +1064,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
         generations = [existing_prompts[i] for i in range(len(prompts))]
         return LLMResult(generations=generations, llm_output=llm_output, run=run_info)
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def __call__(
         self,
         prompt: str,
@@ -1116,7 +1116,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
         )
         return result.generations[0][0].text
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def predict(
         self, text: str, *, stop: Optional[Sequence[str]] = None, **kwargs: Any
     ) -> str:
@@ -1126,7 +1126,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
             _stop = list(stop)
         return self(text, stop=_stop, **kwargs)
 
-    @deprecated("0.1.7", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="invoke", removal="0.3.0")
     def predict_messages(
         self,
         messages: List[BaseMessage],
@@ -1142,7 +1142,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
         content = self(text, stop=_stop, **kwargs)
         return AIMessage(content=content)
 
-    @deprecated("0.1.7", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="ainvoke", removal="0.3.0")
     async def apredict(
         self, text: str, *, stop: Optional[Sequence[str]] = None, **kwargs: Any
     ) -> str:
@@ -1152,7 +1152,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
             _stop = list(stop)
         return await self._call_async(text, stop=_stop, **kwargs)
 
-    @deprecated("0.1.7", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.7", alternative="ainvoke", removal="0.3.0")
     async def apredict_messages(
         self,
         messages: List[BaseMessage],

--- a/libs/core/langchain_core/tracers/schemas.py
+++ b/libs/core/langchain_core/tracers/schemas.py
@@ -14,7 +14,7 @@ from langchain_core.outputs import LLMResult
 from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 
 
-@deprecated("0.1.0", alternative="Use string instead.", removal="0.2.0")
+@deprecated("0.1.0", alternative="Use string instead.", removal="0.3.0")
 def RunTypeEnum() -> Type[RunTypeEnumDep]:
     """RunTypeEnum."""
     warnings.warn(
@@ -25,7 +25,7 @@ def RunTypeEnum() -> Type[RunTypeEnumDep]:
     return RunTypeEnumDep
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class TracerSessionV1Base(BaseModel):
     """Base class for TracerSessionV1."""
 
@@ -34,33 +34,33 @@ class TracerSessionV1Base(BaseModel):
     extra: Optional[Dict[str, Any]] = None
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class TracerSessionV1Create(TracerSessionV1Base):
     """Create class for TracerSessionV1."""
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class TracerSessionV1(TracerSessionV1Base):
     """TracerSessionV1 schema."""
 
     id: int
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class TracerSessionBase(TracerSessionV1Base):
     """Base class for TracerSession."""
 
     tenant_id: UUID
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class TracerSession(TracerSessionBase):
     """TracerSessionV1 schema for the V2 API."""
 
     id: UUID
 
 
-@deprecated("0.1.0", alternative="Run", removal="0.2.0")
+@deprecated("0.1.0", alternative="Run", removal="0.3.0")
 class BaseRun(BaseModel):
     """Base class for Run."""
 
@@ -76,7 +76,7 @@ class BaseRun(BaseModel):
     error: Optional[str] = None
 
 
-@deprecated("0.1.0", alternative="Run", removal="0.2.0")
+@deprecated("0.1.0", alternative="Run", removal="0.3.0")
 class LLMRun(BaseRun):
     """Class for LLMRun."""
 
@@ -84,7 +84,7 @@ class LLMRun(BaseRun):
     response: Optional[LLMResult] = None
 
 
-@deprecated("0.1.0", alternative="Run", removal="0.2.0")
+@deprecated("0.1.0", alternative="Run", removal="0.3.0")
 class ChainRun(BaseRun):
     """Class for ChainRun."""
 
@@ -95,7 +95,7 @@ class ChainRun(BaseRun):
     child_tool_runs: List[ToolRun] = Field(default_factory=list)
 
 
-@deprecated("0.1.0", alternative="Run", removal="0.2.0")
+@deprecated("0.1.0", alternative="Run", removal="0.3.0")
 class ToolRun(BaseRun):
     """Class for ToolRun."""
 

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -78,7 +78,7 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
 @deprecated(
     "0.1.16",
     alternative="langchain_core.utils.function_calling.convert_to_openai_function()",
-    removal="0.2.0",
+    removal="0.3.0",
 )
 def convert_pydantic_to_openai_function(
     model: Type[BaseModel],
@@ -102,7 +102,7 @@ def convert_pydantic_to_openai_function(
 @deprecated(
     "0.1.16",
     alternative="langchain_core.utils.function_calling.convert_to_openai_tool()",
-    removal="0.2.0",
+    removal="0.3.0",
 )
 def convert_pydantic_to_openai_tool(
     model: Type[BaseModel],
@@ -213,7 +213,7 @@ def _get_python_function_required_args(function: Callable) -> List[str]:
 @deprecated(
     "0.1.16",
     alternative="langchain_core.utils.function_calling.convert_to_openai_function()",
-    removal="0.2.0",
+    removal="0.3.0",
 )
 def convert_python_function_to_openai_function(
     function: Callable,
@@ -239,7 +239,7 @@ def convert_python_function_to_openai_function(
 @deprecated(
     "0.1.16",
     alternative="langchain_core.utils.function_calling.convert_to_openai_function()",
-    removal="0.2.0",
+    removal="0.3.0",
 )
 def format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     """Format tool into the OpenAI function API."""
@@ -269,7 +269,7 @@ def format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
 @deprecated(
     "0.1.16",
     alternative="langchain_core.utils.function_calling.convert_to_openai_tool()",
-    removal="0.2.0",
+    removal="0.3.0",
 )
 def format_tool_to_openai_tool(tool: BaseTool) -> ToolDescription:
     """Format tool into the OpenAI function API."""

--- a/libs/core/langchain_core/utils/loading.py
+++ b/libs/core/langchain_core/utils/loading.py
@@ -8,7 +8,7 @@ from langchain_core._api.deprecation import deprecated
 
 @deprecated(
     since="0.1.30",
-    removal="0.2",
+    removal="0.3",
     message=(
         "Using the hwchase17/langchain-hub "
         "repo for prompts is deprecated. Please use "

--- a/libs/experimental/langchain_experimental/llms/anthropic_functions.py
+++ b/libs/experimental/langchain_experimental/llms/anthropic_functions.py
@@ -126,7 +126,7 @@ def _destrip(tool_input: Any) -> Any:
 
 @deprecated(
     since="0.0.54",
-    removal="0.2",
+    removal="0.3",
     alternative_import="langchain_anthropic.experimental.ChatAnthropicTools",
 )
 class AnthropicFunctions(BaseChatModel):

--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -571,7 +571,7 @@ class RunnableMultiActionAgent(BaseMultiActionAgent):
         "Use new agent constructor methods like create_react_agent, create_json_agent, "
         "create_structured_chat_agent, etc."
     ),
-    removal="0.2.0",
+    removal="0.3.0",
 )
 class LLMSingleActionAgent(BaseSingleActionAgent):
     """Base class for single action agents."""
@@ -661,7 +661,7 @@ class LLMSingleActionAgent(BaseSingleActionAgent):
         "Use new agent constructor methods like create_react_agent, create_json_agent, "
         "create_structured_chat_agent, etc."
     ),
-    removal="0.2.0",
+    removal="0.3.0",
 )
 class Agent(BaseSingleActionAgent):
     """Agent that calls the language model and deciding the action.

--- a/libs/langchain/langchain/agents/agent_types.py
+++ b/libs/langchain/langchain/agents/agent_types.py
@@ -10,7 +10,7 @@ from langchain_core._api import deprecated
         "Use new agent constructor methods like create_react_agent, create_json_agent, "
         "create_structured_chat_agent, etc."
     ),
-    removal="0.2.0",
+    removal="0.3.0",
 )
 class AgentType(str, Enum):
     """An enum for agent types.

--- a/libs/langchain/langchain/agents/chat/base.py
+++ b/libs/langchain/langchain/agents/chat/base.py
@@ -25,7 +25,7 @@ from langchain.agents.utils import validate_tools_single_input
 from langchain.chains.llm import LLMChain
 
 
-@deprecated("0.1.0", alternative="create_react_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_react_agent", removal="0.3.0")
 class ChatAgent(Agent):
     """Chat Agent."""
 

--- a/libs/langchain/langchain/agents/conversational/base.py
+++ b/libs/langchain/langchain/agents/conversational/base.py
@@ -18,7 +18,7 @@ from langchain.agents.utils import validate_tools_single_input
 from langchain.chains import LLMChain
 
 
-@deprecated("0.1.0", alternative="create_react_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_react_agent", removal="0.3.0")
 class ConversationalAgent(Agent):
     """An agent that holds a conversation in addition to using tools."""
 

--- a/libs/langchain/langchain/agents/conversational_chat/base.py
+++ b/libs/langchain/langchain/agents/conversational_chat/base.py
@@ -30,7 +30,7 @@ from langchain.agents.utils import validate_tools_single_input
 from langchain.chains import LLMChain
 
 
-@deprecated("0.1.0", alternative="create_json_chat_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_json_chat_agent", removal="0.3.0")
 class ConversationalChatAgent(Agent):
     """An agent designed to hold a conversation in addition to using tools."""
 

--- a/libs/langchain/langchain/agents/initialize.py
+++ b/libs/langchain/langchain/agents/initialize.py
@@ -17,7 +17,7 @@ from langchain.agents.loading import AGENT_TO_CLASS, load_agent
         "Use new agent constructor methods like create_react_agent, create_json_agent, "
         "create_structured_chat_agent, etc."
     ),
-    removal="0.2.0",
+    removal="0.3.0",
 )
 def initialize_agent(
     tools: Sequence[BaseTool],

--- a/libs/langchain/langchain/agents/loading.py
+++ b/libs/langchain/langchain/agents/loading.py
@@ -31,7 +31,7 @@ def _load_agent_from_tools(
     return agent_cls.from_llm_and_tools(llm, tools, **combined_config)
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 def load_agent_from_config(
     config: dict,
     llm: Optional[BaseLanguageModel] = None,
@@ -87,7 +87,7 @@ def load_agent_from_config(
     return agent_cls(**combined_config)  # type: ignore
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 def load_agent(
     path: Union[str, Path], **kwargs: Any
 ) -> Union[BaseSingleActionAgent, BaseMultiActionAgent]:

--- a/libs/langchain/langchain/agents/mrkl/base.py
+++ b/libs/langchain/langchain/agents/mrkl/base.py
@@ -33,7 +33,7 @@ class ChainConfig(NamedTuple):
     action_description: str
 
 
-@deprecated("0.1.0", alternative="create_react_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_react_agent", removal="0.3.0")
 class ZeroShotAgent(Agent):
     """Agent for the MRKL chain."""
 
@@ -139,7 +139,7 @@ class ZeroShotAgent(Agent):
         super()._validate_tools(tools)
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class MRKLChain(AgentExecutor):
     """[Deprecated] Chain that implements the MRKL system."""
 

--- a/libs/langchain/langchain/agents/openai_functions_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_agent/base.py
@@ -30,7 +30,7 @@ from langchain.agents.output_parsers.openai_functions import (
 )
 
 
-@deprecated("0.1.0", alternative="create_openai_functions_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_openai_functions_agent", removal="0.3.0")
 class OpenAIFunctionsAgent(BaseSingleActionAgent):
     """An Agent driven by OpenAIs function powered API.
 

--- a/libs/langchain/langchain/agents/openai_functions_multi_agent/base.py
+++ b/libs/langchain/langchain/agents/openai_functions_multi_agent/base.py
@@ -93,7 +93,7 @@ def _parse_ai_message(message: BaseMessage) -> Union[List[AgentAction], AgentFin
     )
 
 
-@deprecated("0.1.0", alternative="create_openai_tools_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_openai_tools_agent", removal="0.3.0")
 class OpenAIMultiFunctionsAgent(BaseMultiActionAgent):
     """An Agent driven by OpenAIs function powered API.
 

--- a/libs/langchain/langchain/agents/react/base.py
+++ b/libs/langchain/langchain/agents/react/base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from langchain_community.docstore.base import Docstore
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class ReActDocstoreAgent(Agent):
     """Agent for the ReAct chain."""
 
@@ -68,7 +68,7 @@ class ReActDocstoreAgent(Agent):
         return "Thought:"
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class DocstoreExplorer:
     """Class to assist with exploration of a document store."""
 
@@ -118,7 +118,7 @@ class DocstoreExplorer:
         return self.document.page_content.split("\n\n")
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class ReActTextWorldAgent(ReActDocstoreAgent):
     """Agent for the ReAct TextWorld chain."""
 
@@ -138,7 +138,7 @@ class ReActTextWorldAgent(ReActDocstoreAgent):
             raise ValueError(f"Tool name should be Play, got {tool_names}")
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class ReActChain(AgentExecutor):
     """[Deprecated] Chain that implements the ReAct paper."""
 

--- a/libs/langchain/langchain/agents/self_ask_with_search/base.py
+++ b/libs/langchain/langchain/agents/self_ask_with_search/base.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from langchain_community.utilities.serpapi import SerpAPIWrapper
 
 
-@deprecated("0.1.0", alternative="create_self_ask_with_search", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_self_ask_with_search", removal="0.3.0")
 class SelfAskWithSearchAgent(Agent):
     """Agent for the self-ask-with-search paper."""
 
@@ -66,7 +66,7 @@ class SelfAskWithSearchAgent(Agent):
         return ""
 
 
-@deprecated("0.1.0", removal="0.2.0")
+@deprecated("0.1.0", removal="0.3.0")
 class SelfAskWithSearchChain(AgentExecutor):
     """[Deprecated] Chain that does self-ask with search."""
 

--- a/libs/langchain/langchain/agents/structured_chat/base.py
+++ b/libs/langchain/langchain/agents/structured_chat/base.py
@@ -28,7 +28,7 @@ from langchain.tools.render import ToolsRenderer, render_text_description_and_ar
 HUMAN_MESSAGE_TEMPLATE = "{input}\n\n{agent_scratchpad}"
 
 
-@deprecated("0.1.0", alternative="create_structured_chat_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_structured_chat_agent", removal="0.3.0")
 class StructuredChatAgent(Agent):
     """Structured Chat Agent."""
 

--- a/libs/langchain/langchain/agents/xml/base.py
+++ b/libs/langchain/langchain/agents/xml/base.py
@@ -17,7 +17,7 @@ from langchain.chains.llm import LLMChain
 from langchain.tools.render import ToolsRenderer, render_text_description
 
 
-@deprecated("0.1.0", alternative="create_xml_agent", removal="0.2.0")
+@deprecated("0.1.0", alternative="create_xml_agent", removal="0.3.0")
 class XMLAgent(BaseSingleActionAgent):
     """Agent that uses XML tags.
 

--- a/libs/langchain/langchain/chains/base.py
+++ b/libs/langchain/langchain/chains/base.py
@@ -331,7 +331,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
             None, self._call, inputs, run_manager.get_sync() if run_manager else None
         )
 
-    @deprecated("0.1.0", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.0", alternative="invoke", removal="0.3.0")
     def __call__(
         self,
         inputs: Union[Dict[str, Any], Any],
@@ -382,7 +382,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
             include_run_info=include_run_info,
         )
 
-    @deprecated("0.1.0", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.0", alternative="ainvoke", removal="0.3.0")
     async def acall(
         self,
         inputs: Union[Dict[str, Any], Any],
@@ -541,7 +541,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
             )
         return self.output_keys[0]
 
-    @deprecated("0.1.0", alternative="invoke", removal="0.2.0")
+    @deprecated("0.1.0", alternative="invoke", removal="0.3.0")
     def run(
         self,
         *args: Any,
@@ -612,7 +612,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
                 f" but not both. Got args: {args} and kwargs: {kwargs}."
             )
 
-    @deprecated("0.1.0", alternative="ainvoke", removal="0.2.0")
+    @deprecated("0.1.0", alternative="ainvoke", removal="0.3.0")
     async def arun(
         self,
         *args: Any,
@@ -750,7 +750,7 @@ class Chain(RunnableSerializable[Dict[str, Any], Dict[str, Any]], ABC):
         else:
             raise ValueError(f"{save_path} must be json or yaml")
 
-    @deprecated("0.1.0", alternative="batch", removal="0.2.0")
+    @deprecated("0.1.0", alternative="batch", removal="0.3.0")
     def apply(
         self, input_list: List[Dict[str, Any]], callbacks: Callbacks = None
     ) -> List[Dict[str, str]]:

--- a/libs/langchain/langchain/chains/openai_functions/base.py
+++ b/libs/langchain/langchain/chains/openai_functions/base.py
@@ -42,7 +42,7 @@ __all__ = [
 ]
 
 
-@deprecated(since="0.1.1", removal="0.2.0", alternative="create_openai_fn_runnable")
+@deprecated(since="0.1.1", removal="0.3.0", alternative="create_openai_fn_runnable")
 def create_openai_fn_chain(
     functions: Sequence[Union[Dict[str, Any], Type[BaseModel], Callable]],
     llm: BaseLanguageModel,
@@ -144,7 +144,7 @@ def create_openai_fn_chain(
 
 
 @deprecated(
-    since="0.1.1", removal="0.2.0", alternative="ChatOpenAI.with_structured_output"
+    since="0.1.1", removal="0.3.0", alternative="ChatOpenAI.with_structured_output"
 )
 def create_structured_output_chain(
     output_schema: Union[Dict[str, Any], Type[BaseModel]],

--- a/libs/langchain/langchain/retrievers/document_compressors/cohere_rerank.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/cohere_rerank.py
@@ -13,7 +13,7 @@ from langchain.retrievers.document_compressors.base import BaseDocumentCompresso
 
 
 @deprecated(
-    since="0.0.30", removal="0.2.0", alternative_import="langchain_cohere.CohereRerank"
+    since="0.0.30", removal="0.3.0", alternative_import="langchain_cohere.CohereRerank"
 )
 class CohereRerank(BaseDocumentCompressor):
     """Document compressor that uses `Cohere Rerank API`."""

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -756,6 +756,6 @@ def _lc_tool_calls_to_anthropic_tool_use_blocks(
     return blocks
 
 
-@deprecated(since="0.1.0", removal="0.2.0", alternative="ChatAnthropic")
+@deprecated(since="0.1.0", removal="0.3.0", alternative="ChatAnthropic")
 class ChatAnthropicMessages(ChatAnthropic):
     pass

--- a/libs/partners/anthropic/langchain_anthropic/experimental.py
+++ b/libs/partners/anthropic/langchain_anthropic/experimental.py
@@ -145,7 +145,7 @@ def _xml_to_tool_calls(elem: Any, tools: List[Dict]) -> List[Dict[str, Any]]:
 
 @deprecated(
     "0.1.5",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative="ChatAnthropic",
     message=(
         "Tool-calling is now officially supported by the Anthropic API so this "

--- a/libs/partners/anthropic/langchain_anthropic/llms.py
+++ b/libs/partners/anthropic/langchain_anthropic/llms.py
@@ -360,6 +360,6 @@ class AnthropicLLM(LLM, _AnthropicCommon):
         return self.count_tokens(text)
 
 
-@deprecated(since="0.1.0", removal="0.2.0", alternative="AnthropicLLM")
+@deprecated(since="0.1.0", removal="0.3.0", alternative="AnthropicLLM")
 class Anthropic(AnthropicLLM):
     pass

--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -494,7 +494,7 @@ class PineconeVectorStore(VectorStore):
         return None
 
 
-@deprecated(since="0.0.3", removal="0.2.0", alternative="PineconeVectorStore")
+@deprecated(since="0.0.3", removal="0.3.0", alternative="PineconeVectorStore")
 class Pinecone(PineconeVectorStore):
     """Deprecated. Use PineconeVectorStore instead."""
 

--- a/libs/partners/upstage/langchain_upstage/tools/groundedness_check.py
+++ b/libs/partners/upstage/langchain_upstage/tools/groundedness_check.py
@@ -110,7 +110,7 @@ class UpstageGroundednessCheck(BaseTool):
 
 @deprecated(
     since="0.1.3",
-    removal="0.2.0",
+    removal="0.3.0",
     alternative_import="langchain_upstage.UpstageGroundednessCheck",
 )
 class GroundednessCheck(UpstageGroundednessCheck):


### PR DESCRIPTION
We are pushing out the removal of these to 0.3.

`find . -type f -name "*.py" -exec sed -i '' 's/removal="0\.2/removal="0.3/g' {} +`