### PR TITLE
community: Add llm-extraction option to FireCrawl Document Loader

### DIFF
--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -66,5 +66,5 @@ class FireCrawlLoader(BaseLoader):
             yield Document(
                 page_content=doc.get("markdown", ""),
                 metadata=doc.get("metadata", {}),
-                llm_extraction: doc.get("llm_extraction") if self.params.get('extractorOptions', {}).get('mode') == 'llm-extraction' else None
+                llm_extraction= doc.get("llm_extraction") if self.params.get('extractorOptions', {}).get('mode') == 'llm-extraction' else None
             )

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -66,4 +66,5 @@ class FireCrawlLoader(BaseLoader):
             yield Document(
                 page_content=doc.get("markdown", ""),
                 metadata=doc.get("metadata", {}),
+                llm_extraction: doc.get("llm_extraction") if self.params.get('extractorOptions', {}).get('mode') == 'llm-extraction' else None
             )

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -63,8 +63,11 @@ class FireCrawlLoader(BaseLoader):
                 f"Unrecognized mode '{self.mode}'. Expected one of 'crawl', 'scrape'."
             )
         for doc in firecrawl_docs:
+            metadata = doc.get("metadata", {})
+            if self.params.get('extractorOptions', {}).get('mode') == 'llm-extraction':
+                metadata['llm_extraction'] = doc.get("llm_extraction")
+
             yield Document(
                 page_content=doc.get("markdown", ""),
-                metadata=doc.get("metadata", {}),
-                llm_extraction= doc.get("llm_extraction") if self.params.get('extractorOptions', {}).get('mode') == 'llm-extraction' else None
+                metadata=metadata
             )

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -64,10 +64,9 @@ class FireCrawlLoader(BaseLoader):
             )
         for doc in firecrawl_docs:
             metadata = doc.get("metadata", {})
-            if self.params.get('extractorOptions', {}).get('mode') == 'llm-extraction':
-                metadata['llm_extraction'] = doc.get("llm_extraction")
+            if (self.params is not None) and self.params.get(
+                "extractorOptions", {}
+            ).get("mode") == "llm-extraction":
+                metadata["llm_extraction"] = doc.get("llm_extraction")
 
-            yield Document(
-                page_content=doc.get("markdown", ""),
-                metadata=metadata
-            )
+            yield Document(page_content=doc.get("markdown", ""), metadata=metadata)


### PR DESCRIPTION
**Description:** This minor PR aims to add `llm_extraction` to Firecrawl loader.  This feature is supported on API and PythonSDK, but the langchain loader omits adding this to the response.
**Twitter handle:** [scalable_pizza](https://x.com/scalablepizza)
