### PR TITLE
Simple fix, to set "meta" as provider in Bedrock.py (for meta models as Llama)

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -14,6 +14,7 @@ from typing import (
     Tuple,
 )
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -339,10 +340,10 @@ class BedrockBase(BaseModel, ABC):
     provider_stop_sequence_key_name_map: Mapping[str, str] = {
         "anthropic": "stop_sequences",
         "amazon": "stopSequences",
-        "meta": "stop_sequences",
         "ai21": "stop_sequences",
         "cohere": "stop_sequences",
-        "mistral": "stop_sequences",
+        "mistral": "stop",
+        "meta": "stop_sequences",
     }
 
     guardrails: Optional[Mapping[str, Any]] = {
@@ -427,7 +428,7 @@ class BedrockBase(BaseModel, ABC):
             values["client"] = session.client("bedrock-runtime", **client_params)
 
         except ImportError:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Could not import boto3 python package. "
                 "Please install it with `pip install boto3`."
             )
@@ -715,6 +716,9 @@ class BedrockBase(BaseModel, ABC):
                 run_manager.on_llm_new_token(chunk.text, chunk=chunk)  # type: ignore[unused-coroutine]
 
 
+@deprecated(
+    since="0.0.34", removal="0.3", alternative_import="langchain_aws.BedrockLLM"
+)
 class Bedrock(LLM, BedrockBase):
     """Bedrock models.
 
@@ -829,7 +833,7 @@ class Bedrock(LLM, BedrockBase):
         Example:
             .. code-block:: python
 
-                response = llm("Tell me a joke.")
+                response = llm.invoke("Tell me a joke.")
         """
 
         if self.streaming:


### PR DESCRIPTION
- [ ] **PR title**: "community: added "meta" as provider in Bedrock.py"

- [ ] **PR message**: 
    - **Description:** added "meta" as provider in Bedrock.py, it resolves input formatting problems.
    - **Issue:** None
    - **Dependencies:** None

I'm using this change in a personal project, to use "meta.llama3-70b-instruct-v1:0" model with Bedrock.

I hope this can help in future develops.