### PR TITLE
docs: fix typo in text

### DIFF
--- a/docs/docs/modules/agents/index.ipynb
+++ b/docs/docs/modules/agents/index.ipynb
@@ -44,7 +44,7 @@
     "Agents have a lot of related functionality! Check out comprehensive guides including:\n",
     "\n",
     "- [Building a custom agent](/docs/modules/agents/how_to/custom_agent)\n",
-    "- [Streaming (of both intermediate steps and tokens](/docs/modules/agents/how_to/streaming)\n",
+    "- [Streaming (of both intermediate steps and tokens)](/docs/modules/agents/how_to/streaming)\n",
     "- [Building an agent that returns structured output](/docs/modules/agents/how_to/agent_structured)\n",
     "- Lots functionality around using AgentExecutor, including: [using it as an iterator](/docs/modules/agents/how_to/agent_iter), [handle parsing errors](/docs/modules/agents/how_to/handle_parsing_errors), [returning intermediate steps](/docs/modules/agents/how_to/intermediate_steps), [capping the max number of iterations](/docs/modules/agents/how_to/max_iterations), and [timeouts for agents](/docs/modules/agents/how_to/max_time_limit)"
    ]


### PR DESCRIPTION
**Description:** The previous text had an unclosed parenthesis, this fix adds the closing parenthesis