### PR TITLE
community: create_sql_agent Resolve BadRequestError for API requests with pre-filled assistant

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/sql/base.py
+++ b/libs/community/langchain_community/agent_toolkits/sql/base.py
@@ -13,7 +13,7 @@ from typing import (
     cast,
 )
 
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.prompts import BasePromptTemplate, PromptTemplate
 from langchain_core.prompts.chat import (
     ChatPromptTemplate,
@@ -187,8 +187,7 @@ def create_sql_agent(
         if prompt is None:
             messages: List = [
                 SystemMessage(content=cast(str, prefix)),
-                HumanMessagePromptTemplate.from_template("{input}"),
-                AIMessage(content=suffix or SQL_FUNCTIONS_SUFFIX),
+                HumanMessagePromptTemplate.from_template("{input}\n" +  f"{suffix or SQL_FUNCTIONS_SUFFIX}"),
                 MessagesPlaceholder(variable_name="agent_scratchpad"),
             ]
             prompt = ChatPromptTemplate.from_messages(messages)
@@ -202,8 +201,7 @@ def create_sql_agent(
         if prompt is None:
             messages = [
                 SystemMessage(content=cast(str, prefix)),
-                HumanMessagePromptTemplate.from_template("{input}"),
-                AIMessage(content=suffix or SQL_FUNCTIONS_SUFFIX),
+                HumanMessagePromptTemplate.from_template("{input}\n" +  f"{suffix or SQL_FUNCTIONS_SUFFIX}"),
                 MessagesPlaceholder(variable_name="agent_scratchpad"),
             ]
             prompt = ChatPromptTemplate.from_messages(messages)


### PR DESCRIPTION
**Description**: 

Fixes the issue where **API requests with a pre-filled assistant message in the final position were causing a BadRequestError with code 400**. The error message indicated that pre-filling the assistant response is not supported when using tools. The changes in this commit ensure that API requests no longer include an assistant message in the final position, allowing the API to handle the request correctly and prevent the invalid request error from occurring. With this fix, users can now make API requests smoothly without encountering the BadRequestError, improving the overall user experience and reliability of the API.


