### PR TITLE
docs: Fix typo in tutorial about structured data extraction

### DIFF
--- a/docs/docs/how_to/structured_output.ipynb
+++ b/docs/docs/how_to/structured_output.ipynb
@@ -76,7 +76,7 @@
    "id": "a808a401-be1f-49f9-ad13-58dd68f7db5f",
    "metadata": {},
    "source": [
-    "If we want the model to return a Pydantic object, we just need to pass in desired the Pydantic class:"
+    "If we want the model to return a Pydantic object, we just need to pass in the desired Pydantic class:"
    ]
   },
   {


### PR DESCRIPTION
[Fixed typo](docs: Fix typo in tutorial about structured data extraction)