### PR TITLE
community[patch]: Use Custom Logger Instead of Root Logger in get_user_agent Function

### DIFF
--- a/libs/community/langchain_community/utils/user_agent.py
+++ b/libs/community/langchain_community/utils/user_agent.py
@@ -8,7 +8,7 @@ def get_user_agent() -> str:
     """Get user agent from environment variable."""
     env_user_agent = os.environ.get("USER_AGENT")
     if not env_user_agent:
-        logging.warning(
+        log.warning(
             "USER_AGENT environment variable not set, "
             "consider setting it to identify your requests."
         )


### PR DESCRIPTION
## Description
This PR addresses a logging inconsistency in the `get_user_agent` function. Previously, the function was using the root logger to log a warning message when the "USER_AGENT" environment variable was not set. This bypassed the custom logger `log` that was created at the start of the module, leading to potential inconsistencies in logging behavior.

Changes:
- Replaced `logging.warning` with `log.warning` in the `get_user_agent` function to ensure that the custom logger is used.

This change ensures that all logging in the `get_user_agent` function respects the configurations of the custom logger, leading to more consistent and predictable logging behavior.

## Dependencies

None

## Issue 

None

## Tests and docs

☝🏻 see description


## `make format`, `make lint` & `cd libs/community; make test`

```shell
> make format 
poetry run ruff format docs templates cookbook
1417 files left unchanged
poetry run ruff check --select I --fix docs templates cookbook
All checks passed!
```

```shell
> make lint
poetry run ruff check docs templates cookbook
All checks passed!
poetry run ruff format docs templates cookbook --diff
1417 files already formatted
poetry run ruff check --select I docs templates cookbook
All checks passed!
git grep 'from langchain import' docs/docs templates cookbook | grep -vE 'from langchain import (hub)' && exit 1 || exit 0
```

~cd libs/community; make test~ too much dependencies for integration ... 

```shell
>  poetry run pytest tests/unit_tests   
....
==== 884 passed, 466 skipped, 4447 warnings in 15.93s ====
```

I choose you randomly : @ccurme 