### PR TITLE
ibm: docstrings

### DIFF
--- a/libs/partners/ibm/langchain_ibm/embeddings.py
+++ b/libs/partners/ibm/langchain_ibm/embeddings.py
@@ -15,6 +15,8 @@ from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 
 class WatsonxEmbeddings(BaseModel, LangChainEmbeddings):
+    """IBM WatsonX.ai embedding models."""
+
     model_id: str = ""
     """Type of model to use."""
 

--- a/libs/partners/ibm/langchain_ibm/llms.py
+++ b/libs/partners/ibm/langchain_ibm/llms.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class WatsonxLLM(BaseLLM):
     """
-    IBM watsonx.ai large language models.
+    IBM WatsonX.ai large language models.
 
     To use, you should have ``langchain_ibm`` python package installed,
     and the environment variable ``WATSONX_APIKEY`` set with your API key, or pass


### PR DESCRIPTION
Added missed docstrings. Format docstrings to the consistent format (used in the API Reference)