### PR TITLE
community(patch) fix MoonshotChat moonshot_api_key is invaild for api key

### DIFF
--- a/libs/community/langchain_community/chat_models/moonshot.py
+++ b/libs/community/langchain_community/chat_models/moonshot.py
@@ -42,7 +42,7 @@ class MoonshotChat(MoonshotCommon, ChatOpenAI):  # type: ignore[misc]
             )
 
         client_params = {
-            "api_key": values["moonshot_api_key"],
+            "api_key": values["moonshot_api_key"].get_secret_value(),
             "base_url": values["base_url"]
             if "base_url" in values
             else MOONSHOT_SERVICE_URL_BASE,


### PR DESCRIPTION
Description: close https://github.com/langchain-ai/langchain/issues/21237
@baskaryan, @eyurtsev