### PR TITLE
langchain: Copy libs/standard-tests folder when building devcontainer

### DIFF
--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -56,5 +56,8 @@ COPY libs/text-splitters/ ../text-splitters/
 # Copy the partners library for installation
 COPY libs/partners ../partners/
 
+# Copy the partners library for installation
+COPY libs/standard-tests ../standard-tests/
+
 # Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)
 RUN poetry install --no-interaction --no-ansi --with dev,test,docs

--- a/libs/langchain/dev.Dockerfile
+++ b/libs/langchain/dev.Dockerfile
@@ -56,7 +56,7 @@ COPY libs/text-splitters/ ../text-splitters/
 # Copy the partners library for installation
 COPY libs/partners ../partners/
 
-# Copy the partners library for installation
+# Copy the standard-tests library for installation
 COPY libs/standard-tests ../standard-tests/
 
 # Install the Poetry dependencies (this layer will be cached as long as the dependencies don't change)


### PR DESCRIPTION
### Description

* Fix `libs/langchain/dev.Dockerfile` file. copy the `libs/standard-tests` folder when building the devcontainer.
* `poetry install --no-interaction --no-ansi --with dev,test,docs` command requires this folder, but it was not copied.

### Reference

#### Error message when building the devcontainer from the master branch

```
...

[2024-07-20T14:27:34.779Z] ------
 > [langchain langchain-dev-dependencies 7/7] RUN poetry install --no-interaction --no-ansi --with dev,test,docs:
0.409 
0.409 Directory ../standard-tests does not exist
------

...
```

#### After the fix

Build success at vscode:

<img width="866" alt="image" src="https://github.com/user-attachments/assets/10db1b50-6fcf-4dfe-83e1-d93c96aa2317">

