### PR TITLE
community: introduce RAG output parsers

### DIFF
--- a/libs/community/langchain_community/output_parsers/rag_parsers.py
+++ b/libs/community/langchain_community/output_parsers/rag_parsers.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List
+
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
+
 
 class ChatCompletionsOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
     """OutputParser that wraps the string output into an OpenAI-like structured format."""
@@ -21,15 +23,7 @@ class ChatCompletionsOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
 
     def parse(self, text: str) -> Dict[str, Any]:
         """Returns the input text wrapped in an OpenAI-like response structure."""
-        return {
-            "choices": [
-                {
-                    "message": {
-                        "content": text
-                    }
-                }
-            ]
-        }
+        return {"choices": [{"message": {"content": text}}]}
 
 
 class StrObjOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
@@ -52,6 +46,4 @@ class StrObjOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
 
     def parse(self, text: str) -> Dict[str, Any]:
         """Returns the input text wrapped in an OpenAI-like response structure."""
-        return {
-            "content": text
-        }
+        return {"content": text}

--- a/libs/community/langchain_community/output_parsers/rag_parsers.py
+++ b/libs/community/langchain_community/output_parsers/rag_parsers.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, List
+from langchain_core.output_parsers.transform import BaseTransformOutputParser
+
+class ChatCompletionsOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
+    """OutputParser that wraps the string output into an OpenAI-like structured format."""
+
+    @classmethod
+    def is_lc_serializable(cls) -> bool:
+        """Return whether this class is serializable."""
+        return True
+
+    @classmethod
+    def get_lc_namespace(cls) -> List[str]:
+        """Get the namespace of the langchain object."""
+        return ["langchain", "schema", "output_parser"]
+
+    @property
+    def _type(self) -> str:
+        """Return the output parser type for serialization."""
+        return "openai_style"
+
+    def parse(self, text: str) -> Dict[str, Any]:
+        """Returns the input text wrapped in an OpenAI-like response structure."""
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": text
+                    }
+                }
+            ]
+        }
+
+
+class StrObjOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
+    """OutputParser that wraps the string output into a structured format."""
+
+    @classmethod
+    def is_lc_serializable(cls) -> bool:
+        """Return whether this class is serializable."""
+        return True
+
+    @classmethod
+    def get_lc_namespace(cls) -> List[str]:
+        """Get the namespace of the langchain object."""
+        return ["langchain", "schema", "output_parser"]
+
+    @property
+    def _type(self) -> str:
+        """Return the output parser type for serialization."""
+        return "openai_style"
+
+    def parse(self, text: str) -> Dict[str, Any]:
+        """Returns the input text wrapped in an OpenAI-like response structure."""
+        return {
+            "content": text
+        }

--- a/libs/community/langchain_community/output_parsers/rag_parsers.py
+++ b/libs/community/langchain_community/output_parsers/rag_parsers.py
@@ -4,7 +4,10 @@ from langchain_core.output_parsers.transform import BaseTransformOutputParser
 
 
 class ChatCompletionsOutputParser(BaseTransformOutputParser[Dict[str, Any]]):
-    """OutputParser that wraps the string output into an OpenAI-like structured format."""
+    """
+    OutputParser that wraps the string output into a ChatCompletions
+    structured format.
+    """
 
     @classmethod
     def is_lc_serializable(cls) -> bool:


### PR DESCRIPTION
We propose adding output parsers to return JSON objects from chains, which is preferred when deploying these as models.
* `ChatCompletionsOutputParser` make it easier for users to get ChatCompletions-like responses directly from their chain
* `StrObjOutputParser` is similar to the string output parser but return a JSON object

Example usage
```python
return (
    {
        "question": itemgetter("messages") | RunnableLambda(extract_question),
        "chat_history": itemgetter("messages") | RunnableLambda(extract_history),
    }
    | RunnablePassthrough()
    | {
        "relevant_docs": generate_query_to_retrieve_context_prompt
        | chat_model
        | StrOutputParser()
        | retriever,
        "chat_history": itemgetter("chat_history"),
        "question": itemgetter("question"),
    }
    | {
        "context": itemgetter("relevant_docs") | RunnableLambda(format_context),
        "chat_history": itemgetter("chat_history"),
        "question": itemgetter("question"),
    }
    | question_with_history_and_context_prompt
    | ChatDatabricks(
        endpoint=rag_config.get("llm_model"),
        **rag_config.get("llm_parameters"),
    )
    | ChatCompletionsOutputParser()
)
```