### PR TITLE
[RFC] Add support for invoking parents

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1545,6 +1545,7 @@ class CallbackManager(BaseCallbackManager):
         local_tags: Optional[List[str]] = None,
         inheritable_metadata: Optional[Dict[str, Any]] = None,
         local_metadata: Optional[Dict[str, Any]] = None,
+        *,
         parent: Optional[str] = None,
     ) -> CallbackManager:
         """Configure the callback manager.
@@ -1976,6 +1977,7 @@ class AsyncCallbackManager(BaseCallbackManager):
         local_tags: Optional[List[str]] = None,
         inheritable_metadata: Optional[Dict[str, Any]] = None,
         local_metadata: Optional[Dict[str, Any]] = None,
+        *,
         parent: Optional[str] = None,
     ) -> AsyncCallbackManager:
         """Configure the async callback manager.

--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -201,6 +201,7 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
             local_tags=self.tags,
             inheritable_metadata=config.get("metadata"),
             local_metadata=self.metadata,
+            parent=config.get("parent"),
         )
         run_manager = callback_manager.on_retriever_start(
             dumpd(self),
@@ -260,6 +261,7 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
             local_tags=self.tags,
             inheritable_metadata=config.get("metadata"),
             local_metadata=self.metadata,
+            parent=config.get("parent"),
         )
         run_manager = await callback_manager.on_retriever_start(
             dumpd(self),

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -2896,6 +2896,7 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
                 local_tags=None,
                 inheritable_metadata=config.get("metadata"),
                 local_metadata=None,
+                parent=config.get("parent"),
             )
             for config in configs
         ]
@@ -3022,6 +3023,7 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
                 local_tags=None,
                 inheritable_metadata=config.get("metadata"),
                 local_metadata=None,
+                parent=config.get("parent"),
             )
             for config in configs
         ]
@@ -3482,6 +3484,7 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
             local_tags=None,
             inheritable_metadata=config.get("metadata"),
             local_metadata=None,
+            parent=config.get("parent"),
         )
         # start the root run
         run_manager = callback_manager.on_chain_start(

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -104,6 +104,11 @@ class RunnableConfig(TypedDict, total=False):
         will be generated.
     """
 
+    parent: Optional[str]
+    """
+    The parent dotted order in the trace. If not provided, the parent will be inferred
+        from the tracing context."""
+
 
 var_child_runnable_config = ContextVar(
     "child_runnable_config", default=RunnableConfig()
@@ -144,6 +149,7 @@ def ensure_config(config: Optional[RunnableConfig] = None) -> RunnableConfig:
         metadata={},
         callbacks=None,
         recursion_limit=25,
+        parent=None,
     )
     if var_config := var_child_runnable_config.get():
         empty.update(
@@ -435,6 +441,7 @@ def get_callback_manager_for_config(config: RunnableConfig) -> CallbackManager:
         inheritable_callbacks=config.get("callbacks"),
         inheritable_tags=config.get("tags"),
         inheritable_metadata=config.get("metadata"),
+        parent=config.get("parent"),
     )
 
 

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -462,6 +462,7 @@ def get_async_callback_manager_for_config(
         inheritable_callbacks=config.get("callbacks"),
         inheritable_tags=config.get("tags"),
         inheritable_metadata=config.get("metadata"),
+        parent=config.get("parent"),
     )
 
 

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -272,6 +272,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                 local_tags=None,
                 inheritable_metadata=config.get("metadata"),
                 local_metadata=None,
+                parent=config.get("parent"),
             )
             for config in configs
         ]
@@ -364,6 +365,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                 local_tags=None,
                 inheritable_metadata=config.get("metadata"),
                 local_metadata=None,
+                parent=config.get("parent"),
             )
             for config in configs
         ]

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -576,6 +576,7 @@ class ChildTool(BaseTool):
             self.tags,
             metadata,
             self.metadata,
+            parent=config.get("parent"),
         )
 
         run_manager = callback_manager.on_tool_start(
@@ -683,6 +684,7 @@ class ChildTool(BaseTool):
             self.tags,
             metadata,
             self.metadata,
+            parent=config.get("parent"),
         )
         run_manager = await callback_manager.on_tool_start(
             {"name": self.name, "description": self.description},

--- a/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
+++ b/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
@@ -1,6 +1,8 @@
 import json
 import sys
+from typing import Optional
 from unittest.mock import MagicMock, patch
+import uuid
 
 import pytest
 from langsmith import Client, traceable
@@ -29,7 +31,15 @@ def _get_posts(client: Client) -> list:
     return posts
 
 
-def test_config_traceable_handoff() -> None:
+@pytest.mark.parametrize(
+    "dotted_order",
+    [
+        None,
+        "20240716T222505213101Z6bc70600-21d8-41d0-b54b-175f80b02130.20240716T222505315288Z180de013-f114-439a-86e2-ac15d1393f5a",
+        "20240716T222505213101Z6bc70600-21d8-41d0-b54b-175f80b02130",
+    ],
+)
+def test_config_traceable_handoff(dotted_order: Optional[str]) -> None:
     mock_session = MagicMock()
     mock_client_ = Client(
         session=mock_session, api_key="test", auto_batch_tracing=False
@@ -78,6 +88,8 @@ def test_config_traceable_handoff() -> None:
     trace_id = posts[0]["trace_id"]
     last_dotted_order = None
     parent_run_id = None
+    if dotted_order is not None:
+        parent_run_id = uuid.UUID(dotted_order.split(".")[-1].split("Z")[-1])
     for name in ordered_names:
         id_ = name_to_body[name]["id"]
         parent_run_id_ = name_to_body[name]["parent_run_id"]


### PR DESCRIPTION
There's some weird conflicts that need bettter UT's right now:

- If I do:

```
with langsmith.tracing_context(...):
     my_chain.invoke(... {"parent": ...})
```
the parent is ignored. Or more generally, "parent" is only respected if it would otherwise be treated as the root run (i think)