### PR TITLE
huggingface[patch], pinecone[patch], fireworks[patch], mistralai[patch], voyageai[patch], togetherai[path]: convert Pydantic extras to literals

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/llms.py
+++ b/libs/partners/fireworks/langchain_fireworks/llms.py
@@ -10,7 +10,7 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, Field, SecretStr, root_validator
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import (
     convert_to_secret_str,
     get_from_dict_or_env,
@@ -77,7 +77,7 @@ class Fireworks(LLM):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional  # type: ignore[import-not-found]
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field
+from langchain_core.pydantic_v1 import BaseModel, Field
 
 DEFAULT_MODEL_NAME = "sentence-transformers/all-mpnet-base-v2"
 
@@ -65,7 +65,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Compute doc embeddings using a HuggingFace transformer model.

--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Extra, root_validator
+from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 
 DEFAULT_MODEL = "sentence-transformers/all-mpnet-base-v2"
@@ -44,7 +44,7 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
@@ -8,7 +8,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.pydantic_v1 import Extra, Field, root_validator
+from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.utils import get_from_dict_or_env, get_pydantic_field_names
 
 logger = logging.getLogger(__name__)
@@ -119,7 +119,7 @@ class HuggingFaceEndpoint(LLM):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -7,7 +7,6 @@ from typing import Any, Iterator, List, Mapping, Optional
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
-from langchain_core.pydantic_v1 import Extra
 
 DEFAULT_MODEL_ID = "gpt2"
 DEFAULT_TASK = "text-generation"
@@ -67,7 +66,7 @@ class HuggingFacePipeline(BaseLLM):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
 
     @classmethod
     def from_model_id(

--- a/libs/partners/mistralai/langchain_mistralai/embeddings.py
+++ b/libs/partners/mistralai/langchain_mistralai/embeddings.py
@@ -121,7 +121,7 @@ class MistralAIEmbeddings(BaseModel, Embeddings):
     model: str = "mistral-embed"
 
     class Config:
-        extra="forbid"
+        extra = "forbid"
         arbitrary_types_allowed = True
         allow_population_by_field_name = True
 

--- a/libs/partners/mistralai/langchain_mistralai/embeddings.py
+++ b/libs/partners/mistralai/langchain_mistralai/embeddings.py
@@ -7,7 +7,6 @@ import httpx
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
     root_validator,
@@ -122,7 +121,7 @@ class MistralAIEmbeddings(BaseModel, Embeddings):
     model: str = "mistral-embed"
 
     class Config:
-        extra = Extra.forbid
+        extra="forbid"
         arbitrary_types_allowed = True
         allow_population_by_field_name = True
 

--- a/libs/partners/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/partners/pinecone/langchain_pinecone/embeddings.py
@@ -6,7 +6,6 @@ import aiohttp
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
     root_validator,
@@ -49,7 +48,7 @@ class PineconeEmbeddings(BaseModel, Embeddings):
     pinecone_api_key: Optional[SecretStr] = None
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def set_default_config(cls, values: dict) -> dict:

--- a/libs/partners/together/langchain_together/embeddings.py
+++ b/libs/partners/together/langchain_together/embeddings.py
@@ -20,7 +20,6 @@ import openai
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
     root_validator,
@@ -170,7 +169,7 @@ class TogetherEmbeddings(BaseModel, Embeddings):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
         allow_population_by_field_name = True
 
     @root_validator(pre=True)

--- a/libs/partners/together/langchain_together/llms.py
+++ b/libs/partners/together/langchain_together/llms.py
@@ -11,7 +11,7 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.llms import LLM
-from langchain_core.pydantic_v1 import Extra, SecretStr, root_validator
+from langchain_core.pydantic_v1 import SecretStr, root_validator
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class Together(LLM):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/partners/voyageai/langchain_voyageai/embeddings.py
+++ b/libs/partners/voyageai/langchain_voyageai/embeddings.py
@@ -6,7 +6,6 @@ import voyageai  # type: ignore
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import (
     BaseModel,
-    Extra,
     Field,
     SecretStr,
     root_validator,
@@ -36,7 +35,7 @@ class VoyageAIEmbeddings(BaseModel, Embeddings):
     voyage_api_key: Optional[SecretStr] = None
 
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     @root_validator(pre=True)
     def default_values(cls, values: dict) -> dict:


### PR DESCRIPTION
Backwards compatible change that converts pydantic extras to literals which is consistent with pydantic 2 usage.

- fireworks
- voyage ai
- mistralai
- mistral ai
- together ai
- huggigng face
- pinecone