### PR TITLE
doc change for optional variables in chatprompt

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -46,7 +46,9 @@ class BasePromptTemplate(
     """A list of the names of the variables whose values are required as inputs to the 
     prompt."""
     optional_variables: List[str] = Field(default=[])
-    """A list of the names of the variables that are optional in the prompt."""
+    """optional_variables: A list of the names of the variables for placeholder
+       or MessagePlaceholder that are optional. These variables are auto inferred 
+       from the prompt and user need not provide them."""
     input_types: Dict[str, Any] = Field(default_factory=dict, exclude=True)
     """A dictionary of the types of the variables the prompt template expects.
     If not provided, all variables are assumed to be strings."""

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -946,8 +946,9 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
             template_format: format of the template. Defaults to "f-string".
             input_variables: A list of the names of the variables whose values are
                 required as inputs to the prompt.
-            optional_variables: A list of the names of the variables that are optional
-                in the prompt.
+            optional_variables: A list of the names of the variables for placeholder
+            or MessagePlaceholder that are optional. These variables are auto inferred
+            from the prompt and user need not provide them.
             partial_variables: A dictionary of the partial variables the prompt
                 template carries. Partial variables populate the template so that you
                 don't need to pass them in every time you call the prompt.


### PR DESCRIPTION
Issue #24884

- [ ] **PR title**: "langchain-core: docs:  explicitly spell out that the optional_variables  argument is for MessagePlaceholder "


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** Update document to explicitly spell out that the optional_variables  argument is for MessagePlaceholder  and are auto inferred from the prompt itself. "
    - **Issue:**  the current description may also mean  that optional_variables can act as the purpose similar to  partial_variables 
    - **Dependencies:** None
    - **Twitter handle:** @BhujayBhatta


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: 

(venv) (base) bhujay@DESKTOP-MQIKKH7:/mnt/d/mydev/langchainfork/langchain/libs/core$ make test

----------------------------------------------------- snapshot report summary ------------------------------------------------------
54 snapshots passed.
======================================================= slowest 5 durations ========================================================
5.43s call     tests/unit_tests/test_imports.py::test_importable_all_via_subprocess
2.49s call     tests/unit_tests/runnables/test_tracing_interops.py::test_config_traceable_handoff
1.31s call     tests/unit_tests/runnables/test_runnable.py::test_higher_order_lambda_runnable
1.26s call     tests/unit_tests/runnables/test_runnable.py::test_retrying
1.08s call     tests/unit_tests/runnables/test_runnable.py::test_router_runnable
================================ 972 passed, 7 skipped, 5 xfailed, 1 xpassed, 24 warnings in 43.19s ===========================



(venv) (base) bhujay@DESKTOP-MQIKKH7:/mnt/d/mydev/langchainfork/langchain/libs/core$ make format
poetry run ruff format .
282 files left unchanged
poetry run ruff check --select I --fix .
All checks passed!

(venv) (base) bhujay@DESKTOP-MQIKKH7:/mnt/d/mydev/langchainfork/langchain/libs/core$ make lint
./scripts/check_pydantic.sh .
./scripts/lint_imports.sh
poetry run ruff check .
All checks passed!
[ "." = "" ] || poetry run ruff format . --diff
282 files already formatted
[ "." = "" ] || poetry run ruff check --select I .
All checks passed!
[ "." = "" ] || poetry run mypy .
Success: no issues found in 278 source files
[ "." = "" ] || mkdir -p .mypy_cache && poetry run mypy . --cache-dir .mypy_cache
Success: no issues found in 278 source files

