### PR TITLE
rfc: anthropic cache usage

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -757,9 +757,18 @@ class ChatAnthropic(BaseChatModel):
             "output_tokens": data.usage.output_tokens,
             "total_tokens": data.usage.input_tokens + data.usage.output_tokens,
         }
+        if hasattr(data.usage, "cache_creation_input_tokens"):
+            msg.usage_metadata["cache_creation_input_tokens"] = (
+                data.usage.cache_creation_input_tokens
+            )
+            msg.usage_metadata["total_tokens"] += data.usage.cache_creation_input_tokens
+        if hasattr(data.usage, "cache_read_input_tokens"):
+            msg.usage_metadata["cache_read_input_tokens"] = (
+                data.usage.cache_read_input_tokens
+            )
+            msg.usage_metadata["total_tokens"] += data.usage.cache_read_input_tokens
         return ChatResult(
-            generations=[ChatGeneration(message=msg)],
-            llm_output=llm_output,
+            generations=[ChatGeneration(message=msg)], llm_output=llm_output
         )
 
     def _generate(


### PR DESCRIPTION
Alternative to #25644

What do we want to do with anthropic cache token counts and UsageMetadata?
1. do nothing for now: UsageMetadata is meant to be standard across models and we dont know what other providers will do with caching. plus the info is there is AIMessage.response_metadata. main issue here is rn cached input tokens dont show up anywhere (neither in input_tokens nor total_tokens)
2. just add cached input tokens to total_tokens, so at least there's some way to figure out that those tokens exist
3. store cache token counts as their own keys on AIMessage.usage_metadata for anthropic outputs (current implementation in this pr). easy to implement and makes this info easily accessible to user, but will this lock us into to something we can't break in the future?
4. add cache token counts to existing "input_tokens" key (anthropic's data.usage.input_tokens does *not* take into account cached tokens so this isn't double counting). not useful for estimating pricing but useful for general token counting
5. add something like a "cost_adjusted_input_tokens" key that counts tokens in terms of costs (1.5 * cache_creation + 1 * input + 0.1 * cache_read). useful for estimating prices, but makes it a little harder to figure out when you've got cache hits/misses. is that important?