### PR TITLE
community: Added memory to OpenAPI planner and allowed optional endpoint parameters

### DIFF
--- a/docs/docs/integrations/toolkits/openapi.ipynb
+++ b/docs/docs/integrations/toolkits/openapi.ipynb
@@ -593,10 +593,338 @@
   },
   {
    "cell_type": "markdown",
+   "id": "75175211-d24b-4aae-a95c-d3a7faba39de",
+   "metadata": {},
+   "source": [
+    "## 2nd example: hierarchical planning agent with memory\n",
+    "\n",
+    "Continuing with the previous example, we'll enable chat history support for the planner. With memory, we can ask the agent to modify the request or make a new request following the conversation we've made with the agent.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01155ac9-e189-4c54-b79a-e0f3bd399c70",
+   "metadata": {},
+   "source": [
+    "### Load an OpenAPI spec\n",
+    "\n",
+    "We'll use the Klarna product search service for this example.  \n",
+    "If you haven't downloaded the `klarna_openapi.yaml`, please download it according to the instructions in the previous example.\n",
+    "\n",
+    "In this example, since we require setting optional parameters of Klarna service endpoints, we add `include_optinal_params=True` while calling `reduce_openapi_spec`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "edc250cd-005f-45e7-bbb6-19b4a8d7f389",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from langchain_community.agent_toolkits.openapi.spec import reduce_openapi_spec\n",
+    "\n",
+    "with open(\"klarna_openapi.yaml\") as f:\n",
+    "    raw_klarna_api_spec = yaml.load(f, Loader=yaml.Loader)\n",
+    "klarna_api_spec = reduce_openapi_spec(raw_klarna_api_spec, include_optional_params=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f16809f5-15de-4037-bb18-ec46619f27e4",
+   "metadata": {},
+   "source": [
+    "### Setup a LLM\n",
+    "\n",
+    "Here you may want to use your customized LLM models or settings.  \n",
+    "Load your LLM and name it to `llm` for future steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64bf7a1a-784a-4dc4-be27-f38660341c35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "llm = ChatOpenAI(model_name=\"gpt-4\", temperature=0.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61d93ee1-398f-4cb9-987a-34ba8ca0218f",
+   "metadata": {},
+   "source": [
+    "### Setup an OpenAPI Planner Agent with Memory Support\n",
+    "\n",
+    "Here we construct a `ConversationBufferMemory` and pass it to the `shared_memory` parameter of the `create_openapi_agent` function.\n",
+    "Chat history between user and agent will be automatically added to the memory.\n",
+    "\n",
+    "You may set the `human_prefix` and `ai_prefix` parameters to your preference. You can consider these terms as names of roles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a2b43971-5988-42c2-ba25-40cb3bc1fe38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.memory import ConversationBufferMemory\n",
+    "from langchain.requests import RequestsWrapper\n",
+    "from langchain_community.agent_toolkits.openapi import planner\n",
+    "\n",
+    "# Construct a memory for storing chat history between the user and the agent\n",
+    "memory = ConversationBufferMemory(human_prefix=\"User\", ai_prefix=\"Assistance\")\n",
+    "\n",
+    "klarna_agent = planner.create_openapi_agent(\n",
+    "    api_spec=klarna_api_spec,\n",
+    "    requests_wrapper=RequestsWrapper(headers={}),\n",
+    "    llm=llm,\n",
+    "    allow_dangerous_requests=ALLOW_DANGEROUS_REQUEST,\n",
+    "    shared_memory=memory,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af99592c-296a-432b-a8a0-453bbe6874d0",
+   "metadata": {},
+   "source": [
+    "### 1st Round\n",
+    "\n",
+    "In the first round, we ask the agent to list some products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "928e655d-60e9-4467-8fb4-a79e91144944",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mThought: I should generate a plan to help with this query and then copy that plan exactly to the controller.\n",
+      "\n",
+      "Action: api_planner\n",
+      "Action Input: I need to find the right API calls to list 5 laptop products in the US\u001b[0m\n",
+      "Observation: \u001b[36;1m\u001b[1;3mI can help with that!\n",
+      "\n",
+      "Since the user query is to list 5 laptop products in the US, I can generate a plan to achieve this using the provided API endpoints.\n",
+      "\n",
+      "Plan:\n",
+      "1. GET /public/openai/v0/products with a query param to search for laptops in the US (e.g., ?category=laptops&location=US)\n",
+      "2. Since the API endpoint does not have a built-in pagination or limit parameter, we will assume the API returns a list of products. We can then extract the first 5 laptop products from the response.\n",
+      "\n",
+      "Note: The plan assumes that the API endpoint returns a list of products that can be filtered by category and location. If the API endpoint does not support these query parameters, the plan would need to be adjusted accordingly.\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mI'm ready to execute the API calls.\n",
+      "\n",
+      "Action: api_controller\n",
+      "Action Input: 1) GET /public/openai/v0/products with a query param to search for laptops in the US (?category=laptops&location=US\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mPlan: 1) GET /public/openai/v0/products with a query param to search for laptops in the US\n",
+      "\n",
+      "Thought: I need to construct the input for the requests_get tool according to the API documentation.\n",
+      "\n",
+      "Action: requests_get\n",
+      "\n",
+      "Action Input: {\"url\": \"https://www.klarna.com/us/shopping/public/openai/v0/products\", \"params\": {\"countryCode\": \"US\", \"q\": \"laptops\"}, \"output_instructions\": \"extract product ids and names\u001b[0m\n",
+      "Observation: \u001b[36;1m\u001b[1;3mBased on the provided API response, I will extract the product IDs and names. Since the response does not contain explicit product IDs, I will use the URL path to extract a unique identifier for each product.\n",
+      "\n",
+      "Here is the extracted information:\n",
+      "\n",
+      "**Product IDs and Names:**\n",
+      "\n",
+      "1. **ID:** 3200009205, **Name:** Apple MacBook Air (2020) M1 OC 7C GPU 8GB 256GB SSD 13\"\n",
+      "2. **ID:** 3201585850, **Name:** Apple MacBook Air (2022) M2 OC 8C GPU 8GB 256GB SSD 13.6\"\n",
+      "3. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "4. **ID:** 3210594531, **Name:** Apple 2023 MacBook Pro Laptop M3\n",
+      "5. **ID:** 3259367351, **Name:** Apple MacBook Air (2024) M3 OC 8 Core GPU 8GB 256GB SSD 13.6\n",
+      "\n",
+      "Note that I extracted the IDs from the URL path, which seems to be a unique identifier for each product. If the API provides a more explicit ID field in the future, it's recommended to use that instead.\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mThought: I have successfully executed the first API call and extracted the product IDs and names. Since there are no subsequent API calls specified, I will consider this plan complete.\n",
+      "\n",
+      "Final Answer: Here is the final output from executing the plan:\n",
+      "\n",
+      "**Product IDs and Names:**\n",
+      "\n",
+      "1. **ID:** 3200009205, **Name:** Apple MacBook Air (2020) M1 OC 7C GPU 8GB 256GB SSD 13\"\n",
+      "2. **ID:** 3201585850, **Name:** Apple MacBook Air (2022) M2 OC 8C GPU 8GB 256GB SSD 13.6\"\n",
+      "3. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "4. **ID:** 3210594531, **Name:** Apple 2023 MacBook Pro Laptop M3\n",
+      "5. **ID:** 3259367351, **Name:** Apple MacBook Air (2024) M3 OC 8 Core GPU 8GB 256GB SSD 13.6\"\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "\n",
+      "Observation: \u001b[33;1m\u001b[1;3mHere is the final output from executing the plan:\n",
+      "\n",
+      "**Product IDs and Names:**\n",
+      "\n",
+      "1. **ID:** 3200009205, **Name:** Apple MacBook Air (2020) M1 OC 7C GPU 8GB 256GB SSD 13\"\n",
+      "2. **ID:** 3201585850, **Name:** Apple MacBook Air (2022) M2 OC 8C GPU 8GB 256GB SSD 13.6\"\n",
+      "3. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "4. **ID:** 3210594531, **Name:** Apple 2023 MacBook Pro Laptop M3\n",
+      "5. **ID:** 3259367351, **Name:** Apple MacBook Air (2024) M3 OC 8 Core GPU 8GB 256GB SSD 13.6\"\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mI'm finished executing a plan and have the information the user asked for.\n",
+      "\n",
+      "Final Answer: Here are the 5 laptop products in the US: \n",
+      "\n",
+      "**Product IDs and Names:**\n",
+      "1. **ID:** 3200009205, **Name:** Apple MacBook Air (2020) M1 OC 7C GPU 8GB 256GB SSD 13\"\n",
+      "2. **ID:** 3201585850, **Name:** Apple MacBook Air (2022) M2 OC 8C GPU 8GB 256GB SSD 13.6\"\n",
+      "3. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "4. **ID:** 3210594531, **Name:** Apple 2023 MacBook Pro Laptop M3\n",
+      "5. **ID:** 3259367351, **Name:** Apple MacBook Air (2024) M3 OC 8 Core GPU 8GB 256GB SSD 13.6\"\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'input': 'Please list 5 laptop products in US for me.',\n",
+       " 'history': '',\n",
+       " 'output': 'Here are the 5 laptop products in the US: \\n\\n**Product IDs and Names:**\\n1. **ID:** 3200009205, **Name:** Apple MacBook Air (2020) M1 OC 7C GPU 8GB 256GB SSD 13\"\\n2. **ID:** 3201585850, **Name:** Apple MacBook Air (2022) M2 OC 8C GPU 8GB 256GB SSD 13.6\"\\n3. **ID:** 3210938897, **Name:** HP 17-cn2000nr\\n4. **ID:** 3210594531, **Name:** Apple 2023 MacBook Pro Laptop M3\\n5. **ID:** 3259367351, **Name:** Apple MacBook Air (2024) M3 OC 8 Core GPU 8GB 256GB SSD 13.6\"'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "user_query = \"Please list 5 laptop products in US for me.\"\n",
+    "klarna_agent.invoke(user_query)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3113f7b-cda5-449b-b714-c012ff25ef4a",
+   "metadata": {},
+   "source": [
+    "### 2nd Round\n",
+    "\n",
+    "Next, we add a search constraint.\n",
+    "The agent will resolve a new search based on the chat history and the new requirement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "afa6475d-39aa-457c-99d5-fcb5b364996b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mThought: I should plan API calls first to search for laptop products in the US with a maximum price of $500.\n",
+      "\n",
+      "Action: api_planner\n",
+      "Action Input: I need to find the right API calls to search for laptop products in the US with a maximum price of $500\u001b[0m\n",
+      "Observation: \u001b[36;1m\u001b[1;3mI can help with that!\n",
+      "\n",
+      "Since the user query is to search for laptop products in the US with a maximum price of $500, I can generate a plan of API calls to assist with this query.\n",
+      "\n",
+      "Plan:\n",
+      "\n",
+      "1. GET /public/openai/v0/products with a query parameter to filter laptop products in the US with a maximum price of $500.\n",
+      "\n",
+      "This API call will retrieve a list of laptop products that match the specified criteria. Since the API endpoint does not provide a way to filter by price, we cannot guarantee that the results will be within the $500 budget. However, we can try to retrieve the list of laptop products and then filter the results on the client-side to meet the user's requirements.\n",
+      "\n",
+      "Note: The API endpoint does not provide a way to filter by price, so we may need to retrieve a larger list of products and then filter on the client-side. If the user requires a more precise filtering mechanism, we may need to consider alternative API endpoints or modify the existing API to support price filtering.\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mI'm ready to execute the API calls.\n",
+      "\n",
+      "Action: api_controller\n",
+      "Action Input: 1) GET /public/openai/v0/products with a query parameter to filter laptop products in the US with a maximum price of $500\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3mThought: I need to construct the input for the `requests_get` tool to execute the GET request to retrieve laptop products in the US with a maximum price of $500.\n",
+      "\n",
+      "Action: requests_get\n",
+      "Action Input: {\"url\": \"https://www.klarna.com/us/shopping/public/openai/v0/products\", \"params\": {\"countryCode\": \"US\", \"q\": \"laptop\", \"size\": 5, \"max_price\": 500}, \"output_instructions\": \"extract product ids and names\"}\n",
+      "\n",
+      "Please let me know when to proceed with the action.\u001b[0m\n",
+      "Observation: \u001b[36;1m\u001b[1;3mBased on the provided API response, I will extract the product IDs and names as follows:\n",
+      "\n",
+      "**Product IDs and Names:**\n",
+      "\n",
+      "1. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "2. **ID:** 3207475444, **Name:** HP Newest 14\" Ultral Light Laptop for Students and Business, Intel Quad-Core N4120, 8GB RAM, 192GB Storage(64GB eMMC+128GB Micro SD), 1 Year Office 365, Webcam, HDMI, WiFi, USB- A&C, Win 11 S\n",
+      "3. **ID:** 3208117416, **Name:** HP Stream 14-cf2111wm\n",
+      "4. **ID:** 3223050056, **Name:** HP 15.6\" HD Touchscreen, Intel Core i3-1115G4 Processor, 32GB RAM, 1TB PCIe SSD, Webcam, Type-C, HDMI, SD Card Reader, Wi-Fi, Windows 11 Home, Silver\n",
+      "5. **ID:** 3221319441, **Name:** Acer Chromebook 315 CB315-4H-C7A1\n",
+      "\n",
+      "Note that the product IDs are extracted from the URL of each product, and the names are extracted from the \"name\" field in the API response.\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mThought: I have successfully executed the plan and retrieved the list of laptop products in the US with a maximum price of $500. The observation shows the extracted product IDs and names. Since I have completed the plan, I will provide the final answer.\n",
+      "\n",
+      "Final Answer: \n",
+      "**Product IDs and Names:**\n",
+      "1. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "2. **ID:** 3207475444, **Name:** HP Newest 14\" Ultral Light Laptop for Students and Business, Intel Quad-Core N4120, 8GB RAM, 192GB Storage(64GB eMMC+128GB Micro SD), 1 Year Office 365, Webcam, HDMI, WiFi, USB- A&C, Win 11 S\n",
+      "3. **ID:** 3208117416, **Name:** HP Stream 14-cf2111wm\n",
+      "4. **ID:** 3223050056, **Name:** HP 15.6\" HD Touchscreen, Intel Core i3-1115G4 Processor, 32GB RAM, 1TB PCIe SSD, Webcam, Type-C, HDMI, SD Card Reader, Wi-Fi, Windows 11 Home, Silver\n",
+      "5. **ID:** 3221319441, **Name:** Acer Chromebook 315 CB315-4H-C7A1\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "\n",
+      "Observation: \u001b[33;1m\u001b[1;3m**Product IDs and Names:**\n",
+      "1. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "2. **ID:** 3207475444, **Name:** HP Newest 14\" Ultral Light Laptop for Students and Business, Intel Quad-Core N4120, 8GB RAM, 192GB Storage(64GB eMMC+128GB Micro SD), 1 Year Office 365, Webcam, HDMI, WiFi, USB- A&C, Win 11 S\n",
+      "3. **ID:** 3208117416, **Name:** HP Stream 14-cf2111wm\n",
+      "4. **ID:** 3223050056, **Name:** HP 15.6\" HD Touchscreen, Intel Core i3-1115G4 Processor, 32GB RAM, 1TB PCIe SSD, Webcam, Type-C, HDMI, SD Card Reader, Wi-Fi, Windows 11 Home, Silver\n",
+      "5. **ID:** 3221319441, **Name:** Acer Chromebook 315 CB315-4H-C7A1\u001b[0m\n",
+      "Thought:\u001b[32;1m\u001b[1;3mI am finished executing a plan and have the information the user asked for.\n",
+      "\n",
+      "Final Answer: Here are the 5 laptop products in the US with a maximum price of $500: \n",
+      "\n",
+      "**Product IDs and Names:**\n",
+      "1. **ID:** 3210938897, **Name:** HP 17-cn2000nr\n",
+      "2. **ID:** 3207475444, **Name:** HP Newest 14\" Ultral Light Laptop for Students and Business, Intel Quad-Core N4120, 8GB RAM, 192GB Storage(64GB eMMC+128GB Micro SD), 1 Year Office 365, Webcam, HDMI, WiFi, USB- A&C, Win 11 S\n",
+      "3. **ID:** 3208117416, **Name:** HP Stream 14-cf2111wm\n",
+      "4. **ID:** 3223050056, **Name:** HP 15.6\" HD Touchscreen, Intel Core i3-1115G4 Processor, 32GB RAM, 1TB PCIe SSD, Webcam, Type-C, HDMI, SD Card Reader, Wi- Fi, Windows 11 Home, Silver\n",
+      "5. **ID:** 3221319441, **Name:** Acer Chromebook 315 CB315-4H-C7A1\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'input': 'Please search again with a maximum price of $500.',\n",
+       " 'history': 'User: Please list 5 laptop products in US for me.\\nAssistance: Here are the 5 laptop products in the US: \\n\\n**Product IDs and Names:**\\n1. **ID:** 3200009205, **Name:** Apple MacBook Air (2020) M1 OC 7C GPU 8GB 256GB SSD 13\"\\n2. **ID:** 3201585850, **Name:** Apple MacBook Air (2022) M2 OC 8C GPU 8GB 256GB SSD 13.6\"\\n3. **ID:** 3210938897, **Name:** HP 17-cn2000nr\\n4. **ID:** 3210594531, **Name:** Apple 2023 MacBook Pro Laptop M3\\n5. **ID:** 3259367351, **Name:** Apple MacBook Air (2024) M3 OC 8 Core GPU 8GB 256GB SSD 13.6\"',\n",
+       " 'output': 'Here are the 5 laptop products in the US with a maximum price of $500: \\n\\n**Product IDs and Names:**\\n1. **ID:** 3210938897, **Name:** HP 17-cn2000nr\\n2. **ID:** 3207475444, **Name:** HP Newest 14\" Ultral Light Laptop for Students and Business, Intel Quad-Core N4120, 8GB RAM, 192GB Storage(64GB eMMC+128GB Micro SD), 1 Year Office 365, Webcam, HDMI, WiFi, USB- A&C, Win 11 S\\n3. **ID:** 3208117416, **Name:** HP Stream 14-cf2111wm\\n4. **ID:** 3223050056, **Name:** HP 15.6\" HD Touchscreen, Intel Core i3-1115G4 Processor, 32GB RAM, 1TB PCIe SSD, Webcam, Type-C, HDMI, SD Card Reader, Wi- Fi, Windows 11 Home, Silver\\n5. **ID:** 3221319441, **Name:** Acer Chromebook 315 CB315-4H-C7A1'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "user_query = \"Please search again with a maximum price of $500.\"\n",
+    "klarna_agent.invoke(user_query)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "461229e4",
    "metadata": {},
    "source": [
-    "## 2nd example: \"json explorer\" agent\n",
+    "## 3rd example: \"json explorer\" agent\n",
     "\n",
     "Here's an agent that's not particularly practical, but neat! The agent has access to 2 toolkits. One comprises tools to interact with json: one tool to list the keys of a json object and another tool to get the value for a given key. The other toolkit comprises `requests` wrappers to send GET and POST requests. This agent consumes a lot calls to the language model, but does a surprisingly decent job.\n"
    ]

--- a/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
@@ -61,6 +61,12 @@ Here are endpoints you can use. Do not reference any of the endpoints above.
 
 ----
 
+Take care of the following chat history. You should always make a new plan based on the previous conversations with user.
+
+{history}
+
+----
+
 User query: {query}
 Plan:"""
 API_PLANNER_TOOL_NAME = "api_planner"
@@ -79,6 +85,13 @@ Endpoints:
 
 Here are tools to execute requests against the API: {tool_descriptions}
 
+----
+
+Take care of the following chat history. You should always make a new plan based on the previous conversations with user.
+
+{history}
+
+----
 
 Starting below, you should follow this format:
 
@@ -113,6 +126,13 @@ You should never return information without executing the api_controller tool.
 
 Here are the tools to plan and execute API requests: {tool_descriptions}
 
+----
+
+Take care of the following chat history. You should always make a new plan based on the previous conversations with user.
+
+{history}
+
+----
 
 Starting below, you should follow this format:
 

--- a/libs/community/langchain_community/agent_toolkits/openapi/spec.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/spec.py
@@ -23,7 +23,9 @@ class ReducedOpenAPISpec:
     endpoints: List[Tuple[str, str, dict]]
 
 
-def reduce_openapi_spec(spec: dict, dereference: bool = True) -> ReducedOpenAPISpec:
+def reduce_openapi_spec(
+    spec: dict, dereference: bool = True, include_optional_params: bool = False
+) -> ReducedOpenAPISpec:
     """Simplify/distill/minify a spec somehow.
 
     I want a smaller target for retrieval and (more importantly)
@@ -56,7 +58,7 @@ def reduce_openapi_spec(spec: dict, dereference: bool = True) -> ReducedOpenAPIS
             out["parameters"] = [
                 parameter
                 for parameter in docs.get("parameters", [])
-                if parameter.get("required")
+                if parameter.get("required") or include_optional_params
             ]
         if "200" in docs["responses"]:
             out["responses"] = docs["responses"]["200"]


### PR DESCRIPTION
**Description:**

Dear LangChain team.

Thanks for your fantastic framework. LangChain enables us to build innovative LLM applications. While utilizing OpenAPI toolkit from the LangChain community package, I encountered a limitation with the OpenAPI planner agent: it cannot retain information about previous user queries and responses. If users want to add a constraint or requirement to their previous query, they must restate a new query instead of simply mentioning the new condition. I believe the latter approach is more natural and closer to real-world conversations.

For example, let's say I'm searching for laptop products from Klarna, and I initially ask: `Please list 5 laptops in US for me`. Without memory, if I want to add a price constraint, I will need to repeat my initial query and specify the price range: `Please list 5 laptops with a maximum price of $500 in US for me`. However, with memory functionality, I can just continue the conversation by asking: `Please search again with a maximum price of $500.`

This pull request made the following changes:
- Added a `{history}` section to the OpenAPI planner prompts to store chat history.
- If the `shared_memory` parameter is assigned to `create_openapi_agent`:
  - The provided memory object is passed to the root agent of OpenAPI planner to store the chat history with the user.
  - A read-only memory, wrapped from the given memory, is passed to the planner and controller to ensure the chat history remains unchanged during the planning progress.
- Introduced `include_optional_params` as an optional parameter of `reduce_openapi_spec` with a default value of `False`. When set to `True`, optional parameters of OpenAPI endpoints are included in the generated API documentation, allowing LLMs to leverage optional endpoint parameters.
- Added an example showcasing the interaction with memory-enabled OpenAPI planner to the existing OpenAPI toolkit example: `docs/docs/integrations/toolkits/openapi.ipynb`

**Issue:**

None

**Dependencies:**

None

**Twitter handle:**

None