### PR TITLE
docs: how-to index page fix minor typo

### DIFF
--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -171,7 +171,7 @@ LangChain Tools contain a description of the tool (to pass to the language model
 - [How to: create custom tools](/docs/how_to/custom_tools)
 - [How to: use built-in tools and built-in toolkits](/docs/how_to/tools_builtin)
 - [How to: use a chat model to call tools](/docs/how_to/tool_calling/)
-- [How to: use add ad-hoc tool calling capability to LLMs and chat models](/docs/how_to/tools_prompting)
+- [How to: add ad-hoc tool calling capability to LLMs and chat models](/docs/how_to/tools_prompting)
 - [How to: convert LangChain tools to OpenAI functions](/docs/how_to/tools_as_openai_functions)
 - [How to: add a human in the loop to tool usage](/docs/how_to/tools_human)
 - [How to: handle errors when calling tools](/docs/how_to/tools_error)


### PR DESCRIPTION
Fix typo
