### PR TITLE
experimental: Add config to convert_to_graph_documents

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -704,13 +704,13 @@ class LLMGraphTransformer:
             prompt = prompt or default_prompt
             self.chain = prompt | structured_llm
 
-    def process_response(self, document: Document) -> GraphDocument:
+    def process_response(self, document: Document, config) -> GraphDocument:
         """
         Processes a single document, transforming it into a graph document using
         an LLM based on the model's schema and constraints.
         """
         text = document.page_content
-        raw_schema = self.chain.invoke({"input": text})
+        raw_schema = self.chain.invoke({"input": text}, config=config)
         if self._function_call:
             raw_schema = cast(Dict[Any, Any], raw_schema)
             nodes, relationships = _convert_to_graph_document(raw_schema)
@@ -759,7 +759,7 @@ class LLMGraphTransformer:
         return GraphDocument(nodes=nodes, relationships=relationships, source=document)
 
     def convert_to_graph_documents(
-        self, documents: Sequence[Document]
+        self, documents: Sequence[Document], config
     ) -> List[GraphDocument]:
         """Convert a sequence of documents into graph documents.
 
@@ -770,7 +770,7 @@ class LLMGraphTransformer:
         Returns:
             Sequence[GraphDocument]: The transformed documents as graphs.
         """
-        return [self.process_response(document) for document in documents]
+        return [self.process_response(document, config) for document in documents]
 
     async def aprocess_response(self, document: Document) -> GraphDocument:
         """

--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -13,6 +13,7 @@ from langchain_core.prompts import (
     PromptTemplate,
 )
 from langchain_core.pydantic_v1 import BaseModel, Field, create_model
+from langchain_core.runnables import RunnableConfig
 
 examples = [
     {
@@ -704,7 +705,7 @@ class LLMGraphTransformer:
             prompt = prompt or default_prompt
             self.chain = prompt | structured_llm
 
-    def process_response(self, document: Document, config) -> GraphDocument:
+    def process_response(self, document: Document, config: Optional[RunnableConfig] = None) -> GraphDocument:
         """
         Processes a single document, transforming it into a graph document using
         an LLM based on the model's schema and constraints.
@@ -759,7 +760,7 @@ class LLMGraphTransformer:
         return GraphDocument(nodes=nodes, relationships=relationships, source=document)
 
     def convert_to_graph_documents(
-        self, documents: Sequence[Document], config
+        self, documents: Sequence[Document], config: Optional[RunnableConfig] = None
     ) -> List[GraphDocument]:
         """Convert a sequence of documents into graph documents.
 

--- a/templates/pyproject.toml
+++ b/templates/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.setuptools]
+py-modules = []
+
 [tool.poetry]
 name = "templates"
 version = "0.0.0"

--- a/templates/pyproject.toml
+++ b/templates/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.setuptools]
-py-modules = []
-
 [tool.poetry]
 name = "templates"
 version = "0.0.0"


### PR DESCRIPTION
**PR title:** Experimental: Add config to convert_to_graph_documents

 **Description:** In order to use langfuse, i need to pass the langfuse configuration when invoking the chain. langchain_experimental does not allow to add any parameters (beside the documents) to the convert_to_graph_documents method. This way, I cannot monitor the chain in langfuse.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
