### PR TITLE
core: throw error on invalid alternative_import in deprecated

### DIFF
--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -100,10 +100,12 @@ def deprecated(
                 pass
     """
 
-    if (
-        alternative_import
-        and "." not in alternative_import
-        or " " in alternative_import
+    if pending and removal:
+        raise ValueError("A pending deprecation cannot have a scheduled removal")
+    if alternative and alternative_import:
+        raise ValueError("Cannot specify both alternative and alternative_import")
+    if alternative_import and (
+        "." not in alternative_import or " " in alternative_import
     ):
         raise ValueError(
             "alternative_import must be a fully qualified module path, e.g. "
@@ -347,12 +349,6 @@ def warn_deprecated(
             since. Set to other Falsy values to not schedule a removal
             date. Cannot be used together with pending.
     """
-    if pending and removal:
-        raise ValueError("A pending deprecation cannot have a scheduled removal")
-    if alternative and alternative_import:
-        raise ValueError("Cannot specify both alternative and alternative_import")
-    if alternative_import and "." not in alternative_import:
-        raise ValueError("alternative_import must be a fully qualified module path")
 
     if not pending:
         if not removal:

--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -100,6 +100,16 @@ def deprecated(
                 pass
     """
 
+    if (
+        alternative_import
+        and "." not in alternative_import
+        or " " in alternative_import
+    ):
+        raise ValueError(
+            "alternative_import must be a fully qualified module path, e.g. "
+            "`package.module.Class`"
+        )
+
     def deprecate(
         obj: T,
         *,


### PR DESCRIPTION
make the code fail on `@deprecated` instead of when actually throwing a warning