### PR TITLE
docs: Update import in wikipedia tool documentation

### DIFF
--- a/docs/docs/integrations/tools/wikipedia.ipynb
+++ b/docs/docs/integrations/tools/wikipedia.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.tools import WikipediaQueryRun\n",
+    "from langchain_community.tools import WikipediaQueryRun\n",
     "from langchain_community.utilities import WikipediaAPIWrapper"
    ]
   },


### PR DESCRIPTION
Updates docs so the example doesn't lead to a warning:
```
LangChainDeprecationWarning: Importing tools from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.tools import WikipediaQueryRun`.

To install langchain-community run `pip install -U langchain-community`.
```
