### PR TITLE
docs: rag.ipynb - fixing typo

### DIFF
--- a/docs/docs/tutorials/rag.ipynb
+++ b/docs/docs/tutorials/rag.ipynb
@@ -601,7 +601,7 @@
     "relevant documents, constructs a prompt, passes that to a model, and\n",
     "parses the output.\n",
     "\n",
-    "We’ll use the gpt-3.5-turbo OpenAI chat model, but any LangChain `LLM`\n",
+    "We’ll use the gpt-4o-mini OpenAI chat model, but any LangChain `LLM`\n",
     "or `ChatModel` could be substituted in.\n",
     "\n",
     "```{=mdx}\n",


### PR DESCRIPTION
Just changing gpt-3.5 to gpt-4o-mini . That's what's used in the code examples now. It just didn't get updated in the main text.