### PR TITLE
cli[minor]: fix import path for two Astra DB classes in the migration json data

### DIFF
--- a/libs/cli/langchain_cli/namespaces/migrate/codemods/migrations/astradb.json
+++ b/libs/cli/langchain_cli/namespaces/migrate/codemods/migrations/astradb.json
@@ -12,11 +12,11 @@
     "langchain_astradb.AstraDBStore"
   ],
   [
-    "langchain_community.cache.astradb.AstraDBCache",
+    "langchain_community.cache.AstraDBCache",
     "langchain_astradb.AstraDBCache"
   ],
   [
-    "langchain_community.cache.astradb.AstraDBSemanticCache",
+    "langchain_community.cache.AstraDBSemanticCache",
     "langchain_astradb.AstraDBSemanticCache"
   ],
   [


### PR DESCRIPTION
This PR fixes two mistakes in the import paths from community for the json data aiding the cli migration to 0.2.

It is intended as a quick follow-up to https://github.com/langchain-ai/langchain/pull/21913 .

@nicoloboschi FYI