### PR TITLE
community: Add token cost for GPT-4o model

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -6,8 +6,15 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
 
 MODEL_COST_PER_1K_TOKENS = {
-    # GPT-4 input
+    # GPT-4o input
     "gpt-4o": 0.005,
+    "gpt-4o-2024-05-13": 0.005,
+
+    # GPT-4o output
+    "gpt-4o-completion": 0.015,
+    "gpt-4o-2024-05-13-completion": 0.015,
+
+    # GPT-4 input
     "gpt-4": 0.03,
     "gpt-4-0314": 0.03,
     "gpt-4-0613": 0.03,
@@ -21,7 +28,6 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-turbo": 0.01,
     "gpt-4-turbo-2024-04-09": 0.01,
     # GPT-4 output
-    "gpt-4o-completion": 0.015,
     "gpt-4-completion": 0.06,
     "gpt-4-0314-completion": 0.06,
     "gpt-4-0613-completion": 0.06,

--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -9,11 +9,9 @@ MODEL_COST_PER_1K_TOKENS = {
     # GPT-4o input
     "gpt-4o": 0.005,
     "gpt-4o-2024-05-13": 0.005,
-
     # GPT-4o output
     "gpt-4o-completion": 0.015,
     "gpt-4o-2024-05-13-completion": 0.015,
-
     # GPT-4 input
     "gpt-4": 0.03,
     "gpt-4-0314": 0.03,

--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -7,6 +7,7 @@ from langchain_core.outputs import LLMResult
 
 MODEL_COST_PER_1K_TOKENS = {
     # GPT-4 input
+    "gpt-4o": 0.005,
     "gpt-4": 0.03,
     "gpt-4-0314": 0.03,
     "gpt-4-0613": 0.03,
@@ -20,6 +21,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-turbo": 0.01,
     "gpt-4-turbo-2024-04-09": 0.01,
     # GPT-4 output
+    "gpt-4o-completion": 0.015,
     "gpt-4-completion": 0.06,
     "gpt-4-0314-completion": 0.06,
     "gpt-4-0613-completion": 0.06,


### PR DESCRIPTION
Adding [token cost for the new GPT-4o model](https://openai.com/api/pricing/):
* Input cost US$5.00 / 1M tokens
* Output cost US$15.00 / 1M tokens