### PR TITLE
community: allows to disable `HuggingFaceEndpoint` API-Token validation

### DIFF
--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -121,7 +121,7 @@ class HuggingFaceEndpoint(LLM):
     task: Optional[str] = None
     """Task to call the model with.
     Should be a task that returns `generated_text` or `summary_text`."""
-    validate_api_token: Optional[bool] = True
+    validate_api_token: bool = True
     """Whether to validate the API token"""
 
     class Config:

--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -121,6 +121,8 @@ class HuggingFaceEndpoint(LLM):
     task: Optional[str] = None
     """Task to call the model with.
     Should be a task that returns `generated_text` or `summary_text`."""
+    validate_api_token: Optional[bool] = True
+    """Whether to validate the API token"""
 
     class Config:
         """Configuration for this pydantic object."""
@@ -179,10 +181,12 @@ class HuggingFaceEndpoint(LLM):
             )
             login(token=huggingfacehub_api_token)
         except Exception as e:
-            raise ValueError(
-                "Could not authenticate with huggingface_hub. "
-                "Please check your API token."
-            ) from e
+            if values["validate_api_token"]:
+                raise ValueError(
+                    "Could not authenticate with huggingface_hub. "
+                    "Please check your API token."
+                ) from e
+            huggingfacehub_api_token = None
 
         from huggingface_hub import AsyncInferenceClient, InferenceClient
 

--- a/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
+++ b/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
@@ -6,6 +6,7 @@ from langchain_core.pydantic_v1 import ValidationError
 from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
 
 
+@pytest.mark.requires("huggingface_hub")
 def test_disable_api_token_check():
     with pytest.raises(ValidationError):
         HuggingFaceEndpoint(endpoint_url="some-url")

--- a/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
+++ b/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
@@ -7,7 +7,7 @@ from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
 
 
 @pytest.mark.requires("huggingface_hub")
-def test_disable_api_token_check():
+def test_disable_api_token_check() -> None:
     with pytest.raises(ValidationError):
         HuggingFaceEndpoint(endpoint_url="some-url")
 

--- a/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
+++ b/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
@@ -1,0 +1,13 @@
+"""Test `HuggingFaceEndpoint`."""
+
+import pytest
+from langchain_core.pydantic_v1 import ValidationError
+
+from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
+
+
+def test_disable_api_token_check():
+    with pytest.raises(ValidationError):
+        HuggingFaceEndpoint(endpoint_url="some-url")
+
+    HuggingFaceEndpoint(endpoint_url="some-url", validate_api_token=False)

--- a/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
+++ b/libs/community/tests/unit_tests/llms/test_huggingface_endpoint.py
@@ -9,6 +9,6 @@ from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
 @pytest.mark.requires("huggingface_hub")
 def test_disable_api_token_check() -> None:
     with pytest.raises(ValidationError):
-        HuggingFaceEndpoint(endpoint_url="some-url")
+        HuggingFaceEndpoint(endpoint_url="some-url")  # type: ignore[call-arg]
 
-    HuggingFaceEndpoint(endpoint_url="some-url", validate_api_token=False)
+    HuggingFaceEndpoint(endpoint_url="some-url", validate_api_token=False)  # type: ignore[call-arg]


### PR DESCRIPTION
**Description:** Allows to skip the validation of the API-Token in `HuggingFaceEndpoint` by setting `validate_api_token=False`. 