### PR TITLE
text-splitters: Handles cases where the separator is at the beginning of the string

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -36,10 +36,15 @@ def _split_text_with_regex(
         if keep_separator:
             # The parentheses in the pattern keep the delimiters in the result.
             _splits = re.split(f"({separator})", text)
-            splits = [_splits[i] + _splits[i + 1] for i in range(1, len(_splits), 2)]
-            if len(_splits) % 2 == 0:
-                splits += _splits[-1:]
-            splits = [_splits[0]] + splits
+            if separator in _splits[0]:
+                splits = [_splits[i] + _splits[i + 1] for i in range(1, len(_splits), 2)]
+                if len(_splits) % 2 == 0:
+                    splits += _splits[-1:]
+                splits = [_splits[0]] + splits
+            else:
+                splits = [_splits[i] + _splits[i + 1] for i in range(0, len(_splits)-1, 2)]
+                if len(_splits) % 2 != 0:
+                    splits += _splits[-1:]
         else:
             splits = re.split(separator, text)
     else:


### PR DESCRIPTION
  **Description:** 
 When I use the `RecursiveCharacterTextSplitter` to split a string, if the separator is not at the beginning of the string, the  result will be abnormal, such as this example:
```
from langchain.text_splitter import RecursiveCharacterTextSplitter
SPLIT_TAGS = [",", "."]
splitter = RecursiveCharacterTextSplitter(chunk_size=10, chunk_overlap=0, separators=SPLIT_TAGS)
text = "Apple,banana,orange and tomato."
res = splitter.split_text(text)
print(res)
```
output: `['Apple', ',banana', ',orange and tomato', '.']`
The separator is attached to the beginning of the text block, which is strange when dividing the text.
My desired result is this:
`['Apple,', 'banana,', 'orange and tomato.']`
This PR solves this problem by modifying the method `_split_text_with_regex`