### PR TITLE
Add simple node properties to llm graph transformer

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -277,7 +277,7 @@ def create_simple_model(
     Doesn't have any node or relationship properties.
     """
 
-    node_fields: Dict[Tuple[str, Any]] = {
+    node_fields: Dict[str, Tuple[str, Any]] = {
         "id": (
             str,
             Field(..., description="Name or human-readable unique identifier."),

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -291,7 +291,7 @@ def create_simple_model(
         if isinstance(node_properties, list) and "id" in node_properties:
             raise ValueError("The node property 'id' is reserved and cannot be used.")
         # Map True to empty array
-        node_properties = [] if node_properties == True else node_properties
+        node_properties = [] if node_properties is True else node_properties
 
         class Property(BaseModel):
             """A single property consisting of key and value"""

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -300,7 +300,9 @@ def create_simple_model(
             """A single property consisting of key and value"""
 
             key: str = optional_enum_field(
-                node_properties_mapped, description="Property key.", input_type="property"
+                node_properties_mapped,
+                description="Property key.",
+                input_type="property",
             )
             value: str = Field(..., description="value")
 

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -313,7 +313,7 @@ def create_simple_model(
             Optional[List[Property]],
             Field(None, description="List of node properties"),
         )
-    SimpleNode = create_model("SimpleNode", **node_fields)
+    SimpleNode = create_model("SimpleNode", **node_fields)  # type: ignore
 
     class SimpleRelationship(BaseModel):
         """Represents a directed relationship between two nodes in a graph."""
@@ -343,7 +343,7 @@ def create_simple_model(
     class DynamicGraph(_Graph):
         """Represents a graph document consisting of nodes and relationships."""
 
-        nodes: Optional[List[SimpleNode]] = Field(description="List of nodes")
+        nodes: Optional[List[SimpleNode]] = Field(description="List of nodes")  # type: ignore
         relationships: Optional[List[SimpleRelationship]] = Field(
             description="List of relationships"
         )

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -143,6 +143,7 @@ def _get_additional_info(input_type: str) -> str:
         )
     elif input_type == "property":
         return ""
+    return ""
 
 
 def optional_enum_field(
@@ -291,7 +292,9 @@ def create_simple_model(
         if isinstance(node_properties, list) and "id" in node_properties:
             raise ValueError("The node property 'id' is reserved and cannot be used.")
         # Map True to empty array
-        node_properties = [] if node_properties is True else node_properties
+        node_properties_mapped: List[str] = (
+            [] if node_properties is True else node_properties
+        )
 
         class Property(BaseModel):
             """A single property consisting of key and value"""

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -277,7 +277,7 @@ def create_simple_model(
     Doesn't have any node or relationship properties.
     """
 
-    node_fields: Dict[str, Tuple[str, Any]] = {
+    node_fields: Dict[str, Tuple[Any, Any]] = {
         "id": (
             str,
             Field(..., description="Name or human-readable unique identifier."),

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -277,7 +277,7 @@ def create_simple_model(
     Doesn't have any node or relationship properties.
     """
 
-    node_fields = {
+    node_fields: Dict[Tuple[str, Any]] = {
         "id": (
             str,
             Field(..., description="Name or human-readable unique identifier."),

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -300,7 +300,7 @@ def create_simple_model(
             """A single property consisting of key and value"""
 
             key: str = optional_enum_field(
-                node_properties, description="Property key.", input_type="property"
+                node_properties_mapped, description="Property key.", input_type="property"
             )
             value: str = Field(..., description="value")
 


### PR DESCRIPTION
Add support for simple node properties in llm graph transformer.

Linter and dynamic pydantic classes aren't friends, hence I added two ignores