### PR TITLE
core[major]: do not cast tool outputs to str

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1045,7 +1045,6 @@ class AsyncCallbackManagerForToolRun(AsyncParentRunManager, ToolManagerMixin):
         Args:
             output (Any): The output of the tool.
         """
-        output = str(output)
         await ahandle_event(
             self.handlers,
             "on_tool_end",


### PR DESCRIPTION
Update existing callback manager to not cast tool outputs to string.
