### PR TITLE
docs: update import statement for `HuggingFaceEndpoint`

### DIFF
--- a/docs/docs/integrations/llms/huggingface_endpoint.ipynb
+++ b/docs/docs/integrations/llms/huggingface_endpoint.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_community.llms import HuggingFaceEndpoint"
+    "from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint"
    ]
   },
   {


### PR DESCRIPTION
**Description:** 
Updates the documentation to align with the recent changes in the import statements of the HuggingFaceEndpoint class. Previously, the documentation suggested a direct import from langchain_community.llms, which is no longer accurate

**Issue:** 
fixes #20977

**Dependencies:** 
None

**Twitter handle:** 
None

