### PR TITLE
core[patch]: Fix aindex API

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -435,7 +435,7 @@ async def _to_async_iterator(iterator: Iterable[T]) -> AsyncIterator[T]:
 async def aindex(
     docs_source: Union[BaseLoader, Iterable[Document], AsyncIterator[Document]],
     record_manager: RecordManager,
-    vectorstore: Union[VectorStore, DocumentIndex],
+    vector_store: Union[VectorStore, DocumentIndex],
     *,
     batch_size: int = 100,
     cleanup: Literal["incremental", "full", None] = None,

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -506,7 +506,7 @@ async def aindex(
     if cleanup == "incremental" and source_id_key is None:
         raise ValueError("Source id key is required when cleanup mode is incremental.")
 
-    destination = vectorstore  # Renaming internally for clarity
+    destination = vector_store  # Renaming internally for clarity
 
     # If it's a vectorstore, let's check if it has the required methods.
     if isinstance(destination, VectorStore):


### PR DESCRIPTION
A previous PR accidentally broke the aindex API by renaming a positional argument vectorstore into vector_store. This PR reverts this change.