### PR TITLE
community: add preload support to Ollama LLM

### DIFF
--- a/docs/docs/integrations/llms/ollama.ipynb
+++ b/docs/docs/integrations/llms/ollama.ipynb
@@ -200,6 +200,7 @@
    ],
    "source": [
     "from langchain_community.llms import Ollama\n",
+    "\n",
     "print(\"With `preload=True`\")\n",
     "llm = Ollama(model=\"llama3\", preload=True, verbose=True)\n",
     "\n",

--- a/docs/docs/integrations/llms/ollama.ipynb
+++ b/docs/docs/integrations/llms/ollama.ipynb
@@ -175,6 +175,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "To preload the model, pass the kwarg `preload=True` to the `Ollama` constructor, or use the `.preload_model()` method.\n",
+    "(add `verbose=True` to the constructor to see the preload message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "With `preload=True`\n",
+      "Preloading Ollama model 'llama3' into memory...\n",
+      "Ollama model 'llama3' ready in 12.03 seconds.\n",
+      "\n",
+      "Invoking `.preload_model()` method\n",
+      "Preloading Ollama model 'llama3' into memory...\n",
+      "Ollama model 'llama3' ready in 0.25 seconds.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_community.llms import Ollama\n",
+    "print(\"With `preload=True`\")\n",
+    "llm = Ollama(model=\"llama3\", preload=True, verbose=True)\n",
+    "\n",
+    "print(\"\\nInvoking `.preload_model()` method\")\n",
+    "llm.preload_model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To learn more about the LangChain Expressive Language and the available methods on an LLM, see the [LCEL Interface](/docs/concepts#interface)"
    ]
   },
@@ -298,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -141,7 +141,9 @@ class _OllamaCommon(BaseLanguageModel):
 
     See the [Ollama documents](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-pre-load-a-model-to-get-faster-response-times)"""
 
-    def __init__(self, model: str = "llama2", preload: bool = False, *args, **kwargs):
+    def __init__(
+        self, model: str = "llama2", preload: bool = False, *args: Any, **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.model = model
         self.preload = preload
@@ -181,7 +183,7 @@ class _OllamaCommon(BaseLanguageModel):
         """Get the identifying parameters."""
         return {**{"model": self.model, "format": self.format}, **self._default_params}
 
-    def preload_model(self):
+    def preload_model(self) -> None:
         """Public method to preload the model into memory."""
         start_time = time.time()
         if self.verbose:

--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -141,15 +141,6 @@ class _OllamaCommon(BaseLanguageModel):
 
     See the [Ollama documents](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-pre-load-a-model-to-get-faster-response-times)"""
 
-    def __init__(
-        self, model: str = "llama2", preload: bool = False, *args: Any, **kwargs: Any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.model = model
-        self.preload = preload
-        if self.preload:
-            self.preload_model()
-
     @property
     def _default_params(self) -> Dict[str, Any]:
         """Get the default parameters for calling Ollama."""
@@ -182,18 +173,6 @@ class _OllamaCommon(BaseLanguageModel):
     def _identifying_params(self) -> Mapping[str, Any]:
         """Get the identifying parameters."""
         return {**{"model": self.model, "format": self.format}, **self._default_params}
-
-    def preload_model(self) -> None:
-        """Public method to preload the model into memory."""
-        start_time = time.time()
-        if self.verbose:
-            logger.info(f"Preloading Ollama model '{self.model}' into memory...")
-        self._generate([""])
-        if self.verbose:
-            elapsed_time = time.time() - start_time
-            logger.info(
-                f"Ollama model '{self.model}' ready in {elapsed_time:.2f} seconds."
-            )
 
     def _create_generate_stream(
         self,
@@ -412,6 +391,27 @@ class Ollama(BaseLLM, _OllamaCommon):
             from langchain_community.llms import Ollama
             ollama = Ollama(model="llama2")
     """
+
+    def __init__(
+        self, model: str = "llama2", preload: bool = False, *args: Any, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.model = model
+        self.preload = preload
+        if self.preload:
+            self.preload_model()
+
+    def preload_model(self) -> None:
+        """Public method to preload the model into memory."""
+        start_time = time.time()
+        if self.verbose:
+            logger.info(f"Preloading Ollama model '{self.model}' into memory...")
+        self._generate([""])
+        if self.verbose:
+            elapsed_time = time.time() - start_time
+            logger.info(
+                f"Ollama model '{self.model}' ready in {elapsed_time:.2f} seconds."
+            )
 
     class Config:
         """Configuration for this pydantic object."""

--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -405,7 +405,7 @@ class Ollama(BaseLLM, _OllamaCommon):
         """Public method to preload the model into memory."""
         start_time = time.time()
         if self.verbose:
-            logger.info(f"Preloading Ollama model '{self.model}' into memory...")
+            logger.info(f"Preloading Ollama model '{self.model}' into memory.")
         self._generate([""])
         if self.verbose:
             elapsed_time = time.time() - start_time

--- a/libs/community/tests/unit_tests/llms/test_ollama.py
+++ b/libs/community/tests/unit_tests/llms/test_ollama.py
@@ -205,7 +205,7 @@ def test_handle_kwargs_with_options(monkeypatch: MonkeyPatch) -> None:
 
 def test_preload_true_initializes_model(monkeypatch: MonkeyPatch) -> None:
     # Create a mock function to replace the preload_model method
-    def mock_preload():
+    def mock_preload():  # type: ignore[no-untyped-def]
         pass
 
     monkeypatch.setattr(
@@ -215,7 +215,7 @@ def test_preload_true_initializes_model(monkeypatch: MonkeyPatch) -> None:
     # Use a counter to track calls to the mock function
     call_count = 0
 
-    def count_calls(*args, **kwargs):
+    def count_calls(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         nonlocal call_count
         call_count += 1
 
@@ -228,7 +228,7 @@ def test_preload_true_initializes_model(monkeypatch: MonkeyPatch) -> None:
 
 def test_preload_false_does_not_initialize_model(monkeypatch: MonkeyPatch) -> None:
     # Create a mock function to replace the preload_model method
-    def mock_preload():
+    def mock_preload():  # type: ignore[no-untyped-def]
         pass
 
     monkeypatch.setattr(
@@ -238,7 +238,7 @@ def test_preload_false_does_not_initialize_model(monkeypatch: MonkeyPatch) -> No
     # Use a counter to track calls to the mock function
     call_count = 0
 
-    def count_calls(*args, **kwargs):
+    def count_calls(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         nonlocal call_count
         call_count += 1
 
@@ -251,7 +251,7 @@ def test_preload_false_does_not_initialize_model(monkeypatch: MonkeyPatch) -> No
 
 def test_preload_not_set_does_not_initialize_model(monkeypatch: MonkeyPatch) -> None:
     # Create a mock function to replace the preload_model method
-    def mock_preload():
+    def mock_preload():  # type: ignore[no-untyped-def]
         pass
 
     monkeypatch.setattr(
@@ -261,7 +261,7 @@ def test_preload_not_set_does_not_initialize_model(monkeypatch: MonkeyPatch) -> 
     # Use a counter to track calls to the mock function
     call_count = 0
 
-    def count_calls(*args, **kwargs):
+    def count_calls(*args, **kwargs):  # type: ignore[no-untyped-def]
         nonlocal call_count
         call_count += 1
 
@@ -272,14 +272,14 @@ def test_preload_not_set_does_not_initialize_model(monkeypatch: MonkeyPatch) -> 
     assert call_count == 0
 
 
-def test_preload_true_effectiveness(monkeypatch):
+def test_preload_true_effectiveness(monkeypatch: MonkeyPatch) -> None:
     """
     Test that initializing Ollama with `preload=True` actually preloads the model,
     potentially reducing the time for the first invocation.
     """
 
     # Mock the actual API call to simulate model loading and invocation
-    def mock_generate(*args, **kwargs):
+    def mock_generate(*args, **kwargs) -> LLMResult:  # type: ignore[no-untyped-def]
         # Simulate a delay that would be seen in model loading
         import time
 
@@ -317,14 +317,14 @@ def test_preload_true_effectiveness(monkeypatch):
     assert elapsed_time_preload > elapsed_time_no_preload_param
 
 
-def test_preload_false_effectiveness(monkeypatch):
+def test_preload_false_effectiveness(monkeypatch: MonkeyPatch) -> None:
     """
     Test that initializing Ollama with `preload=False` does not preload the model,
     and the first invocation takes longer due to model loading.
     """
 
     # Similar setup as the previous test but reversed logic for assertions
-    def mock_generate(*args, **kwargs):
+    def mock_generate(*args, **kwargs) -> LLMResult:  # type: ignore[no-untyped-def]
         import time
 
         time.sleep(0.1)

--- a/libs/community/tests/unit_tests/llms/test_ollama.py
+++ b/libs/community/tests/unit_tests/llms/test_ollama.py
@@ -1,4 +1,6 @@
 import requests
+from langchain_core.outputs.generation import GenerationChunk
+from langchain_core.outputs.llm_result import LLMResult
 from pytest import MonkeyPatch
 
 from langchain_community.llms.ollama import Ollama
@@ -101,6 +103,7 @@ def test_handle_kwargs_top_level_parameters(monkeypatch: MonkeyPatch) -> None:
             "system": "Test system prompt",
             "template": None,
             "keep_alive": None,
+            "preload": False,
         }
         assert stream is True
         assert timeout == 300
@@ -149,6 +152,7 @@ def test_handle_kwargs_with_unknown_param(monkeypatch: MonkeyPatch) -> None:
             "system": None,
             "template": None,
             "keep_alive": None,
+            "preload": False,
         }
         assert stream is True
         assert timeout == 300
@@ -181,6 +185,7 @@ def test_handle_kwargs_with_options(monkeypatch: MonkeyPatch) -> None:
             "system": None,
             "template": None,
             "keep_alive": None,
+            "preload": False,
         }
         assert stream is True
         assert timeout == 300
@@ -196,3 +201,147 @@ def test_handle_kwargs_with_options(monkeypatch: MonkeyPatch) -> None:
         unknown="Unknown parameter value",
         temperature=0.8,
     )
+
+
+def test_preload_true_initializes_model(monkeypatch: MonkeyPatch) -> None:
+    # Create a mock function to replace the preload_model method
+    def mock_preload():
+        pass
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama.preload_model", mock_preload
+    )
+
+    # Use a counter to track calls to the mock function
+    call_count = 0
+
+    def count_calls(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama.preload_model", count_calls
+    )
+    Ollama(model="llama3", preload=True)
+    assert call_count == 1, "`preload_model()` should be called once when preload=True"
+
+
+def test_preload_false_does_not_initialize_model(monkeypatch: MonkeyPatch) -> None:
+    # Create a mock function to replace the preload_model method
+    def mock_preload():
+        pass
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama.preload_model", mock_preload
+    )
+
+    # Use a counter to track calls to the mock function
+    call_count = 0
+
+    def count_calls(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama.preload_model", count_calls
+    )
+    Ollama(model="llama3", preload=False)
+    assert call_count == 0
+
+
+def test_preload_not_set_does_not_initialize_model(monkeypatch: MonkeyPatch) -> None:
+    # Create a mock function to replace the preload_model method
+    def mock_preload():
+        pass
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama.preload_model", mock_preload
+    )
+
+    # Use a counter to track calls to the mock function
+    call_count = 0
+
+    def count_calls(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama.preload_model", count_calls
+    )
+    Ollama(model="llama3")
+    assert call_count == 0
+
+
+def test_preload_true_effectiveness(monkeypatch):
+    """
+    Test that initializing Ollama with `preload=True` actually preloads the model,
+    potentially reducing the time for the first invocation.
+    """
+
+    # Mock the actual API call to simulate model loading and invocation
+    def mock_generate(*args, **kwargs):
+        # Simulate a delay that would be seen in model loading
+        import time
+
+        time.sleep(0.1 if "preload" in kwargs and kwargs["preload"] else 0.05)
+        return LLMResult(
+            generations=[[GenerationChunk(text="Model loaded and response generated")]]
+        )
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama._generate", mock_generate
+    )
+
+    # Measure time with `preload=True`
+    import time
+
+    start_time = time.time()
+    ollama_preload = Ollama(model="llama3", preload=True)
+    ollama_preload.invoke("Test prompt")
+    elapsed_time_preload = time.time() - start_time
+
+    # Reset and measure time with `preload=False`
+    start_time = time.time()
+    ollama_no_preload = Ollama(model="llama3", preload=False)
+    ollama_no_preload.invoke("Test prompt")
+    elapsed_time_no_preload = time.time() - start_time
+
+    assert elapsed_time_preload > elapsed_time_no_preload
+
+    # Reset and measure time without preload
+    start_time = time.time()
+    ollama_no_preload_param = Ollama(model="llama3")
+    ollama_no_preload_param.invoke("Test prompt")
+    elapsed_time_no_preload_param = time.time() - start_time
+
+    assert elapsed_time_preload > elapsed_time_no_preload_param
+
+
+def test_preload_false_effectiveness(monkeypatch):
+    """
+    Test that initializing Ollama with `preload=False` does not preload the model,
+    and the first invocation takes longer due to model loading.
+    """
+
+    # Similar setup as the previous test but reversed logic for assertions
+    def mock_generate(*args, **kwargs):
+        import time
+
+        time.sleep(0.1)
+        return LLMResult(
+            generations=[[GenerationChunk(text="Model loaded and response generated")]]
+        )
+
+    monkeypatch.setattr(
+        "langchain_community.llms.ollama.Ollama._generate", mock_generate
+    )
+
+    # Only measure time without preload as this test focuses on the negative case
+    import time
+
+    start_time = time.time()
+    ollama_no_preload = Ollama(model="llama3", preload=False)
+    ollama_no_preload.invoke("Test prompt")
+    elapsed_time_no_preload = time.time() - start_time
+
+    assert elapsed_time_no_preload > 0


### PR DESCRIPTION
**Description:** In order to ensure that Ollama model is ready to go at startup, I have introduced an optional `preload` boolean keyword argument (default set to `False`) to the `Ollama` LLM, allowing the model to be preloaded into memory during the initialization phase. This feature includes a `preload_model` method to trigger preloading at a later time if desired. The preloading process leverages the Ollama FAQ's recommended approach of calling `generate` with an empty prompt (see [how-can-i-pre-load-a-model-to-get-faster-response-times](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-pre-load-a-model-to-get-faster-response-times)

**Issue:** N/A

**Dependencies:** None added

**Twitter handle:** @charlyouki