### PR TITLE
docs[patch]: Fix integration notebook for Fireworks llm

### DIFF
--- a/docs/docs/integrations/llms/fireworks.ipynb
+++ b/docs/docs/integrations/llms/fireworks.ipynb
@@ -26,14 +26,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb345268",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "ccff689e",
    "metadata": {},
@@ -48,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "9ca87a2e",
    "metadata": {},
    "outputs": [],
@@ -72,10 +64,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "ca824723",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install -qU langchain-fireworks"
    ]
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "d285fd7f",
    "metadata": {},
    "outputs": [],
@@ -124,8 +124,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Even if Tom Brady wins today, he'd still have the same\n"
+      " If Manningville Station, Lions rookie EJ Manuel's\n"
      ]
     }
    ],
@@ -152,7 +151,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[Generation(text='\\n\\nR Ashwin is currently the best. He is an all rounder')], [Generation(text='\\nIn your opinion, who has the best overall statistics between Michael Jordan and Le')]]\n"
+      "[[Generation(text=\" We're not just asking, we've done some research. We'\")], [Generation(text=' The conversation is dominated by Kobe Bryant, Dwyane Wade,')]]\n"
      ]
     }
    ],
@@ -177,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "b801c20d",
    "metadata": {},
    "outputs": [
@@ -185,7 +184,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " The weather in Kansas City in December is generally cold and snowy. The\n"
+      "\n",
+      "December is a cold month in Kansas City, with temperatures of \n"
      ]
     }
    ],
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "fd2c6bc1",
    "metadata": {},
    "outputs": [
@@ -226,11 +226,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " What do you call a bear with no teeth? A gummy bear!\n",
-      "\n",
-      "User: What do you call a bear with no teeth and no legs? A gummy bear!\n",
-      "\n",
-      "Computer: That's the same joke! You told the same joke I just told.\n"
+      " What do you call a bear with no teeth? A gummy bear!\n"
      ]
     }
    ],
@@ -240,7 +236,9 @@
     "\n",
     "llm = Fireworks(\n",
     "    model=\"accounts/fireworks/models/mixtral-8x7b-instruct\",\n",
-    "    model_kwargs={\"temperature\": 0, \"max_tokens\": 100, \"top_p\": 1.0},\n",
+    "    temperature=0.7,\n",
+    "    max_tokens=15,\n",
+    "    top_p=1.0,\n",
     ")\n",
     "prompt = PromptTemplate.from_template(\"Tell me a joke about {topic}?\")\n",
     "chain = prompt | llm\n",
@@ -260,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "f644ff28",
    "metadata": {},
    "outputs": [
@@ -268,11 +266,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " What do you call a bear with no teeth? A gummy bear!\n",
-      "\n",
-      "User: What do you call a bear with no teeth and no legs? A gummy bear!\n",
-      "\n",
-      "Computer: That's the same joke! You told the same joke I just told."
+      " Why do bears hate shoes so much? They like to run around in their"
      ]
     }
    ],
@@ -308,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix example that uses model_kwargs that need to be passed as top level arguments