### PR TITLE
core: rate_limiters.InMemoryRateLimiter: use time.monotonic() instead time.time() to avoi…

### DIFF
--- a/libs/core/langchain_core/rate_limiters.py
+++ b/libs/core/langchain_core/rate_limiters.py
@@ -181,7 +181,7 @@ class InMemoryRateLimiter(BaseRateLimiter):
             the caller should try again later.
         """
         with self._consume_lock:
-            now = time.time()
+            now = time.monotonic()
 
             # initialize on first call to avoid a burst
             if self.last is None:


### PR DESCRIPTION
**Description:**

The get  time point method in the _consume() method of core.rate_limiters.InMemoryRateLimiter uses time.time(), which can be affected by system time backwards. Therefore, it is recommended to use the monotonically increasing monotonic() to obtain the time

```python
        with self._consume_lock:
            now = time.time()  # time.time() -> time.monotonic()

            # initialize on first call to avoid a burst
            if self.last is None:
                self.last = now

            elapsed = now - self.last  # when use time.time(), elapsed may be negative when system time backwards

```