### PR TITLE
community: fix tool appending logic and update planner prompt in OpenAPI agent toolkit

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/openapi/planner.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/planner.py
@@ -292,17 +292,21 @@ def _create_api_controller_agent(
         )
     if "DELETE" in allowed_operations:
         delete_llm_chain = LLMChain(llm=llm, prompt=PARSING_DELETE_PROMPT)
-        RequestsDeleteToolWithParsing(  # type: ignore[call-arg]
-            requests_wrapper=requests_wrapper,
-            llm_chain=delete_llm_chain,
-            allow_dangerous_requests=allow_dangerous_requests,
+        tools.append(
+            RequestsDeleteToolWithParsing(  # type: ignore[call-arg]
+                requests_wrapper=requests_wrapper,
+                llm_chain=delete_llm_chain,
+                allow_dangerous_requests=allow_dangerous_requests,
+            )
         )
     if "PATCH" in allowed_operations:
         patch_llm_chain = LLMChain(llm=llm, prompt=PARSING_PATCH_PROMPT)
-        RequestsPatchToolWithParsing(  # type: ignore[call-arg]
-            requests_wrapper=requests_wrapper,
-            llm_chain=patch_llm_chain,
-            allow_dangerous_requests=allow_dangerous_requests,
+        tools.append(
+            RequestsPatchToolWithParsing(  # type: ignore[call-arg]
+                requests_wrapper=requests_wrapper,
+                llm_chain=patch_llm_chain,
+                allow_dangerous_requests=allow_dangerous_requests,
+            )
         )
     if not tools:
         raise ValueError("Tools not found")

--- a/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
@@ -118,7 +118,7 @@ Starting below, you should follow this format:
 
 User query: the query a User wants help with related to the API
 Thought: you should always think about what to do
-Action: the action to take, should be one of the tools [{tool_names}]
+Action: the action to take, 'must be' one of the tools [{tool_names}] without additional words
 Action Input: the input to the action
 Observation: the result of the action
 ... (this Thought/Action/Action Input/Observation can repeat N times)

--- a/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
@@ -118,7 +118,7 @@ Starting below, you should follow this format:
 
 User query: the query a User wants help with related to the API
 Thought: you should always think about what to do
-Action: the action to take, 'must be' one of the tools [{tool_names}] without additional words
+Action: the action to take, should be one of the tools [{tool_names}]
 Action Input: the input to the action
 Observation: the result of the action
 ... (this Thought/Action/Action Input/Observation can repeat N times)


### PR DESCRIPTION
**Description:**
- Updated the format for the 'Action' section in the planner prompt to ensure it must be one of the tools without additional words. Adjusted the phrasing from "should be" to "must be" for clarity and enforceability.
- Corrected the tool appending logic in the `_create_api_controller_agent` function to ensure that `RequestsDeleteToolWithParsing` and `RequestsPatchToolWithParsing` are properly added to the tools list for "DELETE" and "PATCH" operations.

**Issue:** #24382

**Dependencies:** None

**Twitter handle:** @lunara_x