### PR TITLE
experimental[patch]: Use get_fields adapter

### DIFF
--- a/libs/experimental/langchain_experimental/open_clip/open_clip.py
+++ b/libs/experimental/langchain_experimental/open_clip/open_clip.py
@@ -5,7 +5,6 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.utils.pydantic import get_fields
 
 
-
 class OpenCLIPEmbeddings(BaseModel, Embeddings):
     """OpenCLIP Embeddings model."""
 

--- a/libs/experimental/langchain_experimental/open_clip/open_clip.py
+++ b/libs/experimental/langchain_experimental/open_clip/open_clip.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List
 
 from langchain.pydantic_v1 import BaseModel, root_validator
 from langchain_core.embeddings import Embeddings
+from langchain_core.utils.pydantic import get_fields
+
 
 
 class OpenCLIPEmbeddings(BaseModel, Embeddings):
@@ -21,8 +23,8 @@ class OpenCLIPEmbeddings(BaseModel, Embeddings):
             import open_clip
 
             # Fall back to class defaults if not provided
-            model_name = values.get("model_name", cls.__fields__["model_name"].default)
-            checkpoint = values.get("checkpoint", cls.__fields__["checkpoint"].default)
+            model_name = values.get("model_name", get_fields(cls)["model_name"].default)
+            checkpoint = values.get("checkpoint", get_fields(cls)["checkpoint"].default)
 
             # Load model
             model, _, preprocess = open_clip.create_model_and_transforms(


### PR DESCRIPTION
Change all usages of __fields__ with get_fields adapter merged into langchain_core.

Code mod generated using the following grit pattern:

```
engine marzano(0.1)
language python


`$X.__fields__` => `get_fields($X)` where {
    add_import(source="langchain_core.utils.pydantic", name="get_fields")
}
```