### PR TITLE
core: add error message for non-structured llm to StructuredPrompt

### DIFF
--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -118,10 +118,19 @@ class StructuredPrompt(ChatPromptTemplate):
         if isinstance(other, BaseLanguageModel) or hasattr(
             other, "with_structured_output"
         ):
-            return RunnableSequence(self, other.with_structured_output(self.schema_))
+            try:
+                return RunnableSequence(
+                    self, other.with_structured_output(self.schema_)
+                )
+            except NotImplementedError as e:
+                raise NotImplementedError(
+                    "Structured prompts must be piped to a language model that "
+                    "implements with_structured_output."
+                ) from e
         else:
             raise NotImplementedError(
-                "Structured prompts need to be piped to a language model."
+                "Structured prompts must be piped to a language model that "
+                "implements with_structured_output."
             )
 
     def pipe(


### PR DESCRIPTION
previously was the blank `NotImplementedError` from `BaseLanguageModel.with_structured_output`