### PR TITLE
docs: Fix link for API reference of Gmail Toolkit

### DIFF
--- a/docs/docs/integrations/tools/gmail.ipynb
+++ b/docs/docs/integrations/tools/gmail.ipynb
@@ -243,7 +243,7 @@
    "source": [
     "## API reference\n",
     "\n",
-    "For detailed documentation of all `GmailToolkit` features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/agent_toolkits/langchain_community.agent_toolkits.slack.toolkit.SlackToolkit.html)."
+    "For detailed documentation of all `GmailToolkit` features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/agent_toolkits/langchain_community.agent_toolkits.gmail.toolkit.GmailToolkit.html)."
    ]
   }
  ],


### PR DESCRIPTION
- **Description:** Fix link for API reference of Gmail Toolkit
- **Issue:** I've just found this issue while I'm reading the doc
- **Dependencies:** N/A
- **Twitter handle:** [@soichisumi](https://x.com/soichisumi)

TODO: If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
