### PR TITLE
cli[minor]: add astradb in the cli migration to 0.2

### DIFF
--- a/libs/cli/langchain_cli/namespaces/migrate/codemods/migrations/astradb.json
+++ b/libs/cli/langchain_cli/namespaces/migrate/codemods/migrations/astradb.json
@@ -1,0 +1,30 @@
+[
+  [
+    "langchain_community.vectorstores.astradb.AstraDB",
+    "langchain_astradb.AstraDBVectorStore"
+  ],
+  [
+    "langchain_community.storage.astradb.AstraDBByteStore",
+    "langchain_astradb.AstraDBByteStore"
+  ],
+  [
+    "langchain_community.storage.astradb.AstraDBStore",
+    "langchain_astradb.AstraDBStore"
+  ],
+  [
+    "langchain_community.cache.astradb.AstraDBCache",
+    "langchain_astradb.AstraDBCache"
+  ],
+  [
+    "langchain_community.cache.astradb.AstraDBSemanticCache",
+    "langchain_astradb.AstraDBSemanticCache"
+  ],
+  [
+    "langchain_community.chat_message_histories.astradb.AstraDBChatMessageHistory",
+    "langchain_astradb.AstraDBChatMessageHistory"
+  ],
+  [
+    "langchain_community.document_loaders.astradb.AstraDBLoader",
+    "langchain_astradb.AstraDBLoader"
+  ]
+]

--- a/libs/cli/langchain_cli/namespaces/migrate/codemods/replace_imports.py
+++ b/libs/cli/langchain_cli/namespaces/migrate/codemods/replace_imports.py
@@ -147,6 +147,7 @@ RULE_TO_PATHS = {
         "ibm.json",
         "openai.json",
         "pinecone.json",
+        "astradb.json",
     ],
 }
 


### PR DESCRIPTION
astradb has a new partner package but the automatic migration cli tool doesn't take care of migration astradb integrations