### PR TITLE
core[patch]: Sort Config attributes

### DIFF
--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -43,10 +43,8 @@ class _VectorStoreExampleSelector(BaseExampleSelector, BaseModel, ABC):
     """Extra arguments passed to similarity_search function of the vectorstore."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = Extra.forbid
 
     @staticmethod
     def _example_to_text(

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -236,8 +236,6 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         return values
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     # --- Runnable methods ---

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -298,8 +298,6 @@ class BaseLLM(BaseLanguageModel[str], ABC):
     """[DEPRECATED]"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @root_validator(pre=True)

--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -48,8 +48,6 @@ class BaseMemory(Serializable, ABC):
     """  # noqa: E501
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @property

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -100,8 +100,6 @@ class BasePromptTemplate(
         return True
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @property

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -33,10 +33,8 @@ class _FewShotPromptTemplateMixin(BaseModel):
     Either this or examples should be provided."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = Extra.forbid
 
     @root_validator(pre=True)
     def check_examples_and_selector(cls, values: Dict) -> Dict:
@@ -161,10 +159,8 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
         return values
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = Extra.forbid
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with inputs generating a string.
@@ -370,10 +366,8 @@ class FewShotChatMessagePromptTemplate(
         return False
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = Extra.forbid
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format kwargs into a list of messages.

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -86,10 +86,8 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
         return values
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = Extra.forbid
 
     def _get_examples(self, **kwargs: Any) -> List[dict]:
         if self.examples is not None:

--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -112,8 +112,6 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
     """  # noqa: E501
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     _new_arg_supported: bool = False

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -374,8 +374,6 @@ class ChildTool(BaseTool):
         super().__init__(**kwargs)
 
     class Config(Serializable.Config):
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @property

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -1208,8 +1208,6 @@ class VectorStoreRetriever(BaseRetriever):
     )
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @root_validator(pre=True)


### PR DESCRIPTION
This PR does an aesthetic sort of the config object attributes. This will make it a bit easier to go back and forth between pydantic v1 and pydantic v2 on the 0.3.x branch

```
engine marzano(0.1)
language python


function sort($values) js {
    return $values.text.split(',').sort().join("\n");
}


class_definition($name, $body) as $C where {
    $name <: `Config`,
    $body <: block($statements),
    $values = [],
    $statements <: some bubble($values) assignment() as $A where {
        $values += $A
    },
    $body => sort($values),
}

```