### PR TITLE
infra: remove nvidia from monorepo scheduled tests

### DIFF
--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -31,7 +31,6 @@ jobs:
           - "libs/partners/google-vertexai"
           - "libs/partners/google-genai"
           - "libs/partners/aws"
-          - "libs/partners/nvidia-ai-endpoints"
 
     steps:
       - uses: actions/checkout@v4
@@ -41,10 +40,6 @@ jobs:
         with:
           repository: langchain-ai/langchain-google
           path: langchain-google
-      - uses: actions/checkout@v4
-        with:
-          repository: langchain-ai/langchain-nvidia
-          path: langchain-nvidia
       - uses: actions/checkout@v4
         with:
           repository: langchain-ai/langchain-cohere
@@ -59,11 +54,9 @@ jobs:
           rm -rf \
             langchain/libs/partners/google-genai \
             langchain/libs/partners/google-vertexai \
-            langchain/libs/partners/nvidia-ai-endpoints \
             langchain/libs/partners/cohere
           mv langchain-google/libs/genai langchain/libs/partners/google-genai
           mv langchain-google/libs/vertexai langchain/libs/partners/google-vertexai
-          mv langchain-nvidia/libs/ai-endpoints langchain/libs/partners/nvidia-ai-endpoints
           mv langchain-cohere/libs/cohere langchain/libs/partners/cohere
           mv langchain-aws/libs/aws langchain/libs/partners/aws
 
@@ -123,7 +116,6 @@ jobs:
           rm -rf \
             langchain/libs/partners/google-genai \
             langchain/libs/partners/google-vertexai \
-            langchain/libs/partners/nvidia-ai-endpoints \
             langchain/libs/partners/cohere \
             langchain/libs/partners/aws
 


### PR DESCRIPTION
Scheduled tests run in https://github.com/langchain-ai/langchain-nvidia/tree/main