### PR TITLE
core: docstrings `outputs`

### DIFF
--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -32,7 +32,17 @@ class ChatGeneration(Generation):
 
     @root_validator(pre=False, skip_on_failure=True)
     def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Set the text attribute to be the contents of the message."""
+        """Set the text attribute to be the contents of the message.
+
+        Args:
+            values: The values of the object.
+
+        Returns:
+            The values of the object with the text attribute set.
+
+        Raises:
+            ValueError: If the message is not a string or a list.
+        """
         try:
             text = ""
             if isinstance(values["message"].content, str):
@@ -64,13 +74,11 @@ class ChatGeneration(Generation):
 
 class ChatGenerationChunk(ChatGeneration):
     """ChatGeneration chunk, which can be concatenated with other
-      ChatGeneration chunks.
-
-    Attributes:
-        message: The message chunk output by the chat model.
+    ChatGeneration chunks.
     """
 
     message: BaseMessageChunk
+    """The message chunk output by the chat model."""
     # Override type to be ChatGeneration, ignore mypy error as this is intentional
     type: Literal["ChatGenerationChunk"] = "ChatGenerationChunk"  # type: ignore[assignment]
     """Type is used exclusively for serialization purposes."""

--- a/libs/core/langchain_core/outputs/generation.py
+++ b/libs/core/langchain_core/outputs/generation.py
@@ -31,7 +31,8 @@ class Generation(Serializable):
     May include things like the reason for finishing or token log probabilities.
     """
     type: Literal["Generation"] = "Generation"
-    """Type is used exclusively for serialization purposes."""
+    """Type is used exclusively for serialization purposes.
+    Set to "Generation" for this class."""
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/outputs/llm_result.py
+++ b/libs/core/langchain_core/outputs/llm_result.py
@@ -48,9 +48,9 @@ class LLMResult(BaseModel):
         """Flatten generations into a single list.
 
         Unpack List[List[Generation]] -> List[LLMResult] where each returned LLMResult
-            contains only a single Generation. If token usage information is available,
-            it is kept only for the LLMResult corresponding to the top-choice
-            Generation, to avoid over-counting of token usage downstream.
+        contains only a single Generation. If token usage information is available,
+        it is kept only for the LLMResult corresponding to the top-choice
+        Generation, to avoid over-counting of token usage downstream.
 
         Returns:
             List of LLMResults where each returned LLMResult contains a single

--- a/libs/core/langchain_core/outputs/run_info.py
+++ b/libs/core/langchain_core/outputs/run_info.py
@@ -8,7 +8,7 @@ from langchain_core.pydantic_v1 import BaseModel
 class RunInfo(BaseModel):
     """Class that contains metadata for a single execution of a Chain or model.
 
-    Here for backwards compatibility with older versions of langchain_core.
+    Defined for backwards compatibility with older versions of langchain_core.
 
     This model will likely be deprecated in the future.
 


### PR DESCRIPTION
Added missed docstrings. Formatted docstrings to the consistent form.