### PR TITLE
langchain[patch]: extended-tests: drop logprobs from OAI expected config

### DIFF
--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -105,7 +105,6 @@ def test_configurable() -> None:
             "model": "gpt-4o",
             "stream": False,
             "n": 1,
-            "logprobs": False,
             "temperature": 0.7,
             "_type": "openai-chat",
         },


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/25229