### PR TITLE
docs: Change SqliteSaver to MemorySaver

### DIFF
--- a/docs/docs/how_to/qa_chat_history_how_to.ipynb
+++ b/docs/docs/how_to/qa_chat_history_how_to.ipynb
@@ -721,9 +721,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langgraph.checkpoint.sqlite import SqliteSaver\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
     "\n",
-    "memory = SqliteSaver.from_conn_string(\":memory:\")\n",
+    "memory = MemorySaver()\n",
     "\n",
     "agent_executor = create_react_agent(llm, tools, checkpointer=memory)"
    ]
@@ -890,9 +890,9 @@
     "from langchain_community.document_loaders import WebBaseLoader\n",
     "from langchain_openai import ChatOpenAI, OpenAIEmbeddings\n",
     "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
-    "from langgraph.checkpoint.sqlite import SqliteSaver\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
     "\n",
-    "memory = SqliteSaver.from_conn_string(\":memory:\")\n",
+    "memory = MemorySaver()\n",
     "llm = ChatOpenAI(model=\"gpt-3.5-turbo\", temperature=0)\n",
     "\n",
     "\n",

--- a/docs/docs/tutorials/agents.ipynb
+++ b/docs/docs/tutorials/agents.ipynb
@@ -71,11 +71,11 @@
     "from langchain_anthropic import ChatAnthropic\n",
     "from langchain_community.tools.tavily_search import TavilySearchResults\n",
     "from langchain_core.messages import HumanMessage\n",
-    "from langgraph.checkpoint.sqlite import SqliteSaver\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
     "from langgraph.prebuilt import create_react_agent\n",
     "\n",
     "# Create the agent\n",
-    "memory = SqliteSaver.from_conn_string(\":memory:\")\n",
+    "memory = MemorySaver()\n",
     "model = ChatAnthropic(model_name=\"claude-3-sonnet-20240229\")\n",
     "search = TavilySearchResults(max_results=2)\n",
     "tools = [search]\n",
@@ -606,9 +606,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langgraph.checkpoint.sqlite import SqliteSaver\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
     "\n",
-    "memory = SqliteSaver.from_conn_string(\":memory:\")"
+    "memory = MemorySaver()"
    ]
   },
   {


### PR DESCRIPTION
fix: #25137

`SqliteSaver.from_conn_string()` has been changed to a `contextmanager` method in `langgraph >= 0.2.0`, the original usage is no longer applicable.

Refer to <https://github.com/langchain-ai/langgraph/pull/1271#issue-2454736415> modification method to replace `SqliteSaver` with `MemorySaver`.
