### PR TITLE
core[minor]: Relax constraints on type checking for tools and parsers

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -15,6 +15,7 @@ from langchain_core.output_parsers.transform import BaseCumulativeTransformOutpu
 from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.pydantic_v1 import BaseModel, ValidationError
 from langchain_core.utils.json import parse_partial_json
+from langchain_core.utils.pydantic import PydanticBaseModel
 
 
 def parse_tool_call(
@@ -255,7 +256,7 @@ class JsonOutputKeyToolsParser(JsonOutputToolsParser):
 class PydanticToolsParser(JsonOutputToolsParser):
     """Parse tools from OpenAI response."""
 
-    tools: List[Type[BaseModel]]
+    tools: List[Type[PydanticBaseModel]]
     """The tools to parse."""
 
     # TODO: Support more granular streaming of objects. Currently only streams once all

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -1,7 +1,7 @@
 import copy
 import json
 from json import JSONDecodeError
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, InvalidToolCall
@@ -15,7 +15,7 @@ from langchain_core.output_parsers.transform import BaseCumulativeTransformOutpu
 from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.pydantic_v1 import ValidationError
 from langchain_core.utils.json import parse_partial_json
-from langchain_core.utils.pydantic import PydanticBaseModel
+from langchain_core.utils.pydantic import TypeBaseModel
 
 
 def parse_tool_call(
@@ -256,7 +256,7 @@ class JsonOutputKeyToolsParser(JsonOutputToolsParser):
 class PydanticToolsParser(JsonOutputToolsParser):
     """Parse tools from OpenAI response."""
 
-    tools: List[Type[PydanticBaseModel]]
+    tools: List[TypeBaseModel]
     """The tools to parse."""
 
     # TODO: Support more granular streaming of objects. Currently only streams once all

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -13,7 +13,7 @@ from langchain_core.messages.tool import (
 )
 from langchain_core.output_parsers.transform import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import BaseModel, ValidationError
+from langchain_core.pydantic_v1 import ValidationError
 from langchain_core.utils.json import parse_partial_json
 from langchain_core.utils.pydantic import PydanticBaseModel
 

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,21 +1,12 @@
 import json
-from typing import Generic, List, Type, TypeVar, Union
+from typing import Generic, List, Type, TypeVar
 
-import pydantic  # pydantic: ignore
+import pydantic
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.outputs import Generation
-from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
-
-if PYDANTIC_MAJOR_VERSION < 2:
-    PydanticBaseModel = pydantic.BaseModel
-
-else:
-    from pydantic.v1 import BaseModel  # pydantic: ignore
-
-    # Union type needs to be last assignment to PydanticBaseModel to make mypy happy.
-    PydanticBaseModel = Union[BaseModel, pydantic.BaseModel]  # type: ignore
+from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION, PydanticBaseModel
 
 TBaseModel = TypeVar("TBaseModel", bound=PydanticBaseModel)
 

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,14 +1,12 @@
 import json
-from typing import Generic, List, Type, TypeVar
+from typing import Generic, List, Type
 
 import pydantic  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.outputs import Generation
-from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION, PydanticBaseModel
-
-TBaseModel = TypeVar("TBaseModel", bound=PydanticBaseModel)
+from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION, TBaseModel
 
 
 class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -6,7 +6,11 @@ import pydantic  # pydantic: ignore
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.outputs import Generation
-from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION, TBaseModel
+from langchain_core.utils.pydantic import (
+    PYDANTIC_MAJOR_VERSION,
+    TBaseModel,
+    PydanticBaseModel,
+)
 
 
 class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
@@ -111,3 +115,10 @@ Here is the output schema:
 ```
 {schema}
 ```"""  # noqa: E501
+
+# Re-exporting types for backwards compatibility
+__all__ = [
+    "PydanticBaseModel",
+    "PydanticOutputParser",
+    "TBaseModel",
+]

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -8,8 +8,8 @@ from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.outputs import Generation
 from langchain_core.utils.pydantic import (
     PYDANTIC_MAJOR_VERSION,
-    TBaseModel,
     PydanticBaseModel,
+    TBaseModel,
 )
 
 

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,7 +1,7 @@
 import json
 from typing import Generic, List, Type, TypeVar
 
-import pydantic
+import pydantic  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -89,6 +89,7 @@ from langchain_core.runnables.config import (
 )
 from langchain_core.runnables.utils import accepts_context
 from langchain_core.utils.pydantic import (
+    PydanticBaseModel,
     _create_subset_model,
     is_basemodel_subclass,
 )
@@ -332,7 +333,7 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[Union[Any, BaseModel]] = None
+    args_schema: Optional[PydanticBaseModel] = None
     """Pydantic model class to validate and parse the tool's input arguments.
     
     Args schema should be either: 
@@ -340,9 +341,6 @@ class ChildTool(BaseTool):
     - A subclass of pydantic.BaseModel.
     or 
     - A subclass of pydantic.v1.BaseModel if accessing v1 namespace in pydantic 2
-    
-    This is typed as Any to prevent validation using pydantic v1 which will not
-    be able to validate pydantic v2 models.
     """
     return_direct: bool = False
     """Whether to return the tool's output directly. 
@@ -901,7 +899,7 @@ class StructuredTool(BaseTool):
     """Tool that can operate on any number of inputs."""
 
     description: str = ""
-    args_schema: Type[BaseModel] = Field(..., description="The tool schema.")
+    args_schema: Type[PydanticBaseModel] = Field(..., description="The tool schema.")
     """The input arguments' schema."""
     func: Optional[Callable[..., Any]]
     """The function to run when the tool is called."""

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -436,8 +436,7 @@ class ChildTool(BaseTool):
             The input schema for the tool.
         """
         if self.args_schema is not None:
-            # We need to fix the typing to account for the floating BaseModel
-            return self.args_schema  # type: ignore
+            return self.args_schema
         else:
             return create_schema_from_function(self.name, self._run)
 

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -332,8 +332,18 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[Type[BaseModel]] = None
-    """Pydantic model class to validate and parse the tool's input arguments."""
+    args_schema: Optional[Union[Any, BaseModel]] = None
+    """Pydantic model class to validate and parse the tool's input arguments.
+    
+    Args schema should be either: 
+    
+    - A subclass of pydantic.BaseModel.
+    or 
+    - A subclass of pydantic.v1.BaseModel if accessing v1 namespace in pydantic 2
+    
+    This is typed as Any to prevent validation using pydantic v1 which will not
+    be able to validate pydantic v2 models.
+    """
     return_direct: bool = False
     """Whether to return the tool's output directly. 
     

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -89,7 +89,7 @@ from langchain_core.runnables.config import (
 )
 from langchain_core.runnables.utils import accepts_context
 from langchain_core.utils.pydantic import (
-    PydanticBaseModel,
+    TypeBaseModel,
     _create_subset_model,
     is_basemodel_subclass,
 )
@@ -333,7 +333,7 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[PydanticBaseModel] = None
+    args_schema: Optional[TypeBaseModel] = None
     """Pydantic model class to validate and parse the tool's input arguments.
     
     Args schema should be either: 
@@ -436,7 +436,8 @@ class ChildTool(BaseTool):
             The input schema for the tool.
         """
         if self.args_schema is not None:
-            return self.args_schema
+            # We need to fix the typing to account for the floating BaseModel
+            return self.args_schema  # type: ignore
         else:
             return create_schema_from_function(self.name, self._run)
 
@@ -899,7 +900,7 @@ class StructuredTool(BaseTool):
     """Tool that can operate on any number of inputs."""
 
     description: str = ""
-    args_schema: Type[PydanticBaseModel] = Field(..., description="The tool schema.")
+    args_schema: TypeBaseModel = Field(..., description="The tool schema.")
     """The input arguments' schema."""
     func: Optional[Callable[..., Any]]
     """The function to run when the tool is called."""

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -7,23 +7,15 @@ import textwrap
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
-import pydantic
+import pydantic  # pydantic: ignore
 
-from langchain_core.pydantic_v1 import BaseModel, root_validator
-
-
-def get_pydantic_major_version() -> int:
-    """Get the major version of Pydantic."""
-    try:
-        import pydantic
-
-        return int(pydantic.__version__.split(".")[0])
-    except ImportError:
-        return 0
-
-
-PYDANTIC_MAJOR_VERSION = get_pydantic_major_version()
-
+from langchain_core.pydantic_v1 import (
+    _PYDANTIC_MAJOR_VERSION as PYDANTIC_MAJOR_VERSION,
+)
+from langchain_core.pydantic_v1 import (
+    BaseModel,
+    root_validator,
+)
 
 if PYDANTIC_MAJOR_VERSION < 2:
     PydanticBaseModel = pydantic.BaseModel
@@ -49,13 +41,13 @@ def is_basemodel_subclass(cls: Type) -> bool:
         return False
 
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1Proper
+        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
 
         if issubclass(cls, BaseModelV1Proper):
             return True
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel as BaseModelV2
-        from pydantic.v1 import BaseModel as BaseModelV1
+        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
+        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
 
         if issubclass(cls, BaseModelV2):
             return True
@@ -77,13 +69,13 @@ def is_basemodel_instance(obj: Any) -> bool:
     * pydantic.v1.BaseModel in Pydantic 2.x
     """
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1Proper
+        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
 
         if isinstance(obj, BaseModelV1Proper):
             return True
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel as BaseModelV2
-        from pydantic.v1 import BaseModel as BaseModelV1
+        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
+        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
 
         if isinstance(obj, BaseModelV2):
             return True

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 import textwrap
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import pydantic  # pydantic: ignore
 
@@ -17,14 +17,20 @@ from langchain_core.pydantic_v1 import (
     root_validator,
 )
 
-if PYDANTIC_MAJOR_VERSION < 2:
+if PYDANTIC_MAJOR_VERSION == 1:
     PydanticBaseModel = pydantic.BaseModel
-
-else:
+    TypeBaseModel = Type[BaseModel]
+elif PYDANTIC_MAJOR_VERSION == 2:
     from pydantic.v1 import BaseModel  # pydantic: ignore
 
     # Union type needs to be last assignment to PydanticBaseModel to make mypy happy.
     PydanticBaseModel = Union[BaseModel, pydantic.BaseModel]  # type: ignore
+    TypeBaseModel = Union[Type[BaseModel], Type[pydantic.BaseModel]]  # type: ignore
+else:
+    raise ValueError(f"Unsupported Pydantic version: {PYDANTIC_MAJOR_VERSION}")
+
+
+TBaseModel = TypeVar("TBaseModel", bound=PydanticBaseModel)
 
 
 def is_basemodel_subclass(cls: Type) -> bool:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import inspect
 import textwrap
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+import pydantic
 
 from langchain_core.pydantic_v1 import BaseModel, root_validator
 
@@ -21,6 +23,16 @@ def get_pydantic_major_version() -> int:
 
 
 PYDANTIC_MAJOR_VERSION = get_pydantic_major_version()
+
+
+if PYDANTIC_MAJOR_VERSION < 2:
+    PydanticBaseModel = pydantic.BaseModel
+
+else:
+    from pydantic.v1 import BaseModel  # pydantic: ignore
+
+    # Union type needs to be last assignment to PydanticBaseModel to make mypy happy.
+    PydanticBaseModel = Union[BaseModel, pydantic.BaseModel]  # type: ignore
 
 
 def is_basemodel_subclass(cls: Type) -> bool:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -10,12 +10,23 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 import pydantic  # pydantic: ignore
 
 from langchain_core.pydantic_v1 import (
-    _PYDANTIC_MAJOR_VERSION as PYDANTIC_MAJOR_VERSION,
-)
-from langchain_core.pydantic_v1 import (
     BaseModel,
     root_validator,
 )
+
+
+def get_pydantic_major_version() -> int:
+    """Get the major version of Pydantic."""
+    try:
+        import pydantic
+
+        return int(pydantic.__version__.split(".")[0])
+    except ImportError:
+        return 0
+
+
+PYDANTIC_MAJOR_VERSION = get_pydantic_major_version()
+
 
 if PYDANTIC_MAJOR_VERSION == 1:
     PydanticBaseModel = pydantic.BaseModel

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -531,8 +531,8 @@ async def test_partial_pydantic_output_parser_async() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="This test is for pydantic 2")
 def test_parse_with_different_pydantic_2_v1() -> None:
-    """Test with different pydantic models."""
-    import pydantic
+    """Test with pydantic.v1.BaseModel from pydantic 2."""
+    import pydantic  # pydantic: ignore
 
     class Forecast(pydantic.v1.BaseModel):
         temperature: int
@@ -564,8 +564,8 @@ def test_parse_with_different_pydantic_2_v1() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="This test is for pydantic 2")
 def test_parse_with_different_pydantic_2_proper() -> None:
-    """Test with different pydantic models."""
-    import pydantic
+    """Test with pydantic.BaseModel from pydantic 2."""
+    import pydantic  # pydantic: ignore
 
     class Forecast(pydantic.BaseModel):
         temperature: int
@@ -597,8 +597,8 @@ def test_parse_with_different_pydantic_2_proper() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 1, reason="This test is for pydantic 1")
 def test_parse_with_different_pydantic_1_proper() -> None:
-    """Test with different pydantic models."""
-    import pydantic
+    """Test with pydantic.BaseModel from pydantic 1."""
+    import pydantic  # pydantic: ignore
 
     class Forecast(pydantic.BaseModel):
         temperature: int

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -538,7 +538,9 @@ def test_parse_with_different_pydantic_2_v1() -> None:
         temperature: int
         forecast: str
 
-    parser = PydanticToolsParser(tools=[Forecast])
+    # Can't get pydantic to work here due to the odd typing of tryig to support
+    # both v1 and v2 in the same codebase.
+    parser = PydanticToolsParser(tools=[Forecast])  # type: ignore[list-item]
     message = AIMessage(
         content="",
         tool_calls=[
@@ -571,7 +573,9 @@ def test_parse_with_different_pydantic_2_proper() -> None:
         temperature: int
         forecast: str
 
-    parser = PydanticToolsParser(tools=[Forecast])
+    # Can't get pydantic to work here due to the odd typing of tryig to support
+    # both v1 and v2 in the same codebase.
+    parser = PydanticToolsParser(tools=[Forecast])  # type: ignore[list-item]
     message = AIMessage(
         content="",
         tool_calls=[
@@ -604,7 +608,9 @@ def test_parse_with_different_pydantic_1_proper() -> None:
         temperature: int
         forecast: str
 
-    parser = PydanticToolsParser(tools=[Forecast])
+    # Can't get pydantic to work here due to the odd typing of tryig to support
+    # both v1 and v2 in the same codebase.
+    parser = PydanticToolsParser(tools=[Forecast])  # type: ignore[list-item]
     message = AIMessage(
         content="",
         tool_calls=[

--- a/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -6,9 +6,9 @@ import pytest
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import ParrotFakeChatModel
 from langchain_core.output_parsers.json import JsonOutputParser
-from langchain_core.output_parsers.pydantic import PydanticOutputParser, TBaseModel
+from langchain_core.output_parsers.pydantic import PydanticOutputParser
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
+from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION, TBaseModel
 
 V1BaseModel = pydantic.BaseModel
 if PYDANTIC_MAJOR_VERSION == 2:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1526,3 +1526,40 @@ def test_args_schema_explicitly_typed() -> None:
         "title": "some_tool",
         "type": "object",
     }
+
+
+@pytest.mark.parametrize("pydantic_model", TEST_MODELS)
+def test_structured_tool_with_different_pydantic_versions(pydantic_model: Any) -> None:
+    """This should test that one can type the args schema as a pydantic model."""
+    from langchain_core.tools import StructuredTool
+
+    def foo(a: int, b: str) -> str:
+        """Hahaha"""
+        return "foo"
+
+    foo_tool = StructuredTool.from_function(
+        func=foo,
+        args_schema=pydantic_model,
+    )
+
+    assert foo_tool.invoke({"a": 5, "b": "hello"}) == "foo"
+
+    assert foo_tool.args_schema.schema() == {
+        "properties": {
+            "a": {"title": "A", "type": "integer"},
+            "b": {"title": "B", "type": "string"},
+        },
+        "required": ["a", "b"],
+        "title": pydantic_model.__name__,
+        "type": "object",
+    }
+
+    assert foo_tool.get_input_schema().schema() == {
+        "properties": {
+            "a": {"title": "A", "type": "integer"},
+            "b": {"title": "B", "type": "string"},
+        },
+        "required": ["a", "b"],
+        "title": pydantic_model.__name__,
+        "type": "object",
+    }


### PR DESCRIPTION
This will allow tools and parsers to accept pydantic models from any of the
following namespaces:

* pydantic.BaseModel with pydantic 1
* pydantic.BaseModel with pydantic 2
* pydantic.v1.BaseModel with pydantic 2
