### PR TITLE
experimental[patch]/docs[patch]: Update links to security docs

### DIFF
--- a/docs/docs/how_to/tools_builtin.ipynb
+++ b/docs/docs/how_to/tools_builtin.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "When using 3rd party tools, make sure that you understand how the tool works, what permissions\n",
     "it has. Read over its documentation and check if anything is required from you\n",
-    "from a security point of view. Please see our [security](https://python.langchain.com/v0.1/docs/security/) \n",
+    "from a security point of view. Please see our [security](https://python.langchain.com/v0.2/docs/security/) \n",
     "guidelines for more information.\n",
     "\n",
     ":::\n",

--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py
@@ -252,7 +252,7 @@ def create_pandas_dataframe_agent(
             "doc-string of this function. You must opt-in to use this functionality "
             "by setting allow_dangerous_code=True."
             "For general security guidelines, please see: "
-            "https://python.langchain.com/v0.1/docs/security/"
+            "https://python.langchain.com/v0.2/docs/security/"
         )
     try:
         if engine == "modin":

--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/spark/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/spark/base.py
@@ -78,7 +78,7 @@ def create_spark_dataframe_agent(
             "doc-string of this function. You must opt-in to use this functionality "
             "by setting allow_dangerous_code=True."
             "For general security guidelines, please see: "
-            "https://python.langchain.com/v0.1/docs/security/"
+            "https://python.langchain.com/v0.2/docs/security/"
         )
 
     if not _validate_spark_df(df) and not _validate_spark_connect_df(df):

--- a/libs/experimental/langchain_experimental/agents/agent_toolkits/xorbits/base.py
+++ b/libs/experimental/langchain_experimental/agents/agent_toolkits/xorbits/base.py
@@ -65,7 +65,7 @@ def create_xorbits_agent(
             "doc-string of this function. You must opt-in to use this functionality "
             "by setting allow_dangerous_code=True."
             "For general security guidelines, please see: "
-            "https://python.langchain.com/v0.1/docs/security/"
+            "https://python.langchain.com/v0.2/docs/security/"
         )
 
     try:


### PR DESCRIPTION
Minor update to newest version of security docs (content should be identical).
