### PR TITLE
community[patch]: Upgrade pydantic extra

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/ainetwork/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/ainetwork/toolkit.py
@@ -54,12 +54,8 @@ class AINetworkToolkit(BaseToolkit):
         return values
 
     class Config:
-        """Pydantic config."""
-
-        # Allow extra fields. This is needed for the `interface` field.
-        validate_all = True
-        # Allow arbitrary types. This is needed for the `interface` field.
         arbitrary_types_allowed = True
+        validate_all = True
 
     def get_tools(self) -> List[BaseTool]:
         """Get the tools in the toolkit."""

--- a/libs/community/langchain_community/agent_toolkits/amadeus/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/amadeus/toolkit.py
@@ -27,9 +27,6 @@ class AmadeusToolkit(BaseToolkit):
     llm: Optional[BaseLanguageModel] = Field(default=None)
 
     class Config:
-        """Pydantic config."""
-
-        # Allow extra fields. This is needed for the `client` field.
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/cassandra_database/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/cassandra_database/toolkit.py
@@ -25,9 +25,6 @@ class CassandraDatabaseToolkit(BaseToolkit):
     db: CassandraDatabase = Field(exclude=True)
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        # Allow arbitrary types. This is needed for the `db` field.
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/financial_datasets/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/financial_datasets/toolkit.py
@@ -32,8 +32,6 @@ class FinancialDatasetsToolkit(BaseToolkit):
         self.api_wrapper = api_wrapper
 
     class Config:
-        """Pydantic config."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/gmail/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/gmail/toolkit.py
@@ -46,8 +46,6 @@ class GmailToolkit(BaseToolkit):
     api_resource: Resource = Field(default_factory=build_resource_service)
 
     class Config:
-        """Pydantic config."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/multion/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/multion/toolkit.py
@@ -26,8 +26,6 @@ class MultionToolkit(BaseToolkit):
     """
 
     class Config:
-        """Pydantic config."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/office365/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/office365/toolkit.py
@@ -41,8 +41,6 @@ class O365Toolkit(BaseToolkit):
     account: Account = Field(default_factory=authenticate)
 
     class Config:
-        """Pydantic config."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/playwright/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/playwright/toolkit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional, Type, cast
 
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 from langchain_core.tools import BaseTool, BaseToolkit
 
 from langchain_community.tools.playwright.base import (
@@ -69,10 +69,8 @@ class PlayWrightBrowserToolkit(BaseToolkit):
     async_browser: Optional["AsyncBrowser"] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_imports_and_browser_provided(cls, values: dict) -> dict:

--- a/libs/community/langchain_community/agent_toolkits/powerbi/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/powerbi/toolkit.py
@@ -64,8 +64,6 @@ class PowerBIToolkit(BaseToolkit):
     tiktoken_model_name: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/slack/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/slack/toolkit.py
@@ -26,8 +26,6 @@ class SlackToolkit(BaseToolkit):
     client: WebClient = Field(default_factory=login)
 
     class Config:
-        """Pydantic config."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/spark_sql/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/spark_sql/toolkit.py
@@ -28,8 +28,6 @@ class SparkSQLToolkit(BaseToolkit):
     llm: BaseLanguageModel = Field(exclude=True)
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/agent_toolkits/sql/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/sql/toolkit.py
@@ -84,8 +84,6 @@ class SQLDatabaseToolkit(BaseToolkit):
         return self.db.dialect
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def get_tools(self) -> List[BaseTool]:

--- a/libs/community/langchain_community/chains/llm_requests.py
+++ b/libs/community/langchain_community/chains/llm_requests.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from langchain.chains import LLMChain
 from langchain.chains.base import Chain
 from langchain_core.callbacks import CallbackManagerForChainRun
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 
 from langchain_community.utilities.requests import TextRequestsWrapper
 
@@ -39,10 +39,8 @@ class LLMRequestsChain(Chain):
     output_key: str = "output"  #: :meta private:
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @property
     def input_keys(self) -> List[str]:

--- a/libs/community/langchain_community/chains/pebblo_retrieval/base.py
+++ b/libs/community/langchain_community/chains/pebblo_retrieval/base.py
@@ -19,7 +19,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.documents import Document
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.pydantic_v1 import Extra, Field, validator
+from langchain_core.pydantic_v1 import Field, validator
 from langchain_core.vectorstores import VectorStoreRetriever
 
 from langchain_community.chains.pebblo_retrieval.enforcement_filters import (
@@ -205,11 +205,9 @@ class PebbloRetrievalQA(Chain):
             return {self.output_key: answer}
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        extra = "forbid"
 
     @property
     def input_keys(self) -> List[str]:

--- a/libs/community/langchain_community/chat_models/anthropic.py
+++ b/libs/community/langchain_community/chat_models/anthropic.py
@@ -92,8 +92,6 @@ class ChatAnthropic(BaseChatModel, _AnthropicCommon):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
         arbitrary_types_allowed = True
 

--- a/libs/community/langchain_community/chat_models/baichuan.py
+++ b/libs/community/langchain_community/chat_models/baichuan.py
@@ -376,8 +376,6 @@ class ChatBaichuan(BaseChatModel):
     """Holds any model parameters valid for API call not explicitly specified."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
+++ b/libs/community/langchain_community/chat_models/baidu_qianfan_endpoint.py
@@ -380,8 +380,6 @@ class QianfanChatEndpoint(BaseChatModel):
     """Endpoint of the Qianfan LLM, required if custom model used."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/bedrock.py
+++ b/libs/community/langchain_community/chat_models/bedrock.py
@@ -16,7 +16,6 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-from langchain_core.pydantic_v1 import Extra
 
 from langchain_community.chat_models.anthropic import (
     convert_messages_to_prompt_anthropic,
@@ -233,9 +232,7 @@ class BedrockChat(BaseChatModel, BedrockBase):
         return attributes
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _stream(
         self,

--- a/libs/community/langchain_community/chat_models/cohere.py
+++ b/libs/community/langchain_community/chat_models/cohere.py
@@ -118,8 +118,6 @@ class ChatCohere(BaseChatModel, BaseCohere):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
         arbitrary_types_allowed = True
 

--- a/libs/community/langchain_community/chat_models/coze.py
+++ b/libs/community/langchain_community/chat_models/coze.py
@@ -112,8 +112,6 @@ class ChatCoze(BaseChatModel):
     the client needs to assemble the final reply based on the type of message. """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/dappier.py
+++ b/libs/community/langchain_community/chat_models/dappier.py
@@ -13,7 +13,7 @@ from langchain_core.messages import (
     BaseMessage,
 )
 from langchain_core.outputs import ChatGeneration, ChatResult
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 from langchain_community.utilities.requests import Requests
@@ -71,9 +71,7 @@ class ChatDappierAI(BaseChatModel):
     dappier_api_key: Optional[SecretStr] = Field(None, description="Dappier API Token")
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/chat_models/edenai.py
+++ b/libs/community/langchain_community/chat_models/edenai.py
@@ -49,7 +49,6 @@ from langchain_core.output_parsers.openai_tools import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
 )
@@ -298,9 +297,7 @@ class ChatEdenAI(BaseChatModel):
     edenai_api_key: Optional[SecretStr] = Field(None, description="EdenAI API Token")
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/chat_models/hunyuan.py
+++ b/libs/community/langchain_community/chat_models/hunyuan.py
@@ -133,8 +133,6 @@ class ChatHunyuan(BaseChatModel):
     """Holds any model parameters valid for API call not explicitly specified."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
+++ b/libs/community/langchain_community/chat_models/javelin_ai_gateway.py
@@ -18,14 +18,14 @@ from langchain_core.outputs import (
     ChatGeneration,
     ChatResult,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr
 
 logger = logging.getLogger(__name__)
 
 
 # Ignoring type because below is valid pydantic code
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"  [call-arg]
-class ChatParams(BaseModel, extra=Extra.allow):
+class ChatParams(BaseModel, extra="allow"):
     """Parameters for the `Javelin AI Gateway` LLM."""
 
     temperature: float = 0.0
@@ -69,8 +69,6 @@ class ChatJavelinAIGateway(BaseChatModel):
     """The API key for the Javelin AI Gateway."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     def __init__(self, **kwargs: Any):

--- a/libs/community/langchain_community/chat_models/jinachat.py
+++ b/libs/community/langchain_community/chat_models/jinachat.py
@@ -189,8 +189,6 @@ class JinaChat(BaseChatModel):
     """Maximum number of tokens to generate."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/kinetica.py
+++ b/libs/community/langchain_community/chat_models/kinetica.py
@@ -544,8 +544,6 @@ class KineticaSqlResponse(BaseModel):
     """The Pandas dataframe containing the fetched data."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
 
@@ -585,8 +583,6 @@ class KineticaSqlOutputParser(BaseOutputParser[KineticaSqlResponse]):
     """ Kinetica DB connection. """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def parse(self, text: str) -> KineticaSqlResponse:

--- a/libs/community/langchain_community/chat_models/llama_edge.py
+++ b/libs/community/langchain_community/chat_models/llama_edge.py
@@ -85,8 +85,6 @@ class LlamaEdgeChatService(BaseChatModel):
     """Whether to stream the results or not."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/minimax.py
+++ b/libs/community/langchain_community/chat_models/minimax.py
@@ -384,8 +384,6 @@ class MiniMaxChat(BaseChatModel):
     """Whether to stream the results or not."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True, allow_reuse=True)

--- a/libs/community/langchain_community/chat_models/mlflow_ai_gateway.py
+++ b/libs/community/langchain_community/chat_models/mlflow_ai_gateway.py
@@ -18,14 +18,14 @@ from langchain_core.outputs import (
     ChatGeneration,
     ChatResult,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 logger = logging.getLogger(__name__)
 
 
 # Ignoring type because below is valid pydantic code
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"  [call-arg]
-class ChatParams(BaseModel, extra=Extra.allow):
+class ChatParams(BaseModel, extra="allow"):
     """Parameters for the `MLflow AI Gateway` LLM."""
 
     temperature: float = 0.0

--- a/libs/community/langchain_community/chat_models/oci_generative_ai.py
+++ b/libs/community/langchain_community/chat_models/oci_generative_ai.py
@@ -38,7 +38,7 @@ from langchain_core.output_parsers.openai_tools import (
     PydanticToolsParser,
 )
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_function
@@ -500,9 +500,7 @@ class ChatOCIGenAI(BaseChatModel, OCIGenAIBase):
     """  # noqa: E501
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _llm_type(self) -> str:

--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -245,8 +245,6 @@ class ChatOpenAI(BaseChatModel):
     """Optional httpx.Client."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/perplexity.py
+++ b/libs/community/langchain_community/chat_models/perplexity.py
@@ -82,8 +82,6 @@ class ChatPerplexity(BaseChatModel):
     """Maximum number of tokens to generate."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @property

--- a/libs/community/langchain_community/chat_models/premai.py
+++ b/libs/community/langchain_community/chat_models/premai.py
@@ -40,7 +40,6 @@ from langchain_core.messages import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
 )
@@ -299,11 +298,9 @@ class ChatPremAI(BaseChatModel, BaseModel):
     client: Any
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         allow_population_by_field_name = True
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @pre_init
     def validate_environments(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/chat_models/solar.py
+++ b/libs/community/langchain_community/chat_models/solar.py
@@ -31,8 +31,6 @@ class SolarChat(SolarCommon, ChatOpenAI):
 
     # this is needed to match ChatOpenAI superclass
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
         arbitrary_types_allowed = True
         extra = "ignore"

--- a/libs/community/langchain_community/chat_models/sparkllm.py
+++ b/libs/community/langchain_community/chat_models/sparkllm.py
@@ -246,8 +246,6 @@ class ChatSparkLLM(BaseChatModel):
     """Holds any model parameters valid for API call not explicitly specified."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -458,8 +458,6 @@ class ChatTongyi(BaseChatModel):
     """Maximum number of retries to make when generating."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @property

--- a/libs/community/langchain_community/chat_models/yuan2.py
+++ b/libs/community/langchain_community/chat_models/yuan2.py
@@ -121,8 +121,6 @@ class ChatYuan2(BaseChatModel):
     """The penalty to apply to repeated tokens."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @property

--- a/libs/community/langchain_community/chat_models/zhipuai.py
+++ b/libs/community/langchain_community/chat_models/zhipuai.py
@@ -373,8 +373,6 @@ class ChatZhipuAI(BaseChatModel):
     """Maximum number of tokens to generate."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/cross_encoders/huggingface.py
+++ b/libs/community/langchain_community/cross_encoders/huggingface.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Tuple
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 
 from langchain_community.cross_encoders.base import BaseCrossEncoder
 
@@ -46,9 +46,7 @@ class HuggingFaceCrossEncoder(BaseModel, BaseCrossEncoder):
         )
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def score(self, text_pairs: List[Tuple[str, str]]) -> List[float]:
         """Compute similarity scores using a HuggingFace transformer model.

--- a/libs/community/langchain_community/cross_encoders/sagemaker_endpoint.py
+++ b/libs/community/langchain_community/cross_encoders/sagemaker_endpoint.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 from langchain_community.cross_encoders.base import BaseCrossEncoder
 
@@ -90,10 +90,8 @@ class SagemakerEndpointCrossEncoder(BaseModel, BaseCrossEncoder):
    """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/document_compressors/dashscope_rerank.py
+++ b/libs/community/langchain_community/document_compressors/dashscope_rerank.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.callbacks.base import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -26,11 +26,9 @@ class DashScopeRerank(BaseDocumentCompressor):
         DASHSCOPE_API_KEY."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/document_compressors/flashrank_rerank.py
+++ b/libs/community/langchain_community/document_compressors/flashrank_rerank.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Sequence
 
 from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 
 if TYPE_CHECKING:
     from flashrank import Ranker, RerankRequest
@@ -34,10 +34,8 @@ class FlashrankRerank(BaseDocumentCompressor):
     """Prefix for flashrank_rerank metadata keys"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/document_compressors/jina_rerank.py
+++ b/libs/community/langchain_community/document_compressors/jina_rerank.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import requests
 from langchain_core.callbacks import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 JINA_API_URL: str = "https://api.jina.ai/v1/rerank"
@@ -28,10 +28,8 @@ class JinaRerank(BaseDocumentCompressor):
     """Identifier for the application making the request."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/document_compressors/llmlingua_filter.py
+++ b/libs/community/langchain_community/document_compressors/llmlingua_filter.py
@@ -72,10 +72,8 @@ class LLMLinguaCompressor(BaseDocumentCompressor):
         return values
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = "forbid"
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @staticmethod
     def _format_context(docs: Sequence[Document]) -> List[str]:

--- a/libs/community/langchain_community/document_compressors/rankllm_rerank.py
+++ b/libs/community/langchain_community/document_compressors/rankllm_rerank.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
 from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
 from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import Extra, Field, PrivateAttr, root_validator
+from langchain_core.pydantic_v1 import Field, PrivateAttr, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 if TYPE_CHECKING:
@@ -37,10 +37,8 @@ class RankLLMRerank(BaseDocumentCompressor):
     _retriever: Any = PrivateAttr()
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/document_compressors/volcengine_rerank.py
+++ b/libs/community/langchain_community/document_compressors/volcengine_rerank.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.callbacks.base import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -33,11 +33,9 @@ class VolcengineRerank(BaseDocumentCompressor):
     """Number of documents to return."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/document_loaders/base_o365.py
+++ b/libs/community/langchain_community/document_loaders/base_o365.py
@@ -38,9 +38,9 @@ class _O365Settings(BaseSettings):
     client_secret: SecretStr = Field(..., env="O365_CLIENT_SECRET")
 
     class Config:
-        env_prefix = ""
         case_sentive = False
         env_file = ".env"
+        env_prefix = ""
 
 
 class _O365TokenStorage(BaseSettings):

--- a/libs/community/langchain_community/document_loaders/onedrive_file.py
+++ b/libs/community/langchain_community/document_loaders/onedrive_file.py
@@ -23,8 +23,6 @@ class OneDriveFileLoader(BaseLoader, BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        """Allow arbitrary types. This is needed for the File type. Default is True.
-         See https://pydantic-docs.helpmanual.io/usage/types/#arbitrary-types-allowed"""
 
     def load(self) -> List[Document]:
         """Load Documents"""

--- a/libs/community/langchain_community/document_loaders/onenote.py
+++ b/libs/community/langchain_community/document_loaders/onenote.py
@@ -21,11 +21,9 @@ class _OneNoteGraphSettings(BaseSettings):
     client_secret: SecretStr = Field(..., env="MS_GRAPH_CLIENT_SECRET")
 
     class Config:
-        """Config for OneNoteGraphSettings."""
-
-        env_prefix = ""
         case_sentive = False
         env_file = ".env"
+        env_prefix = ""
 
 
 class OneNoteLoader(BaseLoader, BaseModel):

--- a/libs/community/langchain_community/document_transformers/embeddings_redundant_filter.py
+++ b/libs/community/langchain_community/document_transformers/embeddings_redundant_filter.py
@@ -154,8 +154,6 @@ class EmbeddingsRedundantFilter(BaseDocumentTransformer, BaseModel):
     to be considered redundant."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def transform_documents(
@@ -204,8 +202,6 @@ class EmbeddingsClusteringFilter(BaseDocumentTransformer, BaseModel):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def transform_documents(

--- a/libs/community/langchain_community/document_transformers/long_context_reorder.py
+++ b/libs/community/langchain_community/document_transformers/long_context_reorder.py
@@ -30,8 +30,6 @@ class LongContextReorder(BaseDocumentTransformer, BaseModel):
     See: https://arxiv.org/abs//2307.03172"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def transform_documents(

--- a/libs/community/langchain_community/embeddings/baichuan.py
+++ b/libs/community/langchain_community/embeddings/baichuan.py
@@ -59,8 +59,6 @@ class BaichuanTextEmbeddings(BaseModel, Embeddings):
     """Chunk size when multiple texts are input"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(allow_reuse=True)

--- a/libs/community/langchain_community/embeddings/bedrock.py
+++ b/libs/community/langchain_community/embeddings/bedrock.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 from langchain_core._api.deprecation import deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.runnables.config import run_in_executor
 
 
@@ -75,9 +75,7 @@ class BedrockEmbeddings(BaseModel, Embeddings):
     """Whether the embeddings should be normalized to unit vectors"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/clarifai.py
+++ b/libs/community/langchain_community/embeddings/clarifai.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +44,7 @@ class ClarifaiEmbeddings(BaseModel, Embeddings):
     api_base: str = "https://api.clarifai.com"
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/cloudflare_workersai.py
+++ b/libs/community/langchain_community/embeddings/cloudflare_workersai.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 DEFAULT_MODEL_NAME = "@cf/baai/bge-base-en-v1.5"
 
@@ -44,9 +44,7 @@ class CloudflareWorkersAIEmbeddings(BaseModel, Embeddings):
         self.headers = {"Authorization": f"Bearer {self.api_token}"}
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using Cloudflare Workers AI.

--- a/libs/community/langchain_community/embeddings/clova.py
+++ b/libs/community/langchain_community/embeddings/clova.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, cast
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 
@@ -54,7 +54,7 @@ class ClovaEmbeddings(BaseModel, Embeddings):
     """Application ID for identifying your application."""
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True, allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/cohere.py
+++ b/libs/community/langchain_community/embeddings/cohere.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from langchain_core._api.deprecation import deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_community.llms.cohere import _create_retry_decorator
@@ -50,9 +50,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
     """Identifier for the application making the request."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -10,7 +10,7 @@ from typing import (
 )
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 from requests.exceptions import HTTPError
 from tenacity import (
@@ -109,9 +109,7 @@ class DashScopeEmbeddings(BaseModel, Embeddings):
     """Maximum number of retries to make when generating."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/deepinfra.py
+++ b/libs/community/langchain_community/embeddings/deepinfra.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 DEFAULT_MODEL_ID = "sentence-transformers/clip-ViT-B-32"
@@ -55,9 +55,7 @@ class DeepInfraEmbeddings(BaseModel, Embeddings):
     """Batch size for embedding requests."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/edenai.py
+++ b/libs/community/langchain_community/embeddings/edenai.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
 )
@@ -30,9 +29,7 @@ class EdenAiEmbeddings(BaseModel, Embeddings):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/embaas.py
+++ b/libs/community/langchain_community/embeddings/embaas.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 from requests.adapters import HTTPAdapter, Retry
 from typing_extensions import NotRequired, TypedDict
@@ -57,9 +57,7 @@ class EmbaasEmbeddings(BaseModel, Embeddings):
     timeout: Optional[int] = 30
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/fastembed.py
+++ b/libs/community/langchain_community/embeddings/fastembed.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import pre_init
 
 MIN_VERSION = "0.2.0"
@@ -67,9 +67,7 @@ class FastEmbedEmbeddings(BaseModel, Embeddings):
     _model: Any  # : :meta private:
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.allow
+        extra = "allow"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/gradient_ai.py
+++ b/libs/community/langchain_community/embeddings/gradient_ai.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 from packaging.version import parse
 
@@ -51,9 +51,7 @@ class GradientEmbeddings(BaseModel, Embeddings):
 
     # LLM call kwargs
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 import requests
 from langchain_core._api import deprecated, warn_deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr
 
 DEFAULT_MODEL_NAME = "sentence-transformers/all-mpnet-base-v2"
 DEFAULT_INSTRUCT_MODEL = "hkunlp/instructor-large"
@@ -81,9 +81,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         )
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace transformer model.
@@ -185,9 +183,7 @@ class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
             self.show_progress = self.encode_kwargs.pop("show_progress_bar")
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace instruct model.
@@ -314,9 +310,7 @@ class HuggingFaceBgeEmbeddings(BaseModel, Embeddings):
             self.show_progress = self.encode_kwargs.pop("show_progress_bar")
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace transformer model.

--- a/libs/community/langchain_community/embeddings/huggingface_hub.py
+++ b/libs/community/langchain_community/embeddings/huggingface_hub.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from langchain_core._api import deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 DEFAULT_MODEL = "sentence-transformers/all-mpnet-base-v2"
@@ -48,9 +48,7 @@ class HuggingFaceHubEmbeddings(BaseModel, Embeddings):
     huggingfacehub_api_token: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/infinity.py
+++ b/libs/community/langchain_community/embeddings/infinity.py
@@ -8,7 +8,7 @@ import aiohttp
 import numpy as np
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 __all__ = ["InfinityEmbeddings"]
@@ -45,9 +45,7 @@ class InfinityEmbeddings(BaseModel, Embeddings):
 
     # LLM call kwargs
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/infinity_local.py
+++ b/libs/community/langchain_community/embeddings/infinity_local.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 __all__ = ["InfinityEmbeddingsLocal"]
 
@@ -58,9 +58,7 @@ class InfinityEmbeddingsLocal(BaseModel, Embeddings):
 
     # LLM call kwargs
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/ipex_llm.py
+++ b/libs/community/langchain_community/embeddings/ipex_llm.py
@@ -4,7 +4,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 
 DEFAULT_BGE_MODEL = "BAAI/bge-small-en-v1.5"
 DEFAULT_QUERY_BGE_INSTRUCTION_EN = (
@@ -107,9 +107,7 @@ class IpexLLMBgeEmbeddings(BaseModel, Embeddings):
             self.query_instruction = DEFAULT_QUERY_BGE_INSTRUCTION_ZH
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace transformer model.

--- a/libs/community/langchain_community/embeddings/itrex.py
+++ b/libs/community/langchain_community/embeddings/itrex.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 
 class QuantizedBgeEmbeddings(BaseModel, Embeddings):
@@ -119,9 +119,7 @@ class QuantizedBgeEmbeddings(BaseModel, Embeddings):
         )
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.allow
+        extra = "allow"
 
     def _embed(self, inputs: Any) -> Any:
         import torch

--- a/libs/community/langchain_community/embeddings/johnsnowlabs.py
+++ b/libs/community/langchain_community/embeddings/johnsnowlabs.py
@@ -3,7 +3,7 @@ import sys
 from typing import Any, List
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 
 class JohnSnowLabsEmbeddings(BaseModel, Embeddings):
@@ -59,9 +59,7 @@ class JohnSnowLabsEmbeddings(BaseModel, Embeddings):
             raise Exception("Failure loading model") from exc
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a JohnSnowLabs transformer model.

--- a/libs/community/langchain_community/embeddings/laser.py
+++ b/libs/community/langchain_community/embeddings/laser.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import pre_init
 
 LASER_MULTILINGUAL_MODEL: str = "laser2"
@@ -38,9 +38,7 @@ class LaserEmbeddings(BaseModel, Embeddings):
     _encoder_pipeline: Any  # : :meta private:
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/llamacpp.py
+++ b/libs/community/langchain_community/embeddings/llamacpp.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 
 
 class LlamaCppEmbeddings(BaseModel, Embeddings):
@@ -58,9 +58,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
     """Print verbose output to stderr."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/llm_rails.py
+++ b/libs/community/langchain_community/embeddings/llm_rails.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 
@@ -33,9 +33,7 @@ class LLMRailsEmbeddings(BaseModel, Embeddings):
     """LLMRails API key."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/localai.py
+++ b/libs/community/langchain_community/embeddings/localai.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import (
     get_from_dict_or_env,
     get_pydantic_field_names,
@@ -167,9 +167,7 @@ class LocalAIEmbeddings(BaseModel, Embeddings):
     """Holds any model parameters valid for `create` call not explicitly specified."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/embeddings/minimax.py
+++ b/libs/community/langchain_community/embeddings/minimax.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 from tenacity import (
     before_sleep_log,
@@ -118,10 +118,8 @@ class MiniMaxEmbeddings(BaseModel, Embeddings):
     """API Key for MiniMax API."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         allow_population_by_field_name = True
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/modelscope_hub.py
+++ b/libs/community/langchain_community/embeddings/modelscope_hub.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 
 class ModelScopeEmbeddings(BaseModel, Embeddings):
@@ -40,9 +40,7 @@ class ModelScopeEmbeddings(BaseModel, Embeddings):
         )
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a modelscope embedding model.

--- a/libs/community/langchain_community/embeddings/mosaicml.py
+++ b/libs/community/langchain_community/embeddings/mosaicml.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -42,9 +42,7 @@ class MosaicMLInstructorEmbeddings(BaseModel, Embeddings):
     mosaicml_api_token: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/oci_generative_ai.py
+++ b/libs/community/langchain_community/embeddings/oci_generative_ai.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict, Iterator, List, Mapping, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import pre_init
 
 CUSTOM_ENDPOINT_PREFIX = "ocid1.generativeaiendpoint"
@@ -86,9 +86,7 @@ class OCIGenAIEmbeddings(BaseModel, Embeddings):
      per request"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:  # pylint: disable=no-self-argument

--- a/libs/community/langchain_community/embeddings/ollama.py
+++ b/libs/community/langchain_community/embeddings/ollama.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +142,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
         return {**{"model": self.model}, **self._default_params}
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _process_emb_response(self, input: str) -> List[float]:
         """Process a response from the API.

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -21,7 +21,7 @@ from typing import (
 import numpy as np
 from langchain_core._api.deprecation import deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import (
     get_from_dict_or_env,
     get_pydantic_field_names,
@@ -255,10 +255,8 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Optional httpx.Client."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         allow_population_by_field_name = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/embeddings/openvino.py
+++ b/libs/community/langchain_community/embeddings/openvino.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 
 DEFAULT_QUERY_INSTRUCTION = (
     "Represent the question for retrieving supporting documents: "
@@ -255,9 +255,7 @@ class OpenVINOEmbeddings(BaseModel, Embeddings):
         return all_embeddings
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace transformer model.

--- a/libs/community/langchain_community/embeddings/optimum_intel.py
+++ b/libs/community/langchain_community/embeddings/optimum_intel.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 
 class QuantizedBiEncoderEmbeddings(BaseModel, Embeddings):
@@ -101,9 +101,7 @@ For more information, please visit:
         self.transformer_model.eval()
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.allow
+        extra = "allow"
 
     def _embed(self, inputs: Any) -> Any:
         try:

--- a/libs/community/langchain_community/embeddings/oracleai.py
+++ b/libs/community/langchain_community/embeddings/oracleai.py
@@ -14,7 +14,7 @@ import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 if TYPE_CHECKING:
     from oracledb import Connection
@@ -38,9 +38,7 @@ class OracleEmbeddings(BaseModel, Embeddings):
         super().__init__(**kwargs)
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     """
     1 - user needs to have create procedure, 

--- a/libs/community/langchain_community/embeddings/ovhcloud.py
+++ b/libs/community/langchain_community/embeddings/ovhcloud.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +24,7 @@ class OVHCloudEmbeddings(BaseModel, Embeddings):
     region: str = "kepler"
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)

--- a/libs/community/langchain_community/embeddings/sagemaker_endpoint.py
+++ b/libs/community/langchain_community/embeddings/sagemaker_endpoint.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import pre_init
 
 from langchain_community.llms.sagemaker_endpoint import ContentHandlerBase
@@ -111,10 +111,8 @@ class SagemakerEndpointEmbeddings(BaseModel, Embeddings):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/self_hosted.py
+++ b/libs/community/langchain_community/embeddings/self_hosted.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, List
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import Extra
 
 from langchain_community.llms.self_hosted import SelfHostedPipeline
 
@@ -67,9 +66,7 @@ class SelfHostedEmbeddings(SelfHostedPipeline, Embeddings):
     """Any kwargs to pass to the model's inference function."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace transformer model.

--- a/libs/community/langchain_community/embeddings/solar.py
+++ b/libs/community/langchain_community/embeddings/solar.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional
 import requests
 from langchain_core._api import deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 from tenacity import (
     before_sleep_log,
@@ -76,9 +76,7 @@ class SolarEmbeddings(BaseModel, Embeddings):
     """API Key for Solar API."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/spacy_embeddings.py
+++ b/libs/community/langchain_community/embeddings/spacy_embeddings.py
@@ -2,7 +2,7 @@ import importlib.util
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class SpacyEmbeddings(BaseModel, Embeddings):
@@ -23,9 +23,7 @@ class SpacyEmbeddings(BaseModel, Embeddings):
     nlp: Optional[Any] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid  # Forbid extra attributes during model initialization
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/sparkllm.py
+++ b/libs/community/langchain_community/embeddings/sparkllm.py
@@ -116,8 +116,6 @@ class SparkLLMTextEmbeddings(BaseModel, Embeddings):
     If "query", it belongs to query Embedding."""
 
     class Config:
-        """Configuration for this pydantic object"""
-
         allow_population_by_field_name = True
 
     @root_validator(allow_reuse=True)

--- a/libs/community/langchain_community/embeddings/tensorflow_hub.py
+++ b/libs/community/langchain_community/embeddings/tensorflow_hub.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 DEFAULT_MODEL_URL = "https://tfhub.dev/google/universal-sentence-encoder-multilingual/3"
 
@@ -44,9 +44,7 @@ class TensorflowHubEmbeddings(BaseModel, Embeddings):
         self.embed = tensorflow_hub.load(self.model_url)
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a TensorflowHub embedding model.

--- a/libs/community/langchain_community/embeddings/textembed.py
+++ b/libs/community/langchain_community/embeddings/textembed.py
@@ -17,7 +17,7 @@ import aiohttp
 import numpy as np
 import requests
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 __all__ = ["TextEmbedEmbeddings"]
@@ -60,9 +60,7 @@ class TextEmbedEmbeddings(BaseModel, Embeddings):
     """TextEmbed client."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/voyageai.py
+++ b/libs/community/langchain_community/embeddings/voyageai.py
@@ -16,7 +16,7 @@ from typing import (
 import requests
 from langchain_core._api.deprecation import deprecated
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 from tenacity import (
     before_sleep_log,
@@ -100,9 +100,7 @@ class VoyageEmbeddings(BaseModel, Embeddings):
         raised if any given text exceeds the context length."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/yandex.py
+++ b/libs/community/langchain_community/embeddings/yandex.py
@@ -72,8 +72,6 @@ class YandexGPTEmbeddings(BaseModel, Embeddings):
     _grpc_metadata: Sequence
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @pre_init

--- a/libs/community/langchain_community/llms/ai21.py
+++ b/libs/community/langchain_community/llms/ai21.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, cast
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr
+from langchain_core.pydantic_v1 import BaseModel, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 
@@ -69,9 +69,7 @@ class AI21(LLM):
     """Base url to use, if None decides based on model name."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/aleph_alpha.py
+++ b/libs/community/langchain_community/llms/aleph_alpha.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr
+from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -163,9 +163,7 @@ class AlephAlpha(LLM):
     by de-prioritizing your request below concurrent ones."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/amazon_api_gateway.py
+++ b/libs/community/langchain_community/llms/amazon_api_gateway.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 
 from langchain_community.llms.utils import enforce_stop_tokens
 
@@ -45,9 +44,7 @@ class AmazonAPIGateway(LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:

--- a/libs/community/langchain_community/llms/anthropic.py
+++ b/libs/community/langchain_community/llms/anthropic.py
@@ -181,8 +181,6 @@ class Anthropic(LLM, _AnthropicCommon):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
         arbitrary_types_allowed = True
 

--- a/libs/community/langchain_community/llms/arcee.py
+++ b/libs/community/langchain_community/llms/arcee.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 from langchain_community.utilities.arcee import ArceeWrapper, DALMFilter
@@ -52,9 +52,7 @@ class Arcee(LLM):
     """Keyword arguments to pass to the model."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
         underscore_attrs_are_private = True
 
     @property

--- a/libs/community/langchain_community/llms/aviary.py
+++ b/libs/community/langchain_community/llms/aviary.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union, cast
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -123,9 +123,7 @@ class Aviary(LLM):
     version: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/bananadev.py
+++ b/libs/community/langchain_community/llms/bananadev.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional, cast
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -41,9 +41,7 @@ class Banana(LLM):
     banana_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/beam.py
+++ b/libs/community/langchain_community/llms/beam.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 logger = logging.getLogger(__name__)
@@ -73,9 +73,7 @@ class Beam(LLM):
     app_id: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -21,7 +21,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -779,9 +779,7 @@ class Bedrock(LLM, BedrockBase):
         return attributes
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _stream(
         self,

--- a/libs/community/langchain_community/llms/cerebriumai.py
+++ b/libs/community/langchain_community/llms/cerebriumai.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Mapping, Optional, cast
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -40,9 +40,7 @@ class CerebriumAI(LLM):
     cerebriumai_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/clarifai.py
+++ b/libs/community/langchain_community/llms/clarifai.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import Generation, LLMResult
-from langchain_core.pydantic_v1 import Extra, Field
+from langchain_core.pydantic_v1 import Field
 from langchain_core.utils import pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -50,9 +50,7 @@ class Clarifai(LLM):
     api_base: str = "https://api.clarifai.com"
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/cohere.py
+++ b/libs/community/langchain_community/llms/cohere.py
@@ -10,7 +10,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.load.serializable import Serializable
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr
+from langchain_core.pydantic_v1 import Field, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 from tenacity import (
     before_sleep_log,
@@ -162,9 +162,7 @@ class Cohere(LLM, BaseCohere):
     """Maximum number of retries to make when generating."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _default_params(self) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/databricks.py
+++ b/libs/community/langchain_community/llms/databricks.py
@@ -9,7 +9,6 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import LLM
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     PrivateAttr,
     root_validator,
@@ -397,7 +396,7 @@ class Databricks(LLM):
     _client: _DatabricksClientBase = PrivateAttr()
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
         underscore_attrs_are_private = True
 
     @property

--- a/libs/community/langchain_community/llms/deepinfra.py
+++ b/libs/community/langchain_community/llms/deepinfra.py
@@ -8,7 +8,6 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.utilities.requests import Requests
@@ -39,9 +38,7 @@ class DeepInfra(LLM):
     deepinfra_api_token: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/edenai.py
+++ b/libs/community/langchain_community/llms/edenai.py
@@ -9,7 +9,7 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -69,9 +69,7 @@ class EdenAI(LLM):
     """Stop sequences to use."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/forefrontai.py
+++ b/libs/community/langchain_community/llms/forefrontai.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -47,9 +47,7 @@ class ForefrontAI(LLM):
     """Base url to use, if None decides based on model name."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/gooseai.py
+++ b/libs/community/langchain_community/llms/gooseai.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 logger = logging.getLogger(__name__)
@@ -63,9 +63,7 @@ class GooseAI(LLM):
     gooseai_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.ignore
+        extra = "ignore"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/gpt4all.py
+++ b/libs/community/langchain_community/llms/gpt4all.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field
+from langchain_core.pydantic_v1 import Field
 from langchain_core.utils import pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -97,9 +97,7 @@ class GPT4All(LLM):
     client: Any = None  #: :meta private:
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @staticmethod
     def _model_param_names() -> Set[str]:

--- a/libs/community/langchain_community/llms/gradient_ai.py
+++ b/libs/community/langchain_community/llms/gradient_ai.py
@@ -11,7 +11,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, LLMResult
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -74,10 +74,8 @@ class GradientLLM(BaseLLM):
 
     # LLM call kwargs
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/huggingface_endpoint.py
+++ b/libs/community/langchain_community/llms/huggingface_endpoint.py
@@ -10,7 +10,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import (
     get_pydantic_field_names,
     pre_init,
@@ -127,9 +127,7 @@ class HuggingFaceEndpoint(LLM):
     Should be a task that returns `generated_text` or `summary_text`."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/huggingface_hub.py
+++ b/libs/community/langchain_community/llms/huggingface_hub.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Mapping, Optional
 from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -57,9 +56,7 @@ class HuggingFaceHub(LLM):
     huggingfacehub_api_token: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/huggingface_pipeline.py
+++ b/libs/community/langchain_community/llms/huggingface_pipeline.py
@@ -8,7 +8,6 @@ from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
-from langchain_core.pydantic_v1 import Extra
 
 DEFAULT_MODEL_ID = "gpt2"
 DEFAULT_TASK = "text-generation"
@@ -71,9 +70,7 @@ class HuggingFacePipeline(BaseLLM):
     """Batch size to use when passing multiple documents to generate."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def from_model_id(

--- a/libs/community/langchain_community/llms/huggingface_text_gen_inference.py
+++ b/libs/community/langchain_community/llms/huggingface_text_gen_inference.py
@@ -8,7 +8,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_pydantic_field_names, pre_init
 
 logger = logging.getLogger(__name__)
@@ -104,9 +104,7 @@ class HuggingFaceTextGenInference(LLM):
     async_client: Any
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/ipex_llm.py
+++ b/libs/community/langchain_community/llms/ipex_llm.py
@@ -3,7 +3,6 @@ from typing import Any, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 
 DEFAULT_MODEL_ID = "gpt2"
 
@@ -33,9 +32,7 @@ class IpexLLM(LLM):
     """Whether to stream the results, token by token."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def from_model_id(

--- a/libs/community/langchain_community/llms/javelin_ai_gateway.py
+++ b/libs/community/langchain_community/llms/javelin_ai_gateway.py
@@ -7,12 +7,12 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 
 # Ignoring type because below is valid pydantic code
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class Params(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class Params(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Parameters for the Javelin AI Gateway LLM."""
 
     temperature: float = 0.0

--- a/libs/community/langchain_community/llms/konko.py
+++ b/libs/community/langchain_community/llms/konko.py
@@ -9,7 +9,7 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import SecretStr, root_validator
 
 from langchain_community.utils.openai import is_openai_v1
 
@@ -61,9 +61,7 @@ class Konko(LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/llamafile.py
+++ b/libs/community/langchain_community/llms/llamafile.py
@@ -8,7 +8,6 @@ import requests
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_pydantic_field_names
 
 
@@ -114,9 +113,7 @@ class Llamafile(LLM):
     """Set the Mirostat learning rate, parameter eta. Default: 0.1."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _llm_type(self) -> str:

--- a/libs/community/langchain_community/llms/manifest.py
+++ b/libs/community/langchain_community/llms/manifest.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import pre_init
 
 
@@ -13,9 +12,7 @@ class ManifestWrapper(LLM):
     llm_kwargs: Optional[Dict] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/mlflow_ai_gateway.py
+++ b/libs/community/langchain_community/llms/mlflow_ai_gateway.py
@@ -5,12 +5,12 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 
 
 # Ignoring type because below is valid pydantic code
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class Params(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class Params(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Parameters for the MLflow AI Gateway LLM."""
 
     temperature: float = 0.0

--- a/libs/community/langchain_community/llms/mlx_pipeline.py
+++ b/libs/community/langchain_community/llms/mlx_pipeline.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Iterator, List, Mapping, Optional
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra
 
 DEFAULT_MODEL_ID = "mlx-community/quantized-gemma-2b"
 
@@ -76,9 +75,7 @@ class MLXPipeline(LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def from_model_id(

--- a/libs/community/langchain_community/llms/modal.py
+++ b/libs/community/langchain_community/llms/modal.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 
 from langchain_community.llms.utils import enforce_stop_tokens
 
@@ -35,9 +35,7 @@ class Modal(LLM):
     explicitly specified."""
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/moonshot.py
+++ b/libs/community/langchain_community/llms/moonshot.py
@@ -45,8 +45,6 @@ class MoonshotCommon(BaseModel):
     """Temperature parameter (higher values make the model more creative)."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @property
@@ -115,8 +113,6 @@ class Moonshot(MoonshotCommon, LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     def _call(

--- a/libs/community/langchain_community/llms/mosaicml.py
+++ b/libs/community/langchain_community/llms/mosaicml.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -60,9 +59,7 @@ class MosaicML(LLM):
     mosaicml_api_token: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/nlpcloud.py
+++ b/libs/community/langchain_community/llms/nlpcloud.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr
+from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 
@@ -52,9 +52,7 @@ class NLPCloud(LLM):
     nlpcloud_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/oci_generative_ai.py
+++ b/libs/community/langchain_community/llms/oci_generative_ai.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterator, List, Mapping, Optional
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -231,9 +231,7 @@ class OCIGenAI(LLM, OCIGenAIBase):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _llm_type(self) -> str:

--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -23,7 +23,6 @@ from langchain_core.callbacks import (
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import GenerationChunk, LLMResult
-from langchain_core.pydantic_v1 import Extra
 
 
 def _stream_response_to_generation_chunk(
@@ -399,9 +398,7 @@ class Ollama(BaseLLM, _OllamaCommon):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _llm_type(self) -> str:

--- a/libs/community/langchain_community/llms/opaqueprompts.py
+++ b/libs/community/langchain_community/llms/opaqueprompts.py
@@ -5,7 +5,6 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.language_models.llms import LLM
 from langchain_core.messages import AIMessage
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 logger = logging.getLogger(__name__)
@@ -34,9 +33,7 @@ class OpaquePrompts(LLM):
     """The base LLM to use."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/openai.py
+++ b/libs/community/langchain_community/llms/openai.py
@@ -259,8 +259,6 @@ class BaseOpenAI(BaseLLM):
         return super().__new__(cls)
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/llms/petals.py
+++ b/libs/community/langchain_community/llms/petals.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -63,9 +63,7 @@ class Petals(LLM):
     huggingface_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/pipelineai.py
+++ b/libs/community/langchain_community/llms/pipelineai.py
@@ -5,7 +5,6 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
     root_validator,
@@ -43,9 +42,7 @@ class PipelineAI(LLM, BaseModel):
     pipeline_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic config."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/predictionguard.py
+++ b/libs/community/langchain_community/llms/predictionguard.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -49,9 +48,7 @@ class PredictionGuard(LLM):
     stop: Optional[List[str]] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/replicate.py
+++ b/libs/community/langchain_community/llms/replicate.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 if TYPE_CHECKING:
@@ -56,10 +56,8 @@ class Replicate(LLM):
     """Stop sequences to early-terminate generation."""
 
     class Config:
-        """Configuration for this pydantic config."""
-
         allow_population_by_field_name = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def lc_secrets(self) -> Dict[str, str]:

--- a/libs/community/langchain_community/llms/rwkv.py
+++ b/libs/community/langchain_community/llms/rwkv.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils import pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -75,9 +75,7 @@ class RWKV(LLM, BaseModel):
     model_state: Any = None  #: :meta private:
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @property
     def _default_params(self) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/sagemaker_endpoint.py
+++ b/libs/community/langchain_community/llms/sagemaker_endpoint.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Generic, Iterator, List, Mapping, Optional, TypeVa
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -246,9 +245,7 @@ class SagemakerEndpoint(LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/sambanova.py
+++ b/libs/community/langchain_community/llms/sambanova.py
@@ -5,7 +5,6 @@ import requests
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 
@@ -211,9 +210,7 @@ class Sambaverse(LLM):
     """Streaming flag to get streamed response."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def is_lc_serializable(cls) -> bool:
@@ -716,9 +713,7 @@ class SambaStudio(LLM):
     """Streaming flag to get streamed response."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/community/langchain_community/llms/self_hosted.py
+++ b/libs/community/langchain_community/llms/self_hosted.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 
 from langchain_community.llms.utils import enforce_stop_tokens
 
@@ -145,9 +144,7 @@ class SelfHostedPipeline(LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def __init__(self, **kwargs: Any):
         """Init the pipeline with an auxiliary function.

--- a/libs/community/langchain_community/llms/self_hosted_hugging_face.py
+++ b/libs/community/langchain_community/llms/self_hosted_hugging_face.py
@@ -3,7 +3,6 @@ import logging
 from typing import Any, Callable, List, Mapping, Optional
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
-from langchain_core.pydantic_v1 import Extra
 
 from langchain_community.llms.self_hosted import SelfHostedPipeline
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -170,9 +169,7 @@ class SelfHostedHuggingFaceLLM(SelfHostedPipeline):
     """Inference function to send to the remote hardware."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def __init__(self, **kwargs: Any):
         """Construct the pipeline remotely using an auxiliary function.

--- a/libs/community/langchain_community/llms/stochasticai.py
+++ b/libs/community/langchain_community/llms/stochasticai.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -36,9 +36,7 @@ class StochasticAI(LLM):
     stochasticai_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/llms/symblai_nebula.py
+++ b/libs/community/langchain_community/llms/symblai_nebula.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr
+from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 from requests import ConnectTimeout, ReadTimeout, RequestException
 from tenacity import (
@@ -61,9 +61,7 @@ class Nebula(LLM):
     max_retries: Optional[int] = 10
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/together.py
+++ b/libs/community/langchain_community/llms/together.py
@@ -10,7 +10,7 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 from langchain_community.utilities.requests import Requests
@@ -67,9 +67,7 @@ class Together(LLM):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/llms/watsonxllm.py
+++ b/libs/community/langchain_community/llms/watsonxllm.py
@@ -6,7 +6,7 @@ from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
-from langchain_core.pydantic_v1 import Extra, SecretStr
+from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
 logger = logging.getLogger(__name__)
@@ -96,9 +96,7 @@ class WatsonxLLM(BaseLLM):
     watsonx_model: Any
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/community/langchain_community/llms/weight_only_quantization.py
+++ b/libs/community/langchain_community/llms/weight_only_quantization.py
@@ -3,7 +3,6 @@ from typing import Any, List, Mapping, Optional
 
 from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 
 from langchain_community.llms.utils import enforce_stop_tokens
 
@@ -73,9 +72,7 @@ class WeightOnlyQuantPipeline(LLM):
     """Key word arguments passed to the pipeline."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.allow
+        extra = "allow"
 
     @classmethod
     def from_model_id(

--- a/libs/community/langchain_community/llms/writer.py
+++ b/libs/community/langchain_community/llms/writer.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Mapping, Optional
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.utils import get_from_dict_or_env, pre_init
 
 from langchain_community.llms.utils import enforce_stop_tokens
@@ -65,9 +64,7 @@ class Writer(LLM):
     """Base url to use, if None decides based on model name."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/retrievers/arcee.py
+++ b/libs/community/langchain_community/retrievers/arcee.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import Extra, SecretStr
+from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
@@ -50,9 +50,7 @@ class ArceeRetriever(BaseRetriever):
     """Keyword arguments to pass to the model."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
         underscore_attrs_are_private = True
 
     def __init__(self, **data: Any) -> None:

--- a/libs/community/langchain_community/retrievers/azure_ai_search.py
+++ b/libs/community/langchain_community/retrievers/azure_ai_search.py
@@ -10,7 +10,7 @@ from langchain_core.callbacks import (
     CallbackManagerForRetrieverRun,
 )
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.utils import get_from_dict_or_env, get_from_env
 
@@ -40,8 +40,8 @@ class AzureAISearchRetriever(BaseRetriever):
     """OData $filter expression to apply to the search query."""
 
     class Config:
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -25,8 +25,6 @@ class BM25Retriever(BaseRetriever):
     """ Preprocessing function to use on the text before BM25 vectorization."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @classmethod

--- a/libs/community/langchain_community/retrievers/chatgpt_plugin_retriever.py
+++ b/libs/community/langchain_community/retrievers/chatgpt_plugin_retriever.py
@@ -27,10 +27,7 @@ class ChatGPTPluginRetriever(BaseRetriever):
     """Aiohttp session to use for requests."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
-        """Allow arbitrary types."""
 
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun

--- a/libs/community/langchain_community/retrievers/cohere_rag_retriever.py
+++ b/libs/community/langchain_community/retrievers/cohere_rag_retriever.py
@@ -62,10 +62,7 @@ class CohereRagRetriever(BaseRetriever):
     """Cohere ChatModel to use."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
-        """Allow arbitrary types."""
 
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any

--- a/libs/community/langchain_community/retrievers/docarray.py
+++ b/libs/community/langchain_community/retrievers/docarray.py
@@ -45,8 +45,6 @@ class DocArrayRetriever(BaseRetriever):
     filters: Optional[Any] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def _get_relevant_documents(

--- a/libs/community/langchain_community/retrievers/google_vertex_ai_search.py
+++ b/libs/community/langchain_community/retrievers/google_vertex_ai_search.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.utils import get_from_dict_or_env
 
@@ -246,10 +246,8 @@ class GoogleVertexAISearchRetriever(BaseRetriever, _BaseGoogleVertexAISearchRetr
     _serving_config: str
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.ignore
         arbitrary_types_allowed = True
+        extra = "ignore"
         underscore_attrs_are_private = True
 
     def __init__(self, **kwargs: Any) -> None:
@@ -413,10 +411,8 @@ class GoogleVertexAIMultiTurnSearchRetriever(
     _serving_config: str
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.ignore
         arbitrary_types_allowed = True
+        extra = "ignore"
         underscore_attrs_are_private = True
 
     def __init__(self, **kwargs: Any):

--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -15,7 +15,6 @@ from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     root_validator,
     validator,
@@ -68,7 +67,7 @@ Dates are also represented as str.
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class Highlight(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class Highlight(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Information that highlights the keywords in the excerpt."""
 
     BeginOffset: int
@@ -82,7 +81,7 @@ class Highlight(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class TextWithHighLights(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class TextWithHighLights(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Text with highlights."""
 
     Text: str
@@ -93,7 +92,7 @@ class TextWithHighLights(BaseModel, extra=Extra.allow):  # type: ignore[call-arg
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
 class AdditionalResultAttributeValue(  # type: ignore[call-arg]
-    BaseModel, extra=Extra.allow
+    BaseModel, extra="allow"
 ):
     """Value of an additional result attribute."""
 
@@ -102,7 +101,7 @@ class AdditionalResultAttributeValue(  # type: ignore[call-arg]
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class AdditionalResultAttribute(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class AdditionalResultAttribute(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Additional result attribute."""
 
     Key: str
@@ -117,7 +116,7 @@ class AdditionalResultAttribute(BaseModel, extra=Extra.allow):  # type: ignore[c
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class DocumentAttributeValue(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class DocumentAttributeValue(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Value of a document attribute."""
 
     DateValue: Optional[str]
@@ -148,7 +147,7 @@ class DocumentAttributeValue(BaseModel, extra=Extra.allow):  # type: ignore[call
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class DocumentAttribute(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class DocumentAttribute(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Document attribute."""
 
     Key: str
@@ -158,7 +157,7 @@ class DocumentAttribute(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class ResultItem(BaseModel, ABC, extra=Extra.allow):  # type: ignore[call-arg]
+class ResultItem(BaseModel, ABC, extra="allow"):  # type: ignore[call-arg]
     """Base class of a result item."""
 
     Id: Optional[str]
@@ -288,7 +287,7 @@ class RetrieveResultItem(ResultItem):
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class QueryResult(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class QueryResult(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """`Amazon Kendra Query API` search result.
 
     It is composed of:
@@ -302,7 +301,7 @@ class QueryResult(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
 
 
 # Unexpected keyword argument "extra" for "__init_subclass__" of "object"
-class RetrieveResult(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class RetrieveResult(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """`Amazon Kendra Retrieve API` search result.
 
     It is composed of:

--- a/libs/community/langchain_community/retrievers/knn.py
+++ b/libs/community/langchain_community/retrievers/knn.py
@@ -46,8 +46,6 @@ class KNNRetriever(BaseRetriever):
     """Threshold for relevancy."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @classmethod

--- a/libs/community/langchain_community/retrievers/nanopq.py
+++ b/libs/community/langchain_community/retrievers/nanopq.py
@@ -46,8 +46,6 @@ class NanoPQRetriever(BaseRetriever):
     """No of clusters to be created"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @classmethod

--- a/libs/community/langchain_community/retrievers/pinecone_hybrid_search.py
+++ b/libs/community/langchain_community/retrievers/pinecone_hybrid_search.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.utils import pre_init
 
@@ -115,10 +114,8 @@ class PineconeHybridSearchRetriever(BaseRetriever):
     """Namespace value for index partition."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     def add_texts(
         self,

--- a/libs/community/langchain_community/retrievers/qdrant_sparse_vector_retriever.py
+++ b/libs/community/langchain_community/retrievers/qdrant_sparse_vector_retriever.py
@@ -15,7 +15,6 @@ from typing import (
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import Extra
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.utils import pre_init
 
@@ -45,10 +44,8 @@ class QdrantSparseVectorRetriever(BaseRetriever):
     """Additional search options to pass to qdrant_client.QdrantClient.search()."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/retrievers/svm.py
+++ b/libs/community/langchain_community/retrievers/svm.py
@@ -46,8 +46,6 @@ class SVMRetriever(BaseRetriever):
     """Threshold for relevancy."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @classmethod

--- a/libs/community/langchain_community/retrievers/tfidf.py
+++ b/libs/community/langchain_community/retrievers/tfidf.py
@@ -26,8 +26,6 @@ class TFIDFRetriever(BaseRetriever):
     """Number of documents to return."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @classmethod

--- a/libs/community/langchain_community/retrievers/thirdai_neuraldb.py
+++ b/libs/community/langchain_community/retrievers/thirdai_neuraldb.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import Extra, SecretStr
+from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
@@ -22,9 +22,7 @@ class NeuralDBRetriever(BaseRetriever):
     """NeuralDB instance"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
         underscore_attrs_are_private = True
 
     @staticmethod

--- a/libs/community/langchain_community/retrievers/weaviate_hybrid_search.py
+++ b/libs/community/langchain_community/retrievers/weaviate_hybrid_search.py
@@ -66,8 +66,6 @@ class WeaviateHybridSearchRetriever(BaseRetriever):
         return values
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     # added text_key

--- a/libs/community/langchain_community/tools/graphql/tool.py
+++ b/libs/community/langchain_community/tools/graphql/tool.py
@@ -23,8 +23,6 @@ class BaseGraphQLTool(BaseTool):
     """  # noqa: E501
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def _run(

--- a/libs/community/langchain_community/tools/office365/events_search.py
+++ b/libs/community/langchain_community/tools/office365/events_search.py
@@ -8,7 +8,7 @@ from datetime import datetime as dt
 from typing import Any, Dict, List, Optional, Type
 
 from langchain_core.callbacks import CallbackManagerForToolRun
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 
 from langchain_community.tools.office365.base import O365BaseTool
 from langchain_community.tools.office365.utils import UTC_FORMAT, clean_body
@@ -71,9 +71,7 @@ class O365SearchEvents(O365BaseTool):
     )
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _run(
         self,

--- a/libs/community/langchain_community/tools/office365/messages_search.py
+++ b/libs/community/langchain_community/tools/office365/messages_search.py
@@ -7,7 +7,7 @@ https://learn.microsoft.com/en-us/graph/auth/
 from typing import Any, Dict, List, Optional, Type
 
 from langchain_core.callbacks import CallbackManagerForToolRun
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 
 from langchain_community.tools.office365.base import O365BaseTool
 from langchain_community.tools.office365.utils import UTC_FORMAT, clean_body
@@ -67,9 +67,7 @@ class O365SearchEmails(O365BaseTool):
     )
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _run(
         self,

--- a/libs/community/langchain_community/tools/powerbi/tool.py
+++ b/libs/community/langchain_community/tools/powerbi/tool.py
@@ -40,8 +40,6 @@ class QueryPowerBITool(BaseTool):
     tiktoken_model_name: Optional[str] = None  # "cl100k_base"
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @validator("llm_chain")
@@ -228,8 +226,6 @@ class InfoPowerBITool(BaseTool):
     powerbi: PowerBIDataset = Field(exclude=True)
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def _run(
@@ -256,8 +252,6 @@ class ListPowerBITool(BaseTool):
     powerbi: PowerBIDataset = Field(exclude=True)
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def _run(

--- a/libs/community/langchain_community/tools/searx_search/tool.py
+++ b/libs/community/langchain_community/tools/searx_search/tool.py
@@ -6,7 +6,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.tools import BaseTool
 
 from langchain_community.utilities.searx_search import SearxSearchWrapper
@@ -62,9 +62,7 @@ class SearxSearchResults(BaseTool):
     kwargs: dict = Field(default_factory=dict)
 
     class Config:
-        """Pydantic config."""
-
-        extra = Extra.allow
+        extra = "allow"
 
     def _run(
         self,

--- a/libs/community/langchain_community/utilities/alpha_vantage.py
+++ b/libs/community/langchain_community/utilities/alpha_vantage.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, List, Optional
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -19,9 +19,7 @@ class AlphaVantageAPIWrapper(BaseModel):
     alphavantage_api_key: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/asknews.py
+++ b/libs/community/langchain_community/utilities/asknews.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -20,9 +20,7 @@ class AskNewsAPIWrapper(BaseModel):
     """Client Secret for the AskNews API."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/awslambda.py
+++ b/libs/community/langchain_community/utilities/awslambda.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class LambdaWrapper(BaseModel):
@@ -31,9 +31,7 @@ class LambdaWrapper(BaseModel):
     """If passing to an agent as a tool, the description"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/bibtex.py
+++ b/libs/community/langchain_community/utilities/bibtex.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Dict, List, Mapping
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +37,7 @@ class BibtexparserWrapper(BaseModel):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/bing_search.py
+++ b/libs/community/langchain_community/utilities/bing_search.py
@@ -3,7 +3,7 @@
 from typing import Dict, List
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 # BING_SEARCH_ENDPOINT is the default endpoint for Bing Web Search API.
@@ -35,9 +35,7 @@ class BingSearchAPIWrapper(BaseModel):
     """Additional keyword arguments to pass to the search request."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _bing_search_results(self, search_term: str, count: int) -> List[dict]:
         headers = {"Ocp-Apim-Subscription-Key": self.bing_subscription_key}

--- a/libs/community/langchain_community/utilities/clickup.py
+++ b/libs/community/langchain_community/utilities/clickup.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass, fields
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 DEFAULT_URL = "https://api.clickup.com/api/v2"
@@ -283,9 +283,7 @@ class ClickupAPIWrapper(BaseModel):
     list_id: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def get_access_code_url(

--- a/libs/community/langchain_community/utilities/dalle_image_generator.py
+++ b/libs/community/langchain_community/utilities/dalle_image_generator.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import (
     get_from_dict_or_env,
     get_pydantic_field_names,
@@ -60,9 +60,7 @@ class DallEAPIWrapper(BaseModel):
     """Optional httpx.Client."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/community/langchain_community/utilities/dataforseo_api_search.py
+++ b/libs/community/langchain_community/utilities/dataforseo_api_search.py
@@ -4,7 +4,7 @@ from urllib.parse import quote
 
 import aiohttp
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -12,10 +12,8 @@ class DataForSeoAPIWrapper(BaseModel):
     """Wrapper around the DataForSeo API."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     default_params: dict = Field(
         default={

--- a/libs/community/langchain_community/utilities/dataherald.py
+++ b/libs/community/langchain_community/utilities/dataherald.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -23,9 +23,7 @@ class DataheraldAPIWrapper(BaseModel):
     dataherald_api_key: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/duckduckgo_search.py
+++ b/libs/community/langchain_community/utilities/duckduckgo_search.py
@@ -6,7 +6,7 @@ https://pypi.org/project/duckduckgo-search/
 
 from typing import Dict, List, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class DuckDuckGoSearchAPIWrapper(BaseModel):
@@ -38,9 +38,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/github.py
+++ b/libs/community/langchain_community/utilities/github.py
@@ -6,7 +6,7 @@ import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 if TYPE_CHECKING:
@@ -38,9 +38,7 @@ class GitHubAPIWrapper(BaseModel):
     github_base_branch: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/gitlab.py
+++ b/libs/community/langchain_community/utilities/gitlab.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 if TYPE_CHECKING:
@@ -31,9 +31,7 @@ class GitLabAPIWrapper(BaseModel):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/golden_query.py
+++ b/libs/community/langchain_community/utilities/golden_query.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict, Optional
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 GOLDEN_BASE_URL = "https://golden.com"
@@ -25,9 +25,7 @@ class GoldenQueryAPIWrapper(BaseModel):
     golden_api_key: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/google_finance.py
+++ b/libs/community/langchain_community/utilities/google_finance.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional, cast
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 
@@ -26,9 +26,7 @@ class GoogleFinanceAPIWrapper(BaseModel):
     serp_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/google_jobs.py
+++ b/libs/community/langchain_community/utilities/google_jobs.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional, cast
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 
@@ -26,9 +26,7 @@ class GoogleJobsAPIWrapper(BaseModel):
     serp_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/google_lens.py
+++ b/libs/community/langchain_community/utilities/google_lens.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, Optional, cast
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 
@@ -31,9 +31,7 @@ class GoogleLensAPIWrapper(BaseModel):
     serp_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/google_places_api.py
+++ b/libs/community/langchain_community/utilities/google_places_api.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from langchain_core._api.deprecation import deprecated
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -38,10 +38,8 @@ class GooglePlacesAPIWrapper(BaseModel):
     top_k_results: Optional[int] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/google_scholar.py
+++ b/libs/community/langchain_community/utilities/google_scholar.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -47,9 +47,7 @@ class GoogleScholarAPIWrapper(BaseModel):
     serp_api_key: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/google_search.py
+++ b/libs/community/langchain_community/utilities/google_search.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core._api.deprecation import deprecated
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -58,9 +58,7 @@ class GoogleSearchAPIWrapper(BaseModel):
     siterestrict: bool = False
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _google_search_results(self, search_term: str, **kwargs: Any) -> List[dict]:
         cse = self.search_engine.cse()

--- a/libs/community/langchain_community/utilities/google_serper.py
+++ b/libs/community/langchain_community/utilities/google_serper.py
@@ -43,8 +43,6 @@ class GoogleSerperAPIWrapper(BaseModel):
     aiosession: Optional[aiohttp.ClientSession] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/utilities/google_trends.py
+++ b/libs/community/langchain_community/utilities/google_trends.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional, cast
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 
@@ -30,9 +30,7 @@ class GoogleTrendsAPIWrapper(BaseModel):
     serp_api_key: Optional[SecretStr] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/graphql.py
+++ b/libs/community/langchain_community/utilities/graphql.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Callable, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class GraphQLAPIWrapper(BaseModel):
@@ -18,9 +18,7 @@ class GraphQLAPIWrapper(BaseModel):
     gql_function: Callable[[str], Any]  #: :meta private:
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/infobip.py
+++ b/libs/community/langchain_community/utilities/infobip.py
@@ -3,7 +3,7 @@
 from typing import Dict, List, Optional
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -16,9 +16,7 @@ class InfobipAPIWrapper(BaseModel):
     infobip_base_url: Optional[str] = "https://api.infobip.com"
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/jira.py
+++ b/libs/community/langchain_community/utilities/jira.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -18,9 +18,7 @@ class JiraAPIWrapper(BaseModel):
     jira_cloud: Optional[bool] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/merriam_webster.py
+++ b/libs/community/langchain_community/utilities/merriam_webster.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterator, List, Optional
 from urllib.parse import quote
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 MERRIAM_WEBSTER_API_URL = (
@@ -29,9 +29,7 @@ class MerriamWebsterAPIWrapper(BaseModel):
     merriam_webster_api_key: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/metaphor_search.py
+++ b/libs/community/langchain_community/utilities/metaphor_search.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 
 import aiohttp
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 METAPHOR_API_URL = "https://api.metaphor.systems"
@@ -21,9 +21,7 @@ class MetaphorSearchAPIWrapper(BaseModel):
     k: int = 10
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _metaphor_search_results(
         self,

--- a/libs/community/langchain_community/utilities/openweathermap.py
+++ b/libs/community/langchain_community/utilities/openweathermap.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -20,9 +20,7 @@ class OpenWeatherMapAPIWrapper(BaseModel):
     openweathermap_api_key: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/passio_nutrition_ai.py
+++ b/libs/community/langchain_community/utilities/passio_nutrition_ai.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, Optional, final
 
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -121,10 +121,8 @@ class NutritionAIAPI(BaseModel):
     auth_: ManagedPassioLifeAuth
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @retry(
         retry=retry_if_result(is_http_retryable),

--- a/libs/community/langchain_community/utilities/powerbi.py
+++ b/libs/community/langchain_community/utilities/powerbi.py
@@ -41,8 +41,6 @@ class PowerBIDataset(BaseModel):
     aiosession: Optional[aiohttp.ClientSession] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @validator("table_names", allow_reuse=True)

--- a/libs/community/langchain_community/utilities/requests.py
+++ b/libs/community/langchain_community/utilities/requests.py
@@ -5,7 +5,7 @@ from typing import Any, AsyncGenerator, Dict, Literal, Optional, Union
 
 import aiohttp
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra
+from langchain_core.pydantic_v1 import BaseModel
 from requests import Response
 
 
@@ -22,10 +22,8 @@ class Requests(BaseModel):
     verify: Optional[bool] = True
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     def get(self, url: str, **kwargs: Any) -> requests.Response:
         """GET the URL and return the text."""
@@ -150,10 +148,8 @@ class GenericRequestsWrapper(BaseModel):
     verify: bool = True
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @property
     def requests(self) -> Requests:

--- a/libs/community/langchain_community/utilities/searchapi.py
+++ b/libs/community/langchain_community/utilities/searchapi.py
@@ -28,8 +28,6 @@ class SearchApiAPIWrapper(BaseModel):
     aiosession: Optional[aiohttp.ClientSession] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/utilities/searx_search.py
+++ b/libs/community/langchain_community/utilities/searx_search.py
@@ -134,7 +134,6 @@ import aiohttp
 import requests
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     PrivateAttr,
     root_validator,
@@ -259,9 +258,7 @@ class SearxSearchWrapper(BaseModel):
         return values
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _searx_api_query(self, params: dict) -> SearxResults:
         """Actual request to searx API."""

--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -53,10 +53,8 @@ class SerpAPIWrapper(BaseModel):
     aiosession: Optional[aiohttp.ClientSession] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = True
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/steam.py
+++ b/libs/community/langchain_community/utilities/steam.py
@@ -2,7 +2,7 @@
 
 from typing import Any, List
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class SteamWebAPIWrapper(BaseModel):
@@ -31,9 +31,7 @@ class SteamWebAPIWrapper(BaseModel):
     ]
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def get_operations(self) -> List[dict]:
         """Return a list of operations."""

--- a/libs/community/langchain_community/utilities/tavily_search.py
+++ b/libs/community/langchain_community/utilities/tavily_search.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional
 
 import aiohttp
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import BaseModel, SecretStr, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 TAVILY_API_URL = "https://api.tavily.com"
@@ -21,9 +21,7 @@ class TavilySearchAPIWrapper(BaseModel):
     tavily_api_key: SecretStr
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/twilio.py
+++ b/libs/community/langchain_community/utilities/twilio.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -44,10 +44,8 @@ class TwilioAPIWrapper(BaseModel):
     """
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
         arbitrary_types_allowed = False
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/wolfram_alpha.py
+++ b/libs/community/langchain_community/utilities/wolfram_alpha.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 
@@ -22,9 +22,7 @@ class WolframAlphaAPIWrapper(BaseModel):
     wolfram_alpha_appid: Optional[str] = None
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/utilities/zapier.py
+++ b/libs/community/langchain_community/utilities/zapier.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 import requests
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 from requests import Request, Session
 
@@ -46,9 +46,7 @@ class ZapierNLAWrapper(BaseModel):
     zapier_nla_api_base: str = "https://nla.zapier.com/api/v1/"
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
 
     def _format_headers(self) -> Dict[str, str]:
         """Format headers for requests."""

--- a/libs/community/langchain_community/vectorstores/apache_doris.py
+++ b/libs/community/langchain_community/vectorstores/apache_doris.py
@@ -63,8 +63,8 @@ class ApacheDorisSettings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        env_prefix = "apache_doris_"
         env_file_encoding = "utf-8"
+        env_prefix = "apache_doris_"
 
 
 class ApacheDoris(VectorStore):

--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -1520,8 +1520,6 @@ class AzureSearchVectorStoreRetriever(BaseRetriever):
     )
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     @root_validator(pre=True)

--- a/libs/community/langchain_community/vectorstores/clickhouse.py
+++ b/libs/community/langchain_community/vectorstores/clickhouse.py
@@ -97,8 +97,8 @@ class ClickhouseSettings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        env_prefix = "clickhouse_"
         env_file_encoding = "utf-8"
+        env_prefix = "clickhouse_"
 
 
 class Clickhouse(VectorStore):

--- a/libs/community/langchain_community/vectorstores/kinetica.py
+++ b/libs/community/langchain_community/vectorstores/kinetica.py
@@ -81,8 +81,8 @@ class KineticaSettings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        env_prefix = "kinetica_"
         env_file_encoding = "utf-8"
+        env_prefix = "kinetica_"
 
 
 class Kinetica(VectorStore):

--- a/libs/community/langchain_community/vectorstores/manticore_search.py
+++ b/libs/community/langchain_community/vectorstores/manticore_search.py
@@ -58,8 +58,8 @@ class ManticoreSearchSettings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        env_prefix = "manticore_"
         env_file_encoding = "utf-8"
+        env_prefix = "manticore_"
 
 
 class ManticoreSearch(VectorStore):

--- a/libs/community/langchain_community/vectorstores/myscale.py
+++ b/libs/community/langchain_community/vectorstores/myscale.py
@@ -87,8 +87,8 @@ class MyScaleSettings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        env_prefix = "myscale_"
         env_file_encoding = "utf-8"
+        env_prefix = "myscale_"
 
 
 class MyScale(VectorStore):

--- a/libs/community/langchain_community/vectorstores/redis/base.py
+++ b/libs/community/langchain_community/vectorstores/redis/base.py
@@ -1453,8 +1453,6 @@ class RedisVectorStoreRetriever(VectorStoreRetriever):
     """Allowed search types."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def _get_relevant_documents(

--- a/libs/community/langchain_community/vectorstores/starrocks.py
+++ b/libs/community/langchain_community/vectorstores/starrocks.py
@@ -114,8 +114,8 @@ class StarRocksSettings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        env_prefix = "starrocks_"
         env_file_encoding = "utf-8"
+        env_prefix = "starrocks_"
 
 
 class StarRocks(VectorStore):

--- a/libs/community/langchain_community/vectorstores/thirdai_neuraldb.py
+++ b/libs/community/langchain_community/vectorstores/thirdai_neuraldb.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import Extra, root_validator
+from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 from langchain_core.vectorstores import VectorStore
 
@@ -33,9 +33,7 @@ class NeuralDBVectorStore(VectorStore):
     """NeuralDB instance"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
         underscore_attrs_are_private = True
 
     @staticmethod
@@ -347,9 +345,7 @@ class NeuralDBClientVectorStore(VectorStore):
     """NeuralDB Client instance"""
 
     class Config:
-        """Configuration for this pydantic object."""
-
-        extra = Extra.forbid
+        extra = "forbid"
         underscore_attrs_are_private = True
 
     def similarity_search(

--- a/libs/community/langchain_community/vectorstores/vectara.py
+++ b/libs/community/langchain_community/vectorstores/vectara.py
@@ -732,8 +732,6 @@ class VectaraRetriever(VectorStoreRetriever):
     """Configuration for this retriever."""
 
     class Config:
-        """Configuration for this pydantic object."""
-
         arbitrary_types_allowed = True
 
     def _get_relevant_documents(

--- a/libs/community/tests/unit_tests/load/test_dump.py
+++ b/libs/community/tests/unit_tests/load/test_dump.py
@@ -183,8 +183,6 @@ class TestClass(Serializable):
     my_other_secret: str = Field()
 
     class Config:
-        """Configuration for this pydantic object."""
-
         allow_population_by_field_name = True
 
     @root_validator(pre=True)


### PR DESCRIPTION
Upgrade to using a literal for specifying the extra which is the recommended approach in pydantic 2.

This works correctly also in pydantic v1.

```python
from pydantic.v1 import BaseModel

class Foo(BaseModel, extra="forbid"):
    x: int

Foo(x=5, y=1)
```

And 


```python
from pydantic.v1 import BaseModel

class Foo(BaseModel):
    x: int

    class Config:
      extra = "forbid"

Foo(x=5, y=1)
```


## Enum -> literal using grit pattern:

```
engine marzano(0.1)
language python
or {
    `extra=Extra.allow` => `extra="allow"`,
    `extra=Extra.forbid` => `extra="forbid"`,
    `extra=Extra.ignore` => `extra="ignore"`
}
```

Resorted attributes in config and removed doc-string in case we will need to deal with going back and forth between pydantic v1 and v2 during the 0.3 release. (This will reduce merge conflicts.)


## Sort attributes in Config:

```
engine marzano(0.1)
language python


function sort($values) js {
    return $values.text.split(',').sort().join("\n");
}


class_definition($name, $body) as $C where {
    $name <: `Config`,
    $body <: block($statements),
    $values = [],
    $statements <: some bubble($values) assignment() as $A where {
        $values += $A
    },
    $body => sort($values),
}

```