### PR TITLE
experimental:Fixed override of `with_structured_output` in `OllamaFunctions` class causing `NotImplementedError`

### DIFF
--- a/libs/experimental/langchain_experimental/llms/ollama_functions.py
+++ b/libs/experimental/langchain_experimental/llms/ollama_functions.py
@@ -121,27 +121,8 @@ class OllamaFunctions(ChatOllama):
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, BaseMessage]:
         return self.bind(functions=tools, **kwargs)
-
+    
     @overload
-    def with_structured_output(
-        self,
-        schema: Optional[_DictOrPydanticClass] = None,
-        *,
-        include_raw: Literal[True] = True,
-        **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, _AllReturnType]:
-        ...
-
-    @overload
-    def with_structured_output(
-        self,
-        schema: Optional[_DictOrPydanticClass] = None,
-        *,
-        include_raw: Literal[False] = False,
-        **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, _DictOrPydantic]:
-        ...
-
     def with_structured_output(
         self,
         schema: Optional[_DictOrPydanticClass] = None,


### PR DESCRIPTION
  **Description:**
Calling `with_structured_output` method of `OllamaFunctions` function resulting in `NotImplementedError` Error

![Screenshot 2024-05-26 at 6 45 20 AM](https://github.com/langchain-ai/langchain/assets/29140664/90a089d7-198e-4056-a57d-6c740ffd711a)


  - **Issue:**
Fixed override for `with_structured_output` method

  - **Dependencies:**
  Not Applicable

  -  **Twitter handle:**
  N/A