### PR TITLE
community: Patch/issue#23308

### DIFF
--- a/libs/community/langchain_community/vectorstores/duckdb.py
+++ b/libs/community/langchain_community/vectorstores/duckdb.py
@@ -193,7 +193,8 @@ class DuckDB(VectorStore):
             df = pd.DataFrame.from_dict(data)
             df.to_sql(name=self._table_name,
                       con=self._connection,
-                      if_exists='append')
+                      if_exists='append',
+                      index=False)
         return ids
 
     def similarity_search(

--- a/libs/community/langchain_community/vectorstores/duckdb.py
+++ b/libs/community/langchain_community/vectorstores/duckdb.py
@@ -191,7 +191,9 @@ class DuckDB(VectorStore):
         if have_pandas:
             # noinspection PyUnusedLocal
             df = pd.DataFrame.from_dict(data)
-            df.to_sql(name=self._table_name, con=self._connection)
+            df.to_sql(name=self._table_name,
+                      con=self._connection,
+                      if_exists='append')
         return ids
 
     def similarity_search(

--- a/libs/community/langchain_community/vectorstores/duckdb.py
+++ b/libs/community/langchain_community/vectorstores/duckdb.py
@@ -190,10 +190,8 @@ class DuckDB(VectorStore):
 
         if have_pandas:
             # noinspection PyUnusedLocal
-            df = pd.DataFrame.from_dict(data)  # noqa: F841
-            self._connection.execute(
-                f"INSERT INTO {self._table_name} SELECT * FROM df",
-            )
+            df = pd.DataFrame.from_dict(data)
+            df.to_sql(name=self._table_name, con=self._connection)
         return ids
 
     def similarity_search(


### PR DESCRIPTION
- **Description:** Changed `langchain/libs/community/langchain_community/vectorstores/duckdb.py` line 194 from `self._connection.execute(...)` to `df.to_sql(...)`
    - Actually I tested both version copying the section of code and test them in notebook environment and both of them works fine
    - But integrating to the package, only my version works in the kaggle notebook where I encountered issue#23308
    - > ⚠️ A warning popped up
duckdb.py:194: UserWarning: pandas only supports SQLAlchemy connectable (engine/connection) or database string URI or sqlite3 DBAPI2 connection. Other DBAPI2 objects are not tested. Please consider using SQLAlchemy.
  df.to_sql(name=self._table_name,
    - ℹ️ The warning did not affect the result of writing to database and `similarity_search()` returns expected response
- **Issue:** #23308 
- **Dependencies:** None
