### PR TITLE
community: Standardise tool import for arxiv & semantic scholar

### DIFF
--- a/libs/community/langchain_community/tools/arxiv/__init__.py
+++ b/libs/community/langchain_community/tools/arxiv/__init__.py
@@ -1,1 +1,6 @@
+from langchain_community.tools.arxiv.tool import ArxivQueryRun
+
 """Arxiv API toolkit."""
+"""Tool for the Arxiv Search API."""
+
+__all__ = ["ArxivQueryRun"]

--- a/libs/community/langchain_community/tools/semanticscholar/__init__.py
+++ b/libs/community/langchain_community/tools/semanticscholar/__init__.py
@@ -1,1 +1,6 @@
+from langchain_community.tools.semanticscholar.tool import SemanticScholarQueryRun
+
 """Semantic Scholar API toolkit."""
+"""Tool for the Semantic Scholar Search API."""
+
+__all__ = ["SemanticScholarQueryRun"]


### PR DESCRIPTION

    - **Description:** Fixing the way users have to import Arxiv and Semantic Scholar
    - **Issue:** Changed to use `from langchain_community.tools.arxiv import ArxivQueryRun` instead of `from langchain_community.tools.arxiv.tool import ArxivQueryRun`
    - **Dependencies:** None
    - **Twitter handle:** Nope

