### PR TITLE
qdrant[patch]: Make path optional in from_existing_collection()

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/vectorstores.py
+++ b/libs/partners/qdrant/langchain_qdrant/vectorstores.py
@@ -1353,7 +1353,8 @@ class Qdrant(VectorStore):
     def from_existing_collection(
         cls: Type[Qdrant],
         embedding: Embeddings,
-        collection_name: str,
+        path: Optional[str] = None,
+        collection_name: Optional[str] = None,
         location: Optional[str] = None,
         url: Optional[str] = None,
         port: Optional[int] = 6333,
@@ -1364,7 +1365,6 @@ class Qdrant(VectorStore):
         prefix: Optional[str] = None,
         timeout: Optional[int] = None,
         host: Optional[str] = None,
-        path: Optional[str] = None,
         content_payload_key: str = CONTENT_KEY,
         metadata_payload_key: str = METADATA_KEY,
         distance_strategy: str = "COSINE",
@@ -1376,6 +1376,10 @@ class Qdrant(VectorStore):
         This method will return the instance of the store without inserting any new
         embeddings
         """
+
+        if collection_name is None:
+            raise ValueError("Must specify collection_name. Received None.")
+
         client, async_client = cls._generate_clients(
             location=location,
             url=url,

--- a/libs/partners/qdrant/langchain_qdrant/vectorstores.py
+++ b/libs/partners/qdrant/langchain_qdrant/vectorstores.py
@@ -1353,7 +1353,6 @@ class Qdrant(VectorStore):
     def from_existing_collection(
         cls: Type[Qdrant],
         embedding: Embeddings,
-        path: str,
         collection_name: str,
         location: Optional[str] = None,
         url: Optional[str] = None,
@@ -1365,6 +1364,7 @@ class Qdrant(VectorStore):
         prefix: Optional[str] = None,
         timeout: Optional[int] = None,
         host: Optional[str] = None,
+        path: Optional[str] = None,
         content_payload_key: str = CONTENT_KEY,
         metadata_payload_key: str = METADATA_KEY,
         distance_strategy: str = "COSINE",


### PR DESCRIPTION
## Description

The `path` param is used to specify the local persistence directory, which isn't required if using Qdrant server.

~~This is a breaking but necessary change.~~