### PR TITLE
**community**: Fix sql_databse.from_databricks issue when ran from Job

### DIFF
--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -201,10 +201,12 @@ class SQLDatabase:
             from dbruntime.databricks_repl_context import get_context
 
             context = get_context()
+            default_host = context.browserHostName
+            
         except ImportError:
-            pass
+            default_host = None
 
-        default_host = context.browserHostName if context else None
+        
         if host is None:
             host = get_from_env("host", "DATABRICKS_HOST", default_host)
 

--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -202,7 +202,6 @@ class SQLDatabase:
 
             context = get_context()
             default_host = context.browserHostName
-            
         except ImportError:
             default_host = None
 

--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -206,7 +206,6 @@ class SQLDatabase:
         except ImportError:
             default_host = None
 
-        
         if host is None:
             host = get_from_env("host", "DATABRICKS_HOST", default_host)
 


### PR DESCRIPTION

**Desscription**: When the ``sql_database.from_databricks`` is executed from a Workflow Job,  the ``context`` object does not have a "browserHostName" property, resulting in an error. This change manages the error so the  "DATABRICKS_HOST" env variable value is used instead of stoping the flow

