### PR TITLE
community:dappier[patch]:Standardize dappier init args

### DIFF
--- a/libs/community/langchain_community/chat_models/dappier.py
+++ b/libs/community/langchain_community/chat_models/dappier.py
@@ -26,9 +26,11 @@ def _format_dappier_messages(
 
     for message in messages:
         if message.type == "human":
-            formatted_messages.append({"role": "user", "content": message.content})
+            formatted_messages.append(
+                {"role": "user", "content": message.content})
         elif message.type == "system":
-            formatted_messages.append({"role": "system", "content": message.content})
+            formatted_messages.append(
+                {"role": "system", "content": message.content})
 
     return formatted_messages
 
@@ -66,21 +68,30 @@ class ChatDappierAI(BaseChatModel):
 
     dappier_endpoint: str = "https://api.dappier.com/app/datamodelconversation"
 
-    dappier_model: str = "dm_01hpsxyfm2fwdt2zet9cg6fdxt"
+    dappier_model: str = Field("dm_01hpsxyfm2fwdt2zet9cg6fdxt", alias="model")
 
-    dappier_api_key: Optional[SecretStr] = Field(None, description="Dappier API Token")
+    dappier_api_key: Optional[SecretStr] = Field(
+        None, description="Dappier API Token", alias="api_key")
 
     class Config:
         """Configuration for this pydantic object."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
 
-    @root_validator()
+    @root_validator
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key exists in environment."""
-        values["dappier_api_key"] = convert_to_secret_str(
-            get_from_dict_or_env(values, "dappier_api_key", "DAPPIER_API_KEY")
-        )
+        api_key = values["dappier_api_key"] or values["api_key"]
+        if not api_key:
+            api_key = convert_to_secret_str(
+                get_from_dict_or_env(
+                    values, "dappier_api_key", "DAPPIER_API_KEY")
+            )
+        if isinstance(api_key, str):
+            api_key = convert_to_secret_str(api_key)
+        values["dappier_api_key"] = api_key
         return values
 
     @staticmethod
@@ -127,7 +138,8 @@ class ChatDappierAI(BaseChatModel):
         message_response = data["message"]
 
         return ChatResult(
-            generations=[ChatGeneration(message=AIMessage(content=message_response))]
+            generations=[ChatGeneration(
+                message=AIMessage(content=message_response))]
         )
 
     async def _agenerate(
@@ -156,6 +168,7 @@ class ChatDappierAI(BaseChatModel):
 
                 return ChatResult(
                     generations=[
-                        ChatGeneration(message=AIMessage(content=message_response))
+                        ChatGeneration(message=AIMessage(
+                            content=message_response))
                     ]
                 )

--- a/libs/community/langchain_community/chat_models/dappier.py
+++ b/libs/community/langchain_community/chat_models/dappier.py
@@ -26,11 +26,9 @@ def _format_dappier_messages(
 
     for message in messages:
         if message.type == "human":
-            formatted_messages.append(
-                {"role": "user", "content": message.content})
+            formatted_messages.append({"role": "user", "content": message.content})
         elif message.type == "system":
-            formatted_messages.append(
-                {"role": "system", "content": message.content})
+            formatted_messages.append({"role": "system", "content": message.content})
 
     return formatted_messages
 
@@ -71,7 +69,8 @@ class ChatDappierAI(BaseChatModel):
     dappier_model: str = Field("dm_01hpsxyfm2fwdt2zet9cg6fdxt", alias="model")
 
     dappier_api_key: Optional[SecretStr] = Field(
-        None, description="Dappier API Token", alias="api_key")
+        None, description="Dappier API Token", alias="api_key"
+    )
 
     class Config:
         """Configuration for this pydantic object."""
@@ -86,8 +85,7 @@ class ChatDappierAI(BaseChatModel):
         api_key = values["dappier_api_key"] or values["api_key"]
         if not api_key:
             api_key = convert_to_secret_str(
-                get_from_dict_or_env(
-                    values, "dappier_api_key", "DAPPIER_API_KEY")
+                get_from_dict_or_env(values, "dappier_api_key", "DAPPIER_API_KEY")
             )
         if isinstance(api_key, str):
             api_key = convert_to_secret_str(api_key)
@@ -138,8 +136,7 @@ class ChatDappierAI(BaseChatModel):
         message_response = data["message"]
 
         return ChatResult(
-            generations=[ChatGeneration(
-                message=AIMessage(content=message_response))]
+            generations=[ChatGeneration(message=AIMessage(content=message_response))]
         )
 
     async def _agenerate(
@@ -168,7 +165,6 @@ class ChatDappierAI(BaseChatModel):
 
                 return ChatResult(
                     generations=[
-                        ChatGeneration(message=AIMessage(
-                            content=message_response))
+                        ChatGeneration(message=AIMessage(content=message_response))
                     ]
                 )

--- a/libs/community/tests/unit_tests/chat_models/test_dappier.py
+++ b/libs/community/tests/unit_tests/chat_models/test_dappier.py
@@ -4,7 +4,11 @@ from typing import List, cast
 import pytest
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_core.pydantic_v1 import SecretStr, ValidationError
-from langchain_community.chat_models.dappier import _format_dappier_messages, ChatDappierAI
+
+from langchain_community.chat_models.dappier import (
+    ChatDappierAI,
+    _format_dappier_messages,
+)
 
 
 @pytest.mark.parametrize(

--- a/libs/community/tests/unit_tests/chat_models/test_dappier.py
+++ b/libs/community/tests/unit_tests/chat_models/test_dappier.py
@@ -1,10 +1,10 @@
 """Test EdenAI Chat API wrapper."""
-from typing import List
+from typing import List, cast
 
 import pytest
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
-
-from langchain_community.chat_models.dappier import _format_dappier_messages
+from langchain_core.pydantic_v1 import SecretStr, ValidationError
+from langchain_community.chat_models.dappier import _format_dappier_messages, ChatDappierAI
 
 
 @pytest.mark.parametrize(
@@ -32,3 +32,15 @@ def test_dappier_messages_formatting(
 ) -> None:
     result = _format_dappier_messages(messages)
     assert result == expected
+
+
+def test_dappierai_initialization():
+    try:
+        for model in [
+            ChatDappierAI(dappier_model="dappier-ai-model", dappier_api_key="xyz"),
+            ChatDappierAI(model="dappier-ai-model", api_key="xyz"),
+        ]:
+            assert model.dappier_model == "dappier-ai-model"
+            assert cast(SecretStr, model.dappier_api_key).get_secret_value() == "xyz"
+    except ValidationError as e:
+        print(e)

--- a/libs/community/tests/unit_tests/chat_models/test_dappier.py
+++ b/libs/community/tests/unit_tests/chat_models/test_dappier.py
@@ -38,7 +38,7 @@ def test_dappier_messages_formatting(
     assert result == expected
 
 
-def test_dappierai_initialization():
+def test_dappierai_initialization() -> None:
     for model in [
         ChatDappierAI(dappier_model="dappier-ai-model", dappier_api_key="xyz"),
         ChatDappierAI(model="dappier-ai-model", api_key="xyz"),

--- a/libs/community/tests/unit_tests/chat_models/test_dappier.py
+++ b/libs/community/tests/unit_tests/chat_models/test_dappier.py
@@ -3,7 +3,7 @@ from typing import List, cast
 
 import pytest
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
-from langchain_core.pydantic_v1 import SecretStr, ValidationError
+from langchain_core.pydantic_v1 import SecretStr
 
 from langchain_community.chat_models.dappier import (
     ChatDappierAI,
@@ -39,12 +39,9 @@ def test_dappier_messages_formatting(
 
 
 def test_dappierai_initialization():
-    try:
-        for model in [
-            ChatDappierAI(dappier_model="dappier-ai-model", dappier_api_key="xyz"),
-            ChatDappierAI(model="dappier-ai-model", api_key="xyz"),
-        ]:
-            assert model.dappier_model == "dappier-ai-model"
-            assert cast(SecretStr, model.dappier_api_key).get_secret_value() == "xyz"
-    except ValidationError as e:
-        print(e)
+    for model in [
+        ChatDappierAI(dappier_model="dappier-ai-model", dappier_api_key="xyz"),
+        ChatDappierAI(model="dappier-ai-model", api_key="xyz"),
+    ]:
+        assert model.dappier_model == "dappier-ai-model"
+        assert cast(SecretStr, model.dappier_api_key).get_secret_value() == "xyz"


### PR DESCRIPTION
I made change to ChatDappierAI so that the object can be instantiated with `model` as an alias for `dappier_model` and `api_key` as an alias for `dappier_api_key`.
- File: langchain/libs/community/langchain_community/chat_models/dappier.py
- Test file: langchain/libs/community/tests/unit_tests/chat_models/test_dappier.py
- Related issue: [Standardized model init arg names #20085](https://github.com/langchain-ai/langchain/issues/20085)