### PR TITLE
docs: `ChatGooglePalm` page fix

### DIFF
--- a/docs/docs/integrations/vectorstores/scann.ipynb
+++ b/docs/docs/integrations/vectorstores/scann.ipynb
@@ -45,21 +45,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "377bc723",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Document(page_content='Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \\n\\nTonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \\n\\nOne of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court. \\n\\nAnd I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.', metadata={'source': 'state_of_the_union.txt'})"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain_community.document_loaders import TextLoader\n",
     "from langchain_community.vectorstores import ScaNN\n",
@@ -95,15 +84,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "fc27ad51",
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain.chains import RetrievalQA\n",
-    "from langchain_community.chat_models import google_palm\n",
+    "from langchain_community.chat_models.google_palm import ChatGooglePalm\n",
     "\n",
-    "palm_client = google_palm.ChatGooglePalm(google_api_key=\"YOUR_GOOGLE_PALM_API_KEY\")\n",
+    "palm_client = ChatGooglePalm(google_api_key=\"YOUR_GOOGLE_PALM_API_KEY\")\n",
     "\n",
     "qa = RetrievalQA.from_chain_type(\n",
     "    llm=palm_client,\n",


### PR DESCRIPTION
**Issue:** now the [ChatGooglePalm](https://python.langchain.com/v0.2/docs/integrations/vectorstores/scann/#retrievalqa-demo) class is not parsed and do not presented in the "API Reference:" line.

**PR:** [Fixed it](https://langchain-7n5k5wkfs-langchain.vercel.app/v0.2/docs/integrations/vectorstores/scann/#retrievalqa-demo) by properly importing.