### PR TITLE
together: update base url

### DIFF
--- a/libs/partners/together/langchain_together/chat_models.py
+++ b/libs/partners/together/langchain_together/chat_models.py
@@ -315,12 +315,12 @@ class ChatTogether(BaseChatOpenAI):
         default_factory=secret_from_env("TOGETHER_API_KEY", default=None),
     )
     """Together AI API key.
-    
+
     Automatically read from env variable `TOGETHER_API_KEY` if not provided.
     """
     together_api_base: str = Field(
         default_factory=from_env(
-            "TOGETHER_API_BASE", default="https://api.together.ai/v1/"
+            "TOGETHER_API_BASE", default="https://api.together.xyz/v1/"
         ),
         alias="base_url",
     )

--- a/libs/partners/together/langchain_together/embeddings.py
+++ b/libs/partners/together/langchain_together/embeddings.py
@@ -106,7 +106,7 @@ class TogetherEmbeddings(BaseModel, Embeddings):
     client: Any = Field(default=None, exclude=True)  #: :meta private:
     async_client: Any = Field(default=None, exclude=True)  #: :meta private:
     model: str = "togethercomputer/m2-bert-80M-8k-retrieval"
-    """Embeddings model name to use. 
+    """Embeddings model name to use.
     Instead, use 'togethercomputer/m2-bert-80M-8k-retrieval' for example.
     """
     dimensions: Optional[int] = None
@@ -119,12 +119,12 @@ class TogetherEmbeddings(BaseModel, Embeddings):
         default_factory=secret_from_env("TOGETHER_API_KEY", default=None),
     )
     """Together AI API key.
-    
+
     Automatically read from env variable `TOGETHER_API_KEY` if not provided.
     """
     together_api_base: str = Field(
         default_factory=from_env(
-            "TOGETHER_API_BASE", default="https://api.together.ai/v1/"
+            "TOGETHER_API_BASE", default="https://api.together.xyz/v1/"
         ),
         alias="base_url",
     )

--- a/libs/partners/together/langchain_together/llms.py
+++ b/libs/partners/together/langchain_together/llms.py
@@ -36,14 +36,14 @@ class Together(LLM):
             model = Together(model_name="mistralai/Mixtral-8x7B-Instruct-v0.1")
     """
 
-    base_url: str = "https://api.together.ai/v1/completions"
+    base_url: str = "https://api.together.xyz/v1/completions"
     """Base completions API URL."""
     together_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=secret_from_env("TOGETHER_API_KEY"),
     )
     """Together AI API key.
-    
+
     Automatically read from env variable `TOGETHER_API_KEY` if not provided.
     """
     model: str


### PR DESCRIPTION
Updated the Together base URL from `.ai` to `.xyz` since some customers have reported problems with `.ai`.
