### PR TITLE
community: fix missing `apify_api_token` field in ApifyWrapper

### DIFF
--- a/libs/community/langchain_community/utilities/apify.py
+++ b/libs/community/langchain_community/utilities/apify.py
@@ -17,6 +17,7 @@ class ApifyWrapper(BaseModel):
 
     apify_client: Any
     apify_client_async: Any
+    apify_api_token: Optional[str] = None
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:


### PR DESCRIPTION
- **Description:** The `ApifyWrapper` class expects `apify_api_token` to be passed as a named parameter or set as an environment variable. But the corresponding field was missing in the class definition causing the argument to be ignored when passed as a named param. This patch fixes that.
