### PR TITLE
groq[patch]: update rate limit in integration tests

### DIFF
--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -11,7 +11,7 @@ from langchain_standard_tests.integration_tests import (
 
 from langchain_groq import ChatGroq
 
-rate_limiter = InMemoryRateLimiter(requests_per_second=0.45)
+rate_limiter = InMemoryRateLimiter(requests_per_second=0.2)
 
 
 class BaseTestGroq(ChatModelIntegrationTests):


### PR DESCRIPTION
Divide by ~2 to account for testing python 3.8 and 3.12 in parallel.