### PR TITLE
[experimental][quick-fix]: Fix import errors and docs of experimental prompt injection identifier

### DIFF
--- a/docs/docs/guides/productionization/safety/hugging_face_prompt_injection.ipynb
+++ b/docs/docs/guides/productionization/safety/hugging_face_prompt_injection.ipynb
@@ -50,7 +50,7 @@
     "from transformers import AutoTokenizer, pipeline\n",
     "\n",
     "# Using https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2\n",
-    "model_path = \"laiyer/deberta-v3-base-prompt-injection-v2\"\n",
+    "model_path = \"protectai/deberta-v3-base-prompt-injection-v2\"\n",
     "revision = None  # We recommend specifiying the revision to avoid breaking changes or supply chain attacks\n",
     "tokenizer = AutoTokenizer.from_pretrained(\n",
     "    model_path, revision=revision, model_input_names=[\"input_ids\", \"attention_mask\"]\n",

--- a/libs/experimental/langchain_experimental/prompt_injection_identifier/hugging_face_identifier.py
+++ b/libs/experimental/langchain_experimental/prompt_injection_identifier/hugging_face_identifier.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Union
 from langchain.pydantic_v1 import Field, root_validator
 from langchain.tools.base import BaseTool
 
-if TYPE_CHECKING:
-    from transformers import Pipeline
+# This import needs to be toplevel to avoid error for refs on HuggingFaceInjectionIdentifier.model 
+from transformers import Pipeline
 
 
 class PromptInjectionException(ValueError):
@@ -98,3 +98,5 @@ class HuggingFaceInjectionIdentifier(BaseTool):
             raise PromptInjectionException("Prompt injection attack detected", score)
 
         return query
+
+HuggingFaceInjectionIdentifier.update_forward_refs()

--- a/libs/experimental/langchain_experimental/prompt_injection_identifier/hugging_face_identifier.py
+++ b/libs/experimental/langchain_experimental/prompt_injection_identifier/hugging_face_identifier.py
@@ -1,13 +1,13 @@
 """Tool for the identification of prompt injection attacks."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any
 
 from langchain.pydantic_v1 import Field, root_validator
 from langchain.tools.base import BaseTool
 
-# This import needs to be toplevel to avoid error for refs on HuggingFaceInjectionIdentifier.model 
-from transformers import Pipeline
+if TYPE_CHECKING:
+    from transformers import Pipeline
 
 
 class PromptInjectionException(ValueError):
@@ -59,7 +59,7 @@ class HuggingFaceInjectionIdentifier(BaseTool):
         "Useful for when you need to ensure that prompt is free of injection attacks. "
         "Input should be any message from the user."
     )
-    model: Union[Pipeline, str, None] = Field(default_factory=_model_default_factory)
+    model: Any = Field(default_factory=_model_default_factory)
     """Model to use for prompt injection detection. 
     
     Can be specified as transformers Pipeline or string. String should correspond to the
@@ -98,5 +98,6 @@ class HuggingFaceInjectionIdentifier(BaseTool):
             raise PromptInjectionException("Prompt injection attack detected", score)
 
         return query
+
 
 HuggingFaceInjectionIdentifier.update_forward_refs()


### PR DESCRIPTION
**Description**

I noticed that code in experimental was not functional due to small errors, and users were complaining at https://stackoverflow.com/questions/78272521/hugging-face-prompt-injection-identifier and https://github.com/langchain-ai/langchain/discussions/19995.

I know folks are busy with `v2.0` now, but I believe this is worthy fix because it is isolated, minor, backwards compatible, and fixes an error with current v0.1 code

**Issue**
https://github.com/langchain-ai/langchain/discussions/19995

**Dependencies**
None

**Twitter handle**
https://twitter.com/nelsonauner


cc @asofter 