### PR TITLE
standard-tests: set integration test parameters independent of unit test

### DIFF
--- a/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
@@ -59,7 +59,6 @@ def _validate_tool_call_message_no_args(message: BaseMessage) -> None:
 
 
 class ChatModelIntegrationTests(ChatModelTests):
-
     @property
     def standard_chat_model_params(self) -> dict:
         return {}

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
@@ -59,6 +59,11 @@ def _validate_tool_call_message_no_args(message: BaseMessage) -> None:
 
 
 class ChatModelIntegrationTests(ChatModelTests):
+
+    @property
+    def standard_chat_model_params(self) -> dict:
+        return {}
+
     def test_invoke(self, model: BaseChatModel) -> None:
         result = model.invoke("Hello")
         assert result is not None

--- a/libs/standard-tests/langchain_standard_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/unit_tests/chat_models.py
@@ -80,7 +80,7 @@ class ChatModelTests(BaseStandardTests):
     def standard_chat_model_params(self) -> dict:
         return {
             "temperature": 0,
-            "max_tokens": 10_000,
+            "max_tokens": 100,
             "timeout": 60,
             "stop": [],
             "max_retries": 2,

--- a/libs/standard-tests/langchain_standard_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/unit_tests/chat_models.py
@@ -80,7 +80,7 @@ class ChatModelTests(BaseStandardTests):
     def standard_chat_model_params(self) -> dict:
         return {
             "temperature": 0,
-            "max_tokens": 100,
+            "max_tokens": 10_000,
             "timeout": 60,
             "stop": [],
             "max_retries": 2,


### PR DESCRIPTION
This ends up getting set in integration tests.