### PR TITLE
Experimental: Repair parsed_json errors made by LLMs, e.g Llama3:8b and Mistral:7b when converting documents into graph nodes.

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -509,6 +509,54 @@ def _convert_to_graph_document(
     return _format_nodes(nodes), _format_relationships(relationships)
 
 
+def _repair_response(json: list[dict]) -> list[dict]:
+    def flatten_nested_lists(data: Any) -> Any:
+        if isinstance(data, list):
+            while isinstance(data, list):
+                data = data[0]
+        return data
+
+    # If the json is nested
+    while isinstance(json, list) and isinstance(json[0], list):
+        json = json[0]
+
+    # Remove any None types, empty strings, and flatten nested lists
+    for rel in json:
+        rel["head"] = flatten_nested_lists(rel.get("head"))
+        rel["head_type"] = flatten_nested_lists(rel.get("head_type"))
+        rel["tail"] = flatten_nested_lists(rel.get("tail"))
+        rel["tail_type"] = flatten_nested_lists(rel.get("tail_type"))
+        rel["relation"] = flatten_nested_lists(rel.get("relation"))
+
+        rel["tail"] = (
+            rel["tail"]
+            if rel.get("tail") is not None and rel.get("tail") != ""
+            else "None"
+        )
+        rel["tail_type"] = (
+            rel["tail_type"]
+            if rel.get("tail_type") is not None and rel.get("tail_type") != ""
+            else "None"
+        )
+        rel["head"] = (
+            rel["head"]
+            if rel.get("head") is not None or rel.get("head") != ""
+            else "None"
+        )
+        rel["head_type"] = (
+            rel["head_type"]
+            if rel.get("head_type") is not None and rel.get("head_type") != ""
+            else "None"
+        )
+        rel["relation"] = (
+            rel["relation"]
+            if rel.get("relation") is not None and rel.get("relation") != ""
+            else "None"
+        )
+
+    return json
+
+
 class LLMGraphTransformer:
     """Transform documents into graph-based documents using a LLM.
 
@@ -612,6 +660,7 @@ class LLMGraphTransformer:
             if not isinstance(raw_schema, str):
                 raw_schema = raw_schema.content
             parsed_json = self.json_repair.loads(raw_schema)
+            parsed_json = _repair_response(parsed_json)
             for rel in parsed_json:
                 # Nodes need to be deduplicated using a set
                 nodes_set.add((rel["head"], rel["head_type"]))


### PR DESCRIPTION
- [ ] **Repair parsed_json dictionary mistakes made by LLMs, e.g Llama3 and Mistral**: "Experimental: Added a __repair_response_ function for the "parsed_json" output"


- [ ] **PR message**:
    - **Description:** The __repair_response_ function checks if the parsed_json has any nested lists, and flattens them into a singular list, moreover, since the nodes cannot hash "List" type, only the first instance of the list is chosen, and the List is then discarded. Moreover, the function also converts any None types into "None", and any empty strings into "None" as well. This is because the node system None type is invalid and neo4j does not allow for empty strings. (Tested for LLama3:8b and Mistral:7b)
    - **Issue:** The LLM output for "process_response()" is unpredictable and not very robust. Different models yield different output structures. When tested for gemma:2b, a properties key is sometimes added making the dictionary parsing fail. For mistral:7b and Llama3:8b, None types, empty strings, and nested lists are sometimes added. To mitigate the latter part, i created a function that parses the "parsed_json" dictionary and removes any; Nested lists: taking the first value instead, None types: converting into "None", and lastly any empty strings: also converting into "None".

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
