### PR TITLE
core: allow message utils to work with lcel

### DIFF
--- a/docs/docs/how_to/merge_message_runs.ipynb
+++ b/docs/docs/how_to/merge_message_runs.ipynb
@@ -65,6 +65,38 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11f7e8d3",
+   "metadata": {},
+   "source": [
+    "The `merge_message_runs` utility also works with messages composed together using the overloaded `+` operation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b51855c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "messages = (\n",
+    "    SystemMessage(\"you're a good assistant.\")\n",
+    "    + SystemMessage(\"you always respond with a joke.\")\n",
+    "    + HumanMessage([{\"type\": \"text\", \"text\": \"i wonder why it's called langchain\"}])\n",
+    "    + HumanMessage(\"and who is harrison chasing anyways\")\n",
+    "    + AIMessage(\n",
+    "        'Well, I guess they thought \"WordRope\" and \"SentenceString\" just didn\\'t have the same ring to it!'\n",
+    "    )\n",
+    "    + AIMessage(\n",
+    "        \"Why, he's probably chasing after the last cup of coffee in the office!\"\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "merged = merge_message_runs(messages)\n",
+    "print(\"\\n\\n\".join([repr(x) for x in merged]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1b2eee74-71c8-4168-b968-bca580c25d18",
    "metadata": {},
    "source": [

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 
     from langchain_core.language_models import BaseLanguageModel
     from langchain_core.prompt_values import PromptValue
-    from langchain_core.prompts.chat import BaseChatPromptTemplate
     from langchain_core.runnables.base import Runnable
 
 AnyMessage = Union[
@@ -287,11 +286,7 @@ def _convert_to_message(message: MessageLikeRepresentation) -> BaseMessage:
 
 
 def convert_to_messages(
-    messages: Union[
-        Iterable[MessageLikeRepresentation],
-        PromptValue,
-        BaseChatPromptTemplate,
-    ],
+    messages: Union[Iterable[MessageLikeRepresentation], PromptValue],
 ) -> List[BaseMessage]:
     """Convert a sequence of messages to a list of messages.
 
@@ -303,12 +298,9 @@ def convert_to_messages(
     """
     # Import here to avoid circular imports
     from langchain_core.prompt_values import PromptValue
-    from langchain_core.prompts.chat import BaseChatPromptTemplate
 
     if isinstance(messages, PromptValue):
-        return [_convert_to_message(m) for m in messages.to_messages()]
-    if isinstance(messages, BaseChatPromptTemplate) and hasattr(messages, "messages"):
-        return [_convert_to_message(m) for m in messages.messages]
+        return messages.to_messages()
     return [_convert_to_message(m) for m in messages]
 
 
@@ -344,11 +336,7 @@ def _runnable_support(func: Callable) -> Callable:
 
 @_runnable_support
 def filter_messages(
-    messages: Union[
-        Iterable[MessageLikeRepresentation],
-        PromptValue,
-        BaseChatPromptTemplate,
-    ],
+    messages: Union[Iterable[MessageLikeRepresentation], PromptValue],
     *,
     include_names: Optional[Sequence[str]] = None,
     exclude_names: Optional[Sequence[str]] = None,
@@ -436,11 +424,7 @@ def filter_messages(
 
 @_runnable_support
 def merge_message_runs(
-    messages: Union[
-        Iterable[MessageLikeRepresentation],
-        PromptValue,
-        BaseChatPromptTemplate,
-    ],
+    messages: Union[Iterable[MessageLikeRepresentation], PromptValue],
 ) -> List[BaseMessage]:
     """Merge consecutive Messages of the same type.
 
@@ -529,11 +513,7 @@ def merge_message_runs(
 
 @_runnable_support
 def trim_messages(
-    messages: Union[
-        Iterable[MessageLikeRepresentation],
-        PromptValue,
-        BaseChatPromptTemplate,
-    ],
+    messages: Union[Iterable[MessageLikeRepresentation], PromptValue],
     *,
     max_tokens: int,
     token_counter: Union[

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1,4 +1,3 @@
-from functools import reduce
 from typing import Dict, List, Type
 
 import pytest
@@ -191,7 +190,6 @@ _MESSAGES_TO_TRIM = [
     HumanMessage("This is a 4 token text.", id="third"),
     AIMessage("This is a 4 token text.", id="fourth"),
 ]
-_MESSAGES_TO_TRIM_LCEL = reduce(lambda x, y: x + y, _MESSAGES_TO_TRIM)
 _MESSAGES_TO_TRIM_COPY = [m.copy(deep=True) for m in _MESSAGES_TO_TRIM]
 
 
@@ -202,21 +200,6 @@ def test_trim_messages_first_30() -> None:
     ]
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
-        max_tokens=30,
-        token_counter=dummy_token_counter,
-        strategy="first",
-    )
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
-def test_trim_messages_first_30_lcel() -> None:
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        HumanMessage("This is a 4 token text.", id="first"),
-    ]
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=30,
         token_counter=dummy_token_counter,
         strategy="first",
@@ -244,25 +227,6 @@ def test_trim_messages_first_30_allow_partial() -> None:
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
-def test_trim_messages_first_30_allow_partial_lcel() -> None:
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        HumanMessage("This is a 4 token text.", id="first"),
-        AIMessage(
-            [{"type": "text", "text": "This is the FIRST 4 token block."}], id="second"
-        ),
-    ]
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
-        max_tokens=30,
-        token_counter=dummy_token_counter,
-        strategy="first",
-        allow_partial=True,
-    )
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
 def test_trim_messages_first_30_allow_partial_end_on_human() -> None:
     expected = [
         SystemMessage("This is a 4 token text."),
@@ -271,24 +235,6 @@ def test_trim_messages_first_30_allow_partial_end_on_human() -> None:
 
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
-        max_tokens=30,
-        token_counter=dummy_token_counter,
-        strategy="first",
-        allow_partial=True,
-        end_on="human",
-    )
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
-def test_trim_messages_first_30_allow_partial_end_on_human_lcel() -> None:
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        HumanMessage("This is a 4 token text.", id="first"),
-    ]
-
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=30,
         token_counter=dummy_token_counter,
         strategy="first",
@@ -317,24 +263,6 @@ def test_trim_messages_last_30_include_system() -> None:
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
-def test_trim_messages_last_30_include_system_lcel() -> None:
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        HumanMessage("This is a 4 token text.", id="third"),
-        AIMessage("This is a 4 token text.", id="fourth"),
-    ]
-
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
-        max_tokens=30,
-        include_system=True,
-        token_counter=dummy_token_counter,
-        strategy="last",
-    )
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
 def test_trim_messages_last_40_include_system_allow_partial() -> None:
     expected = [
         SystemMessage("This is a 4 token text."),
@@ -350,32 +278,6 @@ def test_trim_messages_last_40_include_system_allow_partial() -> None:
 
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
-        max_tokens=40,
-        token_counter=dummy_token_counter,
-        strategy="last",
-        allow_partial=True,
-        include_system=True,
-    )
-
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
-def test_trim_messages_last_40_include_system_allow_partial_lcel() -> None:
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        AIMessage(
-            [
-                {"type": "text", "text": "This is the SECOND 4 token block."},
-            ],
-            id="second",
-        ),
-        HumanMessage("This is a 4 token text.", id="third"),
-        AIMessage("This is a 4 token text.", id="fourth"),
-    ]
-
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=40,
         token_counter=dummy_token_counter,
         strategy="last",
@@ -413,32 +315,6 @@ def test_trim_messages_last_30_include_system_allow_partial_end_on_human() -> No
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
-def test_trim_messages_last_30_include_system_allow_partial_end_on_human_lcel() -> None:
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        AIMessage(
-            [
-                {"type": "text", "text": "This is the SECOND 4 token block."},
-            ],
-            id="second",
-        ),
-        HumanMessage("This is a 4 token text.", id="third"),
-    ]
-
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
-        max_tokens=30,
-        token_counter=dummy_token_counter,
-        strategy="last",
-        allow_partial=True,
-        include_system=True,
-        end_on="human",
-    )
-
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
 def test_trim_messages_last_40_include_system_allow_partial_start_on_human() -> None:
     expected = [
         SystemMessage("This is a 4 token text."),
@@ -448,29 +324,6 @@ def test_trim_messages_last_40_include_system_allow_partial_start_on_human() -> 
 
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
-        max_tokens=30,
-        token_counter=dummy_token_counter,
-        strategy="last",
-        allow_partial=True,
-        include_system=True,
-        start_on="human",
-    )
-
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
-def test_trim_messages_last_40_include_system_allow_partial_start_on_human_lcel() -> (
-    None
-):
-    expected = [
-        SystemMessage("This is a 4 token text."),
-        HumanMessage("This is a 4 token text.", id="third"),
-        AIMessage("This is a 4 token text.", id="fourth"),
-    ]
-
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=30,
         token_counter=dummy_token_counter,
         strategy="last",
@@ -516,55 +369,12 @@ def test_trim_messages_allow_partial_text_splitter() -> None:
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
-def test_trim_messages_allow_partial_text_splitter_lcel() -> None:
-    expected = [
-        HumanMessage("a 4 token text.", id="third"),
-        AIMessage("This is a 4 token text.", id="fourth"),
-    ]
-
-    def count_words(msgs: List[BaseMessage]) -> int:
-        count = 0
-        for msg in msgs:
-            if isinstance(msg.content, str):
-                count += len(msg.content.split(" "))
-            else:
-                count += len(
-                    " ".join(block["text"] for block in msg.content).split(" ")  # type: ignore[index]
-                )
-        return count
-
-    def _split_on_space(text: str) -> List[str]:
-        splits = text.split(" ")
-        return [s + " " for s in splits[:-1]] + splits[-1:]
-
-    actual = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL,
-        max_tokens=10,
-        token_counter=count_words,
-        strategy="last",
-        allow_partial=True,
-        text_splitter=_split_on_space,
-    )
-    assert actual == expected
-    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
-
-
 def test_trim_messages_invoke() -> None:
     actual = trim_messages(max_tokens=10, token_counter=dummy_token_counter).invoke(
         _MESSAGES_TO_TRIM
     )
     expected = trim_messages(
         _MESSAGES_TO_TRIM, max_tokens=10, token_counter=dummy_token_counter
-    )
-    assert actual == expected
-
-
-def test_trim_messages_invoke_lcel() -> None:
-    actual = trim_messages(max_tokens=10, token_counter=dummy_token_counter).invoke(
-        _MESSAGES_TO_TRIM_LCEL
-    )
-    expected = trim_messages(
-        _MESSAGES_TO_TRIM_LCEL, max_tokens=10, token_counter=dummy_token_counter
     )
     assert actual == expected
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from typing import Dict, List, Type
 
 import pytest
@@ -67,6 +68,44 @@ def test_merge_message_runs_content() -> None:
     assert messages == messages_copy
 
 
+def test_merge_message_runs_content_lcel() -> None:
+    messages = (
+        AIMessage("foo", id="1")
+        + AIMessage(
+            [
+                {"text": "bar", "type": "text"},
+                {"image_url": "...", "type": "image_url"},
+            ],
+            tool_calls=[ToolCall(name="foo_tool", args={"x": 1}, id="tool1")],
+            id="2",
+        )
+        + AIMessage(
+            "baz",
+            tool_calls=[ToolCall(name="foo_tool", args={"x": 5}, id="tool2")],
+            id="3",
+        )
+    )
+    expected = [
+        AIMessage(
+            [
+                "foo",
+                {"text": "bar", "type": "text"},
+                {"image_url": "...", "type": "image_url"},
+                "baz",
+            ],
+            tool_calls=[
+                ToolCall(name="foo_tool", args={"x": 1}, id="tool1"),
+                ToolCall(name="foo_tool", args={"x": 5}, id="tool2"),
+            ],
+            id="1",
+        )
+    ]
+    actual = merge_message_runs(messages)
+    assert actual == expected
+    invoked = merge_message_runs().invoke(messages)
+    assert actual == invoked
+
+
 def test_merge_messages_tool_messages() -> None:
     messages = [
         ToolMessage("foo", tool_call_id="1"),
@@ -110,6 +149,35 @@ def test_filter_message(filters: Dict) -> None:
     assert messages == messages_copy
 
 
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"include_names": ["blur"]},
+        {"exclude_names": ["blah"]},
+        {"include_ids": ["2"]},
+        {"exclude_ids": ["1"]},
+        {"include_types": "human"},
+        {"include_types": ["human"]},
+        {"include_types": HumanMessage},
+        {"include_types": [HumanMessage]},
+        {"exclude_types": "system"},
+        {"exclude_types": ["system"]},
+        {"exclude_types": SystemMessage},
+        {"exclude_types": [SystemMessage]},
+        {"include_names": ["blah", "blur"], "exclude_types": [SystemMessage]},
+    ],
+)
+def test_filter_message_lcel(filters: Dict) -> None:
+    system_message = SystemMessage("foo", name="blah", id="1")
+    human_message = HumanMessage("bar", name="blur", id="2")
+    messages = system_message + human_message
+    expected = [human_message]
+    actual = filter_messages(messages, **filters)
+    assert expected == actual
+    invoked = filter_messages(**filters).invoke(messages)
+    assert invoked == actual
+
+
 _MESSAGES_TO_TRIM = [
     SystemMessage("This is a 4 token text."),
     HumanMessage("This is a 4 token text.", id="first"),
@@ -123,7 +191,7 @@ _MESSAGES_TO_TRIM = [
     HumanMessage("This is a 4 token text.", id="third"),
     AIMessage("This is a 4 token text.", id="fourth"),
 ]
-
+_MESSAGES_TO_TRIM_LCEL = reduce(lambda x, y: x + y, _MESSAGES_TO_TRIM)
 _MESSAGES_TO_TRIM_COPY = [m.copy(deep=True) for m in _MESSAGES_TO_TRIM]
 
 
@@ -134,6 +202,21 @@ def test_trim_messages_first_30() -> None:
     ]
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
+        max_tokens=30,
+        token_counter=dummy_token_counter,
+        strategy="first",
+    )
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
+def test_trim_messages_first_30_lcel() -> None:
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        HumanMessage("This is a 4 token text.", id="first"),
+    ]
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=30,
         token_counter=dummy_token_counter,
         strategy="first",
@@ -161,6 +244,25 @@ def test_trim_messages_first_30_allow_partial() -> None:
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
+def test_trim_messages_first_30_allow_partial_lcel() -> None:
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        HumanMessage("This is a 4 token text.", id="first"),
+        AIMessage(
+            [{"type": "text", "text": "This is the FIRST 4 token block."}], id="second"
+        ),
+    ]
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
+        max_tokens=30,
+        token_counter=dummy_token_counter,
+        strategy="first",
+        allow_partial=True,
+    )
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
 def test_trim_messages_first_30_allow_partial_end_on_human() -> None:
     expected = [
         SystemMessage("This is a 4 token text."),
@@ -169,6 +271,24 @@ def test_trim_messages_first_30_allow_partial_end_on_human() -> None:
 
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
+        max_tokens=30,
+        token_counter=dummy_token_counter,
+        strategy="first",
+        allow_partial=True,
+        end_on="human",
+    )
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
+def test_trim_messages_first_30_allow_partial_end_on_human_lcel() -> None:
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        HumanMessage("This is a 4 token text.", id="first"),
+    ]
+
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=30,
         token_counter=dummy_token_counter,
         strategy="first",
@@ -197,6 +317,24 @@ def test_trim_messages_last_30_include_system() -> None:
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
+def test_trim_messages_last_30_include_system_lcel() -> None:
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        HumanMessage("This is a 4 token text.", id="third"),
+        AIMessage("This is a 4 token text.", id="fourth"),
+    ]
+
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
+        max_tokens=30,
+        include_system=True,
+        token_counter=dummy_token_counter,
+        strategy="last",
+    )
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
 def test_trim_messages_last_40_include_system_allow_partial() -> None:
     expected = [
         SystemMessage("This is a 4 token text."),
@@ -212,6 +350,32 @@ def test_trim_messages_last_40_include_system_allow_partial() -> None:
 
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
+        max_tokens=40,
+        token_counter=dummy_token_counter,
+        strategy="last",
+        allow_partial=True,
+        include_system=True,
+    )
+
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
+def test_trim_messages_last_40_include_system_allow_partial_lcel() -> None:
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        AIMessage(
+            [
+                {"type": "text", "text": "This is the SECOND 4 token block."},
+            ],
+            id="second",
+        ),
+        HumanMessage("This is a 4 token text.", id="third"),
+        AIMessage("This is a 4 token text.", id="fourth"),
+    ]
+
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=40,
         token_counter=dummy_token_counter,
         strategy="last",
@@ -249,6 +413,32 @@ def test_trim_messages_last_30_include_system_allow_partial_end_on_human() -> No
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
+def test_trim_messages_last_30_include_system_allow_partial_end_on_human_lcel() -> None:
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        AIMessage(
+            [
+                {"type": "text", "text": "This is the SECOND 4 token block."},
+            ],
+            id="second",
+        ),
+        HumanMessage("This is a 4 token text.", id="third"),
+    ]
+
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
+        max_tokens=30,
+        token_counter=dummy_token_counter,
+        strategy="last",
+        allow_partial=True,
+        include_system=True,
+        end_on="human",
+    )
+
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
 def test_trim_messages_last_40_include_system_allow_partial_start_on_human() -> None:
     expected = [
         SystemMessage("This is a 4 token text."),
@@ -258,6 +448,29 @@ def test_trim_messages_last_40_include_system_allow_partial_start_on_human() -> 
 
     actual = trim_messages(
         _MESSAGES_TO_TRIM,
+        max_tokens=30,
+        token_counter=dummy_token_counter,
+        strategy="last",
+        allow_partial=True,
+        include_system=True,
+        start_on="human",
+    )
+
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
+def test_trim_messages_last_40_include_system_allow_partial_start_on_human_lcel() -> (
+    None
+):
+    expected = [
+        SystemMessage("This is a 4 token text."),
+        HumanMessage("This is a 4 token text.", id="third"),
+        AIMessage("This is a 4 token text.", id="fourth"),
+    ]
+
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
         max_tokens=30,
         token_counter=dummy_token_counter,
         strategy="last",
@@ -303,12 +516,55 @@ def test_trim_messages_allow_partial_text_splitter() -> None:
     assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
 
 
+def test_trim_messages_allow_partial_text_splitter_lcel() -> None:
+    expected = [
+        HumanMessage("a 4 token text.", id="third"),
+        AIMessage("This is a 4 token text.", id="fourth"),
+    ]
+
+    def count_words(msgs: List[BaseMessage]) -> int:
+        count = 0
+        for msg in msgs:
+            if isinstance(msg.content, str):
+                count += len(msg.content.split(" "))
+            else:
+                count += len(
+                    " ".join(block["text"] for block in msg.content).split(" ")  # type: ignore[index]
+                )
+        return count
+
+    def _split_on_space(text: str) -> List[str]:
+        splits = text.split(" ")
+        return [s + " " for s in splits[:-1]] + splits[-1:]
+
+    actual = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL,
+        max_tokens=10,
+        token_counter=count_words,
+        strategy="last",
+        allow_partial=True,
+        text_splitter=_split_on_space,
+    )
+    assert actual == expected
+    assert _MESSAGES_TO_TRIM == _MESSAGES_TO_TRIM_COPY
+
+
 def test_trim_messages_invoke() -> None:
     actual = trim_messages(max_tokens=10, token_counter=dummy_token_counter).invoke(
         _MESSAGES_TO_TRIM
     )
     expected = trim_messages(
         _MESSAGES_TO_TRIM, max_tokens=10, token_counter=dummy_token_counter
+    )
+    assert actual == expected
+
+
+def test_trim_messages_invoke_lcel() -> None:
+    actual = trim_messages(max_tokens=10, token_counter=dummy_token_counter).invoke(
+        _MESSAGES_TO_TRIM_LCEL
+    )
+    expected = trim_messages(
+        _MESSAGES_TO_TRIM_LCEL, max_tokens=10, token_counter=dummy_token_counter
     )
     assert actual == expected
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -67,44 +67,6 @@ def test_merge_message_runs_content() -> None:
     assert messages == messages_copy
 
 
-def test_merge_message_runs_content_lcel() -> None:
-    messages = (
-        AIMessage("foo", id="1")
-        + AIMessage(
-            [
-                {"text": "bar", "type": "text"},
-                {"image_url": "...", "type": "image_url"},
-            ],
-            tool_calls=[ToolCall(name="foo_tool", args={"x": 1}, id="tool1")],
-            id="2",
-        )
-        + AIMessage(
-            "baz",
-            tool_calls=[ToolCall(name="foo_tool", args={"x": 5}, id="tool2")],
-            id="3",
-        )
-    )
-    expected = [
-        AIMessage(
-            [
-                "foo",
-                {"text": "bar", "type": "text"},
-                {"image_url": "...", "type": "image_url"},
-                "baz",
-            ],
-            tool_calls=[
-                ToolCall(name="foo_tool", args={"x": 1}, id="tool1"),
-                ToolCall(name="foo_tool", args={"x": 5}, id="tool2"),
-            ],
-            id="1",
-        )
-    ]
-    actual = merge_message_runs(messages)
-    assert actual == expected
-    invoked = merge_message_runs().invoke(messages)
-    assert actual == invoked
-
-
 def test_merge_messages_tool_messages() -> None:
     messages = [
         ToolMessage("foo", tool_call_id="1"),
@@ -146,35 +108,6 @@ def test_filter_message(filters: Dict) -> None:
     invoked = filter_messages(**filters).invoke(messages)
     assert invoked == actual
     assert messages == messages_copy
-
-
-@pytest.mark.parametrize(
-    "filters",
-    [
-        {"include_names": ["blur"]},
-        {"exclude_names": ["blah"]},
-        {"include_ids": ["2"]},
-        {"exclude_ids": ["1"]},
-        {"include_types": "human"},
-        {"include_types": ["human"]},
-        {"include_types": HumanMessage},
-        {"include_types": [HumanMessage]},
-        {"exclude_types": "system"},
-        {"exclude_types": ["system"]},
-        {"exclude_types": SystemMessage},
-        {"exclude_types": [SystemMessage]},
-        {"include_names": ["blah", "blur"], "exclude_types": [SystemMessage]},
-    ],
-)
-def test_filter_message_lcel(filters: Dict) -> None:
-    system_message = SystemMessage("foo", name="blah", id="1")
-    human_message = HumanMessage("bar", name="blur", id="2")
-    messages = system_message + human_message
-    expected = [human_message]
-    actual = filter_messages(messages, **filters)
-    assert expected == actual
-    invoked = filter_messages(**filters).invoke(messages)
-    assert invoked == actual
 
 
 _MESSAGES_TO_TRIM = [


### PR DESCRIPTION
The functions `convert_to_messages` has had an expansion of the arguments it can take:

1. Previously, it only could take a `Sequence` in order to iterate over it. This has been broadened slightly to an `Iterable` (which should have no other impact).
2. Support for `PromptValue` and `BaseChatPromptTemplate` has been added. These are generated when combining messages using the overloaded `+` operator.

Functions which rely on `convert_to_messages` (namely `filter_messages`, `merge_message_runs` and `trim_messages`) have had the type of their arguments similarly expanded.

Resolves #23706.

<!--
If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
-->