### PR TITLE
langchain[minor]: Add pgvector to list of supported vectorstores in self query retriever

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -168,6 +168,14 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
             if isinstance(vectorstore, Chroma):
                 return ChromaTranslator()
 
+        try:
+            from langchain_postgres import PGVector
+        except ImportError:
+            pass
+        else:
+            if isinstance(vectorstore, PGVector):
+                return PGVectorTranslator()
+
         raise ValueError(
             f"Self query retriever with Vector Store type {vectorstore.__class__}"
             f" not supported."


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **langchain**: "package: description"


- [ ] **PR message**: 
Description:
The fact that we outsourced pgvector to another project has an unintended effect. The mapping dictionary found by `_get_builtin_translator()` cannot recognize the new version of pgvector because it comes from another package.
`SelfQueryRetriever` no longer knows `PGVector`.

I propose to fix this by creating a global dictionary that can be populated by various database implementations. Thus, importing `langchain_postgres` will allow the registration of the `PGvector` mapping.

But for the moment I'm just adding a lazy import

Furthermore, the implementation of _get_builtin_translator() reconstructs the BUILTIN_TRANSLATORS variable with each invocation, which is not very efficient. A global map would be an optimization.

- **Twitter handle:** pprados

@eyurtsev, can you review this PR? And unlock the PR [Add async mode for pgvector](https://github.com/langchain-ai/langchain-postgres/pull/32) and PR [community[minor]: Add SQL storage implementation](https://github.com/langchain-ai/langchain/pull/22207)?

Are you in favour of a global dictionary-based implementation of Translator?
