### PR TITLE
together: Add rate limiter to integration tests

### DIFF
--- a/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
@@ -4,11 +4,16 @@ from typing import Type
 
 import pytest
 from langchain_core.language_models import BaseChatModel
-from langchain_standard_tests.integration_tests import (  # type: ignore[import-not-found]
-    ChatModelIntegrationTests,  # type: ignore[import-not-found]
-)
+from langchain_core.rate_limiters import InMemoryRateLimiter
+from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
 
 from langchain_together import ChatTogether
+
+# Initialize the rate limiter in global scope, so it can be re-used
+# across tests.
+rate_limiter = InMemoryRateLimiter(
+    requests_per_second=0.5,
+)
 
 
 class TestTogetherStandard(ChatModelIntegrationTests):
@@ -18,7 +23,10 @@ class TestTogetherStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "mistralai/Mistral-7B-Instruct-v0.1"}
+        return {
+            "model": "mistralai/Mistral-7B-Instruct-v0.1",
+            "rate_limiter": rate_limiter,
+        }
 
     @pytest.mark.xfail(reason=("May not call a tool."))
     def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:


### PR DESCRIPTION
Rate limit the integration tests to avoid getting 429s.
