### PR TITLE
openai[patch]: add support for extra_body

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -346,6 +346,9 @@ class BaseChatOpenAI(BaseChatModel):
         http_client as well if you'd like a custom client for sync invocations."""
     stop: Optional[Union[List[str], str]] = Field(default=None, alias="stop_sequences")
     """Default stop sequences."""
+    extra_body: Optional[Mapping[str, Any]] = None
+    """Optional additional JSON properties to include in the request parameters when
+    making requests to OpenAI compatible APIs, such as vLLM."""
 
     class Config:
         """Configuration for this pydantic object."""
@@ -445,6 +448,9 @@ class BaseChatOpenAI(BaseChatModel):
             params["max_tokens"] = self.max_tokens
         if self.stop:
             params["stop"] = self.stop
+        if self.extra_body is not None:
+            params["extra_body"] = self.extra_body
+
         return params
 
     def _combine_llm_outputs(self, llm_outputs: List[Optional[dict]]) -> dict:
@@ -918,8 +924,7 @@ class BaseChatOpenAI(BaseChatModel):
         method: Literal["function_calling", "json_mode"] = "function_calling",
         include_raw: Literal[True] = True,
         **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, _AllReturnType]:
-        ...
+    ) -> Runnable[LanguageModelInput, _AllReturnType]: ...
 
     @overload
     def with_structured_output(
@@ -929,8 +934,7 @@ class BaseChatOpenAI(BaseChatModel):
         method: Literal["function_calling", "json_mode"] = "function_calling",
         include_raw: Literal[False] = False,
         **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, _DictOrPydantic]:
-        ...
+    ) -> Runnable[LanguageModelInput, _DictOrPydantic]: ...
 
     def with_structured_output(
         self,

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -924,7 +924,8 @@ class BaseChatOpenAI(BaseChatModel):
         method: Literal["function_calling", "json_mode"] = "function_calling",
         include_raw: Literal[True] = True,
         **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, _AllReturnType]: ...
+    ) -> Runnable[LanguageModelInput, _AllReturnType]:
+        ...
 
     @overload
     def with_structured_output(
@@ -934,7 +935,8 @@ class BaseChatOpenAI(BaseChatModel):
         method: Literal["function_calling", "json_mode"] = "function_calling",
         include_raw: Literal[False] = False,
         **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, _DictOrPydantic]: ...
+    ) -> Runnable[LanguageModelInput, _DictOrPydantic]:
+        ...
 
     def with_structured_output(
         self,

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -137,6 +137,9 @@ class BaseOpenAI(BaseLLM):
     http_async_client: Union[Any, None] = None
     """Optional httpx.AsyncClient. Only used for async invocations. Must specify 
         http_client as well if you'd like a custom client for sync invocations."""
+    extra_body: Optional[Mapping[str, Any]] = None
+    """Optional additional JSON properties to include in the request parameters when
+    making requests to OpenAI compatible APIs, such as vLLM."""
 
     class Config:
         """Configuration for this pydantic object."""
@@ -221,6 +224,9 @@ class BaseOpenAI(BaseLLM):
 
         if self.max_tokens is not None:
             normal_params["max_tokens"] = self.max_tokens
+
+        if self.extra_body is not None:
+            normal_params["extra_body"] = self.extra_body
 
         # Azure gpt-35-turbo doesn't support best_of
         # don't specify best_of if it is 1


### PR DESCRIPTION
**Description:** Add support passing extra_body parameter

Some OpenAI compatible API's have additional parameters (for example [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters)) that can be passed thought  `extra_body`. Same question in https://github.com/openai/openai-python/issues/767

<!--
If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
-->