### PR TITLE
Fix UnionType type var replacement

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import collections
 import inspect
 import logging
+import types
 import typing
 import uuid
 from typing import (
@@ -575,6 +576,7 @@ def _parse_google_docstring(
 
 
 def _py_38_safe_origin(origin: Type) -> Type:
+    union_type_origin = types.UnionType if hasattr(types, "UnionType") else Union
     origin_map: Dict[Type, Any] = {
         dict: Dict,
         list: List,
@@ -584,5 +586,6 @@ def _py_38_safe_origin(origin: Type) -> Type:
         collections.abc.Mapping: typing.Mapping,
         collections.abc.Sequence: typing.Sequence,
         collections.abc.MutableMapping: typing.MutableMapping,
+        union_type_origin: Union,
     }
     return cast(Type, origin_map.get(origin, origin))


### PR DESCRIPTION
[langchain_core] Fix UnionType type var replacement

- Added types.UnionType to typing.Union mapping

Type replacement cause `TypeError: 'type' object is not subscriptable` if any of union type comes as function `_py_38_safe_origin` return `types.UnionType` instead of `typing.Union`

```python
>>> from types import UnionType
>>> from typing import Union, get_origin
>>> type_ = get_origin(str | None)
>>> type_
<class 'types.UnionType'>
>>> UnionType[(str, None)]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'type' object is not subscriptable
>>> Union[(str, None)]
typing.Optional[str]
```