### PR TITLE
core[patch]: update test to catch circular imports

### DIFF
--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -36,7 +36,6 @@ from langchain_core.runnables.config import (
     run_in_executor,
 )
 from langchain_core.runnables.fallbacks import RunnableWithFallbacks
-from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_core.runnables.passthrough import (
     RunnableAssign,
     RunnablePassthrough,
@@ -79,7 +78,6 @@ __all__ = [
     "RunnablePick",
     "RunnableSequence",
     "RunnableWithFallbacks",
-    "RunnableWithMessageHistory",
     "get_config_list",
     "aadd",
     "add",

--- a/libs/core/tests/unit_tests/runnables/test_imports.py
+++ b/libs/core/tests/unit_tests/runnables/test_imports.py
@@ -26,7 +26,6 @@ EXPECTED_ALL = [
     "RunnablePick",
     "RunnableSequence",
     "RunnableWithFallbacks",
-    "RunnableWithMessageHistory",
     "get_config_list",
     "aadd",
     "add",

--- a/libs/core/tests/unit_tests/test_imports.py
+++ b/libs/core/tests/unit_tests/test_imports.py
@@ -1,6 +1,9 @@
 import glob
 import importlib
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 def test_importable_all() -> None:
@@ -9,6 +12,11 @@ def test_importable_all() -> None:
         if relative_path.endswith(".typed"):
             continue
         module_name = relative_path.split(".")[0]
+        result = subprocess.run(
+            ["python", "-c", f"import langchain_core.{module_name}"],
+        )
+        if result.returncode != 0:
+            pytest.fail(f"Failed to import {module_name}.")
         module = importlib.import_module("langchain_core." + module_name)
         all_ = getattr(module, "__all__", [])
         for cls_ in all_:

--- a/libs/core/tests/unit_tests/test_imports.py
+++ b/libs/core/tests/unit_tests/test_imports.py
@@ -12,12 +12,16 @@ def test_importable_all() -> None:
         if relative_path.endswith(".typed"):
             continue
         module_name = relative_path.split(".")[0]
+        module = importlib.import_module("langchain_core." + module_name)
+        all_ = getattr(module, "__all__", [])
+        for cls_ in all_:
+            getattr(module, cls_)
+
+        # Test import in isolation
+        # Note: ImportErrors due to circular imports can be raised
+        # for one sequence of imports but not another.
         result = subprocess.run(
             ["python", "-c", f"import langchain_core.{module_name}"],
         )
         if result.returncode != 0:
             pytest.fail(f"Failed to import {module_name}.")
-        module = importlib.import_module("langchain_core." + module_name)
-        all_ = getattr(module, "__all__", [])
-        for cls_ in all_:
-            getattr(module, cls_)


### PR DESCRIPTION
This raises ImportError due to a circular import:
```python
from langchain_core import chat_history
```

This does not:
```python
from langchain_core import runnables
from langchain_core import chat_history
```

Here we update `test_imports` to run each import in a separate subprocess. Open to other ways of doing this!