### PR TITLE
community: Support gpt-4o in the Chat Model for OpenAI

### DIFF
--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -587,7 +587,7 @@ class ChatOpenAI(BaseChatModel):
                 # gpt-3.5-turbo may change over time.
                 # Returning num tokens assuming gpt-3.5-turbo-0301.
                 model = "gpt-3.5-turbo-0301"
-            elif model == "gpt-4":
+            elif model.startswith("gpt-4"):
                 # gpt-4 may change over time.
                 # Returning num tokens assuming gpt-4-0314.
                 model = "gpt-4-0314"


### PR DESCRIPTION


  - **Description:** Supports other gpt-4 models here: 
  
  - **Issue:** Fixes OpenAI crashes 
  
  Calls to `llm.get_num_tokens_from_messages(buffer)`  would otherwise fail with 
  
  ```
  get_num_tokens_from_messages() is not presently implemented for model cl100k_base.See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens.
```

  - **Dependencies:** N/A 
  - **Twitter handle:** @SumukhSridhara 

