### PR TITLE
Docs: Modify cohere import  by Updating cohere.ipynb

### DIFF
--- a/docs/docs/integrations/text_embedding/cohere.ipynb
+++ b/docs/docs/integrations/text_embedding/cohere.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_cohere import CohereEmbeddings"
+    "from langchain.embeddings import CohereEmbeddings"
    ]
   },
   {


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: "Docs: Modify cohere import"
  
- [ ] **PR message**:
    - **Description:** Updating import library to resolve ```ModuleNotFoundError: No module named 'langchain_cohere'```
    - **Issue:**  Fix's #25238
    - **Dependencies:** None
    - **Twitter handle:** [if your PR gets announced, and you'd like a mention, we'll gladly shout you out!](https://twitter.com/dushyanthreddyb)
    - Files changed: [docs/docs/how_to/embed_text.mdx](https://github.com/langchain-ai/langchain/blob/master/docs/docs/how_to/embed_text.mdx)


Reason for change: Avoids installing a new package langchain-cohere for CohereEmbeddings, it can be directly imported from langchain.embeddings.
```from langchain_cohere import CohereEmbeddings``` to ```from langchain.embeddings import CohereEmbeddings```
