### PR TITLE
docs: `how-to` index page update

### DIFF
--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -13,16 +13,16 @@ For comprehensive descriptions of every class and function see the [API Referenc
 
 ## Installation
 
-- [How to: install LangChain packages](/docs/how_to/installation/)
+- [Install LangChain packages](/docs/how_to/installation/)
 
 ## Key features
 
 This highlights functionality that is core to using LangChain.
 
-- [How to: return structured data from a model](/docs/how_to/structured_output/)
-- [How to: use a model to call tools](/docs/how_to/tool_calling/)
-- [How to: stream runnables](/docs/how_to/streaming)
-- [How to: debug your LLM apps](/docs/how_to/debugging/)
+- [Return structured data from a model](/docs/how_to/structured_output/)
+- [Use a model to call tools](/docs/how_to/tool_calling/)
+- [Stream runnables](/docs/how_to/streaming)
+- [Debug your LLM apps](/docs/how_to/debugging/)
 
 ## LangChain Expression Language (LCEL)
 
@@ -30,18 +30,18 @@ This highlights functionality that is core to using LangChain.
 
 [**LCEL cheatsheet**](/docs/how_to/lcel_cheatsheet/): For a quick overview of how to use the main LCEL primitives.
 
-- [How to: chain runnables](/docs/how_to/sequence)
-- [How to: stream runnables](/docs/how_to/streaming)
-- [How to: invoke runnables in parallel](/docs/how_to/parallel/)
-- [How to: add default invocation args to runnables](/docs/how_to/binding/)
-- [How to: turn any function into a runnable](/docs/how_to/functions)
-- [How to: pass through inputs from one chain step to the next](/docs/how_to/passthrough)
-- [How to: configure runnable behavior at runtime](/docs/how_to/configure)
-- [How to: add message history (memory) to a chain](/docs/how_to/message_history)
-- [How to: route between sub-chains](/docs/how_to/routing)
-- [How to: create a dynamic (self-constructing) chain](/docs/how_to/dynamic_chain/)
-- [How to: inspect runnables](/docs/how_to/inspect)
-- [How to: add fallbacks to a runnable](/docs/how_to/fallbacks)
+- [Chain runnables](/docs/how_to/sequence)
+- [Stream runnables](/docs/how_to/streaming)
+- [Invoke runnables in parallel](/docs/how_to/parallel/)
+- [Add default invocation args to runnables](/docs/how_to/binding/)
+- [Turn any function into a runnable](/docs/how_to/functions)
+- [Pass through inputs from one chain step to the next](/docs/how_to/passthrough)
+- [Configure runnable behavior at runtime](/docs/how_to/configure)
+- [Add message history (memory) to a chain](/docs/how_to/message_history)
+- [Route between sub-chains](/docs/how_to/routing)
+- [Create a dynamic (self-constructing) chain](/docs/how_to/dynamic_chain/)
+- [Inspect runnables](/docs/how_to/inspect)
+- [Add fallbacks to a runnable](/docs/how_to/fallbacks)
 
 ## Components
 
@@ -51,136 +51,136 @@ These are the core building blocks you can use when building applications.
 
 Prompt Templates are responsible for formatting user input into a format that can be passed to a language model.
 
-- [How to: use few shot examples](/docs/how_to/few_shot_examples)
-- [How to: use few shot examples in chat models](/docs/how_to/few_shot_examples_chat/)
-- [How to: partially format prompt templates](/docs/how_to/prompts_partial)
-- [How to: compose prompts together](/docs/how_to/prompts_composition)
+- [Use few shot examples](/docs/how_to/few_shot_examples)
+- [Use few shot examples in chat models](/docs/how_to/few_shot_examples_chat/)
+- [Partially format the prompt templates](/docs/how_to/prompts_partial)
+- [Compose prompts together](/docs/how_to/prompts_composition)
 
 ### Example selectors
 
 Example Selectors are responsible for selecting the correct few shot examples to pass to the prompt.
 
-- [How to: use example selectors](/docs/how_to/example_selectors)
-- [How to: select examples by length](/docs/how_to/example_selectors_length_based)
-- [How to: select examples by semantic similarity](/docs/how_to/example_selectors_similarity)
-- [How to: select examples by semantic ngram overlap](/docs/how_to/example_selectors_ngram)
-- [How to: select examples by maximal marginal relevance](/docs/how_to/example_selectors_mmr)
+- [Use example selectors](/docs/how_to/example_selectors)
+- [Select examples by length](/docs/how_to/example_selectors_length_based)
+- [Select examples by semantic similarity](/docs/how_to/example_selectors_similarity)
+- [Select examples by semantic ngram overlap](/docs/how_to/example_selectors_ngram)
+- [Select examples by maximal marginal relevance](/docs/how_to/example_selectors_mmr)
 
 ### Chat models
 
 Chat Models are newer forms of language models that take messages in and output a message.
 
-- [How to: do function/tool calling](/docs/how_to/tool_calling)
-- [How to: get models to return structured output](/docs/how_to/structured_output)
-- [How to: cache model responses](/docs/how_to/chat_model_caching)
-- [How to: get log probabilities](/docs/how_to/logprobs)
-- [How to: create a custom chat model class](/docs/how_to/custom_chat_model)
-- [How to: stream a response back](/docs/how_to/chat_streaming)
-- [How to: track token usage](/docs/how_to/chat_token_usage_tracking)
-- [How to: track response metadata across providers](/docs/how_to/response_metadata)
-- [How to: let your end users choose their model](/docs/how_to/chat_models_universal_init/)
+- [Do function/tool calling](/docs/how_to/tool_calling)
+- [Get models to return structured output](/docs/how_to/structured_output)
+- [Cache model responses](/docs/how_to/chat_model_caching)
+- [Get log probabilities](/docs/how_to/logprobs)
+- [Create a custom chat model class](/docs/how_to/custom_chat_model)
+- [Stream a response back](/docs/how_to/chat_streaming)
+- [Track token usage](/docs/how_to/chat_token_usage_tracking)
+- [Track response metadata across providers](/docs/how_to/response_metadata)
+- [Let your end users choose their model](/docs/how_to/chat_models_universal_init/)
 
 ### LLMs
 
 What LangChain calls LLMs are older forms of language models that take a string in and output a string.
 
-- [How to: cache model responses](/docs/how_to/llm_caching)
-- [How to: create a custom LLM class](/docs/how_to/custom_llm)
-- [How to: stream a response back](/docs/how_to/streaming_llm)
-- [How to: track token usage](/docs/how_to/llm_token_usage_tracking)
-- [How to: work with local LLMs](/docs/how_to/local_llms)
+- [Cache model responses](/docs/how_to/llm_caching)
+- [Create a custom LLM class](/docs/how_to/custom_llm)
+- [Stream a response back](/docs/how_to/streaming_llm)
+- [Track token usage](/docs/how_to/llm_token_usage_tracking)
+- [Work with local LLMs](/docs/how_to/local_llms)
 
 ### Output parsers
 
 Output Parsers are responsible for taking the output of an LLM and parsing into more structured format.
 
-- [How to: use output parsers to parse an LLM response into structured format](/docs/how_to/output_parser_structured)
-- [How to: parse JSON output](/docs/how_to/output_parser_json)
-- [How to: parse XML output](/docs/how_to/output_parser_xml)
-- [How to: parse YAML output](/docs/how_to/output_parser_yaml)
-- [How to: retry when output parsing errors occur](/docs/how_to/output_parser_retry)
-- [How to: try to fix errors in output parsing](/docs/how_to/output_parser_fixing)
-- [How to: write a custom output parser class](/docs/how_to/output_parser_custom)
+- [Use output parsers to parse an LLM response into structured format](/docs/how_to/output_parser_structured)
+- [Parse JSON output](/docs/how_to/output_parser_json)
+- [Parse XML output](/docs/how_to/output_parser_xml)
+- [Parse YAML output](/docs/how_to/output_parser_yaml)
+- [Retry when output parsing errors occur](/docs/how_to/output_parser_retry)
+- [Try to fix errors in output parsing](/docs/how_to/output_parser_fixing)
+- [Write a custom output parser class](/docs/how_to/output_parser_custom)
 
 ### Document loaders
 
 Document Loaders are responsible for loading documents from a variety of sources.
 
-- [How to: load CSV data](/docs/how_to/document_loader_csv)
-- [How to: load data from a directory](/docs/how_to/document_loader_directory)
-- [How to: load HTML data](/docs/how_to/document_loader_html)
-- [How to: load JSON data](/docs/how_to/document_loader_json)
-- [How to: load Markdown data](/docs/how_to/document_loader_markdown)
-- [How to: load Microsoft Office data](/docs/how_to/document_loader_office_file)
-- [How to: load PDF files](/docs/how_to/document_loader_pdf)
-- [How to: write a custom document loader](/docs/how_to/document_loader_custom)
+- [Load CSV data](/docs/how_to/document_loader_csv)
+- [Load data from a directory](/docs/how_to/document_loader_directory)
+- [Load HTML data](/docs/how_to/document_loader_html)
+- [Load JSON data](/docs/how_to/document_loader_json)
+- [Load Markdown data](/docs/how_to/document_loader_markdown)
+- [Load Microsoft Office data](/docs/how_to/document_loader_office_file)
+- [Load PDF files](/docs/how_to/document_loader_pdf)
+- [Write a custom document loader](/docs/how_to/document_loader_custom)
 
 ### Text splitters
 
 Text Splitters take a document and split into chunks that can be used for retrieval.
 
-- [How to: recursively split text](/docs/how_to/recursive_text_splitter)
-- [How to: split by HTML headers](/docs/how_to/HTML_header_metadata_splitter)
-- [How to: split by HTML sections](/docs/how_to/HTML_section_aware_splitter)
-- [How to: split by character](/docs/how_to/character_text_splitter)
-- [How to: split code](/docs/how_to/code_splitter)
-- [How to: split Markdown by headers](/docs/how_to/markdown_header_metadata_splitter)
-- [How to: recursively split JSON](/docs/how_to/recursive_json_splitter)
-- [How to: split text into semantic chunks](/docs/how_to/semantic-chunker)
-- [How to: split by tokens](/docs/how_to/split_by_token)
+- [Recursively split text](/docs/how_to/recursive_text_splitter)
+- [Split by HTML headers](/docs/how_to/HTML_header_metadata_splitter)
+- [Split by HTML sections](/docs/how_to/HTML_section_aware_splitter)
+- [Split by character](/docs/how_to/character_text_splitter)
+- [Split code](/docs/how_to/code_splitter)
+- [Split Markdown by headers](/docs/how_to/markdown_header_metadata_splitter)
+- [Recursively split JSON](/docs/how_to/recursive_json_splitter)
+- [Split text into semantic chunks](/docs/how_to/semantic-chunker)
+- [Split by tokens](/docs/how_to/split_by_token)
 
 ### Embedding models
 
 Embedding Models take a piece of text and create a numerical representation of it.
 
-- [How to: embed text data](/docs/how_to/embed_text)
-- [How to: cache embedding results](/docs/how_to/caching_embeddings)
+- [Embed text data](/docs/how_to/embed_text)
+- [Cache embedding results](/docs/how_to/caching_embeddings)
 
 ### Vector stores
 
 Vector stores are databases that can efficiently store and retrieve embeddings.
 
-- [How to: use a vector store to retrieve data](/docs/how_to/vectorstores)
+- [Use a vector store to retrieve data](/docs/how_to/vectorstores)
 
 ### Retrievers
 
 Retrievers are responsible for taking a query and returning relevant documents.
 
-- [How to: use a vector store to retrieve data](/docs/how_to/vectorstore_retriever)
-- [How to: generate multiple queries to retrieve data for](/docs/how_to/MultiQueryRetriever)
-- [How to: use contextual compression to compress the data retrieved](/docs/how_to/contextual_compression)
-- [How to: write a custom retriever class](/docs/how_to/custom_retriever)
-- [How to: add similarity scores to retriever results](/docs/how_to/add_scores_retriever)
-- [How to: combine the results from multiple retrievers](/docs/how_to/ensemble_retriever)
-- [How to: reorder retrieved results to mitigate the "lost in the middle" effect](/docs/how_to/long_context_reorder)
-- [How to: generate multiple embeddings per document](/docs/how_to/multi_vector)
-- [How to: retrieve the whole document for a chunk](/docs/how_to/parent_document_retriever)
-- [How to: generate metadata filters](/docs/how_to/self_query)
-- [How to: create a time-weighted retriever](/docs/how_to/time_weighted_vectorstore)
-- [How to: use hybrid vector and keyword retrieval](/docs/how_to/hybrid)
+- [Use a vector store to retrieve data](/docs/how_to/vectorstore_retriever)
+- [Generate multiple queries to retrieve data for](/docs/how_to/MultiQueryRetriever)
+- [Use contextual compression to compress the data retrieved](/docs/how_to/contextual_compression)
+- [Write a custom retriever class](/docs/how_to/custom_retriever)
+- [Add similarity scores to retriever results](/docs/how_to/add_scores_retriever)
+- [Combine the results from multiple retrievers](/docs/how_to/ensemble_retriever)
+- [Reorder retrieved results to mitigate the "lost in the middle" effect](/docs/how_to/long_context_reorder)
+- [Generate multiple embeddings per document](/docs/how_to/multi_vector)
+- [Retrieve the whole document for a chunk](/docs/how_to/parent_document_retriever)
+- [Generate metadata filters](/docs/how_to/self_query)
+- [Create a time-weighted retriever](/docs/how_to/time_weighted_vectorstore)
+- [Use hybrid vector and keyword retrieval](/docs/how_to/hybrid)
 
 ### Indexing
 
 Indexing is the process of keeping your vectorstore in-sync with the underlying data source.
 
-- [How to: reindex data to keep your vectorstore in-sync with the underlying data source](/docs/how_to/indexing)
+- [Reindex data to keep your vectorstore in-sync with the underlying data source](/docs/how_to/indexing)
 
 ### Tools
 
 LangChain Tools contain a description of the tool (to pass to the language model) as well as the implementation of the function to call).
 
-- [How to: create custom tools](/docs/how_to/custom_tools)
-- [How to: use built-in tools and built-in toolkits](/docs/how_to/tools_builtin)
-- [How to: use a chat model to call tools](/docs/how_to/tool_calling/)
-- [How to: add ad-hoc tool calling capability to LLMs and chat models](/docs/how_to/tools_prompting)
-- [How to: pass run time values to tools](/docs/how_to/tool_runtime)
-- [How to: add a human in the loop to tool usage](/docs/how_to/tools_human)
-- [How to: handle errors when calling tools](/docs/how_to/tools_error)
+- [Create custom tools](/docs/how_to/custom_tools)
+- [Use built-in tools and built-in toolkits](/docs/how_to/tools_builtin)
+- [Use a chat model to call tools](/docs/how_to/tool_calling/)
+- [Add ad-hoc tool calling capability to LLMs and chat models](/docs/how_to/tools_prompting)
+- [Pass run time values to tools](/docs/how_to/tool_runtime)
+- [Add a human in the loop to tool usage](/docs/how_to/tools_human)
+- [Handle errors when calling tools](/docs/how_to/tools_error)
 
 ### Multimodal
 
-- [How to: pass multimodal data directly to models](/docs/how_to/multimodal_inputs/)
-- [How to: use multimodal prompts](/docs/how_to/multimodal_prompts/)
+- [Pass multimodal data directly to models](/docs/how_to/multimodal_inputs/)
+- [Use multimodal prompts](/docs/how_to/multimodal_prompts/)
 
 
 ### Agents
@@ -191,28 +191,28 @@ For in depth how-to guides for agents, please check out [LangGraph](https://gith
 
 :::
 
-- [How to: use legacy LangChain Agents (AgentExecutor)](/docs/how_to/agent_executor)
-- [How to: migrate from legacy LangChain agents to LangGraph](/docs/how_to/migrate_agent)
+- [Use legacy LangChain Agents (AgentExecutor)](/docs/how_to/agent_executor)
+- [Migrate from legacy LangChain agents to LangGraph](/docs/how_to/migrate_agent)
 
 ### Callbacks
 
-- [How to: pass in callbacks at runtime](/docs/how_to/callbacks_runtime)
-- [How to: attach callbacks to a module](/docs/how_to/callbacks_attach)
-- [How to: pass callbacks into a module constructor](/docs/how_to/callbacks_constructor)
-- [How to: create custom callback handlers](/docs/how_to/custom_callbacks)
-- [How to: use callbacks in async environments](/docs/how_to/callbacks_async)
+- [Pass in callbacks at runtime](/docs/how_to/callbacks_runtime)
+- [Attach callbacks to a module](/docs/how_to/callbacks_attach)
+- [Pass callbacks into a module constructor](/docs/how_to/callbacks_constructor)
+- [Create custom callback handlers](/docs/how_to/custom_callbacks)
+- [Use callbacks in async environments](/docs/how_to/callbacks_async)
 
 ### Custom
 
 All of LangChain components can easily be extended to support your own versions.
 
-- [How to: create a custom chat model class](/docs/how_to/custom_chat_model)
-- [How to: create a custom LLM class](/docs/how_to/custom_llm)
-- [How to: write a custom retriever class](/docs/how_to/custom_retriever)
-- [How to: write a custom document loader](/docs/how_to/document_loader_custom)
-- [How to: write a custom output parser class](/docs/how_to/output_parser_custom)
-- [How to: create custom callback handlers](/docs/how_to/custom_callbacks)
-- [How to: define a custom tool](/docs/how_to/custom_tools)
+- [Create a custom chat model class](/docs/how_to/custom_chat_model)
+- [Create a custom LLM class](/docs/how_to/custom_llm)
+- [Write a custom retriever class](/docs/how_to/custom_retriever)
+- [Write a custom document loader](/docs/how_to/document_loader_custom)
+- [Write a custom output parser class](/docs/how_to/output_parser_custom)
+- [Create custom callback handlers](/docs/how_to/custom_callbacks)
+- [Define a custom tool](/docs/how_to/custom_tools)
 
 
 ## Use cases
@@ -223,54 +223,54 @@ These guides cover use-case specific details.
 
 Retrieval Augmented Generation (RAG) is a way to connect LLMs to external sources of data.
 
-- [How to: add chat history](/docs/how_to/qa_chat_history_how_to/)
-- [How to: stream](/docs/how_to/qa_streaming/)
-- [How to: return sources](/docs/how_to/qa_sources/)
-- [How to: return citations](/docs/how_to/qa_citations/)
-- [How to: do per-user retrieval](/docs/how_to/qa_per_user/)
+- [Add chat history](/docs/how_to/qa_chat_history_how_to/)
+- [Stream](/docs/how_to/qa_streaming/)
+- [Return sources](/docs/how_to/qa_sources/)
+- [Return citations](/docs/how_to/qa_citations/)
+- [Do per-user retrieval](/docs/how_to/qa_per_user/)
 
 
 ### Extraction
 
 Extraction is when you use LLMs to extract structured information from unstructured text.
 
-- [How to: use reference examples](/docs/how_to/extraction_examples/)
-- [How to: handle long text](/docs/how_to/extraction_long_text/)
-- [How to: do extraction without using function calling](/docs/how_to/extraction_parse)
+- [Use reference examples](/docs/how_to/extraction_examples/)
+- [Handle long text](/docs/how_to/extraction_long_text/)
+- [Do extraction without using function calling](/docs/how_to/extraction_parse)
 
 ### Chatbots
 
 Chatbots involve using an LLM to have a conversation.
 
-- [How to: manage memory](/docs/how_to/chatbots_memory)
-- [How to: do retrieval](/docs/how_to/chatbots_retrieval)
-- [How to: use tools](/docs/how_to/chatbots_tools)
+- [Manage memory](/docs/how_to/chatbots_memory)
+- [Do retrieval](/docs/how_to/chatbots_retrieval)
+- [Use tools](/docs/how_to/chatbots_tools)
 
 ### Query analysis
 
 Query Analysis is the task of using an LLM to generate a query to send to a retriever.
 
-- [How to: add examples to the prompt](/docs/how_to/query_few_shot)
-- [How to: handle cases where no queries are generated](/docs/how_to/query_no_queries)
-- [How to: handle multiple queries](/docs/how_to/query_multiple_queries)
-- [How to: handle multiple retrievers](/docs/how_to/query_multiple_retrievers)
-- [How to: construct filters](/docs/how_to/query_constructing_filters)
-- [How to: deal with high cardinality categorical variables](/docs/how_to/query_high_cardinality)
+- [Add examples to the prompt](/docs/how_to/query_few_shot)
+- [Handle cases where no queries are generated](/docs/how_to/query_no_queries)
+- [Handle multiple queries](/docs/how_to/query_multiple_queries)
+- [Handle multiple retrievers](/docs/how_to/query_multiple_retrievers)
+- [Construct filters](/docs/how_to/query_constructing_filters)
+- [Deal with high cardinality categorical variables](/docs/how_to/query_high_cardinality)
 
 ### Q&A over SQL + CSV
 
 You can use LLMs to do question answering over tabular data.
 
-- [How to: use prompting to improve results](/docs/how_to/sql_prompting)
-- [How to: do query validation](/docs/how_to/sql_query_checking)
-- [How to: deal with large databases](/docs/how_to/sql_large_db)
-- [How to: deal with CSV files](/docs/how_to/sql_csv)
+- [Use prompting to improve results](/docs/how_to/sql_prompting)
+- [Do query validation](/docs/how_to/sql_query_checking)
+- [Deal with large databases](/docs/how_to/sql_large_db)
+- [Deal with CSV files](/docs/how_to/sql_csv)
 
 ### Q&A over graph databases
 
 You can use an LLM to do question answering over graph databases.
 
-- [How to: map values to a database](/docs/how_to/graph_mapping)
-- [How to: add a semantic layer over the database](/docs/how_to/graph_semantic)
-- [How to: improve results with prompting](/docs/how_to/graph_prompting)
-- [How to: construct knowledge graphs](/docs/how_to/graph_constructing)
+- [Map values to a database](/docs/how_to/graph_mapping)
+- [Add a semantic layer over the database](/docs/how_to/graph_semantic)
+- [Improve results with prompting](/docs/how_to/graph_prompting)
+- [Construct knowledge graphs](/docs/how_to/graph_constructing)


### PR DESCRIPTION
Removed repeated "How to: ". That makes the [page more readable](https://langchain-9jq1kef7i-langchain.vercel.app/v0.2/docs/how_to/).
