### PR TITLE
community: Add ID field back to Azure AI Search results

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -1253,6 +1253,11 @@ class AzureSearch(VectorStore):
                     page_content=result.pop(FIELDS_CONTENT),
                     metadata={
                         **(
+                            {FIELDS_ID: result.pop(FIELDS_ID)}
+                            if FIELDS_ID in result
+                            else {}
+                        ),
+                        **(
                             json.loads(result[FIELDS_METADATA])
                             if FIELDS_METADATA in result
                             else {
@@ -1332,6 +1337,11 @@ class AzureSearch(VectorStore):
                     Document(
                         page_content=result.pop(FIELDS_CONTENT),
                         metadata={
+                            **(
+                                {FIELDS_ID: result.pop(FIELDS_ID)}
+                                if FIELDS_ID in result
+                                else {}
+                            ),
                             **(
                                 json.loads(result[FIELDS_METADATA])
                                 if FIELDS_METADATA in result
@@ -1702,10 +1712,19 @@ def _reorder_results_with_maximal_marginal_relevance(
 def _result_to_document(result: Dict) -> Document:
     return Document(
         page_content=result.pop(FIELDS_CONTENT),
-        metadata=json.loads(result[FIELDS_METADATA])
-        if FIELDS_METADATA in result
-        else {
-            key: value for key, value in result.items() if key != FIELDS_CONTENT_VECTOR
+        metadata={
+            **(
+                {FIELDS_ID: result.pop(FIELDS_ID)}
+                if FIELDS_ID in result
+                else {}
+            ),
+            **(
+                json.loads(result[FIELDS_METADATA])
+                if FIELDS_METADATA in result
+                else {
+                    key: value for key, value in result.items() if key != FIELDS_CONTENT_VECTOR
+                }
+            ),
         },
     )
 


### PR DESCRIPTION
**Description**
This pull request adds the `id` field back to documents returned by the AzureSearch vector store, which was removed in `langchain-community==0.0.20`. The removal of the `id` field breaks implementations that rely on being able to reference the document ID in search results.

**Issue**
Fixes #22827 
