### PR TITLE
community: add BytesIO support to PdfLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -94,6 +94,9 @@ class BasePDFLoader(BaseLoader, ABC):
             headers: Headers to use for GET request to download a file from a web path.
             file_obj: An already open BytesIO object containing the PDF file.
         """
+        if file_path is None and file_obj is None:
+            raise ValueError("Either file_path or file_obj must be provided.")
+            
         if file_obj is not None:
             self.file_path = None
             self.web_path = None

--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -96,7 +96,7 @@ class BasePDFLoader(BaseLoader, ABC):
         """
         if file_path is None and file_obj is None:
             raise ValueError("Either file_path or file_obj must be provided.")
-            
+
         if file_obj is not None:
             self.file_path = None
             self.web_path = None

--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -5,7 +5,7 @@ import re
 import tempfile
 import time
 from abc import ABC
-from io import StringIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -80,40 +80,58 @@ class BasePDFLoader(BaseLoader, ABC):
         clean up the temporary file after completion.
     """
 
-    def __init__(self, file_path: Union[str, Path], *, headers: Optional[Dict] = None):
-        """Initialize with a file path.
+    def __init__(
+        self,
+        file_path: Union[str, Path, BytesIO] = None,
+        *,
+        headers: Optional[Dict] = None,
+        file_obj: Optional[BytesIO] = None,
+    ):
+        """Initialize with a file path or a file object.
 
         Args:
             file_path: Either a local, S3 or web path to a PDF file.
             headers: Headers to use for GET request to download a file from a web path.
+            file_obj: An already open BytesIO object containing the PDF file.
         """
-        self.file_path = str(file_path)
-        self.web_path = None
-        self.headers = headers
-        if "~" in self.file_path:
-            self.file_path = os.path.expanduser(self.file_path)
+        if file_obj is not None:
+            self.file_path = None
+            self.web_path = None
+            self.file_obj = file_obj
+        else:
+            self.file_path = str(file_path) if file_path else None
+            self.web_path = None
+            self.headers = headers
+            if self.file_path and "~" in self.file_path:
+                self.file_path = os.path.expanduser(self.file_path)
 
-        # If the file is a web path or S3, download it to a temporary file, and use that
-        if not os.path.isfile(self.file_path) and self._is_valid_url(self.file_path):
-            self.temp_dir = tempfile.TemporaryDirectory()
-            _, suffix = os.path.splitext(self.file_path)
-            if self._is_s3_presigned_url(self.file_path):
-                suffix = urlparse(self.file_path).path.split("/")[-1]
-            temp_pdf = os.path.join(self.temp_dir.name, f"tmp{suffix}")
-            self.web_path = self.file_path
-            if not self._is_s3_url(self.file_path):
-                r = requests.get(self.file_path, headers=self.headers)
-                if r.status_code != 200:
-                    raise ValueError(
-                        "Check the url of your file; returned status code %s"
-                        % r.status_code
-                    )
+            # If the file is a web path or S3, download it to a temporary file
+            if (
+                self.file_path
+                and not os.path.isfile(self.file_path)
+                and self._is_valid_url(self.file_path)
+            ):
+                self.temp_dir = tempfile.TemporaryDirectory()
+                _, suffix = os.path.splitext(self.file_path)
+                if self._is_s3_presigned_url(self.file_path):
+                    suffix = urlparse(self.file_path).path.split("/")[-1]
+                temp_pdf = os.path.join(self.temp_dir.name, f"tmp{suffix}")
+                self.web_path = self.file_path
+                if not self._is_s3_url(self.file_path):
+                    r = requests.get(self.file_path, headers=self.headers)
+                    if r.status_code != 200:
+                        raise ValueError(
+                            "Check the url of your file; returned status code %s"
+                            % r.status_code
+                        )
 
-                with open(temp_pdf, mode="wb") as f:
-                    f.write(r.content)
-                self.file_path = str(temp_pdf)
-        elif not os.path.isfile(self.file_path):
-            raise ValueError("File path %s is not a valid file or url" % self.file_path)
+                    with open(temp_pdf, mode="wb") as f:
+                        f.write(r.content)
+                    self.file_path = str(temp_pdf)
+            elif self.file_path and not os.path.isfile(self.file_path):
+                raise ValueError(
+                    "File path %s is not a valid file or url" % self.file_path
+                )
 
     def __del__(self) -> None:
         if hasattr(self, "temp_dir"):
@@ -146,7 +164,9 @@ class BasePDFLoader(BaseLoader, ABC):
             return False
 
     @property
-    def source(self) -> str:
+    def source(self) -> Union[str, BytesIO]:
+        if self.file_obj is not None:
+            return self.file_obj
         return self.web_path if self.web_path is not None else self.file_path
 
 

--- a/libs/community/tests/unit_tests/document_loaders/test_pdf.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_pdf.py
@@ -1,10 +1,12 @@
 import io
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, mock_open
 
 from langchain_community.document_loaders.pdf import (
     BasePDFLoader,
 )
+
 
 @pytest.fixture
 def pdf_data():

--- a/libs/community/tests/unit_tests/document_loaders/test_pdf.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_pdf.py
@@ -1,0 +1,37 @@
+import io
+import pytest
+from unittest.mock import patch, mock_open
+
+from langchain_community.document_loaders.pdf import (
+    BasePDFLoader,
+)
+
+@pytest.fixture
+def pdf_data():
+    return b'%PDF-1.4\n%\xc2\xb5\xc2\xb3\n'  # Sample PDF data
+
+def test_base_pdf_loader_with_bytesio(pdf_data):
+    file_obj = io.BytesIO(pdf_data)
+    loader = BasePDFLoader(file_obj=file_obj)
+    assert loader.source == file_obj
+
+def test_base_pdf_loader_with_file_path(pdf_data, tmp_path):
+    file_path = tmp_path / "test.pdf"
+    file_path.write_bytes(pdf_data)
+
+    loader = BasePDFLoader(file_path=str(file_path))
+    assert loader.source == str(file_path)
+
+def test_base_pdf_loader_with_web_path(pdf_data):
+    web_path = "https://example.com/test.pdf"
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = pdf_data
+
+        loader = BasePDFLoader(file_path=web_path)
+        assert loader.source.startswith(loader.temp_dir.name)
+
+def test_base_pdf_loader_with_invalid_path():
+    invalid_path = "invalid_path"
+    with pytest.raises(ValueError):
+        BasePDFLoader(file_path=invalid_path)


### PR DESCRIPTION
If LangChain is added to an existing capability (like Streamlit), sometimes the PDF is only available via upload as a BytesIO object. 


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, hwchase17.
