### PR TITLE
docs: fix function name in tutorials/agents.ipynb

### DIFF
--- a/docs/docs/tutorials/agents.ipynb
+++ b/docs/docs/tutorials/agents.ipynb
@@ -383,7 +383,7 @@
    "source": [
     "Now, we can initalize the agent with the LLM and the tools.\n",
     "\n",
-    "Note that we are passing in the `model`, not `model_with_tools`. That is because `create_tool_calling_executor` will call `.bind_tools` for us under the hood."
+    "Note that we are passing in the `model`, not `model_with_tools`. That is because `create_react_agent` will call `.bind_tools` for us under the hood."
    ]
   },
   {


### PR DESCRIPTION
the function called in the following example is  `create_react_agent`, not `create_tool_calling_executor `