### PR TITLE
langchain: revert "init_chat_model() to support ChatOllama from langchain-ollama"

### DIFF
--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -118,7 +118,7 @@ def init_chat_model(
                 - mistralai (langchain-mistralai)
                 - huggingface (langchain-huggingface)
                 - groq (langchain-groq)
-                - ollama (langchain-ollama)
+                - ollama (langchain-community)
 
             Will attempt to infer model_provider from model if not specified. The
             following providers will be inferred based on these model prefixes:
@@ -336,8 +336,8 @@ def _init_chat_model_helper(
 
         return ChatFireworks(model=model, **kwargs)
     elif model_provider == "ollama":
-        _check_pkg("langchain_ollama")
-        from langchain_ollama import ChatOllama
+        _check_pkg("langchain_community")
+        from langchain_community.chat_models import ChatOllama
 
         return ChatOllama(model=model, **kwargs)
     elif model_provider == "together":


### PR DESCRIPTION
Reverts langchain-ai/langchain#24818

Overlooked discussion in https://github.com/langchain-ai/langchain/pull/24801.