### PR TITLE
docs: Fix typo in import statement

### DIFF
--- a/docs/docs/tutorials/rag.ipynb
+++ b/docs/docs/tutorials/rag.ipynb
@@ -765,7 +765,7 @@
     }
    ],
    "source": [
-    "from langchain.chains import create_retrieval_chain\n",
+    "from langchain.chains.retrieval import create_retrieval_chain\n",
     "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",
     "\n",


### PR DESCRIPTION

  - **Description:** Fixed import statement by adding .retreival
  - **Issue:**  #22826
