### PR TITLE
neo4j: Fix test for order-insensitive comparison and floating-point precision issues

### DIFF
--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -681,10 +681,10 @@ def test_hybrid_score_normalization() -> None:
     )
     # Remove deduplication part of the query
     rrf_query = (
-            _get_search_index_query(SearchType.HYBRID)
-            .rstrip("WITH node, max(score) AS score ORDER BY score DESC LIMIT $k")
-            .replace("UNION", "UNION ALL")
-            + "RETURN node.text AS text, score LIMIT 2"
+        _get_search_index_query(SearchType.HYBRID)
+        .rstrip("WITH node, max(score) AS score ORDER BY score DESC LIMIT $k")
+        .replace("UNION", "UNION ALL")
+        + "RETURN node.text AS text, score LIMIT 2"
     )
 
     output = docsearch.query(
@@ -707,7 +707,7 @@ def test_index_fetching() -> None:
     embeddings = FakeEmbeddings()
 
     def create_store(
-            node_label: str, index: str, text_properties: List[str]
+        node_label: str, index: str, text_properties: List[str]
     ) -> Neo4jVector:
         return Neo4jVector.from_existing_graph(
             embedding=embeddings,
@@ -793,7 +793,7 @@ def test_retrieval_dictionary() -> None:
 
     output = docsearch.similarity_search("Foo", k=1)
 
-    def parse_document(doc):
+    def parse_document(doc: Document) -> Any:
         return safe_load(doc.page_content)
 
     parsed_expected = [parse_document(doc) for doc in expected_output]
@@ -812,10 +812,10 @@ def test_metadata_filters_type1() -> None:
     )
     # We don't test type 5, because LIKE has very SQL specific examples
     for example in (
-            TYPE_1_FILTERING_TEST_CASES
-            + TYPE_2_FILTERING_TEST_CASES
-            + TYPE_3_FILTERING_TEST_CASES
-            + TYPE_4_FILTERING_TEST_CASES
+        TYPE_1_FILTERING_TEST_CASES
+        + TYPE_2_FILTERING_TEST_CASES
+        + TYPE_3_FILTERING_TEST_CASES
+        + TYPE_4_FILTERING_TEST_CASES
     ):
         filter_dict = cast(Dict[str, Any], example[0])
         output = docsearch.similarity_search("Foo", filter=filter_dict)

--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -1,7 +1,10 @@
 """Test Neo4jVector functionality."""
 
 import os
+from math import isclose
 from typing import Any, Dict, List, cast
+
+from yaml import safe_load
 
 from langchain_core.documents import Document
 
@@ -217,11 +220,20 @@ def test_neo4jvector_relevance_score() -> None:
     )
 
     output = docsearch.similarity_search_with_relevance_scores("foo", k=3)
-    assert output == [
+    expected_output = [
         (Document(page_content="foo", metadata={"page": "0"}), 1.0),
         (Document(page_content="bar", metadata={"page": "1"}), 0.9998376369476318),
         (Document(page_content="baz", metadata={"page": "2"}), 0.9993523359298706),
     ]
+
+    # Check if the length of the outputs matches
+    assert len(output) == len(expected_output)
+
+    # Check if each document and its relevance score is close to the expected value
+    for (doc, score), (expected_doc, expected_score) in zip(output, expected_output):
+        assert doc.page_content == expected_doc.page_content
+        assert doc.metadata == expected_doc.metadata
+        assert isclose(score, expected_score, rel_tol=1e-5)
 
     drop_vector_indexes(docsearch)
 
@@ -779,8 +791,16 @@ def test_retrieval_dictionary() -> None:
             )
         )
     ]
+
     output = docsearch.similarity_search("Foo", k=1)
-    assert output == expected_output
+
+    def parse_document(doc):
+        return safe_load(doc.page_content)
+
+    parsed_expected = [parse_document(doc) for doc in expected_output]
+    parsed_output = [parse_document(doc) for doc in output]
+
+    assert parsed_output == parsed_expected
     drop_vector_indexes(docsearch)
 
 

--- a/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -4,9 +4,8 @@ import os
 from math import isclose
 from typing import Any, Dict, List, cast
 
-from yaml import safe_load
-
 from langchain_core.documents import Document
+from yaml import safe_load
 
 from langchain_community.graphs import Neo4jGraph
 from langchain_community.vectorstores.neo4j_vector import (
@@ -682,10 +681,10 @@ def test_hybrid_score_normalization() -> None:
     )
     # Remove deduplication part of the query
     rrf_query = (
-        _get_search_index_query(SearchType.HYBRID)
-        .rstrip("WITH node, max(score) AS score ORDER BY score DESC LIMIT $k")
-        .replace("UNION", "UNION ALL")
-        + "RETURN node.text AS text, score LIMIT 2"
+            _get_search_index_query(SearchType.HYBRID)
+            .rstrip("WITH node, max(score) AS score ORDER BY score DESC LIMIT $k")
+            .replace("UNION", "UNION ALL")
+            + "RETURN node.text AS text, score LIMIT 2"
     )
 
     output = docsearch.query(
@@ -708,7 +707,7 @@ def test_index_fetching() -> None:
     embeddings = FakeEmbeddings()
 
     def create_store(
-        node_label: str, index: str, text_properties: List[str]
+            node_label: str, index: str, text_properties: List[str]
     ) -> Neo4jVector:
         return Neo4jVector.from_existing_graph(
             embedding=embeddings,
@@ -813,10 +812,10 @@ def test_metadata_filters_type1() -> None:
     )
     # We don't test type 5, because LIKE has very SQL specific examples
     for example in (
-        TYPE_1_FILTERING_TEST_CASES
-        + TYPE_2_FILTERING_TEST_CASES
-        + TYPE_3_FILTERING_TEST_CASES
-        + TYPE_4_FILTERING_TEST_CASES
+            TYPE_1_FILTERING_TEST_CASES
+            + TYPE_2_FILTERING_TEST_CASES
+            + TYPE_3_FILTERING_TEST_CASES
+            + TYPE_4_FILTERING_TEST_CASES
     ):
         filter_dict = cast(Dict[str, Any], example[0])
         output = docsearch.similarity_search("Foo", filter=filter_dict)


### PR DESCRIPTION
**Description:** 
This PR addresses two main issues in the `test_neo4jvector.py`:
1. **Order-insensitive Comparison:** Modified the `test_retrieval_dictionary` to ensure that it passes regardless of the order of returned values by parsing `page_content` into a structured format (dictionary) before comparison.
2. **Floating-point Precision:** Updated `test_neo4jvector_relevance_score` to handle minor floating-point precision differences by using the `isclose` function for comparing relevance scores with a relative tolerance.

Errors addressed:

- **test_neo4jvector_relevance_score:**
  ```
  AssertionError: assert [(Document(page_content='foo', metadata={'page': '0'}), 1.0000014305114746), (Document(page_content='bar', metadata={'page': '1'}), 0.9998371005058289), (Document(page_content='baz', metadata={'page': '2'}), 0.9993508458137512)] == [(Document(page_content='foo', metadata={'page': '0'}), 1.0), (Document(page_content='bar', metadata={'page': '1'}), 0.9998376369476318), (Document(page_content='baz', metadata={'page': '2'}), 0.9993523359298706)]
  At index 0 diff: (Document(page_content='foo', metadata={'page': '0'}), 1.0000014305114746) != (Document(page_content='foo', metadata={'page': '0'}), 1.0)
  Full diff:
  - [(Document(page_content='foo', metadata={'page': '0'}), 1.0),
  + [(Document(page_content='foo', metadata={'page': '0'}), 1.0000014305114746),
  ?                                                            +++++++++++++++
  - (Document(page_content='bar', metadata={'page': '1'}), 0.9998376369476318),
  ?                                                                 ^^^ ------
  + (Document(page_content='bar', metadata={'page': '1'}), 0.9998371005058289),
  ?                                                                 ^^^^^^^^^
  - (Document(page_content='baz', metadata={'page': '2'}), 0.9993523359298706),
  ?                                                                 ----------
  + (Document(page_content='baz', metadata={'page': '2'}), 0.9993508458137512),
  ?                                                                ++++++++++
  ]
  ```

- **test_retrieval_dictionary:**
  ```
  AssertionError: assert [Document(page_content='skills:\n- Python\n- Data Analysis\n- Machine Learning\nname: John\nage: 30\n')] == [Document(page_content='skills:\n- Python\n- Data Analysis\n- Machine Learning\nage: 30\nname: John\n')]
  At index 0 diff: Document(page_content='skills:\n- Python\n- Data Analysis\n- Machine Learning\nname: John\nage: 30\n') != Document(page_content='skills:\n- Python\n- Data Analysis\n- Machine Learning\nage: 30\nname: John\n')
  Full diff:
  - [Document(page_content='skills:\n- Python\n- Data Analysis\n- Machine Learning\nage: 30\nname: John\n')]
  ?                                                                                 ---------
  + [Document(page_content='skills:\n- Python\n- Data Analysis\n- Machine Learning\nage: John\nage: 30\n')]
  ?                                                                                             +++++++++
  ```