### PR TITLE
community[patch]:Support filter for AzureAISearchRetriever

### DIFF
--- a/libs/community/langchain_community/retrievers/azure_ai_search.py
+++ b/libs/community/langchain_community/retrievers/azure_ai_search.py
@@ -36,6 +36,8 @@ class AzureAISearchRetriever(BaseRetriever):
     """Key in a retrieved result to set as the Document page_content."""
     top_k: Optional[int] = None
     """Number of results to retrieve. Set to None to retrieve all results."""
+    filter: Optional[str] = None
+    """OData $filter expression to apply to the search query."""
 
     class Config:
         extra = Extra.forbid
@@ -72,7 +74,8 @@ class AzureAISearchRetriever(BaseRetriever):
             base_url = self.service_name
         endpoint_path = f"indexes/{self.index_name}/docs?api-version={self.api_version}"
         top_param = f"&$top={self.top_k}" if self.top_k else ""
-        return base_url + endpoint_path + f"&search={query}" + top_param
+        filter_param = f"&$filter={self.filter}" if self.filter else ""
+        return base_url + endpoint_path + f"&search={query}" + top_param + filter_param
 
     @property
     def _headers(self) -> Dict[str, str]:


### PR DESCRIPTION
**Description**: 
The AzureAISearchRetriever does not support the "$filter" argument offered in the AISearch API: https://learn.microsoft.com/en-us/rest/api/searchservice/documents/search-get?view=rest-searchservice-2023-11-01&tabs=HTTP The $filter allows filtering of indexes based on values in metadata.

**Issue**: 
https://github.com/langchain-ai/langchain/issues/19885

**Dependencies**: 
No

**Twitter handle**: 
@Jeffreym9M
 

- [ ] **Add tests and docs**: Not relevant


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

