### PR TITLE
langchain-pinecone: add id to similarity documents results

### DIFF
--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -344,7 +344,7 @@ class PineconeVectorStore(VectorStore):
         )
         for res in results["matches"]:
             metadata = res["metadata"]
-            id = res["id"]
+            id = res.get("id")
             if self._text_key in metadata:
                 text = metadata.pop(self._text_key)
                 score = res["score"]

--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -348,7 +348,9 @@ class PineconeVectorStore(VectorStore):
             if self._text_key in metadata:
                 text = metadata.pop(self._text_key)
                 score = res["score"]
-                docs.append((Document(id=id, page_content=text, metadata=metadata), score))
+                docs.append(
+                    (Document(id=id, page_content=text, metadata=metadata), score)
+                )
             else:
                 logger.warning(
                     f"Found document with no `{self._text_key}` key. Skipping."

--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -344,10 +344,11 @@ class PineconeVectorStore(VectorStore):
         )
         for res in results["matches"]:
             metadata = res["metadata"]
+            id = res["id"]
             if self._text_key in metadata:
                 text = metadata.pop(self._text_key)
                 score = res["score"]
-                docs.append((Document(page_content=text, metadata=metadata), score))
+                docs.append((Document(id=id, page_content=text, metadata=metadata), score))
             else:
                 logger.warning(
                     f"Found document with no `{self._text_key}` key. Skipping."


### PR DESCRIPTION
- **Description:** This change adds the ID field that's required in Pinecone to the result documents of the similarity search method.
- **Issue:** Lack of document metadata namely the ID field

- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
