### PR TITLE
community[patch]: Update TavilySearch to use TavilyClient instead of the deprecated Client

### DIFF
--- a/libs/community/langchain_community/retrievers/tavily_search_api.py
+++ b/libs/community/langchain_community/retrievers/tavily_search_api.py
@@ -31,7 +31,11 @@ class TavilySearchAPIRetriever(BaseRetriever):
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> List[Document]:
         try:
-            from tavily import TavilyClient
+            try:
+                from tavily import TavilyClient
+            except TypeError:
+                # Older of tavily used Client
+                from tavily import Client as TavilyClient
         except ImportError:
             raise ImportError(
                 "Tavily python package not found. "

--- a/libs/community/langchain_community/retrievers/tavily_search_api.py
+++ b/libs/community/langchain_community/retrievers/tavily_search_api.py
@@ -31,14 +31,14 @@ class TavilySearchAPIRetriever(BaseRetriever):
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> List[Document]:
         try:
-            from tavily import Client
+            from tavily import TavilyClient
         except ImportError:
             raise ImportError(
                 "Tavily python package not found. "
                 "Please install it with `pip install tavily-python`."
             )
 
-        tavily = Client(api_key=self.api_key or os.environ["TAVILY_API_KEY"])
+        tavily = TavilyClient(api_key=self.api_key or os.environ["TAVILY_API_KEY"])
         max_results = self.k if not self.include_generated_answer else self.k - 1
         response = tavily.search(
             query=query,

--- a/libs/community/langchain_community/retrievers/tavily_search_api.py
+++ b/libs/community/langchain_community/retrievers/tavily_search_api.py
@@ -33,7 +33,7 @@ class TavilySearchAPIRetriever(BaseRetriever):
         try:
             try:
                 from tavily import TavilyClient
-            except TypeError:
+            except ImportError:
                 # Older of tavily used Client
                 from tavily import Client as TavilyClient
         except ImportError:


### PR DESCRIPTION
On using TavilySearchAPIRetriever with any conversation chain getting error : 

`TypeError: Client.__init__() got an unexpected keyword argument 'api_key'`

It is because the retreiver class is using the depreciated `Client` class, `TavilyClient` need to be used instead.
