### PR TITLE
fix: typo where github should be gitlab

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/gitlab/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/gitlab/toolkit.py
@@ -1,4 +1,4 @@
-"""GitHub Toolkit."""
+"""GitLab Toolkit."""
 
 from typing import Dict, List
 


### PR DESCRIPTION
**PR title**: "GitLabToolkit: fix typo"
    - **Description:** fix typo where GitHub should have been GitLab
    - **Dependencies:** None
