### PR TITLE
community:jinachat[patch]: standardize init args

### DIFF
--- a/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
+++ b/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
@@ -18,7 +18,7 @@ from langchain_core.outputs import (
     ChatGeneration,
     ChatResult,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, Field
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class ChatJavelinAIGateway(BaseChatModel):
     client: Any
     """javelin client."""
 
-    javelin_api_key: Optional[SecretStr] = None
+    javelin_api_key: Optional[SecretStr] = Field(None, alias="api_key")
     """The API key for the Javelin AI Gateway."""
 
     def __init__(self, **kwargs: Any):

--- a/libs/community/langchain_community/chat_models/jinachat.py
+++ b/libs/community/langchain_community/chat_models/jinachat.py
@@ -174,10 +174,10 @@ class JinaChat(BaseChatModel):
     """What sampling temperature to use."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not explicitly specified."""
-    jinachat_api_key: Optional[SecretStr] = None
+    jinachat_api_key: Optional[SecretStr] = Field(None, alias="api_key")
     """Base URL path for API requests, 
     leave blank if not using a proxy or service emulator."""
-    request_timeout: Optional[Union[float, Tuple[float, float]]] = None
+    request_timeout: Optional[Union[float, Tuple[float, float]]] = Field(None, alias="timeout")
     """Timeout for requests to JinaChat completion API. Default is 600 seconds."""
     max_retries: int = 6
     """Maximum number of retries to make when generating."""

--- a/libs/community/tests/unit_tests/chat_models/test_jinachat.py
+++ b/libs/community/tests/unit_tests/chat_models/test_jinachat.py
@@ -1,0 +1,41 @@
+"""Test JinaChat Chat API wrapper."""
+
+import os
+
+import pytest
+
+from langchain_community.chat_models import JinaChat
+
+os.environ["JINACHAT_API_KEY"] = "foo"
+
+
+@pytest.mark.requires("openai")
+def test_jinachat_model_name_param() -> None:
+    llm = JinaChat(model="foo")  # type: ignore[call-arg]
+    assert llm.model_kwargs["model"] == "foo"
+
+
+@pytest.mark.requires("openai")
+def test_jinachat_model_kwargs() -> None:
+    llm = JinaChat(model="test", model_kwargs={"foo": "bar"})  # type: ignore[call-arg]
+    expected_kwargs = {"foo": "bar", "model": "test"}
+    assert llm.model_kwargs == expected_kwargs
+
+
+@pytest.mark.requires("openai")
+def test_jinachat_initialization() -> None:
+    """Test jinachat initialization."""
+    for model in [
+        JinaChat(  # type: ignore[call-arg]
+            model="test", timeout=1, api_key="test", temperature=0.7, verbose=True
+        ),
+        JinaChat(  # type: ignore[call-arg]
+            model="test",
+            request_timeout=1,
+            jinachat_api_key="test",
+            temperature=0.7,
+            verbose=True,
+        ),
+    ]:
+        assert model.request_timeout == 1
+        assert model.jinachat_api_key.get_secret_value() == "test"


### PR DESCRIPTION
Description:
updated jinachat_api_key and request_timeout so that they aliased to api_key, and timeout respectively. Added test that both continue to set the same underlying attributes in a new file titled test_jinachat.py

Issue: 20085
community:javelin[patch]: standardize init args

updated jinachat_api_key so that it aliased to api_key.

Related to [20085](https://github.com/langchain-ai/langchain/issues/20085)

Dependencies: None