### PR TITLE
core[minor]: Add dispatching for custom events

### DIFF
--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -38,11 +38,15 @@ from langchain_core.callbacks.manager import (
     CallbackManagerForToolRun,
     ParentRunManager,
     RunManager,
+    dispatch_adhoc_event,
+    adispatch_adhoc_event,
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
 __all__ = [
+    "dispatch_adhoc_event",
+    "adispatch_adhoc_event",
     "RetrieverManagerMixin",
     "LLMManagerMixin",
     "ChainManagerMixin",

--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -38,8 +38,8 @@ from langchain_core.callbacks.manager import (
     CallbackManagerForToolRun,
     ParentRunManager,
     RunManager,
-    dispatch_custom_event,
     adispatch_custom_event,
+    dispatch_custom_event,
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler

--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -38,15 +38,15 @@ from langchain_core.callbacks.manager import (
     CallbackManagerForToolRun,
     ParentRunManager,
     RunManager,
-    dispatch_adhoc_event,
-    adispatch_adhoc_event,
+    dispatch_custom_event,
+    adispatch_custom_event,
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
 __all__ = [
-    "dispatch_adhoc_event",
-    "adispatch_adhoc_event",
+    "dispatch_custom_event",
+    "adispatch_custom_event",
     "RetrieverManagerMixin",
     "LLMManagerMixin",
     "ChainManagerMixin",

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -370,6 +370,24 @@ class RunManagerMixin:
             kwargs (Any): Additional keyword arguments.
         """
 
+    def on_adhoc_event(
+            self,
+            name: str,
+            data: Any,
+            run_id: Optional[UUID] = None,
+            parent_run_id: Optional[UUID] = None,
+            tags: Optional[List[str]] = None,
+            metadata: Optional[Dict[str, Any]] = None,
+            **kwargs: Any,
+    ) -> None:
+        """Override to define a handler for adhoc events.
+
+        Args:
+            name: The name of the adhoc event.
+            data: The data for the adhoc event.
+            run_id: The ID of the run. Defaults to None.
+            parent_run_id: The ID of the parent run. Defaults to None.
+        """
 
 class BaseCallbackHandler(
     LLMManagerMixin,
@@ -416,6 +434,12 @@ class BaseCallbackHandler(
     def ignore_chat_model(self) -> bool:
         """Whether to ignore chat model callbacks."""
         return False
+
+    @property
+    def ignore_adhoc(self) -> bool:
+        """Ignore adhoc event."""
+        return False
+
 
 
 class AsyncCallbackHandler(BaseCallbackHandler):
@@ -797,6 +821,25 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             parent_run_id (UUID): The parent run ID. This is the ID of the parent run.
             tags (Optional[List[str]]): The tags.
             kwargs (Any): Additional keyword arguments.
+        """
+
+    def on_adhoc_event(
+        self,
+        name: str,
+        data: Any,
+        run_id: Optional[UUID] = None,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Override to define a handler for adhoc events.
+
+        Args:
+            name: The name of the adhoc event.
+            data: The data for the adhoc event.
+            run_id: The ID of the run. Defaults to None.
+            parent_run_id: The ID of the parent run. Defaults to None.
         """
 
 

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -374,19 +374,23 @@ class RunManagerMixin:
         self,
         name: str,
         data: Any,
-        run_id: Optional[UUID] = None,
-        parent_run_id: Optional[UUID] = None,
+        *,
+        run_id: UUID,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        """Override to define a handler for adhoc events.
+        """Override to define a handler for a custom event.
 
         Args:
-            name: The name of the adhoc event.
-            data: The data for the adhoc event.
-            run_id: The ID of the run. Defaults to None.
-            parent_run_id: The ID of the parent run. Defaults to None.
+            name: The name of the custom event.
+            data: The data for the custom event. Format will match
+                  the format specified by the user.
+            run_id: The ID of the run.
+            tags: The tags associated with the custom event
+                (includes inherited tags).
+            metadata: The metadata associated with the custom event
+                (includes inherited metadata).
         """
 
 
@@ -438,7 +442,7 @@ class BaseCallbackHandler(
 
     @property
     def ignore_custom_event(self) -> bool:
-        """Ignore adhoc event."""
+        """Ignore custom event."""
         return False
 
 
@@ -823,21 +827,27 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             kwargs (Any): Additional keyword arguments.
         """
 
-    def on_custom_event(
+    async def on_custom_event(
         self,
         name: str,
         data: Any,
-        run_id: Optional[UUID] = None,
+        *,
+        run_id: UUID,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        """Override to define a handler for adhoc events.
+        """Override to define a handler for a custom event.
 
         Args:
-            name: The name of the adhoc event.
-            data: The data for the adhoc event.
-            run_id: The ID of the run. Defaults to None.
+            name: The name of the custom event.
+            data: The data for the custom event. Format will match
+                  the format specified by the user.
+            run_id: The ID of the run.
+            tags: The tags associated with the custom event
+                (includes inherited tags).
+            metadata: The metadata associated with the custom event
+                (includes inherited metadata).
         """
 
 

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -371,14 +371,14 @@ class RunManagerMixin:
         """
 
     def on_adhoc_event(
-            self,
-            name: str,
-            data: Any,
-            run_id: Optional[UUID] = None,
-            parent_run_id: Optional[UUID] = None,
-            tags: Optional[List[str]] = None,
-            metadata: Optional[Dict[str, Any]] = None,
-            **kwargs: Any,
+        self,
+        name: str,
+        data: Any,
+        run_id: Optional[UUID] = None,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> None:
         """Override to define a handler for adhoc events.
 
@@ -388,6 +388,7 @@ class RunManagerMixin:
             run_id: The ID of the run. Defaults to None.
             parent_run_id: The ID of the parent run. Defaults to None.
         """
+
 
 class BaseCallbackHandler(
     LLMManagerMixin,
@@ -436,10 +437,9 @@ class BaseCallbackHandler(
         return False
 
     @property
-    def ignore_adhoc(self) -> bool:
+    def ignore_adhoc_event(self) -> bool:
         """Ignore adhoc event."""
         return False
-
 
 
 class AsyncCallbackHandler(BaseCallbackHandler):
@@ -828,7 +828,6 @@ class AsyncCallbackHandler(BaseCallbackHandler):
         name: str,
         data: Any,
         run_id: Optional[UUID] = None,
-        parent_run_id: Optional[UUID] = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
@@ -839,7 +838,6 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             name: The name of the adhoc event.
             data: The data for the adhoc event.
             run_id: The ID of the run. Defaults to None.
-            parent_run_id: The ID of the parent run. Defaults to None.
         """
 
 

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -379,7 +379,7 @@ class RunManagerMixin:
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> Any:
         """Override to define a handler for a custom event.
 
         Args:

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -391,6 +391,8 @@ class RunManagerMixin:
                 (includes inherited tags).
             metadata: The metadata associated with the custom event
                 (includes inherited metadata).
+
+        .. versionadded:: 0.2.13
         """
 
 
@@ -848,6 +850,8 @@ class AsyncCallbackHandler(BaseCallbackHandler):
                 (includes inherited tags).
             metadata: The metadata associated with the custom event
                 (includes inherited metadata).
+
+        .. versionadded:: 0.2.13
         """
 
 

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -392,7 +392,7 @@ class RunManagerMixin:
             metadata: The metadata associated with the custom event
                 (includes inherited metadata).
 
-        .. versionadded:: 0.2.13
+        .. versionadded:: 0.2.14
         """
 
 
@@ -851,7 +851,7 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             metadata: The metadata associated with the custom event
                 (includes inherited metadata).
 
-        .. versionadded:: 0.2.13
+        .. versionadded:: 0.2.14
         """
 
 

--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -370,7 +370,7 @@ class RunManagerMixin:
             kwargs (Any): Additional keyword arguments.
         """
 
-    def on_adhoc_event(
+    def on_custom_event(
         self,
         name: str,
         data: Any,
@@ -437,7 +437,7 @@ class BaseCallbackHandler(
         return False
 
     @property
-    def ignore_adhoc_event(self) -> bool:
+    def ignore_custom_event(self) -> bool:
         """Ignore adhoc event."""
         return False
 
@@ -823,7 +823,7 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             kwargs (Any): Additional keyword arguments.
         """
 
-    def on_adhoc_event(
+    def on_custom_event(
         self,
         name: str,
         data: Any,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1512,6 +1512,8 @@ class CallbackManager(BaseCallbackManager):
             name: The name of the adhoc event.
             data: The data for the adhoc event.
             run_id: The ID of the run. Defaults to None.
+
+        .. versionadded:: 0.2.13
         """
         if kwargs:
             raise ValueError(
@@ -1889,6 +1891,8 @@ class AsyncCallbackManager(BaseCallbackManager):
             name: The name of the adhoc event.
             data: The data for the adhoc event.
             run_id: The ID of the run. Defaults to None.
+
+        .. versionadded:: 0.2.13
         """
         if run_id is None:
             run_id = uuid.uuid4()
@@ -2331,11 +2335,13 @@ async def adispatch_custom_event(
             ):
                 print(event)
 
-    .. caution: If using python <= 3.10 and async, you MUST
+    .. warning: If using python <= 3.10 and async, you MUST
         specify the `config` parameter or the function will raise an error.
         This is due to a limitation in asyncio for python <= 3.10 that prevents
         LangChain from automatically propagating the config object on the user's
         behalf.
+
+    .. versionadded:: 0.2.13
     """
     from langchain_core.runnables.config import (
         ensure_config,
@@ -2403,6 +2409,8 @@ def dispatch_custom_event(
 
             foo_ = RunnableLambda(foo)
             foo_.invoke({"a": "1"}, {"callbacks": [CustomCallbackManager()]})
+
+    .. versionadded:: 0.2.13
     """
     from langchain_core.runnables.config import (
         ensure_config,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -2330,6 +2330,12 @@ async def adispatch_custom_event(
                 config={"callbacks": [CustomCallbackManager()]}
             ):
                 print(event)
+
+    .. caution: If using python <= 3.10 and async, you MUST
+        specify the `config` parameter or the function will raise an error.
+        This is due to a limitation in asyncio for python <= 3.10 that prevents
+        LangChain from automatically propagating the config object on the user's
+        behalf.
     """
     from langchain_core.runnables.config import (
         ensure_config,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1513,7 +1513,7 @@ class CallbackManager(BaseCallbackManager):
             data: The data for the adhoc event.
             run_id: The ID of the run. Defaults to None.
 
-        .. versionadded:: 0.2.13
+        .. versionadded:: 0.2.14
         """
         if kwargs:
             raise ValueError(
@@ -1892,7 +1892,7 @@ class AsyncCallbackManager(BaseCallbackManager):
             data: The data for the adhoc event.
             run_id: The ID of the run. Defaults to None.
 
-        .. versionadded:: 0.2.13
+        .. versionadded:: 0.2.14
         """
         if run_id is None:
             run_id = uuid.uuid4()
@@ -2341,7 +2341,7 @@ async def adispatch_custom_event(
         LangChain from automatically propagating the config object on the user's
         behalf.
 
-    .. versionadded:: 0.2.13
+    .. versionadded:: 0.2.14
     """
     from langchain_core.runnables.config import (
         ensure_config,
@@ -2410,7 +2410,7 @@ def dispatch_custom_event(
             foo_ = RunnableLambda(foo)
             foo_.invoke({"a": "1"}, {"callbacks": [CustomCallbackManager()]})
 
-    .. versionadded:: 0.2.13
+    .. versionadded:: 0.2.14
     """
     from langchain_core.runnables.config import (
         ensure_config,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -26,6 +26,9 @@ from typing import (
 )
 from uuid import UUID
 
+from langsmith.run_helpers import get_run_tree_context
+from tenacity import RetryCallState
+
 from langchain_core.callbacks.base import (
     BaseCallbackHandler,
     BaseCallbackManager,
@@ -40,13 +43,12 @@ from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.tracers.schemas import Run
 from langchain_core.utils.env import env_var_is_set
-from langsmith.run_helpers import get_run_tree_context
-from tenacity import RetryCallState
 
 if TYPE_CHECKING:
     from langchain_core.agents import AgentAction, AgentFinish
     from langchain_core.documents import Document
     from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
+    from langchain_core.runnables.config import RunnableConfig
 
 logger = logging.getLogger(__name__)
 
@@ -1518,8 +1520,8 @@ class CallbackManager(BaseCallbackManager):
             self.handlers,
             "on_custom_event",
             "ignore_adhoc",
-            event_name,
-            event_data,
+            name,
+            data,
             run_id=run_id,
             tags=self.tags,
             metadata=self.metadata,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1504,7 +1504,7 @@ class CallbackManager(BaseCallbackManager):
     ) -> None:
         """Dispatch an adhoc event to the handlers (async version).
 
-        This event should be used in any internal LangChain code. The event
+        This event should NOT be used in any internal LangChain code. The event
         is meant specifically for users of the library to dispatch custom
         events that are tailored to their application.
 
@@ -1881,7 +1881,7 @@ class AsyncCallbackManager(BaseCallbackManager):
     ) -> None:
         """Dispatch an adhoc event to the handlers (async version).
 
-        This event should be used in any internal LangChain code. The event
+        This event should NOT be used in any internal LangChain code. The event
         is meant specifically for users of the library to dispatch custom
         events that are tailored to their application.
 

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1493,7 +1493,7 @@ class CallbackManager(BaseCallbackManager):
             inheritable_metadata=self.inheritable_metadata,
         )
 
-    def on_adhoc_event(
+    def on_custom_event(
         self,
         name: str,
         data: Any,
@@ -1516,7 +1516,7 @@ class CallbackManager(BaseCallbackManager):
 
         handle_event(
             self.handlers,
-            "on_adhoc_event",
+            "on_custom_event",
             "ignore_adhoc",
             event_name,
             event_data,
@@ -1865,7 +1865,7 @@ class AsyncCallbackManager(BaseCallbackManager):
             inheritable_metadata=self.inheritable_metadata,
         )
 
-    async def on_adhoc_event(
+    async def on_custom_event(
         self,
         name: str,
         data: Any,
@@ -1890,8 +1890,8 @@ class AsyncCallbackManager(BaseCallbackManager):
 
         await ahandle_event(
             self.handlers,
-            "on_adhoc_event",
-            "ignore_adhoc_event",
+            "on_custom_event",
+            "ignore_custom_event",
             name,
             data,
             run_id=run_id,
@@ -2245,7 +2245,7 @@ def _configure(
 
 
 # TODO(EUGENE): ADD IN CODE DOCUMENTATION
-async def adispatch_adhoc_event(
+async def adispatch_custom_event(
     name: str, data: Any, *, config: Optional[RunnableConfig] = None
 ):
     """Dispatch an adhoc event to the handlers."""
@@ -2271,7 +2271,7 @@ async def adispatch_adhoc_event(
 
     # Hack to get the callback manager for the parent
     callback_manager.run_id = callback_manager.parent_run_id
-    await callback_manager.on_adhoc_event(
+    await callback_manager.on_custom_event(
         name,
         data,
         run_id=callback_manager.parent_run_id,
@@ -2282,7 +2282,7 @@ async def adispatch_adhoc_event(
 
 
 # TODO(EUGENE): TEST THE SYNC PATH with a regular callback handler provided by the user.
-def dispatch_adhoc_event(
+def dispatch_custom_event(
     name: str, data: Any, *, config: Optional[RunnableConfig] = None
 ):
     """Dispatch an adhoc event to the handlers."""
@@ -2305,7 +2305,7 @@ def dispatch_adhoc_event(
             "If you are doing that and still seeing this error, try explicitly"
             "passing the config parameter to this function."
         )
-    callback_manager.on_adhoc_event(
+    callback_manager.on_custom_event(
         name,
         data,
         run_id=callback_manager.parent_run_id,

--- a/libs/core/langchain_core/runnables/schema.py
+++ b/libs/core/langchain_core/runnables/schema.py
@@ -156,7 +156,9 @@ class StandardStreamEvent(BaseStreamEvent):
 class CustomStreamEvent(BaseStreamEvent):
     """A custom stream event created by the user."""
 
-    event: Literal["on_custom_event"]
+    # Overwrite the event field to be more specific.
+    event: Literal["on_custom_event"]  # type: ignore[misc]
+
     """The event type."""
     name: str
     """A user defined name for the event."""

--- a/libs/core/langchain_core/runnables/schema.py
+++ b/libs/core/langchain_core/runnables/schema.py
@@ -156,7 +156,7 @@ class StandardStreamEvent(BaseStreamEvent):
 class CustomStreamEvent(BaseStreamEvent):
     """A custom stream event created by the user.
 
-    .. versionadded:: 0.2.13
+    .. versionadded:: 0.2.14
     """
 
     # Overwrite the event field to be more specific.

--- a/libs/core/langchain_core/runnables/schema.py
+++ b/libs/core/langchain_core/runnables/schema.py
@@ -154,7 +154,10 @@ class StandardStreamEvent(BaseStreamEvent):
 
 
 class CustomStreamEvent(BaseStreamEvent):
-    """A custom stream event created by the user."""
+    """A custom stream event created by the user.
+
+    .. versionadded:: 0.2.13
+    """
 
     # Overwrite the event field to be more specific.
     event: Literal["on_custom_event"]  # type: ignore[misc]

--- a/libs/core/langchain_core/runnables/schema.py
+++ b/libs/core/langchain_core/runnables/schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Literal, Sequence, Union
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -37,7 +37,7 @@ class EventData(TypedDict, total=False):
     """
 
 
-class StreamEvent(TypedDict):
+class BaseStreamEvent(TypedDict):
     """Streaming event.
 
     Schema of a streaming event which is produced from the astream_events method.
@@ -101,8 +101,6 @@ class StreamEvent(TypedDict):
     
     Please see the documentation for `EventData` for more details.
     """
-    name: str
-    """The name of the runnable that generated the event."""
     run_id: str
     """An randomly generated ID to keep track of the execution of the given runnable.
     
@@ -128,11 +126,6 @@ class StreamEvent(TypedDict):
     
         `.astream_events(..., {"metadata": {"foo": "bar"}})`.
     """
-    data: EventData
-    """Event data.
-
-    The contents of the event data depend on the event type.
-    """
 
     parent_ids: Sequence[str]
     """A list of the parent IDs associated with this event.
@@ -146,3 +139,29 @@ class StreamEvent(TypedDict):
     
     Only supported as of v2 of the astream events API. v1 will return an empty list.
     """
+
+
+class StandardStreamEvent(BaseStreamEvent):
+    """A standard stream event that follows LangChain convention for event data."""
+
+    data: EventData
+    """Event data.
+
+    The contents of the event data depend on the event type.
+    """
+    name: str
+    """The name of the runnable that generated the event."""
+
+
+class CustomStreamEvent(BaseStreamEvent):
+    """A custom stream event created by the user."""
+
+    event: Literal["on_custom_event"]
+    """The event type."""
+    name: str
+    """A user defined name for the event."""
+    data: Any
+    """The data associated with the event. Free form and can be anything."""
+
+
+StreamEvent = Union[StandardStreamEvent, CustomStreamEvent]

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -340,7 +340,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
             run_type,
         )
 
-    async def on_adhoc_event(
+    async def on_custom_event(
         self,
         name: str,
         data: Any,
@@ -352,7 +352,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
     ) -> None:
         """Run an ad-hoc event."""
         event = StreamEvent(
-            event="on_adhoc_event",
+            event="on_custom_event",
             run_id=str(run_id),
             name=name,
             tags=tags or [],

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -28,7 +28,12 @@ from langchain_core.outputs import (
     GenerationChunk,
     LLMResult,
 )
-from langchain_core.runnables.schema import EventData, StandardStreamEvent
+from langchain_core.runnables.schema import (
+    CustomStreamEvent,
+    EventData,
+    StandardStreamEvent,
+    StreamEvent,
+)
 from langchain_core.runnables.utils import (
     Input,
     Output,
@@ -111,7 +116,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         )
 
         loop = asyncio.get_event_loop()
-        memory_stream = _MemoryStream[StandardStreamEvent](loop)
+        memory_stream = _MemoryStream[StreamEvent](loop)
         self.send_stream = memory_stream.get_send_stream()
         self.receive_stream = memory_stream.get_receive_stream()
 
@@ -133,7 +138,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         # parent ID is the root and the last ID is the immediate parent.
         return parent_ids[::-1]
 
-    def _send(self, event: StandardStreamEvent, event_type: str) -> None:
+    def _send(self, event: StreamEvent, event_type: str) -> None:
         """Send an event to the stream."""
         if self.root_event_filter.include_event(event, event_type):
             self.send_stream.send_nowait(event)
@@ -351,8 +356,8 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        """Run an ad-hoc event."""
-        event = StandardStreamEvent(
+        """Generate a custom astream event."""
+        event = CustomStreamEvent(
             event="on_custom_event",
             run_id=str(run_id),
             name=name,

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -344,18 +344,16 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         self,
         name: str,
         data: Any,
+        *,
         run_id: UUID,
-        parent_run_id: Optional[UUID] = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         """Run an ad-hoc event."""
-        if run_id is None:
-            run_id = uuid4()
         event = StreamEvent(
             event="on_adhoc_event",
-            run_id=run_id,
+            run_id=str(run_id),
             name=name,
             tags=tags or [],
             metadata=metadata or {},

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -19,6 +19,8 @@ from typing import (
 )
 from uuid import UUID, uuid4
 
+from typing_extensions import NotRequired, TypedDict
+
 from langchain_core.callbacks.base import AsyncCallbackHandler
 from langchain_core.messages import AIMessageChunk, BaseMessage, BaseMessageChunk
 from langchain_core.outputs import (
@@ -36,7 +38,6 @@ from langchain_core.tracers._streaming import _StreamingCallbackHandler
 from langchain_core.tracers.log_stream import LogEntry
 from langchain_core.tracers.memory_stream import _MemoryStream
 from langchain_core.utils.aiter import aclosing, py_anext
-from typing_extensions import NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from langchain_core.documents import Document

--- a/libs/core/tests/unit_tests/callbacks/test_dispatch_custom_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_dispatch_custom_event.py
@@ -1,0 +1,121 @@
+import uuid
+from typing import Any, Optional, List, Dict
+from uuid import UUID
+
+import pytest
+from langchain_core.callbacks import AsyncCallbackHandler, BaseCallbackHandler
+from langchain_core.callbacks.manager import (
+    adispatch_custom_event,
+    dispatch_custom_event,
+)
+from langchain_core.runnables import RunnableLambda
+from langchain_core.runnables.config import RunnableConfig
+
+
+def test_custom_event_root_dispatch() -> None:
+    """Test adhoc event in a nested chain."""
+    # This just tests that nothing breaks on the path.
+    # It shouldn't do anything at the moment, since the tracer isn't configured
+    # to handle adhoc events.
+    # Expected behavior is that the event cannot be dispatched
+    with pytest.raises(RuntimeError):
+        dispatch_custom_event("event1", {"x": 1})
+
+
+async def test_async_custom_event_root_dispatch() -> None:
+    """Test adhoc event in a nested chain."""
+    # This just tests that nothing breaks on the path.
+    # It shouldn't do anything at the moment, since the tracer isn't configured
+    # to handle adhoc events.
+    # Expected behavior is that the event cannot be dispatched
+    with pytest.raises(RuntimeError):
+        await adispatch_custom_event("event1", {"x": 1})
+
+
+async def test_async_callback_manager() -> None:
+    """Test async callback manager."""
+
+    class CustomCallbackManager(AsyncCallbackHandler):
+        def __init__(self):
+            self.events = []
+
+        async def on_custom_event(
+            self,
+            name: str,
+            data: Any,
+            *,
+            run_id: UUID,
+            tags: Optional[List[str]] = None,
+            metadata: Optional[Dict[str, Any]] = None,
+            **kwargs: Any,
+        ) -> None:
+            assert kwargs == {}
+            self.events.append(
+                (
+                    name,
+                    data,
+                    run_id,
+                    tags,
+                    metadata,
+                )
+            )
+
+    callback = CustomCallbackManager()
+
+    run_id = uuid.UUID(int=7)
+
+    @RunnableLambda
+    async def foo(x: int, config: RunnableConfig) -> None:
+        await adispatch_custom_event("event1", {"x": x})
+        await adispatch_custom_event("event2", {"x": x}, config=config)
+        return x
+
+    await foo.ainvoke(1, {"callbacks": [callback], "run_id": run_id})
+
+    assert callback.events == [
+        ("event1", {"x": 1}, UUID("00000000-0000-0000-0000-000000000007"), [], {}),
+        ("event2", {"x": 1}, UUID("00000000-0000-0000-0000-000000000007"), [], {}),
+    ]
+
+
+def test_sync_callback_manager() -> None:
+    """Test async callback manager."""
+
+    class CustomCallbackManager(BaseCallbackHandler):
+        def __init__(self):
+            self.events = []
+
+        def on_custom_event(
+            self,
+            name: str,
+            data: Any,
+            *,
+            run_id: UUID,
+            tags: Optional[List[str]] = None,
+            metadata: Optional[Dict[str, Any]] = None,
+            **kwargs: Any,
+        ) -> None:
+            assert kwargs == {}
+            self.events.append(
+                (
+                    name,
+                    data,
+                    run_id,
+                    tags,
+                    metadata,
+                )
+            )
+
+    callback = CustomCallbackManager()
+
+    run_id = uuid.UUID(int=7)
+
+    @RunnableLambda
+    def foo(x: int, config: RunnableConfig) -> None:
+        dispatch_custom_event("event1", {"x": x})
+        dispatch_custom_event("event2", {"x": x}, config=config)
+        return x
+
+    foo.invoke(1, {"callbacks": [callback], "run_id": run_id})
+
+    assert callback.events == []

--- a/libs/core/tests/unit_tests/callbacks/test_dispatch_custom_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_dispatch_custom_event.py
@@ -64,7 +64,7 @@ IS_GTE_3_11 = sys.version_info >= (3, 11)
 
 
 @pytest.mark.skipif(not IS_GTE_3_11, reason="Requires Python >=3.11")
-async def test_custom_event_root_dispatch() -> None:
+async def test_async_custom_event_implicit_config() -> None:
     """Test dispatch without passing config explicitly."""
     callback = AsyncCustomCallbackHandler()
 

--- a/libs/core/tests/unit_tests/callbacks/test_imports.py
+++ b/libs/core/tests/unit_tests/callbacks/test_imports.py
@@ -31,6 +31,8 @@ EXPECTED_ALL = [
     "StdOutCallbackHandler",
     "StreamingStdOutCallbackHandler",
     "FileCallbackHandler",
+    "adispatch_custom_event",
+    "dispatch_custom_event",
 ]
 
 

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -2546,6 +2546,11 @@ async def test_custom_event_root_dispatch() -> None:
         await adispatch_custom_event("event1", {"x": 1})
 
 
+IS_GTE_3_11 = sys.version_info >= (3, 11)
+
+
+# Test relies on automatically picking up RunnableConfig from contextvars
+@pytest.mark.skipif(not IS_GTE_3_11, reason="Requires Python >=3.11")
 async def test_custom_event_root_dispatch_with_in_tool() -> None:
     """Test adhoc event in a nested chain."""
     from langchain_core.callbacks.manager import adispatch_custom_event

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -2365,7 +2365,7 @@ async def test_custom_event() -> None:
     async def foo(x: int, config: RunnableConfig) -> int:
         """Simple function that emits some adhoc events."""
         await adispatch_custom_event("event1", {"x": x}, config=config)
-        await adispatch_custom_event("event2", "foo")
+        await adispatch_custom_event("event2", "foo", config=config)
         return x + 1
 
     uuid1 = uuid.UUID(int=7)
@@ -2439,7 +2439,7 @@ async def test_custom_event_nested() -> None:
     async def foo(x: int, config: RunnableConfig) -> int:
         """Simple function that emits some adhoc events."""
         await adispatch_custom_event("event1", {"x": x}, config=config)
-        await adispatch_custom_event("event2", "foo")
+        await adispatch_custom_event("event2", "foo", config=config)
         return x + 1
 
     run_id = uuid.UUID(int=7)

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import pytest
-
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.documents import Document
@@ -2353,3 +2352,22 @@ async def test_cancel_astream_events() -> None:
 
     # node "anotherwhile" should never start
     assert anotherwhile.started is False
+
+
+async def test_adhoc_event() -> None:
+    """Test adhoc event."""
+    from langchain_core.callbacks.manager import adispatch_adhoc_event
+
+    @RunnableLambda
+    async def foo(x: int, config):
+        await adispatch_adhoc_event("my_event", {"x": x}, config=config)
+        await adispatch_adhoc_event("event2", "foo")
+        return x + 1
+
+    events = await _collect_events(foo.astream_events(1, version="v2"))
+    assert events == [
+        ]
+
+
+
+

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -2354,15 +2354,15 @@ async def test_cancel_astream_events() -> None:
     assert anotherwhile.started is False
 
 
-async def test_adhoc_event() -> None:
+async def test_custom_event() -> None:
     """Test adhoc event."""
-    from langchain_core.callbacks.manager import adispatch_adhoc_event
+    from langchain_core.callbacks.manager import adispatch_custom_event
 
     @RunnableLambda
     async def foo(x: int, config) -> int:
         """Simple function that emits some adhoc events."""
-        await adispatch_adhoc_event("event1", {"x": x}, config=config)
-        await adispatch_adhoc_event("event2", "foo")
+        await adispatch_custom_event("event1", {"x": x}, config=config)
+        await adispatch_custom_event("event2", "foo")
         return x + 1
 
     run_id = str(uuid.UUID(int=7))
@@ -2387,7 +2387,7 @@ async def test_adhoc_event() -> None:
         },
         {
             "data": {"x": 1},
-            "event": "on_adhoc_event",
+            "event": "on_custom_event",
             "metadata": {},
             "name": "event1",
             "parent_ids": [],
@@ -2396,7 +2396,7 @@ async def test_adhoc_event() -> None:
         },
         {
             "data": "foo",
-            "event": "on_adhoc_event",
+            "event": "on_custom_event",
             "metadata": {},
             "name": "event2",
             "parent_ids": [],
@@ -2424,15 +2424,15 @@ async def test_adhoc_event() -> None:
     ]
 
 
-async def test_adhoc_event_nested() -> None:
+async def test_custom_event_nested() -> None:
     """Test adhoc event in a nested chain."""
-    from langchain_core.callbacks.manager import adispatch_adhoc_event
+    from langchain_core.callbacks.manager import adispatch_custom_event
 
     @RunnableLambda
     async def foo(x: int, config: RunnableConfig) -> int:
         """Simple function that emits some adhoc events."""
-        await adispatch_adhoc_event("event1", {"x": x}, config=config)
-        await adispatch_adhoc_event("event2", "foo")
+        await adispatch_custom_event("event1", {"x": x}, config=config)
+        await adispatch_custom_event("event2", "foo")
         return x + 1
 
     run_id = str(uuid.UUID(int=7))
@@ -2472,7 +2472,7 @@ async def test_adhoc_event_nested() -> None:
         },
         {
             "data": {"x": 1},
-            "event": "on_adhoc_event",
+            "event": "on_custom_event",
             "metadata": {},
             "name": "event1",
             "parent_ids": ["00000000-0000-0000-0000-000000000007"],
@@ -2481,7 +2481,7 @@ async def test_adhoc_event_nested() -> None:
         },
         {
             "data": "foo",
-            "event": "on_adhoc_event",
+            "event": "on_custom_event",
             "metadata": {},
             "name": "event2",
             "parent_ids": ["00000000-0000-0000-0000-000000000007"],
@@ -2518,14 +2518,14 @@ async def test_adhoc_event_nested() -> None:
     ]
 
 
-async def test_adhoc_event_root_dispatch() -> None:
+async def test_custom_event_root_dispatch() -> None:
     """Test adhoc event in a nested chain."""
     # This just tests that nothing breaks on the path.
     # It shouldn't do anything at the moment, since the tracer isn't configured
     # to handle adhoc events.
-    from langchain_core.callbacks.manager import adispatch_adhoc_event
+    from langchain_core.callbacks.manager import adispatch_custom_event
 
     # Expected behavior is that the event cannot be dispatched
     with pytest.raises(RuntimeError):
 
-        await adispatch_adhoc_event("event1", {"x": 1})
+        await adispatch_custom_event("event1", {"x": 1})

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import pytest
+
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.documents import Document
@@ -2527,5 +2528,4 @@ async def test_custom_event_root_dispatch() -> None:
 
     # Expected behavior is that the event cannot be dispatched
     with pytest.raises(RuntimeError):
-
         await adispatch_custom_event("event1", {"x": 1})

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -2557,13 +2557,15 @@ async def test_custom_event_root_dispatch_with_in_tool() -> None:
     from langchain_core.tools import tool
 
     @tool
-    async def foo(x: int):
+    async def foo(x: int) -> int:
         """Foo"""
         await adispatch_custom_event("event1", {"x": x})
         return x + 1
 
-    # Expected behavior is that the event cannot be dispatched
-    events = await _collect_events(foo.astream_events({"x": 2}, version="v2"))
+    # Ignoring type due to @tool not returning correct type annotations
+    events = await _collect_events(
+        foo.astream_events({"x": 2}, version="v2")  # type: ignore[attr-defined]
+    )
     assert events == [
         {
             "data": {"input": {"x": 2}},

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import pytest
+
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.documents import Document

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import pytest
-
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.documents import Document


### PR DESCRIPTION
This PR allows dispatching adhoc events for a given run.

# Context

This PR allows users to send arbitrary data to the callback system and to the astream events API from within a given runnable. This can be extremely useful to surface custom information to end users about progress etc.

Integration with langsmith tracer will be done separately since the data cannot be currently visualized. It'll be accommodated using the events attribute of the Run

# Examples with astream events

```python
from langchain_core.callbacks import adispatch_custom_event
from langchain_core.tools import tool

@tool
async def foo(x: int) -> int:
    """Foo"""
    await adispatch_custom_event("event1", {"x": x})
    await adispatch_custom_event("event2", {"x": x})
    return x + 1

async for event in foo.astream_events({'x': 1}, version='v2'):
    print(event)
```

```python
{'event': 'on_tool_start', 'data': {'input': {'x': 1}}, 'name': 'foo', 'tags': [], 'run_id': 'fd6fb7a7-dd37-4191-962c-e43e245909f6', 'metadata': {}, 'parent_ids': []}
{'event': 'on_custom_event', 'run_id': 'fd6fb7a7-dd37-4191-962c-e43e245909f6', 'name': 'event1', 'tags': [], 'metadata': {}, 'data': {'x': 1}, 'parent_ids': []}
{'event': 'on_custom_event', 'run_id': 'fd6fb7a7-dd37-4191-962c-e43e245909f6', 'name': 'event2', 'tags': [], 'metadata': {}, 'data': {'x': 1}, 'parent_ids': []}
{'event': 'on_tool_end', 'data': {'output': 2}, 'run_id': 'fd6fb7a7-dd37-4191-962c-e43e245909f6', 'name': 'foo', 'tags': [], 'metadata': {}, 'parent_ids': []}
```

```python
from langchain_core.callbacks import adispatch_custom_event
from langchain_core.runnables import RunnableLambda

@RunnableLambda
async def foo(x: int) -> int:
    """Foo"""
    await adispatch_custom_event("event1", {"x": x})
    await adispatch_custom_event("event2", {"x": x})
    return x + 1

async for event in foo.astream_events(1, version='v2'):
    print(event)
```

```python
{'event': 'on_chain_start', 'data': {'input': 1}, 'name': 'foo', 'tags': [], 'run_id': 'ce2beef2-8608-49ea-8eba-537bdaafb8ec', 'metadata': {}, 'parent_ids': []}
{'event': 'on_custom_event', 'run_id': 'ce2beef2-8608-49ea-8eba-537bdaafb8ec', 'name': 'event1', 'tags': [], 'metadata': {}, 'data': {'x': 1}, 'parent_ids': []}
{'event': 'on_custom_event', 'run_id': 'ce2beef2-8608-49ea-8eba-537bdaafb8ec', 'name': 'event2', 'tags': [], 'metadata': {}, 'data': {'x': 1}, 'parent_ids': []}
{'event': 'on_chain_stream', 'run_id': 'ce2beef2-8608-49ea-8eba-537bdaafb8ec', 'name': 'foo', 'tags': [], 'metadata': {}, 'data': {'chunk': 2}, 'parent_ids': []}
{'event': 'on_chain_end', 'data': {'output': 2}, 'run_id': 'ce2beef2-8608-49ea-8eba-537bdaafb8ec', 'name': 'foo', 'tags': [], 'metadata': {}, 'parent_ids': []}
```

# Examples with handlers 

This is copy pasted from unit tests

```python
    class CustomCallbackManager(BaseCallbackHandler):
        def __init__(self) -> None:
            self.events: List[Any] = []

        def on_custom_event(
            self,
            name: str,
            data: Any,
            *,
            run_id: UUID,
            tags: Optional[List[str]] = None,
            metadata: Optional[Dict[str, Any]] = None,
            **kwargs: Any,
        ) -> None:
            assert kwargs == {}
            self.events.append(
                (
                    name,
                    data,
                    run_id,
                    tags,
                    metadata,
                )
            )

    callback = CustomCallbackManager()

    run_id = uuid.UUID(int=7)

    @RunnableLambda
    def foo(x: int, config: RunnableConfig) -> int:
        dispatch_custom_event("event1", {"x": x})
        dispatch_custom_event("event2", {"x": x}, config=config)
        return x

    foo.invoke(1, {"callbacks": [callback], "run_id": run_id})

    assert callback.events == [
        ("event1", {"x": 1}, UUID("00000000-0000-0000-0000-000000000007"), [], {}),
        ("event2", {"x": 1}, UUID("00000000-0000-0000-0000-000000000007"), [], {}),
    ]
```