### PR TITLE
Allow ConfluenceLoader authorization via Personal Access Tokens

### DIFF
--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -262,16 +262,34 @@ class ConfluenceLoader(BaseLoader):
                 f"Cannot provide a value for more than one of: {all_names}. Received "
                 f"values for: {provided}"
             )
+
+        if set(oauth2.keys()) == {
+            "token",
+            "client_id",
+        } and set(oauth2['token'].keys()) != {
+            "access_token",
+            "token_type",
+        }:
+            # OAuth2 token authentication
+            errors.append(
+                "You have either omitted require keys or added extra "
+                "keys to the oauth2 dictionary. key values should be "
+                "`['client_id', token: ['access_token', 'token_type']]`"
+            )
+
         if oauth2 and set(oauth2.keys()) != {
             "access_token",
             "access_token_secret",
             "consumer_key",
             "key_cert",
+        } and set(oauth2.keys()) != {
+            "token",
+            "client_id",
         }:
             errors.append(
                 "You have either omitted require keys or added extra "
                 "keys to the oauth2 dictionary. key values should be "
-                "`['access_token', 'access_token_secret', 'consumer_key', 'key_cert']`"
+                "`['access_token', 'access_token_secret', 'consumer_key', 'key_cert']` or `['client_id', token: ['access_token', 'token_type']]`"
             )
         return errors or None
 

--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -263,33 +263,46 @@ class ConfluenceLoader(BaseLoader):
                 f"values for: {provided}"
             )
 
-        if set(oauth2.keys()) == {
-            "token",
-            "client_id",
-        } and set(oauth2['token'].keys()) != {
-            "access_token",
-            "token_type",
-        }:
+        if (
+            oauth2
+            and set(oauth2.keys())
+            == {
+                "token",
+                "client_id",
+            }
+            and set(oauth2["token"].keys())
+            != {
+                "access_token",
+                "token_type",
+            }
+        ):
             # OAuth2 token authentication
             errors.append(
                 "You have either omitted require keys or added extra "
                 "keys to the oauth2 dictionary. key values should be "
-                "`['client_id', token: ['access_token', 'token_type']]`"
+                "`['client_id', 'token': ['access_token', 'token_type']]`"
             )
 
-        if oauth2 and set(oauth2.keys()) != {
-            "access_token",
-            "access_token_secret",
-            "consumer_key",
-            "key_cert",
-        } and set(oauth2.keys()) != {
-            "token",
-            "client_id",
-        }:
+        if (
+            oauth2
+            and set(oauth2.keys())
+            != {
+                "access_token",
+                "access_token_secret",
+                "consumer_key",
+                "key_cert",
+            }
+            and set(oauth2.keys())
+            != {
+                "token",
+                "client_id",
+            }
+        ):
             errors.append(
-                "You have either omitted require keys or added extra "
+                "You have either omitted required keys or added extra "
                 "keys to the oauth2 dictionary. key values should be "
-                "`['access_token', 'access_token_secret', 'consumer_key', 'key_cert']` or `['client_id', token: ['access_token', 'token_type']]`"
+                "`['access_token', 'access_token_secret', 'consumer_key', 'key_cert']` "
+                "or `['client_id', 'token': ['access_token', 'token_type']]`"
             )
         return errors or None
 

--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -256,7 +256,7 @@ class ConfluenceLoader(BaseLoader):
             x is not None for x in ((api_key or username), session, oauth2, token)
         )
         if sum(non_null_creds) > 1:
-            all_names = ("(api_key, username)", "session", "oath2", "token")
+            all_names = ("(api_key, username)", "session", "oauth2", "token")
             provided = tuple(n for x, n in zip(non_null_creds, all_names) if x)
             errors.append(
                 f"Cannot provide a value for more than one of: {all_names}. Received "


### PR DESCRIPTION
- community: Allow authorization to Confluence with bearer token

- **Description:** Allow authorization to Confluence with [Personal Access Token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) by checking for the keys `['client_id', token: ['access_token', 'token_type']]`

- **Issue:** 

Currently the following error occurs when using an personal access token for authorization.

```python
loader = ConfluenceLoader(
    url=os.getenv('CONFLUENCE_URL'),
    oauth2={
        'token': {"access_token": os.getenv("CONFLUENCE_ACCESS_TOKEN"), "token_type": "bearer"},
        'client_id': 'client_id',
    },
    page_ids=['12345678'], 
)
```

```
ValueError: Error(s) while validating input: ["You have either omitted require keys or added extra keys to the oauth2 dictionary. key values should be `['access_token', 'access_token_secret', 'consumer_key', 'key_cert']`"]
```

With this PR the loader runs as expected. 

