### PR TITLE
[Vector Store] Fix function `add_texts` in `TencentVectorDB`

### DIFF
--- a/libs/community/langchain_community/vectorstores/tencentvectordb.py
+++ b/libs/community/langchain_community/vectorstores/tencentvectordb.py
@@ -375,8 +375,7 @@ class TencentVectorDB(VectorStore):
                 }
                 if embeddings:
                     doc_attrs["vector"] = embeddings[id]
-                else:
-                    doc_attrs["text"] = texts[id]
+                doc_attrs["text"] = texts[id]
                 doc_attrs.update(metadata)
                 doc = self.document.Document(**doc_attrs)
                 docs.append(doc)

--- a/libs/community/tests/integration_tests/vectorstores/test_tencentvectordb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_tencentvectordb.py
@@ -85,3 +85,27 @@ def test_tencent_vector_db_no_drop() -> None:
     time.sleep(3)
     output = docsearch.similarity_search("foo", k=10)
     assert len(output) == 6
+
+
+def test_tencent_vector_db_add_texts_and_search_with_score() -> None:
+    """Test add texts to a new-created db and search with score."""
+    texts = ["foo", "bar", "baz"]
+    metadatas = [{"page": i} for i in range(len(texts))]
+    conn_params = ConnectionParams(
+        url="http://10.0.X.X",
+        key="eC4bLRy2va******************************",
+        username="root",
+        timeout=20,
+    )
+    docsearch = TencentVectorDB(
+        embedding=FakeEmbeddings(),
+        connection_params=conn_params,
+    )
+    docsearch.add_texts(texts, metadatas)
+    output = docsearch.similarity_search_with_score("foo", k=3)
+    docs = [o[0] for o in output]
+    assert docs == [
+        Document(page_content="foo", metadata={"page": 0}),
+        Document(page_content="bar", metadata={"page": 1}),
+        Document(page_content="baz", metadata={"page": 2}),
+    ]


### PR DESCRIPTION
Regardless of whether `embedding_func` is set or not, the 'text' attribute of document should be assigned, otherwise the `page_content` in the document of the final search result will be lost