### PR TITLE
langchain: init_chat_model() to import ChatOllama from langchain-ollama and fallback on langchain-community

### DIFF
--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -118,7 +118,7 @@ def init_chat_model(
                 - mistralai (langchain-mistralai)
                 - huggingface (langchain-huggingface)
                 - groq (langchain-groq)
-                - ollama (langchain-community)
+                - ollama (langchain-ollama)
 
             Will attempt to infer model_provider from model if not specified. The
             following providers will be inferred based on these model prefixes:
@@ -337,7 +337,7 @@ def _init_chat_model_helper(
         return ChatFireworks(model=model, **kwargs)
     elif model_provider == "ollama":
         _check_pkg("langchain_community")
-        from langchain_community.chat_models import ChatOllama
+        from langchain_ollama import ChatOllama
 
         return ChatOllama(model=model, **kwargs)
     elif model_provider == "together":

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -336,8 +336,12 @@ def _init_chat_model_helper(
 
         return ChatFireworks(model=model, **kwargs)
     elif model_provider == "ollama":
-        _check_pkg("langchain_ollama")
-        from langchain_ollama import ChatOllama
+        try:
+            _check_pkg("langchain_ollama")
+            from langchain_ollama import ChatOllama
+        except ImportError:
+            _check_pkg("langchain_community")
+            from langchain_community import ChatOllama
 
         return ChatOllama(model=model, **kwargs)
     elif model_provider == "together":

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -336,7 +336,7 @@ def _init_chat_model_helper(
 
         return ChatFireworks(model=model, **kwargs)
     elif model_provider == "ollama":
-        _check_pkg("langchain_community")
+        _check_pkg("langchain_ollama")
         from langchain_ollama import ChatOllama
 
         return ChatOllama(model=model, **kwargs)


### PR DESCRIPTION
Description: init_chat_model() should import ChatOllama from `langchain-ollama`. If that fails, fallback to `langchain-community`