### PR TITLE
community[patch]: Fix param spelling error in `ElasticsearchChatMessageHistory`

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/elasticsearch.py
+++ b/libs/community/langchain_community/chat_message_histories/elasticsearch.py
@@ -28,7 +28,7 @@ class ElasticsearchChatMessageHistory(BaseChatMessageHistory):
         es_password: Password to use when connecting to Elasticsearch.
         es_api_key: API key to use when connecting to Elasticsearch.
         es_connection: Optional pre-existing Elasticsearch connection.
-        esnsure_ascii: Used to escape ASCII symbols in json.dumps. Defaults to True.
+        ensure_ascii: Used to escape ASCII symbols in json.dumps. Defaults to True.
         index: Name of the index to use.
         session_id: Arbitrary key that is used to store the messages
             of a single chat session.
@@ -45,11 +45,11 @@ class ElasticsearchChatMessageHistory(BaseChatMessageHistory):
         es_user: Optional[str] = None,
         es_api_key: Optional[str] = None,
         es_password: Optional[str] = None,
-        esnsure_ascii: Optional[bool] = True,
+        ensure_ascii: Optional[bool] = True,
     ):
         self.index: str = index
         self.session_id: str = session_id
-        self.ensure_ascii = esnsure_ascii
+        self.ensure_ascii = ensure_ascii
 
         # Initialize Elasticsearch client from passed client arg or connection info
         if es_connection is not None:


### PR DESCRIPTION
Fix param spelling error in `ElasticsearchChatMessageHistory`