### PR TITLE
docs: Fix grammar error in retrievers tutorial

### DIFF
--- a/docs/docs/tutorials/retrievers.ipynb
+++ b/docs/docs/tutorials/retrievers.ipynb
@@ -269,7 +269,7 @@
    "id": "b4991642-7275-40a9-b11a-e3beccbf2614",
    "metadata": {},
    "source": [
-    "Return documents based on similarity to a embedded query:"
+    "Return documents based on similarity to an embedded query:"
    ]
   },
   {


### PR DESCRIPTION
a embedding -> an embedding