### PR TITLE
docs: remove redundant `--quiet` option in `pip install` command

### DIFF
--- a/docs/docs/integrations/llms/huggingface_pipelines.ipynb
+++ b/docs/docs/integrations/llms/huggingface_pipelines.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  transformers --quiet"
+    "%pip install --upgrade --quiet transformers"
    ]
   },
   {


### PR DESCRIPTION
- **Description:** Removes a redundant option in a `pip install` command in the documentation.
- **Issue:** N/A
- **Dependencies:** N/A