### PR TITLE
Fix for AzureSearch delete method not using FIELDS_ID (Generated by A…

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -401,7 +401,7 @@ class AzureSearch(VectorStore):
             False otherwise.
         """
         if ids:
-            res = self.client.delete_documents([{"id": i} for i in ids])
+            res = self.client.delete_documents([{FIELDS_ID: i} for i in ids])
             return len(res) > 0
         else:
             return False


### PR DESCRIPTION
### Description
This PR addresses a bug in the `AzureSearch` class where the `delete` method did not use the `FIELDS_ID` variable, which prevented the complete override of the key field in Azure AI Search. By modifying the `delete` method, we ensure that `FIELDS_ID` is used instead of the hard-coded "id" string, providing the necessary flexibility for different document identifier field names.

### Fixes
This patch fixes [Issue 22314](https://github.com/langchain-ai/langchain/issues/22314).

This patch was generated by [Ana - AI SDE](https://openana.ai/), an AI-powered software development assistant.