### PR TITLE
docs: remove the extra period in docstring

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1144,7 +1144,7 @@ class BaseChatOpenAI(BaseChatModel):
                         API: https://platform.openai.com/docs/guides/function-calling
                     - "json_schema":
                         Uses OpenAI's Structured Output API:
-                        https://platform.openai.com/docs/guides/structured-outputs.
+                        https://platform.openai.com/docs/guides/structured-outputs
                         Supported for "gpt-4o-mini", "gpt-4o-2024-08-06", and later
                         models.
                     - "json_mode":
@@ -1178,7 +1178,7 @@ class BaseChatOpenAI(BaseChatModel):
                 - True:
                     Model output is guaranteed to exactly match the schema.
                     The input schema will also be validated according to
-                    https://platform.openai.com/docs/guides/structured-outputs/supported-schemas.
+                    https://platform.openai.com/docs/guides/structured-outputs/supported-schemas
                 - False:
                     Input schema will not be validated and model output will not be
                     validated.


### PR DESCRIPTION
Remove the period after the hyperlink in the docstring of BaseChatOpenAI.with_structured_output.

I have repeatedly copied the extra period at the end of the hyperlink, which results in a "Page not found" page when pasted into the browser.