### PR TITLE
Replace llm variable with model

### DIFF
--- a/docs/docs/tutorials/pdf_qa.ipynb
+++ b/docs/docs/tutorials/pdf_qa.ipynb
@@ -122,7 +122,7 @@
     "```{=mdx}\n",
     "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",
     "\n",
-    "<ChatModelTabs openaiParams={`model=\"gpt-4o\"`} />\n",
+    "<ChatModelTabs customVarName=\"llm\" openaiParams={`model=\"gpt-4o\"`} />\n",
     "```"
    ]
   },
@@ -239,7 +239,7 @@
     ")\n",
     "\n",
     "\n",
-    "question_answer_chain = create_stuff_documents_chain(model, prompt)\n",
+    "question_answer_chain = create_stuff_documents_chain(llm, prompt)\n",
     "rag_chain = create_retrieval_chain(retriever, question_answer_chain)\n",
     "\n",
     "results = rag_chain.invoke({\"input\": \"What was Nike's revenue in 2023?\"})\n",

--- a/docs/docs/tutorials/pdf_qa.ipynb
+++ b/docs/docs/tutorials/pdf_qa.ipynb
@@ -239,7 +239,7 @@
     ")\n",
     "\n",
     "\n",
-    "question_answer_chain = create_stuff_documents_chain(llm, prompt)\n",
+    "question_answer_chain = create_stuff_documents_chain(model, prompt)\n",
     "rag_chain = create_retrieval_chain(retriever, question_answer_chain)\n",
     "\n",
     "results = rag_chain.invoke({\"input\": \"What was Nike's revenue in 2023?\"})\n",


### PR DESCRIPTION
The code snippet under ‘pdfs_qa’ contains an small incorrect code example , resulting in users getting errors. This pr replaces ‘llm’ variable with ‘model’ to help user avoid a NameError message. 

Resolves #22689


If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
