### PR TITLE
docs: Update langchain-openai package version in chat_token_usage_tracking

### DIFF
--- a/docs/docs/how_to/chat_token_usage_tracking.ipynb
+++ b/docs/docs/how_to/chat_token_usage_tracking.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "Tracking token usage to calculate cost is an important part of putting your app in production. This guide goes over how to obtain this information from your LangChain model calls.\n",
     "\n",
-    "This guide requires `langchain-openai >= 0.1.8`."
+    "This guide requires `langchain-openai >= 0.1.9`."
    ]
   },
   {

--- a/docs/docs/how_to/chat_token_usage_tracking.ipynb
+++ b/docs/docs/how_to/chat_token_usage_tracking.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "#### OpenAI\n",
     "\n",
-    "For example, OpenAI will return a message [chunk](https://api.python.langchain.com/en/latest/messages/langchain_core.messages.ai.AIMessageChunk.html) at the end of a stream with token usage information. This behavior is supported by `langchain-openai >= 0.1.8` and can be enabled by setting `stream_usage=True`. This attribute can also be set when `ChatOpenAI` is instantiated.\n",
+    "For example, OpenAI will return a message [chunk](https://api.python.langchain.com/en/latest/messages/langchain_core.messages.ai.AIMessageChunk.html) at the end of a stream with token usage information. This behavior is supported by `langchain-openai >= 0.1.9` and can be enabled by setting `stream_usage=True`. This attribute can also be set when `ChatOpenAI` is instantiated.\n",
     "\n",
     "```{=mdx}\n",
     ":::note\n",


### PR DESCRIPTION
This PR updates docs to mention correct version of the `langchain-openai` package required to use the `stream_usage` parameter.

As it can be noticed in the details of this [merge commit](https://github.com/langchain-ai/langchain/commit/722c8f50ea0a6ff2e1a35b2380408eca02dbe06a), that functionality is available only in `langchain-openai >= 0.1.9` while docs state it's available in `langchain-openai >= 0.1.8`.