### PR TITLE
core: fix run_manager not being passed to _stream

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -320,7 +320,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
             )
             generation: Optional[ChatGenerationChunk] = None
             try:
-                for chunk in self._stream(messages, stop=stop, **kwargs):
+                for chunk in self._stream(messages, stop=stop, run_manager=run_manager, **kwargs):
                     if chunk.message.id is None:
                         chunk.message.id = f"run-{run_manager.run_id}"
                     chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)


### PR DESCRIPTION
Inside `BaseChatModel` class, `stream` function constructs run_manager, but doesn't pass it to `_stream`, rendering the model invocations unable to interact with the callbacks.