### PR TITLE
huggingface: Added a missing argument to a ChatHuggingFace doc notebook.

### DIFF
--- a/docs/docs/integrations/chat/huggingface.ipynb
+++ b/docs/docs/integrations/chat/huggingface.ipynb
@@ -129,6 +129,7 @@
     "        max_new_tokens=512,\n",
     "        do_sample=False,\n",
     "        repetition_penalty=1.03,\n",
+    "        return_full_text=False\n",
     "    ),\n",
     ")"
    ]

--- a/docs/docs/integrations/chat/huggingface.ipynb
+++ b/docs/docs/integrations/chat/huggingface.ipynb
@@ -129,7 +129,7 @@
     "        max_new_tokens=512,\n",
     "        do_sample=False,\n",
     "        repetition_penalty=1.03,\n",
-    "        return_full_text=False\n",
+    "        return_full_text=False,\n",
     "    ),\n",
     ")"
    ]


### PR DESCRIPTION
 - **Description:** When adding docs for constructing ChatHuggingFace using a HuggingFacePipeline, I forgot to add `return_full_text=False` as an argument. In this setup, the chat response would incorrectly contain all the input text. I am fixing that here by adding that line to the offending notebook.