### PR TITLE
fix: MoonshotChat fails when setting the moonshot_api_key through the OS environment.

### DIFF
--- a/libs/community/langchain_community/chat_models/moonshot.py
+++ b/libs/community/langchain_community/chat_models/moonshot.py
@@ -32,9 +32,7 @@ class MoonshotChat(MoonshotCommon, ChatOpenAI):  # type: ignore[misc]
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that the environment is set up correctly."""
         values["moonshot_api_key"] = convert_to_secret_str(
-            get_from_dict_or_env(
-                values, "moonshot_api_key", "MOONSHOT_API_KEY"
-            )
+            get_from_dict_or_env(values, "moonshot_api_key", "MOONSHOT_API_KEY")
         )
 
         try:

--- a/libs/community/langchain_community/chat_models/moonshot.py
+++ b/libs/community/langchain_community/chat_models/moonshot.py
@@ -2,7 +2,10 @@
 from typing import Dict
 
 from langchain_core.pydantic_v1 import root_validator
-from langchain_core.utils import get_from_dict_or_env
+from langchain_core.utils import (
+    convert_to_secret_str,
+    get_from_dict_or_env,
+)
 
 from langchain_community.chat_models import ChatOpenAI
 from langchain_community.llms.moonshot import MOONSHOT_SERVICE_URL_BASE, MoonshotCommon
@@ -28,8 +31,10 @@ class MoonshotChat(MoonshotCommon, ChatOpenAI):  # type: ignore[misc]
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that the environment is set up correctly."""
-        values["moonshot_api_key"] = get_from_dict_or_env(
-            values, "moonshot_api_key", "MOONSHOT_API_KEY"
+        values["moonshot_api_key"] = convert_to_secret_str(
+            get_from_dict_or_env(
+                values, "moonshot_api_key", "MOONSHOT_API_KEY"
+            )
         )
 
         try:


### PR DESCRIPTION
Close #23174 