### PR TITLE
community: Register pandas df in duckdb when creating vector_store

### DIFF
--- a/libs/community/langchain_community/vectorstores/duckdb.py
+++ b/libs/community/langchain_community/vectorstores/duckdb.py
@@ -191,6 +191,7 @@ class DuckDB(VectorStore):
         if have_pandas:
             # noinspection PyUnusedLocal
             df = pd.DataFrame.from_dict(data)  # noqa: F841
+            self._connection.register("df", df)
             self._connection.execute(
                 f"INSERT INTO {self._table_name} SELECT * FROM df",
             )


### PR DESCRIPTION
- **Description:** Register pandas df in duckdb when creating vector_store
- **Issue:** Resolves #23308
- **Dependencies:** None
- **Twitter handle:** @timvw
