### PR TITLE
community[patch]: Update URL to the 2markdown API

### DIFF
--- a/libs/community/langchain_community/document_loaders/tomarkdown.py
+++ b/libs/community/langchain_community/document_loaders/tomarkdown.py
@@ -21,7 +21,7 @@ class ToMarkdownLoader(BaseLoader):
     ) -> Iterator[Document]:
         """Lazily load the file."""
         response = requests.post(
-            "https://2markdown.com/api/2md",
+            "https://api.2markdown.com/v1/url2md",
             headers={"X-Api-Key": self.api_key},
             json={"url": self.url},
         )


### PR DESCRIPTION
Update the URL to Markdown endpoint.

API information is available here: https://2markdown.com/docs#url2md