### PR TITLE
community[patch]: bugfix for `YoutubeLoader`'s `LINES` format

### DIFF
--- a/libs/community/langchain_community/document_loaders/youtube.py
+++ b/libs/community/langchain_community/document_loaders/youtube.py
@@ -282,11 +282,11 @@ class YoutubeLoader(BaseLoader):
                 map(
                     lambda transcript_piece: Document(
                         page_content=transcript_piece["text"].strip(" "),
-                        metadata={
+                        metadata=dict(
                             filter(
                                 lambda item: item[0] != "text", transcript_piece.items()
                             )
-                        },
+                        ),
                     ),
                     transcript_pieces,
                 )


### PR DESCRIPTION
- **Description:** A change I submitted recently introduced a bug in `YoutubeLoader`'s `LINES` output format.  In those conditions, curly braces ("`{}`") creates a set, not a dictionary.  This bugfix explicitly specifies that a dictionary is created.
- **Issue:** N/A
- **Dependencies:** N/A
- **Twitter:** lsloan_umich
- **Mastodon:** [lsloan@mastodon.social](https://mastodon.social/@lsloan)