### PR TITLE
community:perplexity[patch]: standardize init args

### DIFF
--- a/libs/community/langchain_community/chat_models/perplexity.py
+++ b/libs/community/langchain_community/chat_models/perplexity.py
@@ -68,9 +68,9 @@ class ChatPerplexity(BaseChatModel):
     """Base URL path for API requests, 
     leave blank if not using a proxy or service emulator."""
     request_timeout: Optional[Union[float, Tuple[float, float]]] = Field(
-        600, alias="timeout"
+        None, alias="timeout"
     )
-    """Timeout for requests to PerplexityChat completion API. Default is 600 seconds."""
+    """Timeout for requests to PerplexityChat completion API. Default is None."""
     max_retries: int = 6
     """Maximum number of retries to make when generating."""
     streaming: bool = False

--- a/libs/community/langchain_community/chat_models/perplexity.py
+++ b/libs/community/langchain_community/chat_models/perplexity.py
@@ -68,7 +68,7 @@ class ChatPerplexity(BaseChatModel):
     """Base URL path for API requests, 
     leave blank if not using a proxy or service emulator."""
     request_timeout: Optional[Union[float, Tuple[float, float]]] = Field(
-        None, alias="timeout"
+        600, alias="timeout"
     )
     """Timeout for requests to PerplexityChat completion API. Default is 600 seconds."""
     max_retries: int = 6


### PR DESCRIPTION
updated request_timeout default alias value per related docstring.

Related to [20085](https://github.com/langchain-ai/langchain/issues/20085)

Thank you for contributing to LangChain!

