### PR TITLE
core[patch]: Fix FunctionCallbackHandler._on_tool_end

### DIFF
--- a/libs/core/langchain_core/tracers/stdout.py
+++ b/libs/core/langchain_core/tracers/stdout.py
@@ -156,7 +156,7 @@ class FunctionCallbackHandler(BaseTracer):
                 + get_bolded_text(
                     f"[{crumbs}] [{elapsed(run)}] Exiting Tool run with output:\n"
                 )
-                + f'"{run.outputs["output"].strip()}"'
+                + f'"{str(run.outputs["output"]).strip()}"'
             )
 
     def _on_tool_error(self, run: Run) -> None:


### PR DESCRIPTION
If the global `debug` flag is enabled, the agent will get the following error in `FunctionCallbackHandler._on_tool_end` at runtime.

```
Error in ConsoleCallbackHandler.on_tool_end callback: AttributeError("'list' object has no attribute 'strip'")
```

By calling str() before strip(), the error was avoided.
This error can be seen at [debugging.ipynb](https://github.com/langchain-ai/langchain/blob/master/docs/docs/how_to/debugging.ipynb).

- Issue: NA
- Dependencies: NA
- Twitter handle: https://x.com/kiarina37