### PR TITLE
langchain-robocorp: remove toolkit return content max length

### DIFF
--- a/libs/partners/robocorp/langchain_robocorp/toolkits.py
+++ b/libs/partners/robocorp/langchain_robocorp/toolkits.py
@@ -27,7 +27,6 @@ from langchain_robocorp._prompts import (
     API_CONTROLLER_PROMPT,
 )
 
-MAX_RESPONSE_LENGTH = 5000
 LLM_TRACE_HEADER = "X-action-trace"
 
 
@@ -241,6 +240,6 @@ class ActionServerToolkit(BaseModel):
         url = urljoin(self.url, endpoint)
 
         response = requests.post(url, headers=headers, data=json.dumps(data))
-        output = response.text[:MAX_RESPONSE_LENGTH]
+        output = response.text
 
         return output

--- a/libs/partners/robocorp/langchain_robocorp/toolkits.py
+++ b/libs/partners/robocorp/langchain_robocorp/toolkits.py
@@ -240,6 +240,5 @@ class ActionServerToolkit(BaseModel):
         url = urljoin(self.url, endpoint)
 
         response = requests.post(url, headers=headers, data=json.dumps(data))
-        output = response.text
 
-        return output
+        return response.text


### PR DESCRIPTION
Robocorp (action server) toolkit had a limitation that the content length returned by the tool was always cut to max 5000 chars. This was from the time when context windows were much more limited.

This PR removes the limitation. Whatever the underlying tool provides gets sent back to the agent.

As the robocorp toolkit no longer restricts the content, the implication is that either the Action (tool) developer or the agent developer needs to be aware of potentially oversized tool responses. Our point of view is this should be the agent developer's responsibility, them being in control of the use case and aware of the context window the LLM has.