### PR TITLE
community[patch]: Standardize qianfan model init args name

### DIFF
--- a/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
+++ b/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
@@ -124,11 +124,12 @@ class QianfanChatEndpoint(BaseChatModel):
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """extra params for model invoke using with `do`."""
 
-    client: Any
+    client: Any  #: :meta private:
 
-    qianfan_ak: Optional[SecretStr] = None
-    qianfan_sk: Optional[SecretStr] = None
-
+    qianfan_ak: Optional[SecretStr] = Field(default=None, alias="api_key")
+    """Qianfan API KEY"""
+    qianfan_sk: Optional[SecretStr] = Field(default=None, alias="secret_key")
+    """Qianfan SECRET KEY"""
     streaming: Optional[bool] = False
     """Whether to stream the results or not."""
 
@@ -136,7 +137,9 @@ class QianfanChatEndpoint(BaseChatModel):
     """request timeout for chat http requests"""
 
     top_p: Optional[float] = 0.8
+    """What probability mass to use."""
     temperature: Optional[float] = 0.95
+    """What sampling temperature to use."""
     penalty_score: Optional[float] = 1
     """Model params, only supported in ERNIE-Bot and ERNIE-Bot-turbo.
     In the case of other model, passing these params will not affect the result.
@@ -283,7 +286,6 @@ class QianfanChatEndpoint(BaseChatModel):
         """
         if self.streaming:
             completion = ""
-            token_usage = {}
             chat_generation_info: Dict = {}
             for chunk in self._stream(messages, stop, run_manager, **kwargs):
                 chat_generation_info = (
@@ -328,7 +330,6 @@ class QianfanChatEndpoint(BaseChatModel):
     ) -> ChatResult:
         if self.streaming:
             completion = ""
-            token_usage = {}
             chat_generation_info: Dict = {}
             async for chunk in self._astream(messages, stop, run_manager, **kwargs):
                 chat_generation_info = (

--- a/libs/community/tests/integration_tests/chat_models/test_qianfan_endpoint.py
+++ b/libs/community/tests/integration_tests/chat_models/test_qianfan_endpoint.py
@@ -362,3 +362,19 @@ def test_uses_actual_secret_value_from_secret_str() -> None:
     )
     assert cast(SecretStr, chat.qianfan_ak).get_secret_value() == "test-api-key"
     assert cast(SecretStr, chat.qianfan_sk).get_secret_value() == "test-secret-key"
+
+
+def test_init_api_key_param() -> None:
+    """Test the standardized parameters -- api_key and secret_key"""
+    for chat in [
+        QianfanChatEndpoint(  # type: ignore[call-arg]
+            api_key="test-api-key",  # type: ignore[arg-type]
+            secret_key="test-secret-key",  # type: ignore[arg-type]
+        ),
+        QianfanChatEndpoint(  # type: ignore[call-arg]
+            qianfan_ak="test-api-key",  # type: ignore[arg-type]
+            qianfan_sk="test-secret-key",  # type: ignore[arg-type]
+        ),
+    ]:
+        assert cast(SecretStr, chat.qianfan_ak).get_secret_value() == "test-api-key"
+        assert cast(SecretStr, chat.qianfan_sk).get_secret_value() == "test-secret-key"


### PR DESCRIPTION

- **Description:**  
    - Standardize qianfan chat model intialization arguments name
        - qianfan_ak (qianfan api key)  -> api_key
        - qianfan_sk (qianfan secret key)  ->  secret_key
       
    - Delete unuse variable
- **Issue:** #20085 

