### PR TITLE
[Docs]: v0.1 UseCases Notebooks' Google Colab Links fix

### DIFF
--- a/docs/docs/use_cases/apis.ipynb
+++ b/docs/docs/use_cases/apis.ipynb
@@ -16,7 +16,7 @@
    "id": "a15e6a18",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/use_cases/apis.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/v0.1/docs/docs/use_cases/apis.ipynb)\n",
     "\n",
     "## Use case \n",
     "\n",

--- a/docs/docs/use_cases/code_understanding.ipynb
+++ b/docs/docs/use_cases/code_understanding.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/use_cases/code_understanding.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/v0.1/docs/docs/use_cases/code_understanding.ipynb)\n",
     "\n",
     "## Use case\n",
     "\n",

--- a/docs/docs/use_cases/data_generation.ipynb
+++ b/docs/docs/use_cases/data_generation.ipynb
@@ -17,7 +17,7 @@
    "id": "aa3571cc",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/use_cases/data_generation.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/v0.1/docs/docs/use_cases/data_generation.ipynb)\n",
     "\n",
     "## Use case\n",
     "\n",

--- a/docs/docs/use_cases/summarization.ipynb
+++ b/docs/docs/use_cases/summarization.ipynb
@@ -16,7 +16,7 @@
    "id": "cf13f702",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/use_cases/summarization.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/v0.1/docs/docs/use_cases/summarization.ipynb)\n",
     "\n",
     "## Use case\n",
     "\n",

--- a/docs/docs/use_cases/tagging.ipynb
+++ b/docs/docs/use_cases/tagging.ipynb
@@ -16,7 +16,7 @@
    "id": "a0507a4b",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/use_cases/tagging.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/v0.1/docs/docs/use_cases/tagging.ipynb)\n",
     "\n",
     "## Use case\n",
     "\n",

--- a/docs/docs/use_cases/web_scraping.ipynb
+++ b/docs/docs/use_cases/web_scraping.ipynb
@@ -16,7 +16,7 @@
    "id": "6605e7f7",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/master/docs/docs/use_cases/web_scraping.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/langchain-ai/langchain/blob/v0.1/docs/docs/use_cases/web_scraping.ipynb)\n",
     "\n",
     "## Use case\n",
     "\n",


### PR DESCRIPTION


  - **Description:** v0.1 Usecases Notebooks google colab link were pointing to master but they should point to v0.1 which was raising the following issue.
  - **Issue:** #21690


