### PR TITLE
Rename ‘embedding’ to ‘embeddings’ and use np.max for better performance for maximal_marginal_relevance in qdrant client package

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/_utils.py
+++ b/libs/partners/qdrant/langchain_qdrant/_utils.py
@@ -27,7 +27,7 @@ def maximal_marginal_relevance(
         for i, query_score in enumerate(similarity_to_query):
             if i in idxs:
                 continue
-            redundant_score = max(similarity_to_selected[i])
+            redundant_score = np.max(similarity_to_selected[i])
             equation_score = (
                 lambda_mult * query_score - (1 - lambda_mult) * redundant_score
             )


### PR DESCRIPTION
- **Naming Consistency**: I found that the README example uses 'embeddings', but the code uses 'embedding'. I believe 'embeddings' makes more sense for consistency.
- **Performance Improvement**: I replaced `np.max` with `max` for better performance in maximal_marginal_relevance.