### PR TITLE
docs: `integrations` cache: added class table

### DIFF
--- a/docs/docs/integrations/llm_caching.ipynb
+++ b/docs/docs/integrations/llm_caching.ipynb
@@ -2071,6 +2071,71 @@
     "# so it uses the cached result!\n",
     "llm(\"Tell me one joke\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae1f5e1c-085e-4998-9f2d-b5867d2c3d5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-05-31T17:18:43.345495Z",
+     "iopub.status.busy": "2024-05-31T17:18:43.345015Z",
+     "iopub.status.idle": "2024-05-31T17:18:43.351003Z",
+     "shell.execute_reply": "2024-05-31T17:18:43.350073Z",
+     "shell.execute_reply.started": "2024-05-31T17:18:43.345456Z"
+    }
+   },
+   "source": [
+    "## Cache classes: summary table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65072e45-10bc-40f1-979b-2617656bbbce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-05-31T17:16:05.616430Z",
+     "iopub.status.busy": "2024-05-31T17:16:05.616221Z",
+     "iopub.status.idle": "2024-05-31T17:16:05.624164Z",
+     "shell.execute_reply": "2024-05-31T17:16:05.623673Z",
+     "shell.execute_reply.started": "2024-05-31T17:16:05.616418Z"
+    }
+   },
+   "source": [
+    "**Cache** classes are implemented by inheriting the [BaseCache](https://api.python.langchain.com/en/latest/caches/langchain_core.caches.BaseCache.html) class.\n",
+    "\n",
+    "This table lists all 20 derived classes with links to the API Reference.\n",
+    "\n",
+    "\n",
+    "| Namespace 🔻 | Class |\n",
+    "|------------|---------|\n",
+    "| langchain_astradb.cache | [AstraDBCache](https://api.python.langchain.com/en/latest/cache/langchain_astradb.cache.AstraDBCache.html) |\n",
+    "| langchain_astradb.cache | [AstraDBSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_astradb.cache.AstraDBSemanticCache.html) |\n",
+    "| langchain_community.cache | [AstraDBCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.AstraDBCache.html) |\n",
+    "| langchain_community.cache | [AstraDBSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.AstraDBSemanticCache.html) |\n",
+    "| langchain_community.cache | [AzureCosmosDBSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.AzureCosmosDBSemanticCache.html) |\n",
+    "| langchain_community.cache | [CassandraCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.CassandraCache.html) |\n",
+    "| langchain_community.cache | [CassandraSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.CassandraSemanticCache.html) |\n",
+    "| langchain_community.cache | [GPTCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.GPTCache.html) |\n",
+    "| langchain_community.cache | [InMemoryCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.InMemoryCache.html) |\n",
+    "| langchain_community.cache | [MomentoCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.MomentoCache.html) |\n",
+    "| langchain_community.cache | [OpenSearchSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.OpenSearchSemanticCache.html) |\n",
+    "| langchain_community.cache | [RedisSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.RedisSemanticCache.html) |\n",
+    "| langchain_community.cache | [SQLAlchemyCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.SQLAlchemyCache.html) |\n",
+    "| langchain_community.cache | [SQLAlchemyMd5Cache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.SQLAlchemyMd5Cache.html) |\n",
+    "| langchain_community.cache | [UpstashRedisCache](https://api.python.langchain.com/en/latest/cache/langchain_community.cache.UpstashRedisCache.html) |\n",
+    "| langchain_core.caches | [InMemoryCache](https://api.python.langchain.com/en/latest/caches/langchain_core.caches.InMemoryCache.html) |\n",
+    "| langchain_elasticsearch.cache | [ElasticsearchCache](https://api.python.langchain.com/en/latest/cache/langchain_elasticsearch.cache.ElasticsearchCache.html) |\n",
+    "| langchain_mongodb.cache | [MongoDBAtlasSemanticCache](https://api.python.langchain.com/en/latest/cache/langchain_mongodb.cache.MongoDBAtlasSemanticCache.html) |\n",
+    "| langchain_mongodb.cache | [MongoDBCache](https://api.python.langchain.com/en/latest/cache/langchain_mongodb.cache.MongoDBCache.html) |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19067f14-c69a-4156-9504-af43a0713669",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -2089,7 +2154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added a table with the cache classes. See [this table here](https://langchain-rnpqvikie-langchain.vercel.app/v0.2/docs/integrations/llm_caching/#cache-classes-summary-table).