### PR TITLE
docs[minor]: Hide prev/next buttons on docs in how to / tutorials

### DIFF
--- a/docs/src/theme/DocPaginator/index.js
+++ b/docs/src/theme/DocPaginator/index.js
@@ -1,0 +1,22 @@
+import React from "react";
+import DocPaginator from "@theme-original/DocPaginator";
+
+const BLACKLISTED_PATHS = ["/docs/how_to/", "/docs/tutorials/"];
+
+export default function DocPaginatorWrapper(props) {
+  const [shouldHide, setShouldHide] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const currentPath = window.location.pathname;
+    if (BLACKLISTED_PATHS.some((path) => currentPath.includes(path))) {
+      setShouldHide(true);
+    }
+  }, []);
+
+  if (!shouldHide) {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <DocPaginator {...props} />;
+  }
+  return null;
+}


### PR DESCRIPTION
These buttons don't navigate to the proper prev/next page. Hide in those pages