### PR TITLE
core: add exceptions propagation test for astream_events v2

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -2,6 +2,7 @@
 import asyncio
 import sys
 import uuid
+from functools import partial
 from itertools import cycle
 from typing import (
     Any,
@@ -344,6 +345,22 @@ async def test_event_stream_with_triple_lambda() -> None:
             "tags": [],
         },
     ]
+
+
+async def test_event_stream_exception() -> None:
+    def step(name: str, err: Optional[str], val: str) -> str:
+        if err:
+            raise ValueError(err)
+        return val + name[-1]
+
+    chain = (
+        RunnableLambda(partial(step, "step1", None))
+        | RunnableLambda(partial(step, "step2", "ERR"))
+        | RunnableLambda(partial(step, "step3", None))
+    )
+
+    with pytest.raises(ValueError, match="ERR"):
+        await _collect_events(chain.astream_events("X", version="v2"))
 
 
 async def test_event_stream_with_triple_lambda_test_filtering() -> None:


### PR DESCRIPTION
**Description:** `astream_events(version="v2")` didn't propagate exceptions in `langchain-core<=0.2.6`, fixed in the #22916. This PR adds a unit test to check that exceptions are propagated upwards.

