### PR TITLE
[Community]: FIxed the DocumentDBVectorSearch `_similarity_search_without_score`

### DIFF
--- a/libs/community/langchain_community/vectorstores/documentdb.py
+++ b/libs/community/langchain_community/vectorstores/documentdb.py
@@ -328,8 +328,8 @@ class DocumentDBVectorSearch(VectorStore):
             A list of documents closest to the query vector
         """
         pipeline: List[dict[str, Any]] = [
+            {"$match": filter},
             {
-                "$match": filter,
                 "$search": {
                     "vectorSearch": {
                         "vector": embeddings,
@@ -339,7 +339,7 @@ class DocumentDBVectorSearch(VectorStore):
                         "efSearch": ef_search,
                     }
                 },
-            }
+            },
         ]
 
         cursor = self._collection.aggregate(pipeline)


### PR DESCRIPTION
  - **Description:** The PR #22777 introduced a bug in `_similarity_search_without_score` which was raising the `OperationFailure` error. The mistake was syntax error for MongoDB pipeline which has been corrected now.
    - **Issue:** #22770 
  