### PR TITLE
groq[patch]: update model used for llama tests

### DIFF
--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -28,7 +28,7 @@ class TestGroqLlama(BaseTestGroq):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "llama-3.1-8b-instant",
+            "model": "llama-3.1-70b-versatile",
             "temperature": 0,
             "rate_limiter": rate_limiter,
         }


### PR DESCRIPTION
`llama-3.1-8b-instant` often fails some of the tool calling standard tests. Here we update to `llama-3.1-70b-versatile`.