### PR TITLE
docs: Correct return type in docstring

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -128,11 +128,11 @@ def _load_package_modules(
     of the modules/packages are part of the package vs. 3rd party or built-in.
 
     Parameters:
-        package_directory: Path to the package directory.
-        submodule: Optional name of submodule to load.
+        package_directory (Union[str, Path]): Path to the package directory.
+        submodule (Optional[str]): Optional name of submodule to load.
 
     Returns:
-        list: A list of loaded module objects.
+        Dict[str, ModuleMembers]: A dictionary where keys are module names and values are ModuleMembers objects.
     """
     package_path = (
         Path(package_directory)


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"
  - Where "package" is whichever of langchain, community, core, experimental, etc. is being modified. Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


- [x] **PR message**: 
    - **Description:** This PR corrects the return type in the docstring of the `docs/api_reference/create_api_rst.py/_load_package_modules` function. The return type was previously described as a list of

