### PR TITLE
community: fix AzureSearch vectorstore asyncronous methods

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -523,21 +523,19 @@ class AzureSearch(VectorStore):
             ids.append(key)
             # Upload data in batches
             if len(data) == MAX_UPLOAD_BATCH_SIZE:
-                async with self.async_client as async_client:
-                    response = await async_client.upload_documents(documents=data)
-                    # Check if all documents were successfully uploaded
-                    if not all(r.succeeded for r in response):
-                        raise LangChainException(response)
-                    # Reset data
-                    data = []
+                response = await self.async_client.upload_documents(documents=data)
+                # Check if all documents were successfully uploaded
+                if not all(r.succeeded for r in response):
+                    raise LangChainException(response)
+                # Reset data
+                data = []
 
         # Considering case where data is an exact multiple of batch-size entries
         if len(data) == 0:
             return ids
 
         # Upload data to index
-        async with self.async_client as async_client:
-            response = await async_client.upload_documents(documents=data)
+        response = await self.async_client.upload_documents(documents=data)
         # Check if all documents were successfully uploaded
         if all(r.succeeded for r in response):
             return ids
@@ -571,9 +569,8 @@ class AzureSearch(VectorStore):
             False otherwise.
         """
         if ids:
-            async with self.async_client as async_client:
-                res = await async_client.delete_documents([{"id": i} for i in ids])
-                return len(res) > 0
+            res = await self.async_client.delete_documents([{"id": i} for i in ids])
+            return len(res) > 0
         else:
             return False
 

--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -366,7 +366,7 @@ class AzureSearch(VectorStore):
         self._user_agent = user_agent
         self._cors_options = cors_options
 
-    def __del__(self):
+    def __del__(self) -> None:
         # Close the sync client
         if hasattr(self, "client") and self.client:
             self.client.close()

--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -41,7 +41,12 @@ logger = logging.getLogger()
 
 if TYPE_CHECKING:
     from azure.search.documents import SearchClient, SearchItemPaged
-    from azure.search.documents.aio import SearchClient as AsyncSearchClient, AsyncSearchItemPaged
+    from azure.search.documents.aio import (
+        AsyncSearchItemPaged,
+    )
+    from azure.search.documents.aio import (
+        SearchClient as AsyncSearchClient,
+    )
     from azure.search.documents.indexes.models import (
         CorsOptions,
         ScoringProfile,
@@ -1330,9 +1335,7 @@ class AzureSearch(VectorStore):
                         ),
                         **{
                             "captions": {
-                                "text": result.get("@search.captions", [{}])[
-                                    0
-                                ].text,
+                                "text": result.get("@search.captions", [{}])[0].text,
                                 "highlights": result.get("@search.captions", [{}])[
                                     0
                                 ].highlights,
@@ -1627,6 +1630,7 @@ def _results_to_documents(
         for result in results
     ]
     return docs
+
 
 async def _aresults_to_documents(
     results: AsyncSearchItemPaged[Dict],


### PR DESCRIPTION
**Description**
Fix the asyncronous methods to retrieve documents from AzureSearch VectorStore. The previous changes from [this commit](https://github.com/langchain-ai/langchain/commit/ffe6ca986ee5b439e85c82781c1d8ce3578a3e88) create a similar code for the syncronous methods and the asyncronous ones but the asyncronous client return an asyncronous iterator "AsyncSearchItemPaged" as said in the issue #24740.
To solve this issue, the syncronous iterators in asyncronous methods where changed to asyncronous iterators.

@chrislrobert said in [this comment](https://github.com/langchain-ai/langchain/issues/24740#issuecomment-2254168302) that there was a still a flaw due to `with` blocks that close the client after each call. I removed this `with` blocks in the `async_client` following the same pattern as the sync `client`.

In order to close up the connections, a __del__ method is included to gently close up clients once the vectorstore object is destroyed.

**Issue:** #24740 and #24064
**Dependencies:** No new dependencies for this change

**Example notebook:** I created a notebook just to test the changes work and gives the same results as the syncronous methods for vector and hybrid search. With these changes, the asyncronous methods in the retriever work as well.
![image](https://github.com/user-attachments/assets/697e431b-9d7f-4d0d-b205-59d051ac2b67)


**Lint and test**: Passes the tests and the linter
