### PR TITLE
experimental[patch]: block a few more things from PALValidator

### DIFF
--- a/libs/experimental/langchain_experimental/pal_chain/base.py
+++ b/libs/experimental/langchain_experimental/pal_chain/base.py
@@ -20,13 +20,21 @@ from langchain_experimental.pal_chain.math_prompt import MATH_PROMPT
 from langchain_experimental.pydantic_v1 import Extra, Field, root_validator
 from langchain_experimental.utilities import PythonREPL
 
-COMMAND_EXECUTION_FUNCTIONS = ["system", "exec", "execfile", "eval", "__import__"]
+COMMAND_EXECUTION_FUNCTIONS = [
+    "system",
+    "exec",
+    "execfile",
+    "eval",
+    "__import__",
+    "compile",
+]
 COMMAND_EXECUTION_ATTRIBUTES = [
     "__import__",
     "__subclasses__",
     "__builtins__",
     "__globals__",
     "__getattribute__",
+    "__code__",
     "__bases__",
     "__mro__",
     "__base__",


### PR DESCRIPTION
* Please see security warning already in existing class.
* The approach here is fundamentally insecure as it's relying on a block
  approach rather than an approach based on only running allowed nodes.
  So users should only use this code if its running from a properly sandboxed
  environment.
