### PR TITLE
core[patch]: Deduplicate of callback handlers in merge_configs

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -304,12 +304,12 @@ def merge_configs(*configs: Optional[RunnableConfig]) -> RunnableConfig:
                         base["callbacks"] = mngr
                     else:
                         # base_callbacks is also a manager
-                        base["callbacks"] = base_callbacks.__class__(
+
+                        manager = base_callbacks.__class__(
                             parent_run_id=base_callbacks.parent_run_id
                             or these_callbacks.parent_run_id,
-                            handlers=base_callbacks.handlers + these_callbacks.handlers,
-                            inheritable_handlers=base_callbacks.inheritable_handlers
-                            + these_callbacks.inheritable_handlers,
+                            handlers=[],
+                            inheritable_handlers=[],
                             tags=list(set(base_callbacks.tags + these_callbacks.tags)),
                             inheritable_tags=list(
                                 set(
@@ -322,6 +322,20 @@ def merge_configs(*configs: Optional[RunnableConfig]) -> RunnableConfig:
                                 **these_callbacks.metadata,
                             },
                         )
+
+                        handlers = base_callbacks.handlers + these_callbacks.handlers
+                        inheritable_handlers = (
+                            base_callbacks.inheritable_handlers
+                            + these_callbacks.inheritable_handlers
+                        )
+
+                        for handler in handlers:
+                            manager.add_handler(handler)
+
+                        for handler in inheritable_handlers:
+                            manager.add_handler(handler, inherit=True)
+
+                        base["callbacks"] = manager
             else:
                 base[key] = config[key] or base.get(key)  # type: ignore
     return base

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -1883,8 +1883,8 @@ async def test_with_explicit_config() -> None:
     infinite_cycle = cycle([AIMessage(content="hello world", id="ai3")])
     model = GenericFakeChatModel(messages=infinite_cycle)
 
-    @RunnableLambda
-    async def say_hello(query: str, config):
+    @tool
+    async def say_hello(query: str, callbacks):
         """Use this tool to look up which items are in the given place."""
 
         @RunnableLambda
@@ -1893,11 +1893,7 @@ async def test_with_explicit_config() -> None:
             return x
 
         chain = passthrough_to_trigger_issue | model.with_config(
-            {
-                "run_name": "Get Items LLM",
-                "tags": ["tool_llm"],
-                "callbacks": config["callbacks"],
-            }
+            {"tags": ["hello"], "callbacks": callbacks}
         )
 
         return await chain.ainvoke(query)

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -24,6 +24,7 @@ from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
     BaseMessage,
+    BaseMessageChunk,
     HumanMessage,
     SystemMessage,
 )
@@ -1884,7 +1885,7 @@ async def test_with_explicit_config() -> None:
     model = GenericFakeChatModel(messages=infinite_cycle)
 
     @tool
-    async def say_hello(query: str, callbacks):
+    async def say_hello(query: str, callbacks: Callbacks) -> BaseMessage:
         """Use this tool to look up which items are in the given place."""
 
         @RunnableLambda

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -24,7 +24,6 @@ from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
     BaseMessage,
-    BaseMessageChunk,
     HumanMessage,
     SystemMessage,
 )

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -38,7 +38,6 @@ from langchain_core.runnables import (
     RunnableGenerator,
     RunnableLambda,
     ensure_config,
-    RunnableMap,
 )
 from langchain_core.runnables.config import get_callback_manager_for_config
 from langchain_core.runnables.history import RunnableWithMessageHistory
@@ -1881,24 +1880,27 @@ async def test_runnable_generator() -> None:
 
 async def test_with_explicit_config() -> None:
     """Test astream events with explicit callbacks being passed."""
-    from langchain_core.prompts import ChatPromptTemplate
-
     infinite_cycle = cycle([AIMessage(content="hello world", id="ai3")])
     model = GenericFakeChatModel(messages=infinite_cycle)
 
-    @tool
-    async def say_hello(query: str, callbacks):
+    @RunnableLambda
+    async def say_hello(query: str, config):
         """Use this tool to look up which items are in the given place."""
-        template = ChatPromptTemplate.from_messages(
-            [("human", "what items are in {place}")]
+
+        @RunnableLambda
+        def passthrough_to_trigger_issue(x: str) -> str:
+            """Add passthrough to trigger issue."""
+            return x
+
+        chain = passthrough_to_trigger_issue | model.with_config(
+            {
+                "run_name": "Get Items LLM",
+                "tags": ["tool_llm"],
+                "callbacks": config["callbacks"],
+            }
         )
 
-        chain = template | model.with_config(
-            {"run_name": "Get Items LLM", "tags": ["tool_llm"], "callbacks": callbacks}
-        )
-        return await chain.ainvoke(
-            {"place": query},
-        )
+        return await chain.ainvoke(query)
 
     events = await _collect_events(say_hello.astream_events("meow", version="v2"))
 

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -1898,7 +1898,9 @@ async def test_with_explicit_config() -> None:
 
         return await chain.ainvoke(query)
 
-    events = await _collect_events(say_hello.astream_events("meow", version="v2"))
+    events = await _collect_events(
+        say_hello.astream_events("meow", version="v2")  # type: ignore
+    )
 
     assert [
         event["data"]["chunk"].content


### PR DESCRIPTION
This PR adds deduplication of callback handlers in merge_configs.

Fix for this issue: https://github.com/langchain-ai/langchain/issues/22227

The issue appears when the code is:

1) running python >=3.11
2) invokes a runnable from within a runnable
3) binds the callbacks to the child runnable from the parent runnable using with_config 

In this case, the same callbacks end up appearing twice: (1) the first time from with_config, (2) the second time with langchain automatically propagating them on behalf of the user.


Prior to this PR this will emit duplicate events:

```python
@tool
async def get_items(question: str, callbacks: Callbacks):  # <--- Accept callbacks
    """Ask question"""
    template = ChatPromptTemplate.from_messages(
        [
            (
                "human",
                "'{question}"
            )
        ]
    )
    chain = template | chat_model.with_config(
        {
            "callbacks": callbacks,  # <-- Propagate callbacks
        }
    )
    return await chain.ainvoke({"question": question})
```

Prior to this PR this will work work correctly (no duplicate events):

```python
@tool
async def get_items(question: str, callbacks: Callbacks):  # <--- Accept callbacks
    """Ask question"""
    template = ChatPromptTemplate.from_messages(
        [
            (
                "human",
                "'{question}"
            )
        ]
    )
    chain = template | chat_model
    return await chain.ainvoke({"question": question}, {"callbacks": callbacks})
```

This will also work (as long as the user is using python >= 3.11) -- as langchain will automatically propagate callbacks

```python
@tool
async def get_items(question: str,):  
    """Ask question"""
    template = ChatPromptTemplate.from_messages(
        [
            (
                "human",
                "'{question}"
            )
        ]
    )
    chain = template | chat_model
    return await chain.ainvoke({"question": question})
```