### PR TITLE
community[patch]: support convert FunctionMessage for Tongyi

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -32,6 +32,7 @@ from langchain_core.messages import (
     BaseMessageChunk,
     ChatMessage,
     ChatMessageChunk,
+    FunctionMessage,
     HumanMessage,
     HumanMessageChunk,
     SystemMessage,
@@ -199,6 +200,13 @@ def convert_message_to_dict(message: BaseMessage) -> dict:
         message_dict = {
             "role": "tool",
             "tool_call_id": message.tool_call_id,
+            "content": message.content,
+            "name": message.name,
+        }
+    elif isinstance(message, FunctionMessage):
+        message_dict = {
+            "role": "tool",
+            "tool_call_id": "",
             "content": message.content,
             "name": message.name,
         }

--- a/libs/community/tests/unit_tests/chat_models/test_tongyi.py
+++ b/libs/community/tests/unit_tests/chat_models/test_tongyi.py
@@ -1,5 +1,6 @@
 from langchain_core.messages import (
     AIMessage,
+    FunctionMessage,
     HumanMessage,
     SystemMessage,
 )
@@ -82,4 +83,16 @@ def test__convert_message_to_dict_system() -> None:
     message = SystemMessage(content="foo")
     result = convert_message_to_dict(message)
     expected_output = {"role": "system", "content": "foo"}
+    assert result == expected_output
+
+
+def test__convert_message_to_dict_tool() -> None:
+    message = FunctionMessage(name="foo", content="bar")
+    result = convert_message_to_dict(message)
+    expected_output = {
+        "role": "tool",
+        "tool_call_id": "",
+        "content": "bar",
+        "name": "foo",
+    }
     assert result == expected_output


### PR DESCRIPTION
**Description:** For function call agent with Tongyi, cause the AgentAction will be converted to FunctionMessage by
https://github.com/langchain-ai/langchain/blob/47f69fe0d85056a378d7de7e7210247f5b9a8704/libs/core/langchain_core/agents.py#L188
But now Tongyi's *convert_message_to_dict* doesn't support FunctionMessage
https://github.com/langchain-ai/langchain/blob/47f69fe0d85056a378d7de7e7210247f5b9a8704/libs/community/langchain_community/chat_models/tongyi.py#L184-L207
Then next round conversation will be failed by the *TypeError* exception.

This patch adds the support to convert FunctionMessage for Tongyi.

**Issue:** N/A
**Dependencies:** N/A