### PR TITLE
core[patch]: Include dependencies in sys_info

### DIFF
--- a/libs/core/langchain_core/sys_info.py
+++ b/libs/core/langchain_core/sys_info.py
@@ -2,7 +2,32 @@
 for debugging purposes.
 """
 
-from typing import Sequence
+from typing import List, Sequence
+
+
+def _get_sub_deps(packages: Sequence[str]) -> List[str]:
+    """Get any specified sub-dependencies."""
+    from importlib import metadata
+
+    sub_deps = set()
+    _underscored_packages = set(pkg.replace("-", "_") for pkg in packages)
+
+    for pkg in packages:
+        try:
+            required = metadata.requires(pkg)
+        except metadata.PackageNotFoundError:
+            continue
+
+        for req in required:
+            try:
+                cleaned_req = req.split(" ")[0]
+            except Exception:  # In case parsing of requirement spec fails
+                continue
+
+            if cleaned_req.replace("-", "_") not in _underscored_packages:
+                sub_deps.add(cleaned_req)
+
+    return sorted(sub_deps, key=lambda x: x.lower())
 
 
 def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
@@ -81,12 +106,24 @@ def print_sys_info(*, additional_pkgs: Sequence[str] = tuple()) -> None:
 
     if not_installed:
         print()  # noqa: T201
-        print("Packages not installed (Not Necessarily a Problem)")  # noqa: T201
-        print("--------------------------------------------------")  # noqa: T201
-        print("The following packages were not found:")  # noqa: T201
-        print()  # noqa: T201
+        print("Optional packages not installed")  # noqa: T201
+        print("-------------------------------")  # noqa: T201
         for pkg in not_installed:
             print(f"> {pkg}")  # noqa: T201
+
+    sub_dependencies = _get_sub_deps(all_packages)
+
+    if sub_dependencies:
+        print()  # noqa: T201
+        print("Other Dependencies")  # noqa: T201
+        print("------------------")  # noqa: T201
+
+        for dep in sub_dependencies:
+            try:
+                dep_version = metadata.version(dep)
+                print(f"> {dep}: {dep_version}")  # noqa: T201
+            except Exception:
+                print(f"> {dep}: Installed. No version info available.")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/libs/core/langchain_core/sys_info.py
+++ b/libs/core/langchain_core/sys_info.py
@@ -18,6 +18,9 @@ def _get_sub_deps(packages: Sequence[str]) -> List[str]:
         except metadata.PackageNotFoundError:
             continue
 
+        if not required:
+            continue
+
         for req in required:
             try:
                 cleaned_req = req.split(" ")[0]


### PR DESCRIPTION
`python -m langchain_core.sys_info`

```bash
System Information
------------------
> OS:  Linux
> OS Version:  #44~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jun 18 14:36:16 UTC 2
> Python Version:  3.11.4 (main, Sep 25 2023, 10:06:23) [GCC 11.4.0]

Package Information
-------------------
> langchain_core: 0.2.28
> langchain: 0.2.8
> langsmith: 0.1.85
> langchain_anthropic: 0.1.20
> langchain_openai: 0.1.20
> langchain_standard_tests: 0.1.1
> langchain_text_splitters: 0.2.2
> langgraph: 0.1.19

Optional packages not installed
-------------------------------
> langserve

Other Dependencies
------------------
> aiohttp: 3.9.5
> anthropic: 0.31.1
> async-timeout: Installed. No version info available.
> defusedxml: 0.7.1
> httpx: 0.27.0
> jsonpatch: 1.33
> numpy: 1.26.4
> openai: 1.39.0
> orjson: 3.10.6
> packaging: 24.1
> pydantic: 2.8.2
> pytest: 7.4.4
> PyYAML: 6.0.1
> requests: 2.32.3
> SQLAlchemy: 2.0.31
> tenacity: 8.5.0
> tiktoken: 0.7.0
> typing-extensions: 4.12.2
```