### PR TITLE
community:removed unnecessary authenticate or fail

### DIFF
--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -179,7 +179,7 @@ class HuggingFaceEndpoint(LLM):
             )
             login(token=huggingfacehub_api_token)
         except Exception:
-            huggingfacehub_api_token=None
+            huggingfacehub_api_token = None
 
         from huggingface_hub import AsyncInferenceClient, InferenceClient
 

--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -179,10 +179,7 @@ class HuggingFaceEndpoint(LLM):
             )
             login(token=huggingfacehub_api_token)
         except Exception as e:
-            raise ValueError(
-                "Could not authenticate with huggingface_hub. "
-                "Please check your API token."
-            ) from e
+            huggingfacehub_api_token=None
 
         from huggingface_hub import AsyncInferenceClient, InferenceClient
 

--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -178,7 +178,7 @@ class HuggingFaceEndpoint(LLM):
                 values, "huggingfacehub_api_token", "HUGGINGFACEHUB_API_TOKEN"
             )
             login(token=huggingfacehub_api_token)
-        except Exception as e:
+        except Exception:
             huggingfacehub_api_token=None
 
         from huggingface_hub import AsyncInferenceClient, InferenceClient


### PR DESCRIPTION
Authentication should not be forced here, as the client does not require authentication when running in local.

Thank you for contributing to LangChain!

**Description:** When using HuggingFace client with a local deployment of a hf text gen inference server, it is not mandatory to provide a huggingface_api_token, I am aware my proposed fix is a bit dirty, but I want to propose the idea that the code should not just raise an exception if there is no login to huggingface.

