### PR TITLE
core[minor]: Add from_env utility

### DIFF
--- a/libs/core/langchain_core/utils/__init__.py
+++ b/libs/core/langchain_core/utils/__init__.py
@@ -22,6 +22,7 @@ from langchain_core.utils.utils import (
     build_extra_kwargs,
     check_package_version,
     convert_to_secret_str,
+    from_env,
     get_pydantic_field_names,
     guard_import,
     mock_now,
@@ -54,4 +55,5 @@ __all__ = [
     "pre_init",
     "batch_iterate",
     "abatch_iterate",
+    "from_env",
 ]

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -1,16 +1,17 @@
 """Generic utility functions."""
 
-from importlib.metadata import version
-
 import contextlib
 import datetime
 import functools
 import importlib
 import os
 import warnings
+from importlib.metadata import version
+from types import EllipsisType
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Union, overload
+
 from packaging.version import parse
 from requests import HTTPError, Response
-from typing import Any, Callable, Dict, Optional, Set, Tuple, Union, overload
 
 from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils.pydantic import (
@@ -263,13 +264,6 @@ def convert_to_secret_str(value: Union[SecretStr, str]) -> SecretStr:
     return SecretStr(value)
 
 
-class _NoDefaultType:
-    pass
-
-
-_NoDefault = _NoDefaultType()
-
-
 @overload
 def from_env(key: str, /) -> Callable[[], str]: ...
 
@@ -298,7 +292,7 @@ def from_env(
     key: str,
     /,
     *,
-    default: Union[str, _NoDefaultType, None] = _NoDefault,
+    default: Union[str, EllipsisType, None] = ...,
     error_message: Optional[str] = None,
 ) -> Union[Callable[[], str], Callable[[], Optional[str]]]:
     """Create a factory method that gets a value from an environment variable.

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -7,7 +7,6 @@ import importlib
 import os
 import warnings
 from importlib.metadata import version
-from types import EllipsisType
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Union, overload
 
 from packaging.version import parse
@@ -264,6 +263,15 @@ def convert_to_secret_str(value: Union[SecretStr, str]) -> SecretStr:
     return SecretStr(value)
 
 
+class _NoDefaultType:
+    """Type to indicate no default value is provided."""
+
+    pass
+
+
+_NoDefault = _NoDefaultType()
+
+
 @overload
 def from_env(key: str, /) -> Callable[[], str]: ...
 
@@ -292,7 +300,7 @@ def from_env(
     key: str,
     /,
     *,
-    default: Union[str, EllipsisType, None] = ...,
+    default: Union[str, _NoDefaultType, None] = _NoDefault,
     error_message: Optional[str] = None,
 ) -> Union[Callable[[], str], Callable[[], Optional[str]]]:
     """Create a factory method that gets a value from an environment variable.

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -1,15 +1,16 @@
 """Generic utility functions."""
 
+from importlib.metadata import version
+
 import contextlib
 import datetime
 import functools
 import importlib
+import os
 import warnings
-from importlib.metadata import version
-from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
-
 from packaging.version import parse
 from requests import HTTPError, Response
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Union, overload
 
 from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils.pydantic import (
@@ -260,3 +261,70 @@ def convert_to_secret_str(value: Union[SecretStr, str]) -> SecretStr:
     if isinstance(value, SecretStr):
         return value
     return SecretStr(value)
+
+
+class _NoDefaultType:
+    pass
+
+
+_NoDefault = _NoDefaultType()
+
+
+@overload
+def from_env(key: str, /) -> Callable[[], str]: ...
+
+
+@overload
+def from_env(key: str, /, *, default: str) -> Callable[[], str]: ...
+
+
+@overload
+def from_env(key: str, /, *, error_message: str) -> Callable[[], str]: ...
+
+
+@overload
+def from_env(
+    key: str, /, *, default: str, error_message: Optional[str]
+) -> Callable[[], str]: ...
+
+
+@overload
+def from_env(
+    key: str, /, *, default: None, error_message: Optional[str]
+) -> Callable[[], Optional[str]]: ...
+
+
+def from_env(
+    key: str,
+    /,
+    *,
+    default: Union[str, _NoDefaultType, None] = _NoDefault,
+    error_message: Optional[str] = None,
+) -> Union[Callable[[], str], Callable[[], Optional[str]]]:
+    """Create a factory method that gets a value from an environment variable.
+
+    Args:
+        key: The environment variable to look up.
+        default: The default value to return if the environment variable is not set.
+        error_message: the error message which will be raised if the key is not found
+            and no default value is provided.
+            This will be raised as a ValueError.
+    """
+
+    def get_from_env_fn() -> str:  # type: ignore
+        """Get a value from an environment variable."""
+        if key in os.environ:
+            return os.environ[key]
+        elif isinstance(default, str):
+            return default
+        else:
+            if error_message:
+                raise ValueError(error_message)
+            else:
+                raise ValueError(
+                    f"Did not find {key}, please add an environment variable"
+                    f" `{key}` which contains it, or pass"
+                    f" `{key}` as a named parameter."
+                )
+
+    return get_from_env_fn

--- a/libs/core/tests/unit_tests/utils/test_imports.py
+++ b/libs/core/tests/unit_tests/utils/test_imports.py
@@ -25,6 +25,7 @@ EXPECTED_ALL = [
     "comma_list",
     "stringify_value",
     "pre_init",
+    "from_env",
 ]
 
 


### PR DESCRIPTION
Add a utility that can be used as a default factory

The goal will be to start migrating from of the pydantic models to use `from_env` as a default factory if possible.

```python

from pydantic import Field, BaseModel
from langchain_core.utils import from_env

class Foo(BaseModel):
   name: str = Field(default_factory=from_env('HELLO'))
```