### PR TITLE
Integration of Cambridge Semantics AnzoGraph DB in LangChain community graphs and chains

### DIFF
--- a/docs/docs/integrations/graphs/anzograph.ipynb
+++ b/docs/docs/integrations/graphs/anzograph.ipynb
@@ -1,0 +1,758 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1271ba5c-1700-4872-b193-f7c162944521",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-27T18:44:53.493675Z",
+     "iopub.status.busy": "2024-03-27T18:44:53.493473Z",
+     "iopub.status.idle": "2024-03-27T18:44:53.499541Z",
+     "shell.execute_reply": "2024-03-27T18:44:53.498940Z",
+     "shell.execute_reply.started": "2024-03-27T18:44:53.493660Z"
+    }
+   },
+   "source": [
+    "# AnzoGraph DB\n",
+    "\n",
+    ">[AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) is a graph database and knowledge discovery tool compliant with [RDF](https://www.w3.org/RDF/) and [SPARQL](https://www.w3.org/TR/sparql11-query/) that can be integrated with Apache Zeppelin third-party visualization application. \\\n",
+    "> [AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) is a high performance graph OLAP database that lets users perform BI-style analytics with unparalled speed and scalability. \\\n",
+    "> [AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) uses standards from the W3C regarding RDF data formats and the SPARQL query language. \\\n",
+    "> [AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) can be deployed in cloud environments such as Amazon AWS, Google Cloud, Microsoft Azure, and IBM Cloud Pak, or on-premises on Linux bare metal and virtual machines. \\\n",
+    "> [AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) also supports Docker and Kubernetes deployments with data staged locally or in shared NFS, HDFS, or object storage. \n",
+    "\n",
+    "> This notebook shows how to use LLMs to provide a natural language interface to an [AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) graph database or an ontology local file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04b7bb97",
+   "metadata": {},
+   "source": [
+    "## Setting up\n",
+    "\n",
+    "You can get a local `AnzoGraph DB` instance running via the [AnzoGraph DB Docker image](https://hub.docker.com/r/cambridgesemantics/anzograph):  \n",
+    "\n",
+    "```\n",
+    "docker pull cambridgesemantics/anzograph\n",
+    "```\n",
+    "```\n",
+    "docker run -d -p 80:8080 -p 7070:7070 -p 8443:8443 -p 8256:8256 -v C:\\shared-files:/opt/shared-files --name anzograph cambridgesemantics/anzograph:latest (Windows)\n",
+    "docker run -d -p 80:8080 -p 7070:7070 -p 8443:8443 -p 8256:8256 -v /home/username/shared-files:/opt/shared-files --name anzograph cambridgesemantics/anzograph:latest (Linux)\n",
+    "```\n",
+    "\n",
+    "In this case, we are creating a shared volume between the local disk and the docker container. \\\n",
+    "You just need to copy your ontology file to this local directory, and it will automatically be available for use in AnzoGraph DB.\n",
+    "\n",
+    "\n",
+    "## LangChain packages\n",
+    "\n",
+    "Install\n",
+    "\n",
+    "```bash\n",
+    "pip install langchain langchain-community langchain-openai\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34ed8fab",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "\n",
+    "Install the [rdflib](https://github.com/RDFLib/rdflib) package with\n",
+    "\n",
+    "```bash\n",
+    "pip install rdflib==7.0.0\n",
+    "pip install SPARQLWrapper==2.0.0\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdc3f58e",
+   "metadata": {},
+   "source": [
+    "## Endpoint Types and HTTP Methods\n",
+    "The table below describes the SPARQL and RDF Graph Store HTTP endpoints. Both of the endpoints can be used to send requests through the AnzoGraph DB front end or directly to the database (back end).\n",
+    "\n",
+    "| Endpoint        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |\n",
+    "|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
+    "| SPARQL          | The SPARQL endpoint accepts HTTP GET and POST methods. Use GET to read data from the endpoint (SELECT, ASK, CONSTRUCT, DESCRIBE queries), and use POST to update data via the endpoint (INSERT, INSERT DATA, CREATE, DELETE, DELETE DATA, DROP queries). Update queries must use the POST method, but read-only queries can be submitted using GET or POST.                                                                                                                        |\n",
+    "| RDF Graph Store | The RDF graph store endpoint supports create, read, update, and delete (CRUD) operations and enables programmers to work with RDF graphs in a way that is similar to REST-style interfaces. The graph store endpoint supports GET, POST, UPDATE, and DELETE HTTP methods.                                                                                                                                                                                                          |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deb0cd7b",
+   "metadata": {},
+   "source": [
+    "## Endpoint Base URLs\n",
+    "This base URL that you use to connect to an AnzoGraph DB endpoint depends on whether you want to connect to the SPARQL endpoint or the RDF Graph Store endpoint. This section provides details about the base URLs for each endpoint:\n",
+    "\n",
+    "- SPARQL Endpoint Base URL\n",
+    "- RDF Graph Store Endpoint Base URL\n",
+    "\n",
+    "### SPARQL Endpoint Base URL\n",
+    "In this development, it will be employed queries on the SPARQL endpoint.\n",
+    "To connect to the AnzoGraph DB SPARQL endpoint, use the following base URL:\n",
+    "\n",
+    "protocol://hostname:port/sparql\n",
+    "The table below describes each of the base URL components:\n",
+    "\n",
+    "\n",
+    "| Component | Description |\n",
+    "|-----------|-------------|\n",
+    "| protocol | The protocol to use for the connection: http for HTTP protocol or https for SSL protocol. SPARQL HTTP or HTTPS protocol can be enabled and disabled via the enable_sparql_protocol and enable_ssl_protocol settings. |\n",
+    "| hostname | The DNS name or IP address of the AnzoGraph DB host server. For clusters, this is the name or IP address of the leader server. |\n",
+    "| port | The port number for the endpoint. The port that you specify depends on the protocol and whether the request is sent to the AnzoGraph DB front end or back end. The front end requires that you use Basic Authentication to connect. The back end does not support authentication. Consider whether the client application supports authentication when specifying the port.  <br><br> **Front end**: If the front end ports were mapped to the default HTTP (80) and HTTPS (443) ports on the local host when the front end was deployed, do not specify a port. If the front end ports were mapped to non-default HTTP and HTTPS ports, specify the appropriate port based on the protocol. <br> **Back end**: The port is either the HTTP sparql_protocol_port or the HTTPS ssl_protocol_port. By default, the HTTP SPARQL protocol port is 7070, and the HTTPS SSL protocol port is 8256. |\n",
+    "| sparql | The path for the SPARQL endpoint. |\n",
+    "\n",
+    "\n",
+    "\n",
+    "For example, the following base URLs connect to the front end HTTP and HTTPS SPARQL endpoints. Because the ports for this deployment are mapped to the default HTTP and HTTPS ports on the local host, the port does not need to be specified in the URL (should be port :80): \\\n",
+    "http://10.100.10.20/sparql (\"10.100.10.20\" is an example, usually you can use \"localhost\") \\\n",
+    "https://10.100.10.20/sparql\n",
+    "\n",
+    "The example URLs below connect to the back end HTTP and HTTPS SPARQL endpoints. In the examples, AnzoGraph DB is using the default SPARQL protocol and SSL protocol ports: \\\n",
+    "http://10.100.10.20:7070/sparql \\\n",
+    "https://10.100.10.20:8256/sparql\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09e3544e",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6847bfd",
+   "metadata": {},
+   "source": [
+    "## Specifying the ontology\n",
+    "\n",
+    "\n",
+    "Previously, you crated a shared volume between the local disk and the docker container. \\\n",
+    "Copy your ontology file to the shared-files local directory, and it will automatically be available for use in AnzoGraph DB. \n",
+    "\n",
+    "In order for the LLM to be able to generate SPARQL, it needs to know the knowledge graph schema (the ontology). \\\n",
+    "It can be provided using one of two parameters on the `AnzoGraphDBGraph` class:\n",
+    "\n",
+    "* `query_ontology`: a `CONSTRUCT` query that is executed on the SPARQL backend endpoint (port :7070 for http, or :8256 for https) and returns the KG schema statements, building a RDF 'subgraph' from the database's graph. We recommend that you store the ontology in its own named graph, which will make it easier to get only the relevant statements (as the example below). `DESCRIBE` queries are not supported, because `DESCRIBE` returns the Symmetric Concise Bounded Description (SCBD), i.e. also the incoming class links.\n",
+    "* `source_file`: a local source RDF ontology file. Supported RDF formats are `Turtle`, `N-Triple`, `N-Quad`, `TriG ` or `JSON-LD` files. Turtle (.ttl) files are the most usual.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fa40035",
+   "metadata": {},
+   "source": [
+    "## Download the FOAF ontology and load it into AnzoGraph DB\n",
+    "For this example code, download from the file for the FOAF ontology. \n",
+    "\n",
+    "Please download it from the SPAR Ontologies repository (learn more at http://www.sparontologies.net): \\\n",
+    "https://github.com/SPAROntologies/foaf/blob/master/docs/current/foaf.ttl\n",
+    "\n",
+    "Then:\n",
+    "\n",
+    "* Copy the Turtle (.ttl) ontology file into the shared-files folder in your disk (the bind folder created through docker run)\n",
+    "* Start AnzoGraph DB frontend with the following URI: \"http://localhost:80\"\n",
+    "* Username: admin\n",
+    "* Password: Passw0rd1\n",
+    "\n",
+    "#### Load the ontology file using the query window of the graphic user interface. Run the following SPARQL query:\n",
+    "```\n",
+    "LOAD WITH 'global' <dir:/opt/shared-files/foaf.ttl> INTO GRAPH <http://anzograph.com/foaf>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92f5f180",
+   "metadata": {},
+   "source": [
+    "## Creating the Graph object\n",
+    "There are two methods to create the graph using the `AnzoGraphDBGraph` integration in LangChain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "545e6128",
+   "metadata": {},
+   "source": [
+    "### 1. Querying the loaded ontology against AnzoGraph DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dc8792e0-acfb-4310-b5fa-8f649e448870",
+   "metadata": {
+    "id": "dc8792e0-acfb-4310-b5fa-8f649e448870"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_community.graphs.anzograph_graph import AnzoGraphDBGraph\n",
+    "\n",
+    "# Feeding the graph schema using a CONSTRUCT query against the AnzoGraph DB backend endpoint\n",
+    "\n",
+    "graph = AnzoGraphDBGraph(\n",
+    "    query_endpoint=\"http://localhost:7070/sparql\",  # Or \"https://localhost:8256/sparql\"\n",
+    "    query_ontology=\"CONSTRUCT {?s ?p ?o} FROM <http://anzograph.com/foaf> WHERE {?s ?p ?o}\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7dda02e",
+   "metadata": {},
+   "source": [
+    "### 2. Loading the ontology directly from a local source file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a08b8d8c-af01-4401-8069-5f2cd022a6df",
+   "metadata": {
+    "id": "a08b8d8c-af01-4401-8069-5f2cd022a6df"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_community.graphs.anzograph_graph import AnzoGraphDBGraph\n",
+    "\n",
+    "# Feeding the graph schema using a local RDF file source\n",
+    "\n",
+    "graph = AnzoGraphDBGraph(\n",
+    "    query_endpoint=\"http://example.com/sparql\",  # Placeholder URL string; not used when operating with a local source_file\n",
+    "    source_file=\"/path/to/langchain_graphdb_tutorial/foaf.ttl\",  # change the path here\n",
+    "    standard=\"rdf\",\n",
+    "    local_copy=\"test.ttl\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e10f9df",
+   "metadata": {},
+   "source": [
+    "### Checking the ontology via the graph's content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9e7d35dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "282\n",
+      "In the following, each IRI is followed by the local name and optionally its description in parentheses. \n",
+      "The RDF graph supports the following node types:\n",
+      "<http://www.w3.org/2000/01/rdf-schema#Class> (Class, None), <http://www.w3.org/2002/07/owl#Class> (Class, None), <http://www.w3.org/2002/07/owl#AnnotationProperty> (AnnotationProperty, None), <http://www.w3.org/2002/07/owl#Ontology> (Ontology, None), <http://www.w3.org/2002/07/owl#DatatypeProperty> (DatatypeProperty, None), <http://www.w3.org/2002/07/owl#FunctionalProperty> (FunctionalProperty, None), <http://www.w3.org/2002/07/owl#ObjectProperty> (ObjectProperty, None), <http://www.w3.org/2002/07/owl#InverseFunctionalProperty> (InverseFunctionalProperty, None)\n",
+      "The RDF graph supports the following relationships:\n",
+      "<http://www.w3.org/2000/01/rdf-schema#range> (range, None), <http://purl.org/dc/terms/date> (date, None), <http://www.w3.org/2003/06/sw-vocab-status/nsterm_status> (nsterm_status, None), <http://www.w3.org/2000/01/rdf-schema#comment> (comment, None), <http://www.w3.org/2000/01/rdf-schema#domain> (domain, None), <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> (first, None), <http://www.w3.org/2002/07/owl#complementOf> (complementOf, None), <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> (type, None), <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> (subPropertyOf, None), <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> (isDefinedBy, None), <http://www.w3.org/2002/07/owl#unionOf> (unionOf, None), <http://www.w3.org/2002/07/owl#disjointWith> (disjointWith, None), <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> (rest, None), <http://www.w3.org/2000/01/rdf-schema#subClassOf> (subClassOf, None), <http://www.w3.org/2000/01/rdf-schema#label> (label, None), <http://purl.org/dc/terms/contributor> (contributor, None), <http://purl.org/dc/terms/language> (language, None), <http://www.w3.org/2002/07/owl#versionInfo> (versionInfo, None), <http://www.w3.org/2002/07/owl#inverseOf> (inverseOf, None), <http://purl.org/dc/terms/creator> (creator, None), <http://www.w3.org/2002/07/owl#priorVersion> (priorVersion, None), <http://purl.org/dc/terms/format> (format, None), <http://purl.org/dc/terms/title> (title, None), <http://purl.org/dc/terms/publisher> (publisher, None)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This code snippet is for assessment purposes only\n",
+    "\n",
+    "print(len(graph.graph))\n",
+    "\n",
+    "graph.load_schema()\n",
+    "print(graph.get_schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "583b26ce-fb0d-4e9c-b5cd-9ec0e3be8922",
+   "metadata": {
+    "id": "583b26ce-fb0d-4e9c-b5cd-9ec0e3be8922"
+   },
+   "source": [
+    "Either way, the ontology (schema) is fed to the LLM as `Turtle` since `Turtle` with appropriate prefixes is most compact and easiest for the LLM to remember.\n",
+    "\n",
+    "The Turtle serialized graph looks the following:\n",
+    "\n",
+    "```\n",
+    "@prefix dcterms: <http://purl.org/dc/terms/> .\n",
+    "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
+    "@prefix ns1: <http://www.w3.org/2003/06/sw-vocab-status/> .\n",
+    "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n",
+    "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
+    "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+    "\n",
+    "foaf:Agent a rdfs:Class,\n",
+    "        owl:Class ;\n",
+    "    rdfs:label \"(foaf) Agent\" ;\n",
+    "    rdfs:comment \"An agent (eg. person, group, software or physical artifact).\" ;\n",
+    "    rdfs:isDefinedBy foaf: ;\n",
+    "    owl:disjointWith foaf:Document,\n",
+    "        foaf:OnlineAccount,\n",
+    "        foaf:Project ;\n",
+    "    ns1:nsterm_status \"unstable\" .\n",
+    "\n",
+    "foaf:Document a rdfs:Class,\n",
+    "        owl:Class ;\n",
+    "    rdfs:label \"(foaf) Document\" ;\n",
+    "    rdfs:comment \"A document.\" ;\n",
+    "    rdfs:isDefinedBy foaf: ;\n",
+    "    owl:disjointWith foaf:Agent,\n",
+    "        foaf:OnlineAccount,\n",
+    "        foaf:Project ;\n",
+    "    ns1:nsterm_status \"testing\" .\n",
+    "\n",
+    "foaf:Project a rdfs:Class,\n",
+    "        owl:Class ;\n",
+    "    rdfs:label \"(foaf) Project\" ;\n",
+    "    rdfs:comment \"A project (a collective endeavour of some kind).\" ;\n",
+    "    rdfs:isDefinedBy foaf: ;\n",
+    "    owl:disjointWith foaf:Agent,\n",
+    "        foaf:Document,\n",
+    "        foaf:OnlineAccount ;\n",
+    "    ns1:nsterm_status \"unstable\" .\n",
+    "\n",
+    "    ...\n",
+    "\n",
+    " ```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "446d8a00-c98f-43b8-9e84-77b244f7bb24",
+   "metadata": {
+    "id": "446d8a00-c98f-43b8-9e84-77b244f7bb24"
+   },
+   "source": [
+    "## Question Answering against the FOAF dataset\n",
+    "\n",
+    "#### We can now use the `AnzoGraphDBQAChain` query the graph database or local file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35cf25ac",
+   "metadata": {},
+   "source": [
+    "Any available OpenAI model can be used here.\\\n",
+    "We used 'gpt-4o', 'gpt-4-turbo', and 'gpt-4-turbo-preview', considering their novelty and position in the LMSys Leaderboard.\\\n",
+    "The 'gpt-4-turbo-preview' model was initially considered the most performant.\\\n",
+    "Consult with the OpenAI API https://platform.openai.com/docs/models for the most up-to-date models at the time of reading."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fab63d88-511d-4049-9bf0-ca8748f1fbff",
+   "metadata": {
+    "id": "fab63d88-511d-4049-9bf0-ca8748f1fbff"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from langchain_community.chains.graph_qa.anzograph import AnzoGraphDBQAChain\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "# We'll be using an OpenAI model which requires an OpenAI API Key.\n",
+    "# However, other models are available as well:\n",
+    "# https://python.langchain.com/docs/integrations/chat/\n",
+    "\n",
+    "# Set the environment variable `OPENAI_API_KEY` to your OpenAI API key\n",
+    "os.environ[\"ORGANIZATION_ID\"] = \"org-***\"  # (in case of an organization's account)\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-***\"\n",
+    "\n",
+    "\n",
+    "# Any available OpenAI model can be used here.\n",
+    "\n",
+    "llm = ChatOpenAI(\n",
+    "    model=\"gpt-4-turbo\",\n",
+    "    api_key=os.environ[\"OPENAI_API_KEY\"],\n",
+    "    openai_organization=os.environ[\"ORGANIZATION_ID\"],  # if that is the case\n",
+    "    temperature=0,\n",
+    ")\n",
+    "\n",
+    "# Intantiate the chain with the LLM and the graph\n",
+    "chain = AnzoGraphDBQAChain.from_llm(\n",
+    "    llm=llm,\n",
+    "    graph=graph,\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64de8463-35b1-4c65-91e4-387daf4dd7d4",
+   "metadata": {},
+   "source": [
+    "Let's perform a query against the FOAF ontology."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9af432d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.chains.graph_qa.anzograph import AnzoGraphDBQAChain\n",
+    "\n",
+    "# Instantiate the chain connecting the LLM and the graph, enabling verbose output for detailed debugging\n",
+    "\n",
+    "chain = AnzoGraphDBQAChain.from_llm(\n",
+    "    llm=llm,\n",
+    "    graph=graph,\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "115a183c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new AnzoGraphDBQAChain chain...\u001b[0m\n",
+      "Identified intent:\n",
+      "\u001b[32;1m\u001b[1;3mSELECT\u001b[0m\n",
+      "Generated SPARQL:\n",
+      "\u001b[32;1m\u001b[1;3mPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "\n",
+      "SELECT ?entity\n",
+      "WHERE {\n",
+      "    ?entity rdf:type ?type .\n",
+      "    FILTER (?type IN (owl:Class, rdfs:Class, owl:AnnotationProperty, owl:Ontology, owl:DatatypeProperty, owl:FunctionalProperty, owl:ObjectProperty, owl:InverseFunctionalProperty))\n",
+      "}\u001b[0m\n",
+      "Full Context:\n",
+      "\u001b[32;1m\u001b[1;3m[(rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db1'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db2'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db5'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db6'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db9'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db12'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db13'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db17'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db21'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db22'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'),), (rdflib.term.BNode('nf5f7add225254cb4bfb798306626d28db27'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'),), (rdflib.term.URIRef('http://purl.org/dc/terms/contributor'),), (rdflib.term.URIRef('http://purl.org/dc/terms/creator'),), (rdflib.term.URIRef('http://purl.org/dc/terms/date'),), (rdflib.term.URIRef('http://purl.org/dc/terms/format'),), (rdflib.term.URIRef('http://purl.org/dc/terms/language'),), (rdflib.term.URIRef('http://purl.org/dc/terms/publisher'),), (rdflib.term.URIRef('http://purl.org/dc/terms/title'),), (rdflib.term.URIRef('http://www.w3.org/2003/06/sw-vocab-status/nsterm_status'),), (rdflib.term.URIRef('http://purl.org/spar/foaf'),), (rdflib.term.URIRef('http://swan.mindinformatics.org/ontologies/1.2/foaf-essential.owl'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/aimChatID'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/birthday'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/family_name'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/firstName'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/geekcode'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/gender'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/givenname'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/jabberID'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/myersBriggs'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/name'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/plan'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/sha1'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/surname'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/title'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/yahooChatID'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/nick'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/birthday'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/gender'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/currentProject'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/fundedBy'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/homepage'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/img'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/interest'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/knows'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/logo'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/member'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/pastProject'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/phone'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/publications'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/schoolHomepage'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/thumbnail'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/tipjar'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic_interest'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workInfoHomepage'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workplaceHomepage'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depicts'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/made'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/maker'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/homepage'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'),)]\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The entities listed in the SPARQL query results include various types and properties from the FOAF (Friend of a Friend) ontology and Dublin Core terms. Here are the entities identified:\\n\\n1. **Types of Entities:**\\n   - Agent\\n   - Document\\n   - Project\\n   - PersonalProfileDocument\\n   - Organization\\n   - Group\\n   - OnlineAccount\\n   - Image\\n   - Person\\n\\n2. **Properties and Terms:**\\n   - contributor\\n   - creator\\n   - date\\n   - format\\n   - language\\n   - publisher\\n   - title\\n   - nsterm_status\\n   - aimChatID\\n   - birthday\\n   - family_name\\n   - firstName\\n   - geekcode\\n   - gender\\n   - givenname\\n   - jabberID\\n   - myersBriggs\\n   - name\\n   - plan\\n   - sha1\\n   - surname\\n   - nick\\n   - primaryTopic\\n   - currentProject\\n   - fundedBy\\n   - homepage\\n   - img\\n   - interest\\n   - knows\\n   - logo\\n   - mbox\\n   - member\\n   - pastProject\\n   - phone\\n   - publications\\n   - schoolHomepage\\n   - thumbnail\\n   - tipjar\\n   - topic_interest\\n   - weblog\\n   - workInfoHomepage\\n   - workplaceHomepage\\n   - depicts\\n   - isPrimaryTopicOf\\n   - made\\n   - maker\\n   - topic\\n   - depiction\\n   - page\\n\\nThese entities and properties are part of the semantic web vocabularies used to describe people, documents, and relationships within data on the web.'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.invoke(\n",
+    "    {chain.input_key: \"Find entities and list them.\"}\n",
+    ")[chain.output_key]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dc5d322",
+   "metadata": {},
+   "source": [
+    "Or:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa8092c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new AnzoGraphDBQAChain chain...\u001b[0m\n",
+      "Identified intent:\n",
+      "\u001b[32;1m\u001b[1;3mSELECT\u001b[0m\n",
+      "Generated SPARQL:\n",
+      "\u001b[32;1m\u001b[1;3mPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+      "\n",
+      "SELECT DISTINCT ?class\n",
+      "WHERE {\n",
+      "    { ?class a rdfs:Class . FILTER (STRSTARTS(STR(?class), STR(foaf:))) }\n",
+      "    UNION\n",
+      "    { ?class a owl:Class . FILTER (STRSTARTS(STR(?class), STR(foaf:))) }\n",
+      "}\u001b[0m\n",
+      "Full Context:\n",
+      "\u001b[32;1m\u001b[1;3m[(rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'),), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'),)]\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The classes in the FOAF (Friend of a Friend) ontology include Agent, Document, Project, PersonalProfileDocument, Organization, Group, OnlineAccount, Image, and Person. These classes are used to describe various types of entities and relationships in social networks and personal data.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chain.invoke(\n",
+    "    {chain.input_key: \"Enumerate all Classes (rdfs and owl) in FOAF ontology.\"}\n",
+    ")[chain.output_key]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d3a37f4-5c56-4b3e-b6ae-3eb030ffcc8f",
+   "metadata": {},
+   "source": [
+    "And a little more complex one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4dde8b18-4329-4a86-abfb-26d3e77034b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new AnzoGraphDBQAChain chain...\u001b[0m\n",
+      "Identified intent:\n",
+      "\u001b[32;1m\u001b[1;3mSELECT\u001b[0m\n",
+      "Generated SPARQL:\n",
+      "\u001b[32;1m\u001b[1;3mPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "\n",
+      "SELECT ?entity ?relation ?relatedEntity\n",
+      "WHERE {\n",
+      "    ?entity ?relation ?relatedEntity .\n",
+      "    FILTER (?relation IN (rdf:type, rdfs:domain, owl:disjointWith, rdf:rest, owl:unionOf, owl:complementOf, rdf:first, rdfs:subPropertyOf, rdfs:isDefinedBy, rdfs:comment, rdfs:range, rdfs:label, owl:inverseOf, rdfs:subClassOf, owl:priorVersion))\n",
+      "}\u001b[0m\n",
+      "Full Context:\n",
+      "\u001b[32;1m\u001b[1;3m[(rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/publications'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#InverseFunctionalProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b6'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/myersBriggs'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/myersBriggs'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/jabberID'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b10'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b11')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/fundedBy'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/member'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b17'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#unionOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b18')), (rdflib.term.URIRef('http://purl.org/spar/foaf'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Ontology')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b26'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b22'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/firstName'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b5'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#complementOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b6')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/phone'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b19'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b20')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b24'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/tipjar'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/logo'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b20'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/yahooChatID'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/nick')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/member'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('A document.')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/givenname'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://purl.org/spar/foaf'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('FOAF Essential v. 2.0')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/phone'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/publications'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://purl.org/dc/terms/date'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b18'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b8'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b13'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#unionOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b14')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b16'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/thumbnail'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/tipjar'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/aimChatID'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b18'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b19')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/homepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/thumbnail'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b15'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b16')), (rdflib.term.URIRef('http://purl.org/spar/foaf'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#priorVersion'), rdflib.term.URIRef('http://swan.mindinformatics.org/ontologies/1.2/foaf-essential.owl')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://swan.mindinformatics.org/ontologies/1.2/foaf-essential.owl'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Ontology')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workInfoHomepage'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/givenname'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/fundedBy'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b5')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('An organization.')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b1'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depicts'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/schoolHomepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b11'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b25'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b2'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#unionOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b3')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/made'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/maker')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b12'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/jabberID'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/nick')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/yahooChatID'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://purl.org/dc/terms/publisher'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b4'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/img'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic_interest'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b23'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b24')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#InverseFunctionalProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('An image.')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/interest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depicts'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/img'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/maker'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/made')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#FunctionalProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/knows'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b12'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#complementOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b13')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/member'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Person')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b21'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic_interest'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/currentProject'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/maker'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b2'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/surname'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/thumbnail'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b6'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#unionOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b7')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b16'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workplaceHomepage'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/family_name'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/gender'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://purl.org/dc/terms/title'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b24'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b25')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/surname'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/jabberID'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/pastProject'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/plan'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/birthday'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/birthday'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b20'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workInfoHomepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depicts'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b23'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/interest'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b7'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b8')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/title'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/logo'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/gender'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b26'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('A class of Agents.')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/title'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/homepage'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/knows'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/plan'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/birthday'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#FunctionalProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/family_name'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/gender'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#FunctionalProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) OnlineAccount')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b1'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#complementOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b2')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b25'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b26')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/maker'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/firstName'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('An online account.')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/sha1'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/logo'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b9')), (rdflib.term.URIRef('http://purl.org/dc/terms/contributor'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b13'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/made'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Image')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/homepage'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#InverseFunctionalProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/publications'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b4'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/homepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b3'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b4')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/tipjar'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/phone'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b21')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/sha1'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/geekcode'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/made'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workInfoHomepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/img'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b10'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b7'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Organization'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Organization')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/fundedBy'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Group')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/OnlineAccount')), (rdflib.term.URIRef('http://purl.org/dc/terms/language'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('A personal profile RDF document.')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/aimChatID'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/page'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b27'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#complementOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/tipjar'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('An agent (eg. person, group, software or physical artifact).')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/geekcode'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b8'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b12')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b9'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/maker'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/name'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b19'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://www.w3.org/2003/06/sw-vocab-status/nsterm_status'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b15'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workplaceHomepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/currentProject'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b1')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depiction'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depicts')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/made'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b27')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/nick'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#DatatypeProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b17'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b5'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b9'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#unionOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b10')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/name'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b17')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/depicts'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/knows'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/yahooChatID'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b22'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#unionOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b23')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/nick'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/weblog'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b21'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#complementOf'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b22')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/mbox'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#InverseFunctionalProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b27'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/workplaceHomepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Image'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group')), (rdflib.term.URIRef('http://purl.org/dc/terms/creator'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/primaryTopic'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#inverseOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/img'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://purl.org/dc/terms/format'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/PersonalProfileDocument'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#label'), rdflib.term.Literal('(foaf) PersonalProfileDocument')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/pastProject'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/pastProject'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/interest'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b14'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Group'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('A project (a collective endeavour of some kind).')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.Literal('A person.')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/isPrimaryTopicOf'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/schoolHomepage'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b11'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/currentProject'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b14'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'), rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b15')), (rdflib.term.BNode('n7cba293c15d94b0a8987349e74668727b3'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Agent')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/aimChatID'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subPropertyOf'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/nick')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/schoolHomepage'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Person')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/topic_interest'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty')), (rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Project'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#disjointWith'), rdflib.term.URIRef('http://xmlns.com/foaf/0.1/Document'))]\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'Certainly! Here\\'s an overview of the relationships among the recognized entities based on the provided RDF data:\\n\\n1. **Classes and Their Properties**:\\n   - `foaf:Person` is defined as a subclass of `foaf:Agent` and has various properties such as `foaf:firstName`, `foaf:surname`, `foaf:family_name`, `foaf:givenname`, `foaf:mbox`, `foaf:homepage`, and `foaf:gender`. It is disjoint with `foaf:Organization` and `foaf:Group`.\\n   - `foaf:Organization` is also a subclass of `foaf:Agent` and is defined to be disjoint with `foaf:Person` and `foaf:Group`.\\n   - `foaf:Group` is defined as a class of agents, subclass of `foaf:Agent`, and is disjoint with `foaf:Person` and `foaf:Organization`.\\n   - `foaf:Document` and `foaf:Image` are subclasses of each other, with specific properties like `foaf:depiction` for images. `foaf:Document` is disjoint with `foaf:Agent`, `foaf:OnlineAccount`, and `foaf:Project`.\\n   - `foaf:Project` and `foaf:OnlineAccount` are defined as classes and have specific properties. Both are disjoint with `foaf:Agent` and each other.\\n\\n2. **Properties and Their Characteristics**:\\n   - Properties like `foaf:depiction`, `foaf:isPrimaryTopicOf`, `foaf:page`, and `foaf:homepage` are defined with specific domains and ranges, linking entities like `foaf:Agent`, `foaf:Document`, and `foaf:Image`.\\n   - Inverse properties are defined, such as `foaf:depicts` being the inverse of `foaf:depiction`.\\n   - Some properties are also marked as `owl:ObjectProperty` or `owl:DatatypeProperty`, indicating their nature of linking either to objects or data values.\\n\\n3. **Special Properties**:\\n   - `foaf:isPrimaryTopicOf` is an `owl:InverseFunctionalProperty`, ensuring that it uniquely identifies subjects.\\n   - `foaf:homepage` and `foaf:mbox` are both `owl:InverseFunctionalProperty`, which are unique identifiers for subjects they describe.\\n\\n4. **Annotations and Descriptions**:\\n   - Various entities and properties have annotations like comments or labels to provide more context. For example, `foaf:Document` is simply annotated with \"A document.\"\\n\\nThis structured data interlinks various entities and properties to form a coherent schema under the FOAF (Friend of a Friend) ontology, which is used to describe people, their activities, and their relations to other people and objects.'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.invoke(\n",
+    "    {chain.input_key: \"Can you bring relations among the recognized entities?\"}\n",
+    ")[chain.output_key]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11511345-8436-4634-92c6-36f2c0dd44db",
+   "metadata": {
+    "id": "11511345-8436-4634-92c6-36f2c0dd44db"
+   },
+   "source": [
+    "## Chain modifiers\n",
+    "\n",
+    "AnzoGraph DB QA Chain allows prompt refinement for further improvement of the QA chains and enhancing the overall user experience, in order to prevent errors in LangChain's responses to user prompts, caused by formatting issues in SPARQL queries generated by the LLM. Generation Templates were developed for the SELECT and UPDATE query intents to mitigate this risk of response errors in the Python environment, especially instructing the LLM to avoid the use of backticks.\n",
+    "\n",
+    "\n",
+    "### \"SPARQL Generation\" prompt\n",
+    "\n",
+    "The prompt is used for the SPARQL query generation (SELECT or UPDATE statements) based on the user question detected intent, and the KG schema.\n",
+    "\n",
+    "- `sparql_generation_prompt`\n",
+    "\n",
+    "    Default value:\n",
+    "  ````python\n",
+    "    ANZOGRAPHDB_INTENT_PROMPT = PromptTemplate(\n",
+    "    input_variables=[\"prompt\"], template=ANZOGRAPHDB_INTENT_TEMPLATE)\n",
+    "\n",
+    "    ANZOGRAPHDB_GENERATION_SELECT_TEMPLATE = \"\"\"Task: Generate a SPARQL SELECT statement for querying a graph database.\n",
+    "    Do NOT use neither backticks (```) nor backsticks with \"sparql\" (```sparql) in the Generated SPARQL. \n",
+    "    For instance, to find all email addresses of John Doe, the following query would be suitable:\n",
+    "\n",
+    "    PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "    SELECT ?email\n",
+    "    WHERE {{\n",
+    "        ?person foaf:name \"John Doe\" .\n",
+    "        ?person foaf:mbox ?email .\n",
+    "    }}\n",
+    "\n",
+    "    Instructions:\n",
+    "    Use only the node types and properties provided in the schema.\n",
+    "    Do not use any node types and properties that are not explicitly provided.\n",
+    "    Include all necessary prefixes.\n",
+    "    Schema:\n",
+    "    {schema}\n",
+    "    Note: Be as concise as possible.\n",
+    "    Do not include any explanations or apologies in your responses.\n",
+    "    Do not respond to any questions that ask for anything else than for you to construct a SPARQL query.\n",
+    "    Do not include any text except the SPARQL query generated.\n",
+    "\n",
+    "    The question is:\n",
+    "    {prompt}\"\"\"\n",
+    "    ANZOGRAPHDB_GENERATION_SELECT_PROMPT = PromptTemplate(\n",
+    "        input_variables=[\"schema\", \"prompt\"], template=ANZOGRAPHDB_GENERATION_SELECT_TEMPLATE\n",
+    "    )\n",
+    "\n",
+    "    ANZOGRAPHDB_GENERATION_UPDATE_TEMPLATE = \"\"\"Task: Generate a SPARQL UPDATE statement for updating a graph database.\n",
+    "    Do NOT use neither backticks (```) nor backsticks with \"sparql\" (```sparql) in the Generated SPARQL. \n",
+    "    For instance, to add 'jane.doe@foo.bar' as a new email address for Jane Doe, the following query would be suitable:\n",
+    "\n",
+    "    PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "    INSERT {{\n",
+    "        ?person foaf:mbox <mailto:jane.doe@foo.bar> .\n",
+    "    }}\n",
+    "    WHERE {{\n",
+    "        ?person foaf:name \"Jane Doe\" .\n",
+    "    }}\n",
+    "\n",
+    "    Instructions:\n",
+    "    Make the query as short as possible and avoid adding unnecessary triples.\n",
+    "    Use only the node types and properties provided in the schema.\n",
+    "    Do not use any node types and properties that are not explicitly provided.\n",
+    "    Include all necessary prefixes.\n",
+    "    Schema:\n",
+    "    {schema}\n",
+    "    Note: Be as concise as possible.\n",
+    "    Do not include any explanations or apologies in your responses.\n",
+    "    Do not respond to any questions that ask for anything else than for you to construct a SPARQL query.\n",
+    "    Return only the generated SPARQL query, nothing else.\n",
+    "\n",
+    "    The information to be inserted is:\n",
+    "    {prompt}\"\"\"\n",
+    "    ANZOGRAPHDB_GENERATION_UPDATE_PROMPT = PromptTemplate(\n",
+    "        input_variables=[\"schema\", \"prompt\"], template=ANZOGRAPHDB_GENERATION_UPDATE_TEMPLATE\n",
+    "    )\n",
+    "\n",
+    "  ````\n",
+    "\n",
+    "### \"SPARQL Fix\" prompt\n",
+    "\n",
+    "In our tests, the use of the SPARQL Generation prompts was enough totally prevent errors or missing prefixes, etc. In case it is not sufficient with the use of any LLM, a SPARQL fix prompt was also created and it is available in the documentation of the chain prompts templates. The chain will try to amend this by prompting the LLM to correct it a certain number of times.\n",
+    "\n",
+    "- `sparql_fix_prompt`\n",
+    "\n",
+    "    Default value:\n",
+    "  ````python\n",
+    "    ANZOGRAPHDB_QA_FIX_TEMPLATE = \"\"\"\n",
+    "    This following SPARQL query delimited by triple backticks\n",
+    "    ```\n",
+    "    {generated_sparql}\n",
+    "    ```\n",
+    "    is not valid.\n",
+    "    The error delimited by triple backticks is\n",
+    "    ```\n",
+    "    {error_message}\n",
+    "    ```\n",
+    "\n",
+    "    Give me a correct version of the SPARQL query.\n",
+    "    Include  the SPARQL query generated.\n",
+    "    Do not change the logic of the query.\n",
+    "    Do not include any explanations or apologies in your responses.\n",
+    "    Do not wrap the query in backticks.\n",
+    "    Do not include any text except the SPARQL query generated.\n",
+    "    The ontology schema delimited by triple backticks in Turtle format is:\n",
+    "    ```\n",
+    "    {schema}\n",
+    "    ```\n",
+    "    \"\"\"\n",
+    "    ANZOGRAPHDB_QA_FIX_PROMPT = PromptTemplate(\n",
+    "        input_variables=[\"error_message\", \"generated_sparql\", \"schema\"],\n",
+    "        template=ANZOGRAPHDB_QA_FIX_TEMPLATE\n",
+    "    )\n",
+    "\n",
+    "  ````\n",
+    "\n",
+    "- `max_fix_retries`\n",
+    "  \n",
+    "    Default value: `5`\n",
+    "\n",
+    "### \"Answering\" prompt\n",
+    "\n",
+    "The prompt is used for answering the question based on the results returned from the database and the initial user question. By default, the LLM is instructed to only use the information from the returned result(s). If the result set is empty, the LLM should inform that it can't answer the question.\n",
+    "\n",
+    "- `qa_prompt`\n",
+    "  \n",
+    "  Default value:\n",
+    "  ````python\n",
+    "    ANZOGRAPHDB_QA_TEMPLATE = \"\"\"Task: Generate a natural language response from the results of a SPARQL query.\n",
+    "    You are an assistant that creates well-written and human understandable answers.\n",
+    "    The information part contains the information provided, which you can use to construct an answer.\n",
+    "    The information provided is authoritative, you must never doubt it or try to use your internal knowledge to correct it.\n",
+    "    Make your response sound like the information is coming from an AI assistant, but don't add any information.\n",
+    "    Information:\n",
+    "    {context}\n",
+    "\n",
+    "    Question: {prompt}\n",
+    "    Helpful Answer:\"\"\"\n",
+    "    ANZOGRAPHDB_QA_PROMPT = PromptTemplate(\n",
+    "        input_variables=[\"context\", \"prompt\"], template=ANZOGRAPHDB_QA_TEMPLATE)\n",
+    "  ````"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6689b98",
+   "metadata": {},
+   "source": [
+    "<hr>"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/integrations/providers/anzograph.mdx
+++ b/docs/docs/integrations/providers/anzograph.mdx
@@ -1,0 +1,27 @@
+# AnzoGraph DB
+
+>[AnzoGraph DB](https://docs.cambridgesemantics.com/anzograph/v3.1/userdoc/Home.htm) is a graph database and knowledge discovery tool compliant with RDF and SPARQL 
+> that can be integrated with Apache Zeppelin third-party visualization application.
+> AnzoGraph DB is a high performance graph OLAP database that lets users perform BI-style analytics with unparalled speed and scalability. 
+> AnzoGraph DB uses standards from the W3C regarding RDF data formats and the SPARQL query language.
+> AnzoGraph DB can be deployed in cloud environments such as Amazon AWS, Google Cloud, Microsoft Azure, and IBM Cloud Pak, or on-premises on Linux bare metal and virtual machines.
+> AnzoGraph DB also supports Docker and Kubernetes deployments with data staged locally or in shared NFS, HDFS, or object storage. 
+
+
+## Dependencies
+
+Install the [rdflib](https://github.com/RDFLib/rdflib) package with
+```bash
+pip install rdflib==7.0.0
+```
+
+## Graph QA Chain
+
+Connect your AnzoGraph DB with a chat model to get insights on your data.
+
+See the notebook example [here](/docs/integrations/graphs/anzograph).
+
+```python
+from langchain_community.graphs import AnzoGraphDBGraph
+from langchain.chains import AnzoGraphDBQAChain
+```

--- a/libs/community/langchain_community/chains/graph_qa/anzograph.py
+++ b/libs/community/langchain_community/chains/graph_qa/anzograph.py
@@ -1,0 +1,152 @@
+"""
+Question answering over an RDF or OWL graph using SPARQL.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain.chains.base import Chain
+from langchain.chains.llm import LLMChain
+from langchain_core.callbacks import CallbackManagerForChainRun
+from langchain_core.language_models import BaseLanguageModel
+from langchain_core.prompts.base import BasePromptTemplate
+from langchain_core.pydantic_v1 import Field
+
+from langchain_community.chains.graph_qa.prompts import (
+    ANZOGRAPHDB_GENERATION_SELECT_PROMPT,
+    ANZOGRAPHDB_GENERATION_UPDATE_PROMPT,
+    ANZOGRAPHDB_INTENT_PROMPT,
+    ANZOGRAPHDB_QA_PROMPT,
+)
+from langchain_community.graphs.anzograph_graph import AnzoGraphDBGraph
+
+
+class AnzoGraphDBQAChain(Chain):
+    """Question-answering against an RDF or OWL graph by generating SPARQL statements.
+
+    *Security note*: Make sure that the database connection uses credentials
+        that are narrowly-scoped to only include necessary permissions.
+        Failure to do so may result in data corruption or loss, since the calling
+        code may attempt commands that would result in deletion, mutation
+        of data if appropriately prompted or reading sensitive data if such
+        data is present in the database.
+        The best way to guard against such negative outcomes is to (as appropriate)
+        limit the permissions granted to the credentials used with this tool.
+
+        See https://python.langchain.com/docs/security for more information.
+    """
+
+    graph: AnzoGraphDBGraph = Field(exclude=True)
+    sparql_generation_select_chain: LLMChain
+    sparql_generation_update_chain: LLMChain
+    sparql_intent_chain: LLMChain
+    qa_chain: LLMChain
+    return_sparql_query: bool = False
+    input_key: str = "query"  #: :meta private:
+    output_key: str = "result"  #: :meta private:
+    sparql_query_key: str = "sparql_query"  #: :meta private:
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Return the input keys.
+
+        :meta private:
+        """
+        return [self.input_key]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Return the output keys.
+
+        :meta private:
+        """
+        _output_keys = [self.output_key]
+        return _output_keys
+
+    @classmethod
+    def from_llm(
+        cls,
+        llm: BaseLanguageModel,
+        *,
+        qa_prompt: BasePromptTemplate = ANZOGRAPHDB_QA_PROMPT,
+        sparql_select_prompt: BasePromptTemplate = ANZOGRAPHDB_GENERATION_SELECT_PROMPT,
+        sparql_update_prompt: BasePromptTemplate = ANZOGRAPHDB_GENERATION_UPDATE_PROMPT,
+        sparql_intent_prompt: BasePromptTemplate = ANZOGRAPHDB_INTENT_PROMPT,
+        **kwargs: Any,
+    ) -> AnzoGraphDBQAChain:
+        """Initialize from LLM."""
+        qa_chain = LLMChain(llm=llm, prompt=qa_prompt)
+        sparql_generation_select_chain = LLMChain(llm=llm, prompt=sparql_select_prompt)
+        sparql_generation_update_chain = LLMChain(llm=llm, prompt=sparql_update_prompt)
+        sparql_intent_chain = LLMChain(llm=llm, prompt=sparql_intent_prompt)
+
+        return cls(
+            qa_chain=qa_chain,
+            sparql_generation_select_chain=sparql_generation_select_chain,
+            sparql_generation_update_chain=sparql_generation_update_chain,
+            sparql_intent_chain=sparql_intent_chain,
+            **kwargs,
+        )
+
+    def _call(
+        self,
+        inputs: Dict[str, Any],
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, str]:
+        """
+        Generate SPARQL query, use it to retrieve a response from the gdb and answer
+        the question.
+        """
+        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        callbacks = _run_manager.get_child()
+        prompt = inputs[self.input_key]
+
+        _intent = self.sparql_intent_chain.run({"prompt": prompt}, callbacks=callbacks)
+        intent = _intent.strip()
+
+        if "SELECT" in intent and "UPDATE" not in intent:
+            sparql_generation_chain = self.sparql_generation_select_chain
+            intent = "SELECT"
+        elif "UPDATE" in intent and "SELECT" not in intent:
+            sparql_generation_chain = self.sparql_generation_update_chain
+            intent = "UPDATE"
+        else:
+            raise ValueError(
+                "I am sorry, but this prompt seems to fit none of the currently "
+                "supported SPARQL query types, i.e., SELECT and UPDATE."
+            )
+
+        _run_manager.on_text("Identified intent:", end="\n", verbose=self.verbose)
+        _run_manager.on_text(intent, color="green", end="\n", verbose=self.verbose)
+
+        generated_sparql = sparql_generation_chain.run(
+            {"prompt": prompt, "schema": self.graph.get_schema}, callbacks=callbacks
+        )
+
+        _run_manager.on_text("Generated SPARQL:", end="\n", verbose=self.verbose)
+        _run_manager.on_text(
+            generated_sparql, color="green", end="\n", verbose=self.verbose
+        )
+
+        if intent == "SELECT":
+            context = self.graph.query(generated_sparql)
+
+            _run_manager.on_text("Full Context:", end="\n", verbose=self.verbose)
+            _run_manager.on_text(
+                str(context), color="green", end="\n", verbose=self.verbose
+            )
+            result = self.qa_chain(
+                {"prompt": prompt, "context": context},
+                callbacks=callbacks,
+            )
+            res = result[self.qa_chain.output_key]
+        elif intent == "UPDATE":
+            self.graph.update(generated_sparql)
+            res = "Successfully inserted triples into the graph."
+        else:
+            raise ValueError("Unsupported SPARQL query type.")
+
+        chain_result: Dict[str, Any] = {self.output_key: res}
+        if self.return_sparql_query:
+            chain_result[self.sparql_query_key] = generated_sparql
+        return chain_result

--- a/libs/community/langchain_community/chains/graph_qa/prompts.py
+++ b/libs/community/langchain_community/chains/graph_qa/prompts.py
@@ -411,3 +411,120 @@ NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_PROMPT = PromptTemplate(
     input_variables=["schema", "question", "extra_instructions"],
     template=NEPTUNE_OPENCYPHER_GENERATION_SIMPLE_TEMPLATE,
 )
+
+ANZOGRAPHDB_INTENT_TEMPLATE = """Task: Identify the intent of a prompt and return the appropriate SPARQL query type.
+You are an assistant that distinguishes different types of prompts and returns the corresponding SPARQL query types.
+Consider only the following query types:
+* SELECT: this query type corresponds to questions
+* UPDATE: this query type corresponds to all requests for deleting, inserting, or changing triples
+Note: Be as concise as possible.
+Do not include any explanations or apologies in your responses.
+Do not respond to any questions that ask for anything else than for you to identify a SPARQL query type.
+Do not include any unnecessary whitespaces or any text except the query type, i.e., either return 'SELECT' or 'UPDATE'.
+
+The prompt is:
+{prompt}
+Helpful Answer:"""
+ANZOGRAPHDB_INTENT_PROMPT = PromptTemplate(
+    input_variables=["prompt"], template=ANZOGRAPHDB_INTENT_TEMPLATE
+)
+
+ANZOGRAPHDB_GENERATION_SELECT_TEMPLATE = """Task: Generate a SPARQL SELECT statement for querying a graph database.
+Do NOT use neither backticks (```) nor backsticks with "sparql" (```sparql) in the Generated SPARQL. 
+For instance, to find all email addresses of John Doe, the following query would be suitable:
+
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?email
+WHERE {{
+    ?person foaf:name "John Doe" .
+    ?person foaf:mbox ?email .
+}}
+
+Instructions:
+Use only the node types and properties provided in the schema.
+Do not use any node types and properties that are not explicitly provided.
+Include all necessary prefixes.
+Schema:
+{schema}
+Note: Be as concise as possible.
+Do not include any explanations or apologies in your responses.
+Do not respond to any questions that ask for anything else than for you to construct a SPARQL query.
+Do not include any text except the SPARQL query generated.
+
+The question is:
+{prompt}"""
+ANZOGRAPHDB_GENERATION_SELECT_PROMPT = PromptTemplate(
+    input_variables=["schema", "prompt"],
+    template=ANZOGRAPHDB_GENERATION_SELECT_TEMPLATE,
+)
+
+ANZOGRAPHDB_GENERATION_UPDATE_TEMPLATE = """Task: Generate a SPARQL UPDATE statement for updating a graph database.
+Do NOT use neither backticks (```) nor backsticks with "sparql" (```sparql) in the Generated SPARQL. 
+For instance, to add 'jane.doe@foo.bar' as a new email address for Jane Doe, the following query would be suitable:
+
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+INSERT {{
+    ?person foaf:mbox <mailto:jane.doe@foo.bar> .
+}}
+WHERE {{
+    ?person foaf:name "Jane Doe" .
+}}
+
+Instructions:
+Make the query as short as possible and avoid adding unnecessary triples.
+Use only the node types and properties provided in the schema.
+Do not use any node types and properties that are not explicitly provided.
+Include all necessary prefixes.
+Schema:
+{schema}
+Note: Be as concise as possible.
+Do not include any explanations or apologies in your responses.
+Do not respond to any questions that ask for anything else than for you to construct a SPARQL query.
+Return only the generated SPARQL query, nothing else.
+
+The information to be inserted is:
+{prompt}"""
+ANZOGRAPHDB_GENERATION_UPDATE_PROMPT = PromptTemplate(
+    input_variables=["schema", "prompt"],
+    template=ANZOGRAPHDB_GENERATION_UPDATE_TEMPLATE,
+)
+
+ANZOGRAPHDB_QA_TEMPLATE = """Task: Generate a natural language response from the results of a SPARQL query.
+You are an assistant that creates well-written and human understandable answers.
+The information part contains the information provided, which you can use to construct an answer.
+The information provided is authoritative, you must never doubt it or try to use your internal knowledge to correct it.
+Make your response sound like the information is coming from an AI assistant, but don't add any information.
+Information:
+{context}
+
+Question: {prompt}
+Helpful Answer:"""
+ANZOGRAPHDB_QA_PROMPT = PromptTemplate(
+    input_variables=["context", "prompt"], template=ANZOGRAPHDB_QA_TEMPLATE
+)
+ANZOGRAPHDB_QA_FIX_TEMPLATE = """
+This following SPARQL query delimited by triple backticks
+```
+{generated_sparql}
+```
+is not valid.
+The error delimited by triple backticks is
+```
+{error_message}
+```
+
+Give me a correct version of the SPARQL query.
+Include  the SPARQL query generated.
+Do not change the logic of the query.
+Do not include any explanations or apologies in your responses.
+Do not wrap the query in backticks.
+Do not include any text except the SPARQL query generated.
+The ontology schema delimited by triple backticks in Turtle format is:
+```
+{schema}
+```
+"""
+ANZOGRAPHDB_QA_FIX_PROMPT = PromptTemplate(
+    input_variables=["error_message", "generated_sparql", "schema"],
+    template=ANZOGRAPHDB_QA_FIX_TEMPLATE,
+)

--- a/libs/community/langchain_community/graphs/__init__.py
+++ b/libs/community/langchain_community/graphs/__init__.py
@@ -4,50 +4,54 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from langchain_community.graphs.anzograph_graph import (
+        AnzoGraphDBGraph,  # noqa: F401
+    )
     from langchain_community.graphs.arangodb_graph import (
-        ArangoGraph,
+        ArangoGraph,  # noqa: F401
     )
     from langchain_community.graphs.falkordb_graph import (
-        FalkorDBGraph,
+        FalkorDBGraph,  # noqa: F401
     )
     from langchain_community.graphs.gremlin_graph import (
-        GremlinGraph,
+        GremlinGraph,  # noqa: F401
     )
     from langchain_community.graphs.hugegraph import (
-        HugeGraph,
+        HugeGraph,  # noqa: F401
     )
     from langchain_community.graphs.kuzu_graph import (
-        KuzuGraph,
+        KuzuGraph,  # noqa: F401
     )
     from langchain_community.graphs.memgraph_graph import (
-        MemgraphGraph,
+        MemgraphGraph,  # noqa: F401
     )
     from langchain_community.graphs.nebula_graph import (
-        NebulaGraph,
+        NebulaGraph,  # noqa: F401
     )
     from langchain_community.graphs.neo4j_graph import (
-        Neo4jGraph,
+        Neo4jGraph,  # noqa: F401
     )
     from langchain_community.graphs.neptune_graph import (
-        NeptuneGraph,
+        NeptuneGraph,  # noqa: F401
     )
     from langchain_community.graphs.neptune_rdf_graph import (
-        NeptuneRdfGraph,
+        NeptuneRdfGraph,  # noqa: F401
     )
     from langchain_community.graphs.networkx_graph import (
-        NetworkxEntityGraph,
+        NetworkxEntityGraph,  # noqa: F401
     )
     from langchain_community.graphs.ontotext_graphdb_graph import (
-        OntotextGraphDBGraph,
+        OntotextGraphDBGraph,  # noqa: F401
     )
     from langchain_community.graphs.rdf_graph import (
-        RdfGraph,
+        RdfGraph,  # noqa: F401
     )
     from langchain_community.graphs.tigergraph_graph import (
-        TigerGraph,
+        TigerGraph,  # noqa: F401
     )
 
 __all__ = [
+    "AnzoGraphDBGraph",
     "ArangoGraph",
     "FalkorDBGraph",
     "GremlinGraph",
@@ -65,6 +69,7 @@ __all__ = [
 ]
 
 _module_lookup = {
+    "AnzoGraphDBGraph": "langchain_community.graphs.anzograph_graph",
     "ArangoGraph": "langchain_community.graphs.arangodb_graph",
     "FalkorDBGraph": "langchain_community.graphs.falkordb_graph",
     "GremlinGraph": "langchain_community.graphs.gremlin_graph",

--- a/libs/community/langchain_community/graphs/__init__.py
+++ b/libs/community/langchain_community/graphs/__init__.py
@@ -5,49 +5,49 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from langchain_community.graphs.anzograph_graph import (
-        AnzoGraphDBGraph,  # noqa: F401
+        AnzoGraphDBGraph,
     )
     from langchain_community.graphs.arangodb_graph import (
-        ArangoGraph,  # noqa: F401
+        ArangoGraph,
     )
     from langchain_community.graphs.falkordb_graph import (
-        FalkorDBGraph,  # noqa: F401
+        FalkorDBGraph,
     )
     from langchain_community.graphs.gremlin_graph import (
-        GremlinGraph,  # noqa: F401
+        GremlinGraph,
     )
     from langchain_community.graphs.hugegraph import (
-        HugeGraph,  # noqa: F401
+        HugeGraph,
     )
     from langchain_community.graphs.kuzu_graph import (
-        KuzuGraph,  # noqa: F401
+        KuzuGraph,
     )
     from langchain_community.graphs.memgraph_graph import (
-        MemgraphGraph,  # noqa: F401
+        MemgraphGraph,
     )
     from langchain_community.graphs.nebula_graph import (
-        NebulaGraph,  # noqa: F401
+        NebulaGraph,
     )
     from langchain_community.graphs.neo4j_graph import (
-        Neo4jGraph,  # noqa: F401
+        Neo4jGraph,
     )
     from langchain_community.graphs.neptune_graph import (
-        NeptuneGraph,  # noqa: F401
+        NeptuneGraph,
     )
     from langchain_community.graphs.neptune_rdf_graph import (
-        NeptuneRdfGraph,  # noqa: F401
+        NeptuneRdfGraph,
     )
     from langchain_community.graphs.networkx_graph import (
-        NetworkxEntityGraph,  # noqa: F401
+        NetworkxEntityGraph,
     )
     from langchain_community.graphs.ontotext_graphdb_graph import (
-        OntotextGraphDBGraph,  # noqa: F401
+        OntotextGraphDBGraph,
     )
     from langchain_community.graphs.rdf_graph import (
-        RdfGraph,  # noqa: F401
+        RdfGraph,
     )
     from langchain_community.graphs.tigergraph_graph import (
-        TigerGraph,  # noqa: F401
+        TigerGraph,
     )
 
 __all__ = [

--- a/libs/community/langchain_community/graphs/anzograph_graph.py
+++ b/libs/community/langchain_community/graphs/anzograph_graph.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Optional,
+)
+
+import rdflib
+from SPARQLWrapper import TURTLE, SPARQLWrapper
+
+if TYPE_CHECKING:
+    pass
+
+prefixes = {
+    "owl": """PREFIX owl: <http://www.w3.org/2002/07/owl#>\n""",
+    "rdf": """PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n""",
+    "rdfs": """PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n""",
+    "xsd": """PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n""",
+}
+
+cls_query_rdf = prefixes["rdfs"] + (
+    """SELECT DISTINCT ?cls ?com\n"""
+    """WHERE { \n"""
+    """    ?instance a ?cls . \n"""
+    """    OPTIONAL { ?cls rdfs:comment ?com } \n"""
+    """}"""
+)
+
+cls_query_rdfs = prefixes["rdfs"] + (
+    """SELECT DISTINCT ?cls ?com\n"""
+    """WHERE { \n"""
+    """    ?instance a/rdfs:subClassOf* ?cls . \n"""
+    """    OPTIONAL { ?cls rdfs:comment ?com } \n"""
+    """}"""
+)
+
+cls_query_owl = prefixes["rdfs"] + (
+    """SELECT DISTINCT ?cls ?com\n"""
+    """WHERE { \n"""
+    """    ?instance a/rdfs:subClassOf* ?cls . \n"""
+    """    FILTER (isIRI(?cls)) . \n"""
+    """    OPTIONAL { ?cls rdfs:comment ?com } \n"""
+    """}"""
+)
+
+rel_query_rdf = prefixes["rdfs"] + (
+    """SELECT DISTINCT ?rel ?com\n"""
+    """WHERE { \n"""
+    """    ?subj ?rel ?obj . \n"""
+    """    OPTIONAL { ?rel rdfs:comment ?com } \n"""
+    """}"""
+)
+
+rel_query_rdfs = (
+    prefixes["rdf"]
+    + prefixes["rdfs"]
+    + (
+        """SELECT DISTINCT ?rel ?com\n"""
+        """WHERE { \n"""
+        """    ?rel a/rdfs:subPropertyOf* rdf:Property . \n"""
+        """    OPTIONAL { ?rel rdfs:comment ?com } \n"""
+        """}"""
+    )
+)
+
+op_query_owl = (
+    prefixes["rdfs"]
+    + prefixes["owl"]
+    + (
+        """SELECT DISTINCT ?op ?com\n"""
+        """WHERE { \n"""
+        """    ?op a/rdfs:subPropertyOf* owl:ObjectProperty . \n"""
+        """    OPTIONAL { ?op rdfs:comment ?com } \n"""
+        """}"""
+    )
+)
+
+dp_query_owl = (
+    prefixes["rdfs"]
+    + prefixes["owl"]
+    + (
+        """SELECT DISTINCT ?dp ?com\n"""
+        """WHERE { \n"""
+        """    ?dp a/rdfs:subPropertyOf* owl:DatatypeProperty . \n"""
+        """    OPTIONAL { ?dp rdfs:comment ?com } \n"""
+        """}"""
+    )
+)
+
+
+class AnzoGraphDBGraph:
+    def __init__(
+        self,
+        source_file: Optional[str] = None,
+        query_endpoint: Optional[str] = None,
+        update_endpoint: Optional[str] = None,
+        query_ontology: Optional[str] = None,
+        serialization: Optional[str] = "turtle",
+        standard: Optional[str] = "rdf",
+        local_copy: Optional[str] = None,
+        graph_kwargs: Optional[Dict] = None,
+    ) -> None:
+        """
+        Set up the AnzoGraph SPARQL graph
+
+        :param source_file: either a path for a local file or a URL
+        :param serialization: serialization of the input
+        :param query_endpoint: SPARQL endpoint for queries, read access
+        :param update_endpoint: SPARQL endpoint for UPDATE queries, write access
+        :param standard: RDF, RDFS, or OWL
+        :param local_copy: new local copy for storing changes
+        :param query_ontology: SPARQL CONSTRUCT query against the AnzoGraph DB endpoint
+        :param graph_kwargs: Additional AnzoGraph SPARQL graph specific kwargs
+        that will be used to initialize it,
+        if query_endpoint is provided.
+        """
+        self.source_file = source_file
+        self.query_endpoint = query_endpoint
+        self.update_endpoint = update_endpoint
+        self.query_ontology = query_ontology
+        self.serialization = serialization
+        self.standard = standard
+        self.local_copy = local_copy
+        self.graph = rdflib.Graph(**(graph_kwargs or {}))
+        self.schema = None
+
+        if self.source_file:
+            self.load_local_file()
+        elif self.query_endpoint and self.query_ontology:
+            self.perform_sparql_query()
+        else:
+            raise ValueError("Insufficient parameters to initialize graph.")
+
+    def perform_sparql_query(self):
+        """
+        Execute SPARQL query and get serialized result.
+        """
+        sparql = SPARQLWrapper(self.query_endpoint)
+        sparql.setQuery(self.query_ontology)
+        sparql.setReturnFormat(TURTLE)
+        query_result = sparql.query().convert()
+        self.load_and_serialize_graph(query_result)
+
+    def load_local_file(self):
+        """
+        Load RDF data from a local file.
+        """
+        self.graph.parse(self.source_file, format=self.serialization)
+
+    def load_and_serialize_graph(self, query_result):
+        """
+        Load the SPARQL result into a graph, serialize it to a temporary file,
+        and then reload it into the main graph.
+        """
+        temp_graph = rdflib.Graph()
+        temp_graph.parse(data=query_result, format="turtle")
+        g = temp_graph.serialize(format="turtle")
+
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp:
+            temp.write(g)
+            temp_file_path = temp.name
+
+        try:
+            self.graph = rdflib.Graph()
+            self.graph.parse(temp_file_path, format=self.serialization)
+        finally:
+            os.unlink(temp_file_path)
+
+    @property
+    def get_schema(self) -> str:
+        """
+        Returns the schema of the graph database.
+        """
+        return self.schema
+
+    def query(
+        self,
+        query: str,
+    ) -> List[rdflib.query.ResultRow]:
+        """
+        Query the graph.
+        """
+        from rdflib.exceptions import ParserError
+        from rdflib.query import ResultRow
+
+        try:
+            res = self.graph.query(query)
+        except ParserError as e:
+            raise ValueError("Generated SPARQL statement is invalid\n" f"{e}")
+        return [r for r in res if isinstance(r, ResultRow)]
+
+    def update(
+        self,
+        query: str,
+    ) -> None:
+        """
+        Update the graph.
+        """
+        from rdflib.exceptions import ParserError
+
+        try:
+            self.graph.update(query)
+        except ParserError as e:
+            raise ValueError("Generated SPARQL statement is invalid\n" f"{e}")
+        if self.local_copy:
+            self.graph.serialize(
+                destination=self.local_copy, format=self.local_copy.split(".")[-1]
+            )
+        else:
+            raise ValueError("No target file specified for saving the updated file.")
+
+    @staticmethod
+    def _get_local_name(iri: str) -> str:
+        if "#" in iri:
+            local_name = iri.split("#")[-1]
+        elif "/" in iri:
+            local_name = iri.split("/")[-1]
+        else:
+            raise ValueError(f"Unexpected IRI '{iri}', contains neither '#' nor '/'.")
+        return local_name
+
+    def _res_to_str(self, res: rdflib.query.ResultRow, var: str) -> str:
+        return (
+            "<"
+            + str(res[var])
+            + "> ("
+            + self._get_local_name(res[var])
+            + ", "
+            + str(res["com"])
+            + ")"
+        )
+
+    def _rdf_s_schema(self, classes, relationships):
+        """
+        Constructs a schema description from given classes and relationships.
+        """
+        return (
+            f"In the following, each IRI is followed by the local name and "
+            f"optionally its description in parentheses. \n"
+            f"The RDF graph supports the following node types:\n"
+            f'{", ".join([self._res_to_str(cls, "cls") for cls in classes])}\n'
+            f"The RDF graph supports the following relationships:\n"
+            f'{", ".join([self._res_to_str(rel, "rel") for rel in relationships])}\n'
+        )
+
+    def load_schema(self):
+        if self.query_endpoint:
+            if self.standard == "rdf":
+                clss = self.query(cls_query_rdf)
+                rels = self.query(rel_query_rdf)
+                self.schema = self._rdf_s_schema(clss, rels)
+            elif self.standard == "rdfs":
+                clss = self.query(cls_query_rdfs)
+                rels = self.query(rel_query_rdfs)
+                self.schema = self._rdf_s_schema(clss, rels)
+            elif self.standard == "owl":
+                clss = self.query(cls_query_owl)
+                ops = self.query(op_query_owl)
+                dps = self.query(dp_query_owl)
+                self.schema = self._rdf_s_schema(clss, ops + dps)
+            else:
+                raise ValueError(f"Mode '{self.standard}' currently not supported.")
+        else:
+            self.schema = None

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -105,6 +105,7 @@ httpx-sse = {version = "^0.4.0", optional = true}
 pyjwt = {version = "^2.8.0", optional = true}
 oracledb = {version = "^2.2.0", optional = true}
 aerospike-vector-search = {version = "^0.6.1", optional = true}
+sparqlwrapper = {version = "^2.0.0", optional = true}
 
 [tool.poetry.group.test]
 optional = true
@@ -287,7 +288,8 @@ extended_testing = [
  "vdms",
  "httpx-sse",
  "pyjwt",
- "oracledb"
+ "oracledb",
+ "sparqlwrapper"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
- [x] **PR title**: "community: add integration to AnzoGraph DB"

- [x] **PR message**: 
    - **Description:** To support the integration of the AnzoGraph DB graph database system, we included Python modules and modified Python files within LangChain's GraphQA chains and LangChain Community graphs. We developed two modules and modified one __init__.py file and one prompts.py module to enable support for Cambridge Semantics' AnzoGraphDB. One langchain_community __init__.py file was modified to include the path for the AnzoGraph DB graph module. The prompts.py file (located in langchain_community/chains/graph_qa) was modified to incorporate AnzoGraph DB prompt templates.
    - **Dependencies:** pip install rdflib and pip install sparqlwrapper (included in pyproject.toml)
    - **Twitter handle:** @MarcCorrAI 

- [x] **Add tests and docs**: 
  1. Unit test for testing the integration file is included in folder <langchain\docs\docs\integrations\graphs>, accompanied by the foaf ontology file to perform the test locally.
  2.  Both integration files were added, as requested:
anzograph.ipynb (path in LangChain website: components/graphs/AnzoGraphDB), for inclusion at  https://python.langchain.com/v0.1/docs/integrations/graphs/ 
and anzograph.mdx (path in LangChain website: providers/AnzoGraphDB) for inclusion at   https://python.langchain.com/v0.1/docs/integrations/providers/

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/
"Make tests" were run (test, format_diff, lint_diff, spell_fix). One pytest and unittest is included in the directory "langchain/libs/community/tests/unit_tests/graphs".