### PR TITLE
fix azure_openai.py: some keys do not exists

### DIFF
--- a/libs/community/langchain_community/embeddings/azure_openai.py
+++ b/libs/community/langchain_community/embeddings/azure_openai.py
@@ -61,7 +61,7 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
         # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
         # other forms of azure credentials.
         values["openai_api_key"] = (
-            values["openai_api_key"]
+            values.get("openai_api_key")
             or os.getenv("AZURE_OPENAI_API_KEY")
             or os.getenv("OPENAI_API_KEY")
         )
@@ -75,7 +75,7 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
             values, "openai_api_type", "OPENAI_API_TYPE", default="azure"
         )
         values["openai_organization"] = (
-            values["openai_organization"]
+            values.get("openai_organization")
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
@@ -85,10 +85,10 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
             "OPENAI_PROXY",
             default="",
         )
-        values["azure_endpoint"] = values["azure_endpoint"] or os.getenv(
+        values["azure_endpoint"] = values.get("azure_endpoint") or os.getenv(
             "AZURE_OPENAI_ENDPOINT"
         )
-        values["azure_ad_token"] = values["azure_ad_token"] or os.getenv(
+        values["azure_ad_token"] = values.get("azure_ad_token") or os.getenv(
             "AZURE_OPENAI_AD_TOKEN"
         )
         # Azure OpenAI embedding models allow a maximum of 16 texts


### PR DESCRIPTION
In some lines its trying to read a key that do not exists yet. In this cases I changed the direct access to dict.get() method

Thank you for contributing to LangChain!

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/


