### PR TITLE
community: add default value to bing_search_url

### DIFF
--- a/libs/community/langchain_community/utilities/bing_search.py
+++ b/libs/community/langchain_community/utilities/bing_search.py
@@ -5,6 +5,8 @@ import requests
 from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
+# BING_SEARCH_ENDPOINT is the default endpoint for Bing Search API and is invariant to users.
+BING_SEARCH_ENDPOINT = "https://api.bing.microsoft.com/v7.0/search"
 
 class BingSearchAPIWrapper(BaseModel):
     """Wrapper for Bing Search API."""
@@ -52,7 +54,7 @@ class BingSearchAPIWrapper(BaseModel):
             values,
             "bing_search_url",
             "BING_SEARCH_URL",
-            # default="https://api.bing.microsoft.com/v7.0/search",
+            default=BING_SEARCH_ENDPOINT,
         )
 
         values["bing_search_url"] = bing_search_url

--- a/libs/community/langchain_community/utilities/bing_search.py
+++ b/libs/community/langchain_community/utilities/bing_search.py
@@ -5,9 +5,10 @@ import requests
 from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
-# BING_SEARCH_ENDPOINT is the default endpoint for Bing Search API and is
-# normally invariant to users.
+# BING_SEARCH_ENDPOINT is the default endpoint for Bing Search API and is normally
+# invariant to users.
 BING_SEARCH_ENDPOINT = "https://api.bing.microsoft.com/v7.0/search"
+
 
 class BingSearchAPIWrapper(BaseModel):
     """Wrapper for Bing Search API."""

--- a/libs/community/langchain_community/utilities/bing_search.py
+++ b/libs/community/langchain_community/utilities/bing_search.py
@@ -5,7 +5,8 @@ import requests
 from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
-# BING_SEARCH_ENDPOINT is the default endpoint for Bing Search API and is invariant to users.
+# BING_SEARCH_ENDPOINT is the default endpoint for Bing Search API and is
+# normally invariant to users.
 BING_SEARCH_ENDPOINT = "https://api.bing.microsoft.com/v7.0/search"
 
 class BingSearchAPIWrapper(BaseModel):


### PR DESCRIPTION
bing_search_url is an endpoint to requests bing search resource and is normally invariant to users, we can give it the default value to simply the uesages of this utility/tool