### PR TITLE
langchain: Fixing import in docs per https://github.com/langchain-ai/langchain/issues/21814

### DIFF
--- a/docs/docs/how_to/tools_prompting.ipynb
+++ b/docs/docs/how_to/tools_prompting.ipynb
@@ -162,7 +162,7 @@
     }
    ],
    "source": [
-    "from langchain.tools.render import render_text_description\n",
+    "from langchain_core.tools import render_text_description\n",
     "\n",
     "rendered_tools = render_text_description([multiply])\n",
     "rendered_tools"


### PR DESCRIPTION
Description: The example in the How-To guide had an import which did not work. I changed it to use an import from langchain_core.

Issue: https://github.com/langchain-ai/langchain/issues/21814

