### PR TITLE
community[patch]: set tool name for tongyi&qianfan llm

### DIFF
--- a/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
+++ b/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
@@ -65,7 +65,7 @@ def convert_message_to_dict(message: BaseMessage) -> dict:
         message_dict = {
             "role": "function",
             "content": message.content,
-            "name": message.name,
+            "name": message.name or message.additional_kwargs.get("name"),
         }
     else:
         raise TypeError(f"Got unknown type {message}")

--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -201,7 +201,7 @@ def convert_message_to_dict(message: BaseMessage) -> dict:
             "role": "tool",
             "tool_call_id": message.tool_call_id,
             "content": message.content,
-            "name": message.name,
+            "name": message.name or message.additional_kwargs.get("name"),
         }
     elif isinstance(message, FunctionMessage):
         message_dict = {


### PR DESCRIPTION
  - **Description:** The name of ToolMessage is default to None, which makes tool message send to LLM likes
 ```json
{"role": "tool",
   "tool_call_id": "",
   "content": "{\"time\": \"12:12\"}",
   "name": null}
```
But the name seems essential for some LLMs like TongYi Qwen. so we need to set the name use agent_action's tool value.
  - **Issue:** N/A
  - **Dependencies:** N/A