### PR TITLE
community[patch]: Improve tips in abnormal request for BaichuanTextEmbeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/baichuan.py
+++ b/libs/community/langchain_community/embeddings/baichuan.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -79,34 +80,35 @@ class BaichuanTextEmbeddings(BaseModel, Embeddings):
                 return [result.get("embedding", []) for result in sorted_embeddings]
             # Common Error 1: Invalid `api_key`
             elif response.status_code == 401:
-                raise Exception(
+                warnings.warn(
                     "401 Unauthorized: Access denied for `BaichuanEmbedding`."
                     "Please check your `api_key`."
                 )
             # Common Error 2: Incorrect proxy settings
             elif response.status_code == 407:
-                raise Exception(
+                warnings.warn(
                     "407 Proxy Authentication Required: Please check your proxy "
                     "setting and provide valid credentials."
                 )
             # Client Error
             elif response.status_code >= 400:
-                raise Exception(
+                warnings.warn(
                     f"{response.status_code} Client Error: Please verify your "
                     f"input and try again."
                 )
             # Server Error
             elif response.status_code >= 500:
-                raise Exception(
+                warnings.warn(
                     f"{response.status_code} Service Error: An internal error "
                     f"has occurred on the `BaichuanEmbedding` server."
                 )
             else:
                 # Log error or handle unsuccessful response appropriately
-                raise Exception(  # noqa: T201
+                warnings.warn(  # noqa: T201
                     f"Error: Received status code {response.status_code} from "
                     "`BaichuanEmbedding` API"
                 )
+            return None
         except Exception as e:
             # Log the exception or handle it as needed
             raise Exception(  # noqa: T201

--- a/libs/community/langchain_community/embeddings/baichuan.py
+++ b/libs/community/langchain_community/embeddings/baichuan.py
@@ -1,10 +1,10 @@
-import warnings
 from typing import Any, Dict, List, Optional
 
 import requests
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
+from requests import RequestException
 
 BAICHUAN_API_URL: str = "http://api.baichuan-ai.com/v1/embeddings"
 
@@ -70,6 +70,8 @@ class BaichuanTextEmbeddings(BaseModel, Embeddings):
             response = self.session.post(
                 BAICHUAN_API_URL, json={"input": texts, "model": self.model_name}
             )
+            # Raise exception if response status code from 400 to 600
+            response.raise_for_status()
             # Check if the response status code indicates success
             if response.status_code == 200:
                 resp = response.json()
@@ -78,42 +80,16 @@ class BaichuanTextEmbeddings(BaseModel, Embeddings):
                 sorted_embeddings = sorted(embeddings, key=lambda e: e.get("index", 0))
                 # Return just the embeddings
                 return [result.get("embedding", []) for result in sorted_embeddings]
-            # Common Error 1: Invalid `api_key`
-            elif response.status_code == 401:
-                warnings.warn(
-                    "401 Unauthorized: Access denied for `BaichuanEmbedding`."
-                    "Please check your `api_key`."
-                )
-            # Common Error 2: Incorrect proxy settings
-            elif response.status_code == 407:
-                warnings.warn(
-                    "407 Proxy Authentication Required: Please check your proxy "
-                    "setting and provide valid credentials."
-                )
-            # Client Error
-            elif response.status_code >= 400:
-                warnings.warn(
-                    f"{response.status_code} Client Error: Please verify your "
-                    f"input and try again."
-                )
-            # Server Error
-            elif response.status_code >= 500:
-                warnings.warn(
-                    f"{response.status_code} Service Error: An internal error "
-                    f"has occurred on the `BaichuanEmbedding` server."
-                )
             else:
                 # Log error or handle unsuccessful response appropriately
-                warnings.warn(  # noqa: T201
+                # Handle 100 <= status_code < 400, not include 200
+                raise RequestException(
                     f"Error: Received status code {response.status_code} from "
                     "`BaichuanEmbedding` API"
                 )
-            return None
-        except Exception as e:
+        except Exception:
             # Log the exception or handle it as needed
-            raise Exception(  # noqa: T201
-                f"Exception occurred while trying to get embeddings: {str(e)}"
-            )
+            raise
 
     def embed_documents(self, texts: List[str]) -> Optional[List[List[float]]]:  # type: ignore[override]
         """Public method to get embeddings for a list of documents.

--- a/libs/community/langchain_community/embeddings/baichuan.py
+++ b/libs/community/langchain_community/embeddings/baichuan.py
@@ -77,17 +77,41 @@ class BaichuanTextEmbeddings(BaseModel, Embeddings):
                 sorted_embeddings = sorted(embeddings, key=lambda e: e.get("index", 0))
                 # Return just the embeddings
                 return [result.get("embedding", []) for result in sorted_embeddings]
+            # Common Error 1: Invalid `api_key`
+            elif response.status_code == 401:
+                raise Exception(
+                    "401 Unauthorized: Access denied for `BaichuanEmbedding`."
+                    "Please check your `api_key`."
+                )
+            # Common Error 2: Incorrect proxy settings
+            elif response.status_code == 407:
+                raise Exception(
+                    "407 Proxy Authentication Required: Please check your proxy "
+                    "setting and provide valid credentials."
+                )
+            # Client Error
+            elif response.status_code >= 400:
+                raise Exception(
+                    f"{response.status_code} Client Error: Please verify your "
+                    f"input and try again."
+                )
+            # Server Error
+            elif response.status_code >= 500:
+                raise Exception(
+                    f"{response.status_code} Service Error: An internal error "
+                    f"has occurred on the `BaichuanEmbedding` server."
+                )
             else:
                 # Log error or handle unsuccessful response appropriately
-                print(  # noqa: T201
+                raise Exception(  # noqa: T201
                     f"Error: Received status code {response.status_code} from "
-                    "embedding API"
+                    "`BaichuanEmbedding` API"
                 )
-                return None
         except Exception as e:
             # Log the exception or handle it as needed
-            print(f"Exception occurred while trying to get embeddings: {str(e)}")  # noqa: T201
-            return None
+            raise Exception(  # noqa: T201
+                f"Exception occurred while trying to get embeddings: {str(e)}"
+            )
 
     def embed_documents(self, texts: List[str]) -> Optional[List[List[float]]]:  # type: ignore[override]
         """Public method to get embeddings for a list of documents.


### PR DESCRIPTION
 - **Description:** 
   - When using 'BaichuanEmbedding', the content of the prompt is almost the same regardless of the problem. For example, for 'api_key error' and 'Incorrect proxy settings', there are only differences in the status code, which is not very user-friendly. We should further explain the common status codes! 
 
    - Additionally, it turns out that for ` status_code= 200 ` all directly print statements and return None, but here I think we can directly more clearly prompt the user to discover the problem! (there is no conflict with the previous one)