### PR TITLE
standard-tests[patch]: Add pytest assert rewrites

### DIFF
--- a/libs/core/tests/unit_tests/stores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/stores/test_in_memory.py
@@ -1,11 +1,10 @@
 from typing import Tuple
 
 import pytest
-from langchain_standard_tests.integration_tests import (
+from langchain_standard_tests.integration_tests.base_store import (
     BaseStoreAsyncTests,
     BaseStoreSyncTests,
 )
-from langchain_standard_tests.integration_tests.base_store import V
 
 from langchain_core.stores import InMemoryStore
 
@@ -17,7 +16,7 @@ class TestSyncInMemoryStore(BaseStoreSyncTests):
         return InMemoryStore()
 
     @pytest.fixture
-    def three_values(self) -> Tuple[V, V, V]:
+    def three_values(self) -> Tuple[str, str, str]:  # type: ignore
         return "value1", "value2", "value3"
 
 
@@ -27,7 +26,7 @@ class TestAsyncInMemoryStore(BaseStoreAsyncTests):
         return InMemoryStore()
 
     @pytest.fixture
-    def three_values(self) -> Tuple[V, V, V]:
+    def three_values(self) -> Tuple[str, str, str]:  # type: ignore
         return "value1", "value2", "value3"
 
 

--- a/libs/core/tests/unit_tests/stores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/stores/test_in_memory.py
@@ -1,4 +1,34 @@
+from typing import Tuple
+
+import pytest
+from langchain_standard_tests.integration_tests import (
+    BaseStoreAsyncTests,
+    BaseStoreSyncTests,
+)
+from langchain_standard_tests.integration_tests.base_store import V
+
 from langchain_core.stores import InMemoryStore
+
+
+# Check against standard tests
+class TestSyncInMemoryStore(BaseStoreSyncTests):
+    @pytest.fixture
+    def kv_store(self) -> InMemoryStore:
+        return InMemoryStore()
+
+    @pytest.fixture
+    def three_values(self) -> Tuple[V, V, V]:
+        return "value1", "value2", "value3"
+
+
+class TestAsyncInMemoryStore(BaseStoreAsyncTests):
+    @pytest.fixture
+    async def kv_store(self) -> InMemoryStore:
+        return InMemoryStore()
+
+    @pytest.fixture
+    def three_values(self) -> Tuple[V, V, V]:
+        return "value1", "value2", "value3"
 
 
 def test_mget() -> None:

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/__init__.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/__init__.py
@@ -1,7 +1,36 @@
+import pytest
+
+# Rewrite assert statements for test suite so that implementations can
+# see the full error message from failed asserts.
+# https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html#assertion-rewriting
+modules = [
+    "base_store",
+    "cache",
+    "chat_models",
+    "vectorstores",
+]
+
+for module in modules:
+    pytest.register_assert_rewrite(
+        f"langchain_standard_tests.integration_tests.{module}"
+    )
+
+from langchain_standard_tests.integration_tests.base_store import (
+    BaseStoreAsyncTests,
+    BaseStoreSyncTests,
+)
+from langchain_standard_tests.integration_tests.cache import (
+    AsyncCacheTestSuite,
+    SyncCacheTestSuite,
+)
 from langchain_standard_tests.integration_tests.chat_models import (
     ChatModelIntegrationTests,
 )
 
 __all__ = [
+    "AsyncCacheTestSuite",
+    "BaseStoreAsyncTests",
+    "BaseStoreSyncTests",
     "ChatModelIntegrationTests",
+    "SyncCacheTestSuite",
 ]

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/__init__.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import pytest
 
 # Rewrite assert statements for test suite so that implementations can

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/__init__.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/__init__.py
@@ -15,22 +15,10 @@ for module in modules:
         f"langchain_standard_tests.integration_tests.{module}"
     )
 
-from langchain_standard_tests.integration_tests.base_store import (
-    BaseStoreAsyncTests,
-    BaseStoreSyncTests,
-)
-from langchain_standard_tests.integration_tests.cache import (
-    AsyncCacheTestSuite,
-    SyncCacheTestSuite,
-)
 from langchain_standard_tests.integration_tests.chat_models import (
     ChatModelIntegrationTests,
 )
 
 __all__ = [
-    "AsyncCacheTestSuite",
-    "BaseStoreAsyncTests",
-    "BaseStoreSyncTests",
     "ChatModelIntegrationTests",
-    "SyncCacheTestSuite",
 ]

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/vectorstores.py
@@ -1,4 +1,5 @@
 """Test suite to test vectostores."""
+
 import inspect
 from abc import ABC, abstractmethod
 

--- a/libs/standard-tests/langchain_standard_tests/unit_tests/__init__.py
+++ b/libs/standard-tests/langchain_standard_tests/unit_tests/__init__.py
@@ -1,6 +1,5 @@
+# ruff: noqa: E402
 import pytest
-
-from langchain_standard_tests.unit_tests.chat_models import ChatModelUnitTests
 
 # Rewrite assert statements for test suite so that implementations can
 # see the full error message from failed asserts.
@@ -12,5 +11,6 @@ modules = [
 for module in modules:
     pytest.register_assert_rewrite(f"langchain_standard_tests.unit_tests.{module}")
 
+from langchain_standard_tests.unit_tests.chat_models import ChatModelUnitTests
 
 __all__ = ["ChatModelUnitTests"]

--- a/libs/standard-tests/langchain_standard_tests/unit_tests/__init__.py
+++ b/libs/standard-tests/langchain_standard_tests/unit_tests/__init__.py
@@ -1,3 +1,16 @@
+import pytest
+
 from langchain_standard_tests.unit_tests.chat_models import ChatModelUnitTests
+
+# Rewrite assert statements for test suite so that implementations can
+# see the full error message from failed asserts.
+# https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html#assertion-rewriting
+modules = [
+    "chat_models",
+]
+
+for module in modules:
+    pytest.register_assert_rewrite(f"langchain_standard_tests.unit_tests.{module}")
+
 
 __all__ = ["ChatModelUnitTests"]

--- a/libs/standard-tests/tests/unit_tests/test_in_memory_base_store.py
+++ b/libs/standard-tests/tests/unit_tests/test_in_memory_base_store.py
@@ -1,4 +1,5 @@
 """Tests for the InMemoryStore class."""
+
 from typing import Tuple
 
 import pytest


### PR DESCRIPTION
This will surface nice error messages in subclasses that fail assertions.
