### PR TITLE
[Vector Store] Fix `_euclidean_relevance_score_fn` in base vectorstore

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -635,7 +635,7 @@ class VectorStore(ABC):
         # This function converts the Euclidean norm of normalized embeddings
         # (0 is most similar, sqrt(2) most dissimilar)
         # to a similarity function (0 to 1)
-        return 1.0 - distance / math.sqrt(2)
+        return 1.0 / (1.0 + distance)
 
     @staticmethod
     def _cosine_relevance_score_fn(distance: float) -> float:

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -22,7 +22,6 @@ and retrieve the data that are 'most similar' to the embedded query.
 from __future__ import annotations
 
 import logging
-import math
 import warnings
 from abc import ABC, abstractmethod
 from itertools import cycle


### PR DESCRIPTION
According to the function `_euclidean_relevance_score_fn` in base vectorstore, the euclidean_relevance_score may be negative if the dimension of vector is more than 2. I encountered this warning when using Faiss. Would it be better to change the calculation method of relevant_score?