### PR TITLE
community:javelin[patch]: standardize init args, update for javelin sdk release.

### DIFF
--- a/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
+++ b/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
@@ -18,7 +18,7 @@ from langchain_core.outputs import (
     ChatGeneration,
     ChatResult,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, Field
+from langchain_core.pydantic_v1 import BaseModel, Extra, Field, SecretStr
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
+++ b/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
@@ -90,9 +90,7 @@ class ChatJavelinAIGateway(BaseChatModel):
             try:
                 self.client = JavelinClient(
                     base_url=self.gateway_uri,
-                    javelin_api_key=cast(
-                        SecretStr, self.javelin_api_key
-                    ).get_secret_value(),
+                    api_key=cast(SecretStr, self.javelin_api_key).get_secret_value(),
                 )
             except UnauthorizedError as e:
                 raise ValueError("Javelin: Incorrect API Key.") from e

--- a/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
+++ b/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
@@ -18,7 +18,7 @@ from langchain_core.outputs import (
     ChatGeneration,
     ChatResult,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, Field
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +65,13 @@ class ChatJavelinAIGateway(BaseChatModel):
     client: Any
     """javelin client."""
 
-    javelin_api_key: Optional[SecretStr] = None
+    javelin_api_key: Optional[SecretStr] = Field(None, alias="api_key")
     """The API key for the Javelin AI Gateway."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        allow_population_by_field_name = True
 
     def __init__(self, **kwargs: Any):
         try:
@@ -85,7 +90,9 @@ class ChatJavelinAIGateway(BaseChatModel):
             try:
                 self.client = JavelinClient(
                     base_url=self.gateway_uri,
-                    api_key=cast(SecretStr, self.javelin_api_key).get_secret_value(),
+                    javelin_api_key=cast(
+                        SecretStr, self.javelin_api_key
+                    ).get_secret_value(),
                 )
             except UnauthorizedError as e:
                 raise ValueError("Javelin: Incorrect API Key.") from e

--- a/libs/community/tests/unit_tests/chat_models/test_javelin_ai_gateway.py
+++ b/libs/community/tests/unit_tests/chat_models/test_javelin_ai_gateway.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.pydantic_v1 import SecretStr
 
 from langchain_community.chat_models import ChatJavelinAIGateway
+from typing import cast
 
 
 @pytest.mark.requires("javelin_sdk")
@@ -30,3 +31,17 @@ def test_api_key_masked_when_passed_via_constructor() -> None:
     assert str(llm.javelin_api_key) == "**********"
     assert "secret-api-key" not in repr(llm.javelin_api_key)
     assert "secret-api-key" not in repr(llm)
+
+
+@pytest.mark.requires("javelin_sdk")
+def test_api_key_alias() -> None:
+    for model in [
+        ChatJavelinAIGateway(
+            route="<javelin-ai-gateway-chat-route>",
+            javelin_api_key=SecretStr("test_key"),
+        ),
+        ChatJavelinAIGateway(
+            route="<javelin-ai-gateway-chat-route>", api_key=SecretStr("test_key")
+        ),
+    ]:
+        assert cast(SecretStr, model.javelin_api_key).get_secret_value() == "test_key"

--- a/libs/community/tests/unit_tests/chat_models/test_javelin_ai_gateway.py
+++ b/libs/community/tests/unit_tests/chat_models/test_javelin_ai_gateway.py
@@ -4,7 +4,6 @@ import pytest
 from langchain_core.pydantic_v1 import SecretStr
 
 from langchain_community.chat_models import ChatJavelinAIGateway
-from typing import cast
 
 
 @pytest.mark.requires("javelin_sdk")

--- a/libs/community/tests/unit_tests/chat_models/test_javelin_ai_gateway.py
+++ b/libs/community/tests/unit_tests/chat_models/test_javelin_ai_gateway.py
@@ -38,10 +38,10 @@ def test_api_key_alias() -> None:
     for model in [
         ChatJavelinAIGateway(
             route="<javelin-ai-gateway-chat-route>",
-            javelin_api_key=SecretStr("test_key"),
+            javelin_api_key="secret-api-key",
         ),
         ChatJavelinAIGateway(
-            route="<javelin-ai-gateway-chat-route>", api_key=SecretStr("test_key")
+            route="<javelin-ai-gateway-chat-route>", api_key="secret-api-key"
         ),
     ]:
-        assert cast(SecretStr, model.javelin_api_key).get_secret_value() == "test_key"
+        assert str(model.javelin_api_key) == "**********"


### PR DESCRIPTION
Related to [20085](https://github.com/langchain-ai/langchain/issues/20085) Updated the Javelin chat model to standardize the initialization argument.  Also fixed an existing bug, where code was initialized with incorrect call to the JavelinClient defined in the javelin_sdk, resulting in an initialization error.  See related [Javelin Documentation](https://docs.getjavelin.io/docs/javelin-python/quickstart).