### PR TITLE
dcos: Add admonition to PythonREPL tool

### DIFF
--- a/docs/docs/integrations/tools/python.ipynb
+++ b/docs/docs/integrations/tools/python.ipynb
@@ -9,7 +9,12 @@
     "\n",
     "Sometimes, for complex calculations, rather than have an LLM generate the answer directly, it can be better to have the LLM generate code to calculate the answer, and then run that code to get the answer. In order to easily do that, we provide a simple Python REPL to execute commands in.\n",
     "\n",
-    "This interface will only return things that are printed - therefore, if you want to use it to calculate an answer, make sure to have it print out the answer."
+    "This interface will only return things that are printed - therefore, if you want to use it to calculate an answer, make sure to have it print out the answer.\n",
+    "\n",
+    "\n",
+    ":::{.callout-caution}\n",
+    "Python REPL can execute arbitrary code on the host machine (e.g., delete files, make network requests). Use with caution.\n",
+    ":::"
    ]
   },
   {
@@ -95,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/tools/python.ipynb
+++ b/docs/docs/integrations/tools/python.ipynb
@@ -14,6 +14,8 @@
     "\n",
     ":::{.callout-caution}\n",
     "Python REPL can execute arbitrary code on the host machine (e.g., delete files, make network requests). Use with caution.\n",
+    "\n",
+    "For more information general security guidelines, please see https://python.langchain.com/v0.2/docs/security/.\n",
     ":::"
    ]
   },


### PR DESCRIPTION
Add admonition to the documentation to make sure users are aware that the tool allows execution of code on the host machine using a python interpreter (by design).
