### PR TITLE
docs: fix typo in llm_chain.ipynb

### DIFF
--- a/docs/docs/tutorials/llm_chain.ipynb
+++ b/docs/docs/tutorials/llm_chain.ipynb
@@ -325,7 +325,7 @@
    "id": "fedf6f13",
    "metadata": {},
    "source": [
-    "Next, we can create the PromptTemplate. This will be a combination of the `system_template` as well as a simpler template for where the put the text"
+    "Next, we can create the PromptTemplate. This will be a combination of the `system_template` as well as a simpler template for where to put the text to be translated"
    ]
   },
   {


### PR DESCRIPTION
- Fix typo in the tutorial step
- Add some context on `text`