### PR TITLE
[Bugfix] Make ObjectId JSON-serializable on generation

### DIFF
--- a/libs/partners/mongodb/langchain_mongodb/vectorstores.py
+++ b/libs/partners/mongodb/langchain_mongodb/vectorstores.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import math
 from importlib.metadata import version
 from typing import (
     Any,
@@ -17,6 +16,7 @@ from typing import (
 )
 
 import numpy as np
+from bson import ObjectId
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
@@ -215,6 +215,10 @@ class MongoDBAtlasVectorSearch(VectorStore):
         for res in cursor:
             text = res.pop(self._text_key)
             score = res.pop("score")
+            # Make every ObjectId found JSON-Serializable
+            for key, value in res.items():
+                if isinstance(value, ObjectId):
+                    key[value] = {"$oid": str(value)}
             docs.append((Document(page_content=text, metadata=res), score))
         return docs
 

--- a/libs/partners/mongodb/langchain_mongodb/vectorstores.py
+++ b/libs/partners/mongodb/langchain_mongodb/vectorstores.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 import numpy as np
-from bson import ObjectId
+from bson import ObjectId, json_util
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
@@ -211,13 +211,23 @@ class MongoDBAtlasVectorSearch(VectorStore):
             pipeline.extend(post_filter_pipeline)
         cursor = self._collection.aggregate(pipeline)  # type: ignore[arg-type]
         docs = []
+
+        def _make_serializable(obj: Dict[str, Any]) -> None:
+            for k, v in obj.items():
+                if isinstance(v, dict):
+                    _make_serializable(v)
+                elif isinstance(v, list) and v and isinstance(v[0], ObjectId):
+                    obj[k] = [json_util.default(item) for item in v]
+                elif isinstance(v, ObjectId):
+                    obj[k] = json_util.default(v)
+
         for res in cursor:
             text = res.pop(self._text_key)
             score = res.pop("score")
             # Make every ObjectId found JSON-Serializable
-            for key, value in res.items():
-                if isinstance(value, ObjectId):
-                    res[key] = {"$oid": str(value)}
+            # following format used in bson.json_util.loads
+            # e.g. loads('{"_id": {"$oid": "664..."}}') == {'_id': ObjectId('664..')} # noqa: E501
+            _make_serializable(res)
             docs.append((Document(page_content=text, metadata=res), score))
         return docs
 

--- a/libs/partners/mongodb/langchain_mongodb/vectorstores.py
+++ b/libs/partners/mongodb/langchain_mongodb/vectorstores.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_INSERT_BATCH_SIZE = 100
 
+
 class MongoDBAtlasVectorSearch(VectorStore):
     """`MongoDB Atlas Vector Search` vector store.
 
@@ -161,7 +162,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
                 texts_batch = []
                 metadatas_batch = []
         if texts_batch:
-            result_ids.extend(self._insert_texts(texts_batch, metadatas_batch))  # type: ignore
+            result_ids.extend(self._insert_texts(texts_batch, metadatas_batch))
         return result_ids
 
     def _insert_texts(self, texts: List[str], metadatas: List[Dict[str, Any]]) -> List:
@@ -216,7 +217,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
             # Make every ObjectId found JSON-Serializable
             for key, value in res.items():
                 if isinstance(value, ObjectId):
-                    key[value] = {"$oid": str(value)}
+                    res[key] = {"$oid": str(value)}
             docs.append((Document(page_content=text, metadata=res), score))
         return docs
 

--- a/libs/partners/mongodb/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/mongodb/tests/unit_tests/test_vectorstores.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional
+from json import dumps, loads
 
 import pytest
 from langchain_core.documents import Document
@@ -75,6 +76,8 @@ class TestMongoDBAtlasVectorSearch:
         output = vectorstore.similarity_search("", k=1)
         assert output[0].page_content == page_content
         assert output[0].metadata.get("c") == metadata
+        assert loads(dumps(output[0].page_content)) == output[0].page_content
+        assert loads(dumps(output[0].metadata)) == output[0].metadata
 
     def test_from_documents(
         self, embedding_openai: Embeddings, collection: MockCollection

--- a/libs/partners/mongodb/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/mongodb/tests/unit_tests/test_vectorstores.py
@@ -2,6 +2,7 @@ from json import dumps, loads
 from typing import Any, Optional
 
 import pytest
+from bson import ObjectId, json_util
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from pymongo.collection import Collection
@@ -79,6 +80,8 @@ class TestMongoDBAtlasVectorSearch:
         # Validate the ObjectId provided is json serializable
         assert loads(dumps(output[0].page_content)) == output[0].page_content
         assert loads(dumps(output[0].metadata)) == output[0].metadata
+        json_metadata = dumps(output[0].metadata)  # normal json.dumps
+        assert isinstance(json_util.loads(json_metadata)["_id"], ObjectId)
 
     def test_from_documents(
         self, embedding_openai: Embeddings, collection: MockCollection

--- a/libs/partners/mongodb/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/mongodb/tests/unit_tests/test_vectorstores.py
@@ -1,5 +1,5 @@
-from typing import Any, Optional
 from json import dumps, loads
+from typing import Any, Optional
 
 import pytest
 from langchain_core.documents import Document
@@ -76,6 +76,7 @@ class TestMongoDBAtlasVectorSearch:
         output = vectorstore.similarity_search("", k=1)
         assert output[0].page_content == page_content
         assert output[0].metadata.get("c") == metadata
+        # Validate the ObjectId provided is json serializable
         assert loads(dumps(output[0].page_content)) == output[0].page_content
         assert loads(dumps(output[0].metadata)) == output[0].metadata
 

--- a/libs/partners/mongodb/tests/utils.py
+++ b/libs/partners/mongodb/tests/utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import uuid
 from copy import deepcopy
 from typing import Any, Dict, List, Mapping, Optional, cast
 
+from bson import ObjectId
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -162,7 +162,7 @@ class MockCollection(Collection):
 
     def insert_many(self, to_insert: List[Any], *args, **kwargs) -> InsertManyResult:  # type: ignore
         mongodb_inserts = [
-            {"_id": str(uuid.uuid4()), "score": 1, **insert} for insert in to_insert
+            {"_id": ObjectId(), "score": 1, **insert} for insert in to_insert
         ]
         self._data.extend(mongodb_inserts)
         return self._insert_result or InsertManyResult(


### PR DESCRIPTION
Thank you for contributing to LangChain!

- **Description:** MongoDB ObjectId being non-JSON Serializable creates errors in our code generation.
- **Issue:** [#535](https://github.com/langchain-ai/langserve/issues/535)
- **Dependencies:** dbx/python team (@caseyclements, @blink1073 , @shaneharvey, @NoahStapp)
- **Twitter handle:** @mongodb


- [x] **Add tests and docs**: Added a component to the unit test that ensures the resulting metadata from an Vector Serach result is JSON Serializable. 

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/