### PR TITLE
community: add args_schema to SearxSearchResults tool

### DIFF
--- a/libs/community/langchain_community/tools/searx_search/tool.py
+++ b/libs/community/langchain_community/tools/searx_search/tool.py
@@ -60,6 +60,7 @@ class SearxSearchResults(BaseTool):
     wrapper: SearxSearchWrapper
     num_results: int = 4
     kwargs: dict = Field(default_factory=dict)
+    args_schema: Type[BaseModel] = SearxSearchQueryInput
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
This adds `args_schema` member to `SearxSearchResults` tool. This member is already present in the `SearxSearchRun` tool in the same file.

I was having `TypeError: Type is not JSON serializable: AsyncCallbackManagerForToolRun` being thrown in langserve playground when I was using `SearxSearchResults` tool as a part of chain there. This fixes the issue, so the error is not raised anymore.

This is a example langserve app that was giving me the error, but it works properly after the proposed fix:
```python
#!/usr/bin/env python

from fastapi import FastAPI
from langchain_core.prompts import ChatPromptTemplate
from langchain_core.output_parsers import StrOutputParser
from langchain_core.runnables import RunnablePassthrough
from langchain_openai import ChatOpenAI
from langchain_community.utilities import SearxSearchWrapper
from langchain_community.tools.searx_search.tool import SearxSearchResults
from langserve import add_routes

template = """Answer the question based only on the following context:
{context}

Question: {question}
"""
prompt = ChatPromptTemplate.from_template(template)
model = ChatOpenAI()

s = SearxSearchWrapper(searx_host="http://localhost:8080")

search = SearxSearchResults(wrapper=s)

search_chain = (
    {"context": search, "question": RunnablePassthrough()}
    | prompt
    | model
    | StrOutputParser()
)

app = FastAPI()

add_routes(
    app,
    search_chain,
    path="/chain",
)

if __name__ == "__main__":
    import uvicorn

    uvicorn.run(app, host="localhost", port=8000)
```