### PR TITLE
docs: fix monorepo typo

### DIFF
--- a/docs/docs/contributing/repo_structure.mdx
+++ b/docs/docs/contributing/repo_structure.mdx
@@ -6,7 +6,7 @@ sidebar_position: 0.5
 If you plan on contributing to LangChain code or documentation, it can be useful
 to understand the high level structure of the repository.
 
-LangChain is organized as a [monorep](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages.
+LangChain is organized as a [monorepo](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages.
 
 Here's the structure visualized as a tree:
 


### PR DESCRIPTION
### Description
fix monorepo typo. `monorep` -> `monorepo`