### PR TITLE
langchain: add libs/partners to dev.Dockerfile

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -53,5 +53,8 @@ COPY libs/community/ ../community/
 # Copy the text-splitters library for installation
 COPY libs/text-splitters/ ../text-splitters/
 
+# Copy the partners library for installation
+COPY libs/partners ../partners/
+
 # Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)
 RUN poetry install --no-interaction --no-ansi --with dev,test,docs


### PR DESCRIPTION
Resolves #21886 by adding "COPY libs/partners ../partners/" to libs/dev.Dockerfile