### PR TITLE
langchain-ai21: added `license`

### DIFF
--- a/libs/partners/ai21/pyproject.toml
+++ b/libs/partners/ai21/pyproject.toml
@@ -5,6 +5,7 @@ description = "An integration package connecting AI21 and LangChain"
 authors = []
 readme = "README.md"
 repository = "https://github.com/langchain-ai/langchain"
+license = "MIT"
 
 [tool.poetry.urls]
 "Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/ai21"


### PR DESCRIPTION
The `pyproject.toml` missed the `license` parameter. I've added it as `MIT`