### PR TITLE
fix issue: cannot use document_variable_name to override context in create_stuff_documents_chain

### DIFF
--- a/libs/langchain/langchain/chains/combine_documents/base.py
+++ b/libs/langchain/langchain/chains/combine_documents/base.py
@@ -22,11 +22,11 @@ DOCUMENTS_KEY = "context"
 DEFAULT_DOCUMENT_PROMPT = PromptTemplate.from_template("{page_content}")
 
 
-def _validate_prompt(prompt: BasePromptTemplate, document_variable_name:str) -> None:
+def _validate_prompt(prompt: BasePromptTemplate, document_variable_name: str) -> None:
     if document_variable_name not in prompt.input_variables:
         raise ValueError(
-            f"Prompt must accept {document_variable_name} as an input variable. Received prompt "
-            f"with input variables: {prompt.input_variables}"
+            f"Prompt must accept {document_variable_name} as an input variable. "
+            f"Received prompt with input variables: {prompt.input_variables}"
         )
 
 

--- a/libs/langchain/langchain/chains/combine_documents/base.py
+++ b/libs/langchain/langchain/chains/combine_documents/base.py
@@ -22,10 +22,10 @@ DOCUMENTS_KEY = "context"
 DEFAULT_DOCUMENT_PROMPT = PromptTemplate.from_template("{page_content}")
 
 
-def _validate_prompt(prompt: BasePromptTemplate) -> None:
-    if DOCUMENTS_KEY not in prompt.input_variables:
+def _validate_prompt(prompt: BasePromptTemplate, document_variable_name:str) -> None:
+    if document_variable_name not in prompt.input_variables:
         raise ValueError(
-            f"Prompt must accept {DOCUMENTS_KEY} as an input variable. Received prompt "
+            f"Prompt must accept {document_variable_name} as an input variable. Received prompt "
             f"with input variables: {prompt.input_variables}"
         )
 

--- a/libs/langchain/langchain/chains/combine_documents/stuff.py
+++ b/libs/langchain/langchain/chains/combine_documents/stuff.py
@@ -76,7 +76,7 @@ def create_stuff_documents_chain(
             chain.invoke({"context": docs})
     """  # noqa: E501
 
-    _validate_prompt(prompt)
+    _validate_prompt(prompt, document_variable_name)
     _document_prompt = document_prompt or DEFAULT_DOCUMENT_PROMPT
     _output_parser = output_parser or StrOutputParser()
 


### PR DESCRIPTION
…he prompt in the create_stuff_documents_chain

Thank you for contributing to LangChain!

- [ ] **PR title**: "langchain:add document_variable_name in the function _validate_prompt in create_stuff_documents_chain"
 

- [ ] **PR message**: 
    - **Description:** add document_variable_name in the function _validate_prompt in create_stuff_documents_chain 
    - **Issue:** according to the description of create_stuff_documents_chain function, the parameter document_variable_name can be used to override the "context" in the prompt, but in the function, _validate_prompt it still use DOCUMENTS_KEY to check if it is a valid prompt, the value of DOCUMENTS_KEY is always "context", so even through the user use document_variable_name to override it, the code still tries to check if "context" is in the prompt, and finally it reports error. so I use document_variable_name to replace DOCUMENTS_KEY, the default value of document_variable_name is "context" which is same as DOCUMENTS_KEY, but it can be override by users.
    - **Dependencies:** none
    - **Twitter handle:** https://x.com/xjr199703


- [ ] **Add tests and docs**: none

- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
