### PR TITLE
docs: add itemgetter in how_to/dynamic_chain

### DIFF
--- a/docs/docs/how_to/dynamic_chain.ipynb
+++ b/docs/docs/how_to/dynamic_chain.ipynb
@@ -58,6 +58,8 @@
     }
    ],
    "source": [
+    "from operator import itemgetter\n",
+    "\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",
     "from langchain_core.runnables import Runnable, RunnablePassthrough, chain\n",
@@ -86,7 +88,7 @@
     "        # NOTE: This is returning another Runnable, not an actual output.\n",
     "        return contextualize_question\n",
     "    else:\n",
-    "        return RunnablePassthrough()\n",
+    "        return RunnablePassthrough() | itemgetter(\"question\")\n",
     "\n",
     "\n",
     "@chain\n",


### PR DESCRIPTION
Hello! I am honored to be able to contribute to the LangChain project for the first time.

- **Description:** Using `RunnablePassthrough` logic without providing `chat_history` key will result in nested keys in `question`, so I submit a pull request to resolve this issue.

I am attaching a LangSmith screenshot below.

This is the result of the current version of the document.

<img width="1112" alt="image" src="https://github.com/langchain-ai/langchain/assets/12846075/f0597089-c375-472f-b2bf-793baaecd836">

without `chat_history`:

<img width="1112" alt="image" src="https://github.com/langchain-ai/langchain/assets/12846075/5c0e3ae7-3afe-417c-9132-770387f0fff2">


- **Lint and test**: 

<img width="777" alt="image" src="https://github.com/langchain-ai/langchain/assets/12846075/575d2545-3aed-4338-9779-1a0b17365418">

