### PR TITLE
[RFC] accept with_config(name=...)

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1390,11 +1390,15 @@ class Runnable(Generic[Input, Output], ABC):
         Returns:
             A new Runnable with the config bound.
         """
+        config_ = {**(config or {}), **kwargs}
+        if "name" in config_ and "run_name" not in config_:
+            config_["run_name"] = config_["name"]
+
         return RunnableBinding(
             bound=self,
             config=cast(
                 RunnableConfig,
-                {**(config or {}), **kwargs},
+                config_,
             ),  # type: ignore[misc]
             kwargs={},
         )


### PR DESCRIPTION
I've made this mistake a couple times and have seen others make this mistake.

Also considered a `warnings.warn()` saying "did you mean 'run_name'. Would be open to that to keep the API more pure.