### PR TITLE
community: fix AzureSearch delete documents

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -401,7 +401,7 @@ class AzureSearch(VectorStore):
             False otherwise.
         """
         if ids:
-            res = self.client.delete_documents([{"id": i} for i in ids])
+            res = self.client.delete_documents([{FIELDS_ID: i} for i in ids])
             return len(res) > 0
         else:
             return False


### PR DESCRIPTION
 **Description**

Fix AzureSearch delete documents method by using FIELDS_ID variable instead of the hard coded "id" value

**Issue:** 

This is linked to this issue: https://github.com/langchain-ai/langchain/issues/22314


