### PR TITLE
docs: fix docs/tutorials/llm_chain.ipynb

### DIFF
--- a/docs/docs/tutorials/llm_chain.ipynb
+++ b/docs/docs/tutorials/llm_chain.ipynb
@@ -538,7 +538,7 @@
     "\n",
     "### Client\n",
     "\n",
-    "Now let's set up a client for programmatically interacting with our service. We can easily do this with the `[langserve.RemoteRunnable](/docs/langserve/#client)`.\n",
+    "Now let's set up a client for programmatically interacting with our service. We can easily do this with the [langserve.RemoteRunnable](/docs/langserve/#client).\n",
     "Using this, we can interact with the served chain as if it were running client-side."
    ]
   },


### PR DESCRIPTION
to correctly display the link