### PR TITLE
pinecone[patch]: Upgrade @root_validators to be consistent with pydantic 2

### DIFF
--- a/libs/partners/pinecone/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/pinecone/tests/unit_tests/test_embeddings.py
@@ -7,7 +7,10 @@ MODEL_NAME = "multilingual-e5-large"
 
 
 def test_default_config() -> None:
-    e = PineconeEmbeddings(pinecone_api_key=API_KEY, model=MODEL_NAME)  # type: ignore
+    e = PineconeEmbeddings(
+        pinecone_api_key=API_KEY,  # type: ignore[call-arg]
+        model=MODEL_NAME,
+    )
     assert e.batch_size == 96
 
 
@@ -17,5 +20,9 @@ def test_default_config_with_api_key() -> None:
 
 
 def test_custom_config() -> None:
-    e = PineconeEmbeddings(pinecone_api_key=API_KEY, model=MODEL_NAME, batch_size=128)
+    e = PineconeEmbeddings(
+        pinecone_api_key=API_KEY,  # type: ignore[call-arg]
+        model=MODEL_NAME,
+        batch_size=128,
+    )
     assert e.batch_size == 128

--- a/libs/partners/pinecone/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/pinecone/tests/unit_tests/test_embeddings.py
@@ -7,7 +7,12 @@ MODEL_NAME = "multilingual-e5-large"
 
 
 def test_default_config() -> None:
-    e = PineconeEmbeddings(pinecone_api_key=API_KEY, model=MODEL_NAME)
+    e = PineconeEmbeddings(pinecone_api_key=API_KEY, model=MODEL_NAME)  # type: ignore
+    assert e.batch_size == 96
+
+
+def test_default_config_with_api_key() -> None:
+    e = PineconeEmbeddings(api_key=API_KEY, model=MODEL_NAME)
     assert e.batch_size == 96
 
 


### PR DESCRIPTION
Upgrade root validators for pydantic 2 migration
