### PR TITLE
core[patch]: In astream_events(version=v2) tap output of root run

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -124,7 +124,6 @@ def ensure_config(config: Optional[RunnableConfig] = None) -> RunnableConfig:
         metadata={},
         callbacks=None,
         recursion_limit=25,
-        run_id=None,
     )
     if var_config := var_child_runnable_config.get():
         empty.update(

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -129,19 +129,20 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         run_info = self.run_map.get(run_id)
         if run_info is None:
             # run has finished, don't issue any stream events
-            yield first
+            yield cast(T, first)
             return
         if tap is sentinel:
             # if we are the first to tap, issue stream events
-            event = {
+            event: StreamEvent = {
                 "event": f"on_{run_info['run_type']}_stream",
                 "run_id": str(run_id),
                 "name": run_info["name"],
                 "tags": run_info["tags"],
                 "metadata": run_info["metadata"],
+                "data": {},
             }
             self._send({**event, "data": {"chunk": first}}, run_info["run_type"])
-            yield first
+            yield cast(T, first)
             # consume the rest of the output
             async for chunk in output:
                 self._send(
@@ -151,7 +152,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
                 yield chunk
         else:
             # otherwise just pass through
-            yield first
+            yield cast(T, first)
             # consume the rest of the output
             async for chunk in output:
                 yield chunk
@@ -169,19 +170,20 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         run_info = self.run_map.get(run_id)
         if run_info is None:
             # run has finished, don't issue any stream events
-            yield first
+            yield cast(T, first)
             return
         if tap is sentinel:
             # if we are the first to tap, issue stream events
-            event = {
+            event: StreamEvent = {
                 "event": f"on_{run_info['run_type']}_stream",
                 "run_id": str(run_id),
                 "name": run_info["name"],
                 "tags": run_info["tags"],
                 "metadata": run_info["metadata"],
+                "data": {},
             }
             self._send({**event, "data": {"chunk": first}}, run_info["run_type"])
-            yield first
+            yield cast(T, first)
             # consume the rest of the output
             for chunk in output:
                 self._send(
@@ -191,7 +193,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
                 yield chunk
         else:
             # otherwise just pass through
-            yield first
+            yield cast(T, first)
             # consume the rest of the output
             for chunk in output:
                 yield chunk
@@ -794,7 +796,7 @@ async def _astream_events_implementation_v2(
 
     # Assign the stream handler to the config
     config = ensure_config(config)
-    run_id = config.setdefault("run_id", uuid4())
+    run_id = cast(UUID, config.setdefault("run_id", uuid4()))
     callbacks = config.get("callbacks")
     if callbacks is None:
         config["callbacks"] = [event_streamer]

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -122,7 +122,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         # atomic check and set
         tap = self.is_tapped.setdefault(run_id, sentinel)
         # wait for first chunk
-        first = await py_anext(output, sentinel)
+        first = await py_anext(output, default=sentinel)
         if first is sentinel:
             return
         # get run info

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
     cast,
 )
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -37,6 +37,7 @@ from langchain_core.runnables.utils import (
 from langchain_core.tracers._streaming import _StreamingCallbackHandler
 from langchain_core.tracers.log_stream import LogEntry
 from langchain_core.tracers.memory_stream import _MemoryStream
+from langchain_core.utils.aiter import py_anext
 
 if TYPE_CHECKING:
     from langchain_core.documents import Document
@@ -87,6 +88,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         super().__init__(*args, **kwargs)
         # Map of run ID to run info.
         self.run_map: Dict[UUID, RunInfo] = {}
+        self.is_tapped: Dict[UUID, Any] = {}
 
         # Filter which events will be sent over the queue.
         self.root_event_filter = _RootEventFilter(
@@ -116,41 +118,83 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         self, run_id: UUID, output: AsyncIterator[T]
     ) -> AsyncIterator[T]:
         """Tap the output aiter."""
-        async for chunk in output:
-            run_info = self.run_map.get(run_id)
-            if run_info is None:
-                raise AssertionError(f"Run ID {run_id} not found in run map.")
-            self._send(
-                {
-                    "event": f"on_{run_info['run_type']}_stream",
-                    "data": {"chunk": chunk},
-                    "run_id": str(run_id),
-                    "name": run_info["name"],
-                    "tags": run_info["tags"],
-                    "metadata": run_info["metadata"],
-                },
-                run_info["run_type"],
-            )
-            yield chunk
+        sentinel = object()
+        # atomic check and set
+        tap = self.is_tapped.setdefault(run_id, sentinel)
+        # wait for first chunk
+        first = await py_anext(output, sentinel)
+        if first is sentinel:
+            return
+        # get run info
+        run_info = self.run_map.get(run_id)
+        if run_info is None:
+            # run has finished, don't issue any stream events
+            yield first
+            return
+        if tap is sentinel:
+            # if we are the first to tap, issue stream events
+            event = {
+                "event": f"on_{run_info['run_type']}_stream",
+                "run_id": str(run_id),
+                "name": run_info["name"],
+                "tags": run_info["tags"],
+                "metadata": run_info["metadata"],
+            }
+            self._send({**event, "data": {"chunk": first}}, run_info["run_type"])
+            yield first
+            # consume the rest of the output
+            async for chunk in output:
+                self._send(
+                    {**event, "data": {"chunk": chunk}},
+                    run_info["run_type"],
+                )
+                yield chunk
+        else:
+            # otherwise just pass through
+            yield first
+            # consume the rest of the output
+            async for chunk in output:
+                yield chunk
 
     def tap_output_iter(self, run_id: UUID, output: Iterator[T]) -> Iterator[T]:
         """Tap the output aiter."""
-        for chunk in output:
-            run_info = self.run_map.get(run_id)
-            if run_info is None:
-                raise AssertionError(f"Run ID {run_id} not found in run map.")
-            self._send(
-                {
-                    "event": f"on_{run_info['run_type']}_stream",
-                    "data": {"chunk": chunk},
-                    "run_id": str(run_id),
-                    "name": run_info["name"],
-                    "tags": run_info["tags"],
-                    "metadata": run_info["metadata"],
-                },
-                run_info["run_type"],
-            )
-            yield chunk
+        sentinel = object()
+        # atomic check and set
+        tap = self.is_tapped.setdefault(run_id, sentinel)
+        # wait for first chunk
+        first = next(output, sentinel)
+        if first is sentinel:
+            return
+        # get run info
+        run_info = self.run_map.get(run_id)
+        if run_info is None:
+            # run has finished, don't issue any stream events
+            yield first
+            return
+        if tap is sentinel:
+            # if we are the first to tap, issue stream events
+            event = {
+                "event": f"on_{run_info['run_type']}_stream",
+                "run_id": str(run_id),
+                "name": run_info["name"],
+                "tags": run_info["tags"],
+                "metadata": run_info["metadata"],
+            }
+            self._send({**event, "data": {"chunk": first}}, run_info["run_type"])
+            yield first
+            # consume the rest of the output
+            for chunk in output:
+                self._send(
+                    {**event, "data": {"chunk": chunk}},
+                    run_info["run_type"],
+                )
+                yield chunk
+        else:
+            # otherwise just pass through
+            yield first
+            # consume the rest of the output
+            for chunk in output:
+                yield chunk
 
     async def on_chat_model_start(
         self,
@@ -244,6 +288,8 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
 
         if run_info is None:
             raise AssertionError(f"Run ID {run_id} not found in run map.")
+        if self.is_tapped.get(run_id):
+            return
         if run_info["run_type"] == "chat_model":
             event = "on_chat_model_stream"
 
@@ -748,6 +794,7 @@ async def _astream_events_implementation_v2(
 
     # Assign the stream handler to the config
     config = ensure_config(config)
+    run_id = config.setdefault("run_id", uuid4())
     callbacks = config.get("callbacks")
     if callbacks is None:
         config["callbacks"] = [event_streamer]
@@ -767,7 +814,10 @@ async def _astream_events_implementation_v2(
     # add each chunk to the output stream
     async def consume_astream() -> None:
         try:
-            async for _ in runnable.astream(input, config, **kwargs):
+            # if astream also calls tap_output_aiter this will be a no-op
+            async for _ in event_streamer.tap_output_aiter(
+                run_id, runnable.astream(input, config, **kwargs)
+            ):
                 # All the content will be picked up
                 pass
         finally:

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -1440,7 +1440,6 @@ async def test_with_config_metadata_passthrough(mocker: MockerFixture) -> None:
             recursion_limit=25,
             configurable={"hello": "there"},
             metadata={"hello": "there", "bye": "now"},
-            run_id=None,
         ),
     )
     spy.reset_mock()
@@ -1582,7 +1581,6 @@ async def test_with_config(mocker: MockerFixture) -> None:
                 tags=["c"],
                 callbacks=None,
                 recursion_limit=5,
-                run_id=None,
             ),
         ),
         mocker.call(
@@ -1592,7 +1590,6 @@ async def test_with_config(mocker: MockerFixture) -> None:
                 tags=["c"],
                 callbacks=None,
                 recursion_limit=5,
-                run_id=None,
             ),
         ),
     ]
@@ -1618,7 +1615,6 @@ async def test_with_config(mocker: MockerFixture) -> None:
             tags=["c"],
             callbacks=None,
             recursion_limit=5,
-            run_id=None,
         ),
     )
     second_call = next(call for call in spy.call_args_list if call.args[0] == "wooorld")
@@ -1629,7 +1625,6 @@ async def test_with_config(mocker: MockerFixture) -> None:
             tags=["c"],
             callbacks=None,
             recursion_limit=5,
-            run_id=None,
         ),
     )
 
@@ -1700,7 +1695,6 @@ async def test_default_method_implementations(mocker: MockerFixture) -> None:
             tags=[],
             callbacks=None,
             recursion_limit=25,
-            run_id=None,
         )
 
 


### PR DESCRIPTION
- if tap_output_iter/aiter is called multiple times for the same run issue events only once
- if chat model run is tapped don't issue duplicate on_llm_new_token events
- if first chunk arrives after run has ended do not emit it as a stream event
