### PR TITLE
patch[cli] Fix bug in `check_imports.py`

### DIFF
--- a/libs/cli/langchain_cli/integration_template/scripts/check_imports.py
+++ b/libs/cli/langchain_cli/integration_template/scripts/check_imports.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
         try:
             SourceFileLoader("x", file).load_module()
         except Exception:
-            has_faillure = True
+            has_failure = True
             print(file)  # noqa: T201
             traceback.print_exc()
             print()  # noqa: T201


### PR DESCRIPTION
The variable `has_failure` in check_imports.py is wrong-declared. It's actually an another variable.