### PR TITLE
#22426 - chat_models()._combine_llm_outputs() uses different hardcoded dict keys

### DIFF
--- a/libs/community/langchain_community/callbacks/bedrock_anthropic_callback.py
+++ b/libs/community/langchain_community/callbacks/bedrock_anthropic_callback.py
@@ -77,13 +77,13 @@ class BedrockAnthropicTokenUsageCallbackHandler(BaseCallbackHandler):
         if response.llm_output is None:
             return None
 
-        if "usage" not in response.llm_output:
+        if "token_usage" not in response.llm_output:
             with self._lock:
                 self.successful_requests += 1
             return None
 
         # compute tokens and cost for this request
-        token_usage = response.llm_output["usage"]
+        token_usage = response.llm_output["token_usage"]
         completion_tokens = token_usage.get("completion_tokens", 0)
         prompt_tokens = token_usage.get("prompt_tokens", 0)
         total_tokens = token_usage.get("total_tokens", 0)

--- a/libs/community/langchain_community/chat_models/bedrock.py
+++ b/libs/community/langchain_community/chat_models/bedrock.py
@@ -306,7 +306,7 @@ class BedrockChat(BaseChatModel, BedrockBase):
                 **params,
             )
 
-            llm_output["usage"] = usage_info
+            llm_output["token_usage"] = usage_info
 
         return ChatResult(
             generations=[ChatGeneration(message=AIMessage(content=completion))],
@@ -318,11 +318,13 @@ class BedrockChat(BaseChatModel, BedrockBase):
         final_output = {}
         for output in llm_outputs:
             output = output or {}
-            usage = output.get("usage", {})
-            for token_type, token_count in usage.items():
+            token_usage = output.get("usage", {})
+            for token_type, token_count in token_usage.items():
                 final_usage[token_type] += token_count
             final_output.update(output)
-        final_output["usage"] = final_usage
+        final_output["token_usage"] = final_usage
+        if "model_id" in final_output:
+            final_output["model_name"] = final_output["model_id"]
         return final_output
 
     def get_num_tokens(self, text: str) -> int:

--- a/libs/community/tests/unit_tests/chat_models/test_bedrock.py
+++ b/libs/community/tests/unit_tests/chat_models/test_bedrock.py
@@ -84,6 +84,7 @@ def test_bedrock_combine_llm_output() -> None:
     model = BedrockChat(model_id=model_id, client=client)
     final_output = model._combine_llm_outputs(llm_outputs)  # type: ignore[arg-type]
     assert final_output["model_id"] == model_id
-    assert final_output["usage"]["completion_tokens"] == 2
-    assert final_output["usage"]["prompt_tokens"] == 4
-    assert final_output["usage"]["total_tokens"] == 6
+    assert final_output["model_name"] == model_id
+    assert final_output["token_usage"]["completion_tokens"] == 2
+    assert final_output["token_usage"]["prompt_tokens"] == 4
+    assert final_output["token_usage"]["total_tokens"] == 6


### PR DESCRIPTION
 **Description:**: I searched in the codebase for different naming conventions for 'token_usage' and 'model_name' keys in ` chat_models()._combine_llm_outputs()`, since all models are consistent except Bedrock models (using `usage` and `model_id` instead of `token_usage` and `model_name`) I renamed the latter for consistency.

 **Issue:** [22426](https://github.com/langchain-ai/langchain/issues/22426)
 **Dependencies:** --
 **Twitter handle:** @AxelSync91