### PR TITLE
core: fix VectorStoreRetriever._get_relevant_documents error

### DIFF
--- a/libs/community/langchain_community/vectorstores/redis/base.py
+++ b/libs/community/langchain_community/vectorstores/redis/base.py
@@ -1456,59 +1456,65 @@ class RedisVectorStoreRetriever(VectorStoreRetriever):
         arbitrary_types_allowed = True
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
+        search_kwargs = (
+            {**self.search_kwargs, **kwargs} if kwargs else self.search_kwargs
+        )
         if self.search_type == "similarity":
-            docs = self.vectorstore.similarity_search(query, **self.search_kwargs)
+            docs = self.vectorstore.similarity_search(query, **search_kwargs)
         elif self.search_type == "similarity_distance_threshold":
-            if self.search_kwargs["distance_threshold"] is None:
+            if search_kwargs["distance_threshold"] is None:
                 raise ValueError(
                     "distance_threshold must be provided for "
                     + "similarity_distance_threshold retriever"
                 )
-            docs = self.vectorstore.similarity_search(query, **self.search_kwargs)
+            docs = self.vectorstore.similarity_search(query, **search_kwargs)
 
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 self.vectorstore.similarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = self.vectorstore.max_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
 
     async def _aget_relevant_documents(
-        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun,
+        **kwargs: Any,
     ) -> List[Document]:
+        search_kwargs = (
+            {**self.search_kwargs, **kwargs} if kwargs else self.search_kwargs
+        )
         if self.search_type == "similarity":
-            docs = await self.vectorstore.asimilarity_search(
-                query, **self.search_kwargs
-            )
+            docs = await self.vectorstore.asimilarity_search(query, **search_kwargs)
         elif self.search_type == "similarity_distance_threshold":
-            if self.search_kwargs["distance_threshold"] is None:
+            if search_kwargs["distance_threshold"] is None:
                 raise ValueError(
                     "distance_threshold must be provided for "
                     + "similarity_distance_threshold retriever"
                 )
-            docs = await self.vectorstore.asimilarity_search(
-                query, **self.search_kwargs
-            )
+            docs = await self.vectorstore.asimilarity_search(query, **search_kwargs)
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 await self.vectorstore.asimilarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = await self.vectorstore.amax_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")

--- a/libs/community/langchain_community/vectorstores/vectara.py
+++ b/libs/community/langchain_community/vectorstores/vectara.py
@@ -735,7 +735,7 @@ class VectaraRetriever(VectorStoreRetriever):
         arbitrary_types_allowed = True
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
         docs_and_scores = self.vectorstore.vectara_query(query, self.config)
         return [doc for doc, _ in docs_and_scores]

--- a/libs/community/tests/unit_tests/chains/test_pebblo_retrieval.py
+++ b/libs/community/tests/unit_tests/chains/test_pebblo_retrieval.py
@@ -2,7 +2,7 @@
 Unit tests for the PebbloRetrievalQA chain
 """
 
-from typing import List
+from typing import Any, List
 from unittest.mock import Mock
 
 import pytest
@@ -35,12 +35,16 @@ class FakeRetriever(VectorStoreRetriever):
     vectorstore: VectorStore = Mock()
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
         return [Document(page_content=query)]
 
     async def _aget_relevant_documents(
-        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun,
+        **kwargs: Any,
     ) -> List[Document]:
         return [Document(page_content=query)]
 

--- a/libs/core/langchain_core/graph_vectorstores/base.py
+++ b/libs/core/langchain_core/graph_vectorstores/base.py
@@ -662,32 +662,40 @@ class GraphVectorStoreRetriever(VectorStoreRetriever):
     )
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
+        search_kwargs = (
+            {**self.search_kwargs, **kwargs} if kwargs else self.search_kwargs
+        )
         if self.search_type == "traversal":
-            return list(self.vectorstore.traversal_search(query, **self.search_kwargs))
+            return list(self.vectorstore.traversal_search(query, **search_kwargs))
         elif self.search_type == "mmr_traversal":
-            return list(
-                self.vectorstore.mmr_traversal_search(query, **self.search_kwargs)
-            )
+            return list(self.vectorstore.mmr_traversal_search(query, **search_kwargs))
         else:
             return super()._get_relevant_documents(query, run_manager=run_manager)
 
     async def _aget_relevant_documents(
-        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun,
+        **kwargs: Any,
     ) -> List[Document]:
+        search_kwargs = (
+            {**self.search_kwargs, **kwargs} if kwargs else self.search_kwargs
+        )
         if self.search_type == "traversal":
             return [
                 doc
                 async for doc in self.vectorstore.atraversal_search(
-                    query, **self.search_kwargs
+                    query, **search_kwargs
                 )
             ]
         elif self.search_type == "mmr_traversal":
             return [
                 doc
                 async for doc in self.vectorstore.ammr_traversal_search(
-                    query, **self.search_kwargs
+                    query, **search_kwargs
                 )
             ]
         else:

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -1034,42 +1034,50 @@ class VectorStoreRetriever(BaseRetriever):
         return ls_params
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
+        search_kwargs = (
+            {**self.search_kwargs, **kwargs} if kwargs else self.search_kwargs
+        )
         if self.search_type == "similarity":
-            docs = self.vectorstore.similarity_search(query, **self.search_kwargs)
+            docs = self.vectorstore.similarity_search(query, **search_kwargs)
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 self.vectorstore.similarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = self.vectorstore.max_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")
         return docs
 
     async def _aget_relevant_documents(
-        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun,
+        **kwargs: Any,
     ) -> List[Document]:
+        search_kwargs = (
+            {**self.search_kwargs, **kwargs} if kwargs else self.search_kwargs
+        )
         if self.search_type == "similarity":
-            docs = await self.vectorstore.asimilarity_search(
-                query, **self.search_kwargs
-            )
+            docs = await self.vectorstore.asimilarity_search(query, **search_kwargs)
         elif self.search_type == "similarity_score_threshold":
             docs_and_similarities = (
                 await self.vectorstore.asimilarity_search_with_relevance_scores(
-                    query, **self.search_kwargs
+                    query, **search_kwargs
                 )
             )
             docs = [doc for doc, _ in docs_and_similarities]
         elif self.search_type == "mmr":
             docs = await self.vectorstore.amax_marginal_relevance_search(
-                query, **self.search_kwargs
+                query, **search_kwargs
             )
         else:
             raise ValueError(f"search_type of {self.search_type} not allowed.")


### PR DESCRIPTION
fix #25528

- **Description:** 
  Fix the issue where `VectorStoreRetriever` doesn't accept the keyword arguments passed by `BaseRetriever(...).invoke`.
- **Issue:** #25528 