### PR TITLE
community[patch]: FAISS: ValueError mentions normalize_score_fn isntead of relevance_score_fn

### DIFF
--- a/libs/community/langchain_community/vectorstores/faiss.py
+++ b/libs/community/langchain_community/vectorstores/faiss.py
@@ -1288,7 +1288,7 @@ class FAISS(VectorStore):
         relevance_score_fn = self._select_relevance_score_fn()
         if relevance_score_fn is None:
             raise ValueError(
-                "normalize_score_fn must be provided to"
+                "relevance_score_fn must be provided to"
                 " FAISS constructor to normalize scores"
             )
         docs_and_scores = self.similarity_search_with_score(
@@ -1317,7 +1317,7 @@ class FAISS(VectorStore):
         relevance_score_fn = self._select_relevance_score_fn()
         if relevance_score_fn is None:
             raise ValueError(
-                "normalize_score_fn must be provided to"
+                "relevance_score_fn must be provided to"
                 " FAISS constructor to normalize scores"
             )
         docs_and_scores = await self.asimilarity_search_with_score(


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [X] **PR title**: "community: fix valueerror mentions wrong argument missing"
  - Where "package" is whichever of langchain, community, core, experimental, etc. is being modified. Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


- [X] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** when faiss.py has a None relevance_score_fn it raises a ValueError that says a normalize_fn_score argument is needed.

