### PR TITLE
docs: langgraph link fix

### DIFF
--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -204,7 +204,7 @@ LangChain [Tools](/docs/concepts/#tools) contain a description of the tool (to p
 
 :::note
 
-For in depth how-to guides for agents, please check out [LangGraph](https://github.com/langchain-ai/langgraph) documentation.
+For in depth how-to guides for agents, please check out [LangGraph](https://langchain-ai.github.io/langgraph/) documentation.
 
 :::
 


### PR DESCRIPTION
Link for the LangGraph doc is instead the LG repo link.
Fixed the link