### PR TITLE
Update tools.py

### DIFF
--- a/Unit Test/code_test.py
+++ b/Unit Test/code_test.py
@@ -1,0 +1,61 @@
+from langchain_openai import AzureChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import AgentExecutor, create_openai_tools_agent
+from langchain_experimental.tools import PythonREPLTool
+from llm_factory import llm
+from langchain_core.messages import BaseMessage, HumanMessage
+
+
+def create_agent(llm: AzureChatOpenAI, tools: list, system_prompt: str):
+    """
+    Creates an agent with the given LLM, tools, and system prompt.
+
+    Args:
+        llm (AzureChatOpenAI): The LLM used by the agent.
+        tools (list): The list of tools used by the agent.
+        system_prompt (str): The system prompt for the agent.
+
+    Returns:
+        AgentExecutor: The created agent executor.
+
+    """
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                system_prompt,
+            ),
+            MessagesPlaceholder(variable_name="messages"),
+            MessagesPlaceholder(variable_name="agent_scratchpad"),
+        ]
+    )
+    agent = create_openai_tools_agent(llm, tools, prompt)
+    executor = AgentExecutor(agent=agent, tools=tools, verbose=True, handle_parsing_errors=True)
+    return executor
+
+def get_code_agent():
+    python_repl_tool = PythonREPLTool()
+
+    system_prompt_coder = "You a coding expert. You can generate python code to analyze data and generate charts using matplotlib. You can also wirte code for mathematical calculations. Once code is generated you use the tools to execute them as well"
+
+    code_agent = create_agent(
+        llm,
+        [python_repl_tool],
+        system_prompt_coder,
+    )
+    return code_agent
+
+
+def run_coding_agent(prompt):
+    code_agent = get_code_agent()
+    code_agent.invoke({"messages": [HumanMessage(content=prompt)]})
+
+
+if __name__ == '__main__':
+    prompt = "what are the squares of 5677234 and 676"
+    try:
+        result = run_coding_agent(prompt)
+        print("Unit test PASSED\n ------")
+        print(result)
+    except:
+        print("Unit test FAILED")

--- a/libs/core/langchain_core/tools.py
+++ b/libs/core/langchain_core/tools.py
@@ -510,7 +510,7 @@ class ChildTool(BaseTool):
         if isinstance(tool_input, str):
             return (tool_input,), {}
         else:
-            return (), tool_input
+            return (), dict(tool_input)
 
     def run(
         self,


### PR DESCRIPTION
Explicitly return the dict, if not we get JSON parsing error

Thank you for contributing to LangChain!

- [ ] **PR title**: "core: tools.py should return dict, but it was not explicitly converted, hence was throwing the JSON parsing"



- [ ] **PR message**: 
    - **Description:** Explicitly return the dict, if not we get JSON parsing error
    - **Issue:** TypeError('Object of type CallbackManagerForToolRun is not JSON serializable') on Coder agent
    - **Dependencies:** No dependencies
    - **Twitter handle:** @karthikseeyes


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  Unit test doc: https://github.com/karthikcs/langchain/blob/master/Unit%20test%20tools.py.pdf
 

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
