### PR TITLE
core[patch]: Add unit test when catching generator exit

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1878,7 +1878,7 @@ class Runnable(Generic[Input, Output], ABC):
                                 final_output_supported = False
                     else:
                         final_output = chunk
-            except StopIteration:
+            except (StopIteration, GeneratorExit):
                 pass
             for ichunk in input_for_tracing:
                 if final_input_supported:
@@ -1892,8 +1892,6 @@ class Runnable(Generic[Input, Output], ABC):
                             final_input_supported = False
                 else:
                     final_input = ichunk
-        except GeneratorExit:
-            run_manager.on_chain_end(final_output, inputs=final_input)
         except BaseException as e:
             run_manager.on_chain_error(e, inputs=final_input)
             raise

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5703,17 +5703,20 @@ async def test_listeners_async() -> None:
     assert value1 in shared_state.values(), "Value not found in the dictionary."
     assert value2 in shared_state.values(), "Value not found in the dictionary."
 
+
 async def test_closing_iterator_doesnt_raise_error() -> None:
     """Test that closing an iterator calls on_chain_end rather than on_chain_error."""
-    from langchain_core.output_parsers import StrOutputParser
-    from langchain_core.callbacks import BaseCallbackHandler
-    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
     import time
 
+    from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.output_parsers import StrOutputParser
+
     on_chain_error_triggered = False
+
     class MyHandler(BaseCallbackHandler):
         def on_chain_error(
-                self, error: BaseException, *, run_id, parent_run_id=None, **kwargs
+            self, error: BaseException, *, run_id, parent_run_id=None, **kwargs
         ):
             nonlocal on_chain_error_triggered
             on_chain_error_triggered = True

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5703,20 +5703,17 @@ async def test_listeners_async() -> None:
     assert value1 in shared_state.values(), "Value not found in the dictionary."
     assert value2 in shared_state.values(), "Value not found in the dictionary."
 
-
 async def test_closing_iterator_doesnt_raise_error() -> None:
     """Test that closing an iterator calls on_chain_end rather than on_chain_error."""
-    import time
-
+    from langchain_core.output_parsers import StrOutputParser
     from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-    from langchain_core.output_parsers import StrOutputParser
+    import time
 
     on_chain_error_triggered = False
-
     class MyHandler(BaseCallbackHandler):
         def on_chain_error(
-            self, error: BaseException, *, run_id, parent_run_id=None, **kwargs
+                self, error: BaseException, *, run_id, parent_run_id=None, **kwargs
         ):
             nonlocal on_chain_error_triggered
             on_chain_error_triggered = True
@@ -5725,7 +5722,7 @@ async def test_closing_iterator_doesnt_raise_error() -> None:
     chain = llm | StrOutputParser()
     chain = chain.with_config({"callbacks": [MyHandler()]})
     st = chain.stream("hello")
-    next()
+    next(st)
     st.close()
     # Wait for a bit to make sure that the callback is called.
     time.sleep(0.05)

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5702,3 +5702,31 @@ async def test_listeners_async() -> None:
     assert len(shared_state) == 2
     assert value1 in shared_state.values(), "Value not found in the dictionary."
     assert value2 in shared_state.values(), "Value not found in the dictionary."
+
+
+async def test_closing_iterator_doesnt_raise_error() -> None:
+    """Test that closing an iterator calls on_chain_end rather than on_chain_error."""
+    import time
+
+    from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.output_parsers import StrOutputParser
+
+    on_chain_error_triggered = False
+
+    class MyHandler(BaseCallbackHandler):
+        def on_chain_error(
+            self, error: BaseException, *, run_id, parent_run_id=None, **kwargs
+        ):
+            nonlocal on_chain_error_triggered
+            on_chain_error_triggered = True
+
+    llm = GenericFakeChatModel(messages=iter(["hi there"]))
+    chain = llm | StrOutputParser()
+    chain = chain.with_config({"callbacks": [MyHandler()]})
+    st = chain.stream("hello")
+    next()
+    st.close()
+    # Wait for a bit to make sure that the callback is called.
+    time.sleep(0.05)
+    assert on_chain_error_triggered is False


### PR DESCRIPTION
This pr adds a unit test for: https://github.com/langchain-ai/langchain/pull/22662
And narrows the scope where the exception is caught.