### PR TITLE
docs: fix typo in DSPy docs

### DIFF
--- a/docs/docs/integrations/providers/dspy.ipynb
+++ b/docs/docs/integrations/providers/dspy.ipynb
@@ -355,7 +355,7 @@
    "id": "859daaee-ac5d-47f8-8704-827f5578bf1b",
    "metadata": {},
    "source": [
-    "## Define a metic\n",
+    "## Define a metric\n",
     "\n",
     "We now need to define a metric. This will be used to determine which runs were successful and we can learn from. Here we will use DSPy's metrics, though you can write your own."
    ]


### PR DESCRIPTION
**Description:** Just a missing "r" in metric
**Dependencies:**N/A
