### PR TITLE
docs: readthedocs deprecation fix

### DIFF
--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -178,3 +178,10 @@ autosummary_generate = True
 
 html_copy_source = False
 html_show_sourcelink = False
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/07/addons-by-default/#how-does-it-affect-my-projects

we use build.command so we're already using addons, so I think this is it