### PR TITLE
langchain: update use of predict_and_parse in LLMChainFilter

### DIFF
--- a/libs/langchain/langchain/retrievers/document_compressors/chain_filter.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/chain_filter.py
@@ -1,11 +1,11 @@
 """Filter that uses an LLM to drop documents that aren't relevant to the query."""
 from typing import Any, Callable, Dict, Optional, Sequence
 
+from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import Document
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import BasePromptTemplate, PromptTemplate
 
-from langchain.callbacks.manager import Callbacks
 from langchain.chains import LLMChain
 from langchain.output_parsers.boolean import BooleanOutputParser
 from langchain.retrievers.document_compressors.base import BaseDocumentCompressor

--- a/libs/langchain/langchain/retrievers/document_compressors/chain_filter.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/chain_filter.py
@@ -1,11 +1,11 @@
 """Filter that uses an LLM to drop documents that aren't relevant to the query."""
 from typing import Any, Callable, Dict, Optional, Sequence
 
-from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import Document
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import BasePromptTemplate, PromptTemplate
 
+from langchain.callbacks.manager import Callbacks
 from langchain.chains import LLMChain
 from langchain.output_parsers.boolean import BooleanOutputParser
 from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
@@ -47,9 +47,10 @@ class LLMChainFilter(BaseDocumentCompressor):
         filtered_docs = []
         for doc in documents:
             _input = self.get_input(query, doc)
-            include_doc = self.llm_chain.predict_and_parse(
-                **_input, callbacks=callbacks
-            )
+            output_dict = self.llm_chain.invoke(_input, config={"callbacks": callbacks})
+            output = output_dict[self.llm_chain.output_key]
+            if self.llm_chain.prompt.output_parser is not None:
+                include_doc = self.llm_chain.prompt.output_parser.parse(output)
             if include_doc:
                 filtered_docs.append(doc)
         return filtered_docs


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/20130

Removes deprecation warnings in docs here: https://python.langchain.com/docs/modules/data_connection/retrievers/contextual_compression/

Tested using the same docs notebook + existing integration test.