### PR TITLE
anthropic[patch]: allow tool call mutation

### DIFF
--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -352,10 +352,7 @@ def test__format_messages_with_str_content_and_tool_calls() -> None:
         "thought",
         tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "buzz"}}],
     )
-    tool = ToolMessage(
-        "blurb",
-        tool_call_id="1",
-    )
+    tool = ToolMessage("blurb", tool_call_id="1")
     messages = [system, human, ai, tool]
     expected = (
         "fuzz",
@@ -364,10 +361,7 @@ def test__format_messages_with_str_content_and_tool_calls() -> None:
             {
                 "role": "assistant",
                 "content": [
-                    {
-                        "type": "text",
-                        "text": "thought",
-                    },
+                    {"type": "text", "text": "thought"},
                     {
                         "type": "tool_use",
                         "name": "bar",
@@ -394,12 +388,7 @@ def test__format_messages_with_list_content_and_tool_calls() -> None:
     # If content and tool_calls are specified and content is a list, then content is
     # preferred.
     ai = AIMessage(
-        [
-            {
-                "type": "text",
-                "text": "thought",
-            }
-        ],
+        [{"type": "text", "text": "thought"}],
         tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "buzz"}}],
     )
     tool = ToolMessage(
@@ -413,11 +402,51 @@ def test__format_messages_with_list_content_and_tool_calls() -> None:
             {"role": "user", "content": "foo"},
             {
                 "role": "assistant",
+                "content": [{"type": "text", "text": "thought"}],
+            },
+            {
+                "role": "user",
                 "content": [
+                    {"type": "tool_result", "content": "blurb", "tool_use_id": "1"}
+                ],
+            },
+        ],
+    )
+    actual = _format_messages(messages)
+    assert expected == actual
+
+
+def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
+    """Show that tool_calls are preferred to tool_use blocks when both have same id."""
+    system = SystemMessage("fuzz")
+    human = HumanMessage("foo")
+    # NOTE: tool_use block in contents and tool_calls have different arguments.
+    ai = AIMessage(
+        [
+            {"type": "text", "text": "thought"},
+            {"type": "tool_use", "name": "bar", "id": "1", "input": {"baz": "NOT_BUZZ"}},
+        ],
+        tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "BUZZ"}}],
+    )
+    tool = ToolMessage(
+        "blurb",
+        tool_call_id="1",
+    )
+    messages = [system, human, ai, tool]
+    expected = (
+        "fuzz",
+        [
+            {"role": "user", "content": "foo"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "thought"},
                     {
-                        "type": "text",
-                        "text": "thought",
-                    }
+                        "type": "tool_use",
+                        "name": "bar",
+                        "id": "1",
+                        "input": {"baz": "BUZZ"},  # tool_calls value preferred.
+                    },
                 ],
             },
             {

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -424,14 +424,16 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     ai = AIMessage(
         [
             {"type": "text", "text": "thought"},
-            {"type": "tool_use", "name": "bar", "id": "1", "input": {"baz": "NOT_BUZZ"}},
+            {
+                "type": "tool_use",
+                "name": "bar",
+                "id": "1",
+                "input": {"baz": "NOT_BUZZ"},
+            },
         ],
         tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "BUZZ"}}],
     )
-    tool = ToolMessage(
-        "blurb",
-        tool_call_id="1",
-    )
+    tool = ToolMessage("blurb", tool_call_id="1")
     messages = [system, human, ai, tool]
     expected = (
         "fuzz",


### PR DESCRIPTION
If tool_use blocks and tool_calls with overlapping IDs are present, prefer the values of the tool_calls. Allows for mutating AIMessages just via tool_calls.