### PR TITLE
patch[experimental] Fix prompt in `GenerativeAgentMemory`

### DIFF
--- a/libs/experimental/langchain_experimental/generative_agents/memory.py
+++ b/libs/experimental/langchain_experimental/generative_agents/memory.py
@@ -144,7 +144,7 @@ class GenerativeAgentMemory(BaseMemory):
             + " following piece of memory. Always answer with only a list of numbers."
             + " If just given one memory still respond in a list."
             + " Memories are separated by semi colans (;)"
-            + "\Memories: {memory_content}"
+            + "\nMemories: {memory_content}"
             + "\nRating: "
         )
         scores = self.chain(prompt).run(memory_content=memory_content).strip()


### PR DESCRIPTION
There is an issue with the prompt format in `GenerativeAgentMemory` ,  try to fix it.
The prompt is same as the one in method `_score_memory_importance`.