### PR TITLE
Fix neo4j type error on missing constraint information

### DIFF
--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -555,11 +555,13 @@ class Neo4jGraph(GraphStore):
                     el["labelsOrTypes"] == [BASE_ENTITY_LABEL]
                     and el["properties"] == ["id"]
                     for el in self.structured_schema.get("metadata", {}).get(
-                        "constraint"
+                        "constraint", []
                     )
                 ]
             )
+
             if not constraint_exists:
+                print("create constraint")
                 # Create constraint
                 self.query(
                     f"CREATE CONSTRAINT IF NOT EXISTS FOR (b:{BASE_ENTITY_LABEL}) "

--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -561,7 +561,6 @@ class Neo4jGraph(GraphStore):
             )
 
             if not constraint_exists:
-                print("create constraint")
                 # Create constraint
                 self.query(
                     f"CREATE CONSTRAINT IF NOT EXISTS FOR (b:{BASE_ENTITY_LABEL}) "


### PR DESCRIPTION
If you use `refresh_schema=False`, then the metadata constraint doesn't exist. ATM, we used default `None` in the constraint check, but then `any` fails because it can't iterate over None value