### PR TITLE
Update endpoint for AzureMLEndpointApiType class.

### DIFF
--- a/libs/community/langchain_community/llms/azureml_endpoint.py
+++ b/libs/community/langchain_community/llms/azureml_endpoint.py
@@ -430,8 +430,8 @@ class AzureMLBaseEndpoint(BaseModel):
         if field_value.endswith("inference.ml.azure.com"):
             raise ValueError(
                 "`endpoint_url` should contain the full invocation URL including "
-                "`/score` for `endpoint_api_type='dedicated'` or `/v1/completions` "
-                "or `/v1/chat/completions` for `endpoint_api_type='serverless'`"
+                "`/score` for `endpoint_api_type='dedicated'` or `/completions` "
+                "or `/chat/completions` for `endpoint_api_type='serverless'`"
             )
         return field_value
 
@@ -451,17 +451,17 @@ class AzureMLBaseEndpoint(BaseModel):
             raise ValueError(
                 "Endpoints of type `dedicated` should follow the format "
                 "`https://<your-endpoint>.<your_region>.inference.ml.azure.com/score`."
-                " If your endpoint URL ends with `/v1/completions` or"
-                "`/v1/chat/completions`, use `endpoint_api_type='serverless'` instead."
+                " If your endpoint URL ends with `/completions` or"
+                "`/chat/completions`, use `endpoint_api_type='serverless'` instead."
             )
         if field_value == AzureMLEndpointApiType.serverless and not (
-            endpoint_url.endswith("/v1/completions")  # type: ignore[union-attr]
-            or endpoint_url.endswith("/v1/chat/completions")  # type: ignore[union-attr]
+            endpoint_url.endswith("/completions")  # type: ignore[union-attr]
+            or endpoint_url.endswith("/chat/completions")  # type: ignore[union-attr]
         ):
             raise ValueError(
                 "Endpoints of type `serverless` should follow the format "
-                "`https://<your-endpoint>.<your_region>.inference.ml.azure.com/v1/chat/completions`"
-                " or `https://<your-endpoint>.<your_region>.inference.ml.azure.com/v1/chat/completions`"
+                "`https://<your-endpoint>.<your_region>.inference.ml.azure.com/chat/completions`"
+                " or `https://<your-endpoint>.<your_region>.inference.ml.azure.com/chat/completions`"
             )
 
         return field_value


### PR DESCRIPTION
This addresses the issue mentioned in #25702

I have updated the endpoint used in validating the endpoint API type in the AzureMLBaseEndpoint class from `/v1/completions` to `/completions` and `/v1/chat/completions` to `/chat/completions`.