### PR TITLE
docs[patch]: Hide and deindex template pages from in-docs search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -195,11 +195,6 @@ const config = {
                 label: "Contributing",
               },
               {
-                type: "docSidebar",
-                sidebarId: "templates",
-                label: "Templates",
-              },
-              {
                 label: "Cookbooks",
                 href: "https://github.com/langchain-ai/langchain/blob/master/cookbook/README.md"
               },

--- a/docs/scripts/copy_templates.py
+++ b/docs/scripts/copy_templates.py
@@ -5,6 +5,10 @@ import shutil
 import sys
 from pathlib import Path
 
+deindexed_footer = """
+<span data-lc-docs-search-deindexed="true"></span>
+"""
+
 if __name__ == "__main__":
     intermediate_dir = Path(sys.argv[1])
 
@@ -23,7 +27,7 @@ if __name__ == "__main__":
         # remove images
         content = re.sub(r"\!\[.*?\]\((.*?)\)", "", content)
         with open(full_destination, "w") as f:
-            f.write(content)
+            f.write(content + deindexed_footer)
 
     sidebar_hidden = """---
 sidebar_class_name: hidden
@@ -43,4 +47,4 @@ custom_edit_url:
     content = re.sub(r"\]\(\.\.\/", "](/docs/templates/", content)
 
     with open(templates_index_intermediate, "w") as f:
-        f.write(sidebar_hidden + content)
+        f.write(sidebar_hidden + content + deindexed_footer)


### PR DESCRIPTION
Adds a new element to the bottom of these pages that I'll configure our docs search crawler to skip:

```
<span data-lc-docs-search-deindexed="true"></span>
```