### PR TITLE
core[patch]: Fix word spelling error in `globals.py`

### DIFF
--- a/libs/core/langchain_core/globals.py
+++ b/libs/core/langchain_core/globals.py
@@ -77,7 +77,7 @@ def get_verbose() -> bool:
             # In the meantime, the `verbose` setting is considered True if either the old
             # or the new value are True. This accommodates users who haven't migrated
             # to using `set_verbose()` yet. Those users are getting deprecation warnings
-            # directing them to use `set_verbose()` when they import `langhchain.verbose`.
+            # directing them to use `set_verbose()` when they import `langchain.verbose`.
             old_verbose = langchain.verbose
     except ImportError:
         old_verbose = False
@@ -142,7 +142,7 @@ def get_debug() -> bool:
             # In the meantime, the `debug` setting is considered True if either the old
             # or the new value are True. This accommodates users who haven't migrated
             # to using `set_debug()` yet. Those users are getting deprecation warnings
-            # directing them to use `set_debug()` when they import `langhchain.debug`.
+            # directing them to use `set_debug()` when they import `langchain.debug`.
             old_debug = langchain.debug
     except ImportError:
         old_debug = False
@@ -213,7 +213,7 @@ def get_llm_cache() -> "BaseCache":
             # or the old value if both are falsy. This accommodates users
             # who haven't migrated to using `set_llm_cache()` yet.
             # Those users are getting deprecation warnings directing them
-            # to use `set_llm_cache()` when they import `langhchain.llm_cache`.
+            # to use `set_llm_cache()` when they import `langchain.llm_cache`.
             old_llm_cache = langchain.llm_cache
     except ImportError:
         old_llm_cache = None


### PR DESCRIPTION
Fix word spelling error in `globals.py`