### PR TITLE
docs: fix typo gmail.ipynb

### DIFF
--- a/docs/docs/integrations/chat_loaders/gmail.ipynb
+++ b/docs/docs/integrations/chat_loaders/gmail.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "# This makes messages sent by hchase@langchain.com the AI Messages\n",
-    "# This means you will train an LLM to predict as if it's responding as hchase\n",
+    "# This means you will train an LLM to predict as if it's responding as chase\n",
     "training_data = list(\n",
     "    map_ai_messages(data, sender=\"Harrison Chase <hchase@langchain.com>\")\n",
     ")"


### PR DESCRIPTION
super minor, just pedantically fixing it