### PR TITLE
fix(community): allow support for disabling max_tokens args

### DIFF
--- a/libs/community/langchain_community/chat_models/litellm.py
+++ b/libs/community/langchain_community/chat_models/litellm.py
@@ -191,7 +191,7 @@ class ChatLiteLLM(BaseChatModel):
     n: int = 1
     """Number of chat completions to generate for each prompt. Note that the API may
        not return the full n completions if duplicates are generated."""
-    max_tokens: int = 256
+    max_tokens: Optional[int] = None
 
     max_retries: int = 6
 


### PR DESCRIPTION
This PR fixes an issue with not able to use unlimited/infinity tokens from the respective provider for the LiteLLM provider.

This is an issue when working in an agent environment that the token usage can drastically increase beyond the initial value set causing unexpected behavior. 