### PR TITLE
standard-tests[minor]: add unit tests for testing get_by_ids, aget_by_ids, upsert, aupsert_by_ids

### DIFF
--- a/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
@@ -1,4 +1,5 @@
 """Test suite to test vectostores."""
+import inspect
 from abc import ABC, abstractmethod
 
 import pytest
@@ -115,7 +116,7 @@ class ReadWriteTestSuite(ABC):
         assert documents == [
             Document(page_content="bar", metadata={"id": 2}, id="2"),
             Document(page_content="foo", metadata={"id": 1}, id="1"),
-        ]
+        ], repr(documents)
 
     def test_add_documents_by_id_with_mutation(self, vectorstore: VectorStore) -> None:
         """Test that we can overwrite by ID using add_documents."""
@@ -145,6 +146,58 @@ class ReadWriteTestSuite(ABC):
             ),
             Document(id="2", page_content="bar", metadata={"id": 2}),
         ]
+
+    def test_get_by_ids(self, vectorstore: VectorStore) -> None:
+        """Test get by IDs."""
+        documents = [
+            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
+        ]
+        ids = vectorstore.add_documents(documents, ids=["1", "2"])
+        retrieved_documents = vectorstore.get_by_ids(ids)
+        assert retrieved_documents == [
+            Document(page_content="foo", metadata={"id": 1}, id=ids[0]),
+            Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
+        ]
+
+    def test_get_by_ids_missing(self, vectorstore: VectorStore) -> None:
+        """Test get by IDs with missing IDs."""
+        # This should not raise an exception
+        documents = vectorstore.get_by_ids(["1", "2", "3"])
+        assert documents == []
+
+    def test_upsert_documents(self, vectorstore: VectorStore) -> None:
+        """Run upsert tests."""
+        documents = [
+            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
+        ]
+        response = vectorstore.upsert(documents)
+        ids = response["succeeded"]
+        assert vectorstore.get_by_ids(ids) == [
+            Document(page_content="foo", metadata={"id": 1}, id=ids[0]),
+            Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
+        ]
+
+    def test_upsert_with_existing_ids(self, vectorstore: VectorStore):
+        """Test that upserting with existing IDs is idempotent."""
+        documents = [
+            Document(id="foo", page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
+        ]
+        response = vectorstore.upsert(documents)
+        ids = response["succeeded"]
+        assert response["failed"] == []
+        assert "foo" in ids
+        assert vectorstore.get_by_ids(ids) == [
+            Document(page_content="foo", metadata={"id": 1}, id="foo"),
+            Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
+        ]
+
+    def test_upsert_documents_has_no_ids(self, vectorstore: VectorStore):
+        """Verify that there is not parameter called ids in upsert"""
+        signature = inspect.signature(vectorstore.upsert)
+        assert "ids" not in signature.parameters
 
 
 class AsyncReadWriteTestSuite(ABC):
@@ -284,3 +337,54 @@ class AsyncReadWriteTestSuite(ABC):
             ),
             Document(id="2", page_content="bar", metadata={"id": 2}),
         ]
+
+    async def test_get_by_ids(self, vectorstore: VectorStore) -> None:
+        """Test get by IDs."""
+        documents = [
+            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
+        ]
+        ids = await vectorstore.aadd_documents(documents, ids=["1", "2"])
+        retrieved_documents = await vectorstore.aget_by_ids(ids)
+        assert retrieved_documents == [
+            Document(page_content="foo", metadata={"id": 1}, id=ids[0]),
+            Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
+        ]
+
+    async def test_get_by_ids_missing(self, vectorstore: VectorStore) -> None:
+        """Test get by IDs with missing IDs."""
+        # This should not raise an exception
+        assert await vectorstore.aget_by_ids(["1", "2", "3"]) == []
+
+    async def test_upsert_documents(self, vectorstore: VectorStore) -> None:
+        """Run upsert tests."""
+        documents = [
+            Document(page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
+        ]
+        response = await vectorstore.aupsert(documents)
+        ids = response["succeeded"]
+        assert await vectorstore.aget_by_ids(ids) == [
+            Document(page_content="foo", metadata={"id": 1}, id=ids[0]),
+            Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
+        ]
+
+    async def test_upsert_with_existing_ids(self, vectorstore: VectorStore) -> None:
+        """Test that upserting with existing IDs is idempotent."""
+        documents = [
+            Document(id="foo", page_content="foo", metadata={"id": 1}),
+            Document(page_content="bar", metadata={"id": 2}),
+        ]
+        response = await vectorstore.aupsert(documents)
+        ids = response["succeeded"]
+        assert response["failed"] == []
+        assert "foo" in ids
+        assert await vectorstore.aget_by_ids(ids) == [
+            Document(page_content="foo", metadata={"id": 1}, id="foo"),
+            Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
+        ]
+
+    async def test_upsert_documents_has_no_ids(self, vectorstore: VectorStore):
+        """Verify that there is not parameter called ids in upsert"""
+        signature = inspect.signature(vectorstore.aupsert)
+        assert "ids" not in signature.parameters

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
@@ -179,7 +179,7 @@ class ReadWriteTestSuite(ABC):
             Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
         ]
 
-    def test_upsert_with_existing_ids(self, vectorstore: VectorStore):
+    def test_upsert_with_existing_ids(self, vectorstore: VectorStore) -> None:
         """Test that upserting with existing IDs is idempotent."""
         documents = [
             Document(id="foo", page_content="foo", metadata={"id": 1}),
@@ -194,7 +194,7 @@ class ReadWriteTestSuite(ABC):
             Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
         ]
 
-    def test_upsert_documents_has_no_ids(self, vectorstore: VectorStore):
+    def test_upsert_documents_has_no_ids(self, vectorstore: VectorStore) -> None:
         """Verify that there is not parameter called ids in upsert"""
         signature = inspect.signature(vectorstore.upsert)
         assert "ids" not in signature.parameters
@@ -384,7 +384,7 @@ class AsyncReadWriteTestSuite(ABC):
             Document(page_content="bar", metadata={"id": 2}, id=ids[1]),
         ]
 
-    async def test_upsert_documents_has_no_ids(self, vectorstore: VectorStore):
+    async def test_upsert_documents_has_no_ids(self, vectorstore: VectorStore) -> None:
         """Verify that there is not parameter called ids in upsert"""
         signature = inspect.signature(vectorstore.aupsert)
         assert "ids" not in signature.parameters

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
@@ -116,7 +116,7 @@ class ReadWriteTestSuite(ABC):
         assert documents == [
             Document(page_content="bar", metadata={"id": 2}, id="2"),
             Document(page_content="foo", metadata={"id": 1}, id="1"),
-        ], repr(documents)
+        ]
 
     def test_add_documents_by_id_with_mutation(self, vectorstore: VectorStore) -> None:
         """Test that we can overwrite by ID using add_documents."""


### PR DESCRIPTION
These standard unit tests provide standard tests for functionality introduced in these PRs:

* https://github.com/langchain-ai/langchain/pull/23774
* https://github.com/langchain-ai/langchain/pull/23594