### PR TITLE
core[minor]: Update pgvector transalor for langchain_postgres

### DIFF
--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -170,11 +170,12 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
 
         try:
             from langchain_postgres import PGVector
+            from langchain_postgres import PGVectorTranslator as NewPGVectorTranslator
         except ImportError:
             pass
         else:
             if isinstance(vectorstore, PGVector):
-                return PGVectorTranslator()
+                return NewPGVectorTranslator()
 
         raise ValueError(
             f"Self query retriever with Vector Store type {vectorstore.__class__}"


### PR DESCRIPTION
The SelfQuery PGVectorTranslator is not correct. The operator is "eq" and not "$eq".
This patch use a new version of PGVectorTranslator from langchain_postgres.

It's necessary to release a new version of langchain_postgres (see [here](https://github.com/langchain-ai/langchain-postgres/pull/75) before accepting this PR in langchain.


