### PR TITLE
community: fix dashcope embeddings embed_query func post too much req to api

### DIFF
--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -48,8 +48,9 @@ def embed_with_retry(embeddings: DashScopeEmbeddings, **kwargs: Any) -> Any:
         result = []
         i = 0
         input_data = kwargs["input"]
-        while i < len(input_data):
-            kwargs["input"] = input_data[i : i + 25]
+        input_len = len(input_data) if isinstance(input_data, list) else 1
+        while i < input_len:
+            kwargs["input"] = input_data[i: i + 25] if isinstance(input_data, list) else input_data
             resp = embeddings.client.call(**kwargs)
             if resp.status_code == 200:
                 result += resp.output["embeddings"]

--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -50,7 +50,9 @@ def embed_with_retry(embeddings: DashScopeEmbeddings, **kwargs: Any) -> Any:
         input_data = kwargs["input"]
         input_len = len(input_data) if isinstance(input_data, list) else 1
         while i < input_len:
-            kwargs["input"] = input_data[i: i + 25] if isinstance(input_data, list) else input_data
+            kwargs["input"] = (
+                input_data[i : i + 25] if isinstance(input_data, list) else input_data
+            )
             resp = embeddings.client.call(**kwargs)
             if resp.status_code == 200:
                 result += resp.output["embeddings"]


### PR DESCRIPTION
the fuc of embed_query of dashcope embeddings send a str param, and in the embed_with_retry func will send error content to api