### PR TITLE
langchain-core: added pydantic parser fix for issue #24995

### DIFF
--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -74,7 +74,14 @@ class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
         Returns:
             The parsed pydantic object.
         """
-        return super().parse(text)
+        from langchain_core.messages import AIMessage
+
+        if isinstance(text, AIMessage):
+            text_content = text.content
+        else:
+            text_content = text
+
+        return super().parse(text_content)
 
     def get_format_instructions(self) -> str:
         """Return the format instructions for the JSON output.


### PR DESCRIPTION
  - **Description:**

There was an issue with `PydanticOutputParser`: it doesn't support **ChatOpenAI** response, only supports **OpenAI** response.

_Cause_: **OpenAI** gives text as completion but **ChatOpenAI** gives `AIMessage` object as completion.
_Fix_: Modify `PydanticOutputParser` `parse()` method to support both types of responses.
  
  - **Issue:** #24995
  - **Dependencies:** no any new dependencies
