### PR TITLE
community: add metadata filter to CassandraGraphVectorStore

### DIFF
--- a/libs/community/langchain_community/graph_vectorstores/cassandra.py
+++ b/libs/community/langchain_community/graph_vectorstores/cassandra.py
@@ -120,18 +120,31 @@ class CassandraGraphVectorStore(GraphVectorStore):
         return store
 
     def similarity_search(
-        self, query: str, k: int = 4, **kwargs: Any
+        self,
+        query: str,
+        k: int = 4,
+        metadata_filter: dict[str, Any] = {},
+        **kwargs: Any,
     ) -> List[Document]:
         embedding_vector = self._embedding.embed_query(query)
         return self.similarity_search_by_vector(
             embedding_vector,
             k=k,
+            metadata_filter=metadata_filter,
         )
 
     def similarity_search_by_vector(
-        self, embedding: List[float], k: int = 4, **kwargs: Any
+        self,
+        embedding: List[float],
+        k: int = 4,
+        metadata_filter: dict[str, Any] = {},
+        **kwargs: Any,
     ) -> List[Document]:
-        nodes = self.store.similarity_search(embedding, k=k)
+        nodes = self.store.similarity_search(
+            embedding,
+            k=k,
+            metadata_filter=metadata_filter,
+        )
         return list(nodes_to_documents(nodes))
 
     def traversal_search(
@@ -140,9 +153,15 @@ class CassandraGraphVectorStore(GraphVectorStore):
         *,
         k: int = 4,
         depth: int = 1,
+        metadata_filter: dict[str, Any] = {},
         **kwargs: Any,
     ) -> Iterable[Document]:
-        nodes = self.store.traversal_search(query, k=k, depth=depth)
+        nodes = self.store.traversal_search(
+            query,
+            k=k,
+            depth=depth,
+            metadata_filter=metadata_filter,
+        )
         return nodes_to_documents(nodes)
 
     def mmr_traversal_search(
@@ -155,6 +174,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
         adjacent_k: int = 10,
         lambda_mult: float = 0.5,
         score_threshold: float = float("-inf"),
+        metadata_filter: dict[str, Any] = {},
         **kwargs: Any,
     ) -> Iterable[Document]:
         nodes = self.store.mmr_traversal_search(
@@ -165,5 +185,6 @@ class CassandraGraphVectorStore(GraphVectorStore):
             adjacent_k=adjacent_k,
             lambda_mult=lambda_mult,
             score_threshold=score_threshold,
+            metadata_filter=metadata_filter,
         )
         return nodes_to_documents(nodes)

--- a/libs/community/langchain_community/graph_vectorstores/cassandra.py
+++ b/libs/community/langchain_community/graph_vectorstores/cassandra.py
@@ -6,8 +6,8 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Set,
     Type,
+    cast,
 )
 
 from langchain_core._api import beta
@@ -15,7 +15,6 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.graph_vectorstores.base import (
     GraphVectorStore,
-    Link,
     Node,
     nodes_to_documents,
 )
@@ -48,8 +47,6 @@ class CassandraGraphVectorStore(GraphVectorStore):
         """
         try:
             from ragstack_knowledge_store import EmbeddingModel, graph_store
-            from ragstack_knowledge_store.graph_store import Link as GraphStoreLink
-            from ragstack_knowledge_store.graph_store import Node as GraphStoreNode
         except (ImportError, ModuleNotFoundError):
             raise ImportError(
                 "Could not import ragstack_knowledge_store python package. "
@@ -84,50 +81,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
             **kwargs,
         )
 
-        def _to_graph_store_links(links: List[Link]) -> Set[GraphStoreLink]:
-            return {
-                GraphStoreLink(
-                    kind=link.kind,
-                    direction=link.direction,
-                    tag=link.tag,
-                )
-                for link in links
-            }
-
-        def _from_graph_store_links(links: Set[GraphStoreLink]) -> List[Link]:
-            return [
-                Link(
-                    kind=link.kind,
-                    direction=link.direction,
-                    tag=link.tag,
-                )
-                for link in links
-            ]
-
-        def _to_graph_store_nodes(nodes: Iterable[Node]) -> Iterable[GraphStoreNode]:
-            return (
-                GraphStoreNode(
-                    id=node.id,
-                    metadata=node.metadata,
-                    links=_to_graph_store_links(node.links),
-                    text=node.text,
-                )
-                for node in nodes
-            )
-
-        def _from_graph_store_nodes(nodes: Iterable[GraphStoreNode]) -> Iterable[Node]:
-            return (
-                Node(
-                    id=node.id,
-                    metadata=node.metadata,
-                    links=_from_graph_store_links(node.links),
-                    text=node.text,
-                )
-                for node in nodes
-            )
-
-        self._to_graph_store_nodes = _to_graph_store_nodes
-        self._from_graph_store_nodes = _from_graph_store_nodes
+        self._cast_nodes = lambda nodes: cast(Iterable[graph_store.Node], nodes)
 
     @property
     def embeddings(self) -> Optional[Embeddings]:
@@ -138,7 +92,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
         nodes: Iterable[Node],
         **kwargs: Any,
     ) -> Iterable[str]:
-        return self.store.add_nodes(self._to_graph_store_nodes(nodes))
+        return self.store.add_nodes(self._cast_nodes(nodes))
 
     @classmethod
     def from_texts(
@@ -194,7 +148,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
             k=k,
             metadata_filter=metadata_filter,
         )
-        return list(nodes_to_documents(self._from_graph_store_nodes(nodes)))
+        return list(nodes_to_documents(cast(Iterable[Node], nodes)))
 
     def traversal_search(
         self,
@@ -211,7 +165,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
             depth=depth,
             metadata_filter=metadata_filter,
         )
-        return nodes_to_documents(self._from_graph_store_nodes(nodes))
+        return nodes_to_documents(cast(Iterable[Node], nodes))
 
     def mmr_traversal_search(
         self,
@@ -236,4 +190,4 @@ class CassandraGraphVectorStore(GraphVectorStore):
             score_threshold=score_threshold,
             metadata_filter=metadata_filter,
         )
-        return nodes_to_documents(self._from_graph_store_nodes(nodes))
+        return nodes_to_documents(cast(Iterable[Node], nodes))

--- a/libs/community/langchain_community/graph_vectorstores/cassandra.py
+++ b/libs/community/langchain_community/graph_vectorstores/cassandra.py
@@ -7,7 +7,6 @@ from typing import (
     List,
     Optional,
     Type,
-    cast,
 )
 
 from langchain_core._api import beta
@@ -81,8 +80,6 @@ class CassandraGraphVectorStore(GraphVectorStore):
             **kwargs,
         )
 
-        self._cast_nodes = lambda nodes: cast(Iterable[graph_store.Node], nodes)
-
     @property
     def embeddings(self) -> Optional[Embeddings]:
         return self._embedding
@@ -92,7 +89,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
         nodes: Iterable[Node],
         **kwargs: Any,
     ) -> Iterable[str]:
-        return self.store.add_nodes(self._cast_nodes(nodes))
+        return self.store.add_nodes(nodes)
 
     @classmethod
     def from_texts(
@@ -148,7 +145,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
             k=k,
             metadata_filter=metadata_filter,
         )
-        return list(nodes_to_documents(cast(Iterable[Node], nodes)))
+        return list(nodes_to_documents(nodes))
 
     def traversal_search(
         self,
@@ -165,7 +162,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
             depth=depth,
             metadata_filter=metadata_filter,
         )
-        return nodes_to_documents(cast(Iterable[Node], nodes))
+        return nodes_to_documents(nodes)
 
     def mmr_traversal_search(
         self,
@@ -190,4 +187,4 @@ class CassandraGraphVectorStore(GraphVectorStore):
             score_threshold=score_threshold,
             metadata_filter=metadata_filter,
         )
-        return nodes_to_documents(cast(Iterable[Node], nodes))
+        return nodes_to_documents(nodes)

--- a/libs/community/langchain_community/graph_vectorstores/cassandra.py
+++ b/libs/community/langchain_community/graph_vectorstores/cassandra.py
@@ -211,7 +211,7 @@ class CassandraGraphVectorStore(GraphVectorStore):
             depth=depth,
             metadata_filter=metadata_filter,
         )
-        return list(nodes_to_documents(self._from_graph_store_nodes(nodes)))
+        return nodes_to_documents(self._from_graph_store_nodes(nodes))
 
     def mmr_traversal_search(
         self,
@@ -236,4 +236,4 @@ class CassandraGraphVectorStore(GraphVectorStore):
             score_threshold=score_threshold,
             metadata_filter=metadata_filter,
         )
-        return list(nodes_to_documents(self._from_graph_store_nodes(nodes)))
+        return nodes_to_documents(self._from_graph_store_nodes(nodes))


### PR DESCRIPTION
- **Description:** 
  - Added metadata filtering support to `langchain_community.graph_vectorstores.cassandra.CassandraGraphVectorStore`
  - Also fixed type conversion issues highlighted by mypy.
- **Dependencies:** 
  - `ragstack-ai-knowledge-store 0.2.0` (released July 23, 2024)
