### PR TITLE
Fix type for inner input in base prompts

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -129,7 +129,7 @@ class BasePromptTemplate(
             "PromptInput", **{**required_input_variables, **optional_input_variables}
         )
 
-    def _validate_input(self, inner_input: Dict) -> Dict:
+    def _validate_input(self, inner_input: Any) -> Dict:
         if not isinstance(inner_input, dict):
             if len(self.input_variables) == 1:
                 var_name = self.input_variables[0]


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: "langchain-core: Fix type"
  - The file to modify is located in /libs/core/langchain_core/prompts/base.py


- [ ] **PR message**: 
    - **Description:** The change is a type for the inner input variable, the type go from dict to Any. This change is required since the method _validate input expects a type that is not only a dictionary.
    - **Dependencies:** There are no dependencies for this change


- [ ] **Add tests and docs**: 
  1. A test is not needed. This error occurs because I overrode a portion of the _validate_input method, which is causing a 'beartype' to raise an error.

