### PR TITLE
openai[major] -- test with pydantic 2 and langchain 0.3

### DIFF
--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -39,7 +39,6 @@ lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test
 
 lint lint_diff lint_package lint_tests:
-	./scripts/check_pydantic.sh .
 	./scripts/lint_imports.sh
 	poetry run ruff check .
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES) --diff

--- a/libs/core/langchain_core/beta/runnables/context.py
+++ b/libs/core/langchain_core/beta/runnables/context.py
@@ -18,6 +18,8 @@ from typing import (
     Union,
 )
 
+from pydantic import ConfigDict
+
 from langchain_core._api.beta_decorator import beta
 from langchain_core.runnables.base import (
     Runnable,
@@ -229,8 +231,7 @@ class ContextSet(RunnableSerializable):
 
     keys: Mapping[str, Optional[Runnable]]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     def __init__(
         self,

--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Sequence, Union
 
+from pydantic import BaseModel, Field
+
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     HumanMessage,
     get_buffer_string,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 
 
 class BaseChatMessageHistory(ABC):

--- a/libs/core/langchain_core/documents/compressor.py
+++ b/libs/core/langchain_core/documents/compressor.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks import Callbacks
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import run_in_executor
 
 

--- a/libs/core/langchain_core/embeddings/fake.py
+++ b/libs/core/langchain_core/embeddings/fake.py
@@ -4,8 +4,9 @@
 import hashlib
 from typing import List
 
+from pydantic import BaseModel
+
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class FakeEmbeddings(Embeddings, BaseModel):

--- a/libs/core/langchain_core/example_selectors/length_based.py
+++ b/libs/core/langchain_core/example_selectors/length_based.py
@@ -3,9 +3,10 @@
 import re
 from typing import Callable, Dict, List
 
+from pydantic import BaseModel, validator
+
 from langchain_core.example_selectors.base import BaseExampleSelector
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, validator
 
 
 def _get_length_based(text: str) -> int:

--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
+from pydantic import BaseModel, ConfigDict, Extra
+
 from langchain_core.documents import Document
 from langchain_core.example_selectors.base import BaseExampleSelector
-from langchain_core.pydantic_v1 import BaseModel, Extra
 from langchain_core.vectorstores import VectorStore
 
 if TYPE_CHECKING:
@@ -42,9 +43,7 @@ class _VectorStoreExampleSelector(BaseExampleSelector, BaseModel, ABC):
     vectorstore_kwargs: Optional[Dict[str, Any]] = None
     """Extra arguments passed to similarity_search function of the vectorstore."""
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(arbitrary_types_allowed=True,extra=Extra.forbid,)
 
     @staticmethod
     def _example_to_text(

--- a/libs/core/langchain_core/graph_vectorstores/base.py
+++ b/libs/core/langchain_core/graph_vectorstores/base.py
@@ -12,6 +12,8 @@ from typing import (
     Optional,
 )
 
+from pydantic import Field
+
 from langchain_core._api import beta
 from langchain_core.callbacks import (
     AsyncCallbackManagerForRetrieverRun,
@@ -20,7 +22,6 @@ from langchain_core.callbacks import (
 from langchain_core.documents import Document
 from langchain_core.graph_vectorstores.links import METADATA_LINKS_KEY, Link
 from langchain_core.load import Serializable
-from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import run_in_executor
 from langchain_core.vectorstores import VectorStore, VectorStoreRetriever
 

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -25,10 +25,11 @@ from typing import (
     cast,
 )
 
+from pydantic import model_validator
+
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 from langchain_core.indexing.base import DocumentIndex, RecordManager
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.vectorstores import VectorStore
 
 # Magic UUID to use as a namespace for hashing.
@@ -68,8 +69,9 @@ class _HashedDocument(Document):
     def is_lc_serializable(cls) -> bool:
         return False
 
-    @root_validator(pre=True)
-    def calculate_hashes(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def calculate_hashes(cls, values: Dict[str, Any]) -> Any:
         """Root validator to calculate content and metadata hash."""
         content = values.get("page_content", "")
         metadata = values.get("metadata", {})

--- a/libs/core/langchain_core/indexing/in_memory.py
+++ b/libs/core/langchain_core/indexing/in_memory.py
@@ -1,12 +1,13 @@
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, cast
 
+from pydantic import Field
+
 from langchain_core._api import beta
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.indexing import UpsertResponse
 from langchain_core.indexing.base import DeleteResponse, DocumentIndex
-from langchain_core.pydantic_v1 import Field
 
 
 @beta(message="Introduced in version 0.2.29. Underlying abstraction subject to change.")

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel, ConfigDict, Field, validator
 from typing_extensions import TypeAlias
 
 from langchain_core._api import deprecated
@@ -27,7 +28,6 @@ from langchain_core.messages import (
     get_buffer_string,
 )
 from langchain_core.prompt_values import PromptValue
-from langchain_core.pydantic_v1 import BaseModel, Field, validator
 from langchain_core.runnables import Runnable, RunnableSerializable
 from langchain_core.utils import get_pydantic_field_names
 
@@ -95,7 +95,11 @@ class BaseLanguageModel(
     
     Caching is not currently supported for streaming methods of models.
     """
-    verbose: bool = Field(default_factory=_get_verbosity)
+    # Repr = False is consistent with pydantic 1 if verbose = False
+    # We can relax this for pydantic 2?
+    # TODO(Team): decide what to do here.
+    # Modified just to get unit tests to pass.
+    verbose: bool = Field(default_factory=_get_verbosity, exclude=True, repr=False)
     """Whether to print out response text."""
     callbacks: Callbacks = Field(default=None, exclude=True)
     """Callbacks to add to the run trace."""
@@ -107,6 +111,8 @@ class BaseLanguageModel(
         default=None, exclude=True
     )
     """Optional encoder to use for counting tokens."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @validator("verbose", pre=True, always=True, allow_reuse=True)
     def set_verbose(cls, verbose: Optional[bool]) -> bool:

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -23,6 +23,12 @@ from typing import (
     cast,
 )
 
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 from typing_extensions import TypedDict
 
 from langchain_core._api import deprecated
@@ -30,7 +36,6 @@ from langchain_core.caches import BaseCache
 from langchain_core.callbacks import (
     AsyncCallbackManager,
     AsyncCallbackManagerForLLMRun,
-    BaseCallbackManager,
     CallbackManager,
     CallbackManagerForLLMRun,
     Callbacks,
@@ -55,11 +60,6 @@ from langchain_core.outputs import (
     RunInfo,
 )
 from langchain_core.prompt_values import ChatPromptValue, PromptValue, StringPromptValue
-from langchain_core.pydantic_v1 import (
-    BaseModel,
-    Field,
-    root_validator,
-)
 from langchain_core.rate_limiters import BaseRateLimiter
 from langchain_core.runnables import RunnableMap, RunnablePassthrough
 from langchain_core.runnables.config import ensure_config, run_in_executor
@@ -208,16 +208,6 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
 
     """  # noqa: E501
 
-    callback_manager: Optional[BaseCallbackManager] = deprecated(
-        name="callback_manager", since="0.1.7", removal="1.0", alternative="callbacks"
-    )(
-        Field(
-            default=None,
-            exclude=True,
-            description="Callback manager to add to the run trace.",
-        )
-    )
-
     rate_limiter: Optional[BaseRateLimiter] = Field(default=None, exclude=True)
     "An optional rate limiter to use for limiting the number of requests."
 
@@ -233,8 +223,9 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
     - If False (default), will always use streaming case if available.
     """
 
-    @root_validator(pre=True)
-    def raise_deprecation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def raise_deprecation(cls, values: Dict) -> Any:
         """Raise deprecation warning if callback_manager is used.
 
         Args:
@@ -254,8 +245,9 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
             values["callbacks"] = values.pop("callback_manager", None)
         return values
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     # --- Runnable methods ---
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import yaml
+from pydantic import ConfigDict, Field, model_validator
 from tenacity import (
     RetryCallState,
     before_sleep_log,
@@ -58,7 +59,6 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult, RunInfo
 from langchain_core.prompt_values import ChatPromptValue, PromptValue, StringPromptValue
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables import RunnableConfig, ensure_config, get_config_list
 from langchain_core.runnables.config import run_in_executor
 
@@ -297,11 +297,11 @@ class BaseLLM(BaseLanguageModel[str], ABC):
     callback_manager: Optional[BaseCallbackManager] = Field(default=None, exclude=True)
     """[DEPRECATED]"""
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
-    @root_validator(pre=True)
-    def raise_deprecation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def raise_deprecation(cls, values: Dict) -> Any:
         """Raise deprecation warning if callback_manager is used."""
         if values.get("callback_manager") is not None:
             warnings.warn(

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -10,9 +10,10 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict  # pydantic: ignore
 from typing_extensions import NotRequired
 
-from langchain_core.pydantic_v1 import BaseModel
+from langchain_core.utils.pydantic import v1_repr
 
 
 class BaseSerialized(TypedDict):
@@ -80,7 +81,7 @@ def try_neq_default(value: Any, key: str, model: BaseModel) -> bool:
         Exception: If the key is not in the model.
     """
     try:
-        return model.__fields__[key].get_default() != value
+        return model.model_fields[key].get_default() != value
     except Exception:
         return True
 
@@ -161,16 +162,25 @@ class Serializable(BaseModel, ABC):
         For example, for the class `langchain.llms.openai.OpenAI`, the id is
         ["langchain", "llms", "openai", "OpenAI"].
         """
-        return [*cls.get_lc_namespace(), cls.__name__]
+        # Pydantic generics change the class name. So we need to do the following
+        if (
+            "origin" in cls.__pydantic_generic_metadata__
+            and cls.__pydantic_generic_metadata__["origin"] is not None
+        ):
+            original_name = cls.__pydantic_generic_metadata__["origin"].__name__
+        else:
+            original_name = cls.__name__
+        return [*cls.get_lc_namespace(), original_name]
 
-    class Config:
-        extra = "ignore"
+    model_config = ConfigDict(
+        extra="ignore",
+    )
 
     def __repr_args__(self) -> Any:
         return [
             (k, v)
             for k, v in super().__repr_args__()
-            if (k not in self.__fields__ or try_neq_default(v, k, self))
+            if (k not in self.model_fields or try_neq_default(v, k, self))
         ]
 
     def to_json(self) -> Union[SerializedConstructor, SerializedNotImplemented]:
@@ -184,12 +194,15 @@ class Serializable(BaseModel, ABC):
 
         secrets = dict()
         # Get latest values for kwargs if there is an attribute with same name
-        lc_kwargs = {
-            k: getattr(self, k, v)
-            for k, v in self
-            if not (self.__exclude_fields__ or {}).get(k, False)  # type: ignore
-            and _is_field_useful(self, k, v)
-        }
+        lc_kwargs = {}
+        for k, v in self:
+            if not _is_field_useful(self, k, v):
+                continue
+            # Do nothing if the field is excluded
+            if k in self.model_fields and self.model_fields[k].exclude:
+                continue
+
+            lc_kwargs[k] = getattr(self, k, v)
 
         # Merge the lc_secrets and lc_attributes from every class in the MRO
         for cls in [None, *self.__class__.mro()]:
@@ -221,8 +234,10 @@ class Serializable(BaseModel, ABC):
             # that are not present in the fields.
             for key in list(secrets):
                 value = secrets[key]
-                if key in this.__fields__:
-                    secrets[this.__fields__[key].alias] = value
+                if key in this.model_fields:
+                    alias = this.model_fields[key].alias
+                    if alias is not None:
+                        secrets[alias] = value
             lc_kwargs.update(this.lc_attributes)
 
         # include all secrets, even if not specified in kwargs
@@ -244,6 +259,10 @@ class Serializable(BaseModel, ABC):
     def to_json_not_implemented(self) -> SerializedNotImplemented:
         return to_json_not_implemented(self)
 
+    def __repr__(self) -> str:
+        # TODO(0.3): Remove this override after confirming unit tests!
+        return v1_repr(self)
+
 
 def _is_field_useful(inst: Serializable, key: str, value: Any) -> bool:
     """Check if a field is useful as a constructor argument.
@@ -259,10 +278,26 @@ def _is_field_useful(inst: Serializable, key: str, value: Any) -> bool:
         If the field is not required and the value is None, it is useful if the
         default value is different from the value.
     """
-    field = inst.__fields__.get(key)
+    field = inst.model_fields.get(key)
     if not field:
         return False
-    return field.required is True or value or field.get_default() != value
+
+    if field.is_required():
+        return True
+
+    if value:
+        return True
+
+    # Value is still falsy here!
+    if field.default_factory is dict and isinstance(value, dict):
+        return False
+
+    # Value is still falsy here!
+    if field.default_factory is list and isinstance(value, list):
+        return False
+
+    # If value is falsy and does not match the default
+    return field.get_default() != value
 
 
 def _replace_secrets(

--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
+from pydantic import ConfigDict
+
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import run_in_executor
 
@@ -47,8 +49,7 @@ class BaseMemory(Serializable, ABC):
                     pass
     """  # noqa: E501
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @property
     @abstractmethod

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -1,7 +1,8 @@
 import json
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from typing_extensions import TypedDict
+from pydantic import model_validator
+from typing_extensions import Self, TypedDict
 
 from langchain_core.messages.base import (
     BaseMessage,
@@ -24,7 +25,6 @@ from langchain_core.messages.tool import (
 from langchain_core.messages.tool import (
     tool_call_chunk as create_tool_call_chunk,
 )
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils._merge import merge_dicts, merge_lists
 from langchain_core.utils.json import parse_partial_json
 
@@ -111,8 +111,9 @@ class AIMessage(BaseMessage):
             "invalid_tool_calls": self.invalid_tool_calls,
         }
 
-    @root_validator(pre=True)
-    def _backwards_compat_tool_calls(cls, values: dict) -> dict:
+    @model_validator(mode="before")
+    @classmethod
+    def _backwards_compat_tool_calls(cls, values: dict) -> Any:
         check_additional_kwargs = not any(
             values.get(k)
             for k in ("tool_calls", "invalid_tool_calls", "tool_call_chunks")
@@ -204,7 +205,7 @@ class AIMessage(BaseMessage):
         return (base.strip() + "\n" + "\n".join(lines)).strip()
 
 
-AIMessage.update_forward_refs()
+AIMessage.model_rebuild()
 
 
 class AIMessageChunk(AIMessage, BaseMessageChunk):
@@ -238,8 +239,8 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
             "invalid_tool_calls": self.invalid_tool_calls,
         }
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def init_tool_calls(cls, values: dict) -> dict:
+    @model_validator(mode="after")
+    def init_tool_calls(self) -> Self:
         """Initialize tool calls from tool call chunks.
 
         Args:
@@ -251,33 +252,33 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
         Raises:
             ValueError: If the tool call chunks are malformed.
         """
-        if not values["tool_call_chunks"]:
-            if values["tool_calls"]:
-                values["tool_call_chunks"] = [
+        if not self.tool_call_chunks:
+            if self.tool_calls:
+                self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
                         args=json.dumps(tc["args"]),
                         id=tc["id"],
                         index=None,
                     )
-                    for tc in values["tool_calls"]
+                    for tc in self.tool_calls
                 ]
-            if values["invalid_tool_calls"]:
-                tool_call_chunks = values.get("tool_call_chunks", [])
+            if self.invalid_tool_calls:
+                tool_call_chunks = self.tool_call_chunks
                 tool_call_chunks.extend(
                     [
                         create_tool_call_chunk(
                             name=tc["name"], args=tc["args"], id=tc["id"], index=None
                         )
-                        for tc in values["invalid_tool_calls"]
+                        for tc in self.invalid_tool_calls
                     ]
                 )
-                values["tool_call_chunks"] = tool_call_chunks
+                self.tool_call_chunks = tool_call_chunks
 
-            return values
+            return self
         tool_calls = []
         invalid_tool_calls = []
-        for chunk in values["tool_call_chunks"]:
+        for chunk in self.tool_call_chunks:
             try:
                 args_ = parse_partial_json(chunk["args"]) if chunk["args"] != "" else {}
                 if isinstance(args_, dict):
@@ -299,9 +300,9 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                         error=None,
                     )
                 )
-        values["tool_calls"] = tool_calls
-        values["invalid_tool_calls"] = invalid_tool_calls
-        return values
+        self.tool_calls = tool_calls
+        self.invalid_tool_calls = invalid_tool_calls
+        return self
 
     def __add__(self, other: Any) -> BaseMessageChunk:  # type: ignore
         if isinstance(other, AIMessageChunk):

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, cast
 
+from pydantic import ConfigDict, Extra, Field
+
 from langchain_core.load.serializable import Serializable
-from langchain_core.pydantic_v1 import Extra, Field
 from langchain_core.utils import get_bolded_text
 from langchain_core.utils._merge import merge_dicts, merge_lists
 from langchain_core.utils.interactive_env import is_interactive_env
+from langchain_core.utils.pydantic import v1_repr
 
 if TYPE_CHECKING:
     from langchain_core.prompts.chat import ChatPromptTemplate
@@ -51,8 +53,7 @@ class BaseMessage(Serializable):
     """An optional unique identifier for the message. This should ideally be
     provided by the provider/model which created the message."""
 
-    class Config:
-        extra = Extra.allow
+    model_config = ConfigDict(extra=Extra.allow,)
 
     def __init__(
         self, content: Union[str, List[Union[str, Dict]]], **kwargs: Any
@@ -107,6 +108,10 @@ class BaseMessage(Serializable):
 
     def pretty_print(self) -> None:
         print(self.pretty_repr(html=is_interactive_env()))  # noqa: T201
+
+    def __repr__(self) -> str:
+        # TODO(0.3): Remove this override after confirming unit tests!
+        return v1_repr(self)
 
 
 def merge_content(

--- a/libs/core/langchain_core/messages/chat.py
+++ b/libs/core/langchain_core/messages/chat.py
@@ -25,7 +25,7 @@ class ChatMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-ChatMessage.update_forward_refs()
+ChatMessage.model_rebuild()
 
 
 class ChatMessageChunk(ChatMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/function.py
+++ b/libs/core/langchain_core/messages/function.py
@@ -32,7 +32,7 @@ class FunctionMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-FunctionMessage.update_forward_refs()
+FunctionMessage.model_rebuild()
 
 
 class FunctionMessageChunk(FunctionMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/human.py
+++ b/libs/core/langchain_core/messages/human.py
@@ -56,7 +56,7 @@ class HumanMessage(BaseMessage):
         super().__init__(content=content, **kwargs)
 
 
-HumanMessage.update_forward_refs()
+HumanMessage.model_rebuild()
 
 
 class HumanMessageChunk(HumanMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/modifier.py
+++ b/libs/core/langchain_core/messages/modifier.py
@@ -33,4 +33,4 @@ class RemoveMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-RemoveMessage.update_forward_refs()
+RemoveMessage.model_rebuild()

--- a/libs/core/langchain_core/messages/system.py
+++ b/libs/core/langchain_core/messages/system.py
@@ -50,7 +50,7 @@ class SystemMessage(BaseMessage):
         super().__init__(content=content, **kwargs)
 
 
-SystemMessage.update_forward_refs()
+SystemMessage.model_rebuild()
 
 
 class SystemMessageChunk(SystemMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
+from pydantic import Field
 from typing_extensions import NotRequired, TypedDict
 
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk, merge_content
@@ -70,6 +71,11 @@ class ToolMessage(BaseMessage):
     .. versionadded:: 0.2.24
     """
 
+    additional_kwargs: dict = Field(default_factory=dict, repr=False)
+    """Currently inherited from BaseMessage, but not used."""
+    response_metadata: dict = Field(default_factory=dict, repr=False)
+    """Currently inherited from BaseMessage, but not used."""
+
     @classmethod
     def get_lc_namespace(cls) -> List[str]:
         """Get the namespace of the langchain object.
@@ -88,7 +94,7 @@ class ToolMessage(BaseMessage):
         super().__init__(content=content, **kwargs)
 
 
-ToolMessage.update_forward_refs()
+ToolMessage.model_rebuild()
 
 
 class ToolMessageChunk(ToolMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -13,8 +13,6 @@ from typing import (
     Union,
 )
 
-from typing_extensions import get_args
-
 from langchain_core.language_models import LanguageModelOutput
 from langchain_core.messages import AnyMessage, BaseMessage
 from langchain_core.outputs import ChatGeneration, Generation
@@ -166,10 +164,11 @@ class BaseOutputParser(
         Raises:
             TypeError: If the class doesn't have an inferable OutputType.
         """
-        for cls in self.__class__.__orig_bases__:  # type: ignore[attr-defined]
-            type_args = get_args(cls)
-            if type_args and len(type_args) == 1:
-                return type_args[0]
+        for base in self.__class__.mro():
+            if hasattr(base, "__pydantic_generic_metadata__"):
+                metadata = base.__pydantic_generic_metadata__
+                if "args" in metadata and len(metadata["args"]) > 0:
+                    return metadata["args"][0]
 
         raise TypeError(
             f"Runnable {self.__class__.__name__} doesn't have an inferable OutputType. "

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import json
 from json import JSONDecodeError
-from typing import Any, List, Optional, Type, TypeVar, Union
+from typing import Annotated, Any, List, Optional, Type, TypeVar, Union
 
 import jsonpatch  # type: ignore[import]
 import pydantic  # pydantic: ignore
+from pydantic import SkipValidation  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers.format_instructions import JSON_FORMAT_INSTRUCTIONS
@@ -40,7 +41,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
     describing the difference between the previous and the current object.
     """
 
-    pydantic_object: Optional[Type[TBaseModel]] = None  # type: ignore
+    pydantic_object: Annotated[Optional[Type[TBaseModel]], SkipValidation()] = None  # type: ignore
     """The Pydantic object to use for validation. 
     If None, no validation is performed."""
 

--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -4,6 +4,7 @@ import re
 from abc import abstractmethod
 from collections import deque
 from typing import AsyncIterator, Deque, Iterator, List, TypeVar, Union
+from typing import Optional as Optional
 
 from langchain_core.messages import BaseMessage
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
@@ -120,6 +121,9 @@ class ListOutputParser(BaseTransformOutputParser[List[str]]):
         # yield the last part
         for part in self.parse(buffer):
             yield [part]
+
+
+ListOutputParser.model_rebuild()
 
 
 class CommaSeparatedListOutputParser(ListOutputParser):

--- a/libs/core/langchain_core/output_parsers/openai_functions.py
+++ b/libs/core/langchain_core/output_parsers/openai_functions.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Dict, List, Optional, Type, Union
 
 import jsonpatch  # type: ignore[import]
+from pydantic import BaseModel, model_validator
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import (
@@ -11,7 +12,6 @@ from langchain_core.output_parsers import (
 )
 from langchain_core.output_parsers.json import parse_partial_json
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class OutputFunctionsParser(BaseGenerationOutputParser[Any]):
@@ -226,8 +226,9 @@ class PydanticOutputFunctionsParser(OutputFunctionsParser):
     determine which schema to use.
     """
 
-    @root_validator(pre=True)
-    def validate_schema(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def validate_schema(cls, values: Dict) -> Any:
         """Validate the pydantic schema.
 
         Args:
@@ -263,11 +264,17 @@ class PydanticOutputFunctionsParser(OutputFunctionsParser):
         """
         _result = super().parse_result(result)
         if self.args_only:
-            pydantic_args = self.pydantic_schema.parse_raw(_result)  # type: ignore
+            if hasattr(self.pydantic_schema, "model_validate_json"):
+                pydantic_args = self.pydantic_schema.model_validate_json(_result)
+            else:
+                pydantic_args = self.pydantic_schema.parse_raw(_result)  # type: ignore
         else:
             fn_name = _result["name"]
             _args = _result["arguments"]
-            pydantic_args = self.pydantic_schema[fn_name].parse_raw(_args)  # type: ignore
+            if hasattr(self.pydantic_schema, "model_validate_json"):
+                pydantic_args = self.pydantic_schema[fn_name].model_validate_json(_args)
+            else:
+                pydantic_args = self.pydantic_schema[fn_name].parse_raw(_args)  # type: ignore
         return pydantic_args
 
 

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -1,7 +1,9 @@
 import copy
 import json
 from json import JSONDecodeError
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
+
+from pydantic import SkipValidation, ValidationError  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, InvalidToolCall
@@ -13,7 +15,6 @@ from langchain_core.messages.tool import (
 )
 from langchain_core.output_parsers.transform import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import ValidationError
 from langchain_core.utils.json import parse_partial_json
 from langchain_core.utils.pydantic import TypeBaseModel
 
@@ -256,7 +257,7 @@ class JsonOutputKeyToolsParser(JsonOutputToolsParser):
 class PydanticToolsParser(JsonOutputToolsParser):
     """Parse tools from OpenAI response."""
 
-    tools: List[TypeBaseModel]
+    tools: Annotated[List[TypeBaseModel], SkipValidation()]
     """The tools to parse."""
 
     # TODO: Support more granular streaming of objects. Currently only streams once all

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,7 +1,9 @@
 import json
-from typing import Generic, List, Type
+from typing import Annotated, Generic, List, Type
+from typing import Optional as Optional
 
 import pydantic  # pydantic: ignore
+from pydantic import SkipValidation  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser
@@ -16,7 +18,7 @@ from langchain_core.utils.pydantic import (
 class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
     """Parse an output using a pydantic model."""
 
-    pydantic_object: Type[TBaseModel]  # type: ignore
+    pydantic_object: Annotated[Type[TBaseModel], SkipValidation()]  # type: ignore
     """The pydantic model to parse."""
 
     def _parse_obj(self, obj: dict) -> TBaseModel:
@@ -104,6 +106,9 @@ class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
     def OutputType(self) -> Type[TBaseModel]:
         """Return the pydantic model."""
         return self.pydantic_object
+
+
+PydanticOutputParser.model_rebuild()
 
 
 _PYDANTIC_FORMAT_INSTRUCTIONS = """The output should be formatted as a JSON instance that conforms to the JSON schema below.

--- a/libs/core/langchain_core/output_parsers/string.py
+++ b/libs/core/langchain_core/output_parsers/string.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import Optional as Optional
 
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
 
@@ -24,3 +25,6 @@ class StrOutputParser(BaseTransformOutputParser[str]):
     def parse(self, text: str) -> str:
         """Returns the input text with no changes."""
         return text
+
+
+StrOutputParser.model_rebuild()

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Union
+from typing import List, Literal, Union
+
+from pydantic import model_validator
+from typing_extensions import Self
 
 from langchain_core.messages import BaseMessage, BaseMessageChunk
 from langchain_core.outputs.generation import Generation
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils._merge import merge_dicts
 
 
@@ -30,8 +32,8 @@ class ChatGeneration(Generation):
     type: Literal["ChatGeneration"] = "ChatGeneration"  # type: ignore[assignment]
     """Type is used exclusively for serialization purposes."""
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="after")
+    def set_text(self) -> Self:
         """Set the text attribute to be the contents of the message.
 
         Args:
@@ -45,12 +47,12 @@ class ChatGeneration(Generation):
         """
         try:
             text = ""
-            if isinstance(values["message"].content, str):
-                text = values["message"].content
+            if isinstance(self.message.content, str):
+                text = self.message.content
             # HACK: Assumes text in content blocks in OpenAI format.
             # Uses first text block.
-            elif isinstance(values["message"].content, list):
-                for block in values["message"].content:
+            elif isinstance(self.message.content, list):
+                for block in self.message.content:
                     if isinstance(block, str):
                         text = block
                         break
@@ -61,10 +63,10 @@ class ChatGeneration(Generation):
                         pass
             else:
                 pass
-            values["text"] = text
+            self.text = text
         except (KeyError, AttributeError) as e:
             raise ValueError("Error while initializing ChatGeneration") from e
-        return values
+        return self
 
     @classmethod
     def get_lc_namespace(cls) -> List[str]:

--- a/libs/core/langchain_core/outputs/chat_result.py
+++ b/libs/core/langchain_core/outputs/chat_result.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
+from pydantic import BaseModel
+
 from langchain_core.outputs.chat_generation import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class ChatResult(BaseModel):

--- a/libs/core/langchain_core/outputs/llm_result.py
+++ b/libs/core/langchain_core/outputs/llm_result.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from langchain_core.outputs.generation import Generation
+from pydantic import BaseModel
+
+from langchain_core.outputs.chat_generation import ChatGeneration, ChatGenerationChunk
+from langchain_core.outputs.generation import Generation, GenerationChunk
 from langchain_core.outputs.run_info import RunInfo
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class LLMResult(BaseModel):
@@ -16,7 +18,9 @@ class LLMResult(BaseModel):
     wants to return.
     """
 
-    generations: List[List[Generation]]
+    generations: List[
+        List[Union[Generation, ChatGeneration, GenerationChunk, ChatGenerationChunk]]
+    ]
     """Generated outputs.
     
     The first dimension of the list represents completions for different input

--- a/libs/core/langchain_core/outputs/run_info.py
+++ b/libs/core/langchain_core/outputs/run_info.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class RunInfo(BaseModel):

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -18,6 +18,8 @@ from typing import (
 )
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
 
 from langchain_core.output_parsers.base import BaseOutputParser
 from langchain_core.prompt_values import (
@@ -25,7 +27,6 @@ from langchain_core.prompt_values import (
     PromptValue,
     StringPromptValue,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 from langchain_core.runnables import RunnableConfig, RunnableSerializable
 from langchain_core.runnables.config import ensure_config
 from langchain_core.runnables.utils import create_model
@@ -64,28 +65,28 @@ class BasePromptTemplate(
     tags: Optional[List[str]] = None
     """Tags to be used for tracing."""
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def validate_variable_names(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def validate_variable_names(self) -> Self:
         """Validate variable names do not include restricted names."""
-        if "stop" in values["input_variables"]:
+        if "stop" in self.input_variables:
             raise ValueError(
                 "Cannot have an input variable named 'stop', as it is used internally,"
                 " please rename."
             )
-        if "stop" in values["partial_variables"]:
+        if "stop" in self.partial_variables:
             raise ValueError(
                 "Cannot have an partial variable named 'stop', as it is used "
                 "internally, please rename."
             )
 
-        overall = set(values["input_variables"]).intersection(
-            values["partial_variables"]
+        overall = set(self.input_variables).intersection(
+            self.partial_variables
         )
         if overall:
             raise ValueError(
                 f"Found overlapping input and partial variables: {overall}"
             )
-        return values
+        return self
 
     @classmethod
     def get_lc_namespace(cls) -> List[str]:
@@ -99,8 +100,7 @@ class BasePromptTemplate(
         Returns True."""
         return True
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @property
     def OutputType(self) -> Any:

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
+    Annotated,
     Any,
     Dict,
     List,
@@ -19,6 +20,13 @@ from typing import (
     Union,
     cast,
     overload,
+)
+
+from pydantic import (
+    Field,
+    PositiveInt,
+    SkipValidation,
+    model_validator,
 )
 
 from langchain_core._api import deprecated
@@ -38,7 +46,6 @@ from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.image import ImagePromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import StringPromptTemplate, get_template_variables
-from langchain_core.pydantic_v1 import Field, PositiveInt, root_validator
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.interactive_env import is_interactive_env
 
@@ -207,8 +214,14 @@ class MessagesPlaceholder(BaseMessagePromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "chat"]
 
-    def __init__(self, variable_name: str, *, optional: bool = False, **kwargs: Any):
-        super().__init__(variable_name=variable_name, optional=optional, **kwargs)
+    def __init__(
+        self, variable_name: str, *, optional: bool = False, **kwargs: Any
+    ) -> None:
+        # mypy can't detect the init which is defined in the parent class
+        # b/c these are BaseModel classes.
+        super().__init__(  # type: ignore
+            variable_name=variable_name, optional=optional, **kwargs
+        )
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format messages from kwargs.
@@ -922,7 +935,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
 
     """  # noqa: E501
 
-    messages: List[MessageLike]
+    messages: Annotated[List[MessageLike], SkipValidation]
     """List of messages consisting of either message prompt templates or messages."""
     validate_template: bool = False
     """Whether or not to try validating the template."""
@@ -1038,8 +1051,9 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         else:
             raise NotImplementedError(f"Unsupported operand type for +: {type(other)}")
 
-    @root_validator(pre=True)
-    def validate_input_variables(cls, values: dict) -> dict:
+    @model_validator(mode="before")
+    @classmethod
+    def validate_input_variables(cls, values: dict) -> Any:
         """Validate input variables.
 
         If input_variables is not set, it will be set to the union of

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Extra,
+    Field,
+    model_validator,
+)
+from typing_extensions import Self
+
 from langchain_core.example_selectors import BaseExampleSelector
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.prompts.chat import (
@@ -18,7 +27,6 @@ from langchain_core.prompts.string import (
     check_valid_template,
     get_template_variables,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 
 
 class _FewShotPromptTemplateMixin(BaseModel):
@@ -32,12 +40,11 @@ class _FewShotPromptTemplateMixin(BaseModel):
     """ExampleSelector to choose the examples to format into the prompt.
     Either this or examples should be provided."""
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(arbitrary_types_allowed=True,extra=Extra.forbid,)
 
-    @root_validator(pre=True)
-    def check_examples_and_selector(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def check_examples_and_selector(cls, values: Dict) -> Any:
         """Check that one and only one of examples/example_selector are provided.
 
         Args:
@@ -139,28 +146,26 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
             kwargs["input_variables"] = kwargs["example_prompt"].input_variables
         super().__init__(**kwargs)
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def template_is_valid(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def template_is_valid(self) -> Self:
         """Check that prefix, suffix, and input variables are consistent."""
-        if values["validate_template"]:
+        if self.validate_template:
             check_valid_template(
-                values["prefix"] + values["suffix"],
-                values["template_format"],
-                values["input_variables"] + list(values["partial_variables"]),
+                self.prefix + self.suffix,
+                self.template_format,
+                self.input_variables + list(self.partial_variables),
             )
-        elif values.get("template_format"):
-            values["input_variables"] = [
+        elif (self.template_format or None):
+            self.input_variables = [
                 var
                 for var in get_template_variables(
-                    values["prefix"] + values["suffix"], values["template_format"]
+                    self.prefix + self.suffix, self.template_format
                 )
-                if var not in values["partial_variables"]
+                if var not in self.partial_variables
             ]
-        return values
+        return self
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(arbitrary_types_allowed=True,extra=Extra.forbid,)
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with inputs generating a string.
@@ -365,9 +370,7 @@ class FewShotChatMessagePromptTemplate(
         """Return whether or not the class is serializable."""
         return False
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(arbitrary_types_allowed=True,extra=Extra.forbid,)
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format kwargs into a list of messages.

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -3,12 +3,14 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from pydantic import ConfigDict, Extra, model_validator
+from typing_extensions import Self
+
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     StringPromptTemplate,
 )
-from langchain_core.pydantic_v1 import Extra, root_validator
 
 
 class FewShotPromptWithTemplates(StringPromptTemplate):
@@ -45,8 +47,9 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "few_shot_with_templates"]
 
-    @root_validator(pre=True)
-    def check_examples_and_selector(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def check_examples_and_selector(cls, values: Dict) -> Any:
         """Check that one and only one of examples/example_selector are provided."""
         examples = values.get("examples", None)
         example_selector = values.get("example_selector", None)
@@ -62,15 +65,15 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
 
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def template_is_valid(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def template_is_valid(self) -> Self:
         """Check that prefix, suffix, and input variables are consistent."""
-        if values["validate_template"]:
-            input_variables = values["input_variables"]
-            expected_input_variables = set(values["suffix"].input_variables)
-            expected_input_variables |= set(values["partial_variables"])
-            if values["prefix"] is not None:
-                expected_input_variables |= set(values["prefix"].input_variables)
+        if self.validate_template:
+            input_variables = self.input_variables
+            expected_input_variables = set(self.suffix.input_variables)
+            expected_input_variables |= set(self.partial_variables)
+            if self.prefix is not None:
+                expected_input_variables |= set(self.prefix.input_variables)
             missing_vars = expected_input_variables.difference(input_variables)
             if missing_vars:
                 raise ValueError(
@@ -78,16 +81,14 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
                     f"prefix/suffix expected {expected_input_variables}"
                 )
         else:
-            values["input_variables"] = sorted(
-                set(values["suffix"].input_variables)
-                | set(values["prefix"].input_variables if values["prefix"] else [])
-                - set(values["partial_variables"])
+            self.input_variables = sorted(
+                set(self.suffix.input_variables)
+                | set(self.prefix.input_variables if self.prefix else [])
+                - set(self.partial_variables)
             )
-        return values
+        return self
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(arbitrary_types_allowed=True,extra=Extra.forbid,)
 
     def _get_examples(self, **kwargs: Any) -> List[dict]:
         if self.examples is not None:

--- a/libs/core/langchain_core/prompts/image.py
+++ b/libs/core/langchain_core/prompts/image.py
@@ -1,8 +1,9 @@
 from typing import Any, List
 
+from pydantic import Field
+
 from langchain_core.prompt_values import ImagePromptValue, ImageURL, PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
-from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import run_in_executor
 from langchain_core.utils import image as image_utils
 

--- a/libs/core/langchain_core/prompts/pipeline.py
+++ b/libs/core/langchain_core/prompts/pipeline.py
@@ -1,9 +1,11 @@
 from typing import Any, Dict, List, Tuple
+from typing import Optional as Optional
+
+from pydantic import model_validator
 
 from langchain_core.prompt_values import PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.chat import BaseChatPromptTemplate
-from langchain_core.pydantic_v1 import root_validator
 
 
 def _get_inputs(inputs: dict, input_variables: List[str]) -> dict:
@@ -34,8 +36,9 @@ class PipelinePromptTemplate(BasePromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "pipeline"]
 
-    @root_validator(pre=True)
-    def get_input_variables(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def get_input_variables(cls, values: Dict) -> Any:
         """Get input variables."""
         created_variables = set()
         all_variables = set()
@@ -106,3 +109,6 @@ class PipelinePromptTemplate(BasePromptTemplate):
     @property
     def _prompt_type(self) -> str:
         raise ValueError
+
+
+PipelinePromptTemplate.model_rebuild()

--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -6,6 +6,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import BaseModel, model_validator
+
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     StringPromptTemplate,
@@ -13,7 +15,6 @@ from langchain_core.prompts.string import (
     get_template_variables,
     mustache_schema,
 )
-from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.runnables.config import RunnableConfig
 
 
@@ -73,8 +74,9 @@ class PromptTemplate(StringPromptTemplate):
     validate_template: bool = False
     """Whether or not to try validating the template."""
 
-    @root_validator(pre=True)
-    def pre_init_validation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def pre_init_validation(cls, values: Dict) -> Any:
         """Check that template and input variables are consistent."""
         if values.get("template") is None:
             # Will let pydantic fail with a ValidationError if template

--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -7,10 +7,11 @@ from abc import ABC
 from string import Formatter
 from typing import Any, Callable, Dict, List, Set, Tuple, Type
 
+from pydantic import BaseModel, create_model
+
 import langchain_core.utils.mustache as mustache
 from langchain_core.prompt_values import PromptValue, StringPromptValue
 from langchain_core.prompts.base import BasePromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, create_model
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.formatting import formatter
 from langchain_core.utils.interactive_env import is_interactive_env

--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -12,6 +12,8 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel
+
 from langchain_core._api.beta_decorator import beta
 from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.prompts.chat import (
@@ -22,7 +24,6 @@ from langchain_core.prompts.chat import (
     MessagesPlaceholder,
     _convert_to_message,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import (
     Other,
     Runnable,

--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -26,6 +26,7 @@ from abc import ABC, abstractmethod
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from pydantic import ConfigDict
 from typing_extensions import TypedDict
 
 from langchain_core._api import deprecated
@@ -126,8 +127,7 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
                     return [self.docs[i] for i in results.argsort()[-self.k :][::-1]]
     """  # noqa: E501
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     _new_arg_supported: bool = False
     _expects_other_args: bool = False

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -35,7 +35,8 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Literal, get_args
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+from typing_extensions import Literal, get_args, get_type_hints
 
 from langchain_core._api import beta_decorator
 from langchain_core.load.dump import dumpd
@@ -44,7 +45,6 @@ from langchain_core.load.serializable import (
     SerializedConstructor,
     SerializedNotImplemented,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables.config import (
     RunnableConfig,
     _set_config_context,
@@ -83,7 +83,6 @@ from langchain_core.runnables.utils import (
 )
 from langchain_core.utils.aiter import aclosing, atee, py_anext
 from langchain_core.utils.iter import safetee
-from langchain_core.utils.pydantic import is_basemodel_subclass
 
 if TYPE_CHECKING:
     from langchain_core.callbacks.manager import (
@@ -236,25 +235,56 @@ class Runnable(Generic[Input, Output], ABC):
     For a UI (and much more) checkout LangSmith: https://docs.smith.langchain.com/
     """  # noqa: E501
 
-    name: Optional[str] = None
+    name: Optional[str]
     """The name of the Runnable. Used for debugging and tracing."""
 
     def get_name(
         self, suffix: Optional[str] = None, *, name: Optional[str] = None
     ) -> str:
         """Get the name of the Runnable."""
-        name = name or self.name or self.__class__.__name__
-        if suffix:
-            if name[0].isupper():
-                return name + suffix.title()
-            else:
-                return name + "_" + suffix.lower()
+        if name:
+            name_ = name
+        elif hasattr(self, "name") and self.name:
+            name_ = self.name
         else:
-            return name
+            # Here we handle a case where the runnable subclass is also a pydantic
+            # model.
+            cls = self.__class__
+            # Then it's a pydantic sub-class, and we have to check
+            # whether it's a generic, and if so recover the original name.
+            if (
+                hasattr(
+                    cls,
+                    "__pydantic_generic_metadata__",
+                )
+                and "origin" in cls.__pydantic_generic_metadata__
+                and cls.__pydantic_generic_metadata__["origin"] is not None
+            ):
+                name_ = cls.__pydantic_generic_metadata__["origin"].__name__
+            else:
+                name_ = cls.__name__
+
+        if suffix:
+            if name_[0].isupper():
+                return name_ + suffix.title()
+            else:
+                return name_ + "_" + suffix.lower()
+        else:
+            return name_
 
     @property
     def InputType(self) -> Type[Input]:
         """The type of input this Runnable accepts specified as a type annotation."""
+        # First loop through bases -- this will help generic
+        # any pydantic models.
+        for base in self.__class__.mro():
+            if hasattr(base, "__pydantic_generic_metadata__"):
+                metadata = base.__pydantic_generic_metadata__
+                if "args" in metadata and len(metadata["args"]) == 2:
+                    return metadata["args"][0]
+
+        # then loop through __orig_bases__ -- this will Runnables that do not inherit
+        # from pydantic
         for cls in self.__class__.__orig_bases__:  # type: ignore[attr-defined]
             type_args = get_args(cls)
             if type_args and len(type_args) == 2:
@@ -268,6 +298,14 @@ class Runnable(Generic[Input, Output], ABC):
     @property
     def OutputType(self) -> Type[Output]:
         """The type of output this Runnable produces specified as a type annotation."""
+        # First loop through bases -- this will help generic
+        # any pydantic models.
+        for base in self.__class__.mro():
+            if hasattr(base, "__pydantic_generic_metadata__"):
+                metadata = base.__pydantic_generic_metadata__
+                if "args" in metadata and len(metadata["args"]) == 2:
+                    return metadata["args"][1]
+
         for cls in self.__class__.__orig_bases__:  # type: ignore[attr-defined]
             type_args = get_args(cls)
             if type_args and len(type_args) == 2:
@@ -302,12 +340,12 @@ class Runnable(Generic[Input, Output], ABC):
         """
         root_type = self.InputType
 
-        if inspect.isclass(root_type) and is_basemodel_subclass(root_type):
+        if inspect.isclass(root_type) and issubclass(root_type, BaseModel):
             return root_type
 
         return create_model(
             self.get_name("Input"),
-            __root__=(root_type, None),
+            __root__=root_type,
         )
 
     @property
@@ -334,12 +372,12 @@ class Runnable(Generic[Input, Output], ABC):
         """
         root_type = self.OutputType
 
-        if inspect.isclass(root_type) and is_basemodel_subclass(root_type):
+        if inspect.isclass(root_type) and issubclass(root_type, BaseModel):
             return root_type
 
         return create_model(
             self.get_name("Output"),
-            __root__=(root_type, None),
+            __root__=root_type,
         )
 
     @property
@@ -381,15 +419,19 @@ class Runnable(Generic[Input, Output], ABC):
             else None
         )
 
-        return create_model(  # type: ignore[call-overload]
-            self.get_name("Config"),
+        # Many need to create a typed dict instead to implement NotRequired!
+        all_fields = {
             **({"configurable": (configurable, None)} if configurable else {}),
             **{
                 field_name: (field_type, None)
-                for field_name, field_type in RunnableConfig.__annotations__.items()
+                for field_name, field_type in get_type_hints(RunnableConfig).items()
                 if field_name in [i for i in include if i != "configurable"]
             },
+        }
+        model = create_model(  # type: ignore[call-overload]
+            self.get_name("Config"), **all_fields
         )
+        return model
 
     def get_graph(self, config: Optional[RunnableConfig] = None) -> Graph:
         """Return a graph representation of this Runnable."""
@@ -579,7 +621,7 @@ class Runnable(Generic[Input, Output], ABC):
         """
         from langchain_core.runnables.passthrough import RunnableAssign
 
-        return self | RunnableAssign(RunnableParallel(kwargs))
+        return self | RunnableAssign(RunnableParallel[Dict[str, Any]](kwargs))
 
     """ --- Public API --- """
 
@@ -2129,7 +2171,6 @@ class Runnable(Generic[Input, Output], ABC):
             name=config.get("run_name") or self.get_name(),
             run_id=config.pop("run_id", None),
         )
-        iterator_ = None
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())
             if accepts_config(transformer):
@@ -2314,7 +2355,6 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
     """Runnable that can be serialized to JSON."""
 
     name: Optional[str] = None
-    """The name of the Runnable. Used for debugging and tracing."""
 
     def to_json(self) -> Union[SerializedConstructor, SerializedNotImplemented]:
         """Serialize the Runnable to JSON.
@@ -2369,10 +2409,10 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
         from langchain_core.runnables.configurable import RunnableConfigurableFields
 
         for key in kwargs:
-            if key not in self.__fields__:
+            if key not in self.model_fields:
                 raise ValueError(
                     f"Configuration key {key} not found in {self}: "
-                    f"available keys are {self.__fields__.keys()}"
+                    f"available keys are {self.model_fields.keys()}"
                 )
 
         return RunnableConfigurableFields(default=self, fields=kwargs)
@@ -2447,13 +2487,13 @@ def _seq_input_schema(
         return first.get_input_schema(config)
     elif isinstance(first, RunnableAssign):
         next_input_schema = _seq_input_schema(steps[1:], config)
-        if not next_input_schema.__custom_root_type__:
+        if not issubclass(next_input_schema, RootModel):
             # it's a dict as expected
             return create_model(  # type: ignore[call-overload]
                 "RunnableSequenceInput",
                 **{
                     k: (v.annotation, v.default)
-                    for k, v in next_input_schema.__fields__.items()
+                    for k, v in next_input_schema.model_fields.items()
                     if k not in first.mapper.steps__
                 },
             )
@@ -2474,36 +2514,36 @@ def _seq_output_schema(
     elif isinstance(last, RunnableAssign):
         mapper_output_schema = last.mapper.get_output_schema(config)
         prev_output_schema = _seq_output_schema(steps[:-1], config)
-        if not prev_output_schema.__custom_root_type__:
+        if not issubclass(prev_output_schema, RootModel):
             # it's a dict as expected
             return create_model(  # type: ignore[call-overload]
                 "RunnableSequenceOutput",
                 **{
                     **{
                         k: (v.annotation, v.default)
-                        for k, v in prev_output_schema.__fields__.items()
+                        for k, v in prev_output_schema.model_fields.items()
                     },
                     **{
                         k: (v.annotation, v.default)
-                        for k, v in mapper_output_schema.__fields__.items()
+                        for k, v in mapper_output_schema.model_fields.items()
                     },
                 },
             )
     elif isinstance(last, RunnablePick):
         prev_output_schema = _seq_output_schema(steps[:-1], config)
-        if not prev_output_schema.__custom_root_type__:
+        if not issubclass(prev_output_schema, RootModel):
             # it's a dict as expected
             if isinstance(last.keys, list):
                 return create_model(  # type: ignore[call-overload]
                     "RunnableSequenceOutput",
                     **{
                         k: (v.annotation, v.default)
-                        for k, v in prev_output_schema.__fields__.items()
+                        for k, v in prev_output_schema.model_fields.items()
                         if k in last.keys
                     },
                 )
             else:
-                field = prev_output_schema.__fields__[last.keys]
+                field = prev_output_schema.model_fields[last.keys]
                 return create_model(  # type: ignore[call-overload]
                     "RunnableSequenceOutput",
                     __root__=(field.annotation, field.default),
@@ -2665,8 +2705,9 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
         """
         return True
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def InputType(self) -> Type[Input]:
@@ -3403,8 +3444,9 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
         """Get the namespace of the langchain object."""
         return ["langchain", "schema", "runnable"]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     def get_name(
         self, suffix: Optional[str] = None, *, name: Optional[str] = None
@@ -3451,7 +3493,7 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
                 **{
                     k: (v.annotation, v.default)
                     for step in self.steps__.values()
-                    for k, v in step.get_input_schema(config).__fields__.items()
+                    for k, v in step.get_input_schema(config).model_fields.items()
                     if k != "__root__"
                 },
             )
@@ -3469,11 +3511,8 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
         Returns:
             The output schema of the Runnable.
         """
-        # This is correct, but pydantic typings/mypy don't think so.
-        return create_model(  # type: ignore[call-overload]
-            self.get_name("Output"),
-            **{k: (v.OutputType, None) for k, v in self.steps__.items()},
-        )
+        fields = {k: (v.OutputType, ...) for k, v in self.steps__.items()}
+        return create_model(self.get_name("Output"), **fields)
 
     @property
     def config_specs(self) -> List[ConfigurableFieldSpec]:
@@ -3883,6 +3922,8 @@ class RunnableGenerator(Runnable[Input, Output]):
         atransform: Optional[
             Callable[[AsyncIterator[Input]], AsyncIterator[Output]]
         ] = None,
+        *,
+        name: Optional[str] = None,
     ) -> None:
         """Initialize a RunnableGenerator.
 
@@ -3910,9 +3951,9 @@ class RunnableGenerator(Runnable[Input, Output]):
             )
 
         try:
-            self.name = func_for_name.__name__
+            self.name = name or func_for_name.__name__
         except AttributeError:
-            pass
+            self.name = "RunnableGenerator"
 
     @property
     def InputType(self) -> Any:
@@ -4184,15 +4225,13 @@ class RunnableLambda(Runnable[Input, Output]):
             if all(
                 item[0] == "'" and item[-1] == "'" and len(item) > 2 for item in items
             ):
+                fields = {item[1:-1]: (Any, ...) for item in items}
                 # It's a dict, lol
-                return create_model(
-                    self.get_name("Input"),
-                    **{item[1:-1]: (Any, None) for item in items},  # type: ignore
-                )
+                return create_model(self.get_name("Input"), **fields)
             else:
                 return create_model(
                     self.get_name("Input"),
-                    __root__=(List[Any], None),
+                    __root__=List[Any],
                 )
 
         if self.InputType != Any:
@@ -4201,7 +4240,7 @@ class RunnableLambda(Runnable[Input, Output]):
         if dict_keys := get_function_first_arg_dict_keys(func):
             return create_model(
                 self.get_name("Input"),
-                **{key: (Any, None) for key in dict_keys},  # type: ignore
+                **{key: (Any, ...) for key in dict_keys},  # type: ignore
             )
 
         return super().get_input_schema(config)
@@ -4730,8 +4769,9 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
 
     bound: Runnable[Input, Output]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def InputType(self) -> Any:
@@ -4758,10 +4798,7 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
         schema = self.bound.get_output_schema(config)
         return create_model(
             self.get_name("Output"),
-            __root__=(
-                List[schema],  # type: ignore
-                None,
-            ),
+            __root__=List[schema],  # type: ignore[valid-type]
         )
 
     @property
@@ -4981,8 +5018,9 @@ class RunnableBindingBase(RunnableSerializable[Input, Output]):
     The type can be a pydantic model, or a type annotation (e.g., `List[str]`).
     """
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     def __init__(
         self,
@@ -5318,7 +5356,7 @@ class RunnableBindingBase(RunnableSerializable[Input, Output]):
             yield item
 
 
-RunnableBindingBase.update_forward_refs(RunnableConfig=RunnableConfig)
+RunnableBindingBase.model_rebuild()
 
 
 class RunnableBinding(RunnableBindingBase[Input, Output]):

--- a/libs/core/langchain_core/runnables/branch.py
+++ b/libs/core/langchain_core/runnables/branch.py
@@ -14,8 +14,9 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict
+
 from langchain_core.load.dump import dumpd
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import (
     Runnable,
     RunnableLike,
@@ -134,10 +135,19 @@ class RunnableBranch(RunnableSerializable[Input, Output]):
             runnable = coerce_to_runnable(runnable)
             _branches.append((condition, runnable))
 
-        super().__init__(branches=_branches, default=default_)  # type: ignore[call-arg]
+        super().__init__(
+            branches=_branches,
+            default=default_,
+            # Hard-coding a name here because RunnableBranch is a generic
+            # and with pydantic 2, the class name with pydantic will capture
+            # include the parameterized type, which is not what we want.
+            # e.g., we'd get RunnableBranch[Input, Output] instead of RunnableBranch
+            # for the name. This information is already captured in the
+            # input and output types.
+            name="RunnableBranch",
+        )  # type: ignore[call-arg]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/configurable.py
+++ b/libs/core/langchain_core/runnables/configurable.py
@@ -20,7 +20,8 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel, ConfigDict
+
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
     RunnableConfig,
@@ -58,8 +59,9 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
 
     config: Optional[RunnableConfig] = None
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @classmethod
     def is_lc_serializable(cls) -> bool:
@@ -373,28 +375,33 @@ class RunnableConfigurableFields(DynamicRunnable[Input, Output]):
         Returns:
             List[ConfigurableFieldSpec]: The configuration specs.
         """
-        return get_unique_config_specs(
-            [
-                (
+        # TODO(0.3): This change removes field_info which isn't needed in pydantic 2
+        config_specs = []
+
+        for field_name, spec in self.fields.items():
+            if isinstance(spec, ConfigurableField):
+                config_specs.append(
                     ConfigurableFieldSpec(
                         id=spec.id,
                         name=spec.name,
                         description=spec.description
-                        or self.default.__fields__[field_name].field_info.description,
+                        or self.default.model_fields[field_name].description,
                         annotation=spec.annotation
-                        or self.default.__fields__[field_name].annotation,
+                        or self.default.model_fields[field_name].annotation,
                         default=getattr(self.default, field_name),
                         is_shared=spec.is_shared,
                     )
-                    if isinstance(spec, ConfigurableField)
-                    else make_options_spec(
-                        spec, self.default.__fields__[field_name].field_info.description
+                )
+            else:
+                config_specs.append(
+                    make_options_spec(
+                        spec, self.default.model_fields[field_name].description
                     )
                 )
-                for field_name, spec in self.fields.items()
-            ]
-            + list(self.default.config_specs)
-        )
+
+        config_specs.extend(self.default.config_specs)
+
+        return get_unique_config_specs(config_specs)
 
     def configurable_fields(
         self, **kwargs: AnyConfigurableField
@@ -436,7 +443,7 @@ class RunnableConfigurableFields(DynamicRunnable[Input, Output]):
             init_params = {
                 k: v
                 for k, v in self.default.__dict__.items()
-                if k in self.default.__fields__
+                if k in self.default.model_fields
             }
             return (
                 self.default.__class__(**{**init_params, **configurable}),

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -18,8 +18,9 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict
+
 from langchain_core.load.dump import dumpd
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
     RunnableConfig,
@@ -107,8 +108,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         will not be passed to fallbacks. If used, the base Runnable and its fallbacks 
         must accept a dictionary as input."""
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @property
     def InputType(self) -> Type[Input]:

--- a/libs/core/langchain_core/runnables/graph.py
+++ b/libs/core/langchain_core/runnables/graph.py
@@ -22,8 +22,9 @@ from typing import (
 )
 from uuid import UUID, uuid4
 
-from langchain_core.pydantic_v1 import BaseModel
-from langchain_core.utils.pydantic import is_basemodel_subclass
+from pydantic import BaseModel
+
+from langchain_core.utils.pydantic import _IgnoreUnserializable, is_basemodel_subclass
 
 if TYPE_CHECKING:
     from langchain_core.runnables.base import Runnable as RunnableType
@@ -235,7 +236,9 @@ def node_data_json(
         json = (
             {
                 "type": "schema",
-                "data": node.data.schema(),
+                "data": node.data.model_json_schema(
+                    schema_generator=_IgnoreUnserializable
+                ),
             }
             if with_schemas
             else {

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -13,9 +13,10 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel
+
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.load.load import load
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableBindingBase, RunnableLambda
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (
@@ -372,28 +373,25 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     def get_input_schema(
         self, config: Optional[RunnableConfig] = None
     ) -> Type[BaseModel]:
-        super_schema = super().get_input_schema(config)
-        if super_schema.__custom_root_type__ or not super_schema.schema().get(
-            "properties"
-        ):
-            from langchain_core.messages import BaseMessage
+        # TODO(0.3): Verify that this change was correct
+        # Not enough tests and unclear on why the previous implementation was
+        # necessary.
+        from langchain_core.messages import BaseMessage
 
-            fields: Dict = {}
-            if self.input_messages_key and self.history_messages_key:
-                fields[self.input_messages_key] = (
-                    Union[str, BaseMessage, Sequence[BaseMessage]],
-                    ...,
-                )
-            elif self.input_messages_key:
-                fields[self.input_messages_key] = (Sequence[BaseMessage], ...)
-            else:
-                fields["__root__"] = (Sequence[BaseMessage], ...)
-            return create_model(  # type: ignore[call-overload]
-                "RunnableWithChatHistoryInput",
-                **fields,
+        fields: Dict = {}
+        if self.input_messages_key and self.history_messages_key:
+            fields[self.input_messages_key] = (
+                Union[str, BaseMessage, Sequence[BaseMessage]],
+                ...,
             )
+        elif self.input_messages_key:
+            fields[self.input_messages_key] = (Sequence[BaseMessage], ...)
         else:
-            return super_schema
+            fields["__root__"] = (Sequence[BaseMessage], ...)
+        return create_model(  # type: ignore[call-overload]
+            "RunnableWithChatHistoryInput",
+            **fields,
+        )
 
     def _is_not_async(self, *args: Sequence[Any], **kwargs: Dict[str, Any]) -> bool:
         return False

--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -21,7 +21,8 @@ from typing import (
     cast,
 )
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel, RootModel
+
 from langchain_core.runnables.base import (
     Other,
     Runnable,
@@ -227,7 +228,7 @@ class RunnablePassthrough(RunnableSerializable[Other, Other]):
             A Runnable that merges the Dict input with the output produced by the
             mapping argument.
         """
-        return RunnableAssign(RunnableParallel(kwargs))
+        return RunnableAssign(RunnableParallel[Dict[str, Any]](kwargs))
 
     def invoke(
         self, input: Other, config: Optional[RunnableConfig] = None, **kwargs: Any
@@ -419,7 +420,7 @@ class RunnableAssign(RunnableSerializable[Dict[str, Any], Dict[str, Any]]):
         self, config: Optional[RunnableConfig] = None
     ) -> Type[BaseModel]:
         map_input_schema = self.mapper.get_input_schema(config)
-        if not map_input_schema.__custom_root_type__:
+        if not issubclass(map_input_schema, RootModel):
             # ie. it's a dict
             return map_input_schema
 
@@ -430,20 +431,22 @@ class RunnableAssign(RunnableSerializable[Dict[str, Any], Dict[str, Any]]):
     ) -> Type[BaseModel]:
         map_input_schema = self.mapper.get_input_schema(config)
         map_output_schema = self.mapper.get_output_schema(config)
-        if (
-            not map_input_schema.__custom_root_type__
-            and not map_output_schema.__custom_root_type__
+        if not issubclass(map_input_schema, RootModel) and not issubclass(
+            map_output_schema, RootModel
         ):
-            # ie. both are dicts
+            fields = {}
+
+            for name, field_info in map_input_schema.model_fields.items():
+                fields[name] = (field_info.annotation, field_info.default)
+
+            for name, field_info in map_output_schema.model_fields.items():
+                fields[name] = (field_info.annotation, field_info.default)
+
             return create_model(  # type: ignore[call-overload]
                 "RunnableAssignOutput",
-                **{
-                    k: (v.type_, v.default)
-                    for s in (map_input_schema, map_output_schema)
-                    for k, v in s.__fields__.items()
-                },
+                **fields,
             )
-        elif not map_output_schema.__custom_root_type__:
+        elif not issubclass(map_output_schema, RootModel):
             # ie. only map output is a dict
             # ie. input type is either unknown or inferred incorrectly
             return map_output_schema

--- a/libs/core/langchain_core/runnables/router.py
+++ b/libs/core/langchain_core/runnables/router.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
 )
 
+from pydantic import ConfigDict
 from typing_extensions import TypedDict
 
 from langchain_core.runnables.base import (
@@ -83,8 +84,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
             runnables={key: coerce_to_runnable(r) for key, r in runnables.items()}
         )
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -28,12 +28,18 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
+from pydantic import BaseModel, ConfigDict, RootModel  # pydantic: ignore
+from pydantic import create_model as _create_model_base  # pydantic :ignore
+from pydantic.json_schema import (
+    DEFAULT_REF_TEMPLATE,
+    GenerateJsonSchema,
+    JsonSchemaMode,
+)
 from typing_extensions import TypeGuard
 
-from langchain_core.pydantic_v1 import BaseConfig, BaseModel
-from langchain_core.pydantic_v1 import create_model as _create_model_base
 from langchain_core.runnables.schema import StreamEvent
 
 Input = TypeVar("Input", contravariant=True)
@@ -350,7 +356,7 @@ def get_function_first_arg_dict_keys(func: Callable) -> Optional[List[str]]:
         tree = ast.parse(textwrap.dedent(code))
         visitor = IsFunctionArgDict()
         visitor.visit(tree)
-        return list(visitor.keys) if visitor.keys else None
+        return sorted(visitor.keys) if visitor.keys else None
     except (SyntaxError, TypeError, OSError, SystemError):
         return None
 
@@ -697,9 +703,57 @@ class _RootEventFilter:
         return include
 
 
-class _SchemaConfig(BaseConfig):
-    arbitrary_types_allowed = True
-    frozen = True
+_SchemaConfig = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+NO_DEFAULT = object()
+
+
+def create_base_class(
+    name: str, type_: Any, default_: object = NO_DEFAULT
+) -> Type[BaseModel]:
+    """Create a base class."""
+
+    def schema(
+        cls: Type[BaseModel],
+        by_alias: bool = True,
+        ref_template: str = DEFAULT_REF_TEMPLATE,
+    ) -> Dict[str, Any]:
+        # Complains about schema not being defined in superclass
+        schema_ = super(cls, cls).schema(  # type: ignore[misc]
+            by_alias=by_alias, ref_template=ref_template
+        )
+        schema_["title"] = name
+        return schema_
+
+    def model_json_schema(
+        cls: Type[BaseModel],
+        by_alias: bool = True,
+        ref_template: str = DEFAULT_REF_TEMPLATE,
+        schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+        mode: JsonSchemaMode = "validation",
+    ) -> Dict[str, Any]:
+        # Complains about model_json_schema not being defined in superclass
+        schema_ = super(cls, cls).model_json_schema(  # type: ignore[misc]
+            by_alias=by_alias,
+            ref_template=ref_template,
+            schema_generator=schema_generator,
+            mode=mode,
+        )
+        schema_["title"] = name
+        return schema_
+
+    base_class_attributes = {
+        "__annotations__": {"root": type_},
+        "model_config": ConfigDict(arbitrary_types_allowed=True),
+        "schema": classmethod(schema),
+        "model_json_schema": classmethod(model_json_schema),
+        "__module__": "langchain_core.runnables.utils",
+    }
+
+    if default_ is not NO_DEFAULT:
+        base_class_attributes["root"] = default_
+    custom_root_type = type(name, (RootModel,), base_class_attributes)
+    return cast(Type[BaseModel], custom_root_type)
 
 
 def create_model(
@@ -715,6 +769,21 @@ def create_model(
     Returns:
         Type[BaseModel]: The created model.
     """
+
+    # Move this to caching path
+    if "__root__" in field_definitions:
+        if len(field_definitions) > 1:
+            raise NotImplementedError(
+                "When specifying __root__ no other "
+                f"fields should be provided. Got {field_definitions}"
+            )
+
+        arg = field_definitions["__root__"]
+        if isinstance(arg, tuple):
+            named_root_model = create_base_class(__model_name, arg[0], arg[1])
+        else:
+            named_root_model = create_base_class(__model_name, arg)
+        return named_root_model
     try:
         return _create_model_cached(__model_name, **field_definitions)
     except TypeError:

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, List, Optional, Sequence, Union
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class Visitor(ABC):
@@ -127,7 +127,8 @@ class Comparison(FilterDirective):
     def __init__(
         self, comparator: Comparator, attribute: str, value: Any, **kwargs: Any
     ) -> None:
-        super().__init__(
+        # super exists from BaseModel
+        super().__init__(  # type: ignore[call-arg]
             comparator=comparator, attribute=attribute, value=value, **kwargs
         )
 
@@ -145,8 +146,11 @@ class Operation(FilterDirective):
 
     def __init__(
         self, operator: Operator, arguments: List[FilterDirective], **kwargs: Any
-    ):
-        super().__init__(operator=operator, arguments=arguments, **kwargs)
+    ) -> None:
+        # super exists from BaseModel
+        super().__init__(  # type: ignore[call-arg]
+            operator=operator, arguments=arguments, **kwargs
+        )
 
 
 class StructuredQuery(Expr):
@@ -165,5 +169,8 @@ class StructuredQuery(Expr):
         filter: Optional[FilterDirective],
         limit: Optional[int] = None,
         **kwargs: Any,
-    ):
-        super().__init__(query=query, filter=filter, limit=limit, **kwargs)
+    ) -> None:
+        # super exists from BaseModel
+        super().__init__(  # type: ignore[call-arg]
+            query=query, filter=filter, limit=limit, **kwargs
+        )

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -20,11 +20,20 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
     get_type_hints,
 )
 
-from typing_extensions import Annotated, TypeVar, get_args, get_origin
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Extra,
+    Field,
+    SkipValidation,
+    ValidationError,
+    model_validator,
+    validate_arguments,
+)
+from typing_extensions import Annotated, TypeVar, cast, get_args, get_origin
 
 from langchain_core._api import deprecated
 from langchain_core.callbacks import (
@@ -33,16 +42,7 @@ from langchain_core.callbacks import (
     CallbackManager,
     Callbacks,
 )
-from langchain_core.load import Serializable
-from langchain_core.messages import ToolCall, ToolMessage
-from langchain_core.pydantic_v1 import (
-    BaseModel,
-    Extra,
-    Field,
-    ValidationError,
-    root_validator,
-    validate_arguments,
-)
+from langchain_core.messages.tool import ToolCall, ToolMessage
 from langchain_core.runnables import (
     RunnableConfig,
     RunnableSerializable,
@@ -59,6 +59,7 @@ from langchain_core.utils.function_calling import (
 from langchain_core.utils.pydantic import (
     TypeBaseModel,
     _create_subset_model,
+    get_fields,
     is_basemodel_subclass,
     is_pydantic_v1_subclass,
     is_pydantic_v2_subclass,
@@ -204,20 +205,64 @@ def create_schema_from_function(
     """
     # https://docs.pydantic.dev/latest/usage/validation_decorator/
     validated = validate_arguments(func, config=_SchemaConfig)  # type: ignore
+
+    sig = inspect.signature(func)
+
+    # Let's ignore `self` and `cls` arguments for class and instance methods
+    if func.__qualname__ and "." in func.__qualname__:
+        # Then it likely belongs in a class namespace
+        in_class = True
+    else:
+        in_class = False
+
+    has_args = False
+    has_kwargs = False
+
+    for param in sig.parameters.values():
+        if param.kind == param.VAR_POSITIONAL:
+            has_args = True
+        elif param.kind == param.VAR_KEYWORD:
+            has_kwargs = True
+
     inferred_model = validated.model  # type: ignore
-    filter_args = filter_args if filter_args is not None else FILTERED_ARGS
-    for arg in filter_args:
-        if arg in inferred_model.__fields__:
-            del inferred_model.__fields__[arg]
+
+    if filter_args:
+        filter_args_ = filter_args
+    else:
+        # Handle classmethods and instance methods
+        existing_params: List[str] = list(sig.parameters.keys())
+        if existing_params and existing_params[0] in ("self", "cls") and in_class:
+            filter_args_ = [existing_params[0]] + list(FILTERED_ARGS)
+        else:
+            filter_args_ = list(FILTERED_ARGS)
+
+        for existing_param in existing_params:
+            if not include_injected and _is_injected_arg_type(
+                sig.parameters[existing_param].annotation
+            ):
+                filter_args_.append(existing_param)
+
     description, arg_descriptions = _infer_arg_descriptions(
         func,
         parse_docstring=parse_docstring,
         error_on_invalid_docstring=error_on_invalid_docstring,
     )
     # Pydantic adds placeholder virtual fields we need to strip
-    valid_properties = _get_filtered_args(
-        inferred_model, func, filter_args=filter_args, include_injected=include_injected
-    )
+    valid_properties = []
+    for field in get_fields(inferred_model):
+        if not has_args:
+            if field == "args":
+                continue
+        if not has_kwargs:
+            if field == "kwargs":
+                continue
+
+        if field == "v__duplicate_kwargs":  # Internal pydantic field
+            continue
+
+        if field not in filter_args_:
+            valid_properties.append(field)
+
     return _create_subset_model(
         f"{model_name}Schema",
         inferred_model,
@@ -274,7 +319,10 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[TypeBaseModel] = None
+
+    args_schema: Annotated[Optional[TypeBaseModel], SkipValidation()] = Field(
+        default=None, description="The tool schema."
+    )
     """Pydantic model class to validate and parse the tool's input arguments.
     
     Args schema should be either: 
@@ -345,8 +393,7 @@ class ChildTool(BaseTool):
                 )
         super().__init__(**kwargs)
 
-    class Config(Serializable.Config):
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
     @property
     def is_single_input(self) -> bool:
@@ -416,7 +463,7 @@ class ChildTool(BaseTool):
         input_args = self.args_schema
         if isinstance(tool_input, str):
             if input_args is not None:
-                key_ = next(iter(input_args.__fields__.keys()))
+                key_ = next(iter(get_fields(input_args).keys()))
                 input_args.validate({key_: tool_input})
             return tool_input
         else:
@@ -429,8 +476,9 @@ class ChildTool(BaseTool):
                 }
             return tool_input
 
-    @root_validator(pre=True)
-    def raise_deprecation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def raise_deprecation(cls, values: Dict) -> Any:
         """Raise deprecation warning if callback_manager is used.
 
         Args:

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -1,8 +1,9 @@
 import inspect
 from typing import Any, Callable, Dict, Literal, Optional, Type, Union, get_type_hints
 
+from pydantic import BaseModel, Field, create_model
+
 from langchain_core.callbacks import Callbacks
-from langchain_core.pydantic_v1 import BaseModel, Field, create_model
 from langchain_core.runnables import Runnable
 from langchain_core.tools.base import BaseTool
 from langchain_core.tools.simple import Tool

--- a/libs/core/langchain_core/tools/retriever.py
+++ b/libs/core/langchain_core/tools/retriever.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from functools import partial
 from typing import Optional
 
+from pydantic import BaseModel, Field
+
 from langchain_core.callbacks import Callbacks
 from langchain_core.prompts import (
     BasePromptTemplate,
@@ -10,7 +12,6 @@ from langchain_core.prompts import (
     aformat_document,
     format_document,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.tools.simple import Tool
 

--- a/libs/core/langchain_core/tools/simple.py
+++ b/libs/core/langchain_core/tools/simple.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from inspect import signature
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Type, Union
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
 from langchain_core.messages import ToolCall
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import RunnableConfig, run_in_executor
 from langchain_core.tools.base import (
     BaseTool,

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -2,14 +2,26 @@ from __future__ import annotations
 
 import textwrap
 from inspect import signature
-from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import (
+    Annotated,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
+
+from pydantic import BaseModel, Field, SkipValidation
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
 from langchain_core.messages import ToolCall
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import RunnableConfig, run_in_executor
 from langchain_core.tools.base import (
     FILTERED_ARGS,
@@ -24,7 +36,9 @@ class StructuredTool(BaseTool):
     """Tool that can operate on any number of inputs."""
 
     description: str = ""
-    args_schema: TypeBaseModel = Field(..., description="The tool schema.")
+    args_schema: Annotated[TypeBaseModel, SkipValidation()] = Field(
+        ..., description="The tool schema."
+    )
     """The input arguments' schema."""
     func: Optional[Callable[..., Any]]
     """The function to run when the tool is called."""

--- a/libs/core/langchain_core/tracers/schemas.py
+++ b/libs/core/langchain_core/tracers/schemas.py
@@ -11,7 +11,6 @@ from langsmith.schemas import RunBase as BaseRunV2
 from langsmith.schemas import RunTypeEnum as RunTypeEnumDep
 
 from langchain_core._api import deprecated
-from langchain_core.outputs import LLMResult
 from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 
 
@@ -82,7 +81,8 @@ class LLMRun(BaseRun):
     """Class for LLMRun."""
 
     prompts: List[str]
-    response: Optional[LLMResult] = None
+    # Temporarily, remove but we will completely remove LLMRun
+    # response: Optional[LLMResult] = None
 
 
 @deprecated("0.1.0", alternative="Run", removal="1.0")

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -359,13 +359,7 @@ def secret_from_env(key: str, /, *, default: str) -> Callable[[], SecretStr]: ..
 
 @overload
 def secret_from_env(
-    key: Sequence[str], /, *, default: None
-) -> Callable[[], Optional[SecretStr]]: ...
-
-
-@overload
-def secret_from_env(
-    key: str, /, *, default: None
+    key: Union[str, Sequence[str]], /, *, default: None
 ) -> Callable[[], Optional[SecretStr]]: ...
 
 

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -368,7 +368,7 @@ def secret_from_env(key: str, /, *, error_message: str) -> Callable[[], SecretSt
 
 
 def secret_from_env(
-    key: str,
+    key: Union[str, Sequence[str]],
     /,
     *,
     default: Union[str, _NoDefaultType, None] = _NoDefault,
@@ -389,6 +389,11 @@ def secret_from_env(
 
     def get_secret_from_env() -> Optional[SecretStr]:
         """Get a value from an environment variable."""
+        if isinstance(key, (list, tuple)):
+            for k in key:
+                if k in os.environ:
+                    return SecretStr(os.environ[k])
+
         if key in os.environ:
             return SecretStr(os.environ[key])
         elif isinstance(default, str):

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -301,7 +301,9 @@ def from_env(
 
 
 @overload
-def from_env(key: str, /, *, default: None) -> Callable[[], Optional[str]]: ...
+def from_env(
+    key: Union[str, Sequence[str]], /, *, default: None
+) -> Callable[[], Optional[str]]: ...
 
 
 def from_env(

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -10,9 +10,9 @@ from importlib.metadata import version
 from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Union, overload
 
 from packaging.version import parse
+from pydantic import SecretStr
 from requests import HTTPError, Response
 
-from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils.pydantic import (
     is_pydantic_v1_subclass,
 )
@@ -301,9 +301,7 @@ def from_env(
 
 
 @overload
-def from_env(
-    key: Union[str, Sequence[str]], /, *, default: None
-) -> Callable[[], Optional[str]]: ...
+def from_env(key: str, /, *, default: None) -> Callable[[], Optional[str]]: ...
 
 
 def from_env(
@@ -361,7 +359,7 @@ def secret_from_env(key: str, /, *, default: str) -> Callable[[], SecretStr]: ..
 
 @overload
 def secret_from_env(
-    key: Union[str, Sequence[str]], /, *, default: None
+    key: str, /, *, default: None
 ) -> Callable[[], Optional[SecretStr]]: ...
 
 
@@ -370,7 +368,7 @@ def secret_from_env(key: str, /, *, error_message: str) -> Callable[[], SecretSt
 
 
 def secret_from_env(
-    key: Union[str, Sequence[str]],
+    key: str,
     /,
     *,
     default: Union[str, _NoDefaultType, None] = _NoDefault,
@@ -391,14 +389,9 @@ def secret_from_env(
 
     def get_secret_from_env() -> Optional[SecretStr]:
         """Get a value from an environment variable."""
-        if isinstance(key, (list, tuple)):
-            for k in key:
-                if k in os.environ:
-                    return SecretStr(os.environ[k])
-        if isinstance(key, str):
-            if key in os.environ:
-                return SecretStr(os.environ[key])
-        if isinstance(default, str):
+        if key in os.environ:
+            return SecretStr(os.environ[key])
+        elif isinstance(default, str):
             return SecretStr(default)
         elif isinstance(default, type(None)):
             return None

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -346,6 +346,12 @@ def secret_from_env(key: str, /, *, default: str) -> Callable[[], SecretStr]: ..
 
 @overload
 def secret_from_env(
+    key: Sequence[str], /, *, default: None
+) -> Callable[[], Optional[SecretStr]]: ...
+
+
+@overload
+def secret_from_env(
     key: str, /, *, default: None
 ) -> Callable[[], Optional[SecretStr]]: ...
 
@@ -355,7 +361,7 @@ def secret_from_env(key: str, /, *, error_message: str) -> Callable[[], SecretSt
 
 
 def secret_from_env(
-    key: str,
+    key: Union[str, Sequence[str]],
     /,
     *,
     default: Union[str, _NoDefaultType, None] = _NoDefault,
@@ -376,9 +382,14 @@ def secret_from_env(
 
     def get_secret_from_env() -> Optional[SecretStr]:
         """Get a value from an environment variable."""
-        if key in os.environ:
-            return SecretStr(os.environ[key])
-        elif isinstance(default, str):
+        if isinstance(key, (list, tuple)):
+            for k in key:
+                if k in os.environ:
+                    return SecretStr(os.environ[k])
+        if isinstance(key, str):
+            if key in os.environ:
+                return SecretStr(os.environ[key])
+        if isinstance(default, str):
             return SecretStr(default)
         elif isinstance(default, type(None)):
             return None

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -42,8 +42,9 @@ from typing import (
     TypeVar,
 )
 
+from pydantic import ConfigDict, Field, model_validator
+
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.retrievers import BaseRetriever, LangSmithRetrieverParams
 from langchain_core.runnables.config import run_in_executor
 
@@ -982,11 +983,11 @@ class VectorStoreRetriever(BaseRetriever):
         "mmr",
     )
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True,)
 
-    @root_validator(pre=True)
-    def validate_search_type(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def validate_search_type(cls, values: Dict) -> Any:
         """Validate search type.
 
         Args:

--- a/libs/core/tests/unit_tests/_api/test_beta_decorator.py
+++ b/libs/core/tests/unit_tests/_api/test_beta_decorator.py
@@ -3,9 +3,9 @@ import warnings
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core._api.beta_decorator import beta, warn_beta
-from langchain_core.pydantic_v1 import BaseModel
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -3,9 +3,9 @@ import warnings
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core._api.deprecation import deprecated, warn_deprecated
-from langchain_core.pydantic_v1 import BaseModel
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/fake/callbacks.py
+++ b/libs/core/tests/unit_tests/fake/callbacks.py
@@ -4,9 +4,10 @@ from itertools import chain
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks.base import AsyncCallbackHandler, BaseCallbackHandler
 from langchain_core.messages import BaseMessage
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class BaseFakeCallbackHandler(BaseModel):
@@ -256,7 +257,8 @@ class FakeCallbackHandler(BaseCallbackHandler, BaseFakeCallbackHandlerMixin):
     ) -> Any:
         self.on_retriever_error_common()
 
-    def __deepcopy__(self, memo: dict) -> "FakeCallbackHandler":
+    # Overriding since BaseModel has __deepcopy__ method as well
+    def __deepcopy__(self, memo: dict) -> "FakeCallbackHandler":  # type: ignore
         return self
 
 
@@ -390,5 +392,6 @@ class FakeAsyncCallbackHandler(AsyncCallbackHandler, BaseFakeCallbackHandlerMixi
     ) -> None:
         self.on_text_common()
 
-    def __deepcopy__(self, memo: dict) -> "FakeAsyncCallbackHandler":
+    # Overriding since BaseModel has __deepcopy__ method as well
+    def __deepcopy__(self, memo: dict) -> "FakeAsyncCallbackHandler":  # type: ignore
         return self

--- a/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
+++ b/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
@@ -9,7 +9,6 @@ from langchain_core.language_models import GenericFakeChatModel, ParrotFakeChatM
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 from tests.unit_tests.stubs import (
-    AnyStr,
     _AnyIdAIMessage,
     _AnyIdAIMessageChunk,
     _AnyIdHumanMessage,
@@ -70,8 +69,8 @@ async def test_generic_fake_chat_model_stream() -> None:
     model = GenericFakeChatModel(messages=cycle([message]))
     chunks = [chunk async for chunk in model.astream("meow")]
     assert chunks == [
-        AIMessageChunk(content="", additional_kwargs={"foo": 42}, id=AnyStr()),
-        AIMessageChunk(content="", additional_kwargs={"bar": 24}, id=AnyStr()),
+        _AnyIdAIMessageChunk(content="", additional_kwargs={"foo": 42}),
+        _AnyIdAIMessageChunk(content="", additional_kwargs={"bar": 24}),
     ]
     assert len({chunk.id for chunk in chunks}) == 1
 
@@ -89,29 +88,23 @@ async def test_generic_fake_chat_model_stream() -> None:
     chunks = [chunk async for chunk in model.astream("meow")]
 
     assert chunks == [
-        AIMessageChunk(
-            content="",
-            additional_kwargs={"function_call": {"name": "move_file"}},
-            id=AnyStr(),
+        _AnyIdAIMessageChunk(
+            content="", additional_kwargs={"function_call": {"name": "move_file"}}
         ),
-        AIMessageChunk(
+        _AnyIdAIMessageChunk(
             content="",
             additional_kwargs={
                 "function_call": {"arguments": '{\n  "source_path": "foo"'},
             },
-            id=AnyStr(),
         ),
-        AIMessageChunk(
-            content="",
-            additional_kwargs={"function_call": {"arguments": ","}},
-            id=AnyStr(),
+        _AnyIdAIMessageChunk(
+            content="", additional_kwargs={"function_call": {"arguments": ","}}
         ),
-        AIMessageChunk(
+        _AnyIdAIMessageChunk(
             content="",
             additional_kwargs={
                 "function_call": {"arguments": '\n  "destination_path": "bar"\n}'},
             },
-            id=AnyStr(),
         ),
     ]
     assert len({chunk.id for chunk in chunks}) == 1

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional as Optional
 
 from langchain_core.caches import InMemoryCache
 from langchain_core.language_models import GenericFakeChatModel
@@ -218,6 +219,8 @@ class SerializableModel(GenericFakeChatModel):
     @classmethod
     def is_lc_serializable(cls) -> bool:
         return True
+
+SerializableModel.model_rebuild()
 
 
 def test_serialization_with_rate_limiter() -> None:

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -38,8 +38,9 @@ def test_simple_serialization_is_serializable() -> None:
 
 def test_simple_serialization_secret() -> None:
     """Test handling of secrets."""
+    from pydantic import SecretStr
+
     from langchain_core.load import Serializable
-    from langchain_core.pydantic_v1 import SecretStr
 
     class Foo(Serializable):
         bar: int

--- a/libs/core/tests/unit_tests/output_parsers/test_base_parsers.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_base_parsers.py
@@ -1,6 +1,7 @@
 """Module to test base parser implementations."""
 
 from typing import List
+from typing import Optional as Optional
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import GenericFakeChatModel
@@ -45,6 +46,8 @@ def test_base_generation_parser() -> None:
             content = generation.message.content
             assert isinstance(content, str)
             return content.swapcase()  # type: ignore
+
+    StrInvertCase.model_rebuild()
 
     model = GenericFakeChatModel(messages=iter([AIMessage(content="hEllo")]))
     chain = model | StrInvertCase()

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -2,11 +2,11 @@ import json
 from typing import Any, AsyncIterator, Iterator, Tuple
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.output_parsers.json import (
     SimpleJsonOutputParser,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils.function_calling import convert_to_openai_function
 from langchain_core.utils.json import parse_json_markdown, parse_partial_json
 from tests.unit_tests.pydantic_utils import _schema

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_functions.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_functions.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -10,7 +11,6 @@ from langchain_core.output_parsers.openai_functions import (
     PydanticOutputFunctionsParser,
 )
 from langchain_core.outputs import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel
 
 
 def test_json_output_function_parser() -> None:

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -1,6 +1,7 @@
 from typing import Any, AsyncIterator, Iterator, List
 
 import pytest
+from pydantic import BaseModel, Field
 
 from langchain_core.messages import (
     AIMessage,
@@ -14,7 +15,6 @@ from langchain_core.output_parsers.openai_tools import (
     PydanticToolsParser,
 )
 from langchain_core.outputs import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
 
 STREAMED_MESSAGES: list = [

--- a/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
+++ b/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
@@ -3,6 +3,7 @@
   dict({
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -44,8 +45,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -57,8 +66,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -74,6 +91,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -82,7 +100,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -92,6 +118,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -120,12 +147,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -136,6 +179,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -152,6 +196,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -189,8 +234,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -201,6 +254,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -217,6 +271,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -273,18 +328,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -300,24 +372,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -335,6 +442,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -386,18 +494,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -413,20 +538,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -443,6 +592,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -513,12 +663,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -538,6 +704,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -554,6 +721,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -620,6 +802,7 @@
   dict({
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -661,8 +844,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -674,8 +865,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -691,6 +890,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -699,7 +899,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -709,6 +917,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -737,12 +946,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -753,6 +978,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -769,6 +995,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -806,8 +1033,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -818,6 +1053,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -834,6 +1070,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -890,18 +1127,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -917,24 +1171,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -952,6 +1241,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -1003,18 +1293,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -1030,20 +1337,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -1060,6 +1391,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -1130,12 +1462,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -1155,6 +1503,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -1171,6 +1520,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -1436,7 +1800,7 @@
     'type': 'constructor',
   })
 # ---
-# name: test_chat_prompt_w_msgs_placeholder_ser_des[placholder]
+# name: test_chat_prompt_w_msgs_placeholder_ser_des[placeholder]
   dict({
     'id': list([
       'langchain',

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -4,9 +4,12 @@ from pathlib import Path
 from typing import Any, List, Union
 
 import pytest
+from pydantic import ValidationError
 from syrupy import SnapshotAssertion
 
-from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
+from langchain_core._api.deprecation import (
+    LangChainPendingDeprecationWarning,
+)
 from langchain_core.load import dumpd, load
 from langchain_core.messages import (
     AIMessage,
@@ -28,7 +31,6 @@ from langchain_core.prompts.chat import (
     SystemMessagePromptTemplate,
     _convert_to_message,
 )
-from langchain_core.pydantic_v1 import ValidationError
 from tests.unit_tests.pydantic_utils import _schema
 
 
@@ -810,7 +812,7 @@ def test_chat_prompt_w_msgs_placeholder_ser_des(snapshot: SnapshotAssertion) -> 
     prompt = ChatPromptTemplate.from_messages(
         [("system", "foo"), MessagesPlaceholder("bar"), ("human", "baz")]
     )
-    assert dumpd(MessagesPlaceholder("bar")) == snapshot(name="placholder")
+    assert dumpd(MessagesPlaceholder("bar")) == snapshot(name="placeholder")
     assert load(dumpd(MessagesPlaceholder("bar"))) == MessagesPlaceholder("bar")
     assert dumpd(prompt) == snapshot(name="chat_prompt")
     assert load(dumpd(prompt)) == prompt

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -1,12 +1,14 @@
 from functools import partial
 from inspect import isclass
 from typing import Any, Dict, Type, Union, cast
+from typing import Optional as Optional
+
+from pydantic import BaseModel
 
 from langchain_core.language_models import FakeListChatModel
 from langchain_core.load.dump import dumps
 from langchain_core.load.load import loads
 from langchain_core.prompts.structured import StructuredPrompt
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableLambda
 from langchain_core.utils.pydantic import is_basemodel_subclass
 
@@ -32,6 +34,9 @@ class FakeStructuredChatModel(FakeListChatModel):
     @property
     def _llm_type(self) -> str:
         return "fake-messages-list-chat-model"
+
+
+FakeStructuredChatModel.model_rebuild()
 
 
 def test_structured_prompt_pydantic() -> None:

--- a/libs/core/tests/unit_tests/pydantic_utils.py
+++ b/libs/core/tests/unit_tests/pydantic_utils.py
@@ -1,20 +1,10 @@
-"""Helper utilities for pydantic.
-
-This module includes helper utilities to ease the migration from pydantic v1 to v2.
-
-They're meant to be used in the following way:
-
-1) Use utility code to help (selected) unit tests pass without modifications
-2) Upgrade the unit tests to match pydantic 2
-3) Stop using the utility code
-"""
-
 from typing import Any
+
+from langchain_core.utils.pydantic import is_basemodel_subclass
 
 
 # Function to replace allOf with $ref
-def _replace_all_of_with_ref(schema: Any) -> None:
-    """Replace allOf with $ref in the schema."""
+def replace_all_of_with_ref(schema: Any) -> None:
     if isinstance(schema, dict):
         # If the schema has an allOf key with a single item that contains a $ref
         if (
@@ -30,13 +20,13 @@ def _replace_all_of_with_ref(schema: Any) -> None:
             # Recursively process nested schemas
             for key, value in schema.items():
                 if isinstance(value, (dict, list)):
-                    _replace_all_of_with_ref(value)
+                    replace_all_of_with_ref(value)
     elif isinstance(schema, list):
         for item in schema:
-            _replace_all_of_with_ref(item)
+            replace_all_of_with_ref(item)
 
 
-def _remove_bad_none_defaults(schema: Any) -> None:
+def remove_all_none_default(schema: Any) -> None:
     """Removing all none defaults.
 
     Pydantic v1 did not generate these, but Pydantic v2 does.
@@ -56,39 +46,48 @@ def _remove_bad_none_defaults(schema: Any) -> None:
                             break  # Null type explicitly defined
                     else:
                         del value["default"]
-                _remove_bad_none_defaults(value)
+                remove_all_none_default(value)
             elif isinstance(value, list):
                 for item in value:
-                    _remove_bad_none_defaults(item)
+                    remove_all_none_default(item)
     elif isinstance(schema, list):
         for item in schema:
-            _remove_bad_none_defaults(item)
+            remove_all_none_default(item)
+
+
+def _remove_enum_description(obj: Any) -> None:
+    """Remove the description from enums."""
+    if isinstance(obj, dict):
+        if "enum" in obj:
+            if "description" in obj and obj["description"] == "An enumeration.":
+                del obj["description"]
+        for key, value in obj.items():
+            _remove_enum_description(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            _remove_enum_description(item)
 
 
 def _schema(obj: Any) -> dict:
-    """Get the schema of a pydantic model in the pydantic v1 style.
-
-    This will attempt to map the schema as close as possible to the pydantic v1 schema.
-    """
+    """Return the schema of the object."""
     # Remap to old style schema
+    if not is_basemodel_subclass(obj):
+        raise TypeError(
+            f"Object must be a Pydantic BaseModel subclass. Got {type(obj)}"
+        )
     if not hasattr(obj, "model_json_schema"):  # V1 model
         return obj.schema()
-
-    # Then we're using V2 models internally.
-    raise AssertionError(
-        "Hi there! Looks like you're attempting to upgrade to Pydantic v2. If so: \n"
-        "1) remove this exception\n"
-        "2) confirm that the old unit tests pass, and if not look for difference\n"
-        "3) update the unit tests to match the new schema\n"
-        "4) remove this utility function\n"
-    )
 
     schema_ = obj.model_json_schema(ref_template="#/definitions/{model}")
     if "$defs" in schema_:
         schema_["definitions"] = schema_["$defs"]
         del schema_["$defs"]
 
-    _replace_all_of_with_ref(schema_)
-    _remove_bad_none_defaults(schema_)
+    if "default" in schema_ and schema_["default"] is None:
+        del schema_["default"]
+
+    replace_all_of_with_ref(schema_)
+    remove_all_none_default(schema_)
+    _remove_enum_description(schema_)
 
     return schema_

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -334,31 +334,9 @@
       }),
       dict({
         'data': dict({
-          'anyOf': list([
-            dict({
-              'type': 'string',
-            }),
-            dict({
-              '$ref': '#/definitions/AIMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/HumanMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ChatMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/SystemMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/FunctionMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ToolMessage',
-            }),
-          ]),
-          'definitions': dict({
+          '$defs': dict({
             'AIMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message from an AI.
                 
@@ -400,21 +378,37 @@
                   'type': 'boolean',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'invalid_tool_calls': dict({
                   'default': list([
                   ]),
                   'items': dict({
-                    '$ref': '#/definitions/InvalidToolCall',
+                    '$ref': '#/$defs/InvalidToolCall',
                   }),
                   'title': 'Invalid Tool Calls',
                   'type': 'array',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
@@ -424,12 +418,13 @@
                   'default': list([
                   ]),
                   'items': dict({
-                    '$ref': '#/definitions/ToolCall',
+                    '$ref': '#/$defs/ToolCall',
                   }),
                   'title': 'Tool Calls',
                   'type': 'array',
                 }),
                 'type': dict({
+                  'const': 'ai',
                   'default': 'ai',
                   'enum': list([
                     'ai',
@@ -438,7 +433,15 @@
                   'type': 'string',
                 }),
                 'usage_metadata': dict({
-                  '$ref': '#/definitions/UsageMetadata',
+                  'anyOf': list([
+                    dict({
+                      '$ref': '#/$defs/UsageMetadata',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                 }),
               }),
               'required': list([
@@ -448,6 +451,7 @@
               'type': 'object',
             }),
             'ChatMessage': dict({
+              'additionalProperties': True,
               'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
               'properties': dict({
                 'additional_kwargs': dict({
@@ -476,12 +480,28 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
@@ -492,6 +512,7 @@
                   'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'chat',
                   'default': 'chat',
                   'enum': list([
                     'chat',
@@ -508,6 +529,7 @@
               'type': 'object',
             }),
             'FunctionMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message for passing the result of executing a tool back to a model.
                 
@@ -545,8 +567,16 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
                   'title': 'Name',
@@ -557,6 +587,7 @@
                   'type': 'object',
                 }),
                 'type': dict({
+                  'const': 'function',
                   'default': 'function',
                   'enum': list([
                     'function',
@@ -573,6 +604,7 @@
               'type': 'object',
             }),
             'HumanMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message from a human.
                 
@@ -629,18 +661,35 @@
                   'type': 'boolean',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
                   'type': 'object',
                 }),
                 'type': dict({
+                  'const': 'human',
                   'default': 'human',
                   'enum': list([
                     'human',
@@ -656,24 +705,59 @@
               'type': 'object',
             }),
             'InvalidToolCall': dict({
+              'description': '''
+                Allowance for errors made by LLM.
+                
+                Here we add an `error` key to surface errors made during generation
+                (e.g., invalid JSON arguments.)
+              ''',
               'properties': dict({
                 'args': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Args',
-                  'type': 'string',
                 }),
                 'error': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Error',
-                  'type': 'string',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'invalid_tool_call',
                   'enum': list([
                     'invalid_tool_call',
                   ]),
@@ -691,6 +775,7 @@
               'type': 'object',
             }),
             'SystemMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message for priming AI behavior.
                 
@@ -742,18 +827,35 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
                   'type': 'object',
                 }),
                 'type': dict({
+                  'const': 'system',
                   'default': 'system',
                   'enum': list([
                     'system',
@@ -769,20 +871,44 @@
               'type': 'object',
             }),
             'ToolCall': dict({
+              'description': '''
+                Represents a request to call a tool.
+                
+                Example:
+                
+                    .. code-block:: python
+                
+                        {
+                            "name": "foo",
+                            "args": {"a": 1},
+                            "id": "123"
+                        }
+                
+                    This represents a request to call the tool named "foo" with arguments {"a": 1}
+                    and an identifier of "123".
+              ''',
               'properties': dict({
                 'args': dict({
                   'title': 'Args',
                   'type': 'object',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
                   'title': 'Name',
                   'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'tool_call',
                   'enum': list([
                     'tool_call',
                   ]),
@@ -799,6 +925,7 @@
               'type': 'object',
             }),
             'ToolMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message for passing the result of executing a tool back to a model.
                 
@@ -845,6 +972,7 @@
                   'type': 'object',
                 }),
                 'artifact': dict({
+                  'default': None,
                   'title': 'Artifact',
                 }),
                 'content': dict({
@@ -869,12 +997,28 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
@@ -894,6 +1038,7 @@
                   'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'tool',
                   'default': 'tool',
                   'enum': list([
                     'tool',
@@ -910,6 +1055,21 @@
               'type': 'object',
             }),
             'UsageMetadata': dict({
+              'description': '''
+                Usage metadata for a message, such as token counts.
+                
+                This is a standard representation of token usage that is consistent across models.
+                
+                Example:
+                
+                    .. code-block:: python
+                
+                        {
+                            "input_tokens": 10,
+                            "output_tokens": 20,
+                            "total_tokens": 30
+                        }
+              ''',
               'properties': dict({
                 'input_tokens': dict({
                   'title': 'Input Tokens',
@@ -933,6 +1093,29 @@
               'type': 'object',
             }),
           }),
+          'anyOf': list([
+            dict({
+              'type': 'string',
+            }),
+            dict({
+              '$ref': '#/$defs/AIMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/HumanMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/ChatMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/SystemMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/FunctionMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/ToolMessage',
+            }),
+          ]),
           'title': 'RunnableParallel<as_list,as_str>Input',
         }),
         'id': 3,
@@ -952,6 +1135,10 @@
               'title': 'As Str',
             }),
           }),
+          'required': list([
+            'as_list',
+            'as_str',
+          ]),
           'title': 'RunnableParallel<as_list,as_str>Output',
           'type': 'object',
         }),

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -5176,3910 +5176,11 @@
   }
   '''
 # ---
-# name: test_schemas
-  dict({
-    'anyOf': list([
-      dict({
-        'type': 'string',
-      }),
-      dict({
-        '$ref': '#/definitions/StringPromptValue',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatPromptValueConcrete',
-      }),
-      dict({
-        'items': dict({
-          'anyOf': list([
-            dict({
-              '$ref': '#/definitions/AIMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/HumanMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ChatMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/SystemMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/FunctionMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ToolMessage',
-            }),
-          ]),
-        }),
-        'type': 'array',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'FakeListLLMInput',
-  })
-# ---
-# name: test_schemas.1
-  dict({
-    'anyOf': list([
-      dict({
-        'type': 'string',
-      }),
-      dict({
-        '$ref': '#/definitions/StringPromptValue',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatPromptValueConcrete',
-      }),
-      dict({
-        'items': dict({
-          'anyOf': list([
-            dict({
-              '$ref': '#/definitions/AIMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/HumanMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ChatMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/SystemMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/FunctionMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ToolMessage',
-            }),
-          ]),
-        }),
-        'type': 'array',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'FakeListChatModelInput',
-  })
-# ---
-# name: test_schemas.2
-  dict({
-    'anyOf': list([
-      dict({
-        '$ref': '#/definitions/AIMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/HumanMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/SystemMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/FunctionMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ToolMessage',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'FakeListChatModelOutput',
-  })
-# ---
-# name: test_schemas.5
-  dict({
-    'anyOf': list([
-      dict({
-        '$ref': '#/definitions/StringPromptValue',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatPromptValueConcrete',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'PromptTemplateOutput',
-  })
-# ---
-# name: test_schemas.6
-  dict({
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'PromptTemplateOutput': dict({
-        'anyOf': list([
-          dict({
-            '$ref': '#/definitions/StringPromptValue',
-          }),
-          dict({
-            '$ref': '#/definitions/ChatPromptValueConcrete',
-          }),
-        ]),
-        'title': 'PromptTemplateOutput',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'items': dict({
-      '$ref': '#/definitions/PromptTemplateOutput',
-    }),
-    'title': 'RunnableEach<PromptTemplate>Output',
-    'type': 'array',
-  })
-# ---
-# name: test_schemas.7
-  dict({
-    'anyOf': list([
-      dict({
-        'type': 'string',
-      }),
-      dict({
-        '$ref': '#/definitions/AIMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/HumanMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/SystemMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/FunctionMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ToolMessage',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'CommaSeparatedListOutputParserInput',
-  })
-# ---
 # name: test_schemas[chat_prompt_input_schema]
   dict({
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -9121,8 +5222,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -9134,8 +5243,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9151,6 +5268,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -9159,7 +5277,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -9169,6 +5295,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -9197,12 +5324,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9213,6 +5356,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -9229,6 +5373,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -9266,8 +5411,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -9278,6 +5431,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -9294,6 +5448,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -9350,18 +5505,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -9377,24 +5549,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -9412,6 +5619,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -9463,18 +5671,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -9490,20 +5715,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -9520,6 +5769,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -9590,12 +5840,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9615,6 +5881,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -9631,6 +5898,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -9701,6 +5983,7 @@
     ]),
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -9742,8 +6025,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -9755,8 +6046,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9772,6 +6071,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -9780,7 +6080,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -9790,6 +6098,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -9818,12 +6127,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9834,6 +6159,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -9882,6 +6208,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ChatPromptValueConcrete',
             'default': 'ChatPromptValueConcrete',
             'enum': list([
               'ChatPromptValueConcrete',
@@ -9897,6 +6224,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -9934,8 +6262,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -9946,6 +6282,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -9962,6 +6299,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -10018,18 +6356,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -10045,24 +6400,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -10087,6 +6477,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'StringPromptValue',
             'default': 'StringPromptValue',
             'enum': list([
               'StringPromptValue',
@@ -10102,6 +6493,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -10153,18 +6545,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -10180,20 +6589,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -10210,6 +6643,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -10280,12 +6714,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -10305,6 +6755,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -10321,6 +6772,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -10347,10 +6813,5010 @@
     'title': 'ChatPromptTemplateOutput',
   })
 # ---
+# name: test_schemas[fake_chat_input_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        'type': 'string',
+      }),
+      dict({
+        '$ref': '#/definitions/StringPromptValue',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatPromptValueConcrete',
+      }),
+      dict({
+        'items': dict({
+          'anyOf': list([
+            dict({
+              '$ref': '#/definitions/AIMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/HumanMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ChatMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/SystemMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/FunctionMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ToolMessage',
+            }),
+          ]),
+        }),
+        'type': 'array',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'FakeListChatModelInput',
+  })
+# ---
+# name: test_schemas[fake_chat_output_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        '$ref': '#/definitions/AIMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/HumanMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/SystemMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/FunctionMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ToolMessage',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'FakeListChatModelOutput',
+  })
+# ---
+# name: test_schemas[fake_llm_input_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        'type': 'string',
+      }),
+      dict({
+        '$ref': '#/definitions/StringPromptValue',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatPromptValueConcrete',
+      }),
+      dict({
+        'items': dict({
+          'anyOf': list([
+            dict({
+              '$ref': '#/definitions/AIMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/HumanMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ChatMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/SystemMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/FunctionMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ToolMessage',
+            }),
+          ]),
+        }),
+        'type': 'array',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'FakeListLLMInput',
+  })
+# ---
+# name: test_schemas[list_parser_input_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        'type': 'string',
+      }),
+      dict({
+        '$ref': '#/definitions/AIMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/HumanMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/SystemMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/FunctionMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ToolMessage',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'CommaSeparatedListOutputParserInput',
+  })
+# ---
+# name: test_schemas[prompt_mapper_output_schema]
+  dict({
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'PromptTemplateOutput': dict({
+        'anyOf': list([
+          dict({
+            '$ref': '#/definitions/StringPromptValue',
+          }),
+          dict({
+            '$ref': '#/definitions/ChatPromptValueConcrete',
+          }),
+        ]),
+        'title': 'PromptTemplateOutput',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'items': dict({
+      '$ref': '#/definitions/PromptTemplateOutput',
+    }),
+    'title': 'RunnableEach<PromptTemplate>Output',
+    'type': 'array',
+  })
+# ---
+# name: test_schemas[prompt_output_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        '$ref': '#/definitions/StringPromptValue',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatPromptValueConcrete',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'PromptTemplateOutput',
+  })
+# ---
 # name: test_seq_dict_prompt_llm
   '''
   {
-    question: RunnablePassthrough()
+    question: RunnablePassthrough[str]()
               | RunnableLambda(...),
     documents: RunnableLambda(...)
                | FakeRetriever(),

--- a/libs/core/tests/unit_tests/runnables/test_configurable.py
+++ b/libs/core/tests/unit_tests/runnables/test_configurable.py
@@ -1,8 +1,9 @@
 from typing import Any, Dict, Optional
 
 import pytest
+from pydantic import ConfigDict, Field, model_validator
+from typing_extensions import Self
 
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables import (
     ConfigurableField,
     RunnableConfig,
@@ -14,19 +15,19 @@ class MyRunnable(RunnableSerializable[str, str]):
     my_property: str = Field(alias="my_property_alias")
     _my_hidden_property: str = ""
 
-    class Config:
-        allow_population_by_field_name = True
+    model_config = ConfigDict(populate_by_name=True,)
 
-    @root_validator(pre=True)
-    def my_error(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def my_error(cls, values: Dict[str, Any]) -> Any:
         if "_my_hidden_property" in values:
             raise ValueError("Cannot set _my_hidden_property")
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        values["_my_hidden_property"] = values["my_property"]
-        return values
+    @model_validator(mode="after")
+    def build_extra(self) -> Self:
+        self._my_hidden_property = self.my_property
+        return self
 
     def invoke(self, input: str, config: Optional[RunnableConfig] = None) -> Any:
         return input + self._my_hidden_property

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel
 from syrupy import SnapshotAssertion
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
@@ -25,7 +26,6 @@ from langchain_core.load import dumps
 from langchain_core.messages import BaseMessage
 from langchain_core.outputs import ChatResult
 from langchain_core.prompts import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import (
     Runnable,
     RunnableBinding,

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from pydantic import BaseModel
 from syrupy import SnapshotAssertion
 
 from langchain_core.language_models import FakeListLLM
@@ -7,7 +8,6 @@ from langchain_core.output_parsers.list import CommaSeparatedListOutputParser
 from langchain_core.output_parsers.string import StrOutputParser
 from langchain_core.output_parsers.xml import XMLOutputParser
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableConfig
 from langchain_core.runnables.graph import Graph
 from langchain_core.runnables.graph_mermaid import _escape_node_label

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
@@ -9,7 +10,6 @@ from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import Runnable
 from langchain_core.runnables.base import RunnableBinding, RunnableLambda
 from langchain_core.runnables.config import RunnableConfig
@@ -455,8 +455,9 @@ def test_get_input_schema_input_dict() -> None:
 
 
 def test_get_input_schema_input_messages() -> None:
-    class RunnableWithChatHistoryInput(BaseModel):
-        __root__: Sequence[BaseMessage]
+    from pydantic import RootModel  # pydantic: ignore
+
+    RunnableWithMessageHistoryInput = RootModel[Sequence[BaseMessage]]
 
     runnable = RunnableLambda(
         lambda messages: {
@@ -478,9 +479,9 @@ def test_get_input_schema_input_messages() -> None:
     with_history = RunnableWithMessageHistory(
         runnable, get_session_history, output_messages_key="output"
     )
-    assert _schema(with_history.get_input_schema()) == _schema(
-        RunnableWithChatHistoryInput
-    )
+    expected_schema = _schema(RunnableWithMessageHistoryInput)
+    expected_schema["title"] = "RunnableWithChatHistoryInput"
+    assert _schema(with_history.get_input_schema()) == expected_schema
 
 
 def test_using_custom_config_specs() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -3,8 +3,10 @@
 import sys
 from itertools import cycle
 from typing import Any, AsyncIterator, Dict, List, Sequence, cast
+from typing import Optional as Optional
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -19,7 +21,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     ConfigurableField,
@@ -1174,6 +1175,9 @@ class HardCodedRetriever(BaseRetriever):
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> List[Document]:
         return self.documents
+
+
+HardCodedRetriever.model_rebuild()
 
 
 async def test_event_stream_with_retriever() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -33,7 +34,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     ConfigurableField,

--- a/libs/core/tests/unit_tests/test_json_schema_remapping.py
+++ b/libs/core/tests/unit_tests/test_json_schema_remapping.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, v1
+
+from tests.unit_tests.pydantic_utils import _schema
+
+
+def test_schemas() -> None:
+    """Test schema remapping for the two pydantic versions."""
+
+    class Bar(BaseModel):
+        baz: int
+
+    class Foo(BaseModel):
+        bar: Bar
+
+    schema_2 = _schema(Foo)
+
+    class Bar(v1.BaseModel):  # type: ignore[no-redef]
+        baz: int
+
+    class Foo(v1.BaseModel):  # type: ignore[no-redef]
+        bar: Bar
+
+    schema_1 = _schema(Foo)
+
+    assert schema_1 == schema_2

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel, Field, ValidationError
 from pydantic import BaseModel as BaseModelProper  # pydantic: ignore
 from typing_extensions import Annotated, TypedDict, TypeVar
 
@@ -31,7 +32,6 @@ from langchain_core.callbacks import (
     CallbackManagerForToolRun,
 )
 from langchain_core.messages import ToolMessage
-from langchain_core.pydantic_v1 import BaseModel, Field, ValidationError
 from langchain_core.runnables import (
     Runnable,
     RunnableConfig,
@@ -874,15 +874,13 @@ async def test_async_validation_error_handling_non_validation_error(
 
 def test_optional_subset_model_rewrite() -> None:
     class MyModel(BaseModel):
-        a: Optional[str]
+        a: Optional[str] = None
         b: str
-        c: Optional[List[Optional[str]]]
+        c: Optional[List[Optional[str]]] = None
 
     model2 = _create_subset_model("model2", MyModel, ["a", "b", "c"])
 
-    assert "a" not in _schema(model2)["required"]  # should be optional
-    assert "b" in _schema(model2)["required"]  # should be required
-    assert "c" not in _schema(model2)["required"]  # should be optional
+    assert set(_schema(model2)["required"]) == {"b"}
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -33,8 +33,9 @@ try:
 except ImportError:
     TypingAnnotated = ExtensionsAnnotated
 
+from pydantic import BaseModel, Field
+
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import Runnable, RunnableLambda
 from langchain_core.tools import BaseTool, tool
 from langchain_core.utils.function_calling import (
@@ -411,17 +412,17 @@ def test_multiple_tool_calls() -> None:
         {
             "id": messages[2].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall1"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall1"}'},
         },
         {
             "id": messages[3].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall2"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall2"}'},
         },
         {
             "id": messages[4].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall3"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall3"}'},
         },
     ]
 
@@ -442,7 +443,7 @@ def test_tool_outputs() -> None:
         {
             "id": messages[2].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall1"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall1"}'},
         },
     ]
     assert messages[2].content == "Output1"
@@ -698,7 +699,8 @@ def test__convert_typed_dict_to_openai_function(
 @pytest.mark.parametrize("typed_dict", [ExtensionsTypedDict, TypingTypedDict])
 def test__convert_typed_dict_to_openai_function_fail(typed_dict: Type) -> None:
     class Tool(typed_dict):
-        arg1: MutableSet  # Pydantic doesn't support
+        arg1: MutableSet  # Pydantic 2 supports this, but pydantic v1 does not.
 
+    # Error should be raised since we're using v1 code path here
     with pytest.raises(TypeError):
         _convert_typed_dict_to_openai_function(Tool)

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional
 
 import pytest
+from pydantic import ConfigDict
 
 from langchain_core.utils.pydantic import (
     PYDANTIC_MAJOR_VERSION,
@@ -15,7 +16,7 @@ from langchain_core.utils.pydantic import (
 
 
 def test_pre_init_decorator() -> None:
-    from langchain_core.pydantic_v1 import BaseModel
+    from pydantic import BaseModel
 
     class Foo(BaseModel):
         x: int = 5
@@ -34,7 +35,7 @@ def test_pre_init_decorator() -> None:
 
 
 def test_pre_init_decorator_with_more_defaults() -> None:
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         a: int = 1
@@ -56,14 +57,13 @@ def test_pre_init_decorator_with_more_defaults() -> None:
 
 
 def test_with_aliases() -> None:
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         x: int = Field(default=1, alias="y")
         z: int
 
-        class Config:
-            allow_population_by_field_name = True
+        model_config = ConfigDict(populate_by_name=True,)
 
         @pre_init
         def validator(cls, v: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -5,9 +5,9 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 from langchain_core import utils
-from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils import (
     check_package_version,
     from_env,
@@ -328,7 +328,7 @@ def test_secret_from_env_with_custom_error_message(
 def test_using_secret_from_env_as_default_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         secret: SecretStr = Field(default_factory=secret_from_env("TEST_KEY"))

--- a/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
@@ -10,7 +10,7 @@ from langchain_standard_tests.integration_tests.vectorstores import (
 from langchain_core.documents import Document
 from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 from langchain_core.vectorstores import InMemoryVectorStore
-from tests.unit_tests.stubs import AnyStr, _AnyIdDocument
+from tests.unit_tests.stubs import _AnyIdDocument
 
 
 class TestInMemoryReadWriteTestSuite(ReadWriteTestSuite):
@@ -117,7 +117,7 @@ async def test_inmemory_filter() -> None:
 
     # Check sync version
     output = store.similarity_search("fee", filter=lambda doc: doc.metadata["id"] == 1)
-    assert output == [Document(page_content="foo", metadata={"id": 1}, id=AnyStr())]
+    assert output == [_AnyIdDocument(page_content="foo", metadata={"id": 1})]
 
     # filter with not stored document id
     output = await store.asimilarity_search(

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -31,12 +31,12 @@ from langchain_core.output_parsers.openai_tools import (
     PydanticToolsParser,
 )
 from langchain_core.outputs import ChatResult
-from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_core.utils import from_env, secret_from_env
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
+from pydantic import BaseModel, Field, SecretStr, root_validator
 
 from langchain_openai.chat_models.base import BaseChatOpenAI
 

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -34,10 +34,7 @@ from langchain_core.outputs import ChatResult
 from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
-from langchain_core.utils import (
-    from_env,
-    secret_from_env,
-)
+from langchain_core.utils import from_env, secret_from_env
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
 

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -36,7 +36,8 @@ from langchain_core.tools import BaseTool
 from langchain_core.utils import from_env, secret_from_env
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
-from pydantic import BaseModel, Field, SecretStr, root_validator
+from pydantic import BaseModel, Field, SecretStr, model_validator
+from typing_extensions import Self
 
 from langchain_openai.chat_models.base import BaseChatOpenAI
 
@@ -565,31 +566,31 @@ class AzureChatOpenAI(BaseChatOpenAI):
     def is_lc_serializable(cls) -> bool:
         return True
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def validate_environment(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
-        if values["n"] < 1:
+        if self.n < 1:
             raise ValueError("n must be at least 1.")
-        if values["n"] > 1 and values["streaming"]:
+        if self.n > 1 and self.streaming:
             raise ValueError("n must be 1 when streaming.")
 
         # Check OPENAI_ORGANIZATION for backwards compatibility.
-        values["openai_organization"] = (
-            values["openai_organization"]
+        self.openai_organization = (
+            self.openai_organization
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
         # For backwards compatibility. Before openai v1, no distinction was made
         # between azure_endpoint and base_url (openai_api_base).
-        openai_api_base = values["openai_api_base"]
-        if openai_api_base and values["validate_base_url"]:
+        openai_api_base = self.openai_api_base
+        if openai_api_base and self.validate_base_url:
             if "/openai" not in openai_api_base:
                 raise ValueError(
                     "As of openai>=1.0.0, Azure endpoints should be specified via "
                     "the `azure_endpoint` param not `openai_api_base` "
                     "(or alias `base_url`)."
                 )
-            if values["deployment_name"]:
+            if self.deployment_name:
                 raise ValueError(
                     "As of openai>=1.0.0, if `azure_deployment` (or alias "
                     "`deployment_name`) is specified then "
@@ -603,38 +604,34 @@ class AzureChatOpenAI(BaseChatOpenAI):
                     'base_url="https://xxx.openai.azure.com/openai/deployments/my-deployment"'
                 )
         client_params = {
-            "api_version": values["openai_api_version"],
-            "azure_endpoint": values["azure_endpoint"],
-            "azure_deployment": values["deployment_name"],
+            "api_version": self.openai_api_version,
+            "azure_endpoint": self.azure_endpoint,
+            "azure_deployment": self.deployment_name,
             "api_key": (
-                values["openai_api_key"].get_secret_value()
-                if values["openai_api_key"]
-                else None
+                self.openai_api_key.get_secret_value() if self.openai_api_key else None
             ),
             "azure_ad_token": (
-                values["azure_ad_token"].get_secret_value()
-                if values["azure_ad_token"]
-                else None
+                self.azure_ad_token.get_secret_value() if self.azure_ad_token else None
             ),
-            "azure_ad_token_provider": values["azure_ad_token_provider"],
-            "organization": values["openai_organization"],
-            "base_url": values["openai_api_base"],
-            "timeout": values["request_timeout"],
-            "max_retries": values["max_retries"],
-            "default_headers": values["default_headers"],
-            "default_query": values["default_query"],
+            "azure_ad_token_provider": self.azure_ad_token_provider,
+            "organization": self.openai_organization,
+            "base_url": self.openai_api_base,
+            "timeout": self.request_timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
         }
-        if not values.get("client"):
-            sync_specific = {"http_client": values["http_client"]}
-            values["client"] = openai.AzureOpenAI(
+        if not (self.client or None):
+            sync_specific = {"http_client": self.http_client}
+            self.client = openai.AzureOpenAI(
                 **client_params, **sync_specific
             ).chat.completions
-        if not values.get("async_client"):
-            async_specific = {"http_client": values["http_async_client"]}
-            values["async_client"] = openai.AsyncAzureOpenAI(
+        if not (self.async_client or None):
+            async_specific = {"http_client": self.http_async_client}
+            self.async_client = openai.AsyncAzureOpenAI(
                 **client_params, **async_specific
             ).chat.completions
-        return values
+        return self
 
     def bind_tools(
         self,

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -34,7 +34,10 @@ from langchain_core.outputs import ChatResult
 from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
-from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
+from langchain_core.utils import (
+    from_env,
+    secret_from_env,
+)
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
 
@@ -474,10 +477,13 @@ class AzureChatOpenAI(BaseChatOpenAI):
             }
     """  # noqa: E501
 
-    azure_endpoint: Union[str, None] = None
+    azure_endpoint: Optional[str] = Field(
+        default_factory=from_env("AZURE_OPENAI_ENDPOINT", default=None)
+    )
     """Your Azure endpoint, including the resource.
-    
+
         Automatically inferred from env var `AZURE_OPENAI_ENDPOINT` if not provided.
+
         Example: `https://example-resource.azure.openai.com/`
     """
     deployment_name: Union[str, None] = Field(default=None, alias="azure_deployment")
@@ -486,15 +492,29 @@ class AzureChatOpenAI(BaseChatOpenAI):
         If given sets the base client URL to include `/deployments/{azure_deployment}`.
         Note: this means you won't be able to use non-deployment endpoints.
     """
-    openai_api_version: str = Field(default="", alias="api_version")
+    openai_api_version: Optional[str] = Field(
+        alias="api_version",
+        default_factory=from_env("OPENAI_API_VERSION", default=None),
+    )
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
-    openai_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
+    # Check OPENAI_KEY for backwards compatibility.
+    # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
+    # other forms of azure credentials.
+    openai_api_key: Optional[SecretStr] = Field(
+        alias="api_key",
+        default_factory=secret_from_env(
+            ["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], default=None
+        ),
+    )
     """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
-    azure_ad_token: Optional[SecretStr] = None
+    azure_ad_token: Optional[SecretStr] = Field(
+        default_factory=secret_from_env("AZURE_OPENAI_AD_TOKEN", default=None)
+    )
     """Your Azure Active Directory token.
-    
+
         Automatically inferred from env var `AZURE_OPENAI_AD_TOKEN` if not provided.
-        For more: 
+
+        For more:
         https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id.
     """
     azure_ad_token_provider: Union[Callable[[], str], None] = None
@@ -516,7 +536,9 @@ class AzureChatOpenAI(BaseChatOpenAI):
     correct cost.
     """
 
-    openai_api_type: str = ""
+    openai_api_type: Optional[str] = Field(
+        default_factory=from_env("OPENAI_API_TYPE", default="azure")
+    )
     """Legacy, for openai<1.0.0 support."""
     validate_base_url: bool = True
     """If legacy arg openai_api_base is passed in, try to infer if it is a base_url or 
@@ -546,7 +568,7 @@ class AzureChatOpenAI(BaseChatOpenAI):
     def is_lc_serializable(cls) -> bool:
         return True
 
-    @root_validator()
+    @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["n"] < 1:
@@ -554,44 +576,11 @@ class AzureChatOpenAI(BaseChatOpenAI):
         if values["n"] > 1 and values["streaming"]:
             raise ValueError("n must be 1 when streaming.")
 
-        # Check OPENAI_KEY for backwards compatibility.
-        # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
-        # other forms of azure credentials.
-        openai_api_key = (
-            values["openai_api_key"]
-            or os.getenv("AZURE_OPENAI_API_KEY")
-            or os.getenv("OPENAI_API_KEY")
-        )
-        values["openai_api_key"] = (
-            convert_to_secret_str(openai_api_key) if openai_api_key else None
-        )
-        values["openai_api_base"] = (
-            values["openai_api_base"]
-            if "openai_api_base" in values
-            else os.getenv("OPENAI_API_BASE")
-        )
-        values["openai_api_version"] = values["openai_api_version"] or os.getenv(
-            "OPENAI_API_VERSION"
-        )
         # Check OPENAI_ORGANIZATION for backwards compatibility.
         values["openai_organization"] = (
             values["openai_organization"]
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
-        )
-        values["azure_endpoint"] = values["azure_endpoint"] or os.getenv(
-            "AZURE_OPENAI_ENDPOINT"
-        )
-        azure_ad_token = values["azure_ad_token"] or os.getenv("AZURE_OPENAI_AD_TOKEN")
-        values["azure_ad_token"] = (
-            convert_to_secret_str(azure_ad_token) if azure_ad_token else None
-        )
-
-        values["openai_api_type"] = get_from_dict_or_env(
-            values, "openai_api_type", "OPENAI_API_TYPE", default="azure"
-        )
-        values["openai_proxy"] = get_from_dict_or_env(
-            values, "openai_proxy", "OPENAI_PROXY", default=""
         )
         # For backwards compatibility. Before openai v1, no distinction was made
         # between azure_endpoint and base_url (openai_api_base).

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -73,7 +73,6 @@ from langchain_core.output_parsers.openai_tools import (
     parse_tool_call,
 )
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough, chain
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.tools import BaseTool
@@ -92,6 +91,14 @@ from langchain_core.utils.pydantic import (
     is_basemodel_subclass,
 )
 from langchain_core.utils.utils import build_extra_kwargs
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    model_validator,
+    root_validator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -377,13 +384,11 @@ class BaseChatOpenAI(BaseChatModel):
     include_response_headers: bool = False
     """Whether to include response headers in the output message response_metadata."""
 
-    class Config:
-        """Configuration for this pydantic object."""
+    model_config = ConfigDict(populate_by_name=True)
 
-        allow_population_by_field_name = True
-
-    @root_validator(pre=True)
-    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def build_extra(cls, values: Dict[str, Any]) -> Any:
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
         extra = values.get("model_kwargs", {})

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -392,7 +392,7 @@ class BaseChatOpenAI(BaseChatModel):
         )
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
+    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["n"] < 1:

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Callable, Dict, Optional, Union
 
 import openai
-from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import from_env, secret_from_env
+from pydantic import Field, SecretStr, root_validator
 
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Optional, Union
 
 import openai
 from langchain_core.utils import from_env, secret_from_env
-from pydantic import Field, SecretStr, root_validator
+from pydantic import Field, SecretStr, model_validator
+from typing_extensions import Self
 
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 
@@ -153,21 +154,21 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
     chunk_size: int = 2048
     """Maximum number of texts to embed in each batch"""
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def validate_environment(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
         # For backwards compatibility. Before openai v1, no distinction was made
         # between azure_endpoint and base_url (openai_api_base).
-        openai_api_base = values["openai_api_base"]
-        if openai_api_base and values["validate_base_url"]:
+        openai_api_base = self.openai_api_base
+        if openai_api_base and self.validate_base_url:
             if "/openai" not in openai_api_base:
-                values["openai_api_base"] += "/openai"
+                self.openai_api_base += "/openai"
                 raise ValueError(
                     "As of openai>=1.0.0, Azure endpoints should be specified via "
                     "the `azure_endpoint` param not `openai_api_base` "
                     "(or alias `base_url`). "
                 )
-            if values["deployment"]:
+            if self.deployment:
                 raise ValueError(
                     "As of openai>=1.0.0, if `deployment` (or alias "
                     "`azure_deployment`) is specified then "
@@ -176,38 +177,34 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
                     "and `azure_endpoint`."
                 )
         client_params = {
-            "api_version": values["openai_api_version"],
-            "azure_endpoint": values["azure_endpoint"],
-            "azure_deployment": values["deployment"],
+            "api_version": self.openai_api_version,
+            "azure_endpoint": self.azure_endpoint,
+            "azure_deployment": self.deployment,
             "api_key": (
-                values["openai_api_key"].get_secret_value()
-                if values["openai_api_key"]
-                else None
+                self.openai_api_key.get_secret_value() if self.openai_api_key else None
             ),
             "azure_ad_token": (
-                values["azure_ad_token"].get_secret_value()
-                if values["azure_ad_token"]
-                else None
+                self.azure_ad_token.get_secret_value() if self.azure_ad_token else None
             ),
-            "azure_ad_token_provider": values["azure_ad_token_provider"],
-            "organization": values["openai_organization"],
-            "base_url": values["openai_api_base"],
-            "timeout": values["request_timeout"],
-            "max_retries": values["max_retries"],
-            "default_headers": values["default_headers"],
-            "default_query": values["default_query"],
+            "azure_ad_token_provider": self.azure_ad_token_provider,
+            "organization": self.openai_organization,
+            "base_url": self.openai_api_base,
+            "timeout": self.request_timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
         }
-        if not values.get("client"):
-            sync_specific = {"http_client": values["http_client"]}
-            values["client"] = openai.AzureOpenAI(
+        if not (self.client or None):
+            sync_specific = {"http_client": self.http_client}
+            self.client = openai.AzureOpenAI(
                 **client_params, **sync_specific
             ).embeddings
-        if not values.get("async_client"):
-            async_specific = {"http_client": values["http_async_client"]}
-            values["async_client"] = openai.AsyncAzureOpenAI(
+        if not (self.async_client or None):
+            async_specific = {"http_client": self.http_async_client}
+            self.async_client = openai.AsyncAzureOpenAI(
                 **client_params, **async_specific
             ).embeddings
-        return values
+        return self
 
     @property
     def _llm_type(self) -> str:

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -124,7 +124,7 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
         ),
     )
     """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
-    open_api_version = Field(
+    openai_api_version: Optional[str] = Field(
         default_factory=from_env("OPENAI_API_VERSION", default="2023-05-15")
     )
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided.
@@ -149,8 +149,6 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
     openai_api_type: Optional[str] = Field(
         default_factory=from_env("OPENAI_API_TYPE", default="azure")
     )
-    openai_api_version: Optional[str] = Field(default=None, alias="api_version")
-    """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
     validate_base_url: bool = True
     chunk_size: int = 2048
     """Maximum number of texts to embed in each batch"""

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-import os
 from typing import Callable, Dict, Optional, Union
 
 import openai
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
-from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
+from langchain_core.utils import (
+    from_env,
+    secret_from_env,
+)
 
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 
@@ -100,7 +102,9 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
             [-0.009100092574954033, 0.005071679595857859, -0.0029193938244134188]
     """  # noqa: E501
 
-    azure_endpoint: Union[str, None] = None
+    azure_endpoint: Optional[str] = Field(
+        default_factory=from_env("AZURE_OPENAI_ENDPOINT", default=None)
+    )
     """Your Azure endpoint, including the resource.
 
         Automatically inferred from env var `AZURE_OPENAI_ENDPOINT` if not provided.
@@ -113,9 +117,26 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
         If given sets the base client URL to include `/deployments/{azure_deployment}`.
         Note: this means you won't be able to use non-deployment endpoints.
     """
-    openai_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
+    # Check OPENAI_KEY for backwards compatibility.
+    # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
+    # other forms of azure credentials.
+    openai_api_key: Optional[SecretStr] = Field(
+        alias="api_key",
+        default_factory=secret_from_env(
+            ["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], default=None
+        ),
+    )
     """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
-    azure_ad_token: Optional[SecretStr] = None
+    open_api_version = Field(
+        default_factory=from_env("OPENAI_API_VERSION", default="2023-05-15")
+    )
+    """Automatically inferred from env var `OPENAI_API_VERSION` if not provided.
+    
+    Set to "2023-05-15" by default if env variable `OPENAI_API_VERSION` is not set.
+    """
+    azure_ad_token: Optional[SecretStr] = Field(
+        default_factory=secret_from_env("AZURE_OPENAI_AD_TOKEN", default=None)
+    )
     """Your Azure Active Directory token.
 
         Automatically inferred from env var `AZURE_OPENAI_AD_TOKEN` if not provided.
@@ -128,52 +149,18 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
 
         Will be invoked on every request.
     """
+    openai_api_type: Optional[str] = Field(
+        default_factory=from_env("OPENAI_API_TYPE", default="azure")
+    )
     openai_api_version: Optional[str] = Field(default=None, alias="api_version")
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
     validate_base_url: bool = True
     chunk_size: int = 2048
     """Maximum number of texts to embed in each batch"""
 
-    @root_validator()
+    @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
-        # Check OPENAI_KEY for backwards compatibility.
-        # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
-        # other forms of azure credentials.
-        openai_api_key = (
-            values["openai_api_key"]
-            or os.getenv("AZURE_OPENAI_API_KEY")
-            or os.getenv("OPENAI_API_KEY")
-        )
-        values["openai_api_key"] = (
-            convert_to_secret_str(openai_api_key) if openai_api_key else None
-        )
-        values["openai_api_base"] = (
-            values["openai_api_base"]
-            if "openai_api_base" in values
-            else os.getenv("OPENAI_API_BASE")
-        )
-        values["openai_api_version"] = values["openai_api_version"] or os.getenv(
-            "OPENAI_API_VERSION", default="2023-05-15"
-        )
-        values["openai_api_type"] = get_from_dict_or_env(
-            values, "openai_api_type", "OPENAI_API_TYPE", default="azure"
-        )
-        values["openai_organization"] = (
-            values["openai_organization"]
-            or os.getenv("OPENAI_ORG_ID")
-            or os.getenv("OPENAI_ORGANIZATION")
-        )
-        values["openai_proxy"] = get_from_dict_or_env(
-            values, "openai_proxy", "OPENAI_PROXY", default=""
-        )
-        values["azure_endpoint"] = values["azure_endpoint"] or os.getenv(
-            "AZURE_OPENAI_ENDPOINT"
-        )
-        azure_ad_token = values["azure_ad_token"] or os.getenv("AZURE_OPENAI_AD_TOKEN")
-        values["azure_ad_token"] = (
-            convert_to_secret_str(azure_ad_token) if azure_ad_token else None
-        )
         # For backwards compatibility. Before openai v1, no distinction was made
         # between azure_endpoint and base_url (openai_api_base).
         openai_api_base = values["openai_api_base"]

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -6,10 +6,7 @@ from typing import Callable, Dict, Optional, Union
 
 import openai
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
-from langchain_core.utils import (
-    from_env,
-    secret_from_env,
-)
+from langchain_core.utils import from_env, secret_from_env
 
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -293,7 +293,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         values["model_kwargs"] = extra
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
+    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["openai_api_type"] in ("azure", "azure_ad", "azuread"):

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -21,8 +21,15 @@ from typing import (
 import openai
 import tiktoken
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.utils import from_env, get_pydantic_field_names, secret_from_env
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    model_validator,
+    root_validator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -261,14 +268,11 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """Whether to check the token length of inputs and automatically split inputs 
         longer than embedding_ctx_length."""
 
-    class Config:
-        """Configuration for this pydantic object."""
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-        extra = "forbid"
-        allow_population_by_field_name = True
-
-    @root_validator(pre=True)
-    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def build_extra(cls, values: Dict[str, Any]) -> Any:
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
         extra = values.get("model_kwargs", {})

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -22,14 +22,8 @@ import openai
 import tiktoken
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import from_env, get_pydantic_field_names, secret_from_env
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    SecretStr,
-    model_validator,
-    root_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -297,55 +291,51 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         values["model_kwargs"] = extra
         return values
 
-    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
-    def validate_environment(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
-        if values["openai_api_type"] in ("azure", "azure_ad", "azuread"):
+        if self.openai_api_type in ("azure", "azure_ad", "azuread"):
             default_api_version = "2023-05-15"
             # Azure OpenAI embedding models allow a maximum of 16 texts
             # at a time in each batch
             # See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#embeddings
-            values["chunk_size"] = min(values["chunk_size"], 16)
+            self.chunk_size = min(self.chunk_size, 16)
         else:
             default_api_version = ""
 
-        if values["openai_api_version"] is None:
-            values["openai_api_version"] = os.getenv(
+        if self.openai_api_version is None:
+            self.openai_api_version = os.getenv(
                 "OPENAI_API_VERSION", default=default_api_version
             )
 
-        if values["openai_api_type"] in ("azure", "azure_ad", "azuread"):
+        if self.openai_api_type in ("azure", "azure_ad", "azuread"):
             raise ValueError(
                 "If you are using Azure, "
                 "please use the `AzureOpenAIEmbeddings` class."
             )
         client_params = {
             "api_key": (
-                values["openai_api_key"].get_secret_value()
-                if values["openai_api_key"]
-                else None
+                self.openai_api_key.get_secret_value() if self.openai_api_key else None
             ),
-            "organization": values["openai_organization"],
-            "base_url": values["openai_api_base"],
-            "timeout": values["request_timeout"],
-            "max_retries": values["max_retries"],
-            "default_headers": values["default_headers"],
-            "default_query": values["default_query"],
+            "organization": self.openai_organization,
+            "base_url": self.openai_api_base,
+            "timeout": self.request_timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
         }
 
-        if values["openai_proxy"] and (
-            values["http_client"] or values["http_async_client"]
-        ):
-            openai_proxy = values["openai_proxy"]
-            http_client = values["http_client"]
-            http_async_client = values["http_async_client"]
+        if self.openai_proxy and (self.http_client or self.http_async_client):
+            openai_proxy = self.openai_proxy
+            http_client = self.http_client
+            http_async_client = self.http_async_client
             raise ValueError(
                 "Cannot specify 'openai_proxy' if one of "
                 "'http_client'/'http_async_client' is already specified. Received:\n"
                 f"{openai_proxy=}\n{http_client=}\n{http_async_client=}"
             )
-        if not values.get("client"):
-            if values["openai_proxy"] and not values["http_client"]:
+        if not (self.client or None):
+            if self.openai_proxy and not self.http_client:
                 try:
                     import httpx
                 except ImportError as e:
@@ -353,13 +343,11 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                         "Could not import httpx python package. "
                         "Please install it with `pip install httpx`."
                     ) from e
-                values["http_client"] = httpx.Client(proxy=values["openai_proxy"])
-            sync_specific = {"http_client": values["http_client"]}
-            values["client"] = openai.OpenAI(
-                **client_params, **sync_specific
-            ).embeddings
-        if not values.get("async_client"):
-            if values["openai_proxy"] and not values["http_async_client"]:
+                self.http_client = httpx.Client(proxy=self.openai_proxy)
+            sync_specific = {"http_client": self.http_client}
+            self.client = openai.OpenAI(**client_params, **sync_specific).embeddings
+        if not (self.async_client or None):
+            if self.openai_proxy and not self.http_async_client:
                 try:
                     import httpx
                 except ImportError as e:
@@ -367,14 +355,12 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                         "Could not import httpx python package. "
                         "Please install it with `pip install httpx`."
                     ) from e
-                values["http_async_client"] = httpx.AsyncClient(
-                    proxy=values["openai_proxy"]
-                )
-            async_specific = {"http_client": values["http_async_client"]}
-            values["async_client"] = openai.AsyncOpenAI(
+                self.http_async_client = httpx.AsyncClient(proxy=self.openai_proxy)
+            async_specific = {"http_client": self.http_async_client}
+            self.async_client = openai.AsyncOpenAI(
                 **client_params, **async_specific
             ).embeddings
-        return values
+        return self
 
     @property
     def _invocation_params(self) -> Dict[str, Any]:

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -23,9 +23,9 @@ import tiktoken
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain_core.utils import (
-    convert_to_secret_str,
-    get_from_dict_or_env,
+    from_env,
     get_pydantic_field_names,
+    secret_from_env,
 )
 
 logger = logging.getLogger(__name__)
@@ -188,18 +188,31 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     openai_api_version: Optional[str] = Field(default=None, alias="api_version")
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
     # to support Azure OpenAI Service custom endpoints
-    openai_api_base: Optional[str] = Field(default=None, alias="base_url")
+    openai_api_base: Optional[str] = Field(
+        alias="base_url", default_factory=from_env("OPENAI_API_BASE", default=None)
+    )
     """Base URL path for API requests, leave blank if not using a proxy or service
         emulator."""
     # to support Azure OpenAI Service custom endpoints
-    openai_api_type: Optional[str] = None
+    openai_api_type: Optional[str] = Field(
+        default_factory=from_env("OPENAI_API_TYPE", default=None)
+    )
     # to support explicit proxy for OpenAI
-    openai_proxy: Optional[str] = None
+    openai_proxy: Optional[str] = Field(
+        default_factory=from_env("OPENAI_PROXY", default=None)
+    )
     embedding_ctx_length: int = 8191
     """The maximum number of tokens to embed at once."""
-    openai_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
+    openai_api_key: Optional[SecretStr] = Field(
+        alias="api_key", default_factory=secret_from_env("OPENAI_API_KEY", default=None)
+    )
     """Automatically inferred from env var `OPENAI_API_KEY` if not provided."""
-    openai_organization: Optional[str] = Field(default=None, alias="organization")
+    openai_organization: Optional[str] = Field(
+        alias="organization",
+        default_factory=from_env(
+            ["OPENAI_ORG_ID", "OPENAI_ORGANIZATION"], default=None
+        ),
+    )
     """Automatically inferred from env var `OPENAI_ORG_ID` if not provided."""
     allowed_special: Union[Literal["all"], Set[str], None] = None
     disallowed_special: Union[Literal["all"], Set[str], Sequence[str], None] = None
@@ -284,24 +297,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         values["model_kwargs"] = extra
         return values
 
-    @root_validator()
+    @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
-        openai_api_key = get_from_dict_or_env(
-            values, "openai_api_key", "OPENAI_API_KEY"
-        )
-        values["openai_api_key"] = (
-            convert_to_secret_str(openai_api_key) if openai_api_key else None
-        )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
-        )
-        values["openai_api_type"] = get_from_dict_or_env(
-            values, "openai_api_type", "OPENAI_API_TYPE", default=""
-        )
-        values["openai_proxy"] = get_from_dict_or_env(
-            values, "openai_proxy", "OPENAI_PROXY", default=""
-        )
         if values["openai_api_type"] in ("azure", "azure_ad", "azuread"):
             default_api_version = "2023-05-15"
             # Azure OpenAI embedding models allow a maximum of 16 texts
@@ -310,18 +308,12 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             values["chunk_size"] = min(values["chunk_size"], 16)
         else:
             default_api_version = ""
-        values["openai_api_version"] = get_from_dict_or_env(
-            values,
-            "openai_api_version",
-            "OPENAI_API_VERSION",
-            default=default_api_version,
-        )
-        # Check OPENAI_ORGANIZATION for backwards compatibility.
-        values["openai_organization"] = (
-            values["openai_organization"]
-            or os.getenv("OPENAI_ORG_ID")
-            or os.getenv("OPENAI_ORGANIZATION")
-        )
+
+        if values["openai_api_version"] is None:
+            values["openai_api_version"] = os.getenv(
+                "OPENAI_API_VERSION", default=default_api_version
+            )
+
         if values["openai_api_type"] in ("azure", "azure_ad", "azuread"):
             raise ValueError(
                 "If you are using Azure, "

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -22,11 +22,7 @@ import openai
 import tiktoken
 from langchain_core.embeddings import Embeddings
 from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
-from langchain_core.utils import (
-    from_env,
-    get_pydantic_field_names,
-    secret_from_env,
-)
+from langchain_core.utils import from_env, get_pydantic_field_names, secret_from_env
 
 logger = logging.getLogger(__name__)
 

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -5,7 +5,8 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 import openai
 from langchain_core.utils import from_env, secret_from_env
-from pydantic import Field, SecretStr, root_validator
+from pydantic import Field, SecretStr, model_validator
+from typing_extensions import Self
 
 from langchain_openai.llms.base import BaseOpenAI
 
@@ -99,29 +100,27 @@ class AzureOpenAI(BaseOpenAI):
         """Return whether this model can be serialized by Langchain."""
         return True
 
-    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
-    def validate_environment(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
-        if values["n"] < 1:
+        if self.n < 1:
             raise ValueError("n must be at least 1.")
-        if values["streaming"] and values["n"] > 1:
+        if self.streaming and self.n > 1:
             raise ValueError("Cannot stream results when n > 1.")
-        if values["streaming"] and values["best_of"] > 1:
+        if self.streaming and self.best_of > 1:
             raise ValueError("Cannot stream results when best_of > 1.")
         # For backwards compatibility. Before openai v1, no distinction was made
         # between azure_endpoint and base_url (openai_api_base).
-        openai_api_base = values["openai_api_base"]
-        if openai_api_base and values["validate_base_url"]:
+        openai_api_base = self.openai_api_base
+        if openai_api_base and self.validate_base_url:
             if "/openai" not in openai_api_base:
-                values["openai_api_base"] = (
-                    values["openai_api_base"].rstrip("/") + "/openai"
-                )
+                self.openai_api_base = self.openai_api_base.rstrip("/") + "/openai"
                 raise ValueError(
                     "As of openai>=1.0.0, Azure endpoints should be specified via "
                     "the `azure_endpoint` param not `openai_api_base` "
                     "(or alias `base_url`)."
                 )
-            if values["deployment_name"]:
+            if self.deployment_name:
                 raise ValueError(
                     "As of openai>=1.0.0, if `deployment_name` (or alias "
                     "`azure_deployment`) is specified then "
@@ -129,37 +128,37 @@ class AzureOpenAI(BaseOpenAI):
                     "Instead use `deployment_name` (or alias `azure_deployment`) "
                     "and `azure_endpoint`."
                 )
-                values["deployment_name"] = None
+                self.deployment_name = None
         client_params = {
-            "api_version": values["openai_api_version"],
-            "azure_endpoint": values["azure_endpoint"],
-            "azure_deployment": values["deployment_name"],
-            "api_key": values["openai_api_key"].get_secret_value()
-            if values["openai_api_key"]
+            "api_version": self.openai_api_version,
+            "azure_endpoint": self.azure_endpoint,
+            "azure_deployment": self.deployment_name,
+            "api_key": self.openai_api_key.get_secret_value()
+            if self.openai_api_key
             else None,
-            "azure_ad_token": values["azure_ad_token"].get_secret_value()
-            if values["azure_ad_token"]
+            "azure_ad_token": self.azure_ad_token.get_secret_value()
+            if self.azure_ad_token
             else None,
-            "azure_ad_token_provider": values["azure_ad_token_provider"],
-            "organization": values["openai_organization"],
-            "base_url": values["openai_api_base"],
-            "timeout": values["request_timeout"],
-            "max_retries": values["max_retries"],
-            "default_headers": values["default_headers"],
-            "default_query": values["default_query"],
+            "azure_ad_token_provider": self.azure_ad_token_provider,
+            "organization": self.openai_organization,
+            "base_url": self.openai_api_base,
+            "timeout": self.request_timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
         }
-        if not values.get("client"):
-            sync_specific = {"http_client": values["http_client"]}
-            values["client"] = openai.AzureOpenAI(
+        if not (self.client or None):
+            sync_specific = {"http_client": self.http_client}
+            self.client = openai.AzureOpenAI(
                 **client_params, **sync_specific
             ).completions
-        if not values.get("async_client"):
-            async_specific = {"http_client": values["http_async_client"]}
-            values["async_client"] = openai.AsyncAzureOpenAI(
+        if not (self.async_client or None):
+            async_specific = {"http_client": self.http_async_client}
+            self.async_client = openai.AsyncAzureOpenAI(
                 **client_params, **async_specific
             ).completions
 
-        return values
+        return self
 
     @property
     def _identifying_params(self) -> Mapping[str, Any]:

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -99,7 +99,7 @@ class AzureOpenAI(BaseOpenAI):
         """Return whether this model can be serialized by Langchain."""
         return True
 
-    @root_validator(pre=False, skip_on_failure=True)
+    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["n"] < 1:

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 import openai
-from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import from_env, secret_from_env
+from pydantic import Field, SecretStr, root_validator
 
 from langchain_openai.llms.base import BaseOpenAI
 

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 import openai
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
-from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
+from langchain_core.utils import from_env, secret_from_env
 
 from langchain_openai.llms.base import BaseOpenAI
 
@@ -30,7 +29,9 @@ class AzureOpenAI(BaseOpenAI):
             openai = AzureOpenAI(model_name="gpt-3.5-turbo-instruct")
     """
 
-    azure_endpoint: Union[str, None] = None
+    azure_endpoint: Optional[str] = Field(
+        default_factory=from_env("AZURE_OPENAI_ENDPOINT", default=None)
+    )
     """Your Azure endpoint, including the resource.
 
         Automatically inferred from env var `AZURE_OPENAI_ENDPOINT` if not provided.
@@ -43,16 +44,28 @@ class AzureOpenAI(BaseOpenAI):
         If given sets the base client URL to include `/deployments/{azure_deployment}`.
         Note: this means you won't be able to use non-deployment endpoints.
     """
-    openai_api_version: str = Field(default="", alias="api_version")
+    openai_api_version: Optional[str] = Field(
+        alias="api_version",
+        default_factory=from_env("OPENAI_API_VERSION", default=None),
+    )
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
-    openai_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
-    """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
-    azure_ad_token: Optional[SecretStr] = None
+    # Check OPENAI_KEY for backwards compatibility.
+    # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
+    # other forms of azure credentials.
+    openai_api_key: Optional[SecretStr] = Field(
+        alias="api_key",
+        default_factory=secret_from_env(
+            ["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], default=None
+        ),
+    )
+    azure_ad_token: Optional[SecretStr] = Field(
+        default_factory=secret_from_env("AZURE_OPENAI_AD_TOKEN", default=None)
+    )
     """Your Azure Active Directory token.
 
         Automatically inferred from env var `AZURE_OPENAI_AD_TOKEN` if not provided.
 
-        For more: 
+        For more:
         https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id.
     """
     azure_ad_token_provider: Union[Callable[[], str], None] = None
@@ -60,7 +73,9 @@ class AzureOpenAI(BaseOpenAI):
 
         Will be invoked on every request.
     """
-    openai_api_type: str = ""
+    openai_api_type: Optional[str] = Field(
+        default_factory=from_env("OPENAI_API_TYPE", default="azure")
+    )
     """Legacy, for openai<1.0.0 support."""
     validate_base_url: bool = True
     """For backwards compatibility. If legacy val openai_api_base is passed in, try to 
@@ -84,7 +99,7 @@ class AzureOpenAI(BaseOpenAI):
         """Return whether this model can be serialized by Langchain."""
         return True
 
-    @root_validator()
+    @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["n"] < 1:
@@ -93,43 +108,6 @@ class AzureOpenAI(BaseOpenAI):
             raise ValueError("Cannot stream results when n > 1.")
         if values["streaming"] and values["best_of"] > 1:
             raise ValueError("Cannot stream results when best_of > 1.")
-
-        # Check OPENAI_KEY for backwards compatibility.
-        # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
-        # other forms of azure credentials.
-        openai_api_key = (
-            values["openai_api_key"]
-            or os.getenv("AZURE_OPENAI_API_KEY")
-            or os.getenv("OPENAI_API_KEY")
-        )
-        values["openai_api_key"] = (
-            convert_to_secret_str(openai_api_key) if openai_api_key else None
-        )
-
-        values["azure_endpoint"] = values["azure_endpoint"] or os.getenv(
-            "AZURE_OPENAI_ENDPOINT"
-        )
-        azure_ad_token = values["azure_ad_token"] or os.getenv("AZURE_OPENAI_AD_TOKEN")
-        values["azure_ad_token"] = (
-            convert_to_secret_str(azure_ad_token) if azure_ad_token else None
-        )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
-        )
-        values["openai_proxy"] = get_from_dict_or_env(
-            values, "openai_proxy", "OPENAI_PROXY", default=""
-        )
-        values["openai_organization"] = (
-            values["openai_organization"]
-            or os.getenv("OPENAI_ORG_ID")
-            or os.getenv("OPENAI_ORGANIZATION")
-        )
-        values["openai_api_version"] = values["openai_api_version"] or os.getenv(
-            "OPENAI_API_VERSION"
-        )
-        values["openai_api_type"] = get_from_dict_or_env(
-            values, "openai_api_type", "OPENAI_API_TYPE", default="azure"
-        )
         # For backwards compatibility. Before openai v1, no distinction was made
         # between azure_endpoint and base_url (openai_api_base).
         openai_api_base = values["openai_api_base"]

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -28,7 +28,8 @@ from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.utils import get_pydantic_field_names
 from langchain_core.utils.utils import build_extra_kwargs, from_env, secret_from_env
-from pydantic import ConfigDict, Field, SecretStr, model_validator, root_validator
+from pydantic import ConfigDict, Field, SecretStr, model_validator
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -165,41 +166,37 @@ class BaseOpenAI(BaseLLM):
         )
         return values
 
-    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
-    def validate_environment(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
-        if values["n"] < 1:
+        if self.n < 1:
             raise ValueError("n must be at least 1.")
-        if values["streaming"] and values["n"] > 1:
+        if self.streaming and self.n > 1:
             raise ValueError("Cannot stream results when n > 1.")
-        if values["streaming"] and values["best_of"] > 1:
+        if self.streaming and self.best_of > 1:
             raise ValueError("Cannot stream results when best_of > 1.")
 
         client_params = {
             "api_key": (
-                values["openai_api_key"].get_secret_value()
-                if values["openai_api_key"]
-                else None
+                self.openai_api_key.get_secret_value() if self.openai_api_key else None
             ),
-            "organization": values["openai_organization"],
-            "base_url": values["openai_api_base"],
-            "timeout": values["request_timeout"],
-            "max_retries": values["max_retries"],
-            "default_headers": values["default_headers"],
-            "default_query": values["default_query"],
+            "organization": self.openai_organization,
+            "base_url": self.openai_api_base,
+            "timeout": self.request_timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
         }
-        if not values.get("client"):
-            sync_specific = {"http_client": values["http_client"]}
-            values["client"] = openai.OpenAI(
-                **client_params, **sync_specific
-            ).completions
-        if not values.get("async_client"):
-            async_specific = {"http_client": values["http_async_client"]}
-            values["async_client"] = openai.AsyncOpenAI(
+        if not (self.client or None):
+            sync_specific = {"http_client": self.http_client}
+            self.client = openai.OpenAI(**client_params, **sync_specific).completions
+        if not (self.async_client or None):
+            async_specific = {"http_client": self.http_async_client}
+            self.async_client = openai.AsyncOpenAI(
                 **client_params, **async_specific
             ).completions
 
-        return values
+        return self
 
     @property
     def _default_params(self) -> Dict[str, Any]:

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -27,9 +27,7 @@ from langchain_core.callbacks import (
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
-from langchain_core.utils import (
-    get_pydantic_field_names,
-)
+from langchain_core.utils import get_pydantic_field_names
 from langchain_core.utils.utils import build_extra_kwargs, from_env, secret_from_env
 
 logger = logging.getLogger(__name__)
@@ -169,7 +167,7 @@ class BaseOpenAI(BaseLLM):
         )
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
+    @root_validator(pre=False, skip_on_failure=True, allow_reuse=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["n"] < 1:

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -26,9 +26,9 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
-from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import get_pydantic_field_names
 from langchain_core.utils.utils import build_extra_kwargs, from_env, secret_from_env
+from pydantic import ConfigDict, Field, SecretStr, model_validator, root_validator
 
 logger = logging.getLogger(__name__)
 
@@ -152,13 +152,11 @@ class BaseOpenAI(BaseLLM):
     """Optional additional JSON properties to include in the request parameters when
     making requests to OpenAI compatible APIs, such as vLLM."""
 
-    class Config:
-        """Configuration for this pydantic object."""
+    model_config = ConfigDict(populate_by_name=True)
 
-        allow_population_by_field_name = True
-
-    @root_validator(pre=True)
-    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def build_extra(cls, values: Dict[str, Any]) -> Any:
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
         extra = values.get("model_kwargs", {})

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from typing import (
     AbstractSet,
@@ -29,11 +28,9 @@ from langchain_core.language_models.llms import BaseLLM
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import (
-    convert_to_secret_str,
-    get_from_dict_or_env,
     get_pydantic_field_names,
 )
-from langchain_core.utils.utils import build_extra_kwargs
+from langchain_core.utils.utils import build_extra_kwargs, from_env, secret_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -90,15 +87,26 @@ class BaseOpenAI(BaseLLM):
     """Generates best_of completions server-side and returns the "best"."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not explicitly specified."""
-    openai_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
+    openai_api_key: Optional[SecretStr] = Field(
+        alias="api_key", default_factory=secret_from_env("OPENAI_API_KEY", default=None)
+    )
     """Automatically inferred from env var `OPENAI_API_KEY` if not provided."""
-    openai_api_base: Optional[str] = Field(default=None, alias="base_url")
+    openai_api_base: Optional[str] = Field(
+        alias="base_url", default_factory=from_env("OPENAI_API_BASE", default=None)
+    )
     """Base URL path for API requests, leave blank if not using a proxy or service 
         emulator."""
-    openai_organization: Optional[str] = Field(default=None, alias="organization")
+    openai_organization: Optional[str] = Field(
+        alias="organization",
+        default_factory=from_env(
+            ["OPENAI_ORG_ID", "OPENAI_ORGANIZATION"], default=None
+        ),
+    )
     """Automatically inferred from env var `OPENAI_ORG_ID` if not provided."""
     # to support explicit proxy for OpenAI
-    openai_proxy: Optional[str] = None
+    openai_proxy: Optional[str] = Field(
+        default_factory=from_env("OPENAI_PROXY", default=None)
+    )
     batch_size: int = 20
     """Batch size to use when passing multiple documents to generate."""
     request_timeout: Union[float, Tuple[float, float], Any, None] = Field(
@@ -170,24 +178,6 @@ class BaseOpenAI(BaseLLM):
             raise ValueError("Cannot stream results when n > 1.")
         if values["streaming"] and values["best_of"] > 1:
             raise ValueError("Cannot stream results when best_of > 1.")
-
-        openai_api_key = get_from_dict_or_env(
-            values, "openai_api_key", "OPENAI_API_KEY"
-        )
-        values["openai_api_key"] = (
-            convert_to_secret_str(openai_api_key) if openai_api_key else None
-        )
-        values["openai_api_base"] = values["openai_api_base"] or os.getenv(
-            "OPENAI_API_BASE"
-        )
-        values["openai_proxy"] = get_from_dict_or_env(
-            values, "openai_proxy", "OPENAI_PROXY", default=""
-        )
-        values["openai_organization"] = (
-            values["openai_organization"]
-            or os.getenv("OPENAI_ORG_ID")
-            or os.getenv("OPENAI_ORGANIZATION")
-        )
 
         client_params = {
             "api_key": (

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -161,7 +161,7 @@ class BaseOpenAI(BaseLLM):
         )
         return values
 
-    @root_validator()
+    @root_validator(pre=False, skip_on_failure=True)
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if values["n"] < 1:

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -19,13 +19,13 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, ChatResult, LLMResult
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_standard_tests.integration_tests.chat_models import (
     _validate_tool_call_message,
 )
 from langchain_standard_tests.integration_tests.chat_models import (
     magic_function as invalid_magic_function,
 )
+from pydantic import BaseModel, Field
 
 from langchain_openai import ChatOpenAI
 from tests.unit_tests.fake.callbacks import FakeCallbackHandler

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -40,9 +40,7 @@ def test_initialize_more() -> None:
 
 
 def test_initialize_azure_openai_with_openai_api_base_set() -> None:
-    with mock.patch.dict(
-        os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}
-    ):
+    with mock.patch.dict(os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}):
         llm = AzureChatOpenAI(  # type: ignore[call-arg, call-arg]
             api_key="xyz",  # type: ignore[arg-type]
             azure_endpoint="my-base-url",

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -1,6 +1,7 @@
 """Test Azure OpenAI Chat API wrapper."""
 
 import os
+from unittest import mock
 
 from langchain_openai import AzureChatOpenAI
 
@@ -39,22 +40,24 @@ def test_initialize_more() -> None:
 
 
 def test_initialize_azure_openai_with_openai_api_base_set() -> None:
-    os.environ["OPENAI_API_BASE"] = "https://api.openai.com"
-    llm = AzureChatOpenAI(  # type: ignore[call-arg, call-arg]
-        api_key="xyz",  # type: ignore[arg-type]
-        azure_endpoint="my-base-url",
-        azure_deployment="35-turbo-dev",
-        openai_api_version="2023-05-15",
-        temperature=0,
-        openai_api_base=None,
-    )
-    assert llm.openai_api_key is not None
-    assert llm.openai_api_key.get_secret_value() == "xyz"
-    assert llm.azure_endpoint == "my-base-url"
-    assert llm.deployment_name == "35-turbo-dev"
-    assert llm.openai_api_version == "2023-05-15"
-    assert llm.temperature == 0
+    with mock.patch.dict(
+        os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}
+    ):
+        llm = AzureChatOpenAI(  # type: ignore[call-arg, call-arg]
+            api_key="xyz",  # type: ignore[arg-type]
+            azure_endpoint="my-base-url",
+            azure_deployment="35-turbo-dev",
+            openai_api_version="2023-05-15",
+            temperature=0,
+            openai_api_base=None,
+        )
+        assert llm.openai_api_key is not None
+        assert llm.openai_api_key.get_secret_value() == "xyz"
+        assert llm.azure_endpoint == "my-base-url"
+        assert llm.deployment_name == "35-turbo-dev"
+        assert llm.openai_api_version == "2023-05-15"
+        assert llm.temperature == 0
 
-    ls_params = llm._get_ls_params()
-    assert ls_params["ls_provider"] == "azure"
-    assert ls_params["ls_model_name"] == "35-turbo-dev"
+        ls_params = llm._get_ls_params()
+        assert ls_params["ls_provider"] == "azure"
+        assert ls_params["ls_model_name"] == "35-turbo-dev"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -14,7 +14,7 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
 )
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 from langchain_openai import ChatOpenAI
 from langchain_openai.chat_models.base import (

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 from langchain_openai import AzureOpenAIEmbeddings
 
@@ -15,13 +16,15 @@ def test_initialize_azure_openai() -> None:
 
 
 def test_intialize_azure_openai_with_base_set() -> None:
-    os.environ["OPENAI_API_BASE"] = "https://api.openai.com"
-    embeddings = AzureOpenAIEmbeddings(  # type: ignore[call-arg, call-arg]
-        model="text-embedding-large",
-        api_key="xyz",  # type: ignore[arg-type]
-        azure_endpoint="my-base-url",
-        azure_deployment="35-turbo-dev",
-        openai_api_version="2023-05-15",
-        openai_api_base=None,
-    )
-    assert embeddings.model == "text-embedding-large"
+    with mock.patch.dict(
+            os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}
+    ):
+        embeddings = AzureOpenAIEmbeddings(  # type: ignore[call-arg, call-arg]
+            model="text-embedding-large",
+            api_key="xyz",  # type: ignore[arg-type]
+            azure_endpoint="my-base-url",
+            azure_deployment="35-turbo-dev",
+            openai_api_version="2023-05-15",
+            openai_api_base=None,
+        )
+        assert embeddings.model == "text-embedding-large"

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
@@ -16,9 +16,7 @@ def test_initialize_azure_openai() -> None:
 
 
 def test_intialize_azure_openai_with_base_set() -> None:
-    with mock.patch.dict(
-            os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}
-    ):
+    with mock.patch.dict(os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}):
         embeddings = AzureOpenAIEmbeddings(  # type: ignore[call-arg, call-arg]
             model="text-embedding-large",
             api_key="xyz",  # type: ignore[arg-type]

--- a/libs/partners/openai/tests/unit_tests/fake/callbacks.py
+++ b/libs/partners/openai/tests/unit_tests/fake/callbacks.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from langchain_core.callbacks.base import AsyncCallbackHandler, BaseCallbackHandler
 from langchain_core.messages import BaseMessage
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class BaseFakeCallbackHandler(BaseModel):

--- a/libs/partners/openai/tests/unit_tests/test_secrets.py
+++ b/libs/partners/openai/tests/unit_tests/test_secrets.py
@@ -2,7 +2,7 @@ from typing import Type, cast
 
 import pytest
 from langchain_core.load import dumpd
-from langchain_core.pydantic_v1 import SecretStr
+from pydantic import SecretStr
 from pytest import CaptureFixture, MonkeyPatch
 
 from langchain_openai import (


### PR DESCRIPTION
Grit migrations:


```
engine marzano(0.1)
language python

or {
    `from $IMPORT import $...` where {
        $IMPORT <: contains `pydantic_v1`,
        $IMPORT => `pydantic`
    },
    `$X.update_forward_refs` => `$X.model_rebuild`,
  // This pattern still needs fixing as it fails (populate_by_name vs.
  // allow_populate_by_name)
  class_definition($name, $body) as $C where {
      $name <: `Config`,
      $body <: block($statements),
      $t = "",
      $statements <: some bubble($t) assignment(left=$x, right=$y) as $A where {    
        or {
            $x <: `allow_population_by_field_name` where {
                $t += `populate_by_name=$y,`
            },
            $t += `$x=$y,`
        }
      },
      $C => `model_config = ConfigDict($t)`,
      add_import(source="pydantic", name="ConfigDict")
  }
}

```



```
engine marzano(0.1)
language python

`@root_validator(pre=True)` as $decorator where {
    $decorator <: before function_definition($body, $return_type),
    $decorator => `@model_validator(mode="before")\n@classmethod`,
    add_import(source="pydantic", name="model_validator"),
    $return_type => `Any`
}
```

```
engine marzano(0.1)
language python

`@root_validator(pre=False, skip_on_failure=True)` as $decorator where {
    $decorator <: before function_definition($body, $parameters, $return_type) where {
        $body <: contains bubble or {
            `values["$Q"]` => `self.$Q`,
            `values.get("$Q")` => `(self.$Q or None)`,
            `values.get($Q, $...)` as $V where {
                $Q <: contains `"$QName"`,
                $V => `self.$QName`,
            },
            `return $Q` => `return self`
        }
    },
    $decorator => `@model_validator(mode="after")`,
    // Silly work around a bug in grit
    // Adding Self to pydantic and then will replace it with one from typing
    add_import(source="pydantic", name="model_validator"),
    $parameters => `self`,
    $return_type => `Self`
}

```

```
grit apply --language python '`Self` where { add_import(source="typing_extensions", name="Self")}'

```

At the end, need to restore `langchain-core/traces/schema.py'



------







- update
- update
- x
- update
- fixes
- x
- x
- x
- x
- x
- foo
- xx

Thank you for contributing to LangChain!

- [ ] **PR title**: "package: description"
  - Where "package" is whichever of langchain, community, core, experimental, etc. is being modified. Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change
    - **Twitter handle:** if your PR gets announced, and you'd like a mention, we'll gladly shout you out!


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
