### PR TITLE
community: Overhaul Databricks components documentation

### DIFF
--- a/docs/docs/integrations/chat/databricks.ipynb
+++ b/docs/docs/integrations/chat/databricks.ipynb
@@ -36,7 +36,7 @@
     "### Model features\n",
     "| [Tool calling](/docs/how_to/tool_calling/) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
     "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
-    "| /❌ | ❌ | ❌ | ❌ | ❌ | ❌ |  ✅ | ✅ | ✅ | ❌ | \n",
+    "| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |  ✅ | ✅ | ✅ | ❌ | \n",
     "\n",
     "### Supported Methods\n",
     "\n",

--- a/docs/docs/integrations/chat/databricks.ipynb
+++ b/docs/docs/integrations/chat/databricks.ipynb
@@ -19,11 +19,14 @@
    "source": [
     "# ChatDatabricks\n",
     "\n",
+    "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform. \n",
+    "\n",
     "This notebook provides a quick overview for getting started with Databricks [chat models](/docs/concepts/#chat-models). For detailed documentation of all ChatDatabricks features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.databricks.ChatDatabricks.html).\n",
     "\n",
-    "[Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform. `ChatDatabricks` class wraps a chat model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a chat model in your LangChain application.\n",
-    "\n",
     "## Overview\n",
+    "\n",
+    "`ChatDatabricks` class wraps a chat model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a chat model in your LangChain application.\n",
+    "\n",
     "### Integration details\n",
     "\n",
     "| Class | Package | Local | Serializable | Package downloads | Package latest |\n",
@@ -33,7 +36,21 @@
     "### Model features\n",
     "| [Tool calling](/docs/how_to/tool_calling/) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
     "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
-    "| /❌ | ❌ | ❌ | ❌ | ❌ | ❌ |  ✅ | ✅ | ✅ | ❌ | \n"
+    "| /❌ | ❌ | ❌ | ❌ | ❌ | ❌ |  ✅ | ✅ | ✅ | ❌ | \n",
+    "\n",
+    "### Supported Methods\n",
+    "\n",
+    "`ChatDatabricks` supports all methods of `ChatModel` including async APIs.\n",
+    "\n",
+    "\n",
+    "### Endpoint Requirement\n",
+    "\n",
+    "The serving endpoint `ChatDatabricks` wraps must have OpenAI-compatible chat input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#chat)). As long as the input format is compatible, `ChatDatabricks` can be used for any endpoint type hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html):\n",
+    "\n",
+    "1. Foundation Models - Curated list of state-of-the-art foundation models such as DRBX, Llama3, Mixtral-8x7B, and etc. These endpoint are ready to use in your Databricks workspace without any set up.\n",
+    "2. Custom Models - You can also deploy custom models to a serving endpoint via MLflow with\n",
+    "your choice of framework such as LangChain, Pytorch, Transformers, etc.\n",
+    "3. External Models - Databricks endpoints can serve models that are hosted outside Databricks as a proxy, such as proprietary model service like OpenAI GPT4.\n"
    ]
   },
   {
@@ -48,7 +65,7 @@
     "\n",
     "To access Databricks models you'll need to create a Databricks account, set up credentials (only if you are outside Databricks workspace), and install required packages.\n",
     "\n",
-    "## Credentials (only if you are outside Databricks)\n",
+    "### Credentials (only if you are outside Databricks)\n",
     "\n",
     "If you are running LangChain app inside Databricks, you can skip this step.\n",
     "\n",
@@ -92,25 +109,6 @@
    "outputs": [],
    "source": [
     "%pip install -qU langchain-community mlflow>=2.9.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Supported Methods\n",
-    "\n",
-    "`ChatDatabricks` supports all methods of `ChatModel` including async APIs.\n",
-    "\n",
-    "\n",
-    "### Endpoint Requirement\n",
-    "\n",
-    "The serving endpoint `ChatDatabricks` wraps must have OpenAI-compatible chat input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#chat)). As long as the input format is compatible, `ChatDatabricks` can be used for any endpoint type hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html):\n",
-    "\n",
-    "1. Foundation Models - Curated list of state-of-the-art foundation models such as DRBX, Llama3, Mixtral-8x7B, and etc. These endpoint are ready to use in your Databricks workspace without any set up.\n",
-    "2. Custom Models - You can also deploy custom models to a serving endpoint via MLflow with\n",
-    "your choice of framework such as LangChain, Pytorch, Transformers, etc.\n",
-    "3. External Models - Databricks endpoints can serve models that are hosted outside Databricks as a proxy, such as proprietary model service like OpenAI GPT4.\n"
    ]
   },
   {

--- a/docs/docs/integrations/chat/databricks.ipynb
+++ b/docs/docs/integrations/chat/databricks.ipynb
@@ -19,9 +19,21 @@
    "source": [
     "# ChatDatabricks\n",
     "\n",
-    "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
+    "This notebook provides a quick overview for getting started with Databricks [chat models](/docs/concepts/#chat-models). For detailed documentation of all ChatDatabricks features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.databricks.ChatDatabricks.html).\n",
     "\n",
-    "`ChatDatabricks` class wraps a chat model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a chat model in your LangChain application."
+    "[Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform. `ChatDatabricks` class wraps a chat model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a chat model in your LangChain application.\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "| Class | Package | Local | Serializable | Package downloads | Package latest |\n",
+    "| :--- | :--- | :---: | :---: |  :---: | :---: |\n",
+    "| [ChatDatabricks](https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.databricks.ChatDatabricks.html) | [langchain-community](https://api.python.langchain.com/en/latest/community_api_reference.html) | ❌ | beta | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-community?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-community?style=flat-square&label=%20) |\n",
+    "\n",
+    "### Model features\n",
+    "| [Tool calling](/docs/how_to/tool_calling/) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
+    "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
+    "| /❌ | ❌ | ❌ | ❌ | ❌ | ❌ |  ✅ | ✅ | ✅ | ❌ | \n"
    ]
   },
   {
@@ -34,23 +46,8 @@
    "source": [
     "## Setup\n",
     "\n",
-    "`mlflow >= 2.9 ` is required to run the code in this notebook. If it's not installed, please install it using this command:\n",
+    "To access Databricks models you'll need to create a Databricks account, set up credentials (only if you are outside Databricks workspace), and install required packages.\n",
     "\n",
-    "```sh\n",
-    "pip install mlflow>=2.9\n",
-    "```\n",
-    "\n",
-    "Also, `ChatDatabricks` reside in the LangChain community package, so please install it as well if you haven't installed it.\n",
-    "\n",
-    "```sh\n",
-    "pip install langchain-community\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Credentials (only if you are outside Databricks)\n",
     "\n",
     "If you are running LangChain app inside Databricks, you can skip this step.\n",
@@ -83,8 +80,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Usage\n",
+    "### Installation\n",
     "\n",
+    "The LangChain Databricks integration lives in the `langchain-community` package. Also, `mlflow >= 2.9 ` is required to run the code in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-community mlflow>=2.9.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Supported Methods\n",
     "\n",
     "`ChatDatabricks` supports all methods of `ChatModel` including async APIs.\n",
@@ -188,6 +201,52 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Chaining\n",
+    "Similar to other chat models, `ChatDatabricks` can be used as a part of a complex chain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=\"Unity Catalog is a new data catalog feature in Databricks that allows you to discover, manage, and govern all your data assets across your data landscape, including data lakes, data warehouses, and data marts. It provides a centralized repository for storing and managing metadata, data lineage, and access controls for all your data assets. Unity Catalog enables data teams to easily discover and access the data they need, while ensuring compliance with data privacy and security regulations. It is designed to work seamlessly with Databricks' Lakehouse platform, providing a unified experience for managing and analyzing all your data.\", response_metadata={'prompt_tokens': 32, 'completion_tokens': 118, 'total_tokens': 150}, id='run-82d72624-f8df-4c0d-a976-919feec09a55-0')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\n",
+    "            \"system\",\n",
+    "            \"You are a chatbot that can answer questions about {topic}.\",\n",
+    "        ),\n",
+    "        (\"user\", \"{question}\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "chain = prompt | chat_model\n",
+    "chain.invoke(\n",
+    "    {\n",
+    "        \"topic\": \"Databricks\",\n",
+    "        \"question\": \"What is Unity Catalog?\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Invocation (streaming)\n",
     "\n",
     "`ChatDatabricks` supports streaming response by `stream` method since `langchain-community>=0.2.1`."
@@ -235,53 +294,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Chaining\n",
-    "Similar to other chat models, `ChatDatabricks` can be used as a part of a complex chain."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AIMessage(content=\"Unity Catalog is a new data catalog feature in Databricks that allows you to discover, manage, and govern all your data assets across your data landscape, including data lakes, data warehouses, and data marts. It provides a centralized repository for storing and managing metadata, data lineage, and access controls for all your data assets. Unity Catalog enables data teams to easily discover and access the data they need, while ensuring compliance with data privacy and security regulations. It is designed to work seamlessly with Databricks' Lakehouse platform, providing a unified experience for managing and analyzing all your data.\", response_metadata={'prompt_tokens': 32, 'completion_tokens': 118, 'total_tokens': 150}, id='run-82d72624-f8df-4c0d-a976-919feec09a55-0')"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from langchain_core.prompts import ChatPromptTemplate\n",
-    "\n",
-    "prompt = ChatPromptTemplate.from_messages(\n",
-    "    [\n",
-    "        (\n",
-    "            \"system\",\n",
-    "            \"You are a chatbot that can answer questions about {topic}.\",\n",
-    "        ),\n",
-    "        (\"user\", \"{question}\"),\n",
-    "    ]\n",
-    ")\n",
-    "\n",
-    "chain = prompt | chat_model\n",
-    "chain.invoke(\n",
-    "    {\n",
-    "        \"topic\": \"Databricks\",\n",
-    "        \"question\": \"What is Unity Catalog?\",\n",
-    "    }\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Wrapping Custom Model Endpoint\n",
+    "## Wrapping Custom Model Endpoint\n",
     "\n",
     "Prerequisites:\n",
     "\n",
@@ -316,14 +329,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Wrapping External Models"
+    "## Wrapping External Models"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create Proxy Endpoint\n",
+    "Prerequisite: Create Proxy Endpoint\n",
     "\n",
     "First, create a new Databricks serving endpoint that proxies requests to the target external model. The endpoint creation should be fairy quick for proxying external models.\n",
     "\n",
@@ -373,7 +386,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Invocation\n",
     "Once the endpoint status has become \"Ready\", you can query the endpoint in the same way as other types of endpoints."
    ]
   },
@@ -389,6 +401,15 @@
     "    max_tokens=256,\n",
     ")\n",
     "chat_model_external.invoke(\"How to use Databricks?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For detailed documentation of all ChatDatabricks features and configurations head to the API reference: https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.ChatDatabricks.html"
    ]
   }
  ],

--- a/docs/docs/integrations/chat/databricks.ipynb
+++ b/docs/docs/integrations/chat/databricks.ipynb
@@ -75,7 +75,7 @@
     "import getpass\n",
     "import os\n",
     "\n",
-    "os.environ[\"DATABRICKS_HOST\"] = \"YOUR_WORKSPACE_ENDPOINT\" # e.g. \"https://your-workspace.cloud.databricks.com\"\n",
+    "os.environ[\"DATABRICKS_HOST\"] = \"https://your-workspace.cloud.databricks.com\"\n",
     "os.environ[\"DATABRICKS_TOKEN\"] = getpass.getpass(\"Enter your Databricks access token: \")"
    ]
   },
@@ -178,14 +178,8 @@
    "source": [
     "# You can also pass a list of messages\n",
     "messages = [\n",
-    "    (\n",
-    "        \"system\",\n",
-    "        \"You are a chatbot that can answer questions about Databricks.\"\n",
-    "    ),\n",
-    "    (\n",
-    "        \"user\",\n",
-    "        \"What is Databricks Model Serving?\"\n",
-    "    )\n",
+    "    (\"system\", \"You are a chatbot that can answer questions about Databricks.\"),\n",
+    "    (\"user\", \"What is Databricks Model Serving?\"),\n",
     "]\n",
     "chat_model.invoke(messages)"
    ]
@@ -372,7 +366,7 @@
     "            }\n",
     "        ],\n",
     "    },\n",
-    ")\n"
+    ")"
    ]
   },
   {

--- a/docs/docs/integrations/chat/databricks.ipynb
+++ b/docs/docs/integrations/chat/databricks.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "---\n",
+    "sidebar_label: Databricks\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ChatDatabricks\n",
+    "\n",
+    "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
+    "\n",
+    "`ChatDatabricks` class wraps a chat model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a chat model in your LangChain application."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "`mlflow >= 2.9 ` is required to run the code in this notebook. If it's not installed, please install it using this command:\n",
+    "\n",
+    "```sh\n",
+    "pip install mlflow>=2.9\n",
+    "```\n",
+    "\n",
+    "Also, `ChatDatabricks` reside in the LangChain community package, so please install it as well if you haven't installed it.\n",
+    "\n",
+    "```sh\n",
+    "pip install langchain-community\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Credentials (only if you are outside Databricks)\n",
+    "\n",
+    "If you are running LangChain app inside Databricks, you can skip this step.\n",
+    "\n",
+    "Otherwise, you need manually set the Databricks workspace hostname and personal access token to `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables, respectively. See [Authentication Documentation](https://docs.databricks.com/en/dev-tools/auth/index.html#databricks-personal-access-tokens) for how to get an access token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter your Databricks access token:  ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"DATABRICKS_HOST\"] = \"YOUR_WORKSPACE_ENDPOINT\" # e.g. \"https://your-workspace.cloud.databricks.com\"\n",
+    "os.environ[\"DATABRICKS_TOKEN\"] = getpass.getpass(\"Enter your Databricks access token: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Usage\n",
+    "\n",
+    "### Supported Methods\n",
+    "\n",
+    "`ChatDatabricks` supports all methods of `ChatModel` including async APIs.\n",
+    "\n",
+    "\n",
+    "### Endpoint Requirement\n",
+    "\n",
+    "The serving endpoint `ChatDatabricks` wraps must have OpenAI-compatible chat input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#chat)). As long as the input format is compatible, `ChatDatabricks` can be used for any endpoint type hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html):\n",
+    "\n",
+    "1. Foundation Models - Curated list of state-of-the-art foundation models such as DRBX, Llama3, Mixtral-8x7B, and etc. These endpoint are ready to use in your Databricks workspace without any set up.\n",
+    "2. Custom Models - You can also deploy custom models to a serving endpoint via MLflow with\n",
+    "your choice of framework such as LangChain, Pytorch, Transformers, etc.\n",
+    "3. External Models - Databricks endpoints can serve models that are hosted outside Databricks as a proxy, such as proprietary model service like OpenAI GPT4.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first demonstrates how to query DBRX-instruct model hosted as Foundation Models endpoint with `ChatDatabricks`.\n",
+    "\n",
+    "For other type of endpoints, there are some difference in how to set up the endpoint itself, however, once the endpoint is ready, there is no difference in how to query it with `ChatDatabricks`. Please refer to the bottom of this notebook for the examples with other type of endpoints."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.chat_models import ChatDatabricks\n",
+    "\n",
+    "chat_model = ChatDatabricks(\n",
+    "    endpoint=\"databricks-dbrx-instruct\",\n",
+    "    temperature=0.1,\n",
+    "    max_tokens=256,\n",
+    "    # See https://api.python.langchain.com/en/latest/chat_models/langchain_community.chat_models.databricks.ChatDatabricks.html for other supported parameters\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Invocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content='MLflow is an open-source platform for managing end-to-end machine learning workflows. It was introduced by Databricks in 2018. MLflow provides tools for tracking experiments, packaging and sharing code, and deploying models. It is designed to work with any machine learning library and can be used in a variety of environments, including local machines, virtual machines, and cloud-based clusters. MLflow aims to streamline the machine learning development lifecycle, making it easier for data scientists and engineers to collaborate and deploy models into production.', response_metadata={'prompt_tokens': 229, 'completion_tokens': 104, 'total_tokens': 333}, id='run-d3fb4d06-3e10-4471-83c9-c282cc62b74d-0')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat_model.invoke(\"What is MLflow?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content='Databricks Model Serving is a feature of the Databricks platform that allows data scientists and engineers to easily deploy machine learning models into production. With Model Serving, you can host, manage, and serve machine learning models as APIs, making it easy to integrate them into applications and business processes. It supports a variety of popular machine learning frameworks, including TensorFlow, PyTorch, and scikit-learn, and provides tools for monitoring and managing the performance of deployed models. Model Serving is designed to be scalable, secure, and easy to use, making it a great choice for organizations that want to quickly and efficiently deploy machine learning models into production.', response_metadata={'prompt_tokens': 35, 'completion_tokens': 130, 'total_tokens': 165}, id='run-b3feea21-223e-4105-8627-41d647d5ccab-0')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# You can also pass a list of messages\n",
+    "messages = [\n",
+    "    (\n",
+    "        \"system\",\n",
+    "        \"You are a chatbot that can answer questions about Databricks.\"\n",
+    "    ),\n",
+    "    (\n",
+    "        \"user\",\n",
+    "        \"What is Databricks Model Serving?\"\n",
+    "    )\n",
+    "]\n",
+    "chat_model.invoke(messages)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Invocation (streaming)\n",
+    "\n",
+    "`ChatDatabricks` supports streaming response by `stream` method since `langchain-community>=0.2.1`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I|'m| an| AI| and| don|'t| have| feelings|,| but| I|'m| here| and| ready| to| assist| you|.| How| can| I| help| you| today|?||"
+     ]
+    }
+   ],
+   "source": [
+    "for chunk in chat_model.stream(\"How are you?\"):\n",
+    "    print(chunk.content, end=\"|\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Async Invocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "country = [\"Japan\", \"Italy\", \"Australia\"]\n",
+    "futures = [chat_model.ainvoke(f\"Where is the capital of {c}?\") for c in country]\n",
+    "await asyncio.gather(*futures)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chaining\n",
+    "Similar to other chat models, `ChatDatabricks` can be used as a part of a complex chain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=\"Unity Catalog is a new data catalog feature in Databricks that allows you to discover, manage, and govern all your data assets across your data landscape, including data lakes, data warehouses, and data marts. It provides a centralized repository for storing and managing metadata, data lineage, and access controls for all your data assets. Unity Catalog enables data teams to easily discover and access the data they need, while ensuring compliance with data privacy and security regulations. It is designed to work seamlessly with Databricks' Lakehouse platform, providing a unified experience for managing and analyzing all your data.\", response_metadata={'prompt_tokens': 32, 'completion_tokens': 118, 'total_tokens': 150}, id='run-82d72624-f8df-4c0d-a976-919feec09a55-0')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\n",
+    "            \"system\",\n",
+    "            \"You are a chatbot that can answer questions about {topic}.\",\n",
+    "        ),\n",
+    "        (\"user\", \"{question}\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "chain = prompt | chat_model\n",
+    "chain.invoke(\n",
+    "    {\n",
+    "        \"topic\": \"Databricks\",\n",
+    "        \"question\": \"What is Unity Catalog?\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Wrapping Custom Model Endpoint\n",
+    "\n",
+    "Prerequisites:\n",
+    "\n",
+    "* An LLM was registered and deployed to [a Databricks serving endpoint](https://docs.databricks.com/machine-learning/model-serving/index.html) via MLflow.\n",
+    "* You have [\"Can Query\" permission](https://docs.databricks.com/security/auth-authz/access-control/serving-endpoint-acl.html) to the endpoint.\n",
+    "\n",
+    "The expected MLflow model signature is:\n",
+    "\n",
+    "  * inputs: `[{\"name\": \"messages\", \"type\": \"string\"}, {\"name\": \"stop\", \"type\": \"list[string]\"}]`\n",
+    "  * outputs: `[{\"type\": \"string\"}]`\n",
+    "\n",
+    "\n",
+    "Once the endpoint is ready, the usage pattern is completely same as Foundation Models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_model_custom = ChatDatabricks(\n",
+    "    endpoint=\"YOUR_ENDPOINT_NAME\",\n",
+    "    temperature=0.1,\n",
+    "    max_tokens=256,\n",
+    ")\n",
+    "\n",
+    "chat_model_custom.invoke(\"How are you?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Wrapping External Models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Proxy Endpoint\n",
+    "\n",
+    "First, create a new Databricks serving endpoint that proxies requests to the target external model. The endpoint creation should be fairy quick for proxying external models.\n",
+    "\n",
+    "This requires registering OpenAI API Key in Databricks secret manager with the following comment:\n",
+    "```sh\n",
+    "# Replace `<scope>` with your scope\n",
+    "databricks secrets create-scope <scope>\n",
+    "databricks secrets put-secret <scope> openai-api-key --string-value $OPENAI_API_KEY\n",
+    "```\n",
+    "\n",
+    "For how to set up Databricks CLI and manage secrets, please refer to https://docs.databricks.com/en/security/secrets/secrets.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mlflow.deployments import get_deploy_client\n",
+    "\n",
+    "client = get_deploy_client(\"databricks\")\n",
+    "\n",
+    "secret = \"secrets/<scope>/openai-api-key\"  # replace `<scope>` with your scope\n",
+    "endpoint_name = \"my-chat\"  # rename this if my-chat already exists\n",
+    "client.create_endpoint(\n",
+    "    name=endpoint_name,\n",
+    "    config={\n",
+    "        \"served_entities\": [\n",
+    "            {\n",
+    "                \"name\": \"my-chat\",\n",
+    "                \"external_model\": {\n",
+    "                    \"name\": \"gpt-3.5-turbo\",\n",
+    "                    \"provider\": \"openai\",\n",
+    "                    \"task\": \"llm/v1/chat\",\n",
+    "                    \"openai_config\": {\n",
+    "                        \"openai_api_key\": \"{{\" + secret + \"}}\",\n",
+    "                    },\n",
+    "                },\n",
+    "            }\n",
+    "        ],\n",
+    "    },\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Invocation\n",
+    "Once the endpoint status has become \"Ready\", you can query the endpoint in the same way as other types of endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_model_external = ChatDatabricks(\n",
+    "    endpoint=endpoint_name,\n",
+    "    temperature=0.1,\n",
+    "    max_tokens=256,\n",
+    ")\n",
+    "chat_model_external.invoke(\"How to use Databricks?\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/docs/integrations/chat/databricks.ipynb
+++ b/docs/docs/integrations/chat/databricks.ipynb
@@ -296,14 +296,8 @@
     "\n",
     "Prerequisites:\n",
     "\n",
-    "* An LLM was registered and deployed to [a Databricks serving endpoint](https://docs.databricks.com/machine-learning/model-serving/index.html) via MLflow.\n",
+    "* An LLM was registered and deployed to [a Databricks serving endpoint](https://docs.databricks.com/machine-learning/model-serving/index.html) via MLflow. The endpoint must have OpenAI-compatible chat input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#chat))\n",
     "* You have [\"Can Query\" permission](https://docs.databricks.com/security/auth-authz/access-control/serving-endpoint-acl.html) to the endpoint.\n",
-    "\n",
-    "The expected MLflow model signature is:\n",
-    "\n",
-    "  * inputs: `[{\"name\": \"messages\", \"type\": \"string\"}, {\"name\": \"stop\", \"type\": \"list[string]\"}]`\n",
-    "  * outputs: `[{\"type\": \"string\"}]`\n",
-    "\n",
     "\n",
     "Once the endpoint is ready, the usage pattern is completely same as Foundation Models."
    ]
@@ -427,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/llms/databricks.ipynb
+++ b/docs/docs/integrations/llms/databricks.ipynb
@@ -9,6 +9,11 @@
     "\n",
     "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
     "\n",
+    "\n",
+    "This notebook provides a quick overview for getting started with Databricks [LLM models](https://python.langchain.com/v0.2/docs/concepts/#llms). For detailed documentation of all features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/llms/langchain_community.llms.databricks.Databricks.html).\n",
+    "\n",
+    "## Overview\n",
+    "\n",
     "`Databricks` LLM class wraps a completion endpoint hosted as either of these two endpoint types:\n",
     "\n",
     "* [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html), recommended for production and development,\n",
@@ -37,24 +42,9 @@
    "source": [
     "## Setup\n",
     "\n",
-    "`mlflow >= 2.9 ` is required to run the code in this notebook. If it's not installed, please install it using this command:\n",
+    "To access Databricks models you'll need to create a Databricks account, set up credentials (only if you are outside Databricks workspace), and install required packages.\n",
     "\n",
-    "```sh\n",
-    "pip install mlflow>=2.9\n",
-    "```\n",
-    "\n",
-    "Also, `Databricks` reside in the LangChain community package, so please install it as well if you haven't installed it.\n",
-    "\n",
-    "```sh\n",
-    "pip install langchain-community\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Credentials (only if you are outside Databricks)\n",
+    "### Credentials (only if you are outside Databricks)\n",
     "\n",
     "If you are running LangChain app inside Databricks, you can skip this step.\n",
     "\n",
@@ -96,6 +86,24 @@
     "    # to retrieve the access token that is available within the Databricks notebook.\n",
     "    token=dbutils.secrets.get(scope=\"YOUR_SECRET_SCOPE\", key=\"databricks-token\"),  # noqa: F821\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "The LangChain Databricks integration lives in the `langchain-community` package. Also, `mlflow >= 2.9 ` is required to run the code in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-community mlflow>=2.9.0"
    ]
   },
   {
@@ -247,33 +255,21 @@
     "\n",
     "The following is a minimal example for running a driver proxy app to serve an LLM:\n",
     "\n",
+    "```sh\n",
+    "pip install transformers\n",
+    "```\n",
+    "\n",
     "```python\n",
     "from flask import Flask, request, jsonify\n",
-    "import torch\n",
     "from transformers import pipeline, AutoTokenizer, StoppingCriteria\n",
     "\n",
     "model = \"databricks/dbrx-instruct\"\n",
     "tokenizer = AutoTokenizer.from_pretrained(model, padding_side=\"left\")\n",
     "dbrx = pipeline(model=model, tokenizer=tokenizer, trust_remote_code=True, device_map=\"auto\")\n",
-    "device = dbrx.device\n",
     "\n",
-    "class CheckStop(StoppingCriteria):\n",
-    "    def __init__(self, stop=None):\n",
-    "        super().__init__()\n",
-    "        self.stop = stop or []\n",
-    "        self.matched = \"\"\n",
-    "        self.stop_ids = [tokenizer.encode(s, return_tensors='pt').to(device) for s in self.stop]\n",
-    "    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs):\n",
-    "        for i, s in enumerate(self.stop_ids):\n",
-    "            if torch.all((s == input_ids[0][-s.shape[1]:])).item():\n",
-    "                self.matched = self.stop[i]\n",
-    "                return True\n",
-    "        return False\n",
-    "\n",
-    "def llm(prompt, stop=None, **kwargs):\n",
-    "  check_stop = CheckStop(stop)\n",
-    "  result = dbrx(prompt, stopping_criteria=[check_stop], **kwargs)\n",
-    "  return result[0][\"generated_text\"].rstrip(check_stop.matched)\n",
+    "def predict(prompt, stop=None, **kwargs):\n",
+    "  result = dbrx(prompt, **kwargs)\n",
+    "  return result[0][\"generated_text\"]\n",
     "\n",
     "app = Flask(\"dbrx\")\n",
     "\n",
@@ -333,30 +329,6 @@
     "# as well as Databricks workspace hostname and personal access token.\n",
     "\n",
     "llm = Databricks(cluster_id=\"0000-000000-xxxxxxxx\", cluster_driver_port=\"7777\")\n",
-    "\n",
-    "llm(\"How are you?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'I am very well. It is a pleasure to meet you.'"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# If the app accepts extra parameters like `temperature`,\n",
-    "# you can set them in `model_kwargs`.\n",
-    "llm = Databricks(cluster_driver_port=\"7777\", model_kwargs={\"temperature\": 0.1})\n",
     "\n",
     "llm(\"How are you?\")"
    ]

--- a/docs/docs/integrations/llms/databricks.ipynb
+++ b/docs/docs/integrations/llms/databricks.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "The `Databricks` LLM class is *legacy* implementation and has several limitations in the feature compatibility.\n",
     "\n",
-    "* Only supports synchronous invocation is supported. Streaming or async APIs are not supported.\n",
+    "* Only supports synchronous invocation. Streaming or async APIs are not supported.\n",
     "* `batch` API is not supported.\n",
     "\n",
     "To use those features, please use the new [ChatDatabricks](https://python.langchain.com/v0.2/docs/integrations/chat/databricks) class instead. `ChatDatabricks` supports all APIs of `ChatModel` including streaming, async, batch, etc.\n"
@@ -223,114 +223,6 @@
     ")\n",
     "\n",
     "llm.invoke(\"How are you?\")"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Wrapping a cluster driver proxy app\n",
-    "\n",
-    "Prerequisites:\n",
-    "\n",
-    "* An LLM loaded on a Databricks interactive cluster in \"single user\" or \"no isolation shared\" mode.\n",
-    "* A local HTTP server running on the driver node to serve the model at `\"/\"` using HTTP POST with JSON input/output.\n",
-    "* It uses a port number between `[3000, 8000]` and listens to the driver IP address or simply `0.0.0.0` instead of localhost only.\n",
-    "* You have \"Can Attach To\" permission to the cluster.\n",
-    "\n",
-    "The expected server schema (using JSON schema) is:\n",
-    "\n",
-    "* inputs:\n",
-    "  ```json\n",
-    "  {\"type\": \"object\",\n",
-    "   \"properties\": {\n",
-    "      \"prompt\": {\"type\": \"string\"},\n",
-    "       \"stop\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}}},\n",
-    "    \"required\": [\"prompt\"]}\n",
-    "  ```\n",
-    "* outputs: `{\"type\": \"string\"}`\n",
-    "\n",
-    "If the server schema is incompatible or you want to insert extra configs, you can use `transform_input_fn` and `transform_output_fn` accordingly.\n",
-    "\n",
-    "The following is a minimal example for running a driver proxy app to serve an LLM:\n",
-    "\n",
-    "```sh\n",
-    "pip install transformers\n",
-    "```\n",
-    "\n",
-    "```python\n",
-    "from flask import Flask, request, jsonify\n",
-    "from transformers import pipeline, AutoTokenizer, StoppingCriteria\n",
-    "\n",
-    "model = \"databricks/dbrx-instruct\"\n",
-    "tokenizer = AutoTokenizer.from_pretrained(model, padding_side=\"left\")\n",
-    "dbrx = pipeline(model=model, tokenizer=tokenizer, trust_remote_code=True, device_map=\"auto\")\n",
-    "\n",
-    "def predict(prompt, stop=None, **kwargs):\n",
-    "  result = dbrx(prompt, **kwargs)\n",
-    "  return result[0][\"generated_text\"]\n",
-    "\n",
-    "app = Flask(\"dbrx\")\n",
-    "\n",
-    "@app.route('/', methods=['POST'])\n",
-    "def serve_llm():\n",
-    "  resp = llm(**request.json)\n",
-    "  return jsonify(resp)\n",
-    "\n",
-    "app.run(host=\"0.0.0.0\", port=\"7777\")\n",
-    "```\n",
-    "\n",
-    "Once the server is running, you can create a `Databricks` instance to wrap it as an LLM."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Hello, thank you for asking. It is wonderful to hear that you are well.'"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# If running a Databricks notebook attached to the same cluster that runs the app,\n",
-    "# you only need to specify the driver port to create a `Databricks` instance.\n",
-    "llm = Databricks(cluster_driver_port=\"7777\")\n",
-    "\n",
-    "llm(\"How are you?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'I am well. You?'"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Otherwise, you can manually specify the cluster ID to use,\n",
-    "# as well as Databricks workspace hostname and personal access token.\n",
-    "\n",
-    "llm = Databricks(cluster_id=\"0000-000000-xxxxxxxx\", cluster_driver_port=\"7777\")\n",
-    "\n",
-    "llm(\"How are you?\")"
    ]
   }
  ],

--- a/docs/docs/integrations/llms/databricks.ipynb
+++ b/docs/docs/integrations/llms/databricks.ipynb
@@ -70,7 +70,7 @@
     "import getpass\n",
     "import os\n",
     "\n",
-    "os.environ[\"DATABRICKS_HOST\"] = \"YOUR_WORKSPACE_ENDPOINT\" # e.g. \"https://your-workspace.cloud.databricks.com\"\n",
+    "os.environ[\"DATABRICKS_HOST\"] = \"https://your-workspace.cloud.databricks.com\"\n",
     "os.environ[\"DATABRICKS_TOKEN\"] = getpass.getpass(\"Enter your Databricks access token: \")"
    ]
   },
@@ -94,7 +94,7 @@
     "    # We strongly recommend NOT to hardcode your access token in your code, instead use secret management tools\n",
     "    # or environment variables to store your access token securely. The following example uses Databricks Secrets\n",
     "    # to retrieve the access token that is available within the Databricks notebook.\n",
-    "    token=dbutils.secrets.get(scope=\"YOUR_SECRET_SCOPE\", key=\"databricks-token\")   # noqa: F821\n",
+    "    token=dbutils.secrets.get(scope=\"YOUR_SECRET_SCOPE\", key=\"databricks-token\"),  # noqa: F821\n",
     ")"
    ]
   },
@@ -195,6 +195,7 @@
     "# expects a different input schema and does not return a JSON string,\n",
     "# respectively, or you want to apply a prompt template on top.\n",
     "\n",
+    "\n",
     "def transform_input(**request):\n",
     "    full_prompt = f\"\"\"{request[\"prompt\"]}\n",
     "    Be Concise.\n",
@@ -208,7 +209,7 @@
     "\n",
     "\n",
     "llm = Databricks(\n",
-    "    endpoint_name=\"YOUR_ENDPOINT_NAME\"\n",
+    "    endpoint_name=\"YOUR_ENDPOINT_NAME\",\n",
     "    transform_input_fn=transform_input,\n",
     "    transform_output_fn=transform_output,\n",
     ")\n",

--- a/docs/docs/integrations/llms/databricks.ipynb
+++ b/docs/docs/integrations/llms/databricks.ipynb
@@ -7,31 +7,46 @@
    "source": [
     "# Databricks\n",
     "\n",
-    "The [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
+    "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
     "\n",
-    "This example notebook shows how to wrap Databricks endpoints as LLMs in LangChain.\n",
-    "It supports two endpoint types:\n",
+    "`Databricks` LLM class wraps a completion endpoint hosted as either of these two endpoint types:\n",
     "\n",
-    "* Serving endpoint, recommended for production and development,\n",
-    "* Cluster driver proxy app, recommended for interactive development."
+    "* [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html), recommended for production and development,\n",
+    "* Cluster driver proxy app, recommended for interactive development.\n",
+    "\n",
+    "This example notebook shows how to wrap your LLM endpoint and use it as an LLM in your LangChain application."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Installation\n",
+    "## Limitations\n",
+    "\n",
+    "The `Databricks` LLM class is *legacy* implementation and has several limitations in the feature compatibility.\n",
+    "\n",
+    "* Only supports synchronous invocation is supported. Streaming or async APIs are not supported.\n",
+    "* `batch` API is not supported.\n",
+    "\n",
+    "To use those features, please use the new [ChatDatabricks](https://python.langchain.com/v0.2/docs/integrations/chat/databricks) class instead. `ChatDatabricks` supports all APIs of `ChatModel` including streaming, async, batch, etc.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
     "\n",
     "`mlflow >= 2.9 ` is required to run the code in this notebook. If it's not installed, please install it using this command:\n",
     "\n",
-    "```\n",
+    "```sh\n",
     "pip install mlflow>=2.9\n",
     "```\n",
     "\n",
-    "Also, we need `dbutils` for this example.\n",
+    "Also, `Databricks` reside in the LangChain community package, so please install it as well if you haven't installed it.\n",
     "\n",
-    "```\n",
-    "pip install dbutils\n",
+    "```sh\n",
+    "pip install langchain-community\n",
     "```\n"
    ]
   },
@@ -39,109 +54,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Wrapping a serving endpoint: External model\n",
+    "## Credentials (only if you are outside Databricks)\n",
     "\n",
-    "Prerequisite: Register an OpenAI API key as a secret:\n",
+    "If you are running LangChain app inside Databricks, you can skip this step.\n",
     "\n",
-    "  ```bash\n",
-    "  databricks secrets create-scope <scope>\n",
-    "  databricks secrets put-secret <scope> openai-api-key --string-value $OPENAI_API_KEY\n",
-    "  ```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The following code creates a new serving endpoint with OpenAI's GPT-4 model for chat and generates a response using the endpoint."
+    "Otherwise, you need manually set the Databricks workspace hostname and personal access token to `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables, respectively. See [Authentication Documentation](https://docs.databricks.com/en/dev-tools/auth/index.html#databricks-personal-access-tokens) for how to get an access token."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "content='Hello! How can I assist you today?'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from langchain_community.chat_models import ChatDatabricks\n",
-    "from langchain_core.messages import HumanMessage\n",
-    "from mlflow.deployments import get_deploy_client\n",
+    "import getpass\n",
+    "import os\n",
     "\n",
-    "client = get_deploy_client(\"databricks\")\n",
-    "\n",
-    "secret = \"secrets/<scope>/openai-api-key\"  # replace `<scope>` with your scope\n",
-    "name = \"my-chat\"  # rename this if my-chat already exists\n",
-    "client.create_endpoint(\n",
-    "    name=name,\n",
-    "    config={\n",
-    "        \"served_entities\": [\n",
-    "            {\n",
-    "                \"name\": \"my-chat\",\n",
-    "                \"external_model\": {\n",
-    "                    \"name\": \"gpt-4\",\n",
-    "                    \"provider\": \"openai\",\n",
-    "                    \"task\": \"llm/v1/chat\",\n",
-    "                    \"openai_config\": {\n",
-    "                        \"openai_api_key\": \"{{\" + secret + \"}}\",\n",
-    "                    },\n",
-    "                },\n",
-    "            }\n",
-    "        ],\n",
-    "    },\n",
-    ")\n",
-    "\n",
-    "chat = ChatDatabricks(\n",
-    "    target_uri=\"databricks\",\n",
-    "    endpoint=name,\n",
-    "    temperature=0.1,\n",
-    ")\n",
-    "chat([HumanMessage(content=\"hello\")])"
+    "os.environ[\"DATABRICKS_HOST\"] = \"YOUR_WORKSPACE_ENDPOINT\" # e.g. \"https://your-workspace.cloud.databricks.com\"\n",
+    "os.environ[\"DATABRICKS_TOKEN\"] = getpass.getpass(\"Enter your Databricks access token: \")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Wrapping a serving endpoint: Foundation model\n",
-    "\n",
-    "The following code uses the `databricks-bge-large-en` serving endpoint (no endpoint creation is required) to generate embeddings from input text."
+    "Alternatively, you can pass those parameters when initializing the `Databricks` class."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.051055908203125, 0.007221221923828125, 0.003879547119140625]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from langchain_community.embeddings import DatabricksEmbeddings\n",
+    "from langchain_community.llms import Databricks\n",
     "\n",
-    "embeddings = DatabricksEmbeddings(endpoint=\"databricks-bge-large-en\")\n",
-    "embeddings.embed_query(\"hello\")[:3]"
+    "databricks = Databricks(\n",
+    "    host=\"https://your-workspace.cloud.databricks.com\",\n",
+    "    # We strongly recommend NOT to hardcode your access token in your code, instead use secret management tools\n",
+    "    # or environment variables to store your access token securely. The following example uses Databricks Secrets\n",
+    "    # to retrieve the access token that is available within the Databricks notebook.\n",
+    "    token=dbutils.secrets.get(scope=\"YOUR_SECRET_SCOPE\", key=\"databricks-token\")   # noqa: F821\n",
+    ")"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Wrapping a serving endpoint: Custom model\n",
+    "## Wrapping Model Serving Endpoint\n",
     "\n",
-    "Prerequisites:\n",
+    "### Prerequisites:\n",
     "\n",
     "* An LLM was registered and deployed to [a Databricks serving endpoint](https://docs.databricks.com/machine-learning/model-serving/index.html).\n",
     "* You have [\"Can Query\" permission](https://docs.databricks.com/security/auth-authz/access-control/serving-endpoint-acl.html) to the endpoint.\n",
@@ -149,9 +112,14 @@
     "The expected MLflow model signature is:\n",
     "\n",
     "  * inputs: `[{\"name\": \"prompt\", \"type\": \"string\"}, {\"name\": \"stop\", \"type\": \"list[string]\"}]`\n",
-    "  * outputs: `[{\"type\": \"string\"}]`\n",
-    "\n",
-    "If the model signature is incompatible or you want to insert extra configs, you can set `transform_input_fn` and `transform_output_fn` accordingly."
+    "  * outputs: `[{\"type\": \"string\"}]`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invocation"
    ]
   },
   {
@@ -173,12 +141,8 @@
    "source": [
     "from langchain_community.llms import Databricks\n",
     "\n",
-    "# If running a Databricks notebook attached to an interactive cluster in \"single user\"\n",
-    "# or \"no isolation shared\" mode, you only need to specify the endpoint name to create\n",
-    "# a `Databricks` instance to query a serving endpoint in the same workspace.\n",
-    "llm = Databricks(endpoint_name=\"dolly\")\n",
-    "\n",
-    "llm(\"How are you?\")"
+    "llm = Databricks(endpoint_name=\"YOUR_ENDPOINT_NAME\")\n",
+    "llm.invoke(\"How are you?\")"
    ]
   },
   {
@@ -198,42 +162,16 @@
     }
    ],
    "source": [
-    "llm(\"How are you?\", stop=[\".\"])"
+    "llm.invoke(\"How are you?\", stop=[\".\"])"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'I am fine. Thank you!'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "# Otherwise, you can manually specify the Databricks workspace hostname and personal access token\n",
-    "# or set `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables, respectively.\n",
-    "# See https://docs.databricks.com/dev-tools/auth.html#databricks-personal-access-tokens\n",
-    "# We strongly recommend not exposing the API token explicitly inside a notebook.\n",
-    "# You can use Databricks secret manager to store your API token securely.\n",
-    "# See https://docs.databricks.com/dev-tools/databricks-utils.html#secrets-utility-dbutilssecrets\n",
+    "### Transform Input and Output\n",
     "\n",
-    "import os\n",
-    "\n",
-    "import dbutils\n",
-    "\n",
-    "os.environ[\"DATABRICKS_TOKEN\"] = dbutils.secrets.get(\"myworkspace\", \"api_token\")\n",
-    "\n",
-    "llm = Databricks(host=\"myworkspace.cloud.databricks.com\", endpoint_name=\"dolly\")\n",
-    "\n",
-    "llm(\"How are you?\")"
+    "Sometimes you may want to wrap a serving endpoint that has imcompatible model signature or you want to insert extra configs. You can use the `transform_input_fn` and `transform_output_fn` arguments to define additional pre/post process."
    ]
   },
   {
@@ -244,34 +182,10 @@
     {
      "data": {
       "text/plain": [
-       "'I am fine.'"
+       "'I AM DOING GREAT THANK YOU.'"
       ]
      },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# If the serving endpoint accepts extra parameters like `temperature`,\n",
-    "# you can set them in `model_kwargs`.\n",
-    "llm = Databricks(endpoint_name=\"dolly\", model_kwargs={\"temperature\": 0.1})\n",
-    "\n",
-    "llm(\"How are you?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'I’m Excellent. You?'"
-      ]
-     },
-     "execution_count": 24,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -281,7 +195,6 @@
     "# expects a different input schema and does not return a JSON string,\n",
     "# respectively, or you want to apply a prompt template on top.\n",
     "\n",
-    "\n",
     "def transform_input(**request):\n",
     "    full_prompt = f\"\"\"{request[\"prompt\"]}\n",
     "    Be Concise.\n",
@@ -290,9 +203,17 @@
     "    return request\n",
     "\n",
     "\n",
-    "llm = Databricks(endpoint_name=\"dolly\", transform_input_fn=transform_input)\n",
+    "def transform_output(response):\n",
+    "    return response.upper()\n",
     "\n",
-    "llm(\"How are you?\")"
+    "\n",
+    "llm = Databricks(\n",
+    "    endpoint_name=\"YOUR_ENDPOINT_NAME\"\n",
+    "    transform_input_fn=transform_input,\n",
+    "    transform_output_fn=transform_output,\n",
+    ")\n",
+    "\n",
+    "llm.invoke(\"How are you?\")"
    ]
   },
   {
@@ -330,10 +251,10 @@
     "import torch\n",
     "from transformers import pipeline, AutoTokenizer, StoppingCriteria\n",
     "\n",
-    "model = \"databricks/dolly-v2-3b\"\n",
+    "model = \"databricks/dbrx-instruct\"\n",
     "tokenizer = AutoTokenizer.from_pretrained(model, padding_side=\"left\")\n",
-    "dolly = pipeline(model=model, tokenizer=tokenizer, trust_remote_code=True, device_map=\"auto\")\n",
-    "device = dolly.device\n",
+    "dbrx = pipeline(model=model, tokenizer=tokenizer, trust_remote_code=True, device_map=\"auto\")\n",
+    "device = dbrx.device\n",
     "\n",
     "class CheckStop(StoppingCriteria):\n",
     "    def __init__(self, stop=None):\n",
@@ -350,10 +271,10 @@
     "\n",
     "def llm(prompt, stop=None, **kwargs):\n",
     "  check_stop = CheckStop(stop)\n",
-    "  result = dolly(prompt, stopping_criteria=[check_stop], **kwargs)\n",
+    "  result = dbrx(prompt, stopping_criteria=[check_stop], **kwargs)\n",
     "  return result[0][\"generated_text\"].rstrip(check_stop.matched)\n",
     "\n",
-    "app = Flask(\"dolly\")\n",
+    "app = Flask(\"dbrx\")\n",
     "\n",
     "@app.route('/', methods=['POST'])\n",
     "def serve_llm():\n",
@@ -435,49 +356,6 @@
     "# If the app accepts extra parameters like `temperature`,\n",
     "# you can set them in `model_kwargs`.\n",
     "llm = Databricks(cluster_driver_port=\"7777\", model_kwargs={\"temperature\": 0.1})\n",
-    "\n",
-    "llm(\"How are you?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'I AM DOING GREAT THANK YOU.'"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Use `transform_input_fn` and `transform_output_fn` if the app\n",
-    "# expects a different input schema and does not return a JSON string,\n",
-    "# respectively, or you want to apply a prompt template on top.\n",
-    "\n",
-    "\n",
-    "def transform_input(**request):\n",
-    "    full_prompt = f\"\"\"{request[\"prompt\"]}\n",
-    "    Be Concise.\n",
-    "    \"\"\"\n",
-    "    request[\"prompt\"] = full_prompt\n",
-    "    return request\n",
-    "\n",
-    "\n",
-    "def transform_output(response):\n",
-    "    return response.upper()\n",
-    "\n",
-    "\n",
-    "llm = Databricks(\n",
-    "    cluster_driver_port=\"7777\",\n",
-    "    transform_input_fn=transform_input,\n",
-    "    transform_output_fn=transform_output,\n",
-    ")\n",
     "\n",
     "llm(\"How are you?\")"
    ]

--- a/docs/docs/integrations/text_embedding/databricks.ipynb
+++ b/docs/docs/integrations/text_embedding/databricks.ipynb
@@ -51,7 +51,7 @@
     "import getpass\n",
     "import os\n",
     "\n",
-    "os.environ[\"DATABRICKS_HOST\"] = \"YOUR_WORKSPACE_ENDPOINT\" # e.g. \"https://your-workspace.cloud.databricks.com\"\n",
+    "os.environ[\"DATABRICKS_HOST\"] = \"https://your-workspace.cloud.databricks.com\"\n",
     "os.environ[\"DATABRICKS_TOKEN\"] = getpass.getpass(\"Enter your Databricks access token: \")"
    ]
   },
@@ -120,7 +120,6 @@
     }
    ],
    "source": [
-    "\n",
     "embeddings.embed_query(\"hello\")[:3]"
    ]
   },
@@ -137,10 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "documents = [\n",
-    "    \"This is a dummy document.\",\n",
-    "    \"This is another dummy document.\"\n",
-    "]\n",
+    "documents = [\"This is a dummy document.\", \"This is another dummy document.\"]\n",
     "embeddings.embed_documents(documents)[:3]"
    ]
   },

--- a/docs/docs/integrations/text_embedding/databricks.ipynb
+++ b/docs/docs/integrations/text_embedding/databricks.ipynb
@@ -1,0 +1,181 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Databricks\n",
+    "\n",
+    "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
+    "\n",
+    "`DatabricksEmbeddings` class wraps an embedding model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a embedding model in your LangChain application."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "`mlflow >= 2.9 ` is required to run the code in this notebook. If it's not installed, please install it using this command:\n",
+    "\n",
+    "```sh\n",
+    "pip install mlflow>=2.9\n",
+    "```\n",
+    "\n",
+    "Also, `DatabricksEmbeddings` reside in the LangChain community package, so please install it as well if you haven't installed it.\n",
+    "\n",
+    "```sh\n",
+    "pip install langchain-community\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Credentials (only if you are outside Databricks)\n",
+    "\n",
+    "If you are running LangChain app inside Databricks, you can skip this step.\n",
+    "\n",
+    "Otherwise, you need manually set the Databricks workspace hostname and personal access token to `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables, respectively. See [Authentication Documentation](https://docs.databricks.com/en/dev-tools/auth/index.html#databricks-personal-access-tokens) for how to get an access token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"DATABRICKS_HOST\"] = \"YOUR_WORKSPACE_ENDPOINT\" # e.g. \"https://your-workspace.cloud.databricks.com\"\n",
+    "os.environ[\"DATABRICKS_TOKEN\"] = getpass.getpass(\"Enter your Databricks access token: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Usage\n",
+    "\n",
+    "### Supported Methods\n",
+    "\n",
+    "`DatabricksEmbeddings` supports all methods of `Embeddings` class including async APIs.\n",
+    "\n",
+    "\n",
+    "### Endpoint Requirement\n",
+    "\n",
+    "The serving endpoint `DatabricksEmbeddings` wraps must have OpenAI-compatible embedding input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#embeddings)). As long as the input format is compatible, `DatabricksEmbeddings` can be used for any endpoint type hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html):\n",
+    "\n",
+    "1. Foundation Models - Curated list of state-of-the-art foundation models such as BAAI General Embedding (BGE). These endpoint are ready to use in your Databricks workspace without any set up.\n",
+    "2. Custom Models - You can also deploy custom embedding models to a serving endpoint via MLflow with\n",
+    "your choice of framework such as LangChain, Pytorch, Transformers, etc.\n",
+    "3. External Models - Databricks endpoints can serve models that are hosted outside Databricks as a proxy, such as proprietary model service like OpenAI text-embedding-3.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.embeddings import DatabricksEmbeddings\n",
+    "\n",
+    "embeddings = DatabricksEmbeddings(\n",
+    "    endpoint=\"databricks-bge-large-en\",\n",
+    "    # Specify parameters for embedding queries and documents if needed\n",
+    "    # query_params={...},\n",
+    "    # document_params={...},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embed single text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.051055908203125, 0.007221221923828125, 0.003879547119140625]\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "embeddings.embed_query(\"hello\")[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embed documents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "documents = [\n",
+    "    \"This is a dummy document.\",\n",
+    "    \"This is another dummy document.\"\n",
+    "]\n",
+    "embeddings.embed_documents(documents)[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Other Types of Endpoints\n",
+    "\n",
+    "The example above uses an embedding model hosted as a Foundation Models API. To learn about how to use the other endpoint types, please refer to the documentation for `ChatDatabricks`. While the model type is different, required steps are the same.\n",
+    "\n",
+    "* [Custom Model Endpoint](https://python.langchain.com/v0.2/docs/integrations/chat/databricks/#wrapping-custom-model-endpoint)\n",
+    "* [External Models](https://python.langchain.com/v0.2/docs/integrations/chat/databricks/#wrapping-external-models)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/docs/integrations/text_embedding/databricks.ipynb
+++ b/docs/docs/integrations/text_embedding/databricks.ipynb
@@ -9,7 +9,28 @@
     "\n",
     "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
     "\n",
-    "`DatabricksEmbeddings` class wraps an embedding model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a embedding model in your LangChain application."
+    "This notebook provides a quick overview for getting started with Databricks [embedding models](docs/concepts/#embedding-models). For detailed documentation of all DatabricksEmbeddings features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/embeddings/langchain_community.embeddings.databricks.DatabricksEmbeddings.html).\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "`DatabricksEmbeddings` class wraps an embedding model endpoint hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html). This example notebook shows how to wrap your serving endpoint and use it as a embedding model in your LangChain application.\n",
+    "\n",
+    "\n",
+    "### Supported Methods\n",
+    "\n",
+    "`DatabricksEmbeddings` supports all methods of `Embeddings` class including async APIs.\n",
+    "\n",
+    "\n",
+    "### Endpoint Requirement\n",
+    "\n",
+    "The serving endpoint `DatabricksEmbeddings` wraps must have OpenAI-compatible embedding input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#embeddings)). As long as the input format is compatible, `DatabricksEmbeddings` can be used for any endpoint type hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html):\n",
+    "\n",
+    "1. Foundation Models - Curated list of state-of-the-art foundation models such as BAAI General Embedding (BGE). These endpoint are ready to use in your Databricks workspace without any set up.\n",
+    "2. Custom Models - You can also deploy custom embedding models to a serving endpoint via MLflow with\n",
+    "your choice of framework such as LangChain, Pytorch, Transformers, etc.\n",
+    "3. External Models - Databricks endpoints can serve models that are hosted outside Databricks as a proxy, such as proprietary model service like OpenAI text-embedding-3.\n"
    ]
   },
   {
@@ -18,24 +39,9 @@
    "source": [
     "## Setup\n",
     "\n",
-    "`mlflow >= 2.9 ` is required to run the code in this notebook. If it's not installed, please install it using this command:\n",
+    "To access Databricks models you'll need to create a Databricks account, set up credentials (only if you are outside Databricks workspace), and install required packages.\n",
     "\n",
-    "```sh\n",
-    "pip install mlflow>=2.9\n",
-    "```\n",
-    "\n",
-    "Also, `DatabricksEmbeddings` reside in the LangChain community package, so please install it as well if you haven't installed it.\n",
-    "\n",
-    "```sh\n",
-    "pip install langchain-community\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Credentials (only if you are outside Databricks)\n",
+    "### Credentials (only if you are outside Databricks)\n",
     "\n",
     "If you are running LangChain app inside Databricks, you can skip this step.\n",
     "\n",
@@ -59,21 +65,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Usage\n",
+    "### Installation\n",
     "\n",
-    "### Supported Methods\n",
+    "The LangChain Databricks integration lives in the `langchain-community` package. Also, `mlflow >= 2.9 ` is required to run the code in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-community mlflow>=2.9.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first demonstrates how to query BGE model hosted as Foundation Models endpoint with `DatabricksEmbeddings`.\n",
     "\n",
-    "`DatabricksEmbeddings` supports all methods of `Embeddings` class including async APIs.\n",
-    "\n",
-    "\n",
-    "### Endpoint Requirement\n",
-    "\n",
-    "The serving endpoint `DatabricksEmbeddings` wraps must have OpenAI-compatible embedding input/output format ([reference](https://mlflow.org/docs/latest/llms/deployments/index.html#embeddings)). As long as the input format is compatible, `DatabricksEmbeddings` can be used for any endpoint type hosted on [Databricks Model Serving](https://docs.databricks.com/en/machine-learning/model-serving/index.html):\n",
-    "\n",
-    "1. Foundation Models - Curated list of state-of-the-art foundation models such as BAAI General Embedding (BGE). These endpoint are ready to use in your Databricks workspace without any set up.\n",
-    "2. Custom Models - You can also deploy custom embedding models to a serving endpoint via MLflow with\n",
-    "your choice of framework such as LangChain, Pytorch, Transformers, etc.\n",
-    "3. External Models - Databricks endpoints can serve models that are hosted outside Databricks as a proxy, such as proprietary model service like OpenAI text-embedding-3.\n"
+    "For other type of endpoints, there are some difference in how to set up the endpoint itself, however, once the endpoint is ready, there is no difference in how to query it."
    ]
   },
   {
@@ -137,19 +149,29 @@
    "outputs": [],
    "source": [
     "documents = [\"This is a dummy document.\", \"This is another dummy document.\"]\n",
-    "embeddings.embed_documents(documents)[:3]"
+    "response = embeddings.embed_documents(documents)\n",
+    "print([e[:3] for e in response])  # Show first 3 elements of each embedding"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Other Types of Endpoints\n",
+    "## Wrapping Other Types of Endpoints\n",
     "\n",
     "The example above uses an embedding model hosted as a Foundation Models API. To learn about how to use the other endpoint types, please refer to the documentation for `ChatDatabricks`. While the model type is different, required steps are the same.\n",
     "\n",
     "* [Custom Model Endpoint](https://python.langchain.com/v0.2/docs/integrations/chat/databricks/#wrapping-custom-model-endpoint)\n",
     "* [External Models](https://python.langchain.com/v0.2/docs/integrations/chat/databricks/#wrapping-external-models)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For detailed documentation of all ChatDatabricks features and configurations head to the API reference: https://api.python.langchain.com/en/latest/embeddings/langchain_community.embeddings.databricks.DatabricksEmbeddings.html"
    ]
   }
  ],

--- a/docs/docs/integrations/text_embedding/databricks.ipynb
+++ b/docs/docs/integrations/text_embedding/databricks.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "> [Databricks](https://www.databricks.com/) Lakehouse Platform unifies data, analytics, and AI on one platform.\n",
     "\n",
-    "This notebook provides a quick overview for getting started with Databricks [embedding models](docs/concepts/#embedding-models). For detailed documentation of all DatabricksEmbeddings features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/embeddings/langchain_community.embeddings.databricks.DatabricksEmbeddings.html).\n",
+    "This notebook provides a quick overview for getting started with Databricks [embedding models](/docs/concepts/#embedding-models). For detailed documentation of all DatabricksEmbeddings features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/embeddings/langchain_community.embeddings.databricks.DatabricksEmbeddings.html).\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
**Description:** Documentation at [integrations/llms/databricks](https://python.langchain.com/v0.2/docs/integrations/llms/databricks/) is not up-to-date and includes examples about chat model and embeddings, which should be located in the different corresponding subdirectories. This PR split the page into correct scope and overhaul the contents.

**Note**: This PR might be hard to review on the diffs view, please use the following preview links for the changed pages.
- `ChatDatabricks`: https://langchain-git-fork-b-step62-chat-databricks-doc-langchain.vercel.app/v0.2/docs/integrations/chat/databricks/
- `Databricks`: https://langchain-git-fork-b-step62-chat-databricks-doc-langchain.vercel.app/v0.2/docs/integrations/llms/databricks/
- `DatabricksEmbeddings`: https://langchain-git-fork-b-step62-chat-databricks-doc-langchain.vercel.app/v0.2/docs/integrations/text_embedding/databricks/

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/
