### PR TITLE
baichuan[patch]:standardize chat init args

### DIFF
--- a/libs/community/langchain_community/chat_models/baichuan.py
+++ b/libs/community/langchain_community/chat_models/baichuan.py
@@ -89,7 +89,7 @@ class ChatBaichuan(BaseChatModel):
 
     baichuan_api_base: str = Field(default=DEFAULT_API_BASE)
     """Baichuan custom endpoints"""
-    baichuan_api_key: Optional[SecretStr] = Field(None, alias="api_key")
+    baichuan_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
     """Baichuan API Key"""
     baichuan_secret_key: Optional[SecretStr] = None
     """[DEPRECATED, keeping it for for backward compatibility] Baichuan Secret Key"""

--- a/libs/community/langchain_community/chat_models/baichuan.py
+++ b/libs/community/langchain_community/chat_models/baichuan.py
@@ -89,7 +89,7 @@ class ChatBaichuan(BaseChatModel):
 
     baichuan_api_base: str = Field(default=DEFAULT_API_BASE)
     """Baichuan custom endpoints"""
-    baichuan_api_key: Optional[SecretStr] = None
+    baichuan_api_key: Optional[SecretStr] = Field(None, alias="api_key")
     """Baichuan API Key"""
     baichuan_secret_key: Optional[SecretStr] = None
     """[DEPRECATED, keeping it for for backward compatibility] Baichuan Secret Key"""

--- a/libs/community/langchain_community/chat_models/baichuan.py
+++ b/libs/community/langchain_community/chat_models/baichuan.py
@@ -100,7 +100,7 @@ class ChatBaichuan(BaseChatModel):
     model = "Baichuan2-Turbo-192K"
     """model name of Baichuan, default is `Baichuan2-Turbo-192K`,
     other options include `Baichuan2-Turbo`"""
-    temperature: float = 0.3
+    temperature: Optional[float] = Field(default=0.3)
     """What sampling temperature to use."""
     top_k: int = 5
     """What search sampling control to use."""

--- a/libs/community/tests/unit_tests/chat_models/test_baichuan.py
+++ b/libs/community/tests/unit_tests/chat_models/test_baichuan.py
@@ -26,7 +26,7 @@ def test_initialization() -> None:
 
     for model in [
         ChatBaichuan(
-            model="Baichuan2-Turbo-192K", baichuan_api_key="test-api-key", timeout=40
+            model="Baichuan2-Turbo-192K", api_key="test-api-key", timeout=40
         ),
         ChatBaichuan(
             model="Baichuan2-Turbo-192K",
@@ -35,6 +35,7 @@ def test_initialization() -> None:
         ),
     ]:
         assert model.model == "Baichuan2-Turbo-192K"
+        assert model.baichuan_api_key == 'test-api-key'
         assert model.request_timeout == 40
 
 

--- a/libs/community/tests/unit_tests/chat_models/test_baichuan.py
+++ b/libs/community/tests/unit_tests/chat_models/test_baichuan.py
@@ -35,6 +35,7 @@ def test_initialization() -> None:
         assert model.model == "Baichuan2-Turbo-192K"
         assert isinstance(model.baichuan_api_key, SecretStr)
         assert model.request_timeout == 40
+        assert model.temperature == 0.3
 
 
 def test__convert_message_to_dict_human() -> None:

--- a/libs/community/tests/unit_tests/chat_models/test_baichuan.py
+++ b/libs/community/tests/unit_tests/chat_models/test_baichuan.py
@@ -25,9 +25,7 @@ def test_initialization() -> None:
     """Test chat model initialization."""
 
     for model in [
-        ChatBaichuan(
-            model="Baichuan2-Turbo-192K", api_key="test-api-key", timeout=40
-        ),
+        ChatBaichuan(model="Baichuan2-Turbo-192K", api_key="test-api-key", timeout=40),
         ChatBaichuan(
             model="Baichuan2-Turbo-192K",
             baichuan_api_key="test-api-key",
@@ -35,7 +33,7 @@ def test_initialization() -> None:
         ),
     ]:
         assert model.model == "Baichuan2-Turbo-192K"
-        assert model.baichuan_api_key == 'test-api-key'
+        assert isinstance(model.baichuan_api_key, SecretStr)
         assert model.request_timeout == 40
 
 


### PR DESCRIPTION
Thank you for contributing to LangChain!

community:baichuan[patch]: standardize init args

updated `baichuan_api_key` so that aliased to `api_key`. Added test that it continues to set the same underlying attribute. Test checks for `SecretStr`

updated `temperature` with Pydantic Field, added unit test. 

Related to https://github.com/langchain-ai/langchain/issues/20085