### PR TITLE
Respect injected in bound fns

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -179,6 +179,7 @@ def convert_python_function_to_openai_function(
         filter_args=(),
         parse_docstring=True,
         error_on_invalid_docstring=False,
+        include_injected=False,
     )
     return convert_pydantic_to_openai_function(
         model,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1435,7 +1435,7 @@ def _get_parametrized_tools() -> list:
         return some_tool
 
     async def my_async_tool(
-        x: int, y: str, some_tool: Annotated[Any, InjectedToolArg]
+        x: int, y: str, *, some_tool: Annotated[Any, InjectedToolArg]
     ) -> str:
         """my_tool."""
         return some_tool

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1429,6 +1429,36 @@ def test_tool_injected_arg_with_schema(tool_: BaseTool) -> None:
     }
 
 
+def _get_parametrized_tools() -> list:
+    def my_tool(x: int, y: str, some_tool: Annotated[Any, InjectedToolArg]) -> str:
+        """my_tool."""
+        return some_tool
+
+    async def my_async_tool(
+        x: int, y: str, some_tool: Annotated[Any, InjectedToolArg]
+    ) -> str:
+        """my_tool."""
+        return some_tool
+
+    return [my_tool, my_async_tool]
+
+
+@pytest.mark.parametrize("tool_", _get_parametrized_tools())
+def test_fn_injected_arg_with_schema(tool_: Callable) -> None:
+    assert convert_to_openai_function(tool_) == {
+        "name": tool_.__name__,
+        "description": "my_tool.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer"},
+                "y": {"type": "string"},
+            },
+            "required": ["x", "y"],
+        },
+    }
+
+
 def generate_models() -> List[Any]:
     """Generate a list of base models depending on the pydantic version."""
     from pydantic import BaseModel as BaseModelProper  # pydantic: ignore


### PR DESCRIPTION
Since right now you cant use the nic einjected arg syntas directly with model.bind_tools()

Recently I tried injecting state into tools and had the following sequence of unsupported behavior:

1. Tried to use InjectStateArg(“vector_store”)  and keep as a function (since I use it in a couple places)
    1. Failed because we didn’t add support for this in the bind_tools, only in the tool itself…..
2. Tried to use InjectStateArg(“vector_store”) and then use the tool decorator.
    1. Failed because my object isn’t able to be schemafied. I don’t want it in the schema! Would prefer if we let pydantic set arbitrary types here by default. So then I decided to type as `Any`
3. Updated to `Any `typed
    1. Pydantic infers this as `Optional[Annotated[Optional[Any], StateInjectArg]]`, and since we only check the toop level of get_args, we don't otice the `StateInjectArg` there. 
4. Updated back to `StateInjectArg` (unparametrized, just wanted to accept the whole state)
    1. Failed because we deep copy the tool input, but the vector store contains a DB pool / conn which has a thread loc, which can't be pickeld
5. Gave up on tool node. Split into separate nodes and tried to split the tool calls using `Send`.  Had a few more hiccups but finally worked when i did it manually
