### PR TITLE
groq[patch]: allow warnings during tests

### DIFF
--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -32,7 +32,6 @@ omit = [ "tests/*",]
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --durations=5"
 markers = [ "compile: mark placeholder test used to compile integration tests without running them", "scheduled: mark tests to run in scheduled testing",]
-filterwarnings = [ "error", "ignore::ResourceWarning:", "ignore:The method `ChatGroq.with_structured_output` is in beta", "default:The `dict` method is deprecated; use `model_dump` instead:DeprecationWarning", "ignore:tool_choice='any' is not currently supported. Converting to 'auto'.",]
 asyncio_mode = "auto"
 
 [tool.poetry.group.test]


### PR DESCRIPTION
Among integration packages in libs/partners, Groq is an exception in that it errors on warnings.

Following https://github.com/langchain-ai/langchain/pull/25084, Groq fails with

> pydantic.warnings.PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0.

Here we update the behavior to no longer fail on warning, which is consistent with the rest of the packages in libs/partners.