### PR TITLE
core[patch]: Fix VectorStore's as_retriever mutating tags param

### DIFF
--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -646,9 +646,8 @@ class VectorStore(ABC):
                 search_kwargs={'filter': {'paper_title':'GPT-4 Technical Report'}}
             )
         """
-        tags = kwargs.pop("tags", None) or []
-        tags.extend(self._get_retriever_tags())
-        return VectorStoreRetriever(vectorstore=self, **kwargs, tags=tags)
+        tags = kwargs.pop("tags", None) or [] + self._get_retriever_tags()
+        return VectorStoreRetriever(vectorstore=self, tags=tags, **kwargs)
 
 
 class VectorStoreRetriever(BaseRetriever):


### PR DESCRIPTION
The current VectorStore `as_retriever` implementation mutates the `tags` param when it's passed in kwargs.
This fix ensures that a copy is done.