### PR TITLE
community: Replace deprecated setVectorProperty with setNodeVectorProperty

### DIFF
--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -1441,9 +1441,10 @@ class Neo4jVector(VectorStore):
                 "UNWIND $data AS row "
                 f"MATCH (n:`{node_label}`) "
                 "WHERE elementId(n) = row.id "
-                f"CALL db.create.setVectorProperty(n, "
+                f"CALL db.create.setNodeVectorProperty(n, "
                 f"'{embedding_node_property}', row.embedding) "
-                "YIELD node RETURN count(*)",
+                f"WITH n "
+                f"RETURN count(*)",
                 params=params,
             )
             # If embedding calculation should be stopped


### PR DESCRIPTION
Description: Replace deprecated `setVectorProperty` with `setNodeVectorProperty` in Cypher query to update node embeddings. Since setNodeVectorProperty doesn't return the nodes, the cypher query returns and yields the nodes instead. 
(https://neo4j.com/docs/operations-manual/5/reference/procedures/#procedure_db_create_setNodeVectorProperty)

Dependencies: No dependencies have been introduced.

Tests: The change is covered by previous unit tests.
