### PR TITLE
docs: api reference build fix

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -375,8 +375,9 @@ def main(dirs: Optional[list] = None) -> None:
             try:
                 _build_rst_file(package_name=dir_)
             except FileNotFoundError as e:
-                print(f"Error building API reference for {dir_} package. Error: {e}")
-                pass
+                raise FileNotFoundError(
+                    f"Error building API reference" f" for {dir_} package. Error: {e}"
+                )
     print("API reference files built.")
 
 

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -314,6 +314,7 @@ def _package_dir(package_name: str = "langchain") -> Path:
         "core",
         "cli",
         "text-splitters",
+        "standard-tests",
     ):
         return ROOT_DIR / "libs" / package_name / _package_namespace(package_name)
     else:
@@ -338,7 +339,7 @@ def _get_package_version(package_dir: Path) -> str:
             "the package is missing a pyproject.toml file which should be added."
             "Aborting the build."
         )
-        exit(1)
+        raise e
     return pyproject["tool"]["poetry"]["version"]
 
 
@@ -370,8 +371,12 @@ def main(dirs: Optional[list] = None) -> None:
             print("Skipping dir:", dir_)
             continue
         else:
-            print("Building package:", dir_)
-            _build_rst_file(package_name=dir_)
+            print("Building API Reference for the package:", dir_)
+            try:
+                _build_rst_file(package_name=dir_)
+            except FileNotFoundError as e:
+                print(f"Error building API reference for {dir_} package. Error: {e}")
+                pass
     print("API reference files built.")
 
 


### PR DESCRIPTION
Issues: 1. The `create_api_rst.py` fails on the `standard-tests` directory. 2. An error in building one package stops all build. Build should proceed with building the next package.
Fix: added `standard-tests` directory to the exception list. Added error handling for #2
