### PR TITLE
[community] Support passing extra params for executing functions in UCFunctionToolkit

### DIFF
--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -92,3 +92,4 @@ xata>=1.0.0a7,<2
 xmltodict>=0.13.0,<0.14
 nanopq==0.2.1
 mlflow[genai]>=2.14.0
+databricks-sdk

--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -92,4 +92,4 @@ xata>=1.0.0a7,<2
 xmltodict>=0.13.0,<0.14
 nanopq==0.2.1
 mlflow[genai]>=2.14.0
-databricks-sdk
+databricks-sdk>=0.30.0

--- a/libs/community/langchain_community/tools/databricks/_execution.py
+++ b/libs/community/langchain_community/tools/databricks/_execution.py
@@ -150,7 +150,7 @@ def execute_function(
         ws.statement_execution.execute_statement
     ).parameters
     if not any(
-        p.kind == p.VAR_POSITIONAL or p.kind == p.VAR_KEYWORD
+        p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
         for p in allowed_execute_statement_args.values()
     ):
         invalid_params = set()

--- a/libs/community/langchain_community/tools/databricks/_execution.py
+++ b/libs/community/langchain_community/tools/databricks/_execution.py
@@ -130,8 +130,13 @@ def execute_function(
         ) from e
     from databricks.sdk.service.sql import StatementState
 
-    if any(
-        p.name == EXECUTE_FUNCTION_ARG_NAME for p in function.input_params.parameters
+    if (
+        function.input_params
+        and function.input_params.parameters
+        and any(
+            p.name == EXECUTE_FUNCTION_ARG_NAME
+            for p in function.input_params.parameters
+        )
     ):
         raise ValueError(
             "Parameter name conflicts with the reserved argument name for executing "
@@ -167,7 +172,7 @@ def execute_function(
         statement=parametrized_statement.statement,
         warehouse_id=warehouse_id,
         parameters=parametrized_statement.parameters,
-        **execute_statement_args,
+        **execute_statement_args,  # type: ignore
     )
     status = response.status
     assert status is not None, f"Statement execution failed: {response}"

--- a/libs/community/tests/unit_tests/tools/databricks/test_tools.py
+++ b/libs/community/tests/unit_tests/tools/databricks/test_tools.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+import pytest
+
+from langchain_community.tools.databricks._execution import (
+    DEFAULT_EXECUTE_FUNCTION_ARGS,
+    EXECUTE_FUNCTION_ARG_NAME,
+    execute_function,
+)
+
+
+@pytest.mark.parametrize(
+    ("parameters", "execute_params"),
+    [
+        ({"a": 1, "b": 2}, DEFAULT_EXECUTE_FUNCTION_ARGS),
+        (
+            {"a": 1, EXECUTE_FUNCTION_ARG_NAME: {"wait_timeout": "10s"}},
+            {**DEFAULT_EXECUTE_FUNCTION_ARGS, "wait_timeout": "10s"},
+        ),
+        (
+            {EXECUTE_FUNCTION_ARG_NAME: {"row_limit": "1000"}},
+            {**DEFAULT_EXECUTE_FUNCTION_ARGS, "row_limit": "1000"},
+        ),
+    ],
+)
+def test_execute_function(parameters, execute_params) -> None:
+    workspace_client = mock.Mock()
+
+    def mock_execute_statement(*args, **kwargs):
+        for key, value in execute_params.items():
+            assert kwargs[key] == value
+        return mock.Mock()
+
+    workspace_client.statement_execution.execute_statement = mock_execute_statement
+
+    function = mock.Mock()
+    function.data_type = "TABLE_TYPE"
+    function.input_params.parameters = []
+    execute_function(
+        workspace_client, warehouse_id="id", function=function, parameters=parameters
+    )

--- a/libs/community/tests/unit_tests/tools/databricks/test_tools.py
+++ b/libs/community/tests/unit_tests/tools/databricks/test_tools.py
@@ -9,6 +9,7 @@ from langchain_community.tools.databricks._execution import (
 )
 
 
+@pytest.mark.requires("databricks-sdk")
 @pytest.mark.parametrize(
     ("parameters", "execute_params"),
     [
@@ -53,6 +54,7 @@ def test_execute_function(parameters: dict, execute_params: dict) -> None:
     )
 
 
+@pytest.mark.requires("databricks-sdk")
 def test_execute_function_error() -> None:
     workspace_client = mock.Mock()
 

--- a/libs/community/tests/unit_tests/tools/databricks/test_tools.py
+++ b/libs/community/tests/unit_tests/tools/databricks/test_tools.py
@@ -23,10 +23,10 @@ from langchain_community.tools.databricks._execution import (
         ),
     ],
 )
-def test_execute_function(parameters, execute_params) -> None:
+def test_execute_function(parameters: dict, execute_params: dict) -> None:
     workspace_client = mock.Mock()
 
-    def mock_execute_statement(
+    def mock_execute_statement(  # no-untyped-def: ignore
         statement,
         warehouse_id,
         *,
@@ -56,7 +56,7 @@ def test_execute_function(parameters, execute_params) -> None:
 def test_execute_function_error() -> None:
     workspace_client = mock.Mock()
 
-    def mock_execute_statement(
+    def mock_execute_statement(  # no-untyped-def: ignore
         statement,
         warehouse_id,
         *,

--- a/libs/community/tests/unit_tests/tools/databricks/test_tools.py
+++ b/libs/community/tests/unit_tests/tools/databricks/test_tools.py
@@ -26,7 +26,7 @@ from langchain_community.tools.databricks._execution import (
 def test_execute_function(parameters: dict, execute_params: dict) -> None:
     workspace_client = mock.Mock()
 
-    def mock_execute_statement(  # no-untyped-def: ignore
+    def mock_execute_statement(  # type: ignore
         statement,
         warehouse_id,
         *,
@@ -56,7 +56,7 @@ def test_execute_function(parameters: dict, execute_params: dict) -> None:
 def test_execute_function_error() -> None:
     workspace_client = mock.Mock()
 
-    def mock_execute_statement(  # no-untyped-def: ignore
+    def mock_execute_statement(  # type: ignore
         statement,
         warehouse_id,
         *,

--- a/libs/community/tests/unit_tests/tools/databricks/test_tools.py
+++ b/libs/community/tests/unit_tests/tools/databricks/test_tools.py
@@ -9,7 +9,7 @@ from langchain_community.tools.databricks._execution import (
 )
 
 
-@pytest.mark.requires("databricks-sdk")
+@pytest.mark.requires("databricks.sdk")
 @pytest.mark.parametrize(
     ("parameters", "execute_params"),
     [
@@ -54,7 +54,7 @@ def test_execute_function(parameters: dict, execute_params: dict) -> None:
     )
 
 
-@pytest.mark.requires("databricks-sdk")
+@pytest.mark.requires("databricks.sdk")
 def test_execute_function_error() -> None:
     workspace_client = mock.Mock()
 


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"
  - Where "package" is whichever of langchain, community, core, experimental, etc. is being modified. Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


Support passing extra params when executing UC functions:
The params should be a dictionary with key EXECUTE_FUNCTION_ARG_NAME, the assumption is that the function itself doesn't use such variable name (starting and ending with double underscores), and if it does we raise Exception.
If invalid params passing to the execute_statement, we raise Exception as well.


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
