### PR TITLE
docs: Update clean up API reference

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -90,7 +90,7 @@ def _load_module_members(module_path: str, namespace: str) -> ModuleMembers:
             elif (
                 issubclass(type_, Runnable)
                 and issubclass(type_, BaseModel)
-                and not type_ is Runnable
+                and type_ is not Runnable
             ):
                 # RunnableSerializable subclasses from Pydantic which
                 # for which we use autodoc_pydantic for rendering.
@@ -102,7 +102,7 @@ def _load_module_members(module_path: str, namespace: str) -> ModuleMembers:
             elif (
                 issubclass(type_, Runnable)
                 and not issubclass(type_, BaseModel)
-                and not type_ is Runnable
+                and type_ is not Runnable
             ):
                 # These are not pydantic classes but are Runnable.
                 # We'll hide all the inherited methods from Runnable

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -11,13 +11,13 @@ from typing import Dict, List, Literal, Optional, Sequence, TypedDict, Union
 
 import toml
 import typing_extensions
-from langchain_core.runnables import Runnable
+from langchain_core.runnables import RunnableSerializable
 from pydantic import BaseModel
 
 ROOT_DIR = Path(__file__).parents[2].absolute()
 HERE = Path(__file__).parent
 
-ClassKind = Literal["TypedDict", "Regular", "Pydantic", "enum", "RunnableSubclass"]
+ClassKind = Literal["TypedDict", "Regular", "Pydantic", "enum", "RunableSerializableSubclass"]
 
 
 class ClassInfo(TypedDict):
@@ -78,8 +78,10 @@ def _load_module_members(module_path: str, namespace: str) -> ModuleMembers:
                 kind: ClassKind = "TypedDict"
             elif type(type_) is typing._TypedDictMeta:  # type: ignore
                 kind: ClassKind = "TypedDict"
-            elif issubclass(type_, Runnable) and not type_ is Runnable:
-                kind = "RunnableSubclass"
+            elif issubclass(type_, RunnableSerializable):
+                # RunnableSerializable subclasses from Pydantic which
+                # has a lot of inherited methods are not relevant.
+                kind = "RunableSerializableSubclass"
             elif issubclass(type_, Enum):
                 kind = "enum"
             elif issubclass(type_, BaseModel):
@@ -260,7 +262,7 @@ Classes
                     template = "enum.rst"
                 elif class_["kind"] == "Pydantic":
                     template = "pydantic.rst"
-                elif class_["kind"] == "RunnableSubclass":
+                elif class_["kind"] == "RunableSerializableSubclass":
                     template = "runnable_subclass.rst"
                 else:
                     template = "class.rst"

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -260,8 +260,8 @@ Classes
                     template = "enum.rst"
                 elif class_["kind"] == "Pydantic":
                     template = "pydantic.rst"
-                # elif class_["kind"] == "RunnableSubclass":
-                #     template = "runnable_subclass.rst"
+                elif class_["kind"] == "RunnableSubclass":
+                    template = "runnable_subclass.rst"
                 else:
                     template = "class.rst"
 

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -11,14 +11,19 @@ from typing import Dict, List, Literal, Optional, Sequence, TypedDict, Union
 
 import toml
 import typing_extensions
-from langchain_core.runnables import RunnableSerializable, Runnable
+from langchain_core.runnables import Runnable, RunnableSerializable
 from pydantic import BaseModel
 
 ROOT_DIR = Path(__file__).parents[2].absolute()
 HERE = Path(__file__).parent
 
 ClassKind = Literal[
-    "TypedDict", "Regular", "Pydantic", "enum", "RunnablePydantic", "RunnableNonPydantic"
+    "TypedDict",
+    "Regular",
+    "Pydantic",
+    "enum",
+    "RunnablePydantic",
+    "RunnableNonPydantic",
 ]
 
 

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Sequence, TypedDict, Union
 
 import toml
+import typing_extensions
 from pydantic import BaseModel
 
 ROOT_DIR = Path(__file__).parents[2].absolute()
@@ -69,7 +70,9 @@ def _load_module_members(module_path: str, namespace: str) -> ModuleMembers:
             continue
 
         if inspect.isclass(type_):
-            if type(type_) == typing._TypedDictMeta:  # type: ignore
+            if type(type_) is typing_extensions._TypedDictMeta:  # type: ignore
+                kind: ClassKind = "TypedDict"
+            elif type(type_) is typing._TypedDictMeta:  # type: ignore
                 kind: ClassKind = "TypedDict"
             elif issubclass(type_, Enum):
                 kind = "enum"

--- a/docs/api_reference/templates/pydantic.rst
+++ b/docs/api_reference/templates/pydantic.rst
@@ -17,6 +17,7 @@
     :special-members: __call__
     :exclude-members: construct, copy, dict, from_orm, parse_file, parse_obj, parse_raw, schema, schema_json, update_forward_refs, validate, json, is_lc_serializable, to_json, to_json_not_implemented, lc_secrets, lc_attributes, lc_id, get_lc_namespace
 
+
     {% block attributes %}
     {% endblock %}
 

--- a/docs/api_reference/templates/pydantic.rst
+++ b/docs/api_reference/templates/pydantic.rst
@@ -15,6 +15,7 @@
     :member-order: groupwise
     :show-inheritance: True
     :special-members: __call__
+    :exclude-members: construct, copy, dict, from_orm, parse_file, parse_obj, parse_raw, schema, schema_json, update_forward_refs, validate, json, is_lc_serializable, to_json, to_json_not_implemented, lc_secrets, lc_attributes, lc_id, get_lc_namespace
 
     {% block attributes %}
     {% endblock %}

--- a/docs/api_reference/templates/runnable_non_pydantic.rst
+++ b/docs/api_reference/templates/runnable_non_pydantic.rst
@@ -1,6 +1,9 @@
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 
+.. NOTE:: {{objname}} implements the standard :py:class:`Runnable Interface <langchain_core.runnables.base.Runnable>`. 🏃
+
+
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}

--- a/docs/api_reference/templates/runnable_pydantic.rst
+++ b/docs/api_reference/templates/runnable_pydantic.rst
@@ -1,7 +1,7 @@
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 
-{{objname}} implements the standard :py:class:`Runnable Interface <langchain_core.runnables.base.Runnable>`.
+.. NOTE:: {{objname}} implements the standard :py:class:`Runnable Interface <langchain_core.runnables.base.Runnable>`. 🏃
 
 .. currentmodule:: {{ module }}
 

--- a/docs/api_reference/templates/runnable_subclass.rst
+++ b/docs/api_reference/templates/runnable_subclass.rst
@@ -17,6 +17,6 @@
     :member-order: groupwise
     :show-inheritance: True
     :special-members: __call__
-    :exclude-members: construct, copy, dict, from_orm, parse_file, parse_obj, parse_raw, schema, schema_json, update_forward_refs, validate, json, is_lc_serializable, to_json, to_json_not_implemented, lc_secrets, lc_attributes, lc_id, get_lc_namespace, invoke, ainvoke, batch, abatch, batch_as_completed, abatch_as_completed, astream_log, astream, astream_events, transform, atransform, get_output_schema, get_prompts, configurable_fields, configurable_alternatives, config_schema, map, pick, pipe, with_listeners, with_alisteners, with_config, with_fallbacks
+    :exclude-members: construct, copy, dict, from_orm, parse_file, parse_obj, parse_raw, schema, schema_json, update_forward_refs, validate, json, is_lc_serializable, to_json, to_json_not_implemented, lc_secrets, lc_attributes, lc_id, get_lc_namespace, invoke, ainvoke, batch, abatch, batch_as_completed, abatch_as_completed, astream_log, stream, astream, astream_events, transform, atransform, get_output_schema, get_prompts, configurable_fields, configurable_alternatives, config_schema, map, pick, pipe, with_listeners, with_alisteners, with_config, with_fallbacks, with_types, with_retry, InputType, OutputType, config_specs, output_schema, get_input_schema, get_graph, get_name, input_schema, name, bind, assign
 
 .. example_links:: {{ objname }}

--- a/docs/api_reference/templates/runnable_subclass.rst
+++ b/docs/api_reference/templates/runnable_subclass.rst
@@ -1,0 +1,22 @@
+:mod:`{{module}}`.{{objname}}
+{{ underline }}==============
+
+{{objname}} implements the standard :py:class:`Runnable Interface <langchain_core.runnables.base.Runnable>`.
+
+.. currentmodule:: {{ module }}
+
+.. autopydantic_model:: {{ objname }}
+    :model-show-json: False
+    :model-show-config-summary: False
+    :model-show-validator-members: False
+    :model-show-field-summary: False
+    :field-signature-prefix: param
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :member-order: groupwise
+    :show-inheritance: True
+    :special-members: __call__
+    :exclude-members: construct, copy, dict, from_orm, parse_file, parse_obj, parse_raw, schema, schema_json, update_forward_refs, validate, json, is_lc_serializable, to_json, to_json_not_implemented, lc_secrets, lc_attributes, lc_id, get_lc_namespace, invoke, ainvoke, batch, abatch, batch_as_completed, abatch_as_completed, astream_log, astream, astream_events, transform, atransform, get_output_schema, get_prompts, configurable_fields, configurable_alternatives, config_schema, map, pick, pipe, with_listeners, with_alisteners, with_config, with_fallbacks
+
+.. example_links:: {{ objname }}


### PR DESCRIPTION
- Fix bug with TypedDicts rendering inherited methods if inherting from
  typing_extensions.TypedDict rather than typing.TypedDict
- Do not surface inherited pydantic methods for subclasses of BaseModel
- Subclasses of RunnableSerializable will not how methods inherited from
  Runnable or from BaseModel
- Subclasses of Runnable that not pydantic models will include a link to
  RunnableInterface (they still show inherited methods, we can fix this later)
