### PR TITLE
community: Chroma - remove reference to collection upon delete_collection

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -163,15 +163,32 @@ class Chroma(VectorStore):
             )
 
         self._embedding_function = embedding_function
+        self._chroma_collection: Optional[chromadb.Collection] = None
+        self._collection_name = collection_name
+        self._collection_metadata = collection_metadata
         if create_collection_if_not_exists:
-            self._collection = self._client.get_or_create_collection(
-                name=collection_name,
-                embedding_function=None,
-                metadata=collection_metadata,
-            )
+            self.__ensure_collection()
         else:
-            self._collection = self._client.get_collection(name=collection_name)
+            self._chroma_collection = self._client.get_collection(name=collection_name)
         self.override_relevance_score_fn = relevance_score_fn
+
+    def __ensure_collection(self) -> None:
+        """Ensure that the collection exists or create it."""
+        self._chroma_collection = self._client.get_or_create_collection(
+            name=self._collection_name,
+            embedding_function=None,
+            metadata=self._collection_metadata,
+        )
+
+    @property
+    def _collection(self) -> chromadb.Collection:
+        """Returns the underlying Chroma collection or throws an exception."""
+        if self._chroma_collection is None:
+            raise ValueError(
+                "Chroma collection not initialized. "
+                "Use `reset_collection` to re-create and initialize the collection. "
+            )
+        return self._chroma_collection
 
     @property
     def embeddings(self) -> Optional[Embeddings]:
@@ -607,6 +624,13 @@ class Chroma(VectorStore):
     def delete_collection(self) -> None:
         """Delete the collection."""
         self._client.delete_collection(self._collection.name)
+        self._chroma_collection = None
+
+    def reset_collection(self) -> None:
+        """Resets the collection by deleting the collection
+        and recreating an empty one."""
+        self.delete_collection()
+        self.__ensure_collection()
 
     def get(
         self,


### PR DESCRIPTION
**Description**:

- Reference to `Collection` object is set to `None` when deleting a collection `delete_collection()`
- Added utility method `reset_collection()` to allow recreating the collection
- Moved collection creation out of `__init__` into `__ensure_collection()` to be reused by object init and `reset_collection()`
- `_collection` is now a property to avoid breaking changes

**Issues**: 

- chroma-core/chroma#2213

**Twitter**: @t_azarov
