### PR TITLE
docs: Fix reference to SQL QA migration

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -52,7 +52,7 @@ Now:
 
 `from langchain_experimental.sql import SQLDatabaseChain`
 
-Alternatively, if you are just interested in using the query generation part of the SQL chain, you can check out [`create_sql_query_chain`](https://github.com/langchain-ai/langchain/blob/master/docs/extras/use_cases/tabular/sql_query.ipynb)
+Alternatively, if you are just interested in using the query generation part of the SQL chain, you can check out [`Build a Question/Answering system over SQL data`](https://github.com/JuanFKurucz/langchain/blob/master/docs/docs/tutorials/sql_qa.ipynb)
 
 `from langchain.chains import create_sql_query_chain`
 

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -52,7 +52,7 @@ Now:
 
 `from langchain_experimental.sql import SQLDatabaseChain`
 
-Alternatively, if you are just interested in using the query generation part of the SQL chain, you can check out [`Build a Question/Answering system over SQL data`](https://github.com/JuanFKurucz/langchain/blob/master/docs/docs/tutorials/sql_qa.ipynb)
+Alternatively, if you are just interested in using the query generation part of the SQL chain, you can check out this [`SQL question-answering tutorial`](https://python.langchain.com/v0.2/docs/tutorials/sql_qa/#convert-question-to-sql-query)
 
 `from langchain.chains import create_sql_query_chain`
 


### PR DESCRIPTION
**Description:** I found that the link to the notebook in the Migration notes is broken, i found that it was linked to this file https://github.com/langchain-ai/langchain/blob/v0.0.250/docs/extras/use_cases/tabular/sql_query.ipynb and i think now this tutorial https://github.com/JuanFKurucz/langchain/blob/master/docs/docs/tutorials/sql_qa.ipynb is the best fit for this reference

**Twitter handle:** @juanfkurucz