### PR TITLE
core[patch]: export tool output parsers from langchain_core.output_parsers

### DIFF
--- a/libs/core/langchain_core/output_parsers/__init__.py
+++ b/libs/core/langchain_core/output_parsers/__init__.py
@@ -24,6 +24,11 @@ from langchain_core.output_parsers.list import (
     MarkdownListOutputParser,
     NumberedListOutputParser,
 )
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser,
+    JsonOutputToolsParser,
+    PydanticToolsParser,
+)
 from langchain_core.output_parsers.pydantic import PydanticOutputParser
 from langchain_core.output_parsers.string import StrOutputParser
 from langchain_core.output_parsers.transform import (
@@ -47,4 +52,7 @@ __all__ = [
     "XMLOutputParser",
     "JsonOutputParser",
     "PydanticOutputParser",
+    "JsonOutputToolsParser",
+    "JsonOutputKeyToolsParser",
+    "PydanticToolsParser",
 ]

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, InvalidToolCall
-from langchain_core.output_parsers import BaseCumulativeTransformOutputParser
+from langchain_core.output_parsers.transform import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.pydantic_v1 import BaseModel, ValidationError
 from langchain_core.utils.json import parse_partial_json

--- a/libs/core/tests/unit_tests/output_parsers/test_imports.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_imports.py
@@ -15,6 +15,9 @@ EXPECTED_ALL = [
     "XMLOutputParser",
     "JsonOutputParser",
     "PydanticOutputParser",
+    "JsonOutputToolsParser",
+    "JsonOutputKeyToolsParser",
+    "PydanticToolsParser",
 ]
 
 


### PR DESCRIPTION
These currently read off AIMessage.tool_calls, and only fall back to OpenAI parsing if tool calls aren't populated.

Importing these from `openai_tools` (e.g., in our [tool calling docs](https://python.langchain.com/v0.2/docs/how_to/tool_calling/#tool-calls)) can lead to confusion.

After landing, would need to release core and update docs.