### PR TITLE
core[patch]: Add unit tests with some streaming scenarios

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable_events.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events.py
@@ -1608,7 +1608,7 @@ EXPECTED_EVENTS = [
 
 @pytest.mark.xfail(
     reason="This test is failing due to missing functionality."
-    "Need to implement logic in _transform_stream_with_config that mimicks the async "
+    "Need to implement logic in _transform_stream_with_config that mimics the async "
     "variant that uses tap_output_iter"
 )
 async def test_sync_in_async_stream_lambdas() -> None:
@@ -1651,7 +1651,7 @@ async def test_async_in_async_stream_lambdas() -> None:
 
 @pytest.mark.xfail(
     reason="This test is failing due to missing functionality."
-    "Need to implement logic in _transform_stream_with_config that mimicks the async "
+    "Need to implement logic in _transform_stream_with_config that mimics the async "
     "variant that uses tap_output_iter"
 )
 async def test_sync_in_sync_lambdas() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events.py
@@ -1649,7 +1649,7 @@ async def test_async_in_async_stream_lambdas() -> None:
     assert events == EXPECTED_EVENTS
 
 
-@pytest.xfail(
+@pytest.mark.xfail(
     reason="This test is failing due to missing functionality."
     "Need to implement logic in _transform_stream_with_config that mimicks the async "
     "variant that uses tap_output_iter"

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events.py
@@ -1619,12 +1619,12 @@ async def test_sync_in_async_stream_lambdas() -> None:
 
     add_one = RunnableLambda(add_one_)
 
-    def add_one_proxy_(x: int, config: RunnableConfig) -> int:
+    async def add_one_proxy_(x: int, config: RunnableConfig) -> int:
         streaming = add_one.stream(x, config)
         results = [result for result in streaming]
         return results[0]
 
-    add_one_proxy = RunnableLambda(add_one_proxy_)
+    add_one_proxy = RunnableLambda(add_one_proxy_)  # type: ignore
 
     events = await _collect_events(add_one_proxy.astream_events(1, version="v1"))
     assert events == EXPECTED_EVENTS
@@ -1633,19 +1633,20 @@ async def test_sync_in_async_stream_lambdas() -> None:
 async def test_async_in_async_stream_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 
-    async def add_one_(x: int) -> int:
+    async def add_one(x: int) -> int:
         return x + 1
 
-    add_one = RunnableLambda(func=add_one_, afunc=add_one_)
+    add_one_ = RunnableLambda(add_one)  # type: ignore
 
-    async def add_one_proxy_(x: int, config: RunnableConfig) -> int:
-        streaming = add_one.astream(x, config)
+    async def add_one_proxy(x: int, config: RunnableConfig) -> int:
+        # Use sync streaming
+        streaming = add_one_.astream(x, config)
         results = [result async for result in streaming]
         return results[0]
 
-    add_one_proxy = RunnableLambda(func=add_one_proxy_, afunc=add_one_proxy_)
+    add_one_proxy_ = RunnableLambda(add_one_proxy)  # type: ignore
 
-    events = await _collect_events(add_one_proxy.astream_events(1, version="v1"))
+    events = await _collect_events(add_one_proxy_.astream_events(1, version="v1"))
     assert events == EXPECTED_EVENTS
 
 
@@ -1657,18 +1658,18 @@ async def test_async_in_async_stream_lambdas() -> None:
 async def test_sync_in_sync_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 
-    def add_one_(x: int) -> int:
+    def add_one(x: int) -> int:
         return x + 1
 
-    add_one = RunnableLambda(add_one_)
+    add_one_ = RunnableLambda(add_one)
 
-    def add_one_proxy_(x: int, config: RunnableConfig) -> int:
+    def add_one_proxy(x: int, config: RunnableConfig) -> int:
         # Use sync streaming
-        streaming = add_one.stream(x, config)
+        streaming = add_one_.stream(x, config)
         results = [result for result in streaming]
         return results[0]
 
-    add_one_proxy = RunnableLambda(add_one_proxy_)
+    add_one_proxy_ = RunnableLambda(add_one_proxy)
 
-    events = await _collect_events(add_one_proxy.astream_events(1, version="v1"))
+    events = await _collect_events(add_one_proxy_.astream_events(1, version="v1"))
     assert events == EXPECTED_EVENTS

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events.py
@@ -1614,17 +1614,17 @@ EXPECTED_EVENTS = [
 async def test_sync_in_async_stream_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 
-    def add_one(x: int) -> int:
+    def add_one_(x: int) -> int:
         return x + 1
 
-    add_one = RunnableLambda(func=add_one)
+    add_one = RunnableLambda(add_one_)
 
-    async def add_one_proxy(x: int, config) -> int:
+    def add_one_proxy_(x: int, config: RunnableConfig) -> int:
         streaming = add_one.stream(x, config)
         results = [result for result in streaming]
         return results[0]
 
-    add_one_proxy = RunnableLambda(func=add_one_proxy)
+    add_one_proxy = RunnableLambda(add_one_proxy_)
 
     events = await _collect_events(add_one_proxy.astream_events(1, version="v1"))
     assert events == EXPECTED_EVENTS
@@ -1633,17 +1633,17 @@ async def test_sync_in_async_stream_lambdas() -> None:
 async def test_async_in_async_stream_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 
-    async def add_one(x: int) -> int:
+    async def add_one_(x: int) -> int:
         return x + 1
 
-    add_one = RunnableLambda(func=add_one)
+    add_one = RunnableLambda(func=add_one_, afunc=add_one_)
 
-    async def add_one_proxy(x: int, config) -> int:
+    async def add_one_proxy_(x: int, config: RunnableConfig) -> int:
         streaming = add_one.astream(x, config)
         results = [result async for result in streaming]
         return results[0]
 
-    add_one_proxy = RunnableLambda(func=add_one_proxy)
+    add_one_proxy = RunnableLambda(func=add_one_proxy_, afunc=add_one_proxy_)
 
     events = await _collect_events(add_one_proxy.astream_events(1, version="v1"))
     assert events == EXPECTED_EVENTS
@@ -1657,18 +1657,18 @@ async def test_async_in_async_stream_lambdas() -> None:
 async def test_sync_in_sync_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 
-    def add_one(x: int) -> int:
+    def add_one_(x: int) -> int:
         return x + 1
 
-    add_one = RunnableLambda(func=add_one)
+    add_one = RunnableLambda(add_one_)
 
-    def add_one_proxy(x: int, config) -> int:
+    def add_one_proxy_(x: int, config: RunnableConfig) -> int:
         # Use sync streaming
         streaming = add_one.stream(x, config)
         results = [result for result in streaming]
         return results[0]
 
-    add_one_proxy = RunnableLambda(func=add_one_proxy)
+    add_one_proxy = RunnableLambda(add_one_proxy_)
 
     events = await _collect_events(add_one_proxy.astream_events(1, version="v1"))
     assert events == EXPECTED_EVENTS


### PR DESCRIPTION
Add unit tests that show differences between sync / async versions when streaming.

The inner on_chain_chunk event is missing if mixing sync and async functionality. Likely due to missing tap_output_iter implementation on the sync variant of `_transform_stream_with_config`
