### PR TITLE
qdrant: Update API reference link and install command

### DIFF
--- a/docs/docs/integrations/vectorstores/qdrant.ipynb
+++ b/docs/docs/integrations/vectorstores/qdrant.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -qU langchain-qdrant 'qdrant-client[fastembed]'"
+    "%pip install -qU langchain-qdrant"
    ]
   },
   {
@@ -628,7 +628,7 @@
    "id": "525e3582",
    "metadata": {},
    "source": [
-    "For a full list of all the search functions available for a `QdrantVectorStore`, read the [API reference](https://api.python.langchain.com/en/latest/vectorstores/langchain_qdrant.vectorstores.Qdrant.html)\n",
+    "For a full list of all the search functions available for a `QdrantVectorStore`, read the [API reference](https://api.python.langchain.com/en/latest/qdrant/langchain_qdrant.qdrant.QdrantVectorStore.html)\n",
     "\n",
     "### Metadata filtering\n",
     "\n",
@@ -814,7 +814,7 @@
    "source": [
     "## API reference\n",
     "\n",
-    "For detailed documentation of all `QdrantVectorStore` features and configurations head to the API reference: https://api.python.langchain.com/en/latest/vectorstores/langchain_qdrant.vectorstores.Qdrant.html"
+    "For detailed documentation of all `QdrantVectorStore` features and configurations head to the API reference: https://api.python.langchain.com/en/latest/qdrant/langchain_qdrant.qdrant.QdrantVectorStore.html"
    ]
   }
  ],

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -42,17 +42,19 @@ class QdrantVectorStore(VectorStore):
     """Qdrant vector store integration.
 
     Setup:
-        Install ``langchain-qdrant`` and ``qdrant-client[fastembed]`` packages.
+        Install ``langchain-qdrant`` package.
 
         .. code-block:: bash
 
-            pip install -qU langchain-qdrant 'qdrant-client[fastembed]'
+            pip install -qU langchain-qdrant
 
     Key init args — indexing params:
         collection_name: str
             Name of the collection.
         embedding: Embeddings
             Embedding function to use.
+        sparse_embedding: SparseEmbeddings
+            Optional sparse embedding function to use.
 
     Key init args — client params:
         client: QdrantClient


### PR DESCRIPTION
## Description

As the title goes. The current API reference links to the deprecated class.