### PR TITLE
docs: add example for loading data from LarkSuite wiki.

### DIFF
--- a/docs/docs/integrations/document_loaders/larksuite.ipynb
+++ b/docs/docs/integrations/document_loaders/larksuite.ipynb
@@ -30,11 +30,22 @@
    "source": [
     "from getpass import getpass\n",
     "\n",
-    "from langchain_community.document_loaders.larksuite import LarkSuiteDocLoader\n",
+    "from langchain_community.document_loaders.larksuite import (\n",
+    "    LarkSuiteDocLoader,\n",
+    "    LarkSuiteWikiLoader,\n",
+    ")\n",
     "\n",
     "DOMAIN = input(\"larksuite domain\")\n",
     "ACCESS_TOKEN = getpass(\"larksuite tenant_access_token or user_access_token\")\n",
     "DOCUMENT_ID = input(\"larksuite document id\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b6b9a66",
+   "metadata": {},
+   "source": [
+    "## Load From Document"
    ]
   },
   {
@@ -60,6 +71,38 @@
     "from pprint import pprint\n",
     "\n",
     "larksuite_loader = LarkSuiteDocLoader(DOMAIN, ACCESS_TOKEN, DOCUMENT_ID)\n",
+    "docs = larksuite_loader.load()\n",
+    "\n",
+    "pprint(docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86f4a714",
+   "metadata": {},
+   "source": [
+    "## Load From Wiki"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7332dfb9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Document(page_content='Test doc\\nThis is a test wiki doc.\\n', metadata={'document_id': 'TxOKdtMWaoSTDLxYS4ZcdEI7nwc', 'revision_id': 15, 'title': 'Test doc'})]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "\n",
+    "DOCUMENT_ID = input(\"larksuite wiki id\")\n",
+    "larksuite_loader = LarkSuiteWikiLoader(DOMAIN, ACCESS_TOKEN, DOCUMENT_ID)\n",
     "docs = larksuite_loader.load()\n",
     "\n",
     "pprint(docs)"


### PR DESCRIPTION
**Description:** Update LarkSuite loader doc to give an example for loading data from LarkSuite wiki.
**Issue:** None
**Dependencies:** None
**Twitter handle:** None