### PR TITLE
community[patch]: Add linter to prevent further usage of root_validator and validator

### DIFF
--- a/libs/community/scripts/check_pydantic.sh
+++ b/libs/community/scripts/check_pydantic.sh
@@ -13,6 +13,30 @@ fi
 
 repository_path="$1"
 
+# Check that we are not using features that cannot be captured via init.
+# pre-init is a custom decorator that we introduced to capture the same semantics
+# as @root_validator(pre=False, skip_on_failure=False) available in pydantic 1.
+count=$(git grep -E '(@root_validator)|(@validator)|(@pre_init)' -- "*.py" | wc -l)
+# PRs that increase the current count will not be accepted.
+# PRs that decrease update the code in the repository
+# and allow decreasing the count of are welcome!
+current_count=336
+
+if [ "$count" -gt "$current_count" ]; then
+  echo "The PR seems to be introducing new usage of @root_validator and/or @field_validator."
+  echo "git grep -E '(@root_validator)|(@validator)' | wc -l returned $count"
+  echo "whereas the expected count should be equal or less than $current_count"
+  echo "Please update the code to instead use __init__"
+  echo "For examples, please see: "
+  echo "https://gist.github.com/eyurtsev/d1dcba10c2f35626e302f1b98a0f5a3c "
+  echo "This linter is here to make sure that its easier to upgrade pydantic in the future."
+  exit 1
+elif [ "$count" -lt "$current_count" ]; then
+    echo "Please update the $current_count variable in ./scripts/check_pydantic.sh to $count"
+    exit 1
+fi
+
+
 # Search for lines matching the pattern within the specified repository
 result=$(git -C "$repository_path" grep -En '^import pydantic|^from pydantic')
 
@@ -42,3 +66,5 @@ if [ -n "$result" ]; then
   echo "@root_validator(pre=True) or @root_validator(pre=False, skip_on_failure=True)"
   exit 1
 fi
+
+

--- a/libs/community/scripts/check_pydantic.sh
+++ b/libs/community/scripts/check_pydantic.sh
@@ -66,5 +66,3 @@ if [ -n "$result" ]; then
   echo "@root_validator(pre=True) or @root_validator(pre=False, skip_on_failure=True)"
   exit 1
 fi
-
-


### PR DESCRIPTION
This linter is meant to move development to use __init__ instead of root_validator and validator.

We need to investigate whether we need to lint some of the functionality of Field (e.g., `lt` and `gt`, `alias`)

`alias` is the one that's most popular:

(community) ➜  community git:(eugene/add_linter_to_community) ✗ git grep " Field(" | grep "alias=" | wc -l
144

(community) ➜  community git:(eugene/add_linter_to_community) ✗ git grep " Field(" | grep "ge=" | wc -l
10

(community) ➜  community git:(eugene/add_linter_to_community) ✗ git grep " Field(" | grep "gt=" | wc -l
4