### PR TITLE
community: upgrade default model for ChatAnyscale

### DIFF
--- a/libs/community/langchain_community/chat_models/anyscale.py
+++ b/libs/community/langchain_community/chat_models/anyscale.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_BASE = "https://api.endpoints.anyscale.com/v1"
-DEFAULT_MODEL = "meta-llama/Llama-2-7b-chat-hf"
+DEFAULT_MODEL = "meta-llama/Meta-Llama-3-8B-Instruct"
 
 
 class ChatAnyscale(ChatOpenAI):


### PR DESCRIPTION
Old default `meta-llama/Llama-2-7b-chat-hf` no longer supported.

