### PR TITLE
docs: Add explanation on how to use Hugging Face embeddings

### DIFF
--- a/docs/docs/how_to/embed_text.mdx
+++ b/docs/docs/how_to/embed_text.mdx
@@ -78,6 +78,31 @@ embeddings_model = CohereEmbeddings()
 ```
 
   </TabItem>
+  <TabItem value="huggingface" label="Hugging Face">
+
+To start we'll need to install the Hugging Face partner package:
+
+```bash
+pip install langchain-huggingface
+```
+
+You can then load any [Sentence Transformers model](https://huggingface.co/models?library=sentence-transformers) from the Hugging Face Hub.
+
+```python
+from langchain_huggingface import HuggingFaceEmbeddings
+
+embeddings_model = HuggingFaceEmbeddings(model_name="sentence-transformers/all-mpnet-base-v2")
+```
+
+You can also leave the `model_name` blank to use the default [sentence-transformers/all-mpnet-base-v2](https://huggingface.co/sentence-transformers/all-mpnet-base-v2) model.
+
+```python
+from langchain_huggingface import HuggingFaceEmbeddings
+
+embeddings_model = HuggingFaceEmbeddings()
+```
+
+  </TabItem>
 </Tabs>
 
 ### `embed_documents`


### PR DESCRIPTION
- **Description:** I've added a tab on embedding text with LangChain using Hugging Face models to here: https://python.langchain.com/v0.2/docs/how_to/embed_text/. HF was mentioned in the running text, but not in the tabs, which I thought was odd.
- **Issue:** N/A
- **Dependencies:** N/A
- **Twitter handle:** No need, this is tiny :) 

Also, I had a ton of issues with the poetry docs/lint install, so I haven't linted this. Apologies for that. 

cc @Jofthomas 

- Tom Aarsen
