### PR TITLE
community: add **request_kwargs and expect TimeoutError AsyncHtmlLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/async_html.py
+++ b/libs/community/langchain_community/document_loaders/async_html.py
@@ -137,6 +137,7 @@ class AsyncHtmlLoader(BaseLoader):
                         url,
                         headers=self.session.headers,
                         ssl=None if self.session.verify else False,
+                        **self.requests_kwargs,
                     ) as response:
                         try:
                             text = await response.text()
@@ -144,7 +145,7 @@ class AsyncHtmlLoader(BaseLoader):
                             logger.error(f"Failed to decode content from {url}")
                             text = ""
                         return text
-                except aiohttp.ClientConnectionError as e:
+                except (aiohttp.ClientConnectionError, TimeoutError) as e:
                     if i == retries - 1 and self.ignore_load_errors:
                         logger.warning(f"Error fetching {url} after {retries} retries.")
                         return ""


### PR DESCRIPTION
- **Description:** add `**request_kwargs` and expect `TimeoutError` in `_fetch` function for AsyncHtmlLoader. This allows you to fill in the kwargs parameter when using the `load()` method of the `AsyncHtmlLoader` class.