### PR TITLE
core: runnables: special handling GeneratorExit because no error

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1891,6 +1891,8 @@ class Runnable(Generic[Input, Output], ABC):
                             final_input_supported = False
                 else:
                     final_input = ichunk
+        except GeneratorExit:
+            run_manager.on_chain_end(final_output, inputs=final_input)
         except BaseException as e:
             run_manager.on_chain_error(e, inputs=final_input)
             raise


### PR DESCRIPTION
When using `stream()` with some parts of a chain being stream-able and others not, the results from the non-streamable parts are yielded by langchain, however when a `StopGeneration` exception is raised, this is collected as an error even though it is an "expected" exception.

Reproducer:
```python
from langchain_core.prompts.chat import ChatPromptTemplate
from langchain_openai.chat_models import ChatOpenAI
from langchain_core.output_parsers import StrOutputParser
from langchain_core.callbacks import StdOutCallbackHandler

llm = ChatOpenAI(model="gpt-4o")

class MyHandler(StdOutCallbackHandler):
    def on_chain_error(self, error: BaseException, *, run_id, parent_run_id = None, **kwargs):
        print("error: ", end="")
        print(str(error))

handler = MyHandler()

prompt = ChatPromptTemplate.from_messages([
    ("user", "produce a poem"),
])


def get_f(x: str) -> str:
    return x

chain = prompt | llm | StrOutputParser() | get_f
chain = chain.with_config({'callbacks': [handler]})

print(next(chain.stream({})))
```