### PR TITLE
docs: Fix broken link to Runhouse documentation

### DIFF
--- a/docs/docs/integrations/llms/runhouse.ipynb
+++ b/docs/docs/integrations/llms/runhouse.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Runhouse\n",
     "\n",
-    "The [Runhouse](https://github.com/run-house/runhouse) allows remote compute and data across environments and users. See the [Runhouse docs](https://runhouse-docs.readthedocs-hosted.com/en/latest/).\n",
+    "[Runhouse](https://github.com/run-house/runhouse) allows remote compute and data across environments and users. See the [Runhouse docs](https://www.run.house/docs).\n",
     "\n",
     "This example goes over how to use LangChain and [Runhouse](https://github.com/run-house/runhouse) to interact with models hosted on your own GPU, or on-demand GPUs on AWS, GCP, AWS, or Lambda.\n",
     "\n",


### PR DESCRIPTION
- **Description:** Runhouse recently migrated from Read the Docs to a self-hosted solution. This PR updates a broken link from the old docs to www.run.house/docs. Also changed "The Runhouse" to "Runhouse" (it's cleaner).
- **Issue:** None
- **Dependencies:** None