### PR TITLE
Add kwargs for json.dumps inside `JsonOutputParser.get_format_instructions`

### DIFF
--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -97,7 +97,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
         """
         return self.parse_result([Generation(text=text)])
 
-    def get_format_instructions(self) -> str:
+    def get_format_instructions(self, **kwargs) -> str:
         """Return the format instructions for the JSON output.
 
         Returns:
@@ -116,7 +116,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
             if "type" in reduced_schema:
                 del reduced_schema["type"]
             # Ensure json in context is well-formed with double quotes.
-            schema_str = json.dumps(reduced_schema)
+            schema_str = json.dumps(reduced_schema, **kwargs)
             return JSON_FORMAT_INSTRUCTIONS.format(schema=schema_str)
 
     @property


### PR DESCRIPTION
I have a pydantic object:

```python
from pydantic import BaseModel, Field

class Foo(BaseModel):
    bar: Optional[str] = Field(default=None, description="这是一个说明")
```

Then I want to prompt llm with it:

```python


