### PR TITLE
docs: add prompt to install beautifulsoup4.

### DIFF
--- a/docs/docs/how_to/qa_chat_history_how_to.ipynb
+++ b/docs/docs/how_to/qa_chat_history_how_to.ipynb
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install --upgrade --quiet  langchain langchain-community langchain-chroma bs4"
+    "%pip install --upgrade --quiet  langchain langchain-community langchain-chroma beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/how_to/qa_sources.ipynb
+++ b/docs/docs/how_to/qa_sources.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  langchain langchain-community langchainhub langchain-openai langchain-chroma bs4"
+    "%pip install --upgrade --quiet  langchain langchain-community langchainhub langchain-openai langchain-chroma beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/how_to/qa_streaming.ipynb
+++ b/docs/docs/how_to/qa_streaming.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  langchain langchain-community langchainhub langchain-openai langchain-chroma bs4"
+    "%pip install --upgrade --quiet  langchain langchain-community langchainhub langchain-openai langchain-chroma beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/integrations/callbacks/infino.ipynb
+++ b/docs/docs/integrations/callbacks/infino.ipynb
@@ -37,7 +37,8 @@
     "%pip install --upgrade --quiet  infinopy\n",
     "%pip install --upgrade --quiet  matplotlib\n",
     "%pip install --upgrade --quiet  tiktoken\n",
-    "%pip install --upgrade --quiet  langchain langchain-openai langchain-community"
+    "%pip install --upgrade --quiet  langchain langchain-openai langchain-community\n",
+    "%pip install --upgrade --quiet  beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/integrations/document_transformers/google_cloud_vertexai_rerank.ipynb
+++ b/docs/docs/integrations/document_transformers/google_cloud_vertexai_rerank.ipynb
@@ -23,7 +23,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet langchain langchain-community langchain-google-community langchain-google-community[vertexaisearch] langchain-google-vertexai langchain-chroma langchain-text-splitters"
+    "%pip install --upgrade --quiet langchain langchain-community langchain-google-community langchain-google-community[vertexaisearch] langchain-google-vertexai langchain-chroma langchain-text-splitters beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/tutorials/local_rag.ipynb
+++ b/docs/docs/tutorials/local_rag.ipynb
@@ -57,7 +57,10 @@
     "%pip install -qU langchain_chroma\n",
     "\n",
     "# Local inference and embeddings via Ollama\n",
-    "%pip install -qU langchain_ollama"
+    "%pip install -qU langchain_ollama\n",
+    "\n",
+    "# Web Loader\n",
+    "% pip install -qU beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/tutorials/qa_chat_history.ipynb
+++ b/docs/docs/tutorials/qa_chat_history.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install --upgrade --quiet  langchain langchain-community langchainhub langchain-chroma bs4"
+    "%pip install --upgrade --quiet  langchain langchain-community langchainhub langchain-chroma beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/tutorials/summarization.ipynb
+++ b/docs/docs/tutorials/summarization.ipynb
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  langchain-openai tiktoken chromadb langchain\n",
+    "%pip install --upgrade --quiet  langchain-openai tiktoken chromadb langchain beautifulsoup4\n",
     "\n",
     "# Set env var OPENAI_API_KEY or load from a .env file\n",
     "# import dotenv\n",

--- a/docs/docs/versions/migrating_chains/conversation_retrieval_chain.ipynb
+++ b/docs/docs/versions/migrating_chains/conversation_retrieval_chain.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet langchain-community langchain langchain-openai faiss-cpu"
+    "%pip install --upgrade --quiet langchain-community langchain langchain-openai faiss-cpu beautifulsoup4"
    ]
   },
   {

--- a/docs/docs/versions/migrating_chains/retrieval_qa.ipynb
+++ b/docs/docs/versions/migrating_chains/retrieval_qa.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet langchain-community langchain langchain-openai faiss-cpu"
+    "%pip install --upgrade --quiet langchain-community langchain langchain-openai faiss-cpu beautifulsoup4"
    ]
   },
   {


### PR DESCRIPTION
fix: #25482

- **Description:**
    Add a prompt to install beautifulsoup4 in places where `from langchain_community.document_loaders import WebBaseLoader` is used.
- **Issue:** #25482 

