### PR TITLE
Improvement[VectorStore] Optimize `VectorStoreRetriever`

### DIFF
--- a/libs/community/tests/integration_tests/vectorstores/test_pgvector.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_pgvector.py
@@ -338,6 +338,8 @@ def test_pgvector_retriever_search_threshold() -> None:
         Document(page_content="foo", metadata={"page": "0"}),
         Document(page_content="bar", metadata={"page": "1"}),
     ]
+    assert output[0].metadata["similarity_score"] > 0
+    assert output[1].metadata["similarity_score"] > 0
 
 
 def test_pgvector_retriever_search_threshold_custom_normalization_fn() -> None:

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -1141,6 +1141,8 @@ class VectorStore(ABC):
                     the Retriever should perform.
                     Can be "similarity" (default), "mmr", or
                     "similarity_score_threshold".
+                    For type "similarity_score_threshold", the similarity_score
+                    will be saved in metadata of document with key "similarity_score".
                 search_kwargs (Optional[Dict]): Keyword arguments to pass to the
                     search function. Can include things like:
                         k: Amount of documents to return (Default: 4)
@@ -1252,7 +1254,10 @@ class VectorStoreRetriever(BaseRetriever):
                     query, **self.search_kwargs
                 )
             )
-            docs = [doc for doc, _ in docs_and_similarities]
+            docs = []
+            for doc, score in docs_and_similarities:
+                doc.metadata["similarity_score"] = score
+                docs.append(doc)
         elif self.search_type == "mmr":
             docs = self.vectorstore.max_marginal_relevance_search(
                 query, **self.search_kwargs

--- a/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
@@ -196,22 +196,3 @@ async def test_inmemory_call_embeddings_async() -> None:
     # Ensure the async embedding function is called
     assert embeddings_mock.aembed_documents.await_count == 1
     assert embeddings_mock.aembed_query.await_count == 1
-
-
-async def test_inmemory_as_retriever() -> None:
-    """Test InMemoryVectorStore as retriever and search with score"""
-    store = await InMemoryVectorStore.afrom_texts(
-        ["foo", "bar", "baz"], DeterministicFakeEmbedding(size=3)
-    )
-
-    retriever = store.as_retriever(
-        search_type="similarity_score_threshold",
-        search_kwargs={"k": 2, "score_threshold": 0.0001},
-    )
-
-    output = retriever.invoke("foo")
-    assert output[0].page_content == "foo"
-    assert output[0].metadata["similarity_score"] is not None
-    assert output[1].metadata["similarity_score"] is not None
-    assert output[0].metadata["similarity_score"] > output[1].metadata["similarity_score"]
-


### PR DESCRIPTION
Optimize `VectorStoreRetriever`:

- Store similarity_score in metadata of document when search_type is "similarity_score_threshold".
- Improve test cases for "similarity_score".