### PR TITLE
core[patch]: Fix utils.json_schema.dereference_refs (#24335  KeyError: 400 in JSON schema processing)

### DIFF
--- a/libs/core/langchain_core/utils/json_schema.py
+++ b/libs/core/langchain_core/utils/json_schema.py
@@ -13,9 +13,13 @@ def _retrieve_ref(path: str, schema: dict) -> dict:
         )
     out = schema
     for component in components[1:]:
-        if component not in out:
-            continue
-        out = out[component]
+        if component.isdigit() and int(component) in out:
+            out = out[int(component)]
+        elif component in out:
+            out = out[component]
+        else:
+            # Returning the original schema or a default value if the key is not found
+            return deepcopy(out)
     return deepcopy(out)
 
 

--- a/libs/core/langchain_core/utils/json_schema.py
+++ b/libs/core/langchain_core/utils/json_schema.py
@@ -13,10 +13,9 @@ def _retrieve_ref(path: str, schema: dict) -> dict:
         )
     out = schema
     for component in components[1:]:
-        if component.isdigit():
-            out = out[int(component)]
-        else:
-            out = out[component]
+        if component not in out:
+            continue
+        out = out[component]
     return deepcopy(out)
 
 

--- a/libs/core/langchain_core/utils/json_schema.py
+++ b/libs/core/langchain_core/utils/json_schema.py
@@ -18,8 +18,7 @@ def _retrieve_ref(path: str, schema: dict) -> dict:
         elif component.isdigit() and int(component) in out:
             out = out[int(component)]
         else:
-            # Returning the original schema or a default value if the key is not found
-            return deepcopy(out)
+            raise KeyError(f"Reference '{path}' not found.")
     return deepcopy(out)
 
 

--- a/libs/core/langchain_core/utils/json_schema.py
+++ b/libs/core/langchain_core/utils/json_schema.py
@@ -13,10 +13,10 @@ def _retrieve_ref(path: str, schema: dict) -> dict:
         )
     out = schema
     for component in components[1:]:
-        if component.isdigit() and int(component) in out:
-            out = out[int(component)]
-        elif component in out:
+        if component in out:
             out = out[component]
+        elif component.isdigit() and int(component) in out:
+            out = out[int(component)]
         else:
             # Returning the original schema or a default value if the key is not found
             return deepcopy(out)

--- a/libs/core/tests/unit_tests/utils/test_json_schema.py
+++ b/libs/core/tests/unit_tests/utils/test_json_schema.py
@@ -191,7 +191,7 @@ def test_dereference_refs_string_ref() -> None:
     schema = {
         "type": "object",
         "properties": {
-            "error_400": {"$ref": "#/$defs/'400'"},
+            "error_400": {"$ref": "#/$defs/400"},
         },
         "$defs": {
             "400": {

--- a/libs/core/tests/unit_tests/utils/test_json_schema.py
+++ b/libs/core/tests/unit_tests/utils/test_json_schema.py
@@ -136,12 +136,8 @@ def test_dereference_refs_missing_ref() -> None:
         },
         "$defs": {},
     }
-    # Since _retrieve_ref no longer raises KeyError, this test should be adjusted.
-    try:
+    with pytest.raises(KeyError):
         dereference_refs(schema)
-        assert True  # If no exception is raised, test passes
-    except KeyError:
-        pytest.fail("KeyError should not be raised")
 
 
 def test_dereference_refs_remote_ref() -> None:

--- a/libs/core/tests/unit_tests/utils/test_json_schema.py
+++ b/libs/core/tests/unit_tests/utils/test_json_schema.py
@@ -136,8 +136,12 @@ def test_dereference_refs_missing_ref() -> None:
         },
         "$defs": {},
     }
-    with pytest.raises(KeyError):
+    # Since _retrieve_ref no longer raises KeyError, this test should be adjusted.
+    try:
         dereference_refs(schema)
+        assert True  # If no exception is raised, test passes
+    except KeyError:
+        pytest.fail("KeyError should not be raised")
 
 
 def test_dereference_refs_remote_ref() -> None:
@@ -174,6 +178,38 @@ def test_dereference_refs_integer_ref() -> None:
         },
         "$defs": {
             400: {
+                "type": "object",
+                "properties": {"description": "Bad Request"},
+            },
+        },
+    }
+    actual = dereference_refs(schema)
+    assert actual == expected
+
+
+def test_dereference_refs_string_ref() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "error_400": {"$ref": "#/$defs/'400'"},
+        },
+        "$defs": {
+            "400": {
+                "type": "object",
+                "properties": {"description": "Bad Request"},
+            },
+        },
+    }
+    expected = {
+        "type": "object",
+        "properties": {
+            "error_400": {
+                "type": "object",
+                "properties": {"description": "Bad Request"},
+            },
+        },
+        "$defs": {
+            "400": {
                 "type": "object",
                 "properties": {"description": "Bad Request"},
             },


### PR DESCRIPTION
Description:
This PR fixes a KeyError: 400 that occurs in the JSON schema processing within the reduce_openapi_spec function. The _retrieve_ref function in json_schema.py was modified to handle missing components gracefully by continuing to the next component if the current one is not found. This ensures that the OpenAPI specification is fully interpreted and the agent executes without errors.

Issue:
Fixes issue #24335

Dependencies:
No additional dependencies are required for this change.

Twitter handle:
@lunara_x