### PR TITLE
graph_transformers: bug fix for create_simple_model not passing in ll…

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -332,6 +332,7 @@ def create_simple_model(
             ),
         ),
     }
+
     if node_properties:
         if isinstance(node_properties, list) and "id" in node_properties:
             raise ValueError("The node property 'id' is reserved and cannot be used.")
@@ -347,6 +348,7 @@ def create_simple_model(
                 node_properties_mapped,
                 description="Property key.",
                 input_type="property",
+                llm_type=llm_type,
             )
             value: str = Field(..., description="value")
 
@@ -370,6 +372,7 @@ def create_simple_model(
                 node_labels,
                 description="The type or label of the source node.",
                 input_type="node",
+                llm_type=llm_type,
             ),
         ),
         "target_node_id": (
@@ -385,6 +388,7 @@ def create_simple_model(
                 node_labels,
                 description="The type or label of the target node.",
                 input_type="node",
+                llm_type=llm_type,
             ),
         ),
         "type": (
@@ -393,6 +397,7 @@ def create_simple_model(
                 rel_types,
                 description="The type of the relationship.",
                 input_type="relationship",
+                llm_type=llm_type,
             ),
         ),
     }
@@ -416,6 +421,7 @@ def create_simple_model(
                 relationship_properties_mapped,
                 description="Property key.",
                 input_type="property",
+                llm_type=llm_type,
             )
             value: str = Field(..., description="value")
 


### PR DESCRIPTION
issue: #24615 

descriptions: The _Graph pydantic model generated from create_simple_model (which LLMGraphTransformer uses when allowed nodes and relationships are provided) does not constrain the relationships (source and target types, relationship type), and the node and relationship properties with enums when using ChatOpenAI.
The issue is that when calling optional_enum_field throughout create_simple_model the llm_type parameter is not passed in except for when creating node type. Passing it into each call fixes the issue.