### PR TITLE
together: bump langchain-core

### DIFF
--- a/libs/partners/together/poetry.lock
+++ b/libs/partners/together/poetry.lock
@@ -1679,4 +1679,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "6ce59c865654905e4232fc5ed3564768d6d94e71cb8323dbb914b902c86f5abf"
+content-hash = "e7b21f556475be4c7133b74b6b0e138012bef9d47bc5bdc9709b24e55d9500f0"

--- a/libs/partners/together/pyproject.toml
+++ b/libs/partners/together/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = ">=0.2.0,<0.3"
+langchain-core = ">=0.2.2,<0.3"
 langchain-openai = "^0.1.8"
 requests = "^2"
 aiohttp = "^3.9.1"


### PR DESCRIPTION
langchain-together depends on langchain-openai ^0.1.8
langchain-openai 0.1.8 has langchain-core >= 0.2.2

Here we bump langchain-core to 0.2.2, just to pass minimum dependency version tests.