### PR TITLE
together, standard-tests: specify tool_choice in standard tests

### DIFF
--- a/libs/partners/groq/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/integration_tests/test_chat_models.py
@@ -14,6 +14,7 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, LLMResult
 from langchain_core.pydantic_v1 import BaseModel, Field
+from langchain_core.tools import tool
 
 from langchain_groq import ChatGroq
 from tests.unit_tests.fake.callbacks import (
@@ -391,6 +392,42 @@ def test_json_mode_structured_output() -> None:
     assert type(result) is Joke
     assert len(result.setup) != 0
     assert len(result.punchline) != 0
+
+
+def test_tool_calling_no_arguments() -> None:
+    # Note: this is a variant of a test in langchain_standard_tests
+    # that as of 2024-08-19 fails with "Failed to call a function. Please
+    # adjust your prompt." when `tool_choice="any"` is specified, but
+    # passes when `tool_choice` is not specified.
+    model = ChatGroq(model="llama-3.1-70b-versatile", temperature=0)  # type: ignore[call-arg]
+
+    @tool
+    def magic_function_no_args() -> int:
+        """Calculates a magic function."""
+        return 5
+
+    model_with_tools = model.bind_tools([magic_function_no_args])
+    query = "What is the value of magic_function()? Use the tool."
+    result = model_with_tools.invoke(query)
+    assert isinstance(result, AIMessage)
+    assert len(result.tool_calls) == 1
+    tool_call = result.tool_calls[0]
+    assert tool_call["name"] == "magic_function_no_args"
+    assert tool_call["args"] == {}
+    assert tool_call["id"] is not None
+    assert tool_call["type"] == "tool_call"
+
+    # Test streaming
+    full: Optional[BaseMessageChunk] = None
+    for chunk in model_with_tools.stream(query):
+        full = chunk if full is None else full + chunk  # type: ignore
+    assert isinstance(full, AIMessage)
+    assert len(full.tool_calls) == 1
+    tool_call = full.tool_calls[0]
+    assert tool_call["name"] == "magic_function_no_args"
+    assert tool_call["args"] == {}
+    assert tool_call["id"] is not None
+    assert tool_call["type"] == "tool_call"
 
 
 # Groq does not currently support N > 1

--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -1,6 +1,6 @@
 """Standard LangChain interface tests"""
 
-from typing import Type
+from typing import Optional, Type
 
 import pytest
 from langchain_core.language_models import BaseChatModel
@@ -32,6 +32,11 @@ class TestGroqLlama(BaseTestGroq):
             "temperature": 0,
             "rate_limiter": rate_limiter,
         }
+
+    @property
+    def tool_choice_value(self) -> Optional[str]:
+        """Value to use for tool choice when used in tests."""
+        return "any"
 
     @pytest.mark.xfail(
         reason=("Fails with 'Failed to call a function. Please adjust your prompt.'")

--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -28,10 +28,16 @@ class TestGroqLlama(BaseTestGroq):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "llama-3.1-70b-versatile",
+            "model": "llama-3.1-8b-instant",
             "temperature": 0,
             "rate_limiter": rate_limiter,
         }
+
+    @pytest.mark.xfail(
+        reason=("Fails with 'Failed to call a function. Please adjust your prompt.'")
+    )
+    def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
+        super().test_tool_calling_with_no_arguments(model)
 
     @pytest.mark.xfail(
         reason=("Fails with 'Failed to call a function. Please adjust your prompt.'")

--- a/libs/partners/mistralai/tests/integration_tests/test_standard.py
+++ b/libs/partners/mistralai/tests/integration_tests/test_standard.py
@@ -1,6 +1,6 @@
 """Standard LangChain interface tests"""
 
-from typing import Type
+from typing import Optional, Type
 
 from langchain_core.language_models import BaseChatModel
 from langchain_standard_tests.integration_tests import (  # type: ignore[import-not-found]
@@ -18,3 +18,8 @@ class TestMistralStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {"model": "mistral-large-latest", "temperature": 0}
+
+    @property
+    def tool_choice_value(self) -> Optional[str]:
+        """Value to use for tool choice when used in tests."""
+        return "any"

--- a/libs/partners/together/langchain_together/chat_models.py
+++ b/libs/partners/together/langchain_together/chat_models.py
@@ -393,8 +393,7 @@ class ChatTogether(BaseChatOpenAI):
                 Options are:
                 name of the tool (str): calls corresponding tool;
                 "auto": automatically selects a tool (including no tool);
-                "none": does not call a tool;
-                "any" or "required": force at least one tool to be called;
+                "any": force at least one tool to be called;
                 True: forces tool call (requires `tools` be length 1);
                 False: no effect;
 

--- a/libs/partners/together/langchain_together/chat_models.py
+++ b/libs/partners/together/langchain_together/chat_models.py
@@ -2,28 +2,18 @@
 
 from typing import (
     Any,
-    Callable,
     Dict,
     List,
-    Literal,
     Optional,
-    Sequence,
-    Type,
-    Union,
 )
 
 import openai
-from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import LangSmithParams
-from langchain_core.messages import BaseMessage
-from langchain_core.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
-from langchain_core.runnables import Runnable
-from langchain_core.tools import BaseTool
+from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
 from langchain_core.utils import (
     from_env,
     secret_from_env,
 )
-from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_openai.chat_models.base import BaseChatOpenAI
 
 
@@ -372,43 +362,3 @@ class ChatTogether(BaseChatOpenAI):
                 **client_params, **async_specific
             ).chat.completions
         return values
-
-    def bind_tools(
-        self,
-        tools: Sequence[Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool]],
-        *,
-        tool_choice: Optional[Union[dict, str, Literal["auto", "any"], bool]] = None,
-        **kwargs: Any,
-    ) -> Runnable[LanguageModelInput, BaseMessage]:
-        """Bind tool-like objects to this chat model.
-
-        Assumes model is compatible with Together tool-calling API.
-
-        Args:
-            tools: A list of tool definitions to bind to this chat model.
-                Can be  a dictionary, pydantic model, callable, or BaseTool. Pydantic
-                models, callables, and BaseTools will be automatically converted to
-                their schema dictionary representation.
-            tool_choice: Which tool to require the model to call.
-                Options are:
-                name of the tool (str): calls corresponding tool;
-                "auto": automatically selects a tool (including no tool);
-                "any": force at least one tool to be called;
-                True: forces tool call (requires `tools` be length 1);
-                False: no effect;
-
-                or a dict of the form:
-                {"type": "function", "function": {"name": <<tool_name>>}}.
-            **kwargs: Any additional parameters to pass to the
-                :class:`~langchain.runnable.Runnable` constructor.
-        """
-        if tool_choice == "any" and len(tools) == 1:
-            # Together specifies tool_choice via "auto" or a dict.
-            # https://docs.together.ai/docs/tool-call-with-other-models#tool_choice
-            formatted_tool = convert_to_openai_tool(tools[0])
-            tool_name = formatted_tool["function"]["name"]
-            tool_choice = {"type": "function", "function": {"name": tool_name}}
-        else:
-            pass
-
-        return super().bind_tools(tools=tools, tool_choice=tool_choice, **kwargs)

--- a/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
@@ -28,6 +28,10 @@ class TestTogetherStandard(ChatModelIntegrationTests):
             "rate_limiter": rate_limiter,
         }
 
+    @pytest.mark.xfail(reason=("May not call a tool."))
+    def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
+        super().test_tool_calling_with_no_arguments(model)
+
     @pytest.mark.xfail(reason="Not yet supported.")
     def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
         super().test_usage_metadata_streaming(model)

--- a/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
@@ -28,10 +28,6 @@ class TestTogetherStandard(ChatModelIntegrationTests):
             "rate_limiter": rate_limiter,
         }
 
-    @pytest.mark.xfail(reason=("May not call a tool."))
-    def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
-        super().test_tool_calling_with_no_arguments(model)
-
     @pytest.mark.xfail(reason="Not yet supported.")
     def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
         super().test_usage_metadata_streaming(model)

--- a/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
@@ -31,7 +31,7 @@ class TestTogetherStandard(ChatModelIntegrationTests):
     @property
     def tool_choice_value(self) -> Optional[str]:
         """Value to use for tool choice when used in tests."""
-        return "dict"
+        return "tool_name"
 
     @pytest.mark.xfail(reason="Not yet supported.")
     def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:

--- a/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
@@ -1,6 +1,6 @@
 """Standard LangChain interface tests"""
 
-from typing import Type
+from typing import Optional, Type
 
 import pytest
 from langchain_core.language_models import BaseChatModel
@@ -28,9 +28,10 @@ class TestTogetherStandard(ChatModelIntegrationTests):
             "rate_limiter": rate_limiter,
         }
 
-    @pytest.mark.xfail(reason=("May not call a tool."))
-    def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
-        super().test_tool_calling_with_no_arguments(model)
+    @property
+    def tool_choice_value(self) -> Optional[str]:
+        """Value to use for tool choice when used in tests."""
+        return "dict"
 
     @pytest.mark.xfail(reason="Not yet supported.")
     def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
@@ -170,7 +170,7 @@ class ChatModelIntegrationTests(ChatModelTests):
     def test_tool_calling(self, model: BaseChatModel) -> None:
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
-        model_with_tools = model.bind_tools([magic_function])
+        model_with_tools = model.bind_tools([magic_function], tool_choice="any")
 
         # Test invoke
         query = "What is the value of magic_function(3)? Use the tool."
@@ -188,7 +188,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
 
-        model_with_tools = model.bind_tools([magic_function_no_args])
+        model_with_tools = model.bind_tools([magic_function_no_args], tool_choice="any")
         query = "What is the value of magic_function()? Use the tool."
         result = model_with_tools.invoke(query)
         _validate_tool_call_message_no_args(result)
@@ -212,7 +212,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             name="greeting_generator",
             description="Generate a greeting in a particular style of speaking.",
         )
-        model_with_tools = model.bind_tools([tool_])
+        model_with_tools = model.bind_tools([tool_], tool_choice="any")
         query = "Using the tool, generate a Pirate greeting."
         result = model_with_tools.invoke(query)
         assert isinstance(result, AIMessage)

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import httpx
 import pytest
@@ -170,11 +170,8 @@ class ChatModelIntegrationTests(ChatModelTests):
     def test_tool_calling(self, model: BaseChatModel) -> None:
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
-        if self.tool_choice_value == "dict":
-            tool_choice: Union[dict, str, None] = {
-                "type": "function",
-                "function": {"name": "magic_function"},
-            }
+        if self.tool_choice_value == "tool_name":
+            tool_choice: Optional[str] = "magic_function"
         else:
             tool_choice = self.tool_choice_value
         model_with_tools = model.bind_tools([magic_function], tool_choice=tool_choice)
@@ -195,11 +192,8 @@ class ChatModelIntegrationTests(ChatModelTests):
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
 
-        if self.tool_choice_value == "dict":
-            tool_choice: Union[dict, str, None] = {
-                "type": "function",
-                "function": {"name": "magic_function_no_args"},
-            }
+        if self.tool_choice_value == "tool_name":
+            tool_choice: Optional[str] = "magic_function_no_args"
         else:
             tool_choice = self.tool_choice_value
         model_with_tools = model.bind_tools(
@@ -228,11 +222,8 @@ class ChatModelIntegrationTests(ChatModelTests):
             name="greeting_generator",
             description="Generate a greeting in a particular style of speaking.",
         )
-        if self.tool_choice_value == "dict":
-            tool_choice: Union[dict, str, None] = {
-                "type": "function",
-                "function": {"name": "greeting_generator"},
-            }
+        if self.tool_choice_value == "tool_name":
+            tool_choice: Optional[str] = "greeting_generator"
         else:
             tool_choice = self.tool_choice_value
         model_with_tools = model.bind_tools([tool_], tool_choice=tool_choice)

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import httpx
 import pytest
@@ -171,7 +171,10 @@ class ChatModelIntegrationTests(ChatModelTests):
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
         if self.tool_choice_value == "dict":
-            tool_choice = {"type": "function", "function": {"name": "magic_function"}}
+            tool_choice: Union[dict, str, None] = {
+                "type": "function",
+                "function": {"name": "magic_function"},
+            }
         else:
             tool_choice = self.tool_choice_value
         model_with_tools = model.bind_tools([magic_function], tool_choice=tool_choice)
@@ -193,7 +196,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             pytest.skip("Test requires tool calling.")
 
         if self.tool_choice_value == "dict":
-            tool_choice = {
+            tool_choice: Union[dict, str, None] = {
                 "type": "function",
                 "function": {"name": "magic_function_no_args"},
             }
@@ -226,7 +229,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             description="Generate a greeting in a particular style of speaking.",
         )
         if self.tool_choice_value == "dict":
-            tool_choice = {
+            tool_choice: Union[dict, str, None] = {
                 "type": "function",
                 "function": {"name": "greeting_generator"},
             }

--- a/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/integration_tests/chat_models.py
@@ -170,7 +170,11 @@ class ChatModelIntegrationTests(ChatModelTests):
     def test_tool_calling(self, model: BaseChatModel) -> None:
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
-        model_with_tools = model.bind_tools([magic_function], tool_choice="any")
+        if self.tool_choice_value == "dict":
+            tool_choice = {"type": "function", "function": {"name": "magic_function"}}
+        else:
+            tool_choice = self.tool_choice_value
+        model_with_tools = model.bind_tools([magic_function], tool_choice=tool_choice)
 
         # Test invoke
         query = "What is the value of magic_function(3)? Use the tool."
@@ -188,7 +192,16 @@ class ChatModelIntegrationTests(ChatModelTests):
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
 
-        model_with_tools = model.bind_tools([magic_function_no_args], tool_choice="any")
+        if self.tool_choice_value == "dict":
+            tool_choice = {
+                "type": "function",
+                "function": {"name": "magic_function_no_args"},
+            }
+        else:
+            tool_choice = self.tool_choice_value
+        model_with_tools = model.bind_tools(
+            [magic_function_no_args], tool_choice=tool_choice
+        )
         query = "What is the value of magic_function()? Use the tool."
         result = model_with_tools.invoke(query)
         _validate_tool_call_message_no_args(result)
@@ -212,7 +225,14 @@ class ChatModelIntegrationTests(ChatModelTests):
             name="greeting_generator",
             description="Generate a greeting in a particular style of speaking.",
         )
-        model_with_tools = model.bind_tools([tool_], tool_choice="any")
+        if self.tool_choice_value == "dict":
+            tool_choice = {
+                "type": "function",
+                "function": {"name": "greeting_generator"},
+            }
+        else:
+            tool_choice = self.tool_choice_value
+        model_with_tools = model.bind_tools([tool_], tool_choice=tool_choice)
         query = "Using the tool, generate a Pirate greeting."
         result = model_with_tools.invoke(query)
         assert isinstance(result, AIMessage)

--- a/libs/standard-tests/langchain_standard_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_standard_tests/unit_tests/chat_models.py
@@ -97,6 +97,11 @@ class ChatModelTests(BaseStandardTests):
         return self.chat_model_class.bind_tools is not BaseChatModel.bind_tools
 
     @property
+    def tool_choice_value(self) -> Optional[str]:
+        """Value to use for tool choice when used in tests."""
+        return None
+
+    @property
     def has_structured_output(self) -> bool:
         return (
             self.chat_model_class.with_structured_output


### PR DESCRIPTION
Here we allow standard tests to specify a value for `tool_choice` via a `tool_choice_value` property, which defaults to None.

Chat models [available in Together](https://docs.together.ai/docs/chat-models) have issues passing standard tool calling tests:
- llama 3.1 models currently [appear to rely on user-side parsing](https://docs.together.ai/docs/llama-3-function-calling) in Together;
- Mixtral-8x7B and Mistral-7B (currently tested) consistently do not call tools in some tests.

Specifying tool_choice also lets us remove an existing `xfail` and use a smaller model in Groq tests.