### PR TITLE
core[patch]: support tool calls with non-pickleable args in tools

### DIFF
--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -20,7 +20,6 @@ tool for the job.
 from __future__ import annotations
 
 import asyncio
-import copy
 import functools
 import inspect
 import json
@@ -1482,9 +1481,8 @@ def _prep_run_args(
 ) -> Tuple[Union[str, Dict], Dict]:
     config = ensure_config(config)
     if _is_tool_call(input):
-        input_copy = copy.deepcopy(input)
-        tool_call_id: Optional[str] = cast(ToolCall, input_copy)["id"]
-        tool_input: Union[str, dict] = cast(ToolCall, input_copy)["args"]
+        tool_call_id: Optional[str] = cast(ToolCall, input)["id"]
+        tool_input: Union[str, dict] = cast(ToolCall, input)["args"].copy()
     else:
         tool_call_id = None
         tool_input = cast(Union[str, dict], input)


### PR DESCRIPTION
Deepcopy raises with non-pickleable args.