### PR TITLE
community: fix typo in warning message

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/sql.py
+++ b/libs/community/langchain_community/chat_message_histories/sql.py
@@ -187,7 +187,7 @@ class SQLChatMessageHistory(BaseChatMessageHistory):
                     since="0.2.2",
                     removal="0.3.0",
                     name="connection_string",
-                    alternative="Use connection instead",
+                    alternative="connection",
                 )
                 _warned_once_already = True
             connection = connection_string


### PR DESCRIPTION
- **Description:** 
  This PR fixes a small typo in a warning message
- **Issue:**
![](https://github.com/user-attachments/assets/5aa57724-26c5-49f6-8bc1-5a54bb67ed49)
There were double `Use` and double `instead`