### PR TITLE
core: run_in_executor: Wrap StopIteration in RuntimeError

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -1,10 +1,16 @@
 from typing import Any, cast
 
+import pytest
+
 from langchain_core.callbacks.manager import CallbackManager
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain_core.runnables import RunnableBinding, RunnablePassthrough
-from langchain_core.runnables.config import RunnableConfig, merge_configs
+from langchain_core.runnables.config import (
+    RunnableConfig,
+    merge_configs,
+    run_in_executor,
+)
 from langchain_core.tracers.stdout import ConsoleCallbackHandler
 
 
@@ -43,3 +49,14 @@ def test_config_arbitrary_keys() -> None:
     config = cast(RunnableBinding, bound).config
 
     assert config.get("my_custom_key") == "my custom value"
+
+
+async def test_run_in_executor() -> None:
+    def raises_stop_iter() -> Any:
+        return next(iter([]))
+
+    with pytest.raises(StopIteration):
+        raises_stop_iter()
+
+    with pytest.raises(RuntimeError):
+        await run_in_executor(None, raises_stop_iter)


### PR DESCRIPTION
- StopIteration can't be set on an asyncio.Future it raises a TypeError and leaves the Future pending forever so we need to convert it to a RuntimeError

