### PR TITLE
Pass enum only to openai in llm graph transformer

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -517,7 +517,7 @@ class LLMGraphTransformer:
     relationship properties
 
     Args:
-        llm (BaseChatModel): An instance of a language model supporting structured
+        llm (BaseLanguageModel): An instance of a language model supporting structured
           output.
         allowed_nodes (List[str], optional): Specifies which node types are
           allowed in the graph. Defaults to an empty list, allowing all node types.

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -150,13 +150,21 @@ def optional_enum_field(
     enum_values: Optional[List[str]] = None,
     description: str = "",
     input_type: str = "node",
+    llm_type: Optional[str] = None,
     **field_kwargs: Any,
 ) -> Any:
     """Utility function to conditionally create a field with an enum constraint."""
-    if enum_values:
+    # Only openai supports enum param
+    if enum_values and llm_type == "openai-chat":
         return Field(
             ...,
             enum=enum_values,
+            description=f"{description}. Available options are {enum_values}",
+            **field_kwargs,
+        )
+    elif enum_values:
+        return Field(
+            ...,
             description=f"{description}. Available options are {enum_values}",
             **field_kwargs,
         )
@@ -271,6 +279,7 @@ def create_simple_model(
     node_labels: Optional[List[str]] = None,
     rel_types: Optional[List[str]] = None,
     node_properties: Union[bool, List[str]] = False,
+    llm_type: Optional[str] = None,
 ) -> Type[_Graph]:
     """
     Simple model allows to limit node and/or relationship types.
@@ -288,6 +297,7 @@ def create_simple_model(
                 node_labels,
                 description="The type or label of the node.",
                 input_type="node",
+                llm_type=llm_type,
             ),
         ),
     }
@@ -325,6 +335,7 @@ def create_simple_model(
             node_labels,
             description="The type or label of the source node.",
             input_type="node",
+            llm_type=llm_type,
         )
         target_node_id: str = Field(
             description="Name or human-readable unique identifier of target node"
@@ -333,11 +344,13 @@ def create_simple_model(
             node_labels,
             description="The type or label of the target node.",
             input_type="node",
+            llm_type=llm_type,
         )
         type: str = optional_enum_field(
             rel_types,
             description="The type of the relationship.",
             input_type="relationship",
+            llm_type=llm_type,
         )
 
     class DynamicGraph(_Graph):
@@ -573,7 +586,7 @@ class LLMGraphTransformer:
         else:
             # Define chain
             schema = create_simple_model(
-                allowed_nodes, allowed_relationships, node_properties
+                allowed_nodes, allowed_relationships, node_properties, llm._llm_type
             )
             structured_llm = llm.with_structured_output(schema, include_raw=True)
             prompt = prompt or default_prompt

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -586,7 +586,7 @@ class LLMGraphTransformer:
         else:
             # Define chain
             try:
-                llm_type = llm._llm_type # type: ignore
+                llm_type = llm._llm_type  # type: ignore
             except AttributeError:
                 llm_type = None
             schema = create_simple_model(

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
 
 from langchain_community.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_core.documents import Document
-from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models import BaseLanguageModel
 from langchain_core.messages import SystemMessage
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import (
@@ -547,7 +547,7 @@ class LLMGraphTransformer:
 
     def __init__(
         self,
-        llm: BaseChatModel,
+        llm: BaseLanguageModel,
         allowed_nodes: List[str] = [],
         allowed_relationships: List[str] = [],
         prompt: Optional[ChatPromptTemplate] = None,
@@ -585,8 +585,12 @@ class LLMGraphTransformer:
             self.chain = prompt | llm
         else:
             # Define chain
+            try:
+                llm_type = llm._llm_type # type: ignore
+            except AttributeError:
+                llm_type = None
             schema = create_simple_model(
-                allowed_nodes, allowed_relationships, node_properties, llm._llm_type
+                allowed_nodes, allowed_relationships, node_properties, llm_type
             )
             structured_llm = llm.with_structured_output(schema, include_raw=True)
             prompt = prompt or default_prompt

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
 
 from langchain_community.graphs.graph_document import GraphDocument, Node, Relationship
 from langchain_core.documents import Document
-from langchain_core.language_models import BaseLanguageModel
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import SystemMessage
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import (
@@ -517,7 +517,7 @@ class LLMGraphTransformer:
     relationship properties
 
     Args:
-        llm (BaseLanguageModel): An instance of a language model supporting structured
+        llm (BaseChatModel): An instance of a language model supporting structured
           output.
         allowed_nodes (List[str], optional): Specifies which node types are
           allowed in the graph. Defaults to an empty list, allowing all node types.
@@ -547,7 +547,7 @@ class LLMGraphTransformer:
 
     def __init__(
         self,
-        llm: BaseLanguageModel,
+        llm: BaseChatModel,
         allowed_nodes: List[str] = [],
         allowed_relationships: List[str] = [],
         prompt: Optional[ChatPromptTemplate] = None,


### PR DESCRIPTION
Some models like Groq return bad request if you pass in `enum` parameter in tool definition