### PR TITLE
openai[patch]: Standardized openai init params

### DIFF
--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -218,7 +218,7 @@ class ChatOpenAI(BaseChatModel):
     )
     """Timeout for requests to OpenAI completion API. Can be float, httpx.Timeout or 
         None."""
-    max_retries: Optional[int] = Field(default=2)
+    max_retries: int = Field(default=2)
     """Maximum number of retries to make when generating."""
     streaming: bool = False
     """Whether to stream the results or not."""

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -1,4 +1,5 @@
 """OpenAI chat wrapper."""
+
 from __future__ import annotations
 
 import logging
@@ -217,7 +218,7 @@ class ChatOpenAI(BaseChatModel):
     )
     """Timeout for requests to OpenAI completion API. Can be float, httpx.Timeout or 
         None."""
-    max_retries: int = 2
+    max_retries: Optional[int] = Field(default=2)
     """Maximum number of retries to make when generating."""
     streaming: bool = False
     """Whether to stream the results or not."""

--- a/libs/community/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/community/tests/unit_tests/chat_models/test_openai.py
@@ -1,4 +1,5 @@
 """Test OpenAI Chat API wrapper."""
+
 import json
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -14,13 +15,21 @@ from langchain_core.messages import (
 from langchain_community.adapters.openai import convert_dict_to_message
 from langchain_community.chat_models.openai import ChatOpenAI
 
-
 @pytest.mark.requires("openai")
 def test_openai_model_param() -> None:
-    llm = ChatOpenAI(model="foo", openai_api_key="foo")  # type: ignore[call-arg]
-    assert llm.model_name == "foo"
-    llm = ChatOpenAI(model_name="foo", openai_api_key="foo")  # type: ignore[call-arg]
-    assert llm.model_name == "foo"
+    test_cases = [
+        {"model_name": "foo", "openai_api_key": "foo"},
+        {"model": "foo", "openai_api_key": "foo"},
+        {"model_name": "foo", "api_key": "foo"},
+        {"model_name": "foo", "openai_api_key": "foo", "max_retries": 2}
+    ]
+    
+    for case in test_cases:
+        llm = ChatOpenAI(**case)
+        assert llm.model_name == "foo", "Model name should be 'foo'"
+        assert llm.openai_api_key == "foo", "API key should be 'foo'"
+        assert hasattr(llm, 'max_retries'), "max_retries attribute should exist"
+        assert llm.max_retries == 2, "max_retries default should be set to 2"
 
 
 def test_function_message_dict_to_function_message() -> None:


### PR DESCRIPTION
community:openai[patch]: standardize init args

* updated `max_retries` with Pydantic Field, updated the unit test.

Related to #20085  https://github.com/langchain-ai/langchain/issues/20085