### PR TITLE
core: prevent `'NoneType' object is not iterable` when using HumanMessagePromptTemplate and ImagePromptTemplate in combination

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -459,7 +459,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
                                 )
                             input_variables = [vars[0]]
                         else:
-                            input_variables = None
+                            input_variables = []
                         img_template = {"url": img_template}
                         img_template_obj = ImagePromptTemplate(
                             input_variables=input_variables, template=img_template
@@ -471,7 +471,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
                                 img_template["url"], "f-string"
                             )
                         else:
-                            input_variables = None
+                            input_variables = []
                         img_template_obj = ImagePromptTemplate(
                             input_variables=input_variables, template=img_template
                         )


### PR DESCRIPTION
  - **Description:** prevent `'NoneType' object is not iterable` when using HumanMessagePromptTemplate and ImagePromptTemplate in combination
  - **Issue:** 
      - fixes #20820
      - related to #22024
  - **Dependencies:** none
  - **Twitter handle:** @joegoldin