### PR TITLE
docs: Remove danger on how to migrate to astream events v2

### DIFF
--- a/docs/docs/versions/v0_2/migrating_astream_events.mdx
+++ b/docs/docs/versions/v0_2/migrating_astream_events.mdx
@@ -5,12 +5,6 @@ sidebar_label: astream_events v2
 
 # Migrating to Astream Events v2
 
-:::danger
-
-This migration guide is a work in progress and is not complete. Please wait to migrate astream_events.
-
-:::
-
 We've added a `v2` of the astream_events API with the release of `0.2.0`. You can see this [PR](https://github.com/langchain-ai/langchain/pull/21638) for more details.
 
 The `v2` version is a re-write of the `v1` version, and should be more efficient, with more consistent output for the events. The `v1` version of the API will be deprecated in favor of the `v2` version and will be removed in  `0.4.0`.

--- a/docs/docs/versions/v0_2/migrating_astream_events.mdx
+++ b/docs/docs/versions/v0_2/migrating_astream_events.mdx
@@ -5,7 +5,7 @@ sidebar_label: astream_events v2
 
 # Migrating to Astream Events v2
 
-We've added a `v2` of the astream_events API with the release of `0.2.0`. You can see this [PR](https://github.com/langchain-ai/langchain/pull/21638) for more details.
+We've added a `v2` of the astream_events API with the release of `0.2.x`. You can see this [PR](https://github.com/langchain-ai/langchain/pull/21638) for more details.
 
 The `v2` version is a re-write of the `v1` version, and should be more efficient, with more consistent output for the events. The `v1` version of the API will be deprecated in favor of the `v2` version and will be removed in  `0.4.0`.
 


### PR DESCRIPTION
Users should migrate to v2 now