### PR TITLE
modified MYSQL prompt in libs/langchain/langchain/chains/sql_database…

### DIFF
--- a/libs/langchain/langchain/chains/sql_database/prompt.py
+++ b/libs/langchain/langchain/chains/sql_database/prompt.py
@@ -135,7 +135,7 @@ Use the following format:
 Question: Question here
 SQLQuery: SQL Query to run
 SQLResult: Result of the SQLQuery
-Answer: Final answer here
+Answer: Final answer here (make sure the queiry do not contain 'sql' at the start, the query should start with SELECT)
 
 """
 


### PR DESCRIPTION
…/prompt.py


- [x] experimental: Ensure MYSQL queries are generated perfectly so can be used by the next sequence in SQLDatabaseChain to execute them directly on database"
  - infra: langchain/libs/langchain/langchain/chains/sql_database/prompt.py --> modified _mysql_prompt


    - **Description:** This PR addresses an issue where the SQL queries generated by the GoogleGenerativeAI model in the langchain-experimental package included unwanted syntax. This query when used through SQLDatabaseChain caused the error. The generated queries now start directly with SELECT and do not contain any additional formatting or text. The fix involved modifying the prompt in the prompt.py file to ensure clean SQL query generation.
    - **Issue:** #25278
    - **Dependencies:** No new dependencies are required for this change.
    - **Twitter handle:** @CodeFrek


- [x] **Add tests and docs**: This the image shows the that same query runs perfectly, with the modified prompt.
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/af9c0ca9-dc3c-44aa-ac31-3fc8acea7bac">



- [x] **Lint and test**: Not required.
