### PR TITLE
langchain: fix: example in system prompt for KG extraction was wrong

### DIFF
--- a/libs/langchain/langchain/indexes/prompts/knowledge_triplet_extraction.py
+++ b/libs/langchain/langchain/indexes/prompts/knowledge_triplet_extraction.py
@@ -25,7 +25,7 @@ _DEFAULT_KNOWLEDGE_TRIPLE_EXTRACTION_TEMPLATE = (
     "END OF EXAMPLE\n\n"
     "EXAMPLE\n"
     "Oh huh. I know Descartes likes to drive antique scooters and play the mandolin.\n"
-    f"Output: (Descartes, likes to drive, antique scooters){KG_TRIPLE_DELIMITER}(Descartes, plays, mandolin)\n"
+    f"Output: (Descartes, likes to drive, antique scooters){KG_TRIPLE_DELIMITER}(Descartes, likes to play, the mandolin)\n"
     "END OF EXAMPLE\n\n"
     "EXAMPLE\n"
     "{text}"


### PR DESCRIPTION
- **Description:** The example given in the system prompt to extract knowledge triplets is wrong. The sentence is not "Descartes plays the mandolin" but "Descartes likes to play the mandolin". I think this seemingly minor issue can have dramatic consequences for KG generation.
