### PR TITLE
ollama[patch]: Update extra in ollama package

### DIFF
--- a/libs/partners/ollama/langchain_ollama/embeddings.py
+++ b/libs/partners/ollama/langchain_ollama/embeddings.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
+from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from ollama import AsyncClient, Client
 
 
@@ -139,7 +139,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra="forbid"
 
     @root_validator(pre=False, skip_on_failure=True)
     def _set_clients(cls, values: dict) -> dict:

--- a/libs/partners/ollama/langchain_ollama/embeddings.py
+++ b/libs/partners/ollama/langchain_ollama/embeddings.py
@@ -139,7 +139,7 @@ class OllamaEmbeddings(BaseModel, Embeddings):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra="forbid"
+        extra = "forbid"
 
     @root_validator(pre=False, skip_on_failure=True)
     def _set_clients(cls, values: dict) -> dict:


### PR DESCRIPTION
Backwards compatible change that converts pydantic extras to literals which is consistent with pydantic 2 usage.