### PR TITLE
Community: Fix Deprecated Ruff Command Usage in Makefile

### DIFF
--- a/libs/community/Makefile
+++ b/libs/community/Makefile
@@ -44,14 +44,14 @@ lint_tests: MYPY_CACHE=.mypy_cache_test
 lint lint_diff lint_package lint_tests:
 	./scripts/check_pydantic.sh .
 	./scripts/lint_imports.sh
-	poetry run ruff .
+	poetry run ruff check . 
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES) --diff
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff --select I $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || mkdir -p $(MYPY_CACHE) && poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
 
 format format_diff:
 	poetry run ruff format $(PYTHON_FILES)
-	poetry run ruff --select I --fix $(PYTHON_FILES)
+	poetry run ruff check --select I --fix $(PYTHON_FILES)
 
 spell_check:
 	poetry run codespell --toml pyproject.toml


### PR DESCRIPTION
Deprecated `ruff <path> `command was used in `Makefile`, which caused errors during the execution of formatting & linting tasks. 

Changes Made:
Replaced all instances of `ruff <path> `with `ruff check <path> `in the `Makefile` to align with the new syntax required by the latest version of ruff.

