### PR TITLE
core[minor]: Add optional ID field to Document schema

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -54,15 +54,13 @@ class Document(Serializable):
         return ["langchain", "schema", "document"]
 
     def __str__(self) -> str:
-        """Override __str__ to restrict it to page_content and metadata.
-
-        The format matches pydantic format for __str__.
-
-        The purpose of this change is to make sure that user code that
-        feeds Document objects directly into prompts remains unchanged
-        due to the addition of the id field (or any other fields in the future).
-
-        This override will likely be removed in the future in favor of
-        a more general solution of formatting content directly inside the prompts.
-        """
+        """Override __str__ to restrict it to page_content and metadata."""
+        # The format matches pydantic format for __str__.
+        #
+        # The purpose of this change is to make sure that user code that
+        # feeds Document objects directly into prompts remains unchanged
+        # due to the addition of the id field (or any other fields in the future).
+        #
+        # This override will likely be removed in the future in favor of
+        # a more general solution of formatting content directly inside the prompts.
         return f"page_content='{self.page_content}', metadata={self.metadata}"

--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -63,4 +63,7 @@ class Document(Serializable):
         #
         # This override will likely be removed in the future in favor of
         # a more general solution of formatting content directly inside the prompts.
-        return f"page_content='{self.page_content}', metadata={self.metadata}"
+        if self.metadata:
+            return f"page_content='{self.page_content}' metadata={self.metadata}"
+        else:
+            return f"page_content='{self.page_content}'"

--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -21,14 +21,14 @@ class Document(Serializable):
             )
     """
 
+    # The ID field is optional at the moment.
+    # It will likely become required in a future major release after
+    # it has been adopted by enough vectorstore implementations.
     id: Optional[str] = None
     """An optional identifier for the document.
     
     Ideally this should be unique across the document collection and formatted 
     as a UUID, but this will not be enforced.
-    
-    This field is optional at the moment, but may become a required field 
-    in the future (wil be assigned automatically if not provided).
     """
 
     page_content: str

--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, Literal
+from typing import Any, List, Literal, Optional
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.pydantic_v1 import Field
@@ -19,6 +19,16 @@ class Document(Serializable):
                 page_content="Hello, world!",
                 metadata={"source": "https://example.com"}
             )
+    """
+
+    id: Optional[str] = None
+    """An optional identifier for the document.
+    
+    Ideally this should be unique across the document collection and formatted 
+    as a UUID, but this will not be enforced.
+    
+    This field is optional at the moment, but may become a required field 
+    in the future (wil be assigned automatically if not provided).
     """
 
     page_content: str
@@ -42,3 +52,17 @@ class Document(Serializable):
     def get_lc_namespace(cls) -> List[str]:
         """Get the namespace of the langchain object."""
         return ["langchain", "schema", "document"]
+
+    def __str__(self) -> str:
+        """Override __str__ to restrict it to page_content and metadata.
+
+        The format matches pydantic format for __str__.
+
+        The purpose of this change is to make sure that user code that
+        feeds Document objects directly into prompts remains unchanged
+        due to the addition of the id field (or any other fields in the future).
+
+        This override will likely be removed in the future in favor of
+        a more general solution of formatting content directly inside the prompts.
+        """
+        return f"page_content='{self.page_content}', metadata={self.metadata}"

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -311,6 +311,10 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                 "properties": {
                     "page_content": {"title": "Page Content", "type": "string"},
                     "metadata": {"title": "Metadata", "type": "object"},
+                    "id": {
+                        "title": "Id",
+                        "type": "string",
+                    },
                     "type": {
                         "title": "Type",
                         "enum": ["Document"],


### PR DESCRIPTION
This PR adds an optional ID field to the document schema.

# 1. Optional or Required

- An optional field will will requrie additional checking for the type in user code (annoying).
- However, vectorstores currently don't respect this field. So if we make it
  required and start returning random UUIDs that might be even more confusing
  to users.


**Proposal**:   Start with Optional and convert to Required (with default set to uuid4()) in 1-2 major releases.


# 2. Override __str__ or generic solution in prompts

Overriding __str__ as a simple way to avoid changing user code that relies on
default str(document) in prompts. 


I considered rolling out a more general solution in prompts (https://github.com/langchain-ai/langchain/pull/8685),
but to do that we need to:

1. Make things serializable
2. The more general solution would likely need to be backwards compatible as well
3. It's unclear that one wants to format a List[int] in the same way as
   List[Document]. The former should be `,` seperated (likely), the latter
   should be `---` separated (likely).


**Proposal** Start with __str__ override and focus on the vectorstore APIs, we generalize prompts later

