### PR TITLE
 community: add args_schema to SearxSearch 

### DIFF
--- a/libs/community/langchain_community/tools/searx_search/tool.py
+++ b/libs/community/langchain_community/tools/searx_search/tool.py
@@ -11,7 +11,7 @@ from langchain_core.tools import BaseTool
 from langchain_community.utilities.searx_search import SearxSearchWrapper
 
 class SearxSearchQueryInput(BaseModel):
-    """input for the SearxSearch tool"""
+    """Input for the SearxSearch tool."""
     query: str = Field(description="query to look up on searx")
 
 class SearxSearchRun(BaseTool):

--- a/libs/community/langchain_community/tools/searx_search/tool.py
+++ b/libs/community/langchain_community/tools/searx_search/tool.py
@@ -5,14 +5,17 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
-from langchain_core.pydantic_v1 import Extra, Field, BaseModel
+from langchain_core.pydantic_v1 import BaseModel, Extra, Field
 from langchain_core.tools import BaseTool
 
 from langchain_community.utilities.searx_search import SearxSearchWrapper
 
+
 class SearxSearchQueryInput(BaseModel):
     """Input for the SearxSearch tool."""
+
     query: str = Field(description="query to look up on searx")
+
 
 class SearxSearchRun(BaseTool):
     """Tool that queries a Searx instance."""

--- a/libs/community/langchain_community/tools/searx_search/tool.py
+++ b/libs/community/langchain_community/tools/searx_search/tool.py
@@ -1,15 +1,18 @@
 """Tool for the SearxNG search API."""
-from typing import Optional
+from typing import Optional, Type
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
-from langchain_core.pydantic_v1 import Extra, Field
+from langchain_core.pydantic_v1 import Extra, Field, BaseModel
 from langchain_core.tools import BaseTool
 
 from langchain_community.utilities.searx_search import SearxSearchWrapper
 
+class SearxSearchQueryInput(BaseModel):
+    """input for the SearxSearch tool"""
+    query: str = Field(description="query to look up on searx")
 
 class SearxSearchRun(BaseTool):
     """Tool that queries a Searx instance."""
@@ -22,6 +25,7 @@ class SearxSearchRun(BaseTool):
     )
     wrapper: SearxSearchWrapper
     kwargs: dict = Field(default_factory=dict)
+    args_schema: Type[BaseModel] = SearxSearchQueryInput
 
     def _run(
         self,


### PR DESCRIPTION
This change adds args_schema (pydantic BaseModel) to SearxSearchRun for correct schema formatting on LLM function calls

Issue: currently using SearxSearchRun with OpenAI function calling returns the following error "TypeError: SearxSearchRun._run() got an unexpected keyword argument '__arg1' ". 

This happens because the schema sent to the LLM is "input: '{"__arg1":"foobar"}'" while the method should be called with the "query" parameter.
