### PR TITLE
infra: run CI on large diffs

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -15,6 +15,10 @@ LANGCHAIN_DIRS = [
     "libs/experimental",
 ]
 
+def all_package_dirs() -> Set[str]:
+    return {"/".join(path.split("/")[:-1]) for path in glob.glob("./libs/**/pyproject.toml", recursive=True)}
+
+
 def dependents_graph() -> dict:
     dependents = defaultdict(set)
 
@@ -55,8 +59,9 @@ if __name__ == "__main__":
 
     if len(files) == 300:
         # max diff length is 300 files - there are likely files missing
-        raise ValueError("Max diff reached. Please manually run CI on changed libs.")
-
+        dirs_to_run["lint"] = all_package_dirs()
+        dirs_to_run["test"] = all_package_dirs()
+        dirs_to_run["extended-test"] = set(LANGCHAIN_DIRS)
     for file in files:
         if any(
             file.startswith(dir_)

--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     }
     docs_edited = False
 
-    if len(files) == 300:
+    if len(files) >= 300:
         # max diff length is 300 files - there are likely files missing
         dirs_to_run["lint"] = all_package_dirs()
         dirs_to_run["test"] = all_package_dirs()


### PR DESCRIPTION
currently we skip CI on diffs >= 300 files. think we should just run it on all packages instead