### PR TITLE
langchain: fix systax warning in create_json_chat_agent

### DIFF
--- a/libs/langchain/langchain/agents/json_chat/base.py
+++ b/libs/langchain/langchain/agents/json_chat/base.py
@@ -122,8 +122,8 @@ def create_json_chat_agent(
 
             ```json
             {{
-                "action": string, \ The action to take. Must be one of {tool_names}
-                "action_input": string \ The input to the action
+                "action": string, \\ The action to take. Must be one of {tool_names}
+                "action_input": string \\ The input to the action
             }}
             ```
 
@@ -134,7 +134,7 @@ def create_json_chat_agent(
             ```json
             {{
                 "action": "Final Answer",
-                "action_input": string \ You should put what you want to return to use here
+                "action_input": string \\ You should put what you want to return to use here
             }}
             ```
 


### PR DESCRIPTION
fix systax warning in `create_json_chat_agent`

```
.../langchain/agents/json_chat/base.py:22: SyntaxWarning: invalid escape sequence '\ '
  """Create an agent that uses JSON to format its logic, build for Chat Models.
```