### PR TITLE
Fix Clova embeddings example document

### DIFF
--- a/docs/docs/integrations/text_embedding/clova.ipynb
+++ b/docs/docs/integrations/text_embedding/clova.ipynb
@@ -58,7 +58,7 @@
    "outputs": [],
    "source": [
     "document_text = [\"This is a test doc1.\", \"This is a test doc2.\"]\n",
-    "document_result = embeddings.embed_documents([document_text])"
+    "document_result = embeddings.embed_documents(document_text)"
    ]
   }
  ],


### PR DESCRIPTION
- [ ] **PR title**: "Fix list handling in Clova embeddings example documentation"
  - Description:
Fixes a bug in the Clova Embeddings example documentation where document_text was incorrectly wrapped in an additional list.
   - Rationale
The embed_documents method expects a list, but the previous example wrapped document_text in an unnecessary additional list, causing an error. The updated example correctly passes document_text directly to the method, ensuring it functions as intended.

