### PR TITLE
docs: resolve minor syntax error.

### DIFF
--- a/docs/docs/tutorials/agents.ipynb
+++ b/docs/docs/tutorials/agents.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% pip install -U langchain-community langgraph langchain-anthropic"
+    "%pip install -U langchain-community langgraph langchain-anthropic"
    ]
   },
   {


### PR DESCRIPTION
Used the correct magic command. 
Changed from `% pip...` to `%pip`