### PR TITLE
langchain: Make RetryWithErrorOutputParser.from_llm() create a correct retry chain

### DIFF
--- a/libs/langchain/langchain/output_parsers/retry.py
+++ b/libs/langchain/langchain/output_parsers/retry.py
@@ -214,7 +214,7 @@ class RetryWithErrorOutputParser(BaseOutputParser[T]):
         Returns:
             A RetryWithErrorOutputParser.
         """
-        chain = prompt | llm
+        chain = prompt | llm | StrOutputParser()
         return cls(parser=parser, retry_chain=chain, max_retries=max_retries)
 
     def parse_with_prompt(self, completion: str, prompt_value: PromptValue) -> T:


### PR DESCRIPTION
Description: RetryWithErrorOutputParser.from_llm() creates a retry chain that returns a Generation instance, when it should actually just return a string.
This class was forgotten when fixing the issue in PR #24687 