### PR TITLE
community: Fixes use of ImagePromptTemplate with Ollama

### DIFF
--- a/libs/community/langchain_community/chat_models/ollama.py
+++ b/libs/community/langchain_community/chat_models/ollama.py
@@ -144,7 +144,7 @@ class ChatOllama(BaseChatModel, _OllamaCommon):
                         elif (
                             isinstance(temp_image_url, dict) and "url" in temp_image_url
                         ):
-                            image_url = temp_image_url
+                            image_url = temp_image_url["url"]
                         else:
                             raise ValueError(
                                 "Only string image_url or dict with string 'url' "


### PR DESCRIPTION
Description: ImagePromptTemplate for Multimodal llms like llava when using Ollama 
Twitter handle: https://x.com/a7ulr

Details:

When using llava models / any ollama multimodal llms and passing images in the prompt as urls, langchain breaks with this error. 

```python
image_url_components = image_url.split(",")
                           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'split'
```

From the looks of it, there was bug where the condition did check for a `url` field in the variable but missed to actually assign it.

This PR fixes ImagePromptTemplate for Multimodal llms like llava when using Ollama specifically.

@hwchase17