### PR TITLE
docs: fix ValidationError in FewShotChatMessagePromptTemplate examples

### DIFF
--- a/docs/docs/how_to/few_shot_examples_chat.ipynb
+++ b/docs/docs/how_to/few_shot_examples_chat.ipynb
@@ -160,6 +160,7 @@
     "    ]\n",
     ")\n",
     "few_shot_prompt = FewShotChatMessagePromptTemplate(\n",
+    "    input_variables=[],\n",
     "    example_prompt=example_prompt,\n",
     "    examples=examples,\n",
     ")\n",

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -277,6 +277,7 @@ class FewShotChatMessagePromptTemplate(
             )
 
             few_shot_prompt = FewShotChatMessagePromptTemplate(
+                input_variables=[],
                 examples=examples,
                 # This is a prompt template used to format each individual example.
                 example_prompt=example_prompt,


### PR DESCRIPTION
Encountered following error when running the FewShotChatMessagePromptTemplate example

ValidationError: 1 validation error for FewShotChatMessagePromptTemplate
input_variables
  field required (type=value_error.missing)