### PR TITLE
core[minor]: add upsert, streaming_upsert, aupsert, astreaming_upsert methods to the VectorStore abstraction

### DIFF
--- a/libs/community/langchain_community/vectorstores/inmemory.py
+++ b/libs/community/langchain_community/vectorstores/inmemory.py
@@ -71,7 +71,7 @@ class InMemoryVectorStore(VectorStore):
                 )
         return documents
 
-    await def aget_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+    async def aget_by_ids(self, ids: Sequence[str], /) -> List[Document]:
         return self.get_by_ids(ids)
 
     async def aadd_texts(

--- a/libs/community/langchain_community/vectorstores/inmemory.py
+++ b/libs/community/langchain_community/vectorstores/inmemory.py
@@ -71,7 +71,7 @@ class InMemoryVectorStore(VectorStore):
                 )
         return documents
 
-    def aget_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+    await def aget_by_ids(self, ids: Sequence[str], /) -> List[Document]:
         return self.get_by_ids(ids)
 
     async def aadd_texts(

--- a/libs/community/langchain_community/vectorstores/inmemory.py
+++ b/libs/community/langchain_community/vectorstores/inmemory.py
@@ -39,13 +39,14 @@ class InMemoryVectorStore(VectorStore):
         self.delete(ids)
 
     def upsert(self, items: Sequence[Document], /, **kwargs: Any) -> UpsertResponse:
+        vectors = self.embedding.embed_documents([item.page_content for item in items])
         ids = []
-        for item in items:
+        for item, vector in zip(items, vectors):
             doc_id = item.id if item.id else str(uuid.uuid4())
             ids.append(doc_id)
             self.store[doc_id] = {
                 "id": doc_id,
-                "vector": self.embedding.embed_documents([item.page_content])[0],
+                "vector": vector,
                 "text": item.page_content,
                 "metadata": item.metadata,
             }

--- a/libs/community/langchain_community/vectorstores/inmemory.py
+++ b/libs/community/langchain_community/vectorstores/inmemory.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
+from langchain_core.indexing import UpsertResponse
 from langchain_core.load import dumpd, load
 from langchain_core.vectorstores import VectorStore
 
@@ -37,27 +38,40 @@ class InMemoryVectorStore(VectorStore):
     async def adelete(self, ids: Optional[Sequence[str]] = None, **kwargs: Any) -> None:
         self.delete(ids)
 
-    def add_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        ids: Optional[Sequence[str]] = None,
-        **kwargs: Any,
-    ) -> List[str]:
-        """Add texts to the store."""
-        vectors = self.embedding.embed_documents(list(texts))
-        ids_ = []
-
-        for i, text in enumerate(texts):
-            doc_id = ids[i] if ids else str(uuid.uuid4())
-            ids_.append(doc_id)
+    def upsert(self, items: Sequence[Document], /, **kwargs: Any) -> UpsertResponse:
+        ids = []
+        for item in items:
+            doc_id = item.id if item.id else str(uuid.uuid4())
+            ids.append(doc_id)
             self.store[doc_id] = {
                 "id": doc_id,
-                "vector": vectors[i],
-                "text": text,
-                "metadata": metadatas[i] if metadatas else {},
+                "vector": self.embedding.embed_documents([item.page_content])[0],
+                "text": item.page_content,
+                "metadata": item.metadata,
             }
-        return ids_
+        return {
+            "succeeded": ids,
+            "failed": [],
+        }
+
+    def get_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+        """Get documents by their ids."""
+        documents = []
+
+        for doc_id in ids:
+            doc = self.store.get(doc_id)
+            if doc:
+                documents.append(
+                    Document(
+                        id=doc["id"],
+                        page_content=doc["text"],
+                        metadata=doc["metadata"],
+                    )
+                )
+        return documents
+
+    def aget_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+        return self.get_by_ids(ids)
 
     async def aadd_texts(
         self,
@@ -80,7 +94,9 @@ class InMemoryVectorStore(VectorStore):
             similarity = float(cosine_similarity([embedding], [vector]).item(0))
             result.append(
                 (
-                    Document(page_content=doc["text"], metadata=doc["metadata"]),
+                    Document(
+                        id=doc["id"], page_content=doc["text"], metadata=doc["metadata"]
+                    ),
                     similarity,
                     vector,
                 )

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1053,7 +1053,7 @@ class Milvus(VectorStore):
         pks = [item.get(self._primary_field) for item in query_result]
         return pks
 
-    def upsert(  # type: ignore[overrides]
+    def upsert(  # type: ignore[override]
         self,
         ids: Optional[List[str]] = None,
         documents: List[Document] | None = None,

--- a/libs/community/langchain_community/vectorstores/milvus.py
+++ b/libs/community/langchain_community/vectorstores/milvus.py
@@ -1053,7 +1053,7 @@ class Milvus(VectorStore):
         pks = [item.get(self._primary_field) for item in query_result]
         return pks
 
-    def upsert(
+    def upsert(  # type: ignore[overrides]
         self,
         ids: Optional[List[str]] = None,
         documents: List[Document] | None = None,

--- a/libs/community/tests/unit_tests/vectorstores/test_inmemory.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_inmemory.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 from langchain_core.documents import Document
@@ -11,6 +12,11 @@ from langchain_community.vectorstores.inmemory import InMemoryVectorStore
 from tests.integration_tests.vectorstores.fake_embeddings import (
     ConsistentFakeEmbeddings,
 )
+
+
+class AnyStr(str):
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, str)
 
 
 class TestInMemoryReadWriteTestSuite(ReadWriteTestSuite):
@@ -31,10 +37,13 @@ async def test_inmemory() -> None:
         ["foo", "bar", "baz"], ConsistentFakeEmbeddings()
     )
     output = await store.asimilarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [Document(page_content="foo", id=AnyStr())]
 
     output = await store.asimilarity_search("bar", k=2)
-    assert output == [Document(page_content="bar"), Document(page_content="baz")]
+    assert output == [
+        Document(page_content="bar", id=AnyStr()),
+        Document(page_content="baz", id=AnyStr()),
+    ]
 
     output2 = await store.asimilarity_search_with_score("bar", k=2)
     assert output2[0][1] > output2[1][1]
@@ -61,8 +70,8 @@ async def test_inmemory_mmr() -> None:
         "foo", k=10, lambda_mult=0.1
     )
     assert len(output) == len(texts)
-    assert output[0] == Document(page_content="foo")
-    assert output[1] == Document(page_content="foy")
+    assert output[0] == Document(page_content="foo", id=AnyStr())
+    assert output[1] == Document(page_content="foy", id=AnyStr())
 
 
 async def test_inmemory_dump_load(tmp_path: Path) -> None:
@@ -90,4 +99,4 @@ async def test_inmemory_filter() -> None:
     output = await store.asimilarity_search(
         "baz", filter=lambda doc: doc.metadata["id"] == 1
     )
-    assert output == [Document(page_content="foo", metadata={"id": 1})]
+    assert output == [Document(page_content="foo", metadata={"id": 1}, id=AnyStr())]

--- a/libs/core/langchain_core/indexing/__init__.py
+++ b/libs/core/langchain_core/indexing/__init__.py
@@ -5,7 +5,11 @@ a vectorstore while avoiding duplicated content and over-writing content
 if it's unchanged.
 """
 from langchain_core.indexing.api import IndexingResult, aindex, index
-from langchain_core.indexing.base import InMemoryRecordManager, RecordManager
+from langchain_core.indexing.base import (
+    InMemoryRecordManager,
+    RecordManager,
+    UpsertResponse,
+)
 
 __all__ = [
     "aindex",
@@ -13,4 +17,5 @@ __all__ = [
     "IndexingResult",
     "InMemoryRecordManager",
     "RecordManager",
+    "UpsertResponse",
 ]

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -405,7 +405,7 @@ async def _to_async_iterator(iterator: Iterable[T]) -> AsyncIterator[T]:
 
 
 async def aindex(
-    docs_source: Union[BaseLoader, Iterable[Document], AsyncIterable[Document]],
+    docs_source: Union[BaseLoader, Iterable[Document], AsyncIterator[Document]],
     record_manager: RecordManager,
     vector_store: VectorStore,
     *,

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -405,7 +405,7 @@ async def _to_async_iterator(iterator: Iterable[T]) -> AsyncIterator[T]:
 
 
 async def aindex(
-    docs_source: Union[BaseLoader, Iterable[Document], AsyncIterator[Document]],
+    docs_source: Union[BaseLoader, Iterable[Document], AsyncIterable[Document]],
     record_manager: RecordManager,
     vector_store: VectorStore,
     *,

--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -317,3 +317,16 @@ class InMemoryRecordManager(RecordManager):
 
     async def adelete_keys(self, keys: Sequence[str]) -> None:
         self.delete_keys(keys)
+
+
+class UpsertResponse(TypedDict):
+    """A generic response for upsert operations.
+
+    The upsert response will be used by abstractions that implement an upsert
+    operation for content that can be upserted by ID.
+    """
+
+    succeeded: List[str]
+    """The IDs that were successfully indexed."""
+    failed: List[str]
+    """The IDs that failed to index."""

--- a/libs/core/langchain_core/utils/__init__.py
+++ b/libs/core/langchain_core/utils/__init__.py
@@ -5,6 +5,7 @@ These functions do not depend on any other LangChain module.
 """
 
 from langchain_core.utils import image
+from langchain_core.utils.aiter import abatch_iterate
 from langchain_core.utils.env import get_from_dict_or_env, get_from_env
 from langchain_core.utils.formatting import StrictFormatter, formatter
 from langchain_core.utils.input import (
@@ -13,6 +14,7 @@ from langchain_core.utils.input import (
     get_colored_text,
     print_text,
 )
+from langchain_core.utils.iter import batch_iterate
 from langchain_core.utils.loading import try_load_from_hub
 from langchain_core.utils.strings import comma_list, stringify_dict, stringify_value
 from langchain_core.utils.utils import (
@@ -48,4 +50,6 @@ __all__ = [
     "stringify_dict",
     "comma_list",
     "stringify_value",
+    "batch_iterate",
+    "abatch_iterate",
 ]

--- a/libs/core/langchain_core/utils/aiter.py
+++ b/libs/core/langchain_core/utils/aiter.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     AsyncContextManager,
     AsyncGenerator,
+    AsyncIterable,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -247,3 +248,28 @@ class aclosing(AbstractAsyncContextManager):
     ) -> None:
         if hasattr(self.thing, "aclose"):
             await self.thing.aclose()
+
+
+async def abatch_iterate(
+    size: int, iterable: AsyncIterable[T]
+) -> AsyncIterator[List[T]]:
+    """Utility batching function for async iterables.
+
+    Args:
+        size: The size of the batch.
+        iterable: The async iterable to batch.
+
+    Returns:
+        An async iterator over the batches
+    """
+    batch: List[T] = []
+    async for element in iterable:
+        if len(batch) < size:
+            batch.append(element)
+
+        if len(batch) >= size:
+            yield batch
+            batch = []
+
+    if batch:
+        yield batch

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -29,6 +29,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterable,
+    AsyncIterator,
     Callable,
     ClassVar,
     Collection,
@@ -230,7 +231,7 @@ class VectorStore(ABC):
         /,
         batch_size: int,
         **kwargs: Any,
-    ) -> Iterator[UpsertResponse]:
+    ) -> AsyncIterator[UpsertResponse]:
         """Upsert documents in a streaming fashion. Async version of streaming_upsert.
 
         Args:

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -191,7 +191,7 @@ class VectorStore(ABC):
         #  to take in additional data per document.
         #
         #  This data **SHOULD NOT** be part of the **kwargs** parameter, instead
-        #  a sub-classes can use a Union type on `documents` to include additional
+        #  sub-classes can use a Union type on `documents` to include additional
         #  supported formats for the input data stream.
         #
         #  For example,
@@ -442,7 +442,7 @@ class VectorStore(ABC):
                 ids = kwargs.pop("ids")
                 if ids and len(ids) != len(documents):
                     raise ValueError(
-                        "The number of ids must match the number of documents."
+                        "The number of ids must match the number of documents. "
                         "Got {len(ids)} ids and {len(documents)} documents."
                     )
 

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -131,7 +131,7 @@ class VectorStore(ABC):
         """Upsert documents in a streaming fashion.
 
         Args:
-            documents: Iterable of Documents to add to the vectorstore.
+            items: Iterable of Documents to add to the vectorstore.
             batch_size: The size of each batch to upsert. Required and
                 should not be associa
             **kwargs: Additional keyword arguments.

--- a/libs/core/langchain_core/vectorstores.py
+++ b/libs/core/langchain_core/vectorstores.py
@@ -102,7 +102,18 @@ class VectorStore(ABC):
             return self.upsert(docs, **kwargs)
         raise NotImplementedError()
 
-    def upsert(self, documents: Iterable[Document], /, **kwargs) -> Iterator[str]:
+    def streaming_upsert(
+        self, documents: Iterable[Document], /, batch_size: int, **kwargs
+    ) -> Iterable[UpsertResponse]:
+        """Add or update documents in the vectorstore."""
+        from langchain_core.utils.iter import batch_iterable
+
+        for batch_documents in batch_iterable(documents, batch_size):
+            yield self.upsert([document], **kwargs)
+
+    def upsert(
+        self, documents: Sequence[Document], /, **kwargs
+    ) -> List[UpsertResponse]:
         """Add or update documents in the vectorstore.
 
         The upsert functionality should utilize the ID field of the Document object

--- a/libs/core/tests/unit_tests/indexing/test_public_api.py
+++ b/libs/core/tests/unit_tests/indexing/test_public_api.py
@@ -10,4 +10,5 @@ def test_all() -> None:
         "IndexingResult",
         "InMemoryRecordManager",
         "RecordManager",
+        "UpsertResponse",
     ]

--- a/libs/core/tests/unit_tests/utils/test_aiter.py
+++ b/libs/core/tests/unit_tests/utils/test_aiter.py
@@ -1,0 +1,31 @@
+from typing import AsyncIterator, List
+
+import pytest
+
+from langchain_core.utils.aiter import abatch_iterate
+
+
+@pytest.mark.parametrize(
+    "input_size, input_iterable, expected_output",
+    [
+        (2, [1, 2, 3, 4, 5], [[1, 2], [3, 4], [5]]),
+        (3, [10, 20, 30, 40, 50], [[10, 20, 30], [40, 50]]),
+        (1, [100, 200, 300], [[100], [200], [300]]),
+        (4, [], []),
+    ],
+)
+async def test_abatch_iterate(
+    input_size: int, input_iterable: List[str], expected_output: List[str]
+) -> None:
+    """Test batching function."""
+
+    async def _to_async_iterable(iterable: List[str]) -> AsyncIterator[str]:
+        for item in iterable:
+            yield item
+
+    iterator_ = abatch_iterate(input_size, _to_async_iterable(input_iterable))
+
+    assert isinstance(iterator_, AsyncIterator)
+
+    output = [el async for el in iterator_]
+    assert output == expected_output

--- a/libs/core/tests/unit_tests/utils/test_imports.py
+++ b/libs/core/tests/unit_tests/utils/test_imports.py
@@ -6,6 +6,8 @@ EXPECTED_ALL = [
     "convert_to_secret_str",
     "formatter",
     "get_bolded_text",
+    "abatch_iterate",
+    "batch_iterate",
     "get_color_mapping",
     "get_colored_text",
     "get_pydantic_field_names",

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from typing_extensions import TypedDict
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.indexing.base import UpsertResponse
+from langchain_core.vectorstores import VectorStore
+
+
+def test_custom_upsert_type() -> None:
+    """Test that we can override the signature of the upsert method
+    of the VectorStore class without creating typing issues by violating
+    the Liskov Substitution Principle.
+    """
+
+    class ByVector(TypedDict):
+        document: Document
+        vector: List[float]
+
+    class CustomVectorStore(VectorStore):
+        def upsert(
+            # This unit test verifies that the signature of the upsert method
+            # specifically the items parameter can be overridden without
+            # violating the Liskov Substitution Principle (and getting
+            # typing errors).
+            self,
+            items: Union[Sequence[Document], Sequence[ByVector]],
+            /,
+            **kwargs: Any,
+        ) -> UpsertResponse:
+            raise NotImplementedError()
+
+
+def test_implement_upsert() -> None:
+    """Test that we can implement the upsert method of the CustomVectorStore
+    class without violating the Liskov Substitution Principle.
+    """
+
+    class CustomVectorStore(VectorStore):
+        def __init__(self) -> None:
+            self.store: Dict[str, Document] = {}
+
+        def upsert(
+            self,
+            items: Sequence[Document],
+            /,
+            **kwargs: Any,
+        ) -> UpsertResponse:
+            ids = []
+            for item in items:
+                if item.id is None:
+                    new_item = item.copy()
+                    id_: str = str(uuid.uuid4())
+                    new_item.id = id_
+                else:
+                    id_ = item.id
+                    new_item = item
+
+                self.store[id_] = new_item
+                ids.append(id_)
+
+            return {
+                "succeeded": ids,
+                "failed": [],
+            }
+
+        def get_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+            return [self.store[id] for id in ids if id in self.store]
+
+        def from_texts(  # type: ignore
+            cls,
+            texts: List[str],
+            embedding: Embeddings,
+            metadatas: Optional[List[dict]] = None,
+            **kwargs: Any,
+        ) -> CustomVectorStore:
+            vectorstore = CustomVectorStore()
+            vectorstore.add_texts(texts, metadatas=metadatas, **kwargs)
+            return vectorstore
+
+        def similarity_search(
+            self, query: str, k: int = 4, **kwargs: Any
+        ) -> List[Document]:
+            raise NotImplementedError()
+
+    store = CustomVectorStore()
+
+    # Check upsert with id
+    assert store.upsert([Document(id="1", page_content="hello")]) == {
+        "succeeded": ["1"],
+        "failed": [],
+    }
+
+    assert store.get_by_ids(["1"]) == [Document(id="1", page_content="hello")]
+
+    # Check upsert without id
+    response = store.upsert([Document(page_content="world")])
+    assert len(response["succeeded"]) == 1
+    id_ = response["succeeded"][0]
+    assert id_ is not None
+    assert store.get_by_ids([id_]) == [Document(id=id_, page_content="world")]
+
+    # Check that default implementation of add_texts works
+    assert store.add_texts(["hello", "world"], ids=["3", "4"]) == ["3", "4"]
+    assert store.get_by_ids(["3", "4"]) == [
+        Document(id="3", page_content="hello"),
+        Document(id="4", page_content="world"),
+    ]
+
+    # Add texts without ids
+    ids_ = store.add_texts(["foo", "bar"])
+    assert len(ids_) == 2
+    assert store.get_by_ids(ids_) == [
+        Document(id=ids_[0], page_content="foo"),
+        Document(id=ids_[1], page_content="bar"),
+    ]
+
+    # Add texts with metadatas
+    ids_2 = store.add_texts(["foo", "bar"], metadatas=[{"foo": "bar"}] * 2)
+    assert len(ids_2) == 2
+    assert store.get_by_ids(ids_2) == [
+        Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
+        Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
+    ]
+
+    # Check that add_documents works
+    assert store.add_documents([Document(id="5", page_content="baz")]) == ["5"]
+
+    # Test add documents with id specified in both document and ids
+    original_document = Document(id="7", page_content="baz")
+    assert store.add_documents([original_document], ids=["6"]) == ["6"]
+    assert original_document.id == "7"  # original document should not be modified
+    assert store.get_by_ids(["6"]) == [Document(id="6", page_content="baz")]

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -35,59 +35,62 @@ def test_custom_upsert_type() -> None:
             raise NotImplementedError()
 
 
+class CustomSyncVectorStore(VectorStore):
+    """A vectorstore that only implements the synchronous methods."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, Document] = {}
+
+    def upsert(
+        self,
+        items: Sequence[Document],
+        /,
+        **kwargs: Any,
+    ) -> UpsertResponse:
+        ids = []
+        for item in items:
+            if item.id is None:
+                new_item = item.copy()
+                id_: str = str(uuid.uuid4())
+                new_item.id = id_
+            else:
+                id_ = item.id
+                new_item = item
+
+            self.store[id_] = new_item
+            ids.append(id_)
+
+        return {
+            "succeeded": ids,
+            "failed": [],
+        }
+
+    def get_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+        return [self.store[id] for id in ids if id in self.store]
+
+    def from_texts(  # type: ignore
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        **kwargs: Any,
+    ) -> CustomSyncVectorStore:
+        vectorstore = CustomSyncVectorStore()
+        vectorstore.add_texts(texts, metadatas=metadatas, **kwargs)
+        return vectorstore
+
+    def similarity_search(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        raise NotImplementedError()
+
+
 def test_implement_upsert() -> None:
     """Test that we can implement the upsert method of the CustomVectorStore
     class without violating the Liskov Substitution Principle.
     """
 
-    class CustomVectorStore(VectorStore):
-        def __init__(self) -> None:
-            self.store: Dict[str, Document] = {}
-
-        def upsert(
-            self,
-            items: Sequence[Document],
-            /,
-            **kwargs: Any,
-        ) -> UpsertResponse:
-            ids = []
-            for item in items:
-                if item.id is None:
-                    new_item = item.copy()
-                    id_: str = str(uuid.uuid4())
-                    new_item.id = id_
-                else:
-                    id_ = item.id
-                    new_item = item
-
-                self.store[id_] = new_item
-                ids.append(id_)
-
-            return {
-                "succeeded": ids,
-                "failed": [],
-            }
-
-        def get_by_ids(self, ids: Sequence[str], /) -> List[Document]:
-            return [self.store[id] for id in ids if id in self.store]
-
-        def from_texts(  # type: ignore
-            cls,
-            texts: List[str],
-            embedding: Embeddings,
-            metadatas: Optional[List[dict]] = None,
-            **kwargs: Any,
-        ) -> CustomVectorStore:
-            vectorstore = CustomVectorStore()
-            vectorstore.add_texts(texts, metadatas=metadatas, **kwargs)
-            return vectorstore
-
-        def similarity_search(
-            self, query: str, k: int = 4, **kwargs: Any
-        ) -> List[Document]:
-            raise NotImplementedError()
-
-    store = CustomVectorStore()
+    store = CustomSyncVectorStore()
 
     # Check upsert with id
     assert store.upsert([Document(id="1", page_content="hello")]) == {
@@ -135,3 +138,57 @@ def test_implement_upsert() -> None:
     assert store.add_documents([original_document], ids=["6"]) == ["6"]
     assert original_document.id == "7"  # original document should not be modified
     assert store.get_by_ids(["6"]) == [Document(id="6", page_content="baz")]
+
+
+async def test_aupsert_delegation_to_upsert() -> None:
+    """Test delegation to the synchronous upsert method in async execution
+    if async methods are not implemented.
+    """
+    store = CustomSyncVectorStore()
+
+    # Check upsert with id
+    assert await store.aupsert([Document(id="1", page_content="hello")]) == {
+        "succeeded": ["1"],
+        "failed": [],
+    }
+
+    assert await store.aget_by_ids(["1"]) == [Document(id="1", page_content="hello")]
+
+    # Check upsert without id
+    response = await store.aupsert([Document(page_content="world")])
+    assert len(response["succeeded"]) == 1
+    id_ = response["succeeded"][0]
+    assert id_ is not None
+    assert await store.aget_by_ids([id_]) == [Document(id=id_, page_content="world")]
+
+    # Check that default implementation of add_texts works
+    assert await store.aadd_texts(["hello", "world"], ids=["3", "4"]) == ["3", "4"]
+    assert await store.aget_by_ids(["3", "4"]) == [
+        Document(id="3", page_content="hello"),
+        Document(id="4", page_content="world"),
+    ]
+
+    # Add texts without ids
+    ids_ = await store.aadd_texts(["foo", "bar"])
+    assert len(ids_) == 2
+    assert await store.aget_by_ids(ids_) == [
+        Document(id=ids_[0], page_content="foo"),
+        Document(id=ids_[1], page_content="bar"),
+    ]
+
+    # Add texts with metadatas
+    ids_2 = await store.aadd_texts(["foo", "bar"], metadatas=[{"foo": "bar"}] * 2)
+    assert len(ids_2) == 2
+    assert await store.aget_by_ids(ids_2) == [
+        Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
+        Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
+    ]
+
+    # Check that add_documents works
+    assert await store.aadd_documents([Document(id="5", page_content="baz")]) == ["5"]
+
+    # Test add documents with id specified in both document and ids
+    original_document = Document(id="7", page_content="baz")
+    assert await store.aadd_documents([original_document], ids=["6"]) == ["6"]
+    assert original_document.id == "7"  # original document should not be modified
+    assert await store.aget_by_ids(["6"]) == [Document(id="6", page_content="baz")]

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
@@ -46,15 +46,21 @@ class ReadWriteTestSuite(ABC):
 
     def test_add_documents(self, vectorstore: VectorStore) -> None:
         """Test adding documents into the vectorstore."""
-        documents = [
+        original_documents = [
             Document(page_content="foo", metadata={"id": 1}),
             Document(page_content="bar", metadata={"id": 2}),
         ]
-        ids = vectorstore.add_documents(documents)
+        ids = vectorstore.add_documents(original_documents)
         documents = vectorstore.similarity_search("bar", k=2)
         assert documents == [
             Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
             Document(page_content="foo", metadata={"id": 1}, id=ids[0]),
+        ]
+        # Verify that the original document object does not get mutated!
+        # (e.g., an ID is added to the original document object)
+        assert original_documents == [
+            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
         ]
 
     def test_vectorstore_still_empty(self, vectorstore: VectorStore) -> None:
@@ -176,15 +182,22 @@ class AsyncReadWriteTestSuite(ABC):
 
     async def test_add_documents(self, vectorstore: VectorStore) -> None:
         """Test adding documents into the vectorstore."""
-        documents = [
+        original_documents = [
             Document(page_content="foo", metadata={"id": 1}),
             Document(page_content="bar", metadata={"id": 2}),
         ]
-        ids = await vectorstore.aadd_documents(documents)
+        ids = await vectorstore.aadd_documents(original_documents)
         documents = await vectorstore.asimilarity_search("bar", k=2)
         assert documents == [
             Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
             Document(page_content="foo", metadata={"id": 1}, id=ids[0]),
+        ]
+
+        # Verify that the original document object does not get mutated!
+        # (e.g., an ID is added to the original document object)
+        assert original_documents == [
+            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
         ]
 
     async def test_vectorstore_still_empty(self, vectorstore: VectorStore) -> None:

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
@@ -74,7 +74,7 @@ class ReadWriteTestSuite(ABC):
         vectorstore.add_documents(documents, ids=["1", "2"])
         vectorstore.delete(["1"])
         documents = vectorstore.similarity_search("foo", k=1)
-        assert documents == [Document(page_content="bar", metadata={"id": 2})]
+        assert documents == [Document(page_content="bar", metadata={"id": 2}, id="1")]
 
     def test_deleting_bulk_documents(self, vectorstore: VectorStore) -> None:
         """Test that we can delete several documents at once."""
@@ -87,7 +87,7 @@ class ReadWriteTestSuite(ABC):
         vectorstore.add_documents(documents, ids=["1", "2", "3"])
         vectorstore.delete(["1", "2"])
         documents = vectorstore.similarity_search("foo", k=1)
-        assert documents == [Document(page_content="baz", metadata={"id": 3})]
+        assert documents == [Document(page_content="baz", metadata={"id": 3}, id="3")]
 
     def test_delete_missing_content(self, vectorstore: VectorStore) -> None:
         """Deleting missing content should not raise an exception."""
@@ -106,8 +106,8 @@ class ReadWriteTestSuite(ABC):
         vectorstore.add_documents(documents, ids=["1", "2"])
         documents = vectorstore.similarity_search("bar", k=2)
         assert documents == [
-            Document(page_content="bar", metadata={"id": 2}),
-            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}, id="2"),
+            Document(page_content="foo", metadata={"id": 1}, id="1"),
         ]
 
     def test_add_documents_without_ids_gets_duplicated(


### PR DESCRIPTION
This PR rolls out part of the new proposed interface for vectorstores (https://github.com/langchain-ai/langchain/pull/23544) to existing store implementations.

The PR makes the following changes:

1. Adds standard upsert, streaming_upsert, aupsert, astreaming_upsert methods to the vectorstore.
2. Updates `add_texts` and `aadd_texts` to be non required with a default implementation that delegates to `upsert` and `aupsert` if those have been implemented.  The original `add_texts`  and `aadd_texts` methods are problematic as they spread object specific information across document and **kwargs. (e.g., ids are not a part of the document)
3. Adds a default implementation to `add_documents` and `aadd_documents` that delegates to `upsert` and `aupsert` respectively.
4. Adds standard unit tests to verify that a given vectorstore implements a correct read/write API.

A downside of this implementation is that it creates `upsert` with a very similar signature to `add_documents`. 
The reason for introducing `upsert` is to:
* Remove any ambiguities about what information is allowed in `kwargs`. Specifically kwargs should only be used for information common to all indexed data. (e.g., indexing timeout). 
*Allow inheriting from an anticipated generalized interface for indexing that will allow indexing `BaseMedia` (i.e., allow making a vectorstore for images/audio etc.)
 
`add_documents` can be deprecated in the future in favor of `upsert` to make sure that users have a single correct way of indexing content.
