### PR TITLE
community: Fix #22975 (Add SSL Verification Option to Requests Class in langchain_community)

### DIFF
--- a/libs/community/langchain_community/utilities/requests.py
+++ b/libs/community/langchain_community/utilities/requests.py
@@ -29,11 +29,7 @@ class Requests(BaseModel):
     def get(self, url: str, **kwargs: Any) -> requests.Response:
         """GET the URL and return the text."""
         return requests.get(
-            url,
-            headers=self.headers,
-            auth=self.auth,
-            verify=self.verify,
-            **kwargs
+            url, headers=self.headers, auth=self.auth, verify=self.verify, **kwargs
         )
 
     def post(self, url: str, data: Dict[str, Any], **kwargs: Any) -> requests.Response:
@@ -44,7 +40,7 @@ class Requests(BaseModel):
             headers=self.headers,
             auth=self.auth,
             verify=self.verify,
-            **kwargs
+            **kwargs,
         )
 
     def patch(self, url: str, data: Dict[str, Any], **kwargs: Any) -> requests.Response:
@@ -55,7 +51,7 @@ class Requests(BaseModel):
             headers=self.headers,
             auth=self.auth,
             verify=self.verify,
-            **kwargs
+            **kwargs,
         )
 
     def put(self, url: str, data: Dict[str, Any], **kwargs: Any) -> requests.Response:
@@ -66,17 +62,13 @@ class Requests(BaseModel):
             headers=self.headers,
             auth=self.auth,
             verify=self.verify,
-            **kwargs
+            **kwargs,
         )
 
     def delete(self, url: str, **kwargs: Any) -> requests.Response:
         """DELETE the URL and return the text."""
         return requests.delete(
-            url,
-            headers=self.headers,
-            auth=self.auth,
-            verify=self.verify,
-            **kwargs
+            url, headers=self.headers, auth=self.auth, verify=self.verify, **kwargs
         )
 
     @asynccontextmanager
@@ -92,7 +84,7 @@ class Requests(BaseModel):
                     headers=self.headers,
                     auth=self.auth,
                     verify=self.verify,
-                    **kwargs
+                    **kwargs,
                 ) as response:
                     yield response
         else:
@@ -102,7 +94,7 @@ class Requests(BaseModel):
                 headers=self.headers,
                 auth=self.auth,
                 verify=self.verify,
-                **kwargs
+                **kwargs,
             ) as response:
                 yield response
 
@@ -168,7 +160,7 @@ class GenericRequestsWrapper(BaseModel):
             headers=self.headers,
             aiosession=self.aiosession,
             auth=self.auth,
-            verify=self.verify
+            verify=self.verify,
         )
 
     def _get_resp_content(self, response: Response) -> Union[str, Dict[str, Any]]:

--- a/libs/community/langchain_community/utilities/requests.py
+++ b/libs/community/langchain_community/utilities/requests.py
@@ -18,6 +18,7 @@ class Requests(BaseModel):
     headers: Optional[Dict[str, str]] = None
     aiosession: Optional[aiohttp.ClientSession] = None
     auth: Optional[Any] = None
+    verify: Optional[bool] = True
 
     class Config:
         """Configuration for this pydantic object."""
@@ -27,29 +28,56 @@ class Requests(BaseModel):
 
     def get(self, url: str, **kwargs: Any) -> requests.Response:
         """GET the URL and return the text."""
-        return requests.get(url, headers=self.headers, auth=self.auth, **kwargs)
+        return requests.get(
+            url,
+            headers=self.headers,
+            auth=self.auth,
+            verify=self.verify,
+            **kwargs
+        )
 
     def post(self, url: str, data: Dict[str, Any], **kwargs: Any) -> requests.Response:
         """POST to the URL and return the text."""
         return requests.post(
-            url, json=data, headers=self.headers, auth=self.auth, **kwargs
+            url,
+            json=data,
+            headers=self.headers,
+            auth=self.auth,
+            verify=self.verify,
+            **kwargs
         )
 
     def patch(self, url: str, data: Dict[str, Any], **kwargs: Any) -> requests.Response:
         """PATCH the URL and return the text."""
         return requests.patch(
-            url, json=data, headers=self.headers, auth=self.auth, **kwargs
+            url,
+            json=data,
+            headers=self.headers,
+            auth=self.auth,
+            verify=self.verify,
+            **kwargs
         )
 
     def put(self, url: str, data: Dict[str, Any], **kwargs: Any) -> requests.Response:
         """PUT the URL and return the text."""
         return requests.put(
-            url, json=data, headers=self.headers, auth=self.auth, **kwargs
+            url,
+            json=data,
+            headers=self.headers,
+            auth=self.auth,
+            verify=self.verify,
+            **kwargs
         )
 
     def delete(self, url: str, **kwargs: Any) -> requests.Response:
         """DELETE the URL and return the text."""
-        return requests.delete(url, headers=self.headers, auth=self.auth, **kwargs)
+        return requests.delete(
+            url,
+            headers=self.headers,
+            auth=self.auth,
+            verify=self.verify,
+            **kwargs
+        )
 
     @asynccontextmanager
     async def _arequest(
@@ -59,12 +87,22 @@ class Requests(BaseModel):
         if not self.aiosession:
             async with aiohttp.ClientSession() as session:
                 async with session.request(
-                    method, url, headers=self.headers, auth=self.auth, **kwargs
+                    method,
+                    url,
+                    headers=self.headers,
+                    auth=self.auth,
+                    verify=self.verify,
+                    **kwargs
                 ) as response:
                     yield response
         else:
             async with self.aiosession.request(
-                method, url, headers=self.headers, auth=self.auth, **kwargs
+                method,
+                url,
+                headers=self.headers,
+                auth=self.auth,
+                verify=self.verify,
+                **kwargs
             ) as response:
                 yield response
 
@@ -116,6 +154,7 @@ class GenericRequestsWrapper(BaseModel):
     aiosession: Optional[aiohttp.ClientSession] = None
     auth: Optional[Any] = None
     response_content_type: Literal["text", "json"] = "text"
+    verify: bool = True
 
     class Config:
         """Configuration for this pydantic object."""
@@ -126,7 +165,10 @@ class GenericRequestsWrapper(BaseModel):
     @property
     def requests(self) -> Requests:
         return Requests(
-            headers=self.headers, aiosession=self.aiosession, auth=self.auth
+            headers=self.headers,
+            aiosession=self.aiosession,
+            auth=self.auth,
+            verify=self.verify
         )
 
     def _get_resp_content(self, response: Response) -> Union[str, Dict[str, Any]]:


### PR DESCRIPTION
- **PR title**: "community: Fix #22975 (Add SSL Verification Option to Requests Class in langchain_community)"
- **PR message**: 
    - **Description:**
        - Added an optional verify parameter to the Requests class with a default value of True.
        - Modified the get, post, patch, put, and delete methods to include the verify parameter.
        - Updated the _arequest async context manager to include the verify parameter.
        - Added the verify parameter to the GenericRequestsWrapper class and passed it to the Requests class.
    - **Issue:** This PR fixes issue #22975.
    - **Dependencies:** No additional dependencies are required for this change.
    - **Twitter handle:** @lunara_x

You can check this change with below code.
```python
from langchain_openai.chat_models import ChatOpenAI
from langchain.requests import RequestsWrapper
from langchain_community.agent_toolkits.openapi import planner
from langchain_community.agent_toolkits.openapi.spec import reduce_openapi_spec

with open("swagger.yaml") as f:
    data = yaml.load(f, Loader=yaml.FullLoader)
swagger_api_spec = reduce_openapi_spec(data)

llm = ChatOpenAI(model='gpt-4o')
swagger_requests_wrapper = RequestsWrapper(verify=False) # modified point
superset_agent = planner.create_openapi_agent(swagger_api_spec, swagger_requests_wrapper, llm, allow_dangerous_requests=True, handle_parsing_errors=True)

superset_agent.run(
    "Tell me the number and types of charts and dashboards available."
)
```
