### PR TITLE
core[patch]: set schema format for AsyncRootListenersTracer

### DIFF
--- a/libs/core/langchain_core/tracers/root_listeners.py
+++ b/libs/core/langchain_core/tracers/root_listeners.py
@@ -71,7 +71,7 @@ class AsyncRootListenersTracer(AsyncBaseTracer):
         on_end: Optional[AsyncListener],
         on_error: Optional[AsyncListener],
     ) -> None:
-        super().__init__()
+        super().__init__(_schema_format="original+chat")
 
         self.config = config
         self._arg_on_start = on_start


### PR DESCRIPTION
  - **Description:** AsyncRootListenersTracer support on_chat_model_start, it's schema_format should be "original+chat".
  - **Issue:** N/A
  - **Dependencies:**
