### PR TITLE
core[minor]: Support all versions of pydantic base model in argsschema

### DIFF
--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -360,11 +360,6 @@ def create_schema_from_function(
         A pydantic model with the same arguments as the function.
     """
     # https://docs.pydantic.dev/latest/usage/validation_decorator/
-
-    from pydantic import (
-        validate_arguments,
-    )
-
     validated = validate_arguments(func, config=_SchemaConfig)  # type: ignore
     inferred_model = validated.model  # type: ignore
     filter_args = filter_args if filter_args is not None else FILTERED_ARGS
@@ -482,7 +477,7 @@ class ChildTool(BaseTool):
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the tool."""
-        if "args_schema" in kwargs:
+        if "args_schema" in kwargs and kwargs["args_schema"] is not None:
             if not is_basemodel_subclass(kwargs["args_schema"]):
                 raise SchemaAnnotationError(
                     f"args_schema must be a subclass of pydantic BaseModel. "

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -123,6 +123,10 @@ def _create_subset_model_v1(
     fn_description: Optional[str] = None,
 ) -> Type[BaseModel]:
     """Create a pydantic model with only a subset of model's fields."""
+    if PYDANTIC_MAJOR_VERSION == 2:
+        from pydantic.v1 import create_model
+    else:
+        from pydantic import create_model
     fields = {}
 
     for field_name in field_names:
@@ -152,6 +156,7 @@ def _create_subset_model_2(
 ) -> Type[BaseModel]:
     """Create a pydantic model with a subset of the model fields."""
     from pydantic.fields import FieldInfo  # pydantic: ignore
+    from pydantic import create_model
 
     descriptions_ = descriptions or {}
     fields = {}
@@ -429,7 +434,7 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[Type[AnyBaseModel]] = None
+    args_schema: Optional[Any] = None
     """Pydantic model class to validate and parse the tool's input arguments."""
     return_direct: bool = False
     """Whether to return the tool's output directly. 

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -71,11 +71,9 @@ from langchain_core.pydantic_v1 import (
     Extra,
     Field,
     ValidationError,
+    create_model,
     root_validator,
     validate_arguments,
-)
-from langchain_core.pydantic_v1 import (
-    create_model as create_model_v1,
 )
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
@@ -384,7 +382,7 @@ class ChildTool(BaseTool):
         """Initialize the tool."""
         if "args_schema" in kwargs and kwargs["args_schema"] is not None:
             if not is_basemodel_subclass(kwargs["args_schema"]):
-                raise SchemaAnnotationError(
+                raise TypeError(
                     f"args_schema must be a subclass of pydantic BaseModel. "
                     f"Got: {kwargs['args_schema']}."
                 )
@@ -1544,7 +1542,7 @@ def _get_schema_from_runnable_and_arg_types(
                 f"arg_types into `.as_tool` to specify. {str(e)}"
             )
     fields = {key: (key_type, Field(...)) for key, key_type in arg_types.items()}
-    return create_model_v1(name, **fields)  # type: ignore
+    return create_model(name, **fields)  # type: ignore
 
 
 def convert_runnable_to_tool(

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -438,7 +438,7 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[AnyBaseModel] = None
+    args_schema: Optional[BaseModel] = None
     """Pydantic model class to validate and parse the tool's input arguments."""
     return_direct: bool = False
     """Whether to return the tool's output directly. 

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -34,16 +34,16 @@ def is_basemodel_subclass(cls: Type) -> bool:
         return False
 
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1
+        from pydantic import BaseModel as BaseModelV1Proper
 
-        if issubclass(cls, BaseModelV1):
+        if issubclass(cls, BaseModelV1Proper):
             return True
     elif PYDANTIC_MAJOR_VERSION == 2:
         from pydantic import BaseModel as BaseModelV2
+        from pydantic.v1 import BaseModel as BaseModelV1
 
         if issubclass(cls, BaseModelV2):
             return True
-        from pydantic.v1 import BaseModel as BaseModelV1
 
         if issubclass(cls, BaseModelV1):
             return True
@@ -60,9 +60,9 @@ def _get_any_base_model_type_annotation(cls: Type) -> Any:
 
         return Union[BaseModel, BaseModelV1]
     else:
-        from pydantic import BaseModel
+        from pydantic import BaseModel as BaseModelV1Proper
 
-        return BaseModel
+        return BaseModelV1Proper
 
 
 AnyBaseModel = _get_any_base_model_type_annotation(BaseModel)

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -139,12 +139,8 @@ def _create_subset_model_v1(
     fn_description: Optional[str] = None,
 ) -> Type[BaseModel]:
     """Create a pydantic model with only a subset of model's fields."""
-    if PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic.v1 import create_model  # pydantic: ignore
-    else:
-        from pydantic import (  # type: ignore[no-redef] # pydantic: ignore
-            create_model,
-        )
+    from langchain_core.pydantic_v1 import create_model
+
     fields = {}
 
     for field_name in field_names:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -51,6 +51,23 @@ def is_basemodel_subclass(cls: Type) -> bool:
         raise ValueError(f"Unsupported Pydantic version: {PYDANTIC_MAJOR_VERSION}")
     return False
 
+
+def _get_any_base_model_type_annotation() -> Any:
+    """Get the type annotation for any Pydantic BaseModel subclass."""
+    if PYDANTIC_MAJOR_VERSION == 2:
+        from pydantic import BaseModel
+        from pydantic.v1 import BaseModel as BaseModelV1
+
+        return Union[BaseModel, BaseModelV1]
+    else:
+        from pydantic import BaseModel as BaseModelV1Proper
+
+        return BaseModelV1Proper
+
+
+AnyBaseModel = _get_any_base_model_type_annotation()
+
+
 def is_basemodel_instance(obj: Any) -> bool:
     """Check if the given class is an instance of Pydantic BaseModel.
 

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -78,16 +78,16 @@ def is_basemodel_instance(obj: Any) -> bool:
     * pydantic.v1.BaseModel in Pydantic 2.x
     """
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1
+        from pydantic import BaseModel as BaseModelV1Proper
 
-        if isinstance(obj, BaseModelV1):
+        if isinstance(obj, BaseModelV1Proper):
             return True
     elif PYDANTIC_MAJOR_VERSION == 2:
         from pydantic import BaseModel as BaseModelV2
+        from pydantic.v1 import BaseModel as BaseModelV1
 
         if isinstance(obj, BaseModelV2):
             return True
-        from pydantic.v1 import BaseModel as BaseModelV1
 
         if isinstance(obj, BaseModelV1):
             return True

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -164,7 +164,7 @@ def _create_subset_model_v1(
     return rtn
 
 
-def _create_subset_model_2(
+def _create_subset_model_v2(
     name: str,
     model: Type[BaseModel],
     field_names: List[str],
@@ -224,7 +224,7 @@ def _create_subset_model(
                 fn_description=fn_description,
             )
         else:
-            return _create_subset_model_2(
+            return _create_subset_model_v2(
                 name,
                 model,
                 field_names,

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -51,23 +51,6 @@ def is_basemodel_subclass(cls: Type) -> bool:
         raise ValueError(f"Unsupported Pydantic version: {PYDANTIC_MAJOR_VERSION}")
     return False
 
-
-def _get_any_base_model_type_annotation(cls: Type) -> Any:
-    """Get the type annotation for any Pydantic BaseModel subclass."""
-    if PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel
-        from pydantic.v1 import BaseModel as BaseModelV1
-
-        return Union[BaseModel, BaseModelV1]
-    else:
-        from pydantic import BaseModel as BaseModelV1Proper
-
-        return BaseModelV1Proper
-
-
-AnyBaseModel = _get_any_base_model_type_annotation(BaseModel)
-
-
 def is_basemodel_instance(obj: Any) -> bool:
     """Check if the given class is an instance of Pydantic BaseModel.
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1451,6 +1451,8 @@ TEST_MODELS = generate_models() + generate_backwards_compatible_v1()
 @pytest.mark.parametrize("pydantic_model", TEST_MODELS)
 def test_args_schema_as_pydantic(pydantic_model: Any) -> None:
     class SomeTool(BaseTool):
+        args_schema: Type[pydantic_model] = pydantic_model
+
         def _run(self, *args: Any, **kwargs: Any) -> str:
             return "foo"
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2,6 +2,7 @@
 
 import inspect
 import json
+import sys
 import textwrap
 from datetime import datetime
 from enum import Enum
@@ -9,7 +10,6 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import pytest
-import sys
 from typing_extensions import Annotated, TypedDict
 
 from langchain_core.callbacks import (

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -31,10 +31,10 @@ from langchain_core.tools import (
     StructuredTool,
     Tool,
     ToolException,
-    _create_subset_model,
     tool,
 )
 from langchain_core.utils.function_calling import convert_to_openai_function
+from langchain_core.utils.pydantic import _create_subset_model
 from tests.unit_tests.fake.callbacks import FakeCallbackHandler
 
 
@@ -1496,7 +1496,10 @@ def test_args_schema_explicitly_typed() -> None:
         b: str
 
     class SomeTool(BaseTool):
-        args_schema: Type[BaseModel] = Foo
+        # type ignoring here since we're allowing overriding a type
+        # signature of pydantic.v1.BaseModel with pydantic.BaseModel
+        # for pydantic 2!
+        args_schema: Type[BaseModel] = Foo  # type: ignore[assignment]
 
         def _run(self, *args: Any, **kwargs: Any) -> str:
             return "foo"

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -3,7 +3,12 @@
 from typing import Any, Dict, Optional
 
 from langchain_core.pydantic_v1 import BaseModel, Field
-from langchain_core.utils.pydantic import pre_init
+from langchain_core.utils.pydantic import (
+    PYDANTIC_MAJOR_VERSION,
+    is_basemodel_instance,
+    is_basemodel_subclass,
+    pre_init,
+)
 
 
 def test_pre_init_decorator() -> None:
@@ -73,3 +78,46 @@ def test_with_aliases() -> None:
     foo = Foo(y=2)  # type: ignore
     assert foo.x == 2
     assert foo.z == 2
+
+
+def test_is_basemodel_subclass() -> None:
+    """Test pydantic."""
+    if PYDANTIC_MAJOR_VERSION == 1:
+        from pydantic import BaseModel as BaseModelV1  # pydantic: ignore
+
+        assert is_basemodel_subclass(BaseModelV1)
+    elif PYDANTIC_MAJOR_VERSION == 2:
+        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
+        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+
+        assert is_basemodel_subclass(BaseModelV2)
+
+        assert is_basemodel_subclass(BaseModelV1)
+    else:
+        raise ValueError(f"Unsupported Pydantic version: {PYDANTIC_MAJOR_VERSION}")
+
+
+def test_is_basemodel_instance() -> None:
+    """Test pydantic."""
+    if PYDANTIC_MAJOR_VERSION == 1:
+        from pydantic import BaseModel as BaseModelV1  # pydantic: ignore
+
+        class Foo(BaseModelV1):
+            x: int
+
+        assert is_basemodel_instance(Foo(x=5))
+    elif PYDANTIC_MAJOR_VERSION == 2:
+        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
+        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+
+        class Foo(BaseModelV2):
+            x: int
+
+        assert is_basemodel_instance(Foo(x=5))
+
+        class Bar(BaseModelV1):
+            x: int
+
+        assert is_basemodel_instance(Bar(x=5))
+    else:
+        raise ValueError(f"Unsupported Pydantic version: {PYDANTIC_MAJOR_VERSION}")

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -83,9 +83,9 @@ def test_with_aliases() -> None:
 def test_is_basemodel_subclass() -> None:
     """Test pydantic."""
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
 
-        assert is_basemodel_subclass(BaseModelV1)
+        assert is_basemodel_subclass(BaseModelV1Proper)
     elif PYDANTIC_MAJOR_VERSION == 2:
         from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
         from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
@@ -100,12 +100,12 @@ def test_is_basemodel_subclass() -> None:
 def test_is_basemodel_instance() -> None:
     """Test pydantic."""
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
 
-        class Foo(BaseModelV1):
+        class FooV1(BaseModelV1Proper):
             x: int
 
-        assert is_basemodel_instance(Foo(x=5))
+        assert is_basemodel_instance(FooV1(x=5))
     elif PYDANTIC_MAJOR_VERSION == 2:
         from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
         from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore


### PR DESCRIPTION
This adds support to any pydantic base model for tools.

The only potential issue is that `get_input_schema()` will not always return a v1 base model.
