### PR TITLE
 community: Fix TypeError in PebbloRetrievalQA

### DIFF
--- a/libs/community/langchain_community/chains/pebblo_retrieval/base.py
+++ b/libs/community/langchain_community/chains/pebblo_retrieval/base.py
@@ -127,8 +127,10 @@ class PebbloRetrievalQA(Chain):
                 "data": answer,
             },
             "prompt_time": prompt_time,
-            "user": getattr(auth_context, "user_id", "unknown"),
-            "user_identities": getattr(auth_context, "user_auth", []),
+            "user": auth_context.user_id if auth_context else "unknown",
+            "user_identities": auth_context.user_auth
+            if auth_context and hasattr(auth_context, "user_auth")
+            else [],
         }
         qa_payload = Qa(**qa)
         self._send_prompt(qa_payload)

--- a/libs/community/langchain_community/chains/pebblo_retrieval/base.py
+++ b/libs/community/langchain_community/chains/pebblo_retrieval/base.py
@@ -127,12 +127,8 @@ class PebbloRetrievalQA(Chain):
                 "data": answer,
             },
             "prompt_time": prompt_time,
-            "user": auth_context.user_id if auth_context else "unknown",
-            "user_identities": auth_context.user_auth
-            if "user_auth" in dict(auth_context)
-            else []
-            if auth_context
-            else [],
+            "user": getattr(auth_context, "user_id", "unknown"),
+            "user_identities": getattr(auth_context, "user_auth", []),
         }
         qa_payload = Qa(**qa)
         self._send_prompt(qa_payload)


### PR DESCRIPTION
**Description:** 
Fix "`TypeError: 'NoneType' object is not iterable`" when the auth_context is absent in PebbloRetrievalQA. The auth_context is optional; hence, PebbloRetrievalQA should work without it, but it throws an error at the moment. This PR fixes that issue.

**Issue:** NA
**Dependencies:** None
**Unit tests:** NA