### PR TITLE
core[minor]: Prevent PydanticOutputParser from encoding schema as ASCII

### DIFF
--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -92,7 +92,7 @@ class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
         if "type" in reduced_schema:
             del reduced_schema["type"]
         # Ensure json in context is well-formed with double quotes.
-        schema_str = json.dumps(reduced_schema)
+        schema_str = json.dumps(reduced_schema, ensure_ascii=False)
 
         return _PYDANTIC_FORMAT_INSTRUCTIONS.format(schema=schema_str)
 

--- a/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -96,3 +96,24 @@ def test_json_parser_chaining(
     assert res["f_or_c"] == "C"
     assert res["temperature"] == 20
     assert res["forecast"] == "Sunny"
+
+
+def test_format_instructions_preserves_language() -> None:
+    """Test format instructions does not attempt to encode into ascii."""
+    from langchain_core.pydantic_v1 import BaseModel, Field
+
+    description = (
+        "你好, こんにちは, नमस्ते, Bonjour, Hola, "
+        "Olá, 안녕하세요, Jambo, Merhaba, Γειά σου"
+    )
+
+    class Foo(BaseModel):
+        hello: str = Field(
+            description=(
+                "你好, こんにちは, नमस्ते, Bonjour, Hola, "
+                "Olá, 안녕하세요, Jambo, Merhaba, Γειά σου"
+            )
+        )
+
+    parser = PydanticOutputParser(pydantic_object=Foo)
+    assert description in parser.get_format_instructions()


### PR DESCRIPTION
This allows users to provide parameter descriptions in the pydantic models in other languages.