### PR TITLE
How To: Custom tools

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -59,6 +59,7 @@
    "source": [
     "from langchain_core.tools import tool\n",
     "\n",
+    "\n",
     "@tool\n",
     "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
@@ -87,6 +88,7 @@
    "outputs": [],
    "source": [
     "from langchain_core.tools import tool\n",
+    "\n",
     "\n",
     "@tool\n",
     "async def amultiply(a: int, b: int) -> int:\n",
@@ -122,6 +124,7 @@
    "source": [
     "from langchain.pydantic_v1 import BaseModel, Field\n",
     "\n",
+    "\n",
     "class CalculatorInput(BaseModel):\n",
     "    a: int = Field(description=\"first number\")\n",
     "    b: int = Field(description=\"second number\")\n",
@@ -132,11 +135,12 @@
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
     "\n",
+    "\n",
     "# Let's inspect some of the attributes associated with the tool.\n",
     "print(multiply.name)\n",
     "print(multiply.description)\n",
     "print(multiply.args)\n",
-    "print(multiply.return_direct)\n"
+    "print(multiply.return_direct)"
    ]
   },
   {
@@ -167,6 +171,7 @@
    "source": [
     "from langchain_core.tools import StructuredTool\n",
     "\n",
+    "\n",
     "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
@@ -179,8 +184,8 @@
     "\n",
     "calculator = StructuredTool.from_function(func=multiply, coroutine=amultiply)\n",
     "\n",
-    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
-    "print(await calculator.ainvoke({'a': 2, 'b': 5}))"
+    "print(calculator.invoke({\"a\": 2, \"b\": 3}))\n",
+    "print(await calculator.ainvoke({\"a\": 2, \"b\": 5}))"
    ]
   },
   {
@@ -228,7 +233,7 @@
     "    # coroutine= ... <- you can specify an async method if desired as well\n",
     ")\n",
     "\n",
-    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
+    "print(calculator.invoke({\"a\": 2, \"b\": 3}))\n",
     "print(calculator.name)\n",
     "print(calculator.description)\n",
     "print(calculator.args)"
@@ -259,17 +264,19 @@
    "outputs": [],
    "source": [
     "from typing import Optional, Type\n",
-    "from langchain.pydantic_v1 import BaseModel\n",
-    "from langchain_core.tools import BaseTool\n",
     "\n",
     "from langchain.callbacks.manager import (\n",
     "    AsyncCallbackManagerForToolRun,\n",
     "    CallbackManagerForToolRun,\n",
     ")\n",
+    "from langchain.pydantic_v1 import BaseModel\n",
+    "from langchain_core.tools import BaseTool\n",
+    "\n",
     "\n",
     "class CalculatorInput(BaseModel):\n",
     "    a: int = Field(description=\"first number\")\n",
     "    b: int = Field(description=\"second number\")\n",
+    "\n",
     "\n",
     "class CustomCalculatorTool(BaseTool):\n",
     "    name = \"Calculator\"\n",
@@ -367,6 +374,7 @@
    "source": [
     "from langchain_core.tools import StructuredTool\n",
     "\n",
+    "\n",
     "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
@@ -374,8 +382,10 @@
     "\n",
     "calculator = StructuredTool.from_function(func=multiply)\n",
     "\n",
-    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
-    "print(await calculator.ainvoke({'a': 2, 'b': 5})) # Uses default LangChain async implementation incurs small overhead"
+    "print(calculator.invoke({\"a\": 2, \"b\": 3}))\n",
+    "print(\n",
+    "    await calculator.ainvoke({\"a\": 2, \"b\": 5})\n",
+    ")  # Uses default LangChain async implementation incurs small overhead"
    ]
   },
   {
@@ -396,18 +406,23 @@
    "source": [
     "from langchain_core.tools import StructuredTool\n",
     "\n",
+    "\n",
     "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
-    "    \n",
+    "\n",
+    "\n",
     "async def amultiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
     "\n",
+    "\n",
     "calculator = StructuredTool.from_function(func=multiply, coroutine=amultiply)\n",
     "\n",
-    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
-    "print(await calculator.ainvoke({'a': 2, 'b': 5})) # Uses use provided amultiply without additional overhead"
+    "print(calculator.invoke({\"a\": 2, \"b\": 3}))\n",
+    "print(\n",
+    "    await calculator.ainvoke({\"a\": 2, \"b\": 5})\n",
+    ")  # Uses use provided amultiply without additional overhead"
    ]
   },
   {
@@ -438,10 +453,11 @@
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
     "\n",
+    "\n",
     "try:\n",
     "    multiply.invoke({\"a\": 2, \"b\": 3})\n",
     "except NotImplementedError:\n",
-    "    print('Raised not implemented error. You should not be doing this.')"
+    "    print(\"Raised not implemented error. You should not be doing this.\")"
    ]
   },
   {
@@ -500,7 +516,7 @@
     "    handle_tool_error=True,\n",
     ")\n",
     "\n",
-    "get_weather_tool.invoke({'city': 'foobar'})"
+    "get_weather_tool.invoke({\"city\": \"foobar\"})"
    ]
   },
   {
@@ -526,7 +542,7 @@
     "    handle_tool_error=\"There is no such city, but it's probably above 0K there!\",\n",
     ")\n",
     "\n",
-    "get_weather_tool.invoke({'city': 'foobar'})"
+    "get_weather_tool.invoke({\"city\": \"foobar\"})"
    ]
   },
   {
@@ -558,12 +574,13 @@
     "def _handle_error(error: ToolException) -> str:\n",
     "    return f\"The following errors occurred during tool execution: `{error.args[0]}`\"\n",
     "\n",
+    "\n",
     "get_weather_tool = StructuredTool.from_function(\n",
     "    func=get_weather,\n",
     "    handle_tool_error=_handle_error,\n",
     ")\n",
     "\n",
-    "get_weather_tool.invoke({'city': 'foobar'})"
+    "get_weather_tool.invoke({\"city\": \"foobar\"})"
    ]
   }
  ],

--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -5,35 +5,21 @@
    "id": "5436020b",
    "metadata": {},
    "source": [
-    "# How to create custom Tools\n",
+    "# How to create a custom tool\n",
     "\n",
-    "When constructing your own agent, you will need to provide it with a list of Tools that it can use. Besides the actual function that is called, the Tool consists of several components:\n",
+    "When constructing an agent, you will need to provide it with a list of Tools that it can use. Besides the actual function that is called, the Tool consists of several components:\n",
     "\n",
-    "- `name` (str), is required and must be unique within a set of tools provided to an agent\n",
-    "- `description` (str), is optional but recommended, as it is used by an agent to determine tool use\n",
-    "- `args_schema` (Pydantic BaseModel), is optional but recommended, can be used to provide more information (e.g., few-shot examples) or validation for expected parameters.\n",
+    "| Attribute       | Type                      | Description                                                                                                      |\n",
+    "|-----------------|---------------------------|------------------------------------------------------------------------------------------------------------------|\n",
+    "| name          | str                     | Must be unique within a set of tools provided to an agent                                           |\n",
+    "| description   | str                     | Describes what the tool does. Used as context by the LLM or agent.                                       |\n",
+    "| args_schema   | Pydantic BaseModel      | Optional but recommended, can be used to provide more information (e.g., few-shot examples) or validation for expected parameters |\n",
     "\n",
+    "LangChain provides a few ways to define tools:\n",
     "\n",
-    "There are multiple ways to define a tool. In this guide, we will walk through how to do for two functions:\n",
-    "\n",
-    "1. A made up search function that always returns the string \"LangChain\"\n",
-    "2. A multiplier function that will multiply two numbers by eachother\n",
-    "\n",
-    "The biggest difference here is that the first function only requires one input, while the second one requires multiple. Many agents only work with functions that require single inputs, so it's important to know how to work with those. For the most part, defining these custom tools is the same, but there are some differences."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "id": "1aaba18c",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Import things that are needed generically\n",
-    "from langchain.pydantic_v1 import BaseModel, Field\n",
-    "from langchain.tools import BaseTool, StructuredTool, tool"
+    "1. @tool decorator -- the simplest way to define a custom tool.\n",
+    "2. Subclass from `BaseTool` -- provides more control and allows providing both sync and async implementations.\n",
+    "3. Using `StructuredTool.from_function` class method, also allows providing both sync and async implementations."
    ]
   },
   {
@@ -48,21 +34,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "b0ce7de8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@tool\n",
-    "def search(query: str) -> str:\n",
-    "    \"\"\"Look up things online.\"\"\"\n",
-    "    return \"LangChain\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "e889fa34",
+   "execution_count": 213,
+   "id": "96903182-6596-4532-9fd1-84308c1104cb",
    "metadata": {},
    "outputs": [
     {
@@ -76,28 +49,33 @@
     }
    ],
    "source": [
+    "from langchain.tools import tool\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def search(query: str) -> str:\n",
+    "    \"\"\"Look up things online.\"\"\"\n",
+    "    return \"LangChain\"\n",
+    "\n",
+    "\n",
+    "# Let's inspect some of the attributes associated with the tool.\n",
     "print(search.name)\n",
     "print(search.description)\n",
     "print(search.args)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "0b9694d9",
+   "cell_type": "markdown",
+   "id": "55da97d8-38c2-4cdb-afdd-34bc271d4702",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "@tool\n",
-    "def multiply(a: int, b: int) -> int:\n",
-    "    \"\"\"Multiply two numbers.\"\"\"\n",
-    "    return a * b"
+    "To create a tool with multiple inputs you can do the following:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "d7f9395b",
+   "execution_count": 214,
+   "id": "4d9be27d-543f-4ea2-ad5e-95af57d4ee9b",
    "metadata": {},
    "outputs": [
     {
@@ -111,6 +89,13 @@
     }
    ],
    "source": [
+    "@tool\n",
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "# Let's inspect some of the attributes associated with the tool.\n",
     "print(multiply.name)\n",
     "print(multiply.description)\n",
     "print(multiply.args)"
@@ -126,25 +111,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
-   "id": "dbbf4b6c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class SearchInput(BaseModel):\n",
-    "    query: str = Field(description=\"should be a search query\")\n",
-    "\n",
-    "\n",
-    "@tool(\"search-tool\", args_schema=SearchInput, return_direct=True)\n",
-    "def search(query: str) -> str:\n",
-    "    \"\"\"Look up things online.\"\"\"\n",
-    "    return \"LangChain\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "id": "5950ce32",
+   "execution_count": 215,
+   "id": "9216d03a-f6ea-4216-b7e1-0661823a4c0b",
    "metadata": {},
    "outputs": [
     {
@@ -159,10 +127,127 @@
     }
    ],
    "source": [
+    "from langchain.pydantic_v1 import BaseModel, Field\n",
+    "\n",
+    "\n",
+    "class SearchInput(BaseModel):\n",
+    "    query: str = Field(description=\"should be a search query\")\n",
+    "\n",
+    "\n",
+    "@tool(\"search-tool\", args_schema=SearchInput, return_direct=True)\n",
+    "def search(query: str) -> str:\n",
+    "    \"\"\"Look up things online.\"\"\"\n",
+    "    return \"LangChain\"\n",
+    "\n",
+    "\n",
+    "# Let's inspect some of the attributes associated with the tool.\n",
+    "\n",
     "print(search.name)\n",
     "print(search.description)\n",
     "print(search.args)\n",
     "print(search.return_direct)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67eea921-58db-4916-853b-fbd5bce11e76",
+   "metadata": {},
+   "source": [
+    ":::{.callout-tip}\n",
+    "\n",
+    "Because tools implement the [Runnable interface](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.base.Runnable.html), you\n",
+    "can use all the standard Runnable methods with tools!\n",
+    "\n",
+    "These methods can be helpful to create test that the tool is implemented correctly.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 223,
+   "id": "d76253b4-b701-46db-9d64-dceb8759c010",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LangChain\n",
+      "8\n",
+      "LangChain\n",
+      "8\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(search.invoke({\"query\": \"hello\"}))\n",
+    "print(multiply.invoke({\"a\": 4, \"b\": 2}))\n",
+    "# And the async variants. These incur a small overhead since they're\n",
+    "# delegating to the sync implementation from another thread.\n",
+    "print(await search.ainvoke({\"query\": \"hello\"}))\n",
+    "print(await multiply.ainvoke({\"a\": 4, \"b\": 2}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "488b013d-5fe8-42ee-842f-15050ace151f",
+   "metadata": {},
+   "source": [
+    "### async\n",
+    "\n",
+    ":::{.callout-important}\n",
+    "\n",
+    "If you're working in an async codebase, you should create async tools rather than sync tools using the @tool decorator.\n",
+    "\n",
+    "Using `ainvoke` using a sync provided tool incurs a small overhead if the tool is not associated with a native\n",
+    "`async` implementation.\n",
+    ":::\n",
+    "\n",
+    ":::{.callout-tip}\n",
+    "\n",
+    "If you need to have both synd and async implementation for your tool, consider subclassing from `BaseTool` instead.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "id": "4ad0932c-8610-4278-8c57-f9218f654c8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 224,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@tool\n",
+    "async def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "await multiply.ainvoke({\"a\": 2, \"b\": 3})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81454e2a-de12-4138-b5bc-802e598db623",
+   "metadata": {},
+   "source": [
+    ":::{.callout-important}\n",
+    "\n",
+    "If you've created an async tool. You **cannot** and **should not** use\n",
+    "it via the the sync `invoke`, `batch` or `stream` methods. \n",
+    "\n",
+    "For example, this using `invoke` instead of `ainvoke` will fail by design: `multiply.invoke({'a': 3, 'b': 5})`\n",
+    ":::"
    ]
   },
   {
@@ -172,12 +257,12 @@
    "source": [
     "## Subclass BaseTool\n",
     "\n",
-    "You can also explicitly define a custom tool by subclassing the BaseTool class. This provides maximal control over the tool definition, but is a bit more work."
+    "You can also explicitly define a custom tool by subclassing the BaseTool class. This provides maximal control over the tool definition at the expense of a bit more effort."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 230,
    "id": "1dad8f8e",
    "metadata": {},
    "outputs": [],
@@ -214,6 +299,9 @@
     "        self, query: str, run_manager: Optional[AsyncCallbackManagerForToolRun] = None\n",
     "    ) -> str:\n",
     "        \"\"\"Use the tool asynchronously.\"\"\"\n",
+    "        # Provide a native async implementation here.\n",
+    "        # For example, if you're connection to an API\n",
+    "        # you can use httpx with an async rather than sync client.\n",
     "        raise NotImplementedError(\"custom_search does not support async\")\n",
     "\n",
     "\n",
@@ -236,12 +324,17 @@
     "        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,\n",
     "    ) -> str:\n",
     "        \"\"\"Use the tool asynchronously.\"\"\"\n",
-    "        raise NotImplementedError(\"Calculator does not support async\")"
+    "        # If the calculation is cheap, you can just delegate to the sync implementation\n",
+    "        # as shown below.\n",
+    "        # If teh sync calculation is expensive, you should delete the entire _arun method.\n",
+    "        # LangChain will automatically provide a better implementation that will\n",
+    "        # kick off the task in a thread to make sure it doesn't block other async code.\n",
+    "        return self._run(a, b, run_manager=run_manager.get_sync())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 231,
    "id": "89933e27",
    "metadata": {},
    "outputs": [
@@ -264,7 +357,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 239,
+   "id": "6cedd31c-6bba-4c71-b3ad-01119d316601",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LangChain\n",
+      "LangChain\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(search.invoke({\"query\": \"hello\"}))\n",
+    "# Or you can use the short hand if there's only a single parameter\n",
+    "print(search.invoke(\"hello\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 244,
    "id": "bb551c33",
    "metadata": {},
    "outputs": [
@@ -275,7 +389,9 @@
       "Calculator\n",
       "useful for when you need to answer questions about math\n",
       "{'a': {'title': 'A', 'description': 'first number', 'type': 'integer'}, 'b': {'title': 'B', 'description': 'second number', 'type': 'integer'}}\n",
-      "True\n"
+      "True\n",
+      "6\n",
+      "6\n"
      ]
     }
    ],
@@ -284,7 +400,10 @@
     "print(multiply.name)\n",
     "print(multiply.description)\n",
     "print(multiply.args)\n",
-    "print(multiply.return_direct)"
+    "print(multiply.return_direct)\n",
+    "\n",
+    "print(multiply.invoke({\"a\": 2, \"b\": 3}))\n",
+    "print(await multiply.ainvoke({\"a\": 2, \"b\": 3}))"
    ]
   },
   {
@@ -294,12 +413,13 @@
    "source": [
     "## StructuredTool dataclass\n",
     "\n",
-    "You can also use a `StructuredTool` dataclass. This methods is a mix between the previous two. It's more convenient than inheriting from the BaseTool class, but provides more functionality than just using a decorator."
+    "You can also use a `StructuredTool` dataclass. This methods is a mix between the previous two. It's more convenient than inheriting from the BaseTool class, but provides more functionality than just using a decorator.\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 245,
    "id": "56ff7670",
    "metadata": {
     "tags": []
@@ -320,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 246,
    "id": "d3fd3896",
    "metadata": {},
    "outputs": [
@@ -350,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 247,
    "id": "712c1967",
    "metadata": {},
    "outputs": [],
@@ -377,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 248,
    "id": "f634081e",
    "metadata": {},
    "outputs": [
@@ -414,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 249,
    "id": "f8bf4668",
    "metadata": {},
    "outputs": [],
@@ -436,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 250,
    "id": "f3dfbcb0",
    "metadata": {},
    "outputs": [
@@ -447,11 +567,11 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mToolException\u001b[0m                             Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[58], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m search \u001b[38;5;241m=\u001b[39m StructuredTool\u001b[38;5;241m.\u001b[39mfrom_function(\n\u001b[1;32m      2\u001b[0m     func\u001b[38;5;241m=\u001b[39msearch_tool1,\n\u001b[1;32m      3\u001b[0m     name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSearch_tool1\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m      4\u001b[0m     description\u001b[38;5;241m=\u001b[39mdescription,\n\u001b[1;32m      5\u001b[0m )\n\u001b[0;32m----> 7\u001b[0m \u001b[43msearch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtest\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/workplace/langchain/libs/core/langchain_core/tools.py:344\u001b[0m, in \u001b[0;36mBaseTool.run\u001b[0;34m(self, tool_input, verbose, start_color, color, callbacks, tags, metadata, run_name, **kwargs)\u001b[0m\n\u001b[1;32m    342\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error:\n\u001b[1;32m    343\u001b[0m     run_manager\u001b[38;5;241m.\u001b[39mon_tool_error(e)\n\u001b[0;32m--> 344\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m    345\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error, \u001b[38;5;28mbool\u001b[39m):\n\u001b[1;32m    346\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m e\u001b[38;5;241m.\u001b[39margs:\n",
-      "File \u001b[0;32m~/workplace/langchain/libs/core/langchain_core/tools.py:337\u001b[0m, in \u001b[0;36mBaseTool.run\u001b[0;34m(self, tool_input, verbose, start_color, color, callbacks, tags, metadata, run_name, **kwargs)\u001b[0m\n\u001b[1;32m    334\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    335\u001b[0m     tool_args, tool_kwargs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_to_args_and_kwargs(parsed_input)\n\u001b[1;32m    336\u001b[0m     observation \u001b[38;5;241m=\u001b[39m (\n\u001b[0;32m--> 337\u001b[0m         \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtool_args\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrun_manager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrun_manager\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtool_kwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    338\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m new_arg_supported\n\u001b[1;32m    339\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_run(\u001b[38;5;241m*\u001b[39mtool_args, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mtool_kwargs)\n\u001b[1;32m    340\u001b[0m     )\n\u001b[1;32m    341\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m ToolException \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    342\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error:\n",
-      "File \u001b[0;32m~/workplace/langchain/libs/core/langchain_core/tools.py:631\u001b[0m, in \u001b[0;36mStructuredTool._run\u001b[0;34m(self, run_manager, *args, **kwargs)\u001b[0m\n\u001b[1;32m    622\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc:\n\u001b[1;32m    623\u001b[0m     new_argument_supported \u001b[38;5;241m=\u001b[39m signature(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc)\u001b[38;5;241m.\u001b[39mparameters\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcallbacks\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    624\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m (\n\u001b[1;32m    625\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc(\n\u001b[1;32m    626\u001b[0m             \u001b[38;5;241m*\u001b[39margs,\n\u001b[1;32m    627\u001b[0m             callbacks\u001b[38;5;241m=\u001b[39mrun_manager\u001b[38;5;241m.\u001b[39mget_child() \u001b[38;5;28;01mif\u001b[39;00m run_manager \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    628\u001b[0m             \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    629\u001b[0m         )\n\u001b[1;32m    630\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m new_argument_supported\n\u001b[0;32m--> 631\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    632\u001b[0m     )\n\u001b[1;32m    633\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTool does not support sync\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "Cell \u001b[0;32mIn[55], line 5\u001b[0m, in \u001b[0;36msearch_tool1\u001b[0;34m(s)\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msearch_tool1\u001b[39m(s: \u001b[38;5;28mstr\u001b[39m):\n\u001b[0;32m----> 5\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ToolException(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe search tool1 is not available.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "Cell \u001b[0;32mIn[250], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m search \u001b[38;5;241m=\u001b[39m StructuredTool\u001b[38;5;241m.\u001b[39mfrom_function(\n\u001b[1;32m      2\u001b[0m     func\u001b[38;5;241m=\u001b[39msearch_tool1,\n\u001b[1;32m      3\u001b[0m     name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSearch_tool1\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m      4\u001b[0m     description\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mA bad tool\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m      5\u001b[0m )\n\u001b[0;32m----> 7\u001b[0m \u001b[43msearch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtest\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/src/langchain/libs/core/langchain_core/tools.py:433\u001b[0m, in \u001b[0;36mBaseTool.run\u001b[0;34m(self, tool_input, verbose, start_color, color, callbacks, tags, metadata, run_name, run_id, config, **kwargs)\u001b[0m\n\u001b[1;32m    431\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error:\n\u001b[1;32m    432\u001b[0m     run_manager\u001b[38;5;241m.\u001b[39mon_tool_error(e)\n\u001b[0;32m--> 433\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m    434\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error, \u001b[38;5;28mbool\u001b[39m):\n\u001b[1;32m    435\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m e\u001b[38;5;241m.\u001b[39margs:\n",
+      "File \u001b[0;32m~/src/langchain/libs/core/langchain_core/tools.py:409\u001b[0m, in \u001b[0;36mBaseTool.run\u001b[0;34m(self, tool_input, verbose, start_color, color, callbacks, tags, metadata, run_name, run_id, config, **kwargs)\u001b[0m\n\u001b[1;32m    406\u001b[0m     parsed_input \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_parse_input(tool_input)\n\u001b[1;32m    407\u001b[0m     tool_args, tool_kwargs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_to_args_and_kwargs(parsed_input)\n\u001b[1;32m    408\u001b[0m     observation \u001b[38;5;241m=\u001b[39m (\n\u001b[0;32m--> 409\u001b[0m         \u001b[43mcontext\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    410\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtool_args\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrun_manager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrun_manager\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtool_kwargs\u001b[49m\n\u001b[1;32m    411\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    412\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m new_arg_supported\n\u001b[1;32m    413\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m context\u001b[38;5;241m.\u001b[39mrun(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_run, \u001b[38;5;241m*\u001b[39mtool_args, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mtool_kwargs)\n\u001b[1;32m    414\u001b[0m     )\n\u001b[1;32m    415\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m ValidationError \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    416\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_validation_error:\n",
+      "File \u001b[0;32m~/src/langchain/libs/core/langchain_core/tools.py:750\u001b[0m, in \u001b[0;36mStructuredTool._run\u001b[0;34m(self, run_manager, *args, **kwargs)\u001b[0m\n\u001b[1;32m    741\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc:\n\u001b[1;32m    742\u001b[0m     new_argument_supported \u001b[38;5;241m=\u001b[39m signature(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc)\u001b[38;5;241m.\u001b[39mparameters\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcallbacks\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    743\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m (\n\u001b[1;32m    744\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc(\n\u001b[1;32m    745\u001b[0m             \u001b[38;5;241m*\u001b[39margs,\n\u001b[1;32m    746\u001b[0m             callbacks\u001b[38;5;241m=\u001b[39mrun_manager\u001b[38;5;241m.\u001b[39mget_child() \u001b[38;5;28;01mif\u001b[39;00m run_manager \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    747\u001b[0m             \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    748\u001b[0m         )\n\u001b[1;32m    749\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m new_argument_supported\n\u001b[0;32m--> 750\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    751\u001b[0m     )\n\u001b[1;32m    752\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTool does not support sync\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "Cell \u001b[0;32mIn[249], line 5\u001b[0m, in \u001b[0;36msearch_tool1\u001b[0;34m(s)\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msearch_tool1\u001b[39m(s: \u001b[38;5;28mstr\u001b[39m):\n\u001b[0;32m----> 5\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ToolException(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe search tool1 is not available.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
       "\u001b[0;31mToolException\u001b[0m: The search tool1 is not available."
      ]
     }
@@ -476,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 251,
    "id": "ab81e0f0",
    "metadata": {},
    "outputs": [
@@ -486,7 +606,7 @@
        "'The search tool1 is not available.'"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 251,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -512,17 +632,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 254,
    "id": "ad16fbcf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The following errors occurred during tool execution:The search tool1 is not available.Please try another tool.'"
+       "'The following errors occurred during tool execution: The search tool1 is not available. Please try another tool.'"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 254,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -530,9 +650,9 @@
    "source": [
     "def _handle_error(error: ToolException) -> str:\n",
     "    return (\n",
-    "        \"The following errors occurred during tool execution:\"\n",
+    "        \"The following errors occurred during tool execution: \"\n",
     "        + error.args[0]\n",
-    "        + \"Please try another tool.\"\n",
+    "        + \" Please try another tool.\"\n",
     "    )\n",
     "\n",
     "\n",
@@ -563,7 +683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -5,21 +5,29 @@
    "id": "5436020b",
    "metadata": {},
    "source": [
-    "# How to create a custom tool\n",
+    "# How to create custom tools\n",
     "\n",
-    "When constructing an agent, you will need to provide it with a list of Tools that it can use. Besides the actual function that is called, the Tool consists of several components:\n",
+    "When constructing an agent, you will need to provide it with a list of `Tool`s that it can use. Besides the actual function that is called, the Tool consists of several components:\n",
     "\n",
     "| Attribute       | Type                      | Description                                                                                                      |\n",
     "|-----------------|---------------------------|------------------------------------------------------------------------------------------------------------------|\n",
-    "| name          | str                     | Must be unique within a set of tools provided to an agent                                           |\n",
+    "| name          | str                     | Must be unique within a set of tools provided to an LLM or agent.                                           |\n",
     "| description   | str                     | Describes what the tool does. Used as context by the LLM or agent.                                       |\n",
     "| args_schema   | Pydantic BaseModel      | Optional but recommended, can be used to provide more information (e.g., few-shot examples) or validation for expected parameters |\n",
+    "| return_direct   | boolean      | Only relevant for agents. When True, after invoking the given tool, the agent will stop and return the result direcly to the user.  |\n",
     "\n",
-    "LangChain provides a few ways to define tools:\n",
+    "LangChain provides 3 ways to create tools:\n",
     "\n",
-    "1. @tool decorator -- the simplest way to define a custom tool.\n",
-    "2. Subclass from `BaseTool` -- provides more control and allows providing both sync and async implementations.\n",
-    "3. Using `StructuredTool.from_function` class method, also allows providing both sync and async implementations."
+    "1. Using [@tool decorator](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.tool.html#langchain_core.tools.tool) -- the simplest way to define a custom tool.\n",
+    "2. Using [StructuredTool.from_function](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.StructuredTool.html#langchain_core.tools.StructuredTool.from_function) class method -- this is similar to the `@tool` decorator, but allows more configuration and specification of both sync and async implementations.\n",
+    "3. By sub-classing from [BaseTool](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.BaseTool.html) -- This is the most flexible methoed, it provides the largest degree of control, at the expense of more effort and code.\n",
+    "\n",
+    "The `@tool` or the `StructuredTool.from_function` class method should be sufficient for most use cases.\n",
+    "\n",
+    ":::{.callout-tip}\n",
+    "\n",
+    "Models will perform better if the tools have well chosen names, descriptions and JSON schemas.\n",
+    ":::"
    ]
   },
   {
@@ -34,48 +42,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
-   "id": "96903182-6596-4532-9fd1-84308c1104cb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "search\n",
-      "search(query: str) -> str - Look up things online.\n",
-      "{'query': {'title': 'Query', 'type': 'string'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "from langchain.tools import tool\n",
-    "\n",
-    "\n",
-    "@tool\n",
-    "def search(query: str) -> str:\n",
-    "    \"\"\"Look up things online.\"\"\"\n",
-    "    return \"LangChain\"\n",
-    "\n",
-    "\n",
-    "# Let's inspect some of the attributes associated with the tool.\n",
-    "print(search.name)\n",
-    "print(search.description)\n",
-    "print(search.args)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55da97d8-38c2-4cdb-afdd-34bc271d4702",
-   "metadata": {},
-   "source": [
-    "To create a tool with multiple inputs you can do the following:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 214,
-   "id": "4d9be27d-543f-4ea2-ad5e-95af57d4ee9b",
+   "execution_count": 1,
+   "id": "cc7005cd-072f-4d37-8453-6297468e5192",
    "metadata": {},
    "outputs": [
     {
@@ -89,6 +57,8 @@
     }
    ],
    "source": [
+    "from langchain_core.tools import tool\n",
+    "\n",
     "@tool\n",
     "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
@@ -103,6 +73,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "96698b67-993a-4c97-b867-333132e1eb14",
+   "metadata": {},
+   "source": [
+    "Or create an **async** implementation, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0c0991db-b997-4611-be37-4346e660506b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "@tool\n",
+    "async def amultiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "98d6eee9",
    "metadata": {},
    "source": [
@@ -111,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 3,
    "id": "9216d03a-f6ea-4216-b7e1-0661823a4c0b",
    "metadata": {},
    "outputs": [
@@ -119,9 +112,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "search-tool\n",
-      "search-tool(query: str) -> str - Look up things online.\n",
-      "{'query': {'title': 'Query', 'description': 'should be a search query', 'type': 'string'}}\n",
+      "multiplication-tool\n",
+      "multiplication-tool(a: int, b: int) -> int - Multiply two numbers.\n",
+      "{'a': {'title': 'A', 'description': 'first number', 'type': 'integer'}, 'b': {'title': 'B', 'description': 'second number', 'type': 'integer'}}\n",
       "True\n"
      ]
     }
@@ -129,181 +122,154 @@
    "source": [
     "from langchain.pydantic_v1 import BaseModel, Field\n",
     "\n",
+    "class CalculatorInput(BaseModel):\n",
+    "    a: int = Field(description=\"first number\")\n",
+    "    b: int = Field(description=\"second number\")\n",
     "\n",
-    "class SearchInput(BaseModel):\n",
-    "    query: str = Field(description=\"should be a search query\")\n",
     "\n",
-    "\n",
-    "@tool(\"search-tool\", args_schema=SearchInput, return_direct=True)\n",
-    "def search(query: str) -> str:\n",
-    "    \"\"\"Look up things online.\"\"\"\n",
-    "    return \"LangChain\"\n",
-    "\n",
+    "@tool(\"multiplication-tool\", args_schema=CalculatorInput, return_direct=True)\n",
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
     "\n",
     "# Let's inspect some of the attributes associated with the tool.\n",
-    "\n",
-    "print(search.name)\n",
-    "print(search.description)\n",
-    "print(search.args)\n",
-    "print(search.return_direct)"
+    "print(multiply.name)\n",
+    "print(multiply.description)\n",
+    "print(multiply.args)\n",
+    "print(multiply.return_direct)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "67eea921-58db-4916-853b-fbd5bce11e76",
+   "id": "b63fcc3b",
    "metadata": {},
    "source": [
-    ":::{.callout-tip}\n",
+    "## StructuredTool\n",
     "\n",
-    "Because tools implement the [Runnable interface](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.base.Runnable.html), you\n",
-    "can use all the standard Runnable methods with tools!\n",
-    "\n",
-    "These methods can be helpful to create test that the tool is implemented correctly.\n",
-    ":::"
+    "The `StrurcturedTool.from_function` class method provides a bit more configurability than the `@tool` decorator, without requiring much additional code."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
-   "id": "d76253b4-b701-46db-9d64-dceb8759c010",
+   "execution_count": 4,
+   "id": "564fbe6f-11df-402d-b135-ef6ff25e1e63",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LangChain\n",
-      "8\n",
-      "LangChain\n",
-      "8\n"
+      "6\n",
+      "10\n"
      ]
     }
    ],
    "source": [
-    "print(search.invoke({\"query\": \"hello\"}))\n",
-    "print(multiply.invoke({\"a\": 4, \"b\": 2}))\n",
-    "# And the async variants. These incur a small overhead since they're\n",
-    "# delegating to the sync implementation from another thread.\n",
-    "print(await search.ainvoke({\"query\": \"hello\"}))\n",
-    "print(await multiply.ainvoke({\"a\": 4, \"b\": 2}))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "488b013d-5fe8-42ee-842f-15050ace151f",
-   "metadata": {},
-   "source": [
-    "### async\n",
+    "from langchain_core.tools import StructuredTool\n",
     "\n",
-    ":::{.callout-important}\n",
-    "\n",
-    "If you're working in an async codebase, you should create async tools rather than sync tools using the @tool decorator.\n",
-    "\n",
-    "Using `ainvoke` using a sync provided tool incurs a small overhead if the tool is not associated with a native\n",
-    "`async` implementation.\n",
-    ":::\n",
-    "\n",
-    ":::{.callout-tip}\n",
-    "\n",
-    "If you need to have both synd and async implementation for your tool, consider subclassing from `BaseTool` instead.\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 224,
-   "id": "4ad0932c-8610-4278-8c57-f9218f654c8a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "6"
-      ]
-     },
-     "execution_count": 224,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "@tool\n",
-    "async def multiply(a: int, b: int) -> int:\n",
+    "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
     "\n",
     "\n",
-    "await multiply.ainvoke({\"a\": 2, \"b\": 3})"
+    "async def amultiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "calculator = StructuredTool.from_function(func=multiply, coroutine=amultiply)\n",
+    "\n",
+    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
+    "print(await calculator.ainvoke({'a': 2, 'b': 5}))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "81454e2a-de12-4138-b5bc-802e598db623",
+   "id": "26b3712a-b38d-4582-b6e6-bc7cfb1d6680",
    "metadata": {},
    "source": [
-    ":::{.callout-important}\n",
-    "\n",
-    "If you've created an async tool. You **cannot** and **should not** use\n",
-    "it via the the sync `invoke`, `batch` or `stream` methods. \n",
-    "\n",
-    "For example, this using `invoke` instead of `ainvoke` will fail by design: `multiply.invoke({'a': 3, 'b': 5})`\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9d11e80c",
-   "metadata": {},
-   "source": [
-    "## Subclass BaseTool\n",
-    "\n",
-    "You can also explicitly define a custom tool by subclassing the BaseTool class. This provides maximal control over the tool definition at the expense of a bit more effort."
+    "To configure it:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 5,
+   "id": "6bc055d4-1fbe-4db5-8881-9c382eba6b1b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6\n",
+      "Calculator\n",
+      "Calculator(a: int, b: int) -> int - multiply numbers\n",
+      "{'a': {'title': 'A', 'description': 'first number', 'type': 'integer'}, 'b': {'title': 'B', 'description': 'second number', 'type': 'integer'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "class CalculatorInput(BaseModel):\n",
+    "    a: int = Field(description=\"first number\")\n",
+    "    b: int = Field(description=\"second number\")\n",
+    "\n",
+    "\n",
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "calculator = StructuredTool.from_function(\n",
+    "    func=multiply,\n",
+    "    name=\"Calculator\",\n",
+    "    description=\"multiply numbers\",\n",
+    "    args_schema=CalculatorInput,\n",
+    "    return_direct=True,\n",
+    "    # coroutine= ... <- you can specify an async method if desired as well\n",
+    ")\n",
+    "\n",
+    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
+    "print(calculator.name)\n",
+    "print(calculator.description)\n",
+    "print(calculator.args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b840074b-9c10-4ca0-aed8-626c52b2398f",
+   "metadata": {},
+   "source": [
+    "## Subclass BaseTool\n",
+    "\n",
+    "You can define a custom tool by sub-classing from `BaseTool`. This provides maximal control over the tool definition, but requires writing more code.\n",
+    "\n",
+    ":::{.callout-tip}\n",
+    "\n",
+    "This pattern is often used to bind additional parameters to the tool (e.g., an API key), that should not be controlled or seen by the LLM.\n",
+    "\n",
+    "The same behavior can be achieved with the previous two methods by creating the tools from inside a function.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "1dad8f8e",
    "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Optional, Type\n",
+    "from langchain.pydantic_v1 import BaseModel\n",
+    "from langchain_core.tools import BaseTool\n",
     "\n",
     "from langchain.callbacks.manager import (\n",
     "    AsyncCallbackManagerForToolRun,\n",
     "    CallbackManagerForToolRun,\n",
     ")\n",
     "\n",
-    "\n",
-    "class SearchInput(BaseModel):\n",
-    "    query: str = Field(description=\"should be a search query\")\n",
-    "\n",
-    "\n",
     "class CalculatorInput(BaseModel):\n",
     "    a: int = Field(description=\"first number\")\n",
     "    b: int = Field(description=\"second number\")\n",
-    "\n",
-    "\n",
-    "class CustomSearchTool(BaseTool):\n",
-    "    name = \"custom_search\"\n",
-    "    description = \"useful for when you need to answer questions about current events\"\n",
-    "    args_schema: Type[BaseModel] = SearchInput\n",
-    "\n",
-    "    def _run(\n",
-    "        self, query: str, run_manager: Optional[CallbackManagerForToolRun] = None\n",
-    "    ) -> str:\n",
-    "        \"\"\"Use the tool.\"\"\"\n",
-    "        return \"LangChain\"\n",
-    "\n",
-    "    async def _arun(\n",
-    "        self, query: str, run_manager: Optional[AsyncCallbackManagerForToolRun] = None\n",
-    "    ) -> str:\n",
-    "        \"\"\"Use the tool asynchronously.\"\"\"\n",
-    "        # Provide a native async implementation here.\n",
-    "        # For example, if you're connection to an API\n",
-    "        # you can use httpx with an async rather than sync client.\n",
-    "        raise NotImplementedError(\"custom_search does not support async\")\n",
-    "\n",
     "\n",
     "class CustomCalculatorTool(BaseTool):\n",
     "    name = \"Calculator\"\n",
@@ -326,7 +292,7 @@
     "        \"\"\"Use the tool asynchronously.\"\"\"\n",
     "        # If the calculation is cheap, you can just delegate to the sync implementation\n",
     "        # as shown below.\n",
-    "        # If teh sync calculation is expensive, you should delete the entire _arun method.\n",
+    "        # If the sync calculation is expensive, you should delete the entire _arun method.\n",
     "        # LangChain will automatically provide a better implementation that will\n",
     "        # kick off the task in a thread to make sure it doesn't block other async code.\n",
     "        return self._run(a, b, run_manager=run_manager.get_sync())"
@@ -334,51 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
-   "id": "89933e27",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "custom_search\n",
-      "useful for when you need to answer questions about current events\n",
-      "{'query': {'title': 'Query', 'description': 'should be a search query', 'type': 'string'}}\n"
-     ]
-    }
-   ],
-   "source": [
-    "search = CustomSearchTool()\n",
-    "print(search.name)\n",
-    "print(search.description)\n",
-    "print(search.args)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 239,
-   "id": "6cedd31c-6bba-4c71-b3ad-01119d316601",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "LangChain\n",
-      "LangChain\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(search.invoke({\"query\": \"hello\"}))\n",
-    "# Or you can use the short hand if there's only a single parameter\n",
-    "print(search.invoke(\"hello\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": 7,
    "id": "bb551c33",
    "metadata": {},
    "outputs": [
@@ -408,223 +330,208 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b63fcc3b",
+   "id": "97aba6cc-4bdf-4fab-aff3-d89e7d9c3a09",
    "metadata": {},
    "source": [
-    "## StructuredTool dataclass\n",
+    "## How to create async tools\n",
     "\n",
-    "You can also use a `StructuredTool` dataclass. This methods is a mix between the previous two. It's more convenient than inheriting from the BaseTool class, but provides more functionality than just using a decorator.\n",
-    "\n"
+    "LangChain Tools implement the [Runnable interface 🏃](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.base.Runnable.html).\n",
+    "\n",
+    "All Runnables expose the `invoke` and `ainvoke` methods (as well as other methods like `batch`, `abatch`, `astream` etc).\n",
+    "\n",
+    "So even if you only provide an `sync` implementation of a tool, you could still use the `ainvoke` interface, but there\n",
+    "are some important things to know:\n",
+    "\n",
+    "* LangChain's by default provides an async implementation that assumes that the function is expensive to compute, so it'll delegate execution to another thread.\n",
+    "* If you're working in an async codebase, you should create async tools rather than sync tools, to avoid incuring a small overhead due to that thread.\n",
+    "* If you need both sync and async implementations, use `StructuredTool.from_function` or sub-class from `BaseTool`.\n",
+    "* If implementing both sync and async, and the sync code is fast to run, override the default LangChain async implementation and simply call the sync code.\n",
+    "* You CANNOT and SHOULD NOT use the sync `invoke` with an `async tool`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
-   "id": "56ff7670",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def search_function(query: str):\n",
-    "    return \"LangChain\"\n",
-    "\n",
-    "\n",
-    "search = StructuredTool.from_function(\n",
-    "    func=search_function,\n",
-    "    name=\"Search\",\n",
-    "    description=\"useful for when you need to answer questions about current events\",\n",
-    "    # coroutine= ... <- you can specify an async method if desired as well\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 246,
-   "id": "d3fd3896",
+   "execution_count": 8,
+   "id": "6615cb77-fd4c-4676-8965-f92cc71d4944",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Search\n",
-      "Search(query: str) - useful for when you need to answer questions about current events\n",
-      "{'query': {'title': 'Query', 'type': 'string'}}\n"
+      "6\n",
+      "10\n"
      ]
     }
    ],
    "source": [
-    "print(search.name)\n",
-    "print(search.description)\n",
-    "print(search.args)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e9b560f7",
-   "metadata": {},
-   "source": [
-    "You can also define a custom `args_schema` to provide more information about inputs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 247,
-   "id": "712c1967",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class CalculatorInput(BaseModel):\n",
-    "    a: int = Field(description=\"first number\")\n",
-    "    b: int = Field(description=\"second number\")\n",
-    "\n",
+    "from langchain_core.tools import StructuredTool\n",
     "\n",
     "def multiply(a: int, b: int) -> int:\n",
     "    \"\"\"Multiply two numbers.\"\"\"\n",
     "    return a * b\n",
     "\n",
     "\n",
-    "calculator = StructuredTool.from_function(\n",
-    "    func=multiply,\n",
-    "    name=\"Calculator\",\n",
-    "    description=\"multiply numbers\",\n",
-    "    args_schema=CalculatorInput,\n",
-    "    return_direct=True,\n",
-    "    # coroutine= ... <- you can specify an async method if desired as well\n",
-    ")"
+    "calculator = StructuredTool.from_function(func=multiply)\n",
+    "\n",
+    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
+    "print(await calculator.ainvoke({'a': 2, 'b': 5})) # Uses default LangChain async implementation incurs small overhead"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
-   "id": "f634081e",
+   "execution_count": 9,
+   "id": "bb2af583-eadd-41f4-a645-bf8748bd3dcd",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Calculator\n",
-      "Calculator(a: int, b: int) -> int - multiply numbers\n",
-      "{'a': {'title': 'A', 'description': 'first number', 'type': 'integer'}, 'b': {'title': 'B', 'description': 'second number', 'type': 'integer'}}\n"
+      "6\n",
+      "10\n"
      ]
     }
    ],
    "source": [
-    "print(calculator.name)\n",
-    "print(calculator.description)\n",
-    "print(calculator.args)"
+    "from langchain_core.tools import StructuredTool\n",
+    "\n",
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "    \n",
+    "async def amultiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "calculator = StructuredTool.from_function(func=multiply, coroutine=amultiply)\n",
+    "\n",
+    "print(calculator.invoke({'a': 2, 'b': 3}))\n",
+    "print(await calculator.ainvoke({'a': 2, 'b': 5})) # Uses use provided amultiply without additional overhead"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f1da459d",
+   "id": "c80ffdaa-e4ba-4a70-8500-32bf4f60cc1a",
+   "metadata": {},
+   "source": [
+    "You should not and cannot use `.invoke` when providing only an async definition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4ad0932c-8610-4278-8c57-f9218f654c8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raised not implemented error. You should not be doing this.\n"
+     ]
+    }
+   ],
+   "source": [
+    "@tool\n",
+    "async def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiply two numbers.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "try:\n",
+    "    multiply.invoke({\"a\": 2, \"b\": 3})\n",
+    "except NotImplementedError:\n",
+    "    print('Raised not implemented error. You should not be doing this.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9c746a7-88d7-4afb-bcb8-0e98b891e8b6",
    "metadata": {},
    "source": [
     "## Handling Tool Errors \n",
-    "When a tool encounters an error and the exception is not caught, the agent will stop executing. If you want the agent to continue execution, you can raise a `ToolException` and set `handle_tool_error` accordingly. \n",
     "\n",
-    "When `ToolException` is thrown, the agent will not stop working, but will handle the exception according to the `handle_tool_error` variable of the tool, and the processing result will be returned to the agent as observation, and printed in red.\n",
+    "If you're using tools with agents, you will likely need an error handling strategy, so the agent can recover from the error and continue execution.\n",
     "\n",
-    "You can set `handle_tool_error` to `True`, set it a unified string value, or set it as a function. If it's set as a function, the function should take a `ToolException` as a parameter and return a `str` value.\n",
+    "A simple strategy is to throw a `ToolException` from inside the tool and specify an error handler using `handle_tool_error`. \n",
+    "\n",
+    "When the error handler is specified, the exception will be caught and the error handler will decide which output to return from the tool.\n",
+    "\n",
+    "You can set `handle_tool_error` to `True`, a string value, or a function. If it's a function, the function should take a `ToolException` as a parameter and return a value.\n",
     "\n",
     "Please note that only raising a `ToolException` won't be effective. You need to first set the `handle_tool_error` of the tool because its default value is `False`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
-   "id": "f8bf4668",
+   "execution_count": 11,
+   "id": "7094c0e8-6192-4870-a942-aad5b5ae48fd",
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain_core.tools import ToolException\n",
     "\n",
     "\n",
-    "def search_tool1(s: str):\n",
-    "    raise ToolException(\"The search tool1 is not available.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7fb56757",
-   "metadata": {},
-   "source": [
-    "First, let's see what happens if we don't set `handle_tool_error` - it will error."
+    "def get_weather(city: str) -> int:\n",
+    "    \"\"\"Get weather for the given city.\"\"\"\n",
+    "    raise ToolException(f\"Error: There is no city by the name of {city}.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
-   "id": "f3dfbcb0",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "ToolException",
-     "evalue": "The search tool1 is not available.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mToolException\u001b[0m                             Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[250], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m search \u001b[38;5;241m=\u001b[39m StructuredTool\u001b[38;5;241m.\u001b[39mfrom_function(\n\u001b[1;32m      2\u001b[0m     func\u001b[38;5;241m=\u001b[39msearch_tool1,\n\u001b[1;32m      3\u001b[0m     name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSearch_tool1\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m      4\u001b[0m     description\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mA bad tool\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m      5\u001b[0m )\n\u001b[0;32m----> 7\u001b[0m \u001b[43msearch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtest\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/src/langchain/libs/core/langchain_core/tools.py:433\u001b[0m, in \u001b[0;36mBaseTool.run\u001b[0;34m(self, tool_input, verbose, start_color, color, callbacks, tags, metadata, run_name, run_id, config, **kwargs)\u001b[0m\n\u001b[1;32m    431\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error:\n\u001b[1;32m    432\u001b[0m     run_manager\u001b[38;5;241m.\u001b[39mon_tool_error(e)\n\u001b[0;32m--> 433\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m e\n\u001b[1;32m    434\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_tool_error, \u001b[38;5;28mbool\u001b[39m):\n\u001b[1;32m    435\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m e\u001b[38;5;241m.\u001b[39margs:\n",
-      "File \u001b[0;32m~/src/langchain/libs/core/langchain_core/tools.py:409\u001b[0m, in \u001b[0;36mBaseTool.run\u001b[0;34m(self, tool_input, verbose, start_color, color, callbacks, tags, metadata, run_name, run_id, config, **kwargs)\u001b[0m\n\u001b[1;32m    406\u001b[0m     parsed_input \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_parse_input(tool_input)\n\u001b[1;32m    407\u001b[0m     tool_args, tool_kwargs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_to_args_and_kwargs(parsed_input)\n\u001b[1;32m    408\u001b[0m     observation \u001b[38;5;241m=\u001b[39m (\n\u001b[0;32m--> 409\u001b[0m         \u001b[43mcontext\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    410\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtool_args\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrun_manager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrun_manager\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtool_kwargs\u001b[49m\n\u001b[1;32m    411\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    412\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m new_arg_supported\n\u001b[1;32m    413\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m context\u001b[38;5;241m.\u001b[39mrun(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_run, \u001b[38;5;241m*\u001b[39mtool_args, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mtool_kwargs)\n\u001b[1;32m    414\u001b[0m     )\n\u001b[1;32m    415\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m ValidationError \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    416\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandle_validation_error:\n",
-      "File \u001b[0;32m~/src/langchain/libs/core/langchain_core/tools.py:750\u001b[0m, in \u001b[0;36mStructuredTool._run\u001b[0;34m(self, run_manager, *args, **kwargs)\u001b[0m\n\u001b[1;32m    741\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc:\n\u001b[1;32m    742\u001b[0m     new_argument_supported \u001b[38;5;241m=\u001b[39m signature(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc)\u001b[38;5;241m.\u001b[39mparameters\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcallbacks\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    743\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m (\n\u001b[1;32m    744\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfunc(\n\u001b[1;32m    745\u001b[0m             \u001b[38;5;241m*\u001b[39margs,\n\u001b[1;32m    746\u001b[0m             callbacks\u001b[38;5;241m=\u001b[39mrun_manager\u001b[38;5;241m.\u001b[39mget_child() \u001b[38;5;28;01mif\u001b[39;00m run_manager \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    747\u001b[0m             \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    748\u001b[0m         )\n\u001b[1;32m    749\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m new_argument_supported\n\u001b[0;32m--> 750\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    751\u001b[0m     )\n\u001b[1;32m    752\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTool does not support sync\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "Cell \u001b[0;32mIn[249], line 5\u001b[0m, in \u001b[0;36msearch_tool1\u001b[0;34m(s)\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msearch_tool1\u001b[39m(s: \u001b[38;5;28mstr\u001b[39m):\n\u001b[0;32m----> 5\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ToolException(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe search tool1 is not available.\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[0;31mToolException\u001b[0m: The search tool1 is not available."
-     ]
-    }
-   ],
-   "source": [
-    "search = StructuredTool.from_function(\n",
-    "    func=search_tool1,\n",
-    "    name=\"Search_tool1\",\n",
-    "    description=\"A bad tool\",\n",
-    ")\n",
-    "\n",
-    "search.run(\"test\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d2475acd",
-   "metadata": {},
-   "source": [
-    "Now, let's set `handle_tool_error` to be True"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 251,
-   "id": "ab81e0f0",
+   "execution_count": 12,
+   "id": "b4d22022-b105-4ccc-a15b-412cb9ea3097",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The search tool1 is not available.'"
+       "'Error: There is no city by the name of foobar.'"
       ]
      },
-     "execution_count": 251,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "search = StructuredTool.from_function(\n",
-    "    func=search_tool1,\n",
-    "    name=\"Search_tool1\",\n",
-    "    description=\"A bad tool\",\n",
+    "get_weather_tool = StructuredTool.from_function(\n",
+    "    func=get_weather,\n",
     "    handle_tool_error=True,\n",
     ")\n",
     "\n",
-    "search.run(\"test\")"
+    "get_weather_tool.invoke({'city': 'foobar'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3fad1728-d367-4e1b-9b54-3172981271cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"There is no such city, but it's probably above 0K there!\""
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_weather_tool = StructuredTool.from_function(\n",
+    "    func=get_weather,\n",
+    "    handle_tool_error=\"There is no such city, but it's probably above 0K there!\",\n",
+    ")\n",
+    "\n",
+    "get_weather_tool.invoke({'city': 'foobar'})"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dafbbcbe",
+   "id": "b0a640c1-e08f-4413-83b6-f599f304935f",
    "metadata": {},
    "source": [
     "We can also define a custom way to handle the tool error"
@@ -632,38 +539,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
-   "id": "ad16fbcf",
+   "execution_count": 15,
+   "id": "ebfe7c1f-318d-4e58-99e1-f31e69473c46",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The following errors occurred during tool execution: The search tool1 is not available. Please try another tool.'"
+       "'The following errors occurred during tool execution: `Error: There is no city by the name of foobar.`.'"
       ]
      },
-     "execution_count": 254,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "def _handle_error(error: ToolException) -> str:\n",
-    "    return (\n",
-    "        \"The following errors occurred during tool execution: \"\n",
-    "        + error.args[0]\n",
-    "        + \" Please try another tool.\"\n",
-    "    )\n",
+    "    return f\"The following errors occurred during tool execution: `{error.args[0]}`\"\n",
     "\n",
-    "\n",
-    "search = StructuredTool.from_function(\n",
-    "    func=search_tool1,\n",
-    "    name=\"Search_tool1\",\n",
-    "    description=\"A bad tool\",\n",
+    "get_weather_tool = StructuredTool.from_function(\n",
+    "    func=get_weather,\n",
     "    handle_tool_error=_handle_error,\n",
     ")\n",
     "\n",
-    "search.run(\"test\")"
+    "get_weather_tool.invoke({'city': 'foobar'})"
    ]
   }
  ],

--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "1. Using [@tool decorator](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.tool.html#langchain_core.tools.tool) -- the simplest way to define a custom tool.\n",
     "2. Using [StructuredTool.from_function](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.StructuredTool.html#langchain_core.tools.StructuredTool.from_function) class method -- this is similar to the `@tool` decorator, but allows more configuration and specification of both sync and async implementations.\n",
-    "3. By sub-classing from [BaseTool](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.BaseTool.html) -- This is the most flexible methoed, it provides the largest degree of control, at the expense of more effort and code.\n",
+    "3. By sub-classing from [BaseTool](https://api.python.langchain.com/en/latest/tools/langchain_core.tools.BaseTool.html) -- This is the most flexible method, it provides the largest degree of control, at the expense of more effort and code.\n",
     "\n",
     "The `@tool` or the `StructuredTool.from_function` class method should be sufficient for most use cases.\n",
     "\n",
@@ -246,19 +246,12 @@
    "source": [
     "## Subclass BaseTool\n",
     "\n",
-    "You can define a custom tool by sub-classing from `BaseTool`. This provides maximal control over the tool definition, but requires writing more code.\n",
-    "\n",
-    ":::{.callout-tip}\n",
-    "\n",
-    "This pattern is often used to bind additional parameters to the tool (e.g., an API key), that should not be controlled or seen by the LLM.\n",
-    "\n",
-    "The same behavior can be achieved with the previous two methods by creating the tools from inside a function.\n",
-    ":::"
+    "You can define a custom tool by sub-classing from `BaseTool`. This provides maximal control over the tool definition, but requires writing more code."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "id": "1dad8f8e",
    "metadata": {},
    "outputs": [],
@@ -353,7 +346,7 @@
     "* If you're working in an async codebase, you should create async tools rather than sync tools, to avoid incuring a small overhead due to that thread.\n",
     "* If you need both sync and async implementations, use `StructuredTool.from_function` or sub-class from `BaseTool`.\n",
     "* If implementing both sync and async, and the sync code is fast to run, override the default LangChain async implementation and simply call the sync code.\n",
-    "* You CANNOT and SHOULD NOT use the sync `invoke` with an `async tool`."
+    "* You CANNOT and SHOULD NOT use the sync `invoke` with an `async` tool."
    ]
   },
   {
@@ -494,6 +487,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9d93b217-1d44-4d31-8956-db9ea680ff4f",
+   "metadata": {},
+   "source": [
+    "Here's an example with the default `handle_tool_error=True` behavior."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "b4d22022-b105-4ccc-a15b-412cb9ea3097",
@@ -517,6 +518,14 @@
     ")\n",
     "\n",
     "get_weather_tool.invoke({\"city\": \"foobar\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f91d6dc0-3271-4adc-a155-21f2e62ffa56",
+   "metadata": {},
+   "source": [
+    "We can set `handle_tool_error` to a string that will always be returned."
    ]
   },
   {
@@ -550,22 +559,22 @@
    "id": "b0a640c1-e08f-4413-83b6-f599f304935f",
    "metadata": {},
    "source": [
-    "We can also define a custom way to handle the tool error"
+    "Handling the error using a function:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "ebfe7c1f-318d-4e58-99e1-f31e69473c46",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The following errors occurred during tool execution: `Error: There is no city by the name of foobar.`.'"
+       "'The following errors occurred during tool execution: `Error: There is no city by the name of foobar.`'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
- Remove double implementations of functions. The single input is just taking up space.
- Added tool specific information for `async + showing invoke vs. ainvoke.
- Added more general information about about `async` (this should live in a different place eventually since it's not specific to tools).
- Changed ordering of custom tools (StructuredTool is simpler and should appear before the inheritance)
- Improved the error handling section (not convinced it should be here though)
