### PR TITLE
chore(community): reduce number of list creations and calls in Azure AI Search

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -398,9 +398,9 @@ class AzureSearch(VectorStore):
         self, query: str, k: int = 4, **kwargs: Any
     ) -> List[Document]:
         search_type = kwargs.pop("search_type", self.search_type)
-        if search_type == "similarity":
+        if search_type in ("similarity", "similarity_score_threshold"):
             docs = self.vector_search(query, k=k, **kwargs)
-        elif search_type == "hybrid":
+        elif search_type in ("hybrid", "hybrid_score_threshold"):
             docs = self.hybrid_search(query, k=k, **kwargs)
         elif search_type == "semantic_hybrid":
             docs = self.semantic_hybrid_search(query, k=k, **kwargs)
@@ -758,15 +758,9 @@ class AzureSearchVectorStoreRetriever(BaseRetriever):
         run_manager: CallbackManagerForRetrieverRun,
         **kwargs: Any,
     ) -> List[Document]:
-        if self.search_type in ("similarity", "similarity_score_threshold"):
-            docs = self.vectorstore.vector_search(query, k=self.k, **kwargs)
-        elif self.search_type in ("hybrid", "hybrid_score_threshold"):
-            docs = self.vectorstore.hybrid_search(query, k=self.k, **kwargs)
-        elif self.search_type == "semantic_hybrid":
-            docs = self.vectorstore.semantic_hybrid_search(query, k=self.k, **kwargs)
-        else:
-            raise ValueError(f"search_type of {self.search_type} not allowed.")
-        return docs
+        return self.vectorstore.similarity_search(
+            query, k=self.k, search_type=self.search_type, **kwargs
+        )
 
     async def _aget_relevant_documents(
         self,

--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -397,7 +397,7 @@ class AzureSearch(VectorStore):
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any
     ) -> List[Document]:
-        search_type = kwargs.pop("search_type", self.search_type)
+        search_type = kwargs.get("search_type", self.search_type)
         if search_type in ("similarity", "similarity_score_threshold"):
             docs = self.vector_search(query, k=k, **kwargs)
         elif search_type in ("hybrid", "hybrid_score_threshold"):
@@ -517,8 +517,8 @@ class AzureSearch(VectorStore):
         Args:
             query: Text to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-           filters: OData $filter expression to apply to the search query.
-           score_threshold: Optional threshold to filter the results.
+            filters: OData $filter expression to apply to the search query.
+            score_threshold: Optional threshold to filter the results.
 
         Returns:
             List of Documents most similar to the query and score for each
@@ -537,11 +537,9 @@ class AzureSearch(VectorStore):
             filter=kwargs.get("filters", None),
             top=k,
         )
-
         # Convert results to Document objects
-        docs = []
         score_threshold: Optional[float] = kwargs.get("score_threshold", None)
-
+        docs = []
         for result in results:
             score = float(result["@search.score"])
             if score_threshold is None or score > score_threshold:


### PR DESCRIPTION
This PR aims at making the `AzureSearch` vectorstore a bit more efficient by reducing the number of calls and lists being created by the corresponding retriever. 

The current version operates as follows:
- a client wrapper returns a `List[Document, float]` containing all the matching documents with the corresponding score
- then a second method is called to create a new list after filtering out according to a score threshold
- finally a third list is created dropping the score "column".

Here's an example:
![image](https://github.com/langchain-ai/langchain/assets/44113430/220c6c30-5e7a-47e9-b346-6b9c3f361fc9)

However one could avoid the intermediate step by filtering directly in the first step (if a threshold is passed). One could even skip the third step specifying whether to include the scores or not, but this would not be consistent with the naming conventions of many methods (starting from the base class), thus I decided not to do that.