### PR TITLE
infra: codespell in ci v1 branch

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@ name: CI / cd . / make spell_check
 
 on:
   push:
-    branches: [master]
+    branches: [master, v0.1]
   pull_request:
-    branches: [master]
+    branches: [master, v0.1]
 
 permissions:
   contents: read

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -70,5 +70,14 @@ md-sync:
 
 build: install-py-deps generate-files copy-infra render md-sync
 
+vercel-build: install-vercel-deps build
+	rm -rf docs
+	mv $(OUTPUT_NEW_DOCS_DIR) docs
+	rm -rf build
+	yarn run docusaurus build
+	mv build v0.1
+	mkdir build
+	mv v0.1 build
+
 start:
 	cd $(OUTPUT_NEW_DIR) && yarn && yarn start --port=$(PORT)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -78,6 +78,7 @@ vercel-build: install-vercel-deps build
 	mv build v0.1
 	mkdir build
 	mv v0.1 build
+	mv build/v0.1/404.html build
 
 start:
 	cd $(OUTPUT_NEW_DIR) && yarn && yarn start --port=$(PORT)

--- a/docs/docs/expression_language/how_to/decorator.ipynb
+++ b/docs/docs/expression_language/how_to/decorator.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Create a runnable with the @chain decorator\n",
     "\n",
-    "You can also turn an arbitrary function into a chain by adding a `@chain` decorator. This is functionaly equivalent to wrapping in a [`RunnableLambda`](/docs/expression_language/primitives/functions).\n",
+    "You can also turn an arbitrary function into a chain by adding a `@chain` decorator. This is functionally equivalent to wrapping in a [`RunnableLambda`](/docs/expression_language/primitives/functions).\n",
     "\n",
-    "This will have the benefit of improved observability by tracing your chain correctly. Any calls to runnables inside this function will be traced as nested childen.\n",
+    "This will have the benefit of improved observability by tracing your chain correctly. Any calls to runnables inside this function will be traced as nested children.\n",
     "\n",
     "It will also allow you to use this as any other runnable, compose it in chain, etc.\n",
     "\n",

--- a/docs/docs/get_started/introduction.mdx
+++ b/docs/docs/get_started/introduction.mdx
@@ -13,12 +13,13 @@ LangChain simplifies every stage of the LLM application lifecycle:
 - **Deployment**: Turn any chain into an API with [LangServe](/docs/langserve).
 
 import ThemedImage from '@theme/ThemedImage';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 <ThemedImage
   alt="Diagram outlining the hierarchical organization of the LangChain framework, displaying the interconnected parts across multiple layers."
   sources={{
-    light: '/svg/langchain_stack.svg',
-    dark: '/svg/langchain_stack_dark.svg',
+    light: useBaseUrl('/svg/langchain_stack.svg'),
+    dark: useBaseUrl('/svg/langchain_stack_dark.svg'),
   }}
   title="LangChain Framework Overview"
 />

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -120,11 +120,10 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      // TODO(erick): enable this when 0.2 docs are ready for banner
-      // announcementBar: {
-      //   content: 'LangChain v0.2 is coming soon! Preview the new docs <a href="/v0.2/docs/introduction/">here</a>.',
-      //   isCloseable: true,
-      // },
+      announcementBar: {
+        content: 'LangChain v0.2 is coming soon! Preview the new docs <a href="/v0.2/docs/introduction/">here</a>.',
+        isCloseable: true,
+      },
       docs: {
         sidebar: {
           hideable: true,

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,7 +18,7 @@ const config = {
   url: "https://python.langchain.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  baseUrl: "/v0.1/",
   trailingSlash: true,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
@@ -118,6 +118,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      // TODO(erick): enable this when 0.2 docs are ready for banner
+      // announcementBar: {
+      //   content: 'LangChain v0.2 is coming soon! Preview the new docs <a href="/v0.2/docs/introduction/">here</a>.',
+      //   isCloseable: true,
+      // },
       docs: {
         sidebar: {
           hideable: true,

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -9,6 +9,8 @@ require("dotenv").config();
 const baseLightCodeBlockTheme = require("prism-react-renderer/themes/vsLight");
 const baseDarkCodeBlockTheme = require("prism-react-renderer/themes/vsDark");
 
+const baseUrl = "/v0.1/";
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "🦜️🔗 LangChain",
@@ -18,7 +20,7 @@ const config = {
   url: "https://python.langchain.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/v0.1/",
+  baseUrl: baseUrl,
   trailingSlash: true,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
@@ -323,7 +325,7 @@ const config = {
     }),
 
   scripts: [
-    "/js/google_analytics.js",
+    baseUrl + "js/google_analytics.js",
     {
       src: "https://www.googletagmanager.com/gtag/js?id=G-9B66JQQH2F",
       async: true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "rm -rf ./docs/api && docusaurus start",
-    "build": "bash vercel_build.sh && rm -rf ./build && docusaurus build",
+    "build": "make vercel-build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -243,3 +243,17 @@ nav, h1, h2, h3, h4 {
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
     no-repeat;
 }
+
+.announcementBar_node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module {
+  height:40px !important;
+  font-size: 20px !important;
+}
+
+[data-theme='dark'] .announcementBar_node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module {
+  background-color: #1b1b1b;
+  color: #fff;
+}
+
+[data-theme='dark'] .announcementBar_node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module button {
+  color: #fff;
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -244,16 +244,16 @@ nav, h1, h2, h3, h4 {
     no-repeat;
 }
 
-.announcementBar_node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module {
+div[class^=announcementBar_] {
   height:40px !important;
   font-size: 20px !important;
 }
 
-[data-theme='dark'] .announcementBar_node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module {
+[data-theme='dark'] div[class^=announcementBar_] {
   background-color: #1b1b1b;
   color: #fff;
 }
 
-[data-theme='dark'] .announcementBar_node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module button {
+[data-theme='dark'] div[class^=announcementBar_] button {
   color: #fff;
 }

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -9,7 +9,8 @@
 
 import React from "react";
 import { Redirect } from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 export default function Home() {
-  return <Redirect to="docs/get_started/introduction" />;
+  return <Redirect to={useBaseUrl("/docs/get_started/introduction")} />;
 }

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -14,7 +14,7 @@
       "destination": "/v0.1/docs/:path*/"
     },
     {
-      "source": "(/?)",
+      "source": "(/?)|(/v0.1/?)",
       "destination": "/v0.1/docs/get_started/introduction/"
     },
     {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -14,7 +14,7 @@
       "destination": "/v0.1/docs/:path*/"
     },
     {
-      "source": "(/?)|(/v0.1/?)",
+      "source": "(/?)",
       "destination": "/v0.1/docs/get_started/introduction/"
     },
     {

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,1198 +1,1218 @@
 {
+  "buildCommand": "yarn build",
+  "outputDirectory": "build",
   "trailingSlash": true,
+  "rewrites": [
+    {
+      "source": "/v0.2/:path(.*/?)*",
+      "destination": "https://langchain-v02.vercel.app/v0.2/:path*"
+    }
+  ],
   "redirects": [
     {
-      "source": "/docs/integrations/llms/titan_takeoff_pro",
-      "destination": "/docs/integrations/llms/titan_takeoff"
+      "source": "/docs/:path*(/?)",
+      "destination": "/v0.1/docs/:path*/"
     },
     {
-      "source": "/docs/integrations/providers/optimum_intel(/?)",
-      "destination": "/docs/integrations/providers/intel/"
+      "source": "(/?)",
+      "destination": "/v0.1/docs/get_started/introduction/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/diffbot_graphtransformer(/?)",
-      "destination": "/docs/integrations/graphs/diffbot/"
+      "source": "/v0.1(/?)",
+      "destination": "/v0.1/docs/get_started/introduction/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_arangodb_qa(/?)",
-      "destination": "/docs/integrations/graphs/arangodb/"
+      "source": "/v0.1/docs/integrations/llms/titan_takeoff_pro",
+      "destination": "/v0.1/docs/integrations/llms/titan_takeoff"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_cypher_qa(/?)",
-      "destination": "/docs/integrations/graphs/neo4j_cypher/"
+      "source": "/v0.1/docs/integrations/providers/optimum_intel(/?)",
+      "destination": "/v0.1/docs/integrations/providers/intel/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_falkordb_qa(/?)",
-      "destination": "/docs/integrations/graphs/falkordb/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/diffbot_graphtransformer(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/diffbot/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_gremlin_cosmosdb_qa(/?)",
-      "destination": "/docs/integrations/graphs/azure_cosmosdb_gremlin/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_arangodb_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/arangodb/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_hugegraph_qa(/?)",
-      "destination": "/docs/integrations/graphs/hugegraph/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_cypher_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/neo4j_cypher/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_kuzu_qa(/?)",
-      "destination": "/docs/integrations/graphs/kuzu_db/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_falkordb_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/falkordb/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_memgraph_qa(/?)",
-      "destination": "/docs/integrations/graphs/memgraph/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_gremlin_cosmosdb_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/azure_cosmosdb_gremlin/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_nebula_qa(/?)",
-      "destination": "/docs/integrations/graphs/nebula_graph/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_hugegraph_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/hugegraph/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_networkx_qa(/?)",
-      "destination": "/docs/integrations/graphs/networkx/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_kuzu_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/kuzu_db/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_ontotext_graphdb_qa(/?)",
-      "destination": "/docs/integrations/graphs/ontotext/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_memgraph_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/memgraph/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/graph_sparql_qa(/?)",
-      "destination": "/docs/integrations/graphs/rdflib_sparql/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_nebula_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/nebula_graph/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/neptune_cypher_qa(/?)",
-      "destination": "/docs/integrations/graphs/amazon_neptune_open_cypher/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_networkx_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/networkx/"
     },
     {
-      "source": "/docs/use_cases/graph/integrations/neptune_sparql_qa(/?)",
-      "destination": "/docs/integrations/graphs/amazon_neptune_sparql/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_ontotext_graphdb_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/ontotext/"
     },
     {
-      "source": "/docs/integrations/providers/facebook_chat(/?)",
-      "destination": "/docs/integrations/providers/facebook/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/graph_sparql_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/rdflib_sparql/"
     },
     {
-      "source": "/docs/integrations/providers/facebook_faiss(/?)",
-      "destination": "/docs/integrations/providers/facebook/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/neptune_cypher_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/amazon_neptune_open_cypher/"
     },
     {
-      "source": "/docs/use_cases/graph/diffbot_graphtransformer(/?)",
-      "destination": "/docs/use_cases/graph/integrations/diffbot_graphtransformer/"
+      "source": "/v0.1/docs/use_cases/graph/integrations/neptune_sparql_qa(/?)",
+      "destination": "/v0.1/docs/integrations/graphs/amazon_neptune_sparql/"
     },
     {
-      "source": "/docs/use_cases/graph/graph_arangodb_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_arangodb_qa/"
+      "source": "/v0.1/docs/integrations/providers/facebook_chat(/?)",
+      "destination": "/v0.1/docs/integrations/providers/facebook/"
+    },
+    {
+      "source": "/v0.1/docs/integrations/providers/facebook_faiss(/?)",
+      "destination": "/v0.1/docs/integrations/providers/facebook/"
+    },
+    {
+      "source": "/v0.1/docs/use_cases/graph/diffbot_graphtransformer(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/diffbot_graphtransformer/"
+    },
+    {
+      "source": "/v0.1/docs/use_cases/graph/graph_arangodb_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_arangodb_qa/"
     },
     {
       "source":  "/docs/use_cases/graph/graph_cypher_qa(/?)",
       "destination":  "/docs/use_cases/graph/integrations/graph_cypher_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_falkordb_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_falkordb_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_falkordb_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_falkordb_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_gremlin_cosmosdb_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_gremlin_cosmosdb_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_gremlin_cosmosdb_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_gremlin_cosmosdb_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_hugegraph_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_hugegraph_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_hugegraph_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_hugegraph_qa"
     },
     {
       "source":  "/docs/use_cases/graph/graph_kuzu_qa(/?)",
       "destination":  "/docs/use_cases/graph/integrations/graph_kuzu_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_memgraph_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_memgraph_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_memgraph_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_memgraph_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_nebula_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_nebula_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_nebula_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_nebula_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_networkx_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_networkx_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_networkx_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_networkx_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_ontotext_graphdb_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_ontotext_graphdb_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_ontotext_graphdb_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_ontotext_graphdb_qa"
     },
     {
-      "source": "/docs/use_cases/graph/graph_sparql_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/graph_sparql_qa"
+      "source": "/v0.1/docs/use_cases/graph/graph_sparql_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/graph_sparql_qa"
     },
     {
-      "source": "/docs/use_cases/graph/neptune_cypher_qa.ipynb(/?)",
-      "destination": "/docs/use_cases/graph/integrations/neptune_cypher_qa.ipynb"
+      "source": "/v0.1/docs/use_cases/graph/neptune_cypher_qa.ipynb(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/neptune_cypher_qa.ipynb"
     },
     {
-      "source": "/docs/use_cases/graph/neptune_sparql_qa(/?)",
-      "destination": "/docs/use_cases/graph/integrations/neptune_sparql_qa"
+      "source": "/v0.1/docs/use_cases/graph/neptune_sparql_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/integrations/neptune_sparql_qa"
     },
     {
-      "source": "/docs/integrations/memory/google_cloud_sql_mssql(/?)",
-      "destination": "/docs/integrations/memory/google_sql_mssql"
+      "source": "/v0.1/docs/integrations/memory/google_cloud_sql_mssql(/?)",
+      "destination": "/v0.1/docs/integrations/memory/google_sql_mssql"
     },
     {
-      "source": "/docs/integrations/memory/google_cloud_sql_mysql(/?)",
-      "destination": "/docs/integrations/memory/google_sql_mysql"
+      "source": "/v0.1/docs/integrations/memory/google_cloud_sql_mysql(/?)",
+      "destination": "/v0.1/docs/integrations/memory/google_sql_mysql"
     },
     {
-      "source": "/docs/integrations/memory/google_cloud_sql_pg(/?)",
-      "destination": "/docs/integrations/memory/google_sql_pg"
+      "source": "/v0.1/docs/integrations/memory/google_cloud_sql_pg(/?)",
+      "destination": "/v0.1/docs/integrations/memory/google_sql_pg"
     },
     {
-      "source": "/docs/integrations/memory/google_datastore(/?)",
-      "destination": "/docs/integrations/memory/google_firestore_datastore"
+      "source": "/v0.1/docs/integrations/memory/google_datastore(/?)",
+      "destination": "/v0.1/docs/integrations/memory/google_firestore_datastore"
     },
     {
-      "source": "/docs/integrations/llms/huggingface_textgen_inference(/?)",
-      "destination": "/docs/integrations/llms/huggingface_endpoint"
+      "source": "/v0.1/docs/integrations/llms/huggingface_textgen_inference(/?)",
+      "destination": "/v0.1/docs/integrations/llms/huggingface_endpoint"
     },
     {
-      "source": "/docs/integrations/llms/huggingface_hub(/?)",
-      "destination": "/docs/integrations/llms/huggingface_endpoint"
+      "source": "/v0.1/docs/integrations/llms/huggingface_hub(/?)",
+      "destination": "/v0.1/docs/integrations/llms/huggingface_endpoint"
     },
     {
-      "source": "/docs/integrations/llms/bigdl(/?)",
-      "destination": "/docs/integrations/llms/ipex_llm"
+      "source": "/v0.1/docs/integrations/llms/bigdl(/?)",
+      "destination": "/v0.1/docs/integrations/llms/ipex_llm"
     },
     {
-      "source": "/docs/integrations/llms/watsonxllm(/?)",
-      "destination": "/docs/integrations/llms/ibm_watsonx"
+      "source": "/v0.1/docs/integrations/llms/watsonxllm(/?)",
+      "destination": "/v0.1/docs/integrations/llms/ibm_watsonx"
     },
     {
-      "source": "/docs/integrations/llms/pai_eas_endpoint(/?)",
-      "destination": "/docs/integrations/llms/alibabacloud_pai_eas_endpoint"
+      "source": "/v0.1/docs/integrations/llms/pai_eas_endpoint(/?)",
+      "destination": "/v0.1/docs/integrations/llms/alibabacloud_pai_eas_endpoint"
     },
     {
-      "source": "/docs/integrations/vectorstores/hanavector(/?)",
-      "destination": "/docs/integrations/vectorstores/sap_hanavector"
+      "source": "/v0.1/docs/integrations/vectorstores/hanavector(/?)",
+      "destination": "/v0.1/docs/integrations/vectorstores/sap_hanavector"
     },
     {
-      "source": "/docs/use_cases/qa_structured/sql(/?)",
-      "destination": "/docs/use_cases/sql/"
+      "source": "/v0.1/docs/use_cases/qa_structured/sql(/?)",
+      "destination": "/v0.1/docs/use_cases/sql/"
     },
     {
-      "source": "/docs/contributing/packages(/?)",
-      "destination": "/docs/packages"
+      "source": "/v0.1/docs/contributing/packages(/?)",
+      "destination": "/v0.1/docs/packages"
     },
     {
-      "source": "/docs/community(/?)",
-      "destination": "/docs/contributing"
+      "source": "/v0.1/docs/community(/?)",
+      "destination": "/v0.1/docs/contributing"
     },
     {
-      "source": "/docs/modules/chains/(.+)(/?)",
-      "destination": "/docs/modules/chains"
+      "source": "/v0.1/docs/modules/chains/(.+)(/?)",
+      "destination": "/v0.1/docs/modules/chains"
     },
     {
-      "source": "/docs/modules/agents/how_to/custom_llm_agent(/?)",
-      "destination": "/docs/modules/agents/how_to/custom_agent"
+      "source": "/v0.1/docs/modules/agents/how_to/custom_llm_agent(/?)",
+      "destination": "/v0.1/docs/modules/agents/how_to/custom_agent"
     },
     {
-      "source": "/docs/modules/agents/how_to/custom-functions-with-openai-functions-agent(/?)",
-      "destination": "/docs/modules/agents/how_to/custom_agent"
+      "source": "/v0.1/docs/modules/agents/how_to/custom-functions-with-openai-functions-agent(/?)",
+      "destination": "/v0.1/docs/modules/agents/how_to/custom_agent"
     },
     {
-      "source": "/docs/modules/agents/how_to/custom_llm_chat_agent(/?)",
-      "destination": "/docs/modules/agents/how_to/custom_agent"
+      "source": "/v0.1/docs/modules/agents/how_to/custom_llm_chat_agent(/?)",
+      "destination": "/v0.1/docs/modules/agents/how_to/custom_agent"
     },
     {
-      "source": "/docs/modules/agents/how_to/custom_mrkl_agent(/?)",
-      "destination": "/docs/modules/agents/how_to/custom_agent"
+      "source": "/v0.1/docs/modules/agents/how_to/custom_mrkl_agent(/?)",
+      "destination": "/v0.1/docs/modules/agents/how_to/custom_agent"
     },
     {
-      "source": "/docs/modules/agents/how_to/streaming_stdout_final_only(/?)",
-      "destination": "/docs/modules/agents/how_to/streaming"
+      "source": "/v0.1/docs/modules/agents/how_to/streaming_stdout_final_only(/?)",
+      "destination": "/v0.1/docs/modules/agents/how_to/streaming"
     },
     {
-      "source": "/docs/modules/data_connection/document_transformers/text_splitters(/?)",
-      "destination": "/docs/modules/data_connection/document_transformers/"
+      "source": "/v0.1/docs/modules/data_connection/document_transformers/text_splitters(/?)",
+      "destination": "/v0.1/docs/modules/data_connection/document_transformers/"
     },
     {
-      "source": "/docs/modules/data_connection/document_transformers/text_splitters/:path*(/?)",
-      "destination": "/docs/modules/data_connection/document_transformers/:path*"
+      "source": "/v0.1/docs/modules/data_connection/document_transformers/text_splitters/:path*(/?)",
+      "destination": "/v0.1/docs/modules/data_connection/document_transformers/:path*"
     },
     {
-      "source": "/docs/modules/model_io/prompts/prompt_templates(/?)",
-      "destination": "/docs/modules/model_io/prompts/"
+      "source": "/v0.1/docs/modules/model_io/prompts/prompt_templates(/?)",
+      "destination": "/v0.1/docs/modules/model_io/prompts/"
     },
     {
-      "source": "/docs/modules/model_io/prompts/prompts_pipelining(/?)",
-      "destination": "/docs/modules/model_io/prompts/composition"
+      "source": "/v0.1/docs/modules/model_io/prompts/prompts_pipelining(/?)",
+      "destination": "/v0.1/docs/modules/model_io/prompts/composition"
     },
     {
-      "source": "/docs/modules/model_io/prompts/prompt_templates/:path*(/?)",
-      "destination": "/docs/modules/model_io/prompts/:path*"
+      "source": "/v0.1/docs/modules/model_io/prompts/prompt_templates/:path*(/?)",
+      "destination": "/v0.1/docs/modules/model_io/prompts/:path*"
     },
     {
-      "source": "/docs/modules/model_io/output_parsers/comma_separated(/?)",
-      "destination": "/docs/modules/model_io/output_parsers/types/comma_separated"
+      "source": "/v0.1/docs/modules/model_io/output_parsers/comma_separated(/?)",
+      "destination": "/v0.1/docs/modules/model_io/output_parsers/types/comma_separated"
     },
     {
-      "source": "/docs/modules/model_io/output_parsers/enum(/?)",
-      "destination": "/docs/modules/model_io/output_parsers/types/enum"
+      "source": "/v0.1/docs/modules/model_io/output_parsers/enum(/?)",
+      "destination": "/v0.1/docs/modules/model_io/output_parsers/types/enum"
     },
     {
-      "source": "/docs/modules/model_io/output_parsers/output_fixing_parser(/?)",
-      "destination": "/docs/modules/model_io/output_parsers/types/output_fixing_parser"
+      "source": "/v0.1/docs/modules/model_io/output_parsers/output_fixing_parser(/?)",
+      "destination": "/v0.1/docs/modules/model_io/output_parsers/types/output_fixing_parser"
     },
     {
-      "source": "/docs/modules/model_io/output_parsers/pandas_dataframe(/?)",
-      "destination": "/docs/modules/model_io/output_parsers/types/pandas_dataframe"
+      "source": "/v0.1/docs/modules/model_io/output_parsers/pandas_dataframe(/?)",
+      "destination": "/v0.1/docs/modules/model_io/output_parsers/types/pandas_dataframe"
     },
     {
-      "source": "/docs/modules/model_io/output_parsers/structured(/?)",
-      "destination": "/docs/modules/model_io/output_parsers/types/structured"
+      "source": "/v0.1/docs/modules/model_io/output_parsers/structured(/?)",
+      "destination": "/v0.1/docs/modules/model_io/output_parsers/types/structured"
     },
     {
-      "source": "/docs/modules/model_io/output_parsers/xml(/?)",
-      "destination": "/docs/modules/model_io/output_parsers/types/xml"
+      "source": "/v0.1/docs/modules/model_io/output_parsers/xml(/?)",
+      "destination": "/v0.1/docs/modules/model_io/output_parsers/types/xml"
     },
     {
-      "source": "/docs/use_cases/question_answering/code_understanding(/?)",
-      "destination": "/docs/use_cases/code_understanding"
+      "source": "/v0.1/docs/use_cases/question_answering/code_understanding(/?)",
+      "destination": "/v0.1/docs/use_cases/code_understanding"
     },
     {
-      "source": "/docs/use_cases/question_answering/document-context-aware-QA(/?)",
-      "destination": "/docs/modules/data_connection/document_transformers/"
+      "source": "/v0.1/docs/use_cases/question_answering/document-context-aware-QA(/?)",
+      "destination": "/v0.1/docs/modules/data_connection/document_transformers/"
     },
     {
-      "source": "/docs/integrations/providers/alibabacloud_opensearch(/?)",
-      "destination": "/docs/integrations/providers/alibaba_cloud"
+      "source": "/v0.1/docs/integrations/providers/alibabacloud_opensearch(/?)",
+      "destination": "/v0.1/docs/integrations/providers/alibaba_cloud"
     },
     {
-      "source": "/docs/integrations/chat/pai_eas_chat_endpoint(/?)",
-      "destination": "/docs/integrations/chat/alibaba_cloud_pai_eas"
+      "source": "/v0.1/docs/integrations/chat/pai_eas_chat_endpoint(/?)",
+      "destination": "/v0.1/docs/integrations/chat/alibaba_cloud_pai_eas"
     },
     {
-      "source": "/docs/integrations/providers/tencentvectordb(/?)",
-      "destination": "/docs/integrations/providers/tencent"
+      "source": "/v0.1/docs/integrations/providers/tencentvectordb(/?)",
+      "destination": "/v0.1/docs/integrations/providers/tencent"
     },
     {
-      "source": "/docs/integrations/chat/hunyuan(/?)",
-      "destination": "/docs/integrations/chat/tencent_hunyuan"
+      "source": "/v0.1/docs/integrations/chat/hunyuan(/?)",
+      "destination": "/v0.1/docs/integrations/chat/tencent_hunyuan"
     },
     {
-      "source": "/docs/integrations/document_loaders/excel(/?)",
-      "destination": "/docs/integrations/document_loaders/microsoft_excel"
+      "source": "/v0.1/docs/integrations/document_loaders/excel(/?)",
+      "destination": "/v0.1/docs/integrations/document_loaders/microsoft_excel"
     },
     {
-      "source": "/docs/integrations/document_loaders/onenote(/?)",
-      "destination": "/docs/integrations/document_loaders/microsoft_onenote"
+      "source": "/v0.1/docs/integrations/document_loaders/onenote(/?)",
+      "destination": "/v0.1/docs/integrations/document_loaders/microsoft_onenote"
     },
     {
-      "source": "/docs/integrations/providers/aws_dynamodb(/?)",
-      "destination": "/docs/integrations/platforms/aws#aws-dynamodb"
+      "source": "/v0.1/docs/integrations/providers/aws_dynamodb(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/aws#aws-dynamodb"
     },
     {
-      "source": "/docs/integrations/providers/scann(/?)",
-      "destination": "/docs/integrations/platforms/google#google-scann"
+      "source": "/v0.1/docs/integrations/providers/scann(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google#google-scann"
     },
     {
-      "source": "/docs/integrations/toolkits/google_drive(/?)",
-      "destination": "/docs/integrations/tools/google_drive"
+      "source": "/v0.1/docs/integrations/toolkits/google_drive(/?)",
+      "destination": "/v0.1/docs/integrations/tools/google_drive"
     },
     {
-      "source": "/docs/use_cases/question_answering/analyze_document(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/analyze_document(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/qa_citations(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/qa_citations(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/chat_vector_db(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/chat_vector_db(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/in_memory_question_answering(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/in_memory_question_answering(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/multi_retrieval_qa_router(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/multi_retrieval_qa_router(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/multiple_retrieval(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/multiple_retrieval(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/vector_db_qa(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/vector_db_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/vector_db_text_generation(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/vector_db_text_generation(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/modules/agents/toolkits(/?)",
-      "destination": "/docs/modules/agents/tools/toolkits"
+      "source": "/v0.1/docs/modules/agents/toolkits(/?)",
+      "destination": "/v0.1/docs/modules/agents/tools/toolkits"
     },
     {
-      "source": "/docs/modules/model_io/models(/?)",
-      "destination": "/docs/modules/model_io/"
+      "source": "/v0.1/docs/modules/model_io/models(/?)",
+      "destination": "/v0.1/docs/modules/model_io/"
     },
     {
-      "source": "/docs/modules/model_io/models/:path*(/?)",
-      "destination": "/docs/modules/model_io/:path*"
+      "source": "/v0.1/docs/modules/model_io/models/:path*(/?)",
+      "destination": "/v0.1/docs/modules/model_io/:path*"
     },
     {
-      "source": "/docs/modules/model_io/llms/fake_llm(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/modules/model_io/llms/fake_llm(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/modules/model_io/llms/human_input_llm(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/modules/model_io/llms/human_input_llm(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/modules/model_io/chat/human_input_chat_model(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/modules/model_io/chat/human_input_chat_model(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/modules/model_io/chat/llm_chain(/?)",
-      "destination": "/docs/modules/chains/foundational/llm_chain"
+      "source": "/v0.1/docs/modules/model_io/chat/llm_chain(/?)",
+      "destination": "/v0.1/docs/modules/chains/foundational/llm_chain"
     },
     {
-      "source": "/docs/guides/langsmith(/?)",
-      "destination": "/docs/langsmith/"
+      "source": "/v0.1/docs/guides/langsmith(/?)",
+      "destination": "/v0.1/docs/langsmith/"
     },
     {
-      "source": "/docs/guides/langsmith/walkthrough(/?)",
-      "destination": "/docs/langsmith/walkthrough"
+      "source": "/v0.1/docs/guides/langsmith/walkthrough(/?)",
+      "destination": "/v0.1/docs/langsmith/walkthrough"
     },
     {
-      "source": "/docs/modules/data_connection/retrievers/self_query/:path+(/?)",
-      "destination": "/docs/integrations/retrievers/self_query/:path+"
+      "source": "/v0.1/docs/modules/data_connection/retrievers/self_query/:path+(/?)",
+      "destination": "/v0.1/docs/integrations/retrievers/self_query/:path+"
     },
     {
-      "source": "/docs/use_cases/more/agents/autonomous_agents/:path*(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/autonomous_agents/:path*(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agent_simulations/:path*(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agent_simulations/:path*(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/code/code-analysis-deeplake(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/code/code-analysis-deeplake(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/code_writing/cpal(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/code_writing/cpal(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agents/custom_agent_with_plugin_retrieval(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agents/custom_agent_with_plugin_retrieval(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agents/custom_agent_with_plugin_retrieval_using_plugnplai(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agents/custom_agent_with_plugin_retrieval_using_plugnplai(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/qa_structured/integrations/databricks(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/qa_structured/integrations/databricks(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/qa_structured/integrations/elasticsearch(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/qa_structured/integrations/elasticsearch(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/flare(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/flare(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/hyde(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/hyde(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/code_writing(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/code_writing(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/learned_prompt_optimization(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/learned_prompt_optimization(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/code_writing/llm_bash(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/code_writing/llm_bash(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/self_check/llm_checker(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/self_check/llm_checker(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/code_writing/llm_math(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/code_writing/llm_math(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/self_check/llm_summarization_checker(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/self_check/llm_summarization_checker(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/code_writing/llm_symbolic_math(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/code_writing/llm_symbolic_math(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/multi_modal/multi_modal_output_agent(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/multi_modal/multi_modal_output_agent(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/qa_structured/integrations/myscale_vector_sql(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/qa_structured/integrations/myscale_vector_sql(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/integrations/openai_functions_retrieval_qa(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/integrations/openai_functions_retrieval_qa(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/code_writing/pal(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/code_writing/pal(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agents/sales_agent_with_context(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agents/sales_agent_with_context(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/integrations/semantic-search-over-chat(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/integrations/semantic-search-over-chat(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/self_check/smart_llm(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/self_check/smart_llm(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/qa_structured/integrations/sqlite(/?)",
-      "destination": "/docs/use_cases/sql/"
+      "source": "/v0.1/docs/use_cases/qa_structured/integrations/sqlite(/?)",
+      "destination": "/v0.1/docs/use_cases/sql/"
     },
     {
-      "source": "/docs/use_cases/more/graph/tot(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/graph/tot(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/code/twitter-the-algorithm-analysis-deeplake(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/code/twitter-the-algorithm-analysis-deeplake(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agents/wikibase_agent(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agents/wikibase_agent(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/data_generation(/?)",
-      "destination": "/docs/use_cases/data_generation"
+      "source": "/v0.1/docs/use_cases/more/data_generation(/?)",
+      "destination": "/v0.1/docs/use_cases/data_generation"
     },
     {
-      "source": "/docs/use_cases/more/graph/:path*(/?)",
-      "destination": "/docs/use_cases/graph/:path*"
+      "source": "/v0.1/docs/use_cases/more/graph/:path*(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/:path*"
     },
     {
-      "source": "/docs/use_cases/more/graph(/?)",
-      "destination": "/docs/use_cases/graph/"
+      "source": "/v0.1/docs/use_cases/more/graph(/?)",
+      "destination": "/v0.1/docs/use_cases/graph/"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/chat_vector_db(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/chat_vector_db(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/conversational_retrieval_agents(/?)",
-      "destination": "/docs/use_cases/question_answering/conversational_retrieval_agents"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/conversational_retrieval_agents(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/conversational_retrieval_agents"
     },
     {
-      "source": "/docs/use_cases/question_answering/question_answering(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/question_answering(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/local_retrieval_qa(/?)",
-      "destination": "/docs/use_cases/question_answering/local_retrieval_qa"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/local_retrieval_qa(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/local_retrieval_qa"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/qa_citations(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/qa_citations(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/question_answering(/?)",
-      "destination": "/docs/use_cases/question_answering/"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/question_answering(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering/"
     },
     {
-      "source": "/docs/use_cases/more/agents/agent_simulations(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agent_simulations(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agents(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agents(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/agents/camel_role_playing(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/agents/camel_role_playing(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/agents/autonomous_agents(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/agents/autonomous_agents(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/more/self_check(/?)(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/more/self_check(/?)(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/analyze_document(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/analyze_document(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/use_cases/question_answering/how_to/code/(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/docs/use_cases/question_answering/how_to/code/(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/docs/modules/agents/agents/examples/mrkl_chat(.html?)(/?)",
-      "destination": "/docs/modules/agents/"
+      "source": "/v0.1/docs/modules/agents/agents/examples/mrkl_chat(.html?)(/?)",
+      "destination": "/v0.1/docs/modules/agents/"
     },
     {
-      "source": "/docs/integrations(/?)",
-      "destination": "/docs/integrations/providers/"
+      "source": "/v0.1/docs/integrations(/?)",
+      "destination": "/v0.1/docs/integrations/providers/"
     },
     {
-      "source": "/docs/expression_language/cookbook/routing(/?)",
-      "destination": "/docs/expression_language/how_to/routing"
+      "source": "/v0.1/docs/expression_language/cookbook/routing(/?)",
+      "destination": "/v0.1/docs/expression_language/how_to/routing"
     },
     {
-      "source": "/docs/guides/expression_language(/?)",
-      "destination": "/docs/expression_language/"
+      "source": "/v0.1/docs/guides/expression_language(/?)",
+      "destination": "/v0.1/docs/expression_language/"
     },
     {
-      "source": "/docs/integrations/providers/amazon_api_gateway(/?)",
-      "destination": "/docs/integrations/platforms/aws"
+      "source": "/v0.1/docs/integrations/providers/amazon_api_gateway(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/aws"
     },
     {
-      "source": "/docs/integrations/providers/huggingface(/?)",
-      "destination": "/docs/integrations/platforms/huggingface"
+      "source": "/v0.1/docs/integrations/providers/huggingface(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/huggingface"
     },
     {
-      "source": "/docs/integrations/providers/azure_blob_storage(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/azure_blob_storage(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/google_vertexai_matchingengine(/?)",
-      "destination": "/docs/integrations/platforms/google"
+      "source": "/v0.1/docs/integrations/providers/google_vertexai_matchingengine(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google"
     },
     {
-      "source": "/docs/integrations/providers/aws_s3(/?)",
-      "destination": "/docs/integrations/platforms/aws"
+      "source": "/v0.1/docs/integrations/providers/aws_s3(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/aws"
     },
     {
-      "source": "/docs/integrations/providers/azure_openai(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/azure_openai(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/azure_blob_storage(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/azure_blob_storage(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/azure_cognitive_search_(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/azure_cognitive_search_(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/bedrock(/?)",
-      "destination": "/docs/integrations/platforms/aws"
+      "source": "/v0.1/docs/integrations/providers/bedrock(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/aws"
     },
     {
-      "source": "/docs/integrations/providers/google_bigquery(/?)",
-      "destination": "/docs/integrations/platforms/google"
+      "source": "/v0.1/docs/integrations/providers/google_bigquery(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google"
     },
     {
-      "source": "/docs/integrations/providers/google_cloud_storage(/?)",
-      "destination": "/docs/integrations/platforms/google"
+      "source": "/v0.1/docs/integrations/providers/google_cloud_storage(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google"
     },
     {
-      "source": "/docs/integrations/providers/google_drive(/?)",
-      "destination": "/docs/integrations/platforms/google"
+      "source": "/v0.1/docs/integrations/providers/google_drive(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google"
     },
     {
-      "source": "/docs/integrations/providers/google_search(/?)",
-      "destination": "/docs/integrations/platforms/google"
+      "source": "/v0.1/docs/integrations/providers/google_search(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google"
     },
     {
-      "source": "/docs/integrations/providers/microsoft_onedrive(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/microsoft_onedrive(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/microsoft_powerpoint(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/microsoft_powerpoint(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/microsoft_word(/?)",
-      "destination": "/docs/integrations/platforms/microsoft"
+      "source": "/v0.1/docs/integrations/providers/microsoft_word(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/microsoft"
     },
     {
-      "source": "/docs/integrations/providers/sagemaker_endpoint(/?)",
-      "destination": "/docs/integrations/platforms/aws"
+      "source": "/v0.1/docs/integrations/providers/sagemaker_endpoint(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/aws"
     },
     {
-      "source": "/docs/integrations/providers/sagemaker_tracking(/?)",
-      "destination": "/docs/integrations/callbacks/sagemaker_tracking"
+      "source": "/v0.1/docs/integrations/providers/sagemaker_tracking(/?)",
+      "destination": "/v0.1/docs/integrations/callbacks/sagemaker_tracking"
     },
     {
-      "source": "/docs/integrations/providers/openai(/?)",
-      "destination": "/docs/integrations/platforms/openai"
+      "source": "/v0.1/docs/integrations/providers/openai(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/openai"
     },
     {
-      "source": "/docs/integrations/cassandra(/?)",
-      "destination": "/docs/integrations/providers/cassandra"
+      "source": "/v0.1/docs/integrations/cassandra(/?)",
+      "destination": "/v0.1/docs/integrations/providers/cassandra"
     },
     {
-      "source": "/docs/integrations/providers/providers/semadb(/?)",
-      "destination": "/docs/integrations/providers/semadb"
+      "source": "/v0.1/docs/integrations/providers/providers/semadb(/?)",
+      "destination": "/v0.1/docs/integrations/providers/semadb"
     },
     {
-      "source": "/docs/integrations/vectorstores/vectorstores/semadb(/?)",
-      "destination": "/docs/integrations/vectorstores/semadb"
+      "source": "/v0.1/docs/integrations/vectorstores/vectorstores/semadb(/?)",
+      "destination": "/v0.1/docs/integrations/vectorstores/semadb"
     },
     {
-      "source": "/docs/integrations/vectorstores/async_faiss(/?)",
-      "destination": "/docs/integrations/vectorstores/faiss_async"
+      "source": "/v0.1/docs/integrations/vectorstores/async_faiss(/?)",
+      "destination": "/v0.1/docs/integrations/vectorstores/faiss_async"
     },
     {
-      "source": "/docs/integrations/vectorstores/matchingengine(/?)",
-      "destination": "/docs/integrations/vectorstores/google_vertex_ai_vector_search"
+      "source": "/v0.1/docs/integrations/vectorstores/matchingengine(/?)",
+      "destination": "/v0.1/docs/integrations/vectorstores/google_vertex_ai_vector_search"
     },
 
     {
-      "source": "/docs/integrations/tools/sqlite(/?)",
-      "destination": "/docs/use_cases/sql"
+      "source": "/v0.1/docs/integrations/tools/sqlite(/?)",
+      "destination": "/v0.1/docs/use_cases/sql"
     },
     {
-      "source": "/docs/integrations/document_loaders/pdf-amazonTextractPDFLoader(/?)",
-      "destination": "/docs/integrations/document_loaders/amazon_textract"
+      "source": "/v0.1/docs/integrations/document_loaders/pdf-amazonTextractPDFLoader(/?)",
+      "destination": "/v0.1/docs/integrations/document_loaders/amazon_textract"
     },
     {
-      "source": "/docs/integrations/document_loaders/Etherscan(/?)",
-      "destination": "/docs/integrations/document_loaders/etherscan"
+      "source": "/v0.1/docs/integrations/document_loaders/Etherscan(/?)",
+      "destination": "/v0.1/docs/integrations/document_loaders/etherscan"
     },
     {
-      "source": "/docs/integrations/document_loaders/merge_doc_loader(/?)",
-      "destination": "/docs/integrations/document_loaders/merge_doc"
+      "source": "/v0.1/docs/integrations/document_loaders/merge_doc_loader(/?)",
+      "destination": "/v0.1/docs/integrations/document_loaders/merge_doc"
     },
     {
-      "source": "/docs/integrations/document_loaders/recursive_url_loader(/?)",
-      "destination": "/docs/integrations/document_loaders/recursive_url"
+      "source": "/v0.1/docs/integrations/document_loaders/recursive_url_loader(/?)",
+      "destination": "/v0.1/docs/integrations/document_loaders/recursive_url"
     },
     {
-      "source": "/en/latest/modules/indexes/text_splitters/examples/markdown_header_metadata.html(/?)",
-      "destination": "/docs/modules/data_connection/document_transformers/text_splitters/markdown_header_metadata"
+      "source": "/v0.1/en/latest/modules/indexes/text_splitters/examples/markdown_header_metadata.html(/?)",
+      "destination": "/v0.1/docs/modules/data_connection/document_transformers/text_splitters/markdown_header_metadata"
     },
     {
-      "source": "/docs/integrations/providers/aws_dynamodb(/?)",
-      "destination": "/docs/integrations/platforms/aws#aws-dynamodb"
+      "source": "/v0.1/docs/integrations/providers/aws_dynamodb(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/aws#aws-dynamodb"
     },
     {
-      "source": "/docs/integrations/providers/google_document_ai(/?)",
-      "destination": "/docs/integrations/platforms/google#google-document-ai"
+      "source": "/v0.1/docs/integrations/providers/google_document_ai(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google#google-document-ai"
     },
     {
-      "source": "/docs/integrations/providers/scann(/?)",
-      "destination": "/docs/integrations/platforms/google#google-scann"
+      "source": "/v0.1/docs/integrations/providers/scann(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google#google-scann"
     },
     {
-      "source": "/docs/integrations/memory/motorhead_memory_managed(/?)",
-      "destination": "/docs/integrations/memory/motorhead_memory"
+      "source": "/v0.1/docs/integrations/memory/motorhead_memory_managed(/?)",
+      "destination": "/v0.1/docs/integrations/memory/motorhead_memory"
     },
     {
-      "source": "/docs/integrations/memory/dynamodb_chat_message_history(/?)",
-      "destination": "/docs/integrations/memory/aws_dynamodb"
+      "source": "/v0.1/docs/integrations/memory/dynamodb_chat_message_history(/?)",
+      "destination": "/v0.1/docs/integrations/memory/aws_dynamodb"
     },
     {
-      "source": "/docs/integrations/memory/entity_memory_with_sqlite(/?)",
-      "destination": "/docs/integrations/memory/sqlite"
+      "source": "/v0.1/docs/integrations/memory/entity_memory_with_sqlite(/?)",
+      "destination": "/v0.1/docs/integrations/memory/sqlite"
     },
     {
-      "source": "/docs/modules/model_io/chat/integrations/anthropic(/?)",
-      "destination": "/docs/integrations/chat/anthropic"
+      "source": "/v0.1/docs/modules/model_io/chat/integrations/anthropic(/?)",
+      "destination": "/v0.1/docs/integrations/chat/anthropic"
     },
     {
-      "source": "/docs/modules/model_io/chat/integrations/azure_chat_openai(/?)",
-      "destination": "/docs/integrations/chat/azure_chat_openai"
+      "source": "/v0.1/docs/modules/model_io/chat/integrations/azure_chat_openai(/?)",
+      "destination": "/v0.1/docs/integrations/chat/azure_chat_openai"
     },
     {
-      "source": "/docs/modules/model_io/chat/integrations/google_vertex_ai_palm(/?)",
-      "destination": "/docs/integrations/chat/google_vertex_ai_palm"
+      "source": "/v0.1/docs/modules/model_io/chat/integrations/google_vertex_ai_palm(/?)",
+      "destination": "/v0.1/docs/integrations/chat/google_vertex_ai_palm"
     },
     {
-      "source": "/docs/modules/model_io/chat/integrations/openai(/?)",
-      "destination": "/docs/integrations/chat/openai"
+      "source": "/v0.1/docs/modules/model_io/chat/integrations/openai(/?)",
+      "destination": "/v0.1/docs/integrations/chat/openai"
     },
     {
-      "source": "/docs/modules/model_io/chat/integrations/promptlayer_chatopenai(/?)",
-      "destination": "/docs/integrations/chat/promptlayer_chatopenai"
+      "source": "/v0.1/docs/modules/model_io/chat/integrations/promptlayer_chatopenai(/?)",
+      "destination": "/v0.1/docs/integrations/chat/promptlayer_chatopenai"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/ai21(/?)",
-      "destination": "/docs/integrations/llms/ai21"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/ai21(/?)",
+      "destination": "/v0.1/docs/integrations/llms/ai21"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/aleph_alpha(/?)",
-      "destination": "/docs/integrations/llms/aleph_alpha"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/aleph_alpha(/?)",
+      "destination": "/v0.1/docs/integrations/llms/aleph_alpha"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/anyscale(/?)",
-      "destination": "/docs/integrations/llms/anyscale"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/anyscale(/?)",
+      "destination": "/v0.1/docs/integrations/llms/anyscale"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/azure_openai_example(/?)",
-      "destination": "/docs/integrations/llms/azure_openai_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/azure_openai_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/azure_openai_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/banana(/?)",
-      "destination": "/docs/integrations/llms/banana"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/banana(/?)",
+      "destination": "/v0.1/docs/integrations/llms/banana"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/baseten(/?)",
-      "destination": "/docs/integrations/llms/baseten"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/baseten(/?)",
+      "destination": "/v0.1/docs/integrations/llms/baseten"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/beam(/?)",
-      "destination": "/docs/integrations/llms/beam"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/beam(/?)",
+      "destination": "/v0.1/docs/integrations/llms/beam"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/bedrock(/?)",
-      "destination": "/docs/integrations/llms/bedrock"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/bedrock(/?)",
+      "destination": "/v0.1/docs/integrations/llms/bedrock"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/cerebriumai_example(/?)",
-      "destination": "/docs/integrations/llms/cerebriumai_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/cerebriumai_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/cerebriumai_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/cohere(/?)",
-      "destination": "/docs/integrations/llms/cohere"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/cohere(/?)",
+      "destination": "/v0.1/docs/integrations/llms/cohere"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/ctransformers(/?)",
-      "destination": "/docs/integrations/llms/ctransformers"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/ctransformers(/?)",
+      "destination": "/v0.1/docs/integrations/llms/ctransformers"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/databricks(/?)",
-      "destination": "/docs/integrations/llms/databricks"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/databricks(/?)",
+      "destination": "/v0.1/docs/integrations/llms/databricks"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/deepinfra_example(/?)",
-      "destination": "/docs/integrations/llms/deepinfra_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/deepinfra_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/deepinfra_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/forefrontai_example(/?)",
-      "destination": "/docs/integrations/llms/forefrontai_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/forefrontai_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/forefrontai_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/google_vertex_ai_palm(/?)",
-      "destination": "/docs/integrations/llms/google_vertex_ai_palm"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/google_vertex_ai_palm(/?)",
+      "destination": "/v0.1/docs/integrations/llms/google_vertex_ai_palm"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/gooseai_example(/?)",
-      "destination": "/docs/integrations/llms/gooseai_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/gooseai_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/gooseai_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/huggingface_hub(/?)",
-      "destination": "/docs/integrations/llms/huggingface_hub"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/huggingface_hub(/?)",
+      "destination": "/v0.1/docs/integrations/llms/huggingface_hub"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/huggingface_pipelines(/?)",
-      "destination": "/docs/integrations/llms/huggingface_pipelines"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/huggingface_pipelines(/?)",
+      "destination": "/v0.1/docs/integrations/llms/huggingface_pipelines"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/huggingface_textgen_inference(/?)",
-      "destination": "/docs/integrations/llms/huggingface_textgen_inference"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/huggingface_textgen_inference(/?)",
+      "destination": "/v0.1/docs/integrations/llms/huggingface_textgen_inference"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/jsonformer_experimental(/?)",
-      "destination": "/docs/integrations/llms/jsonformer_experimental"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/jsonformer_experimental(/?)",
+      "destination": "/v0.1/docs/integrations/llms/jsonformer_experimental"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/llamacpp(/?)",
-      "destination": "/docs/integrations/llms/llamacpp"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/llamacpp(/?)",
+      "destination": "/v0.1/docs/integrations/llms/llamacpp"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/llm_caching(/?)",
-      "destination": "/docs/integrations/llms/llm_caching"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/llm_caching(/?)",
+      "destination": "/v0.1/docs/integrations/llms/llm_caching"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/manifest(/?)",
-      "destination": "/docs/integrations/llms/manifest"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/manifest(/?)",
+      "destination": "/v0.1/docs/integrations/llms/manifest"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/modal(/?)",
-      "destination": "/docs/integrations/llms/modal"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/modal(/?)",
+      "destination": "/v0.1/docs/integrations/llms/modal"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/mosaicml(/?)",
-      "destination": "/docs/integrations/llms/mosaicml"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/mosaicml(/?)",
+      "destination": "/v0.1/docs/integrations/llms/mosaicml"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/nlpcloud(/?)",
-      "destination": "/docs/integrations/llms/nlpcloud"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/nlpcloud(/?)",
+      "destination": "/v0.1/docs/integrations/llms/nlpcloud"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/openai(/?)",
-      "destination": "/docs/integrations/llms/openai"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/openai(/?)",
+      "destination": "/v0.1/docs/integrations/llms/openai"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/openlm(/?)",
-      "destination": "/docs/integrations/llms/openlm"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/openlm(/?)",
+      "destination": "/v0.1/docs/integrations/llms/openlm"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/petals_example(/?)",
-      "destination": "/docs/integrations/llms/petals_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/petals_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/petals_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/pipelineai_example(/?)",
-      "destination": "/docs/integrations/llms/pipelineai_example"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/pipelineai_example(/?)",
+      "destination": "/v0.1/docs/integrations/llms/pipelineai_example"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/predictionguard(/?)",
-      "destination": "/docs/integrations/llms/predictionguard"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/predictionguard(/?)",
+      "destination": "/v0.1/docs/integrations/llms/predictionguard"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/promptlayer_openai(/?)",
-      "destination": "/docs/integrations/llms/promptlayer_openai"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/promptlayer_openai(/?)",
+      "destination": "/v0.1/docs/integrations/llms/promptlayer_openai"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/rellm_experimental(/?)",
-      "destination": "/docs/integrations/llms/rellm_experimental"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/rellm_experimental(/?)",
+      "destination": "/v0.1/docs/integrations/llms/rellm_experimental"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/replicate(/?)",
-      "destination": "/docs/integrations/llms/replicate"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/replicate(/?)",
+      "destination": "/v0.1/docs/integrations/llms/replicate"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/runhouse(/?)",
-      "destination": "/docs/integrations/llms/runhouse"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/runhouse(/?)",
+      "destination": "/v0.1/docs/integrations/llms/runhouse"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/sagemaker(/?)",
-      "destination": "/docs/integrations/llms/sagemaker"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/sagemaker(/?)",
+      "destination": "/v0.1/docs/integrations/llms/sagemaker"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/stochasticai(/?)",
-      "destination": "/docs/integrations/llms/stochasticai"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/stochasticai(/?)",
+      "destination": "/v0.1/docs/integrations/llms/stochasticai"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/writer(/?)",
-      "destination": "/docs/integrations/llms/writer"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/writer(/?)",
+      "destination": "/v0.1/docs/integrations/llms/writer"
     },
     {
-      "source": "/en/latest/use_cases/agent_simulations/:path*(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/en/latest/use_cases/agent_simulations/:path*(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/en/latest/use_cases/agents/baby_agi.html",
-      "destination": "/docs/use_cases/agents/baby_agi"
+      "source": "/v0.1/en/latest/use_cases/agents/baby_agi.html",
+      "destination": "/v0.1/docs/use_cases/agents/baby_agi"
     },
     {
-      "source": "/en/latest/use_cases/agents/baby_agi_with_agent.html",
-      "destination": "/docs/use_cases/agents/baby_agi_with_agent"
+      "source": "/v0.1/en/latest/use_cases/agents/baby_agi_with_agent.html",
+      "destination": "/v0.1/docs/use_cases/agents/baby_agi_with_agent"
     },
     {
-      "source": "/en/latest/use_cases/agents/camel_role_playing.html",
-      "destination": "/docs/use_cases/agents/camel_role_playing"
+      "source": "/v0.1/en/latest/use_cases/agents/camel_role_playing.html",
+      "destination": "/v0.1/docs/use_cases/agents/camel_role_playing"
     },
     {
-      "source": "/en/latest/use_cases/agents/custom_agent_with_plugin_retrieval.html",
-      "destination": "/docs/use_cases/agents/custom_agent_with_plugin_retrieval"
+      "source": "/v0.1/en/latest/use_cases/agents/custom_agent_with_plugin_retrieval.html",
+      "destination": "/v0.1/docs/use_cases/agents/custom_agent_with_plugin_retrieval"
     },
     {
-      "source": "/en/latest/use_cases/agents/custom_agent_with_plugin_retrieval_using_plugnplai.html",
-      "destination": "/docs/use_cases/agents/custom_agent_with_plugin_retrieval_using_plugnplai"
+      "source": "/v0.1/en/latest/use_cases/agents/custom_agent_with_plugin_retrieval_using_plugnplai.html",
+      "destination": "/v0.1/docs/use_cases/agents/custom_agent_with_plugin_retrieval_using_plugnplai"
     },
     {
-      "source": "/en/latest/use_cases/agents/multi_modal_output_agent.html",
-      "destination": "/docs/use_cases/agents/multi_modal_output_agent"
+      "source": "/v0.1/en/latest/use_cases/agents/multi_modal_output_agent.html",
+      "destination": "/v0.1/docs/use_cases/agents/multi_modal_output_agent"
     },
     {
-      "source": "/en/latest/use_cases/agents/sales_agent_with_context.html",
-      "destination": "/docs/use_cases/agents/sales_agent_with_context"
+      "source": "/v0.1/en/latest/use_cases/agents/sales_agent_with_context.html",
+      "destination": "/v0.1/docs/use_cases/agents/sales_agent_with_context"
     },
     {
-      "source": "/en/latest/use_cases/agents/wikibase_agent.html",
-      "destination": "/docs/use_cases/agents/wikibase_agent"
+      "source": "/v0.1/en/latest/use_cases/agents/wikibase_agent.html",
+      "destination": "/v0.1/docs/use_cases/agents/wikibase_agent"
     },
     {
-      "source": "/en/latest/use_cases/apis.html",
-      "destination": "/docs/use_cases/apis"
+      "source": "/v0.1/en/latest/use_cases/apis.html",
+      "destination": "/v0.1/docs/use_cases/apis"
     },
     {
-      "source": "/en/latest/use_cases/autonomous_agents/:path*(/?)",
-      "destination": "/cookbook"
+      "source": "/v0.1/en/latest/use_cases/autonomous_agents/:path*(/?)",
+      "destination": "/v0.1/cookbook"
     },
     {
-      "source": "/en/latest/use_cases/chatbots/voice_assistant.html",
-      "destination": "/docs/use_cases/chatbots/voice_assistant"
+      "source": "/v0.1/en/latest/use_cases/chatbots/voice_assistant.html",
+      "destination": "/v0.1/docs/use_cases/chatbots/voice_assistant"
     },
     {
-      "source": "/en/latest/use_cases/code/code-analysis-deeplake.html",
-      "destination": "/docs/use_cases/code/code-analysis-deeplake"
+      "source": "/v0.1/en/latest/use_cases/code/code-analysis-deeplake.html",
+      "destination": "/v0.1/docs/use_cases/code/code-analysis-deeplake"
     },
     {
-      "source": "/en/latest/use_cases/code/twitter-the-algorithm-analysis-deeplake.html",
-      "destination": "/docs/use_cases/code/twitter-the-algorithm-analysis-deeplake"
+      "source": "/v0.1/en/latest/use_cases/code/twitter-the-algorithm-analysis-deeplake.html",
+      "destination": "/v0.1/docs/use_cases/code/twitter-the-algorithm-analysis-deeplake"
     },
     {
-      "source": "/en/latest/use_cases/extraction.html",
-      "destination": "/docs/use_cases/extraction"
+      "source": "/v0.1/en/latest/use_cases/extraction.html",
+      "destination": "/v0.1/docs/use_cases/extraction"
     },
     {
-      "source": "/en/latest/use_cases/multi_modal/image_agent.html",
-      "destination": "/docs/use_cases/multi_modal/image_agent"
+      "source": "/v0.1/en/latest/use_cases/multi_modal/image_agent.html",
+      "destination": "/v0.1/docs/use_cases/multi_modal/image_agent"
     },
     {
-      "source": "/en/latest/use_cases/question_answering/semantic-search-over-chat.html",
-      "destination": "/docs/use_cases/question_answering/semantic-search-over-chat"
+      "source": "/v0.1/en/latest/use_cases/question_answering/semantic-search-over-chat.html",
+      "destination": "/v0.1/docs/use_cases/question_answering/semantic-search-over-chat"
     },
     {
-      "source": "/en/latest/use_cases/summarization.html",
-      "destination": "/docs/use_cases/summarization"
+      "source": "/v0.1/en/latest/use_cases/summarization.html",
+      "destination": "/v0.1/docs/use_cases/summarization"
     },
     {
-      "source": "/en/latest/use_cases/tabular.html",
-      "destination": "/docs/use_cases/sql"
+      "source": "/v0.1/en/latest/use_cases/tabular.html",
+      "destination": "/v0.1/docs/use_cases/sql"
     },
     {
-      "source": "/en/latest/youtube.html",
-      "destination": "/docs/additional_resources/youtube"
+      "source": "/v0.1/en/latest/youtube.html",
+      "destination": "/v0.1/docs/additional_resources/youtube"
     },
     {
-      "source": "/en/latest/modules/agents/agents/wikibase_agent.html",
-      "destination": "/docs/use_cases/agents/wikibase_agent"
+      "source": "/v0.1/en/latest/modules/agents/agents/wikibase_agent.html",
+      "destination": "/v0.1/docs/use_cases/agents/wikibase_agent"
     },
     {
-      "source": "/en/latest/modules/indexes/retrievers/examples/twitter-the-algorithm-analysis-deeplake.html",
-      "destination": "/docs/use_cases/code/twitter-the-algorithm-analysis-deeplake"
+      "source": "/v0.1/en/latest/modules/indexes/retrievers/examples/twitter-the-algorithm-analysis-deeplake.html",
+      "destination": "/v0.1/docs/use_cases/code/twitter-the-algorithm-analysis-deeplake"
     },
     {
-      "source": "/en/latest/explanation/tools.html",
-      "destination": "/docs/modules/agents/tools"
+      "source": "/v0.1/en/latest/explanation/tools.html",
+      "destination": "/v0.1/docs/modules/agents/tools"
     },
     {
-      "source": "/docs",
-      "destination": "/"
+      "source": "/v0.1/docs",
+      "destination": "/v0.1/"
     },
     {
-      "source": "/docs/",
-      "destination": "/"
+      "source": "/v0.1/docs/",
+      "destination": "/v0.1/"
     },
     {
-      "source": "/en/latest",
-      "destination": "/"
+      "source": "/v0.1/en/latest",
+      "destination": "/v0.1/"
     },
     {
-      "source": "/en/latest/",
-      "destination": "/"
+      "source": "/v0.1/en/latest/",
+      "destination": "/v0.1/"
     },
     {
-      "source": "/en/latest/index.html",
-      "destination": "/"
+      "source": "/v0.1/en/latest/index.html",
+      "destination": "/v0.1/"
     },
     {
-      "source": "/en/latest/modules/indexes/retrievers/examples/self_query_retriever.html",
-      "destination": "/docs/modules/data_connection/retrievers/how_to/self_query/"
+      "source": "/v0.1/en/latest/modules/indexes/retrievers/examples/self_query_retriever.html",
+      "destination": "/v0.1/docs/modules/data_connection/retrievers/how_to/self_query/"
     },
     {
-      "source": "/en/latest/modules/indexes/retrievers/examples/:path*(/?)",
-      "destination": "/docs/integrations/retrievers/:path*"
+      "source": "/v0.1/en/latest/modules/indexes/retrievers/examples/:path*(/?)",
+      "destination": "/v0.1/docs/integrations/retrievers/:path*"
     },
     {
-      "source": "/docs/modules/model_io/chat/how_to/:path*(/?)",
-      "destination": "/docs/modules/model_io/chat/:path*"
+      "source": "/v0.1/docs/modules/model_io/chat/how_to/:path*(/?)",
+      "destination": "/v0.1/docs/modules/model_io/chat/:path*"
     },
     {
-      "source": "/docs/modules/model_io/llms/how_to/:path*(/?)",
-      "destination": "/docs/modules/model_io/llms/:path*"
+      "source": "/v0.1/docs/modules/model_io/llms/how_to/:path*(/?)",
+      "destination": "/v0.1/docs/modules/model_io/llms/:path*"
     },
     {
-      "source": "/docs/modules/model_io/llms/integrations/:path*(/?)",
-      "destination": "/docs/integrations/llms/:path*"
+      "source": "/v0.1/docs/modules/model_io/llms/integrations/:path*(/?)",
+      "destination": "/v0.1/docs/integrations/llms/:path*"
     },
     {
-      "source": "/docs/modules/model_io/chat/integrations/:path*(/?)",
-      "destination": "/docs/integrations/chat/:path*"
+      "source": "/v0.1/docs/modules/model_io/chat/integrations/:path*(/?)",
+      "destination": "/v0.1/docs/integrations/chat/:path*"
     },
     {
-      "source": "/en/latest/modules/models.html(/?)",
-      "destination": "/docs/modules/model_io/"
+      "source": "/v0.1/en/latest/modules/models.html(/?)",
+      "destination": "/v0.1/docs/modules/model_io/"
     },
     {
-      "source": "/en/latest/modules/models/:path*(/?)",
-      "destination": "/docs/modules/model_io/:path*"
+      "source": "/v0.1/en/latest/modules/models/:path*(/?)",
+      "destination": "/v0.1/docs/modules/model_io/:path*"
     },
     {
-      "source": "/docs/integrations/retrievers/google_cloud_enterprise_search(/?)",
-      "destination": "/docs/integrations/retrievers/google_vertex_ai_search"
+      "source": "/v0.1/docs/integrations/retrievers/google_cloud_enterprise_search(/?)",
+      "destination": "/v0.1/docs/integrations/retrievers/google_vertex_ai_search"
     },
     {
-      "source": "/docs/integrations/providers/google_document_ai(/?)",
-      "destination": "/docs/integrations/platforms/google#google-document-ai"
+      "source": "/v0.1/docs/integrations/providers/google_document_ai(/?)",
+      "destination": "/v0.1/docs/integrations/platforms/google#google-document-ai"
     },
     {
-      "source": "/docs/integrations/tools/metaphor_search(/?)",
-      "destination": "/docs/integrations/tools/exa_search"
+      "source": "/v0.1/docs/integrations/tools/metaphor_search(/?)",
+      "destination": "/v0.1/docs/integrations/tools/exa_search"
     },
     {
-      "source": "/docs/expression_language/how_to/fallbacks(/?)",
-      "destination": "/docs/guides/productionization/fallbacks"
+      "source": "/v0.1/docs/expression_language/how_to/fallbacks(/?)",
+      "destination": "/v0.1/docs/guides/productionization/fallbacks"
     },
     {
-      "source": "/docs/expression_language/cookbook/retrieval(/?)",
-      "destination": "/docs/use_cases/question_answering"
+      "source": "/v0.1/docs/expression_language/cookbook/retrieval(/?)",
+      "destination": "/v0.1/docs/use_cases/question_answering"
     },
     {
-      "source": "/docs/expression_language/cookbook/agent(/?)",
-      "destination": "/docs/modules/agents/agent_types/xml_agent"
+      "source": "/v0.1/docs/expression_language/cookbook/agent(/?)",
+      "destination": "/v0.1/docs/modules/agents/agent_types/xml_agent"
     },
     {
-      "source": "/docs/modules/model_io/prompts/message_prompts(/?)",
-      "destination": "/docs/modules/model_io/prompts/quick_start#message-prompts"
+      "source": "/v0.1/docs/modules/model_io/prompts/message_prompts(/?)",
+      "destination": "/v0.1/docs/modules/model_io/prompts/quick_start#message-prompts"
     },
     {
-      "source": "/docs/modules/model_io/prompts/pipeline(/?)",
-      "destination": "/docs/modules/model_io/prompts/composition#using-pipelineprompt"
+      "source": "/v0.1/docs/modules/model_io/prompts/pipeline(/?)",
+      "destination": "/v0.1/docs/modules/model_io/prompts/composition#using-pipelineprompt"
     },
     {
-      "source": "/docs/expression_language/cookbook/memory(/?)",
-      "destination": "/docs/modules/memory"
+      "source": "/v0.1/docs/expression_language/cookbook/memory(/?)",
+      "destination": "/v0.1/docs/modules/memory"
     },
     {
-      "source": "/docs/expression_language/cookbook/tools(/?)",
-      "destination": "/docs/use_cases/tool_use/quickstart"
+      "source": "/v0.1/docs/expression_language/cookbook/tools(/?)",
+      "destination": "/v0.1/docs/use_cases/tool_use/quickstart"
     },
     {
-      "source": "/docs/expression_language/cookbook/sql_db(/?)",
-      "destination": "/docs/use_cases/sql/quickstart"
+      "source": "/v0.1/docs/expression_language/cookbook/sql_db(/?)",
+      "destination": "/v0.1/docs/use_cases/sql/quickstart"
     },
     {
-      "source": "/docs/expression_language/cookbook/moderation(/?)",
-      "destination": "/docs/guides/productionization/safety/moderation"
+      "source": "/v0.1/docs/expression_language/cookbook/moderation(/?)",
+      "destination": "/v0.1/docs/guides/productionization/safety/moderation"
     },
     {
-      "source": "/docs/expression_language/cookbook/embedding_router(/?)",
-      "destination": "/docs/expression_language/how_to/routing"
+      "source": "/v0.1/docs/expression_language/cookbook/embedding_router(/?)",
+      "destination": "/v0.1/docs/expression_language/how_to/routing"
     },
     {
-      "source": "/docs/modules/model_io/prompts/example_selector_types/:path*(/?)",
-      "destination": "/docs/modules/model_io/prompts/example_selectors/:path*"
+      "source": "/v0.1/docs/modules/model_io/prompts/example_selector_types/:path*(/?)",
+      "destination": "/v0.1/docs/modules/model_io/prompts/example_selectors/:path*"
     },
     {
-      "source": "/docs/modules/agents/tools/:path*(/?)",
-      "destination": "/docs/modules/tools/:path*"
+      "source": "/v0.1/docs/modules/agents/tools/:path*(/?)",
+      "destination": "/v0.1/docs/modules/tools/:path*"
     },
     {
-      "source": "/docs/guides/structured_output(/?)",
-      "destination": "/docs/modules/model_io/chat/structured_output"
+      "source": "/v0.1/docs/guides/structured_output(/?)",
+      "destination": "/v0.1/docs/modules/model_io/chat/structured_output"
     },
     {
-      "source": "/docs/modules/agents/how_to/structured_tools(/?)",
-      "destination": "/docs/modules/tools"
+      "source": "/v0.1/docs/modules/agents/how_to/structured_tools(/?)",
+      "destination": "/v0.1/docs/modules/tools"
     },
     {
-      "source": "/docs/use_cases/csv(/?)",
-      "destination": "/docs/use_cases/sql/csv"
+      "source": "/v0.1/docs/use_cases/csv(/?)",
+      "destination": "/v0.1/docs/use_cases/sql/csv"
     },
     {
-      "source": "/docs/guides/debugging(/?)",
-      "destination": "/docs/guides/development/debugging"
+      "source": "/v0.1/docs/guides/debugging(/?)",
+      "destination": "/v0.1/docs/guides/development/debugging"
     },
     {
-      "source": "/docs/guides/deployments/:path*(/?)",
-      "destination": "/docs/guides/productionization/deployments/:path*"
+      "source": "/v0.1/docs/guides/deployments/:path*(/?)",
+      "destination": "/v0.1/docs/guides/productionization/deployments/:path*"
     },
     {
-      "source": "/docs/guides/evaluation/:path*",
-      "destination": "/docs/guides/productionization/evaluation/:path*"
+      "source": "/v0.1/docs/guides/evaluation/:path*",
+      "destination": "/v0.1/docs/guides/productionization/evaluation/:path*"
     },
     {
-      "source": "/docs/guides/extending_langchain(/?)",
-      "destination": "/docs/guides/development/extending_langchain"
+      "source": "/v0.1/docs/guides/extending_langchain(/?)",
+      "destination": "/v0.1/docs/guides/development/extending_langchain"
     },
     {
-      "source": "/docs/guides/fallbacks(/?)",
-      "destination": "/docs/guides/productionization/fallbacks"
+      "source": "/v0.1/docs/guides/fallbacks(/?)",
+      "destination": "/v0.1/docs/guides/productionization/fallbacks"
     },
     {
-      "source": "/docs/guides/privacy/:path*(/?)",
-      "destination": "/docs/guides/productionization/safety/:path*"
+      "source": "/v0.1/docs/guides/privacy/:path*(/?)",
+      "destination": "/v0.1/docs/guides/productionization/safety/:path*"
     },
     {
-      "source": "/docs/guides/safety/:path*(/?)",
-      "destination": "/docs/guides/productionization/safety/:path*"
+      "source": "/v0.1/docs/guides/safety/:path*(/?)",
+      "destination": "/v0.1/docs/guides/productionization/safety/:path*"
     },
     {
-      "source": "/docs/guides/model_laboratory(/?)",
-      "destination": "/docs/guides/productionization/evaluation"
+      "source": "/v0.1/docs/guides/model_laboratory(/?)",
+      "destination": "/v0.1/docs/guides/productionization/evaluation"
     },
     {
-      "source": "/docs/guides/pydantic_compatibility(/?)",
-      "destination": "/docs/guides/development/pydantic_compatibility"
+      "source": "/v0.1/docs/guides/pydantic_compatibility(/?)",
+      "destination": "/v0.1/docs/guides/development/pydantic_compatibility"
     },
     {
-      "source": "/docs/guides/local_llms(/?)",
-      "destination": "/docs/guides/development/local_llms"
+      "source": "/v0.1/docs/guides/local_llms(/?)",
+      "destination": "/v0.1/docs/guides/development/local_llms"
     },
     {
-      "source": "/docs/modules/model_io/quick_start(/?)",
-      "destination": "/docs/modules/model_io"
+      "source": "/v0.1/docs/modules/model_io/quick_start(/?)",
+      "destination": "/v0.1/docs/modules/model_io"
     },
     {
-      "source": "/docs/expression_language/how_to/generators(/?)",
-      "destination": "/docs/expression_language/primitives/functions"
+      "source": "/v0.1/docs/expression_language/how_to/generators(/?)",
+      "destination": "/v0.1/docs/expression_language/primitives/functions"
     },
     {
-      "source": "/docs/expression_language/how_to/functions(/?)",
-      "destination": "/docs/expression_language/primitives/functions"
+      "source": "/v0.1/docs/expression_language/how_to/functions(/?)",
+      "destination": "/v0.1/docs/expression_language/primitives/functions"
     },
     {
-      "source": "/docs/expression_language/how_to/passthrough(/?)",
-      "destination": "/docs/expression_language/primitives/passthrough"
+      "source": "/v0.1/docs/expression_language/how_to/passthrough(/?)",
+      "destination": "/v0.1/docs/expression_language/primitives/passthrough"
     },
     {
-      "source": "/docs/expression_language/how_to/map(/?)",
-      "destination": "/docs/expression_language/primitives/parallel"
+      "source": "/v0.1/docs/expression_language/how_to/map(/?)",
+      "destination": "/v0.1/docs/expression_language/primitives/parallel"
     },
     {
-      "source": "/docs/expression_language/how_to/binding(/?)",
-      "destination": "/docs/expression_language/primitives/binding"
+      "source": "/v0.1/docs/expression_language/how_to/binding(/?)",
+      "destination": "/v0.1/docs/expression_language/primitives/binding"
     },
     {
-      "source": "/docs/expression_language/how_to/configure(/?)",
-      "destination": "/docs/expression_language/primitives/configure"
+      "source": "/v0.1/docs/expression_language/how_to/configure(/?)",
+      "destination": "/v0.1/docs/expression_language/primitives/configure"
     },
     {
-      "source": "/docs/expression_language/cookbook/prompt_llm_parser(/?)",
-      "destination": "/docs/expression_language/get_started"
+      "source": "/v0.1/docs/expression_language/cookbook/prompt_llm_parser(/?)",
+      "destination": "/v0.1/docs/expression_language/get_started"
     },
     {
-      "source": "/docs/contributing/documentation(/?)",
-      "destination": "/docs/contributing/documentation/technical_logistics"
+      "source": "/v0.1/docs/contributing/documentation(/?)",
+      "destination": "/v0.1/docs/contributing/documentation/technical_logistics"
     },
     {
-      "source": "/docs/modules/agents/tools/custom_tools(/?)",
-      "destination": "/docs/modules/tools/custom_tools/"
+      "source": "/v0.1/docs/modules/agents/tools/custom_tools(/?)",
+      "destination": "/v0.1/docs/modules/tools/custom_tools/"
     },
     {
-      "source": "/docs/expression_language/cookbook(/?)",
-      "destination": "/docs/expression_language/"
+      "source": "/v0.1/docs/expression_language/cookbook(/?)",
+      "destination": "/v0.1/docs/expression_language/"
     },
     {
-      "source": "/docs/guides/evaluation(/?)",
-      "destination": "/docs/guides/productionization/evaluation/"
+      "source": "/v0.1/docs/guides/evaluation(/?)",
+      "destination": "/v0.1/docs/guides/productionization/evaluation/"
     },
     {
-      "source": "/docs/guides/evaluation/:path*(/?)",
-      "destination": "/docs/guides/productionization/evaluation/:path*/"
+      "source": "/v0.1/docs/guides/evaluation/:path*(/?)",
+      "destination": "/v0.1/docs/guides/productionization/evaluation/:path*/"
     },
     {
-      "source": "/docs/integrations/text_embedding/solar(/?)",
-      "destination": "/docs/integrations/text_embedding/upstage"
+      "source": "/v0.1/docs/integrations/text_embedding/solar(/?)",
+      "destination": "/v0.1/docs/integrations/text_embedding/upstage"
     },
     {
-      "source": "/docs/integrations/chat/solar(/?)",
-      "destination": "/docs/integrations/chat/upstage"
+      "source": "/v0.1/docs/integrations/chat/solar(/?)",
+      "destination": "/v0.1/docs/integrations/chat/upstage"
     }
   ]
 }

--- a/libs/community/poetry.lock
+++ b/libs/community/poetry.lock
@@ -3964,7 +3964,7 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.1.51"
+version = "0.1.52"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
@@ -10044,4 +10044,4 @@ extended-testing = ["aiosqlite", "aleph-alpha-client", "anthropic", "arxiv", "as
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "ca64e52a60e8ee6f2f4ea303e1779a4508f401e283f63861161cb6a9560e2178"
+content-hash = "6427b52f752b6b8e46c1bc56f03db5a25e959fb471d0b2de3607696a97fdcd77"

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-community"
-version = "0.0.37"
+version = "0.0.38"
 description = "Community contributed LangChain integrations."
 authors = []
 license = "MIT"

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/langchain-ai/langchain"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = "^0.1.51"
+langchain-core = "^0.1.52"
 SQLAlchemy = ">=1.4,<3"
 requests = "^2"
 PyYAML = ">=5.3"

--- a/libs/langchain/poetry.lock
+++ b/libs/langchain/poetry.lock
@@ -3469,7 +3469,7 @@ files = [
 
 [[package]]
 name = "langchain-community"
-version = "0.0.37"
+version = "0.0.38"
 description = "Community contributed LangChain integrations."
 optional = false
 python-versions = ">=3.8.1,<4.0"
@@ -3479,7 +3479,7 @@ develop = true
 [package.dependencies]
 aiohttp = "^3.8.3"
 dataclasses-json = ">= 0.5.7, < 0.7"
-langchain-core = "^0.1.51"
+langchain-core = "^0.1.52"
 langsmith = "^0.1.0"
 numpy = "^1"
 PyYAML = ">=5.3"
@@ -9404,4 +9404,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "c96cce249835459653029fe2af63714b6374ae9d1913c8e3ca0b1e1d127f99a0"
+content-hash = "56e0417edc75e591b9265c6986b87115c27ddd98b87466f698c68df6f3fb60d3"

--- a/libs/langchain/poetry.lock
+++ b/libs/langchain/poetry.lock
@@ -3497,7 +3497,7 @@ url = "../community"
 
 [[package]]
 name = "langchain-core"
-version = "0.1.51"
+version = "0.1.52"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
@@ -9404,4 +9404,4 @@ text-helpers = ["chardet"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "9ed4d0b11749d1f98e8fbe2895a94e4bc90975817873e52a70f2bbcee934ce19"
+content-hash = "c96cce249835459653029fe2af63714b6374ae9d1913c8e3ca0b1e1d127f99a0"

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -12,9 +12,9 @@ langchain-server = "langchain.server:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = "^0.1.51"
+langchain-core = "^0.1.52"
 langchain-text-splitters = ">=0.0.1,<0.1"
-langchain-community = ">=0.0.37,<0.1"
+langchain-community = ">=0.0.38,<0.1"
 langsmith = "^0.1.17"
 pydantic = ">=1,<3"
 SQLAlchemy = ">=1.4,<3"

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.1.18"
+version = "0.1.19"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -12,7 +12,7 @@ langchain-server = "langchain.server:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = "^0.1.48"
+langchain-core = "^0.1.51"
 langchain-text-splitters = ">=0.0.1,<0.1"
 langchain-community = ">=0.0.37,<0.1"
 langsmith = "^0.1.17"


### PR DESCRIPTION
- docs: v0.1 build semantics [BEGIN v0.1 BRANCH] (#21444)
- langchain: release 0.1.19 (#21447)
- langchain: fix core version dep (#21449)
- community: release 0.0.38 (#21451)
- community: fix core version str (#21452)
- langchain: bump core community (#21453)
- docs: baseUrl for ganalytics (0.1) (#21456)
- docs: spell correction (#21459)
- docs: redirect base slug (0.1) (#21458)
- Revert "docs: redirect base slug (0.1)" (#21500)
- docs: 404 page top level (#21510)
- docs: announcement bar (#21511)
- infra: run codespell on v0.1 prs (#21545)
