### PR TITLE
bugfix(community): fix Playwright import paths.

### DIFF
--- a/libs/community/langchain_community/tools/gmail/utils.py
+++ b/libs/community/langchain_community/tools/gmail/utils.py
@@ -69,19 +69,8 @@ def get_gmail_credentials(
 ) -> Credentials:
     """Get credentials."""
     # From https://developers.google.com/gmail/api/quickstart/python
-    Request, Credentials = (
-        guard_import(
-            module_name="google.auth.transport.requests",
-            pip_name="google-auth-httplib2",
-        ).Request,
-        guard_import(
-            module_name="google.oauth2.credentials", pip_name="google-auth-httplib2"
-        ).Credentials,
-    )
-
-    InstalledAppFlow = guard_import(
-        module_name="google_auth_oauthlib.flow", pip_name="google-auth-oauthlib"
-    ).InstalledAppFlow
+    Request, Credentials = import_google()
+    InstalledAppFlow = import_installed_app_flow()
     creds = None
     scopes = scopes or DEFAULT_SCOPES
     token_file = token_file or DEFAULT_CREDS_TOKEN_FILE
@@ -114,9 +103,7 @@ def build_resource_service(
 ) -> Resource:
     """Build a Gmail service."""
     credentials = credentials or get_gmail_credentials()
-    builder = guard_import(
-        module_name="googleapiclient.discovery", pip_name="google-api-python-client"
-    ).build
+    builder = import_googleapiclient_resource_builder()
     return builder(service_name, service_version, credentials=credentials)
 
 

--- a/libs/community/langchain_community/tools/playwright/base.py
+++ b/libs/community/langchain_community/tools/playwright/base.py
@@ -27,8 +27,8 @@ def lazy_import_playwright_browsers() -> Tuple[Type[AsyncBrowser], Type[SyncBrow
             AsyncBrowser and SyncBrowser classes.
     """
     return (
-        guard_import(module_name="playwright.async_api").AsyncBrowser,
-        guard_import(module_name="playwright.sync_api").SyncBrowser,
+        guard_import(module_name="playwright.async_api").Browser,
+        guard_import(module_name="playwright.sync_api").Browser,
     )
 
 
@@ -41,8 +41,7 @@ class BaseBrowserTool(BaseTool):
     @root_validator
     def validate_browser_provided(cls, values: dict) -> dict:
         """Check that the arguments are valid."""
-        guard_import(module_name="playwright.async_api").AsyncBrowser
-        guard_import(module_name="playwright.sync_api").SyncBrowser
+        lazy_import_playwright_browsers()
         if values.get("async_browser") is None and values.get("sync_browser") is None:
             raise ValueError("Either async_browser or sync_browser must be specified.")
         return values
@@ -54,6 +53,5 @@ class BaseBrowserTool(BaseTool):
         async_browser: Optional[AsyncBrowser] = None,
     ) -> BaseBrowserTool:
         """Instantiate the tool."""
-        guard_import(module_name="playwright.async_api").AsyncBrowser
-        guard_import(module_name="playwright.sync_api").SyncBrowser
+        lazy_import_playwright_browsers()
         return cls(sync_browser=sync_browser, async_browser=async_browser)

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -200,7 +200,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"
-playwright = "^1.43.0"
+playwright = "^1.28.0"
 setuptools = "^67.6.1"
 langchain-core = {path = "../core", develop = true}
 langchain-community = {path = "../community", develop = true}

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -200,7 +200,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"
-playwright = "^1.28.0"
+playwright = "^1.43.0"
 setuptools = "^67.6.1"
 langchain-core = {path = "../core", develop = true}
 langchain-community = {path = "../community", develop = true}


### PR DESCRIPTION
- **Description:**  Fix import class name exporeted from 'playwright.async_api' and 'playwright.sync_api' to match the correct name in playwright tool. Change import from inline guard_import to helper function that calls guard_import to make code more readable in gmail tool. Upgrade playwright version to 1.43.0
- **Issue:** #21354
 - **Dependencies:** upgrade playwright version(this is not required for the bugfix itself, just trying to keep dependencies fresh. I can remove the playwright version upgrade if you want.)