### PR TITLE
Neo4j: Fixed similarity docs

### DIFF
--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -909,6 +909,9 @@ class Neo4jVector(VectorStore):
         Args:
             query (str): Query text to search for.
             k (int): Number of results to return. Defaults to 4.
+            params (Dict[str, Any]): The search params for the index type.
+                Defaults to empty dict.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
 
         Returns:
             List of Documents most similar to the query.
@@ -936,6 +939,9 @@ class Neo4jVector(VectorStore):
         Args:
             query: Text to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
+            params (Dict[str, Any]): The search params for the index type.
+                Defaults to empty dict.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
 
         Returns:
             List of Documents most similar to the query and score for each
@@ -972,6 +978,9 @@ class Neo4jVector(VectorStore):
         Args:
             embedding (List[float]): The embedding vector to compare against.
             k (int, optional): The number of top similar documents to retrieve.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
+            params (Dict[str, Any]): The search params for the index type.
+                Defaults to empty dict.
 
         Returns:
             List[Tuple[Document, float]]: A list of tuples, each containing
@@ -1077,6 +1086,7 @@ class Neo4jVector(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[Dict[str, Any]] = None,
+        params: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> List[Document]:
         """Return docs most similar to embedding vector.
@@ -1084,6 +1094,9 @@ class Neo4jVector(VectorStore):
         Args:
             embedding: Embedding to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
+            params (Dict[str, Any]): The search params for the index type.
+                Defaults to empty dict.
 
         Returns:
             List of Documents most similar to the query vector.

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -911,7 +911,9 @@ class Neo4jVector(VectorStore):
             k (int): Number of results to return. Defaults to 4.
             params (Dict[str, Any]): The search params for the index type.
                 Defaults to empty dict.
-            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to
+                    filter on metadata.
+                Defaults to None.
 
         Returns:
             List of Documents most similar to the query.
@@ -941,7 +943,9 @@ class Neo4jVector(VectorStore):
             k: Number of Documents to return. Defaults to 4.
             params (Dict[str, Any]): The search params for the index type.
                 Defaults to empty dict.
-            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to
+                    filter on metadata.
+                Defaults to None.
 
         Returns:
             List of Documents most similar to the query and score for each
@@ -978,7 +982,9 @@ class Neo4jVector(VectorStore):
         Args:
             embedding (List[float]): The embedding vector to compare against.
             k (int, optional): The number of top similar documents to retrieve.
-            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to
+                    filter on metadata.
+                Defaults to None.
             params (Dict[str, Any]): The search params for the index type.
                 Defaults to empty dict.
 
@@ -1094,7 +1100,9 @@ class Neo4jVector(VectorStore):
         Args:
             embedding: Embedding to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to filter on metadata. Defaults to None.
+            filter (Optional[Dict[str, Any]]): Dictionary of argument(s) to
+                    filter on metadata.
+                Defaults to None.
             params (Dict[str, Any]): The search params for the index type.
                 Defaults to empty dict.
 

--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -1110,7 +1110,7 @@ class Neo4jVector(VectorStore):
             List of Documents most similar to the query vector.
         """
         docs_and_scores = self.similarity_search_with_score_by_vector(
-            embedding=embedding, k=k, filter=filter, **kwargs
+            embedding=embedding, k=k, filter=filter, params=params, **kwargs
         )
         return [doc for doc, _ in docs_and_scores]
 


### PR DESCRIPTION
 **Description:** There was missing some documentation regarding the `filter` and `params` attributes in similarity search methods.