### PR TITLE
[Core] Check is async callable

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -1,4 +1,5 @@
 """Utility code for runnables."""
+
 from __future__ import annotations
 
 import ast
@@ -532,4 +533,22 @@ def _create_model_cached(
 ) -> Type[BaseModel]:
     return _create_model_base(
         __model_name, __config__=_SchemaConfig, **field_definitions
+    )
+
+
+def is_async_generator(func: Any) -> bool:
+    """Check if a function is an async generator."""
+    return (
+        inspect.isasyncgenfunction(func)
+        or hasattr(func, "__call__")
+        and inspect.isasyncgenfunction(func.__call__)
+    )
+
+
+def is_async_callable(func: Any) -> bool:
+    """Check if a function is async."""
+    return (
+        asyncio.iscoroutinefunction(func)
+        or hasattr(func, "__call__")
+        and asyncio.iscoroutinefunction(func.__call__)
     )

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -12,6 +12,7 @@ from itertools import groupby
 from typing import (
     Any,
     AsyncIterable,
+    Awaitable,
     Callable,
     Coroutine,
     Dict,
@@ -24,6 +25,7 @@ from typing import (
     Sequence,
     Set,
     Type,
+    TypeGuard,
     TypeVar,
     Union,
 )
@@ -536,7 +538,7 @@ def _create_model_cached(
     )
 
 
-def is_async_generator(func: Any) -> bool:
+def is_async_generator(func: Any) -> TypeGuard[AsyncIterable]:
     """Check if a function is an async generator."""
     return (
         inspect.isasyncgenfunction(func)
@@ -545,7 +547,7 @@ def is_async_generator(func: Any) -> bool:
     )
 
 
-def is_async_callable(func: Any) -> bool:
+def is_async_callable(func: Any) -> TypeGuard[Awaitable]:
     """Check if a function is async."""
     return (
         asyncio.iscoroutinefunction(func)

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -25,10 +25,11 @@ from typing import (
     Sequence,
     Set,
     Type,
-    TypeGuard,
     TypeVar,
     Union,
 )
+
+from typing_extensions import TypeGuard
 
 from langchain_core.pydantic_v1 import BaseConfig, BaseModel
 from langchain_core.pydantic_v1 import create_model as _create_model_base

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -12,6 +12,7 @@ from itertools import groupby
 from typing import (
     Any,
     AsyncIterable,
+    AsyncIterator,
     Awaitable,
     Callable,
     Coroutine,
@@ -539,7 +540,9 @@ def _create_model_cached(
     )
 
 
-def is_async_generator(func: Any) -> TypeGuard[AsyncIterable]:
+def is_async_generator(
+    func: Any,
+) -> TypeGuard[Callable[..., AsyncIterator]]:
     """Check if a function is an async generator."""
     return (
         inspect.isasyncgenfunction(func)
@@ -548,7 +551,9 @@ def is_async_generator(func: Any) -> TypeGuard[AsyncIterable]:
     )
 
 
-def is_async_callable(func: Any) -> TypeGuard[Awaitable]:
+def is_async_callable(
+    func: Any,
+) -> TypeGuard[Callable[..., Awaitable]]:
     """Check if a function is async."""
     return (
         asyncio.iscoroutinefunction(func)

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -4883,6 +4883,23 @@ async def test_runnable_gen() -> None:
     assert [p async for p in arunnable.astream(None)] == [1, 2, 3]
     assert await arunnable.abatch([None, None]) == [6, 6]
 
+    class AsyncGen:
+        async def __call__(self, input: AsyncIterator[Any]) -> AsyncIterator[int]:
+            yield 1
+            yield 2
+            yield 3
+
+    arunnablecallable = RunnableGenerator(AsyncGen())
+    assert await arunnablecallable.ainvoke(None) == 6
+    assert [p async for p in arunnablecallable.astream(None)] == [1, 2, 3]
+    assert await arunnablecallable.abatch([None, None]) == [6, 6]
+    with pytest.raises(NotImplementedError):
+        arunnablecallable.invoke(None)
+    with pytest.raises(NotImplementedError):
+        arunnablecallable.stream(None)
+    with pytest.raises(NotImplementedError):
+        arunnablecallable.batch([None, None])
+
 
 async def test_runnable_gen_context_config() -> None:
     """Test that a generator can call other runnables with config


### PR DESCRIPTION
To permit proper coercion of objects like the following:


```python
class MyAsyncCallable:
    async def __call__(self, foo):
        return await ...

class MyAsyncGenerator:
    async def __call__(self, foo):
        await ...
        yield 
```