### PR TITLE
community: Replace `filters` argument to `filter` in DatabricksVectorSearch

### DIFF
--- a/libs/community/langchain_community/vectorstores/databricks_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/databricks_vector_search.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Tuple, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+)
 
 import numpy as np
 from langchain_core.documents import Document
@@ -193,7 +203,7 @@ class DatabricksVectorSearch(VectorStore):
         cls: Type[VST],
         texts: List[str],
         embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[List[Dict]] = None,
         **kwargs: Any,
     ) -> VST:
         raise NotImplementedError(
@@ -204,7 +214,7 @@ class DatabricksVectorSearch(VectorStore):
     def add_texts(
         self,
         texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
+        metadatas: Optional[List[Dict]] = None,
         ids: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> List[str]:
@@ -280,7 +290,7 @@ class DatabricksVectorSearch(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filters: Optional[Any] = None,
+        filter: Optional[Dict[str, Any]] = None,
         *,
         query_type: Optional[str] = None,
         **kwargs: Any,
@@ -290,14 +300,18 @@ class DatabricksVectorSearch(VectorStore):
         Args:
             query: Text to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-            filters: Filters to apply to the query. Defaults to None.
+            filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
 
         Returns:
             List of Documents most similar to the embedding.
         """
         docs_with_score = self.similarity_search_with_score(
-            query=query, k=k, filters=filters, query_type=query_type, **kwargs
+            query=query,
+            k=k,
+            filter=filter,
+            query_type=query_type,
+            **kwargs,
         )
         return [doc for doc, _ in docs_with_score]
 
@@ -305,7 +319,7 @@ class DatabricksVectorSearch(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filters: Optional[Any] = None,
+        filter: Optional[Dict[str, Any]] = None,
         *,
         query_type: Optional[str] = None,
         **kwargs: Any,
@@ -315,7 +329,7 @@ class DatabricksVectorSearch(VectorStore):
         Args:
             query: Text to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-            filters: Filters to apply to the query. Defaults to None.
+            filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
 
         Returns:
@@ -328,12 +342,11 @@ class DatabricksVectorSearch(VectorStore):
             assert self.embeddings is not None, "embedding model is required."
             query_text = None
             query_vector = self.embeddings.embed_query(query)
-
         search_resp = self.index.similarity_search(
             columns=self.columns,
             query_text=query_text,
             query_vector=query_vector,
-            filters=filters,
+            filters=filter or self._alias_filters(kwargs),
             num_results=k,
             query_type=query_type,
         )
@@ -357,7 +370,7 @@ class DatabricksVectorSearch(VectorStore):
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
-        filters: Optional[Any] = None,
+        filter: Optional[Dict[str, Any]] = None,
         *,
         query_type: Optional[str] = None,
         **kwargs: Any,
@@ -375,7 +388,7 @@ class DatabricksVectorSearch(VectorStore):
                         of diversity among the results with 0 corresponding
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
-            filters: Filters to apply to the query. Defaults to None.
+            filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
         Returns:
             List of Documents selected by maximal marginal relevance.
@@ -394,7 +407,7 @@ class DatabricksVectorSearch(VectorStore):
             k,
             fetch_k,
             lambda_mult=lambda_mult,
-            filters=filters,
+            filter=filter or self._alias_filters(kwargs),
             query_type=query_type,
         )
         return docs
@@ -405,7 +418,7 @@ class DatabricksVectorSearch(VectorStore):
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
-        filters: Optional[Any] = None,
+        filter: Optional[Any] = None,
         *,
         query_type: Optional[str] = None,
         **kwargs: Any,
@@ -423,7 +436,7 @@ class DatabricksVectorSearch(VectorStore):
                         of diversity among the results with 0 corresponding
                         to maximum diversity and 1 to minimum diversity.
                         Defaults to 0.5.
-            filters: Filters to apply to the query. Defaults to None.
+            filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
         Returns:
             List of Documents selected by maximal marginal relevance.
@@ -435,12 +448,11 @@ class DatabricksVectorSearch(VectorStore):
                 "`max_marginal_relevance_search` is not supported for index with "
                 "Databricks-managed embeddings."
             )
-
         search_resp = self.index.similarity_search(
             columns=list(set(self.columns + [embedding_column])),
             query_text=None,
             query_vector=embedding,
-            filters=filters,
+            filters=filter or self._alias_filters(kwargs),
             num_results=fetch_k,
             query_type=query_type,
         )
@@ -471,7 +483,7 @@ class DatabricksVectorSearch(VectorStore):
         self,
         embedding: List[float],
         k: int = 4,
-        filters: Optional[Any] = None,
+        filter: Optional[Any] = None,
         *,
         query_type: Optional[str] = None,
         **kwargs: Any,
@@ -481,14 +493,18 @@ class DatabricksVectorSearch(VectorStore):
         Args:
             embedding: Embedding to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-            filters: Filters to apply to the query. Defaults to None.
+            filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
 
         Returns:
             List of Documents most similar to the embedding.
         """
         docs_with_score = self.similarity_search_by_vector_with_score(
-            embedding=embedding, k=k, filters=filters, query_type=query_type, **kwargs
+            embedding=embedding,
+            k=k,
+            filter=filter,
+            query_type=query_type,
+            **kwargs,
         )
         return [doc for doc, _ in docs_with_score]
 
@@ -496,7 +512,7 @@ class DatabricksVectorSearch(VectorStore):
         self,
         embedding: List[float],
         k: int = 4,
-        filters: Optional[Any] = None,
+        filter: Optional[Any] = None,
         *,
         query_type: Optional[str] = None,
         **kwargs: Any,
@@ -506,7 +522,7 @@ class DatabricksVectorSearch(VectorStore):
         Args:
             embedding: Embedding to look up documents similar to.
             k: Number of Documents to return. Defaults to 4.
-            filters: Filters to apply to the query. Defaults to None.
+            filter: Filters to apply to the query. Defaults to None.
             query_type: The type of this query. Supported values are "ANN" and "HYBRID".
 
         Returns:
@@ -520,14 +536,27 @@ class DatabricksVectorSearch(VectorStore):
         search_resp = self.index.similarity_search(
             columns=self.columns,
             query_vector=embedding,
-            filters=filters,
+            filters=filter or self._alias_filters(kwargs),
             num_results=k,
             query_type=query_type,
         )
         return self._parse_search_response(search_resp)
 
+    def _alias_filters(self, kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        The `filters` argument was used in the previous versions. It is now
+        replaced with `filter` for consistency with other vector stores, but
+        we still support `filters` for backward compatibility.
+        """
+        if "filters" in kwargs:
+            logger.warning(
+                "DatabricksVectorSearch received a key `filters` in search_kwargs, "
+                "which is deprecated. Please use `filter` instead."
+            )
+        return kwargs.pop("filters", None)
+
     def _parse_search_response(
-        self, search_resp: dict, ignore_cols: Optional[List[str]] = None
+        self, search_resp: Dict, ignore_cols: Optional[List[str]] = None
     ) -> List[Tuple[Document, float]]:
         """Parse the search response into a list of Documents with score."""
         if ignore_cols is None:
@@ -552,7 +581,7 @@ class DatabricksVectorSearch(VectorStore):
             docs_with_score.append((doc, score))
         return docs_with_score
 
-    def _index_schema(self) -> Optional[dict]:
+    def _index_schema(self) -> Optional[Dict]:
         """Return the index schema as a dictionary.
         Return None if no schema found.
         """
@@ -574,7 +603,7 @@ class DatabricksVectorSearch(VectorStore):
         """
         return self._embedding_vector_column().get("embedding_dimension")
 
-    def _embedding_vector_column(self) -> dict:
+    def _embedding_vector_column(self) -> Dict:
         """Return the embedding vector column configs as a dictionary.
         Empty if the index is not a self-managed embedding index.
         """
@@ -591,7 +620,7 @@ class DatabricksVectorSearch(VectorStore):
         """
         return self._embedding_source_column().get("name")
 
-    def _embedding_source_column(self) -> dict:
+    def _embedding_source_column(self) -> Dict:
         """Return the embedding source column configs as a dictionary.
         Empty if the index is not a Databricks-managed embedding index.
         """

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -54,8 +54,9 @@ select = [ "E", "F", "I", "T201",]
 omit = [ "tests/*",]
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --strict-config --durations=5  -vv"
+addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused -vv"
 markers = [ "requires: mark tests as requiring a specific library", "scheduled: mark tests to run in scheduled testing", "compile: mark placeholder test used to compile integration tests without running them",]
+asyncio_mode = "auto"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -54,9 +54,8 @@ select = [ "E", "F", "I", "T201",]
 omit = [ "tests/*",]
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused -vv"
+addopts = "--strict-markers --strict-config --durations=5  -vv"
 markers = [ "requires: mark tests as requiring a specific library", "scheduled: mark tests to run in scheduled testing", "compile: mark placeholder test used to compile integration tests without running them",]
-asyncio_mode = "auto"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/community/tests/unit_tests/vectorstores/test_databricks_vector_search.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_databricks_vector_search.py
@@ -683,6 +683,7 @@ def test_similarity_search_by_vector_not_supported_for_managed_embedding() -> No
     )
 
 
+@pytest.mark.requires("databricks", "databricks.vector_search")
 @pytest.mark.parametrize(
     "method",
     [


### PR DESCRIPTION
The [DatabricksVectorSearch](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/vectorstores/databricks_vector_search.py#L21) class exposes similarity search APIs with argument `filters`, which is inconsistent with other VS classes who uses `filter` (singular). This PR updates the argument and add alias for backward compatibility.