### PR TITLE
core[major]: pydantic 2 scope out b

### DIFF
--- a/libs/core/langchain_core/beta/runnables/context.py
+++ b/libs/core/langchain_core/beta/runnables/context.py
@@ -26,6 +26,7 @@ from langchain_core.runnables.base import (
 )
 from langchain_core.runnables.config import RunnableConfig, ensure_config, patch_config
 from langchain_core.runnables.utils import ConfigurableFieldSpec, Input, Output
+from pydantic import ConfigDict
 
 T = TypeVar("T")
 Values = Dict[Union[asyncio.Event, threading.Event], Any]
@@ -228,9 +229,7 @@ class ContextSet(RunnableSerializable):
     prefix: str = ""
 
     keys: Mapping[str, Optional[Runnable]]
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(
         self,

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, TypeVar, Union
 from uuid import UUID
 
+from pydantic import ConfigDict
 from tenacity import RetryCallState
 
 if TYPE_CHECKING:

--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Sequence, Union
 
+from pydantic import BaseModel, Field
+
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     HumanMessage,
     get_buffer_string,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import run_in_executor
 
 

--- a/libs/core/langchain_core/document_loaders/blob_loaders.py
+++ b/libs/core/langchain_core/document_loaders/blob_loaders.py
@@ -13,7 +13,7 @@ from io import BufferedReader, BytesIO
 from pathlib import PurePath
 from typing import Any, Dict, Generator, Iterable, Mapping, Optional, Union, cast
 
-from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
+from pydantic import BaseModel, Field, root_validator
 
 PathLike = Union[str, PurePath]
 

--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any, List, Literal
 
+from pydantic import Field
+
 from langchain_core.load.serializable import Serializable
-from langchain_core.pydantic_v1 import Field
 
 
 class Document(Serializable):

--- a/libs/core/langchain_core/documents/compressor.py
+++ b/libs/core/langchain_core/documents/compressor.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks import Callbacks
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import run_in_executor
 
 

--- a/libs/core/langchain_core/embeddings/fake.py
+++ b/libs/core/langchain_core/embeddings/fake.py
@@ -1,8 +1,9 @@
 import hashlib
 from typing import List
 
+from pydantic import BaseModel
+
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class FakeEmbeddings(Embeddings, BaseModel):

--- a/libs/core/langchain_core/example_selectors/length_based.py
+++ b/libs/core/langchain_core/example_selectors/length_based.py
@@ -39,6 +39,8 @@ class LengthBasedExampleSelector(BaseExampleSelector, BaseModel):
         """Add new example to list."""
         self.add_example(example)
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("example_text_lengths", always=True)
     def calculate_example_text_lengths(cls, v: List[int], values: Dict) -> List[int]:
         """Calculate text lengths if they don't exist."""

--- a/libs/core/langchain_core/example_selectors/length_based.py
+++ b/libs/core/langchain_core/example_selectors/length_based.py
@@ -2,9 +2,10 @@
 import re
 from typing import Callable, Dict, List
 
+from pydantic import BaseModel, validator
+
 from langchain_core.example_selectors.base import BaseExampleSelector
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, validator
 
 
 def _get_length_based(text: str) -> int:

--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
-from pydantic import BaseModel, Extra
+from pydantic import ConfigDict, BaseModel
 
 from langchain_core.documents import Document
 from langchain_core.example_selectors.base import BaseExampleSelector
@@ -33,12 +33,7 @@ class _VectorStoreExampleSelector(BaseExampleSelector, BaseModel, ABC):
     the input variables instead of all variables."""
     vectorstore_kwargs: Optional[Dict[str, Any]] = None
     """Extra arguments passed to similarity_search function of the vectorstore."""
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     @staticmethod
     def _example_to_text(

--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
+from pydantic import BaseModel, Extra
+
 from langchain_core.documents import Document
 from langchain_core.example_selectors.base import BaseExampleSelector
-from langchain_core.pydantic_v1 import BaseModel, Extra
 from langchain_core.vectorstores import VectorStore
 
 if TYPE_CHECKING:

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -24,7 +24,7 @@ from typing import (
     cast,
 )
 
-from pydantic import root_validator
+from pydantic import model_validator
 
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
@@ -68,7 +68,8 @@ class _HashedDocument(Document):
     def is_lc_serializable(cls) -> bool:
         return False
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def calculate_hashes(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Root validator to calculate content and metadata hash."""
         content = values.get("page_content", "")

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -24,10 +24,11 @@ from typing import (
     cast,
 )
 
+from pydantic import root_validator
+
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 from langchain_core.indexing.base import RecordManager
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.vectorstores import VectorStore
 
 # Magic UUID to use as a namespace for hashing.

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, validator, ConfigDict
 from typing_extensions import TypeAlias
 
 from langchain_core._api import deprecated
@@ -80,6 +80,7 @@ class BaseLanguageModel(
     All language model wrappers inherit from BaseLanguageModel.
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     cache: Union[BaseCache, bool, None] = None
     """Whether to cache the response.
     
@@ -103,6 +104,8 @@ class BaseLanguageModel(
     )
     """Optional encoder to use for counting tokens."""
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("verbose", pre=True, always=True)
     def set_verbose(cls, verbose: Optional[bool]) -> bool:
         """If verbose is None, set it.

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel, Field, validator
 from typing_extensions import TypeAlias
 
 from langchain_core._api import deprecated
@@ -27,7 +28,6 @@ from langchain_core.messages import (
     get_buffer_string,
 )
 from langchain_core.prompt_values import PromptValue
-from langchain_core.pydantic_v1 import BaseModel, Field, validator
 from langchain_core.runnables import Runnable, RunnableSerializable
 from langchain_core.utils import get_pydantic_field_names
 

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -21,7 +21,7 @@ from typing import (
     cast,
 )
 
-from pydantic import Field, root_validator
+from pydantic import model_validator, ConfigDict, Field
 from typing_extensions import TypedDict
 
 from langchain_core._api import deprecated
@@ -118,10 +118,13 @@ async def agenerate_from_stream(
 class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
     """Base class for Chat models."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     callback_manager: Optional[BaseCallbackManager] = Field(default=None, exclude=True)
     """[DEPRECATED] Callback manager to add to the run trace."""
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def raise_deprecation(cls, values: Dict) -> Dict:
         """Raise deprecation warning if callback_manager is used."""
         if values.get("callback_manager") is not None:
@@ -131,11 +134,6 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
             )
             values["callbacks"] = values.pop("callback_manager", None)
         return values
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
 
     # --- Runnable methods ---
 

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -21,6 +21,7 @@ from typing import (
     cast,
 )
 
+from pydantic import Field, root_validator
 from typing_extensions import TypedDict
 
 from langchain_core._api import deprecated
@@ -53,12 +54,12 @@ from langchain_core.outputs import (
     RunInfo,
 )
 from langchain_core.prompt_values import ChatPromptValue, PromptValue, StringPromptValue
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables.config import ensure_config, run_in_executor
 from langchain_core.tracers._streaming import _StreamingCallbackHandler
 
 if TYPE_CHECKING:
-    from langchain_core.pydantic_v1 import BaseModel
+    from pydantic import BaseModel
+
     from langchain_core.runnables import Runnable, RunnableConfig
     from langchain_core.tools import BaseTool
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import yaml
+from pydantic import Field, root_validator
 from tenacity import (
     RetryCallState,
     before_sleep_log,
@@ -58,7 +59,6 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult, RunInfo
 from langchain_core.prompt_values import ChatPromptValue, PromptValue, StringPromptValue
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables import RunnableConfig, ensure_config, get_config_list
 from langchain_core.runnables.config import run_in_executor
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 import yaml
-from pydantic import Field, root_validator
+from pydantic import model_validator, ConfigDict, Field
 from tenacity import (
     RetryCallState,
     before_sleep_log,
@@ -226,13 +226,10 @@ class BaseLLM(BaseLanguageModel[str], ABC):
 
     callback_manager: Optional[BaseCallbackManager] = Field(default=None, exclude=True)
     """[DEPRECATED]"""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
-
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def raise_deprecation(cls, values: Dict) -> Dict:
         """Raise deprecation warning if callback_manager is used."""
         if values.get("callback_manager") is not None:

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -10,7 +10,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 from typing_extensions import NotRequired
 
 
@@ -102,9 +102,7 @@ class Serializable(BaseModel, ABC):
         to the object.
         """
         return [*cls.get_lc_namespace(), cls.__name__]
-
-    class Config:
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
     def __repr_args__(self) -> Any:
         return [

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -10,9 +10,8 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel
 from typing_extensions import NotRequired
-
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class BaseSerialized(TypedDict):

--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import run_in_executor
+from pydantic import ConfigDict
 
 
 class BaseMemory(Serializable, ABC):
@@ -45,11 +46,7 @@ class BaseMemory(Serializable, ABC):
                 def clear(self) -> None:
                     pass
     """  # noqa: E501
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     @abstractmethod

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import root_validator
+from pydantic import model_validator
 from typing_extensions import TypedDict
 
 from langchain_core.messages.base import (
@@ -68,7 +68,8 @@ class AIMessage(BaseMessage):
             "invalid_tool_calls": self.invalid_tool_calls,
         }
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def _backwards_compat_tool_calls(cls, values: dict) -> dict:
         raw_tool_calls = values.get("additional_kwargs", {}).get("tool_calls")
         tool_calls = (
@@ -122,7 +123,7 @@ class AIMessage(BaseMessage):
         return (base.strip() + "\n" + "\n".join(lines)).strip()
 
 
-AIMessage.update_forward_refs()
+AIMessage.model_rebuild()
 
 
 class AIMessageChunk(AIMessage, BaseMessageChunk):
@@ -149,9 +150,11 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
             "invalid_tool_calls": self.invalid_tool_calls,
         }
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def init_tool_calls(cls, values: dict) -> dict:
-        if not values["tool_call_chunks"]:
+        # TODO(EUGENE): Apply
+        if not values.get("tool_call_chunks"):
             values["tool_calls"] = []
             values["invalid_tool_calls"] = []
             return values

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import root_validator
 from typing_extensions import TypedDict
 
 from langchain_core.messages.base import (
@@ -14,7 +15,6 @@ from langchain_core.messages.tool import (
     default_tool_chunk_parser,
     default_tool_parser,
 )
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils._merge import merge_dicts, merge_lists
 from langchain_core.utils.json import (
     parse_partial_json,

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, cast
 
-from pydantic import Extra, Field
+from pydantic import ConfigDict, Field
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.utils import get_bolded_text
@@ -37,9 +37,7 @@ class BaseMessage(Serializable):
     id: Optional[str] = None
     """An optional unique identifier for the message. This should ideally be
     provided by the provider/model which created the message."""
-
-    class Config:
-        extra = Extra.allow
+    model_config = ConfigDict(extra="allow")
 
     def __init__(
         self, content: Union[str, List[Union[str, Dict]]], **kwargs: Any

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, cast
 
+from pydantic import Extra, Field
+
 from langchain_core.load.serializable import Serializable
-from langchain_core.pydantic_v1 import Extra, Field
 from langchain_core.utils import get_bolded_text
 from langchain_core.utils._merge import merge_dicts, merge_lists
 from langchain_core.utils.interactive_env import is_interactive_env

--- a/libs/core/langchain_core/messages/chat.py
+++ b/libs/core/langchain_core/messages/chat.py
@@ -22,7 +22,7 @@ class ChatMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-ChatMessage.update_forward_refs()
+ChatMessage.model_rebuild()
 
 
 class ChatMessageChunk(ChatMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/function.py
+++ b/libs/core/langchain_core/messages/function.py
@@ -22,7 +22,7 @@ class FunctionMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-FunctionMessage.update_forward_refs()
+FunctionMessage.model_rebuild()
 
 
 class FunctionMessageChunk(FunctionMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/human.py
+++ b/libs/core/langchain_core/messages/human.py
@@ -19,7 +19,7 @@ class HumanMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-HumanMessage.update_forward_refs()
+HumanMessage.model_rebuild()
 
 
 class HumanMessageChunk(HumanMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/system.py
+++ b/libs/core/langchain_core/messages/system.py
@@ -16,7 +16,7 @@ class SystemMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-SystemMessage.update_forward_refs()
+SystemMessage.model_rebuild()
 
 
 class SystemMessageChunk(SystemMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -28,7 +28,7 @@ class ToolMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-ToolMessage.update_forward_refs()
+ToolMessage.model_rebuild()
 
 
 class ToolMessageChunk(ToolMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -130,7 +130,7 @@ class CommaSeparatedListOutputParser(ListOutputParser):
 class NumberedListOutputParser(ListOutputParser):
     """Parse a numbered list."""
 
-    pattern = r"\d+\.\s([^\n]+)"
+    pattern: str = r"\d+\.\s([^\n]+)"
 
     def get_format_instructions(self) -> str:
         return (
@@ -154,7 +154,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a markdown list."""
 
-    pattern = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*]\s([^\n]+)$"
 
     def get_format_instructions(self) -> str:
         return "Your response should be a markdown list, " "eg: `- foo\n- bar\n- baz`"

--- a/libs/core/langchain_core/output_parsers/openai_functions.py
+++ b/libs/core/langchain_core/output_parsers/openai_functions.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Dict, List, Optional, Type, Union
 
 import jsonpatch  # type: ignore[import]
+from pydantic import BaseModel, root_validator
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import (
@@ -11,7 +12,6 @@ from langchain_core.output_parsers import (
 )
 from langchain_core.output_parsers.json import parse_partial_json
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class OutputFunctionsParser(BaseGenerationOutputParser[Any]):

--- a/libs/core/langchain_core/output_parsers/openai_functions.py
+++ b/libs/core/langchain_core/output_parsers/openai_functions.py
@@ -3,7 +3,7 @@ import json
 from typing import Any, Dict, List, Optional, Type, Union
 
 import jsonpatch  # type: ignore[import]
-from pydantic import BaseModel, root_validator
+from pydantic import model_validator, BaseModel
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import (
@@ -184,7 +184,8 @@ class PydanticOutputFunctionsParser(OutputFunctionsParser):
     determine which schema to use.
     """
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def validate_schema(cls, values: Dict) -> Dict:
         schema = values["pydantic_schema"]
         if "args_only" not in values:

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -3,11 +3,12 @@ import json
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional, Type
 
+from pydantic import BaseModel, ValidationError
+
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, InvalidToolCall
 from langchain_core.output_parsers import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import BaseModel, ValidationError
 from langchain_core.utils.json import parse_partial_json
 
 

--- a/libs/core/langchain_core/output_parsers/string.py
+++ b/libs/core/langchain_core/output_parsers/string.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
 
@@ -24,3 +24,6 @@ class StrOutputParser(BaseTransformOutputParser[str]):
     def parse(self, text: str) -> str:
         """Returns the input text with no changes."""
         return text
+
+
+StrOutputParser.model_rebuild()

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal
 
+from pydantic import root_validator
+
 from langchain_core.messages import BaseMessage, BaseMessageChunk
 from langchain_core.outputs.generation import Generation
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils._merge import merge_dicts
 
 

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal
 
-from pydantic import root_validator
+from pydantic import root_validator, model_validator
 
 from langchain_core.messages import BaseMessage, BaseMessageChunk
 from langchain_core.outputs.generation import Generation
@@ -20,7 +20,8 @@ class ChatGeneration(Generation):
     type: Literal["ChatGeneration"] = "ChatGeneration"  # type: ignore[assignment]
     """Type is used exclusively for serialization purposes."""
 
-    @root_validator
+    @model_validator(mode="before")
+    @classmethod
     def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Set the text attribute to be the contents of the message."""
         try:

--- a/libs/core/langchain_core/outputs/chat_result.py
+++ b/libs/core/langchain_core/outputs/chat_result.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
+from pydantic import BaseModel
+
 from langchain_core.outputs.chat_generation import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class ChatResult(BaseModel):

--- a/libs/core/langchain_core/outputs/llm_result.py
+++ b/libs/core/langchain_core/outputs/llm_result.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import List, Optional
 
+from pydantic import BaseModel
+
 from langchain_core.outputs.generation import Generation
 from langchain_core.outputs.run_info import RunInfo
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class LLMResult(BaseModel):

--- a/libs/core/langchain_core/outputs/run_info.py
+++ b/libs/core/langchain_core/outputs/run_info.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class RunInfo(BaseModel):

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import yaml
+from pydantic import BaseModel, Field, root_validator
 
 from langchain_core.output_parsers.base import BaseOutputParser
 from langchain_core.prompt_values import (
@@ -25,7 +26,6 @@ from langchain_core.prompt_values import (
     PromptValue,
     StringPromptValue,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.runnables import RunnableConfig, RunnableSerializable
 from langchain_core.runnables.config import ensure_config
 from langchain_core.runnables.utils import create_model

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -21,7 +21,7 @@ from typing import (
     overload,
 )
 
-from pydantic import Field, root_validator
+from pydantic import model_validator, Field
 
 from langchain_core._api import deprecated
 from langchain_core.load import Serializable
@@ -847,7 +847,8 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         else:
             raise NotImplementedError(f"Unsupported operand type for +: {type(other)}")
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def validate_input_variables(cls, values: dict) -> dict:
         """Validate input variables.
 

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -21,6 +21,8 @@ from typing import (
     overload,
 )
 
+from pydantic import Field, root_validator
+
 from langchain_core._api import deprecated
 from langchain_core.load import Serializable
 from langchain_core.messages import (
@@ -38,7 +40,6 @@ from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.image import ImagePromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import StringPromptTemplate, get_template_variables
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.interactive_env import is_interactive_env
 

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Extra, Field, root_validator
+from pydantic import model_validator, ConfigDict, BaseModel, Field
 
 from langchain_core.example_selectors import BaseExampleSelector
 from langchain_core.messages import BaseMessage, get_buffer_string
@@ -32,14 +32,10 @@ class _FewShotPromptTemplateMixin(BaseModel):
     example_selector: Optional[BaseExampleSelector] = None
     """ExampleSelector to choose the examples to format into the prompt.
     Either this or examples should be provided."""
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
-    class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
-
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def check_examples_and_selector(cls, values: Dict) -> Dict:
         """Check that one and only one of examples/example_selector are provided."""
         examples = values.get("examples", None)
@@ -122,7 +118,8 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
     template_format: Literal["f-string", "jinja2"] = "f-string"
     """The format of the prompt template. Options are: 'f-string', 'jinja2'."""
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def template_is_valid(cls, values: Dict) -> Dict:
         """Check that prefix, suffix, and input variables are consistent."""
         if values["validate_template"]:
@@ -140,12 +137,7 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
                 if var not in values["partial_variables"]
             ]
         return values
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     def format(self, **kwargs: Any) -> str:
         kwargs = self._merge_partial_and_user_variables(**kwargs)
@@ -320,12 +312,7 @@ class FewShotChatMessagePromptTemplate(
     to pass to the example_selector, if provided."""
     example_prompt: Union[BaseMessagePromptTemplate, BaseChatPromptTemplate]
     """The class to format each example."""
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format kwargs into a list of messages.

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import BaseModel, Extra, Field, root_validator
+
 from langchain_core.example_selectors import BaseExampleSelector
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.prompts.chat import (
@@ -18,7 +20,6 @@ from langchain_core.prompts.string import (
     check_valid_template,
     get_template_variables,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 
 
 class _FewShotPromptTemplateMixin(BaseModel):

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -2,12 +2,13 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from pydantic import Extra, root_validator
+
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     StringPromptTemplate,
 )
-from langchain_core.pydantic_v1 import Extra, root_validator
 
 
 class FewShotPromptWithTemplates(StringPromptTemplate):

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import Extra, root_validator
+from pydantic import model_validator, ConfigDict
 
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import (
@@ -48,7 +48,8 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "few_shot_with_templates"]
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def check_examples_and_selector(cls, values: Dict) -> Dict:
         """Check that one and only one of examples/example_selector are provided."""
         examples = values.get("examples", None)
@@ -65,7 +66,8 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
 
         return values
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def template_is_valid(cls, values: Dict) -> Dict:
         """Check that prefix, suffix, and input variables are consistent."""
         if values["validate_template"]:
@@ -87,12 +89,7 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
                 - set(values["partial_variables"])
             )
         return values
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     def _get_examples(self, **kwargs: Any) -> List[dict]:
         if self.examples is not None:

--- a/libs/core/langchain_core/prompts/image.py
+++ b/libs/core/langchain_core/prompts/image.py
@@ -1,8 +1,9 @@
 from typing import Any, List
 
+from pydantic import Field
+
 from langchain_core.prompt_values import ImagePromptValue, ImageURL, PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
-from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import run_in_executor
 from langchain_core.utils import image as image_utils
 

--- a/libs/core/langchain_core/prompts/pipeline.py
+++ b/libs/core/langchain_core/prompts/pipeline.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Tuple
 
-from pydantic import root_validator
+from pydantic import model_validator
 
 from langchain_core.prompt_values import PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
@@ -34,7 +34,8 @@ class PipelinePromptTemplate(BasePromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "pipeline"]
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def get_input_variables(cls, values: Dict) -> Dict:
         """Get input variables."""
         created_variables = set()

--- a/libs/core/langchain_core/prompts/pipeline.py
+++ b/libs/core/langchain_core/prompts/pipeline.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List, Tuple
 
+from pydantic import root_validator
+
 from langchain_core.prompt_values import PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.chat import BaseChatPromptTemplate
-from langchain_core.pydantic_v1 import root_validator
 
 
 def _get_inputs(inputs: dict, input_variables: List[str]) -> dict:

--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -5,7 +5,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, root_validator
+from pydantic import model_validator, BaseModel
 
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
@@ -127,10 +127,12 @@ class PromptTemplate(StringPromptTemplate):
         kwargs = self._merge_partial_and_user_variables(**kwargs)
         return DEFAULT_FORMATTER_MAPPING[self.template_format](self.template, **kwargs)
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def template_is_valid(cls, values: Dict) -> Dict:
         """Check that template and input variables are consistent."""
-        if values["validate_template"]:
+        # TODO(EUGENE): APPLY
+        if values.get("validate_template", False):
             if values["template_format"] == "mustache":
                 raise ValueError("Mustache templates cannot be validated.")
             all_inputs = values["input_variables"] + list(values["partial_variables"])

--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -5,6 +5,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import BaseModel, root_validator
+
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     StringPromptTemplate,
@@ -12,7 +14,6 @@ from langchain_core.prompts.string import (
     get_template_variables,
     mustache_schema,
 )
-from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.runnables.config import RunnableConfig
 
 

--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -7,10 +7,11 @@ from abc import ABC
 from string import Formatter
 from typing import Any, Callable, Dict, List, Set, Tuple, Type
 
+from pydantic import BaseModel, create_model
+
 import langchain_core.utils.mustache as mustache
 from langchain_core.prompt_values import PromptValue, StringPromptValue
 from langchain_core.prompts.base import BasePromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, create_model
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.formatting import formatter
 from langchain_core.utils.interactive_env import is_interactive_env

--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -12,6 +12,8 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel
+
 from langchain_core._api.beta_decorator import beta
 from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.prompts.chat import (
@@ -22,7 +24,6 @@ from langchain_core.prompts.chat import (
     MessagesPlaceholder,
     _convert_to_message,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import (
     Other,
     Runnable,

--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -35,6 +35,7 @@ from langchain_core.runnables import (
     ensure_config,
 )
 from langchain_core.runnables.config import run_in_executor
+from pydantic import ConfigDict
 
 if TYPE_CHECKING:
     from langchain_core.callbacks.manager import (
@@ -110,11 +111,7 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
                     results = cosine_similarity(self.tfidf_array, query_vec).reshape((-1,))
                     return [self.docs[i] for i in results.argsort()[-self.k :][::-1]]
     """  # noqa: E501
-
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     _new_arg_supported: bool = False
     _expects_other_args: bool = False

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -33,7 +33,7 @@ from typing import (
     overload,
 )
 
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 from typing_extensions import Literal, get_args
 
 from langchain_core._api import beta_decorator
@@ -2317,9 +2317,7 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
     @classmethod
     def is_lc_serializable(cls) -> bool:
         return True
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def InputType(self) -> Type[Input]:
@@ -3013,9 +3011,7 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
     def get_lc_namespace(cls) -> List[str]:
         """Get the namespace of the langchain object."""
         return ["langchain", "schema", "runnable"]
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def get_name(
         self, suffix: Optional[str] = None, *, name: Optional[str] = None
@@ -4206,9 +4202,7 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
     """
 
     bound: Runnable[Input, Output]
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def InputType(self) -> Any:
@@ -4448,9 +4442,7 @@ class RunnableBindingBase(RunnableSerializable[Input, Output]):
 
     The type can be a pydantic model, or a type annotation (e.g., `List[str]`).
     """
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(
         self,
@@ -4786,7 +4778,7 @@ class RunnableBindingBase(RunnableSerializable[Input, Output]):
             yield item
 
 
-RunnableBindingBase.update_forward_refs(RunnableConfig=RunnableConfig)
+RunnableBindingBase.model_rebuild()
 
 
 class RunnableBinding(RunnableBindingBase[Input, Output]):

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -33,6 +33,7 @@ from typing import (
     overload,
 )
 
+from pydantic import BaseModel, Field
 from typing_extensions import Literal, get_args
 
 from langchain_core._api import beta_decorator
@@ -42,7 +43,6 @@ from langchain_core.load.serializable import (
     SerializedConstructor,
     SerializedNotImplemented,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables.config import (
     RunnableConfig,
     _set_config_context,

--- a/libs/core/langchain_core/runnables/branch.py
+++ b/libs/core/langchain_core/runnables/branch.py
@@ -14,8 +14,9 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel
+
 from langchain_core.load.dump import dumpd
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import (
     Runnable,
     RunnableLike,

--- a/libs/core/langchain_core/runnables/branch.py
+++ b/libs/core/langchain_core/runnables/branch.py
@@ -14,7 +14,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from langchain_core.load.dump import dumpd
 from langchain_core.runnables.base import (
@@ -121,9 +121,7 @@ class RunnableBranch(RunnableSerializable[Input, Output]):
             _branches.append((condition, runnable))
 
         super().__init__(branches=_branches, default=default_)  # type: ignore[call-arg]
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/configurable.py
+++ b/libs/core/langchain_core/runnables/configurable.py
@@ -20,7 +20,8 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
+
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
     RunnableConfig,

--- a/libs/core/langchain_core/runnables/configurable.py
+++ b/libs/core/langchain_core/runnables/configurable.py
@@ -20,7 +20,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
@@ -50,9 +50,7 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
     default: RunnableSerializable[Input, Output]
 
     config: Optional[RunnableConfig] = None
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -18,7 +18,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from langchain_core.load.dump import dumpd
 from langchain_core.runnables.base import Runnable, RunnableSerializable
@@ -105,9 +105,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         part of the input under the specified key. If None, exceptions
         will not be passed to fallbacks. If used, the base runnable and its fallbacks 
         must accept a dictionary as input."""
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def InputType(self) -> Type[Input]:

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -18,8 +18,9 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel
+
 from langchain_core.load.dump import dumpd
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
     RunnableConfig,

--- a/libs/core/langchain_core/runnables/graph.py
+++ b/libs/core/langchain_core/runnables/graph.py
@@ -19,7 +19,7 @@ from typing import (
 )
 from uuid import UUID, uuid4
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from langchain_core.runnables.base import Runnable as RunnableType

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -13,9 +13,10 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel
+
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.load.load import load
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableBindingBase, RunnableLambda
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (

--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -21,7 +21,8 @@ from typing import (
     cast,
 )
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
+
 from langchain_core.runnables.base import (
     Other,
     Runnable,

--- a/libs/core/langchain_core/runnables/router.py
+++ b/libs/core/langchain_core/runnables/router.py
@@ -31,6 +31,7 @@ from langchain_core.runnables.utils import (
     gather_with_concurrency,
     get_unique_config_specs,
 )
+from pydantic import ConfigDict
 
 
 class RouterInput(TypedDict):
@@ -79,9 +80,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
         super().__init__(  # type: ignore[call-arg]
             runnables={key: coerce_to_runnable(r) for key, r in runnables.items()}
         )
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -30,10 +30,10 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseConfig, BaseModel
+from pydantic import create_model as _create_model_base
 from typing_extensions import TypeGuard
 
-from langchain_core.pydantic_v1 import BaseConfig, BaseModel
-from langchain_core.pydantic_v1 import create_model as _create_model_base
 from langchain_core.runnables.schema import StreamEvent
 
 Input = TypeVar("Input", contravariant=True)

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -101,7 +101,7 @@ class Comparison(FilterDirective):
 
     comparator: Comparator
     attribute: str
-    value: Any
+    value: Any = None
 
     def __init__(
         self, comparator: Comparator, attribute: str, value: Any, **kwargs: Any
@@ -128,9 +128,9 @@ class StructuredQuery(Expr):
 
     query: str
     """Query string."""
-    filter: Optional[FilterDirective]
+    filter: Optional[FilterDirective] = None
     """Filtering expression."""
-    limit: Optional[int]
+    limit: Optional[int] = None
     """Limit on the number of results."""
 
     def __init__(

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, List, Optional, Sequence, Union
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class Visitor(ABC):

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -30,6 +30,16 @@ from functools import partial
 from inspect import signature
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    ValidationError,
+    create_model,
+    root_validator,
+    validate_arguments,
+)
+
 from langchain_core._api import deprecated
 from langchain_core.callbacks import (
     AsyncCallbackManager,
@@ -47,15 +57,6 @@ from langchain_core.prompts import (
     PromptTemplate,
     aformat_document,
     format_document,
-)
-from langchain_core.pydantic_v1 import (
-    BaseModel,
-    Extra,
-    Field,
-    ValidationError,
-    create_model,
-    root_validator,
-    validate_arguments,
 )
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (

--- a/libs/core/langchain_core/tracers/run_schema.py
+++ b/libs/core/langchain_core/tracers/run_schema.py
@@ -1,0 +1,724 @@
+"""Schemas for the LangSmith API."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Union,
+    runtime_checkable,
+)
+from uuid import UUID
+
+from typing_extensions import TypedDict
+
+from pydantic import (  # type: ignore[assignment]
+    BaseModel,
+    Field,
+    PrivateAttr,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+)
+
+from typing_extensions import Literal
+
+SCORE_TYPE = Union[StrictBool, StrictInt, StrictFloat, None]
+VALUE_TYPE = Union[Dict, StrictBool, StrictInt, StrictFloat, str, None]
+
+
+class ExampleBase(BaseModel):
+    """Example base model."""
+
+    dataset_id: UUID
+    inputs: Dict[str, Any]
+    outputs: Optional[Dict[str, Any]] = Field(default=None)
+    metadata: Optional[Dict[str, Any]] = Field(default=None)
+
+    class Config:
+        """Configuration class for the schema."""
+
+        frozen = True
+
+
+class ExampleCreate(ExampleBase):
+    """Example create model."""
+
+    id: Optional[UUID]
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    split: Optional[Union[str, List[str]]] = None
+
+
+class Example(ExampleBase):
+    """Example model."""
+
+    id: UUID
+    created_at: datetime
+    modified_at: Optional[datetime] = Field(default=None)
+    runs: List[Run] = Field(default_factory=list)
+    source_run_id: Optional[UUID] = None
+    _host_url: Optional[str] = PrivateAttr(default=None)
+    _tenant_id: Optional[UUID] = PrivateAttr(default=None)
+
+    def __init__(
+            self,
+            _host_url: Optional[str] = None,
+            _tenant_id: Optional[UUID] = None,
+            **kwargs: Any,
+    ) -> None:
+        """Initialize a Dataset object."""
+        super().__init__(**kwargs)
+        self._host_url = _host_url
+        self._tenant_id = _tenant_id
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of this run within the app."""
+        if self._host_url:
+            path = f"/datasets/{self.dataset_id}/e/{self.id}"
+            if self._tenant_id:
+                return f"{self._host_url}/o/{str(self._tenant_id)}{path}"
+            return f"{self._host_url}{path}"
+        return None
+
+
+class ExampleUpdate(BaseModel):
+    """Update class for Example."""
+
+    dataset_id: Optional[UUID] = None
+    inputs: Optional[Dict[str, Any]] = None
+    outputs: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    split: Optional[Union[str, List[str]]] = None
+
+    class Config:
+        """Configuration class for the schema."""
+
+        frozen = True
+
+
+class DataType(str, Enum):
+    """Enum for dataset data types."""
+
+    kv = "kv"
+    llm = "llm"
+    chat = "chat"
+
+
+class DatasetBase(BaseModel):
+    """Dataset base model."""
+
+    name: str
+    description: Optional[str] = None
+    data_type: Optional[DataType] = None
+
+    class Config:
+        """Configuration class for the schema."""
+
+        frozen = True
+
+
+class DatasetCreate(DatasetBase):
+    """Dataset create model."""
+
+    id: Optional[UUID] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Dataset(DatasetBase):
+    """Dataset ORM model."""
+
+    id: UUID
+    created_at: datetime
+    modified_at: Optional[datetime] = Field(default=None)
+    example_count: Optional[int] = None
+    session_count: Optional[int] = None
+    last_session_start_time: Optional[datetime] = None
+    _host_url: Optional[str] = PrivateAttr(default=None)
+    _tenant_id: Optional[UUID] = PrivateAttr(default=None)
+    _public_path: Optional[str] = PrivateAttr(default=None)
+
+    def __init__(
+            self,
+            _host_url: Optional[str] = None,
+            _tenant_id: Optional[UUID] = None,
+            _public_path: Optional[str] = None,
+            **kwargs: Any,
+    ) -> None:
+        """Initialize a Dataset object."""
+        super().__init__(**kwargs)
+        self._host_url = _host_url
+        self._tenant_id = _tenant_id
+        self._public_path = _public_path
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of this run within the app."""
+        if self._host_url:
+            if self._public_path:
+                return f"{self._host_url}{self._public_path}"
+            if self._tenant_id:
+                return f"{self._host_url}/o/{str(self._tenant_id)}/datasets/{self.id}"
+            return f"{self._host_url}/datasets/{self.id}"
+        return None
+
+
+class DatasetVersion(BaseModel):
+    """Class representing a dataset version."""
+
+    tags: Optional[List[str]] = None
+    as_of: datetime
+
+
+class RunBase(BaseModel):
+    """Base Run schema.
+
+    A Run is a span representing a single unit of work or operation within your LLM app.
+    This could be a single call to an LLM or chain, to a prompt formatting call,
+    to a runnable lambda invocation. If you are familiar with OpenTelemetry,
+    you can think of a run as a span.
+    """
+
+    id: UUID
+    """Unique identifier for the run."""
+
+    name: str
+    """Human-readable name for the run."""
+
+    start_time: datetime
+    """Start time of the run."""
+
+    run_type: str
+    """The type of run, such as tool, chain, llm, retriever,
+    embedding, prompt, parser."""
+
+    end_time: Optional[datetime] = None
+    """End time of the run, if applicable."""
+
+    extra: Optional[dict] = None
+    """Additional metadata or settings related to the run."""
+
+    error: Optional[str] = None
+    """Error message, if the run encountered any issues."""
+
+    serialized: Optional[dict] = None
+    """Serialized object that executed the run for potential reuse."""
+
+    events: Optional[List[Dict]] = None
+    """List of events associated with the run, like
+    start and end events."""
+
+    inputs: dict = Field(default_factory=dict)
+    """Inputs used for the run."""
+
+    outputs: Optional[dict] = None
+    """Outputs generated by the run, if any."""
+
+    reference_example_id: Optional[UUID] = None
+    """Reference to an example that this run may be based on."""
+
+    parent_run_id: Optional[UUID] = None
+    """Identifier for a parent run, if this run is a sub-run."""
+
+    tags: Optional[List[str]] = None
+    """Tags for categorizing or annotating the run."""
+
+    _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Retrieve the metadata (if any)."""
+        with self._lock:
+            if self.extra is None:
+                self.extra = {}
+            metadata = self.extra.setdefault("metadata", {})
+        return metadata
+
+    @property
+    def revision_id(self) -> Optional[UUID]:
+        """Retrieve the revision ID (if any)."""
+        return self.metadata.get("revision_id")
+
+
+class Run(RunBase):
+    """Run schema when loading from the DB."""
+
+    session_id: Optional[UUID] = None
+    """The project ID this run belongs to."""
+    child_run_ids: Optional[List[UUID]] = None
+    """The child run IDs of this run."""
+    child_runs: Optional[List[Run]] = None
+    """The child runs of this run, if instructed to load using the client
+    These are not populated by default, as it is a heavier query to make."""
+    feedback_stats: Optional[Dict[str, Any]] = None
+    """Feedback stats for this run."""
+    app_path: Optional[str] = None
+    """Relative URL path of this run within the app."""
+    manifest_id: Optional[UUID] = None
+    """Unique ID of the serialized object for this run."""
+    status: Optional[str] = None
+    """Status of the run (e.g., 'success')."""
+    prompt_tokens: Optional[int] = None
+    """Number of tokens used for the prompt."""
+    completion_tokens: Optional[int] = None
+    """Number of tokens generated as output."""
+    total_tokens: Optional[int] = None
+    """Total tokens for prompt and completion."""
+    first_token_time: Optional[datetime] = None
+    """Time the first token was processed."""
+    total_cost: Optional[Decimal] = None
+    """The total estimated LLM cost associated with the completion tokens."""
+    prompt_cost: Optional[Decimal] = None
+    """The estimated cost associated with the prompt (input) tokens."""
+    completion_cost: Optional[Decimal] = None
+    """The estimated cost associated with the completion tokens."""
+
+    parent_run_ids: Optional[List[UUID]] = None
+    """List of parent run IDs."""
+    trace_id: UUID
+    """Unique ID assigned to every run within this nested trace."""
+    dotted_order: str = Field(default="")
+    """Dotted order for the run.
+
+    This is a string composed of {time}{run-uuid}.* so that a trace can be
+    sorted in the order it was executed.
+
+    Example:
+    - Parent: 20230914T223155647Z1b64098b-4ab7-43f6-afee-992304f198d8
+    - Children:
+        - 20230914T223155647Z1b64098b-4ab7-43f6-afee-992304f198d8.20230914T223155649Z809ed3a2-0172-4f4d-8a02-a64e9b7a0f8a
+        - 20230915T223155647Z1b64098b-4ab7-43f6-afee-992304f198d8.20230914T223155650Zc8d9f4c5-6c5a-4b2d-9b1c-3d9d7a7c5c7c
+    """  # noqa: E501
+    in_dataset: Optional[bool] = None
+    """Whether this run is in a dataset."""
+    _host_url: Optional[str] = PrivateAttr(default=None)
+
+    def __init__(self, _host_url: Optional[str] = None, **kwargs: Any) -> None:
+        """Initialize a Run object."""
+        if not kwargs.get("trace_id"):
+            kwargs = {"trace_id": kwargs.get("id"), **kwargs}
+        inputs = kwargs.pop("inputs", None) or {}
+        super().__init__(**kwargs, inputs=inputs)
+        self._host_url = _host_url
+        if not self.dotted_order.strip() and not self.parent_run_id:
+            self.dotted_order = f"{self.start_time.isoformat()}{self.id}"
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of this run within the app."""
+        if self._host_url and self.app_path:
+            return f"{self._host_url}{self.app_path}"
+        return None
+
+
+class RunTypeEnum(str, Enum):
+    """(Deprecated) Enum for run types. Use string directly."""
+
+    tool = "tool"
+    chain = "chain"
+    llm = "llm"
+    retriever = "retriever"
+    embedding = "embedding"
+    prompt = "prompt"
+    parser = "parser"
+
+
+class RunLikeDict(TypedDict, total=False):
+    """Run-like dictionary, for type-hinting."""
+
+    name: str
+    run_type: RunTypeEnum
+    start_time: datetime
+    inputs: Optional[dict]
+    outputs: Optional[dict]
+    end_time: Optional[datetime]
+    extra: Optional[dict]
+    error: Optional[str]
+    serialized: Optional[dict]
+    parent_run_id: Optional[UUID]
+    manifest_id: Optional[UUID]
+    events: Optional[List[dict]]
+    tags: Optional[List[str]]
+    inputs_s3_urls: Optional[dict]
+    outputs_s3_urls: Optional[dict]
+    id: Optional[UUID]
+    session_id: Optional[UUID]
+    session_name: Optional[str]
+    reference_example_id: Optional[UUID]
+    input_attachments: Optional[dict]
+    output_attachments: Optional[dict]
+    trace_id: UUID
+    dotted_order: str
+
+
+class RunWithAnnotationQueueInfo(RunBase):
+    """Run schema with annotation queue info."""
+
+    last_reviewed_time: Optional[datetime] = None
+    """The last time this run was reviewed."""
+    added_at: Optional[datetime] = None
+    """The time this run was added to the queue."""
+
+
+class FeedbackSourceBase(BaseModel):
+    """Base class for feedback sources.
+
+    This represents whether feedback is submitted from the API, model, human labeler,
+        etc.
+
+    Attributes:
+        type (str): The type of the feedback source.
+        metadata (Optional[Dict[str, Any]]): Additional metadata for the feedback
+            source.
+    """
+
+    type: str
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+
+class APIFeedbackSource(FeedbackSourceBase):
+    """API feedback source."""
+
+    type: Literal["api"] = "api"
+
+
+class ModelFeedbackSource(FeedbackSourceBase):
+    """Model feedback source."""
+
+    type: Literal["model"] = "model"
+
+
+class FeedbackSourceType(Enum):
+    """Feedback source type."""
+
+    API = "api"
+    """General feedback submitted from the API."""
+    MODEL = "model"
+    """Model-assisted feedback."""
+
+
+class FeedbackBase(BaseModel):
+    """Feedback schema."""
+
+    id: UUID
+    """The unique ID of the feedback."""
+    created_at: Optional[datetime] = None
+    """The time the feedback was created."""
+    modified_at: Optional[datetime] = None
+    """The time the feedback was last modified."""
+    run_id: Optional[UUID]
+    """The associated run ID this feedback is logged for."""
+    key: str
+    """The metric name, tag, or aspect to provide feedback on."""
+    score: SCORE_TYPE = None
+    """Value or score to assign the run."""
+    value: VALUE_TYPE = None
+    """The display value, tag or other value for the feedback if not a metric."""
+    comment: Optional[str] = None
+    """Comment or explanation for the feedback."""
+    correction: Union[str, dict, None] = None
+    """Correction for the run."""
+    feedback_source: Optional[FeedbackSourceBase] = None
+    """The source of the feedback."""
+    session_id: Optional[UUID] = None
+    """The associated project ID (Session = Project) this feedback is logged for."""
+    comparative_experiment_id: Optional[UUID] = None
+    """If logged within a 'comparative experiment', this is the ID of the experiment."""
+    feedback_group_id: Optional[UUID] = None
+    """For preference scoring, this group ID is shared across feedbacks for each
+
+    run in the group that was being compared."""
+
+    class Config:
+        """Configuration class for the schema."""
+
+        frozen = True
+
+
+class FeedbackCategory(TypedDict, total=False):
+    """Specific value and label pair for feedback."""
+
+    value: float
+    label: Optional[str]
+
+
+class FeedbackConfig(TypedDict, total=False):
+    """Represents _how_ a feedback value ought to be interpreted.
+
+    Attributes:
+        type (Literal["continuous", "categorical", "freeform"]): The type of feedback.
+        min (Optional[float]): The minimum value for continuous feedback.
+        max (Optional[float]): The maximum value for continuous feedback.
+        categories (Optional[List[FeedbackCategory]]): If feedback is categorical,
+            This defines the valid categories the server will accept.
+            Not applicable to continuosu or freeform feedback types.
+    """
+
+    type: Literal["continuous", "categorical", "freeform"]
+    min: Optional[float]
+    max: Optional[float]
+    categories: Optional[List[FeedbackCategory]]
+
+
+class FeedbackCreate(FeedbackBase):
+    """Schema used for creating feedback."""
+
+    feedback_source: FeedbackSourceBase
+    """The source of the feedback."""
+    feedback_config: Optional[FeedbackConfig] = None
+
+
+class Feedback(FeedbackBase):
+    """Schema for getting feedback."""
+
+    id: UUID
+    created_at: datetime
+    """The time the feedback was created."""
+    modified_at: datetime
+    """The time the feedback was last modified."""
+    feedback_source: Optional[FeedbackSourceBase] = None
+    """The source of the feedback. In this case"""
+
+
+class TracerSession(BaseModel):
+    """TracerSession schema for the API.
+
+    Sessions are also referred to as "Projects" in the UI.
+    """
+
+    id: UUID
+    """The ID of the project."""
+    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    """The time the project was created."""
+    end_time: Optional[datetime] = None
+    """The time the project was ended."""
+    description: Optional[str] = None
+    """The description of the project."""
+    name: Optional[str] = None
+    """The name of the session."""
+    extra: Optional[Dict[str, Any]] = None
+    """Extra metadata for the project."""
+    tenant_id: UUID
+    """The tenant ID this project belongs to."""
+    reference_dataset_id: Optional[UUID]
+    """The reference dataset IDs this project's runs were generated on."""
+
+    _host_url: Optional[str] = PrivateAttr(default=None)
+
+    def __init__(self, _host_url: Optional[str] = None, **kwargs: Any) -> None:
+        """Initialize a Run object."""
+        super().__init__(**kwargs)
+        self._host_url = _host_url
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of this run within the app."""
+        if self._host_url:
+            return f"{self._host_url}/o/{self.tenant_id}/projects/p/{self.id}"
+        return None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Retrieve the metadata (if any)."""
+        if self.extra is None or "metadata" not in self.extra:
+            return {}
+        return self.extra["metadata"]
+
+    @property
+    def tags(self) -> List[str]:
+        """Retrieve the tags (if any)."""
+        if self.extra is None or "tags" not in self.extra:
+            return []
+        return self.extra["tags"]
+
+
+class TracerSessionResult(TracerSession):
+    """A project, hydrated with additional information.
+
+    Sessions are also referred to as "Projects" in the UI.
+    """
+
+    run_count: Optional[int]
+    """The number of runs in the project."""
+    latency_p50: Optional[timedelta]
+    """The median (50th percentile) latency for the project."""
+    latency_p99: Optional[timedelta]
+    """The 99th percentile latency for the project."""
+    total_tokens: Optional[int]
+    """The total number of tokens consumed in the project."""
+    prompt_tokens: Optional[int]
+    """The total number of prompt tokens consumed in the project."""
+    completion_tokens: Optional[int]
+    """The total number of completion tokens consumed in the project."""
+    last_run_start_time: Optional[datetime]
+    """The start time of the last run in the project."""
+    feedback_stats: Optional[Dict[str, Any]]
+    """Feedback stats for the project."""
+    run_facets: Optional[List[Dict[str, Any]]]
+    """Facets for the runs in the project."""
+
+
+@runtime_checkable
+class BaseMessageLike(Protocol):
+    """A protocol representing objects similar to BaseMessage."""
+
+    content: str
+    additional_kwargs: Dict
+
+    @property
+    def type(self) -> str:
+        """Type of the Message, used for serialization."""
+
+
+class DatasetShareSchema(TypedDict, total=False):
+    """Represents the schema for a dataset share.
+
+    Attributes:
+        dataset_id (UUID): The ID of the dataset.
+        share_token (UUID): The token for sharing the dataset.
+        url (str): The URL of the shared dataset.
+    """
+
+    dataset_id: UUID
+    share_token: UUID
+    url: str
+
+
+class AnnotationQueue(BaseModel):
+    """Represents an annotation queue.
+
+    Attributes:
+        id (UUID): The ID of the annotation queue.
+        name (str): The name of the annotation queue.
+        description (Optional[str], optional): The description of the annotation queue.
+            Defaults to None.
+        created_at (datetime, optional): The creation timestamp of the annotation queue.
+            Defaults to the current UTC time.
+        updated_at (datetime, optional): The last update timestamp of the annotation
+             queue. Defaults to the current UTC time.
+        tenant_id (UUID): The ID of the tenant associated with the annotation queue.
+    """
+
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    tenant_id: UUID
+
+
+class BatchIngestConfig(TypedDict, total=False):
+    """Configuration for batch ingestion.
+
+    Attributes:
+        scale_up_qsize_trigger (int): The queue size threshold that triggers scaling up.
+        scale_up_nthreads_limit (int): The maximum number of threads to scale up to.
+        scale_down_nempty_trigger (int): The number of empty threads that triggers
+            scaling down.
+        size_limit (int): The maximum size limit for the batch.
+    """
+
+    scale_up_qsize_trigger: int
+    scale_up_nthreads_limit: int
+    scale_down_nempty_trigger: int
+    size_limit: int
+    size_limit_bytes: Optional[int]
+
+
+class LangSmithInfo(BaseModel):
+    """Information about the LangSmith server."""
+
+    version: str = ""
+    """The version of the LangSmith server."""
+    license_expiration_time: Optional[datetime] = None
+    """The time the license will expire."""
+    batch_ingest_config: Optional[BatchIngestConfig] = None
+
+
+Example.model_rebuild()
+
+
+class FeedbackIngestToken(BaseModel):
+    """Represents the schema for a feedback ingest token.
+
+    Attributes:
+        id (UUID): The ID of the feedback ingest token.
+        token (str): The token for ingesting feedback.
+        expires_at (datetime): The expiration time of the token.
+    """
+
+    id: UUID
+    url: str
+    expires_at: datetime
+
+
+class RunEvent(TypedDict, total=False):
+    """Run event schema."""
+
+    name: str
+    """Type of event."""
+    time: Union[datetime, str]
+    """Time of the event."""
+    kwargs: Optional[Dict[str, Any]]
+    """Additional metadata for the event."""
+
+
+class TimeDeltaInput(TypedDict, total=False):
+    """Timedelta input schema."""
+
+    days: int
+    """Number of days."""
+    hours: int
+    """Number of hours."""
+    minutes: int
+    """Number of minutes."""
+
+
+class DatasetDiffInfo(BaseModel):
+    """Represents the difference information between two datasets.
+
+    Attributes:
+        examples_modified (List[UUID]): A list of UUIDs representing
+            the modified examples.
+        examples_added (List[UUID]): A list of UUIDs representing
+            the added examples.
+        examples_removed (List[UUID]): A list of UUIDs representing
+            the removed examples.
+    """
+
+    examples_modified: List[UUID]
+    examples_added: List[UUID]
+    examples_removed: List[UUID]
+
+
+class ComparativeExperiment(BaseModel):
+    """Represents a comparative experiment.
+
+    This information summarizes evaluation results comparing
+    two or more models on a given dataset.
+    """
+
+    id: UUID
+    name: Optional[str] = None
+    description: Optional[str] = None
+    tenant_id: UUID
+    created_at: datetime
+    modified_at: datetime
+    reference_dataset_id: UUID
+    extra: Optional[Dict[str, Any]] = None
+    experiments_info: Optional[List[dict]] = None
+    feedback_stats: Optional[Dict[str, Any]] = None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Retrieve the metadata (if any)."""
+        if self.extra is None or "metadata" not in self.extra:
+            return {}
+        return self.extra["metadata"]

--- a/libs/core/langchain_core/tracers/schemas.py
+++ b/libs/core/langchain_core/tracers/schemas.py
@@ -6,9 +6,10 @@ import warnings
 from typing import Any, Dict, List, Optional, Type
 from uuid import UUID
 
-from langsmith.schemas import RunBase as BaseRunV2
-from langsmith.schemas import RunTypeEnum as RunTypeEnumDep
-from pydantic import BaseModel, Field, root_validator
+from langchain_core.tracers.run_schema import RunBase as BaseRunV2
+from langchain_core.tracers.run_schema import RunTypeEnum as RunTypeEnumDep
+
+from pydantic import model_validator, BaseModel, Field
 
 from langchain_core._api import deprecated
 from langchain_core.outputs import LLMResult
@@ -119,7 +120,8 @@ class Run(BaseRunV2):
     trace_id: Optional[UUID] = None
     dotted_order: Optional[str] = None
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def assign_name(cls, values: dict) -> dict:
         """Assign name to the run."""
         if values.get("name") is None:
@@ -132,9 +134,9 @@ class Run(BaseRunV2):
         return values
 
 
-ChainRun.update_forward_refs()
-ToolRun.update_forward_refs()
-Run.update_forward_refs()
+ChainRun.model_rebuild()
+ToolRun.model_rebuild()
+Run.model_rebuild()
 
 __all__ = [
     "BaseRun",

--- a/libs/core/langchain_core/tracers/schemas.py
+++ b/libs/core/langchain_core/tracers/schemas.py
@@ -8,10 +8,10 @@ from uuid import UUID
 
 from langsmith.schemas import RunBase as BaseRunV2
 from langsmith.schemas import RunTypeEnum as RunTypeEnumDep
+from pydantic import BaseModel, Field, root_validator
 
 from langchain_core._api import deprecated
 from langchain_core.outputs import LLMResult
-from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 
 
 @deprecated("0.1.0", alternative="Use string instead.", removal="0.3.0")

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -19,6 +19,7 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from langchain_core._api import deprecated
@@ -28,7 +29,6 @@ from langchain_core.messages import (
     HumanMessage,
     ToolMessage,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils.json_schema import dereference_refs
 
 if TYPE_CHECKING:

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -9,9 +9,8 @@ from importlib.metadata import version
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
 
 from packaging.version import parse
+from pydantic import SecretStr
 from requests import HTTPError, Response
-
-from langchain_core.pydantic_v1 import SecretStr
 
 
 def xor_args(*arg_groups: Tuple[str, ...]) -> Callable:

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -39,8 +39,9 @@ from typing import (
     TypeVar,
 )
 
+from pydantic import Field, root_validator
+
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables.config import run_in_executor
 

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -39,7 +39,7 @@ from typing import (
     TypeVar,
 )
 
-from pydantic import Field, root_validator
+from pydantic import model_validator, ConfigDict, Field
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
@@ -767,13 +767,10 @@ class VectorStoreRetriever(BaseRetriever):
         "similarity_score_threshold",
         "mmr",
     )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    class Config:
-        """Configuration for this pydantic object."""
-
-        arbitrary_types_allowed = True
-
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def validate_search_type(cls, values: Dict) -> Dict:
         """Validate search type."""
         search_type = values["search_type"]

--- a/libs/core/tests/unit_tests/_api/test_beta_decorator.py
+++ b/libs/core/tests/unit_tests/_api/test_beta_decorator.py
@@ -3,9 +3,9 @@ import warnings
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core._api.beta_decorator import beta, warn_beta
-from langchain_core.pydantic_v1 import BaseModel
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -3,9 +3,9 @@ import warnings
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core._api.deprecation import deprecated, warn_deprecated
-from langchain_core.pydantic_v1 import BaseModel
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/fake/callbacks.py
+++ b/libs/core/tests/unit_tests/fake/callbacks.py
@@ -3,9 +3,10 @@ from itertools import chain
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks.base import AsyncCallbackHandler, BaseCallbackHandler
 from langchain_core.messages import BaseMessage
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class BaseFakeCallbackHandler(BaseModel):

--- a/libs/core/tests/unit_tests/fake/memory.py
+++ b/libs/core/tests/unit_tests/fake/memory.py
@@ -1,10 +1,11 @@
 from typing import List
 
+from pydantic import BaseModel, Field
+
 from langchain_core.chat_history import (
     BaseChatMessageHistory,
 )
 from langchain_core.messages import BaseMessage
-from langchain_core.pydantic_v1 import BaseModel, Field
 
 
 class ChatMessageHistory(BaseChatMessageHistory, BaseModel):

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -2,11 +2,11 @@ import json
 from typing import Any, AsyncIterator, Iterator, Tuple
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.output_parsers.json import (
     SimpleJsonOutputParser,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils.function_calling import convert_to_openai_function
 from langchain_core.utils.json import parse_json_markdown, parse_partial_json
 

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_functions.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_functions.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -10,7 +11,6 @@ from langchain_core.output_parsers.openai_functions import (
     PydanticOutputFunctionsParser,
 )
 from langchain_core.outputs import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel
 
 
 def test_json_output_function_parser() -> None:

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -1,12 +1,13 @@
 from typing import Any, AsyncIterator, Iterator, List
 
+from pydantic import BaseModel, Field
+
 from langchain_core.messages import AIMessageChunk, BaseMessage, ToolCallChunk
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
     JsonOutputToolsParser,
     PydanticToolsParser,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 
 STREAMED_MESSAGES: list = [
     AIMessageChunk(content=""),

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -2,11 +2,12 @@ from functools import partial
 from inspect import isclass
 from typing import Any, Dict, Type, Union, cast
 
+from pydantic import BaseModel
+
 from langchain_core.language_models import FakeListChatModel
 from langchain_core.load.dump import dumps
 from langchain_core.load.load import loads
 from langchain_core.prompts.structured import StructuredPrompt
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableLambda
 
 

--- a/libs/core/tests/unit_tests/runnables/test_configurable.py
+++ b/libs/core/tests/unit_tests/runnables/test_configurable.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 
 import pytest
-from pydantic import Field, root_validator
+from pydantic import model_validator, ConfigDict, Field
 
 from langchain_core.runnables import (
     ConfigurableField,
@@ -13,17 +13,17 @@ from langchain_core.runnables import (
 class MyRunnable(RunnableSerializable[str, str]):
     my_property: str = Field(alias="my_property_alias")
     _my_hidden_property: str = ""
+    model_config = ConfigDict(populate_by_name=True)
 
-    class Config:
-        allow_population_by_field_name = True
-
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def my_error(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if "_my_hidden_property" in values:
             raise ValueError("Cannot set _my_hidden_property")
         return values
 
-    @root_validator()
+    @model_validator(mode="before")
+    @classmethod
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values["_my_hidden_property"] = values["my_property"]
         return values

--- a/libs/core/tests/unit_tests/runnables/test_configurable.py
+++ b/libs/core/tests/unit_tests/runnables/test_configurable.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Optional
 
 import pytest
+from pydantic import Field, root_validator
 
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables import (
     ConfigurableField,
     RunnableConfig,

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel
 from syrupy import SnapshotAssertion
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
@@ -25,7 +26,6 @@ from langchain_core.load import dumps
 from langchain_core.messages import BaseMessage
 from langchain_core.outputs import ChatResult
 from langchain_core.prompts import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import (
     Runnable,
     RunnableBinding,

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -1,12 +1,13 @@
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import RunnableLambda
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.runnables.history import RunnableWithMessageHistory

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
+from pydantic import BaseModel
 from pytest_mock import MockerFixture
 from syrupy import SnapshotAssertion
 from typing_extensions import TypedDict
@@ -58,7 +59,6 @@ from langchain_core.prompts import (
     PromptTemplate,
     SystemMessagePromptTemplate,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     AddableDict,

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -4,6 +4,7 @@ from itertools import cycle
 from typing import Any, AsyncIterator, Dict, List, Sequence, cast
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -18,7 +19,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     ConfigurableField,

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -1747,7 +1747,7 @@ async def test_runnable_with_message_history() -> None:
         # the content in the store!
 
         # Using Any type here rather than List[BaseMessage] due to pydantic issue!
-        messages: Any
+        messages: Any = None
 
         def add_message(self, message: BaseMessage) -> None:
             """Add a self-created message to the store."""

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -30,7 +31,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     ConfigurableField,

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -1689,7 +1689,7 @@ async def test_runnable_with_message_history() -> None:
         # the content in the store!
 
         # Using Any type here rather than List[BaseMessage] due to pydantic issue!
-        messages: Any
+        messages: Any = None
 
         def add_message(self, message: BaseMessage) -> None:
             """Add a self-created message to the store."""

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -828,9 +828,9 @@ async def test_async_validation_error_handling_non_validation_error(
 
 def test_optional_subset_model_rewrite() -> None:
     class MyModel(BaseModel):
-        a: Optional[str]
+        a: Optional[str] = None
         b: str
-        c: Optional[List[Optional[str]]]
+        c: Optional[List[Optional[str]]] = None
 
     model2 = _create_subset_model("model2", MyModel, ["a", "b", "c"])
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -10,12 +10,12 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
-from langchain_core.pydantic_v1 import BaseModel, ValidationError
 from langchain_core.runnables import ensure_config
 from langchain_core.tools import (
     BaseTool,

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1,9 +1,9 @@
 from typing import Any, Callable, Dict, List, Literal, Optional, Type
 
 import pytest
+from pydantic import BaseModel, Field
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.tools import BaseTool, tool
 from langchain_core.utils.function_calling import (
     convert_to_openai_function,


### PR DESCRIPTION
- [ ]  Identify all occurrences of root_validator() in the code that can be converted into an explicit  root_validator(pre=True). The code will need to be adjusted to deal with missing values since the default values will not be available for values.
- [ ]  Replace occurrences of update_forward_ref with model_rebuild (Found one case where a new import had to be brought into file scope -- need to investigate why)

For core in particular:

1. Dependency on langsmith-sdk in terms of pydantic (so copy schema?)
2. 

