### PR TITLE
community[patch]: add size for message histories

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/file.py
+++ b/libs/community/langchain_community/chat_message_histories/file.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from langchain_core.chat_history import (
     BaseChatMessageHistory,
@@ -11,21 +11,27 @@ from langchain_core.messages import BaseMessage, messages_from_dict, messages_to
 class FileChatMessageHistory(BaseChatMessageHistory):
     """Chat message history that stores history in a local file."""
 
-    def __init__(self, file_path: str) -> None:
+    def __init__(self, file_path: str, *, history_size: Optional[int] = None) -> None:
         """Initialize the file path for the chat history.
 
         Args:
             file_path: The path to the local file to store the chat history.
+            history_size: Maximum number fo messages to retrieve. If None then
+                there is no limit. If not None then only the latest `history_size`
+                messages are retrieved.
         """
         self.file_path = Path(file_path)
         if not self.file_path.exists():
             self.file_path.touch()
             self.file_path.write_text(json.dumps([]))
+        self.history_size = history_size
 
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the messages from the local file"""
         items = json.loads(self.file_path.read_text())
+        if self.history_size:
+            items = items[-self.history_size :]
         messages = messages_from_dict(items)
         return messages
 

--- a/libs/community/langchain_community/chat_message_histories/redis.py
+++ b/libs/community/langchain_community/chat_message_histories/redis.py
@@ -23,6 +23,8 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         url: str = "redis://localhost:6379/0",
         key_prefix: str = "message_store:",
         ttl: Optional[int] = None,
+        *,
+        history_size: Optional[int] = None,
     ):
         try:
             import redis
@@ -40,6 +42,7 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
         self.session_id = session_id
         self.key_prefix = key_prefix
         self.ttl = ttl
+        self.history_size = history_size
 
     @property
     def key(self) -> str:
@@ -49,7 +52,8 @@ class RedisChatMessageHistory(BaseChatMessageHistory):
     @property
     def messages(self) -> List[BaseMessage]:
         """Retrieve the messages from Redis"""
-        _items = self.redis_client.lrange(self.key, 0, -1)
+        end = self.history_size - 1 if self.history_size else -1
+        _items = self.redis_client.lrange(self.key, 0, end)
         items = [json.loads(m.decode("utf-8")) for m in _items[::-1]]
         messages = messages_from_dict(items)
         return messages

--- a/libs/community/langchain_community/chat_message_histories/streamlit.py
+++ b/libs/community/langchain_community/chat_message_histories/streamlit.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage
@@ -10,9 +10,14 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
 
     Args:
         key: The key to use in Streamlit session state for storing messages.
+        history_size: Maximum number fo messages to retrieve. If None then
+            there is no limit. If not None then only the latest `history_size`
+            messages are retrieved.
     """
 
-    def __init__(self, key: str = "langchain_messages"):
+    def __init__(
+        self, key: str = "langchain_messages", *, history_size: Optional[int] = None
+    ):
         try:
             import streamlit as st
         except ImportError as e:
@@ -24,11 +29,15 @@ class StreamlitChatMessageHistory(BaseChatMessageHistory):
             st.session_state[key] = []
         self._messages = st.session_state[key]
         self._key = key
+        self._history_size = history_size
 
     @property
     def messages(self) -> List[BaseMessage]:
         """Retrieve the current list of messages"""
-        return self._messages
+        messages = self._messages
+        if self._history_size:
+            messages = messages[-self._history_size :]
+        return messages
 
     @messages.setter
     def messages(self, value: List[BaseMessage]) -> None:

--- a/libs/community/langchain_community/chat_message_histories/upstash_redis.py
+++ b/libs/community/langchain_community/chat_message_histories/upstash_redis.py
@@ -22,6 +22,8 @@ class UpstashRedisChatMessageHistory(BaseChatMessageHistory):
         token: str = "",
         key_prefix: str = "message_store:",
         ttl: Optional[int] = None,
+        *,
+        history_size: Optional[int] = None,
     ):
         try:
             from upstash_redis import Redis
@@ -44,6 +46,7 @@ class UpstashRedisChatMessageHistory(BaseChatMessageHistory):
         self.session_id = session_id
         self.key_prefix = key_prefix
         self.ttl = ttl
+        self.history_size = history_size
 
     @property
     def key(self) -> str:
@@ -53,7 +56,8 @@ class UpstashRedisChatMessageHistory(BaseChatMessageHistory):
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
         """Retrieve the messages from Upstash Redis"""
-        _items = self.redis_client.lrange(self.key, 0, -1)
+        end = self.history_size - 1 if self.history_size else -1
+        _items = self.redis_client.lrange(self.key, 0, end)
         items = [json.loads(m) for m in _items[::-1]]
         messages = messages_from_dict(items)
         return messages

--- a/libs/community/langchain_community/chat_message_histories/zep.py
+++ b/libs/community/langchain_community/chat_message_histories/zep.py
@@ -74,6 +74,8 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         session_id: str,
         url: str = "http://localhost:8000",
         api_key: Optional[str] = None,
+        *,
+        history_size: Optional[int] = None,
     ) -> None:
         try:
             from zep_python import ZepClient
@@ -85,6 +87,7 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
 
         self.zep_client = ZepClient(base_url=url, api_key=api_key)
         self.session_id = session_id
+        self.history_size = history_size
 
     @property
     def messages(self) -> List[BaseMessage]:  # type: ignore
@@ -141,7 +144,10 @@ class ZepChatMessageHistory(BaseChatMessageHistory):
         from zep_python import NotFoundError
 
         try:
-            zep_memory: Memory = self.zep_client.memory.get_memory(self.session_id)
+            zep_memory: Memory = self.zep_client.memory.get_memory(
+                self.session_id,
+                lastn=self.history_size,
+            )
         except NotFoundError:
             logger.warning(
                 f"Session {self.session_id} not found in Zep. Returning None"


### PR DESCRIPTION
  - **Description:** 
Currently some ChatMessageHistory (neo4j, zep_cloud) support limit the size of message history, others are not. So this patch add history_size parameter to other ChatMessageHistory. 
I have tried to use native database `sort`&`limit` capability to do this, but some databases seem not easy to handle it, then python list slice used.
NOTE: for deprecated ChatMessageHistory like AstraDB, I will try make PR to correspending repo.
  - **Issue:** N/A
  - **Dependencies:** N/A