### PR TITLE
docs: update the name of the tool passio_nutrition_ai 

### DIFF
--- a/docs/docs/integrations/tools/passio_nutrition_ai.ipynb
+++ b/docs/docs/integrations/tools/passio_nutrition_ai.ipynb
@@ -5,7 +5,7 @@
    "id": "f4c03f40-1328-412d-8a48-1db0cd481b77",
    "metadata": {},
    "source": [
-    "# Quickstart\n",
+    "# Passio NutritionAI\n",
     "\n",
     "To best understand how NutritionAI can give your agents super food-nutrition powers, let's build an agent that can find that information via Passio NutritionAI.\n",
     "\n",


### PR DESCRIPTION
Updating the name of the Passion Nutrition AI tool so that the name of the tool is correctly displayed in the sidebar menu.

Currently the name of the tool says "Quickstart" in the side bar.
The patch fixed the name to be Passio Nutrition AI.

<img width="681" alt="image" src="https://github.com/langchain-ai/langchain/assets/4603110/9609975e-78ea-4032-9024-10c4f838170a">
