### PR TITLE
together[patch]: use mixtral in standard integration tests

### DIFF
--- a/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/together/tests/integration_tests/test_chat_models_standard.py
@@ -24,7 +24,7 @@ class TestTogetherStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "mistralai/Mistral-7B-Instruct-v0.1",
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
             "rate_limiter": rate_limiter,
         }
 


### PR DESCRIPTION
Mistral 7B occasionally fails tool-calling tests. Updating to Mixtral appears to improve this.