### PR TITLE
docs: how to: tool calling: Fix typo in sentence

### DIFF
--- a/docs/docs/how_to/tool_calling.ipynb
+++ b/docs/docs/how_to/tool_calling.ipynb
@@ -33,7 +33,7 @@
     "result.\n",
     "\n",
     "However, tool calling goes beyond [structured output](/docs/how_to/structured_output/)\n",
-    "since you can pass responses to caled tools back to the model to create longer interactions.\n",
+    "since you can pass responses from called tools back to the model to create longer interactions.\n",
     "For instance, given a search engine tool, an LLM might handle a \n",
     "query by first issuing a call to the search engine with arguments. The system calling the LLM can \n",
     "receive the tool call, execute it, and return the output to the LLM to inform its \n",


### PR DESCRIPTION
- **Description:** Fix grammar error.