### PR TITLE
community: Fix HuggingFaceEmbeddings deprecation warning

### DIFF
--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -21,7 +21,7 @@ DEFAULT_QUERY_BGE_INSTRUCTION_ZH = "为这个句子生成表示以用于检索�
 @deprecated(
     since="0.2.2",
     removal="0.3.0",
-    alternative_import="from langchain_huggingface import HuggingFaceEmbeddings",
+    alternative_import="from langchain_huggingface.embeddings import HuggingFaceEmbeddings",
 )
 class HuggingFaceEmbeddings(BaseModel, Embeddings):
     """HuggingFace sentence_transformers embedding models.


### PR DESCRIPTION
alternative_import requires the import to contain a '.'. Updating the import to be specific. Without this fix, we get the exception below when using the deprecated implementation.

    def warn_deprecated(
        since: str,
        *,
        message: str = "",
        name: str = "",
        alternative: str = "",
        alternative_import: str = "",
        pending: bool = False,
        obj_type: str = "",
        addendum: str = "",
        removal: str = "",
        package: str = "",
    ) -> None:
        """Display a standardized deprecation.
        Arguments:
            since : str
                The release at which this API became deprecated.
            message : str, optional
                Override the default deprecation message. The %(since)s,
                %(name)s, %(alternative)s, %(obj_type)s, %(addendum)s,
                and %(removal)s format specifiers will be replaced by the
                values of the respective arguments passed to this function.
            name : str, optional
                The name of the deprecated object.
            alternative : str, optional
                An alternative API that the user may use in place of the
                deprecated API. The deprecation warning will tell the user
                about this alternative if provided.
            pending : bool, optional
                If True, uses a PendingDeprecationWarning instead of a
                DeprecationWarning. Cannot be used together with removal.
            obj_type : str, optional
                The object type being deprecated.
            addendum : str, optional
                Additional text appended directly to the final message.
            removal : str, optional
                The expected removal version. With the default (an empty
                string), a removal version is automatically computed from
                since. Set to other Falsy values to not schedule a removal
                date. Cannot be used together with pending.
        """
        if pending and removal:
            raise ValueError("A pending deprecation cannot have a scheduled removal")
        if alternative and alternative_import:
            raise ValueError("Cannot specify both alternative and alternative_import")
        if alternative_import and "." not in alternative_import:
>           raise ValueError("alternative_import must be a fully qualified module path")
E           ValueError: alternative_import must be a fully qualified module path
.venv/lib/python3.9/site-packages/langchain_core/_api/deprecation.py:345: ValueError 

We are @docugami.

