### PR TITLE
Neo4j: Update with non-deprecated cypher methods, and new method to associate relationship embeddings

### DIFF
--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -856,9 +856,11 @@ class Neo4jVector(VectorStore):
             "WITH c, row "
             f"CALL db.create.setNodeVectorProperty(c, "
             f"'{self.embedding_node_property}', row.embedding) "
-            "YIELD node "
             f"SET c.`{self.text_node_property}` = row.text "
-            "SET c += row.metadata } IN TRANSACTIONS OF 1000 ROWS"
+            "SET c += row.metadata "
+            "RETURN c "
+            "} IN TRANSACTIONS OF 1000 ROWS "
+            "RETURN c "
         )
 
         parameters = {
@@ -873,6 +875,56 @@ class Neo4jVector(VectorStore):
         self.query(import_query, params=parameters)
 
         return ids
+
+    def add_relation_embeddings(
+        self,
+        texts: Iterable[str],
+        embeddings: List[List[float]],
+        relation_type: str,
+        text_relation_property: str = "text",
+        embedding_relation_property: str = "embeddings",
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Add embeddings to the relations in the vectorstore.
+
+        Args:
+            texts: Iterable of strings to add embeddings to.
+            embeddings: List of list of embedding vectors.
+            relation_type:The relationship type to associate the embeddings.
+            text_relation_property: The property name to search relations.
+            embedding_relation_property: The property name for the embedding vectors.
+            metadatas: List of metadatas associated with the relations.
+            kwargs: vectorstore specific parameters
+        """
+
+        if ids is None:
+            ids = [md5(text.encode("utf-8")).hexdigest() for text in texts]
+
+        if not metadatas:
+            metadatas = [{} for _ in texts]
+
+        import_query = (
+            "UNWIND $data AS row "
+            f"MATCH ()-[r:`{relation_type}`]->() "
+            f"WHERE r.`{text_relation_property}` = row.text "
+            f"CALL db.create.setRelationshipVectorProperty(r, "
+            f"'{embedding_relation_property}', row.embedding) "
+        )
+
+        parameters = {
+            "data": [
+                {"text": text, "metadata": metadata, "embedding": embedding, "id": id}
+                for text, metadata, embedding, id in zip(
+                    texts, metadatas, embeddings, ids
+                )
+            ]
+        }
+
+        self.query(import_query, params=parameters)
+
+        return list(ids)
 
     def add_texts(
         self,
@@ -1443,7 +1495,7 @@ class Neo4jVector(VectorStore):
                 "WHERE elementId(n) = row.id "
                 f"CALL db.create.setNodeVectorProperty(n, "
                 f"'{embedding_node_property}', row.embedding) "
-                "YIELD node RETURN count(*)",
+                "RETURN count(*)",
                 params=params,
             )
             # If embedding calculation should be stopped

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -854,7 +854,7 @@ class Neo4jVector(VectorStore):
             "CALL { WITH row "
             f"MERGE (c:`{self.node_label}` {{id: row.id}}) "
             "WITH c, row "
-            f"CALL db.create.setVectorProperty(c, "
+            f"CALL db.create.setNodeVectorProperty(c, "
             f"'{self.embedding_node_property}', row.embedding) "
             "YIELD node "
             f"SET c.`{self.text_node_property}` = row.text "
@@ -1441,7 +1441,7 @@ class Neo4jVector(VectorStore):
                 "UNWIND $data AS row "
                 f"MATCH (n:`{node_label}`) "
                 "WHERE elementId(n) = row.id "
-                f"CALL db.create.setVectorProperty(n, "
+                f"CALL db.create.setNodeVectorProperty(n, "
                 f"'{embedding_node_property}', row.embedding) "
                 "YIELD node RETURN count(*)",
                 params=params,

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -858,9 +858,7 @@ class Neo4jVector(VectorStore):
             f"'{self.embedding_node_property}', row.embedding) "
             f"SET c.`{self.text_node_property}` = row.text "
             "SET c += row.metadata "
-            "RETURN c "
             "} IN TRANSACTIONS OF 1000 ROWS "
-            "RETURN c "
         )
 
         parameters = {

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -876,56 +876,6 @@ class Neo4jVector(VectorStore):
 
         return ids
 
-    def add_relation_embeddings(
-        self,
-        texts: Iterable[str],
-        embeddings: List[List[float]],
-        relation_type: str,
-        text_relation_property: str = "text",
-        embedding_relation_property: str = "embeddings",
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> List[str]:
-        """Add embeddings to the relations in the vectorstore.
-
-        Args:
-            texts: Iterable of strings to add embeddings to.
-            embeddings: List of list of embedding vectors.
-            relation_type:The relationship type to associate the embeddings.
-            text_relation_property: The property name to search relations.
-            embedding_relation_property: The property name for the embedding vectors.
-            metadatas: List of metadatas associated with the relations.
-            kwargs: vectorstore specific parameters
-        """
-
-        if ids is None:
-            ids = [md5(text.encode("utf-8")).hexdigest() for text in texts]
-
-        if not metadatas:
-            metadatas = [{} for _ in texts]
-
-        import_query = (
-            "UNWIND $data AS row "
-            f"MATCH ()-[r:`{relation_type}`]->() "
-            f"WHERE r.`{text_relation_property}` = row.text "
-            f"CALL db.create.setRelationshipVectorProperty(r, "
-            f"'{embedding_relation_property}', row.embedding) "
-        )
-
-        parameters = {
-            "data": [
-                {"text": text, "metadata": metadata, "embedding": embedding, "id": id}
-                for text, metadata, embedding, id in zip(
-                    texts, metadatas, embeddings, ids
-                )
-            ]
-        }
-
-        self.query(import_query, params=parameters)
-
-        return list(ids)
-
     def add_texts(
         self,
         texts: Iterable[str],

--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -885,7 +885,6 @@ def test_neo4jvector_relationship_embeddings() -> None:
             f"CREATE "
             f"(:Chunk {{text: '{texts[1]}'}})-[:REL {{id: 'rel1', text: '{texts[0]}'}}]"
             f"->(:Chunk {{text: '{texts[2]}'}}), "
-
             f"(:Chunk {{text: '{texts[2]}'}})-[:REL {{id: 'rel2', text: '{texts[1]}'}}]"
             f"->(:Chunk {{text: '{texts[1]}'}})"
         )

--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -863,62 +863,6 @@ OPTIONS {indexConfig: {
     drop_vector_indexes(docsearch)
 
 
-def test_neo4jvector_relationship_embeddings() -> None:
-    """Test end to end construction and search."""
-    embeddings = FakeEmbeddingsWithOsDimension()
-    docsearch = Neo4jVector.from_texts(
-        texts=texts[1:],  # Create the nodes with texts after (including) index 1
-        embedding=embeddings,
-        url=url,
-        username=username,
-        password=password,
-        pre_delete_collection=True,
-    )
-    # Ingest data
-    relation_ids = ["rel1", "rel2"]
-    embeddings_list = [
-        embeddings.embed_query(texts[0]),
-        embeddings.embed_query(texts[1]),
-    ]
-    docsearch.query(
-        (  # Creates bidirectional relation between the texts[1] and texts[2] nodes
-            f"CREATE "
-            f"(:Chunk {{text: '{texts[1]}'}})-[:REL {{id: 'rel1', text: '{texts[0]}'}}]"
-            f"->(:Chunk {{text: '{texts[2]}'}}), "
-            f"(:Chunk {{text: '{texts[2]}'}})-[:REL {{id: 'rel2', text: '{texts[1]}'}}]"
-            f"->(:Chunk {{text: '{texts[1]}'}})"
-        )
-    )
-
-    # Add relationship embeddings
-    docsearch.add_relation_embeddings(
-        texts=texts,
-        relation_ids=relation_ids,
-        embeddings=embeddings_list,
-        relation_type="REL",
-        embedding_relation_property="embedding",
-        text_relation_property="text",
-    )
-
-    # Create relationship index
-    docsearch.query(
-        """CREATE VECTOR INDEX `relationship`
-FOR ()-[r:REL]-() ON (r.embedding)
-OPTIONS {indexConfig: {
- `vector.dimensions`: 1536,
- `vector.similarity_function`: 'cosine'
-}}
-"""
-    )
-    relationship_index = Neo4jVector.from_existing_relationship_index(
-        embeddings, index_name="relationship"
-    )
-
-    output = relationship_index.similarity_search(texts[0], k=1)
-    assert output == [Document(page_content=texts[0])]
-    drop_vector_indexes(docsearch)
-
-
 def test_neo4jvector_relationship_index_retrieval() -> None:
     """Test end to end construction and search."""
     embeddings = FakeEmbeddingsWithOsDimension()


### PR DESCRIPTION
**Description:** At the moment neo4j wrapper is using setVectorProperty, which is deprecated ([link](https://neo4j.com/docs/operations-manual/5/reference/procedures/#procedure_db_create_setVectorProperty)). I replaced with the non-deprecated version.

Neo4j recently introduced a new cypher method to associate embeddings into relations using "setRelationshipVectorProperty" method. In this PR I also implemented a new method to perform this association maintaining the same format used in the "add_embeddings" method which is used to associate embeddings into Nodes.
I also included a test case for this new method.
