### PR TITLE
upstage : add merge_and_split function for document loader

### DIFF
--- a/libs/partners/upstage/langchain_upstage/layout_analysis_parsers.py
+++ b/libs/partners/upstage/langchain_upstage/layout_analysis_parsers.py
@@ -246,6 +246,8 @@ class UpstageLayoutAnalysisParser(BaseBlobParser):
                 "id": elements["id"],
                 "type": self.output_type,
                 "split": self.split,
+                "bbox": elements["bounding_box"],
+                "category": elements["category"],
             },
         )
 


### PR DESCRIPTION
- Introduce the `merge_and_split` function in the `UpstageLayoutAnalysisLoader`.
- The `merge_and_split` function takes a list of documents and a splitter as inputs.
- This function merges all documents and then divides them using the `split_documents` method, which is a proprietary function of the splitter.
- If the provided splitter is `None` (which is the default setting), the function will simply merge the documents without splitting them.