### PR TITLE
community[patch]: Fix unintended newline in print statement in exception for BaichuanTextEmbeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/baichuan.py
+++ b/libs/community/langchain_community/embeddings/baichuan.py
@@ -80,8 +80,8 @@ class BaichuanTextEmbeddings(BaseModel, Embeddings):
             else:
                 # Log error or handle unsuccessful response appropriately
                 print(  # noqa: T201
-                    f"""Error: Received status code {response.status_code} from 
-                    embedding API"""
+                    f"Error: Received status code {response.status_code} from "
+                    "embedding API"
                 )
                 return None
         except Exception as e:


### PR DESCRIPTION
- **Code:** langchain_community/embeddings/baichuan.py:82
- **Description:** When I make an error using 'baichuan embeddings', the printed error message is wrapped (there is actually no need to wrap)
```python
# example
from langchain_community.embeddings import BaichuanTextEmbeddings

# error key
BAICHUAN_API_KEY = "sk-xxxxxxxxxxxxx"
embeddings = BaichuanTextEmbeddings(baichuan_api_key=BAICHUAN_API_KEY)

text_1 = "今天天气不错"
query_result = embeddings.embed_query(text_1)
```



![unintended newline](https://github.com/langchain-ai/langchain/assets/55082429/e1178ce8-62bb-405d-a4af-e3b28eabc158)



