### PR TITLE
community[minor]: [PebbloSafeLoader] Rename loader type and add SharePointLoader to supported loaders

### DIFF
--- a/libs/community/langchain_community/utilities/pebblo.py
+++ b/libs/community/langchain_community/utilities/pebblo.py
@@ -45,16 +45,17 @@ dir_loader = [
 ]
 
 in_memory = ["DataFrameLoader"]
-remote_db = [
+cloud_folder = [
     "NotionDBLoader",
     "GoogleDriveLoader",
+    "SharePointLoader",
 ]
 
 LOADER_TYPE_MAPPING = {
     "file": file_loader,
     "dir": dir_loader,
     "in-memory": in_memory,
-    "remote_db": remote_db,
+    "cloud-folder": cloud_folder,
 }
 
 SUPPORTED_LOADERS = (*file_loader, *dir_loader, *in_memory)


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: [PebbloSafeLoader] Rename loader type and add SharePointLoader to supported loaders
    - **Description:** Minor fixes in the PebbloSafeLoader:
        - Renamed the loader type from `remote_db` to `cloud_folder`.
        - Added `SharePointLoader` to the list of loaders supported by PebbloSafeLoader.
    - **Issue:** NA
    - **Dependencies:** NA
- [x] **Add tests and docs**: NA