### PR TITLE
community[neo4j_vector]: make embedding dimension check optional

### DIFF
--- a/libs/community/langchain_community/vectorstores/neo4j_vector.py
+++ b/libs/community/langchain_community/vectorstores/neo4j_vector.py
@@ -692,9 +692,10 @@ class Neo4jVector(VectorStore):
             self.node_label = index_information[0]["labelsOrTypes"][0]
             self.embedding_node_property = index_information[0]["properties"][0]
             self._index_type = index_information[0]["entityType"]
-            embedding_dimension = index_information[0]["options"]["indexConfig"][
-                "vector.dimensions"
-            ]
+            embedding_dimension = None
+            index_config = index_information[0]["options"]["indexConfig"]
+            if "vector.dimensions" in index_config:
+                embedding_dimension = index_config["vector.dimensions"]
 
             return embedding_dimension, index_information[0]["entityType"]
         except IndexError:
@@ -808,10 +809,12 @@ class Neo4jVector(VectorStore):
             )
 
         # If the vector index doesn't exist yet
-        if not embedding_dimension:
+        if not index_type:
             store.create_new_index()
         # If the index already exists, check if embedding dimensions match
-        elif not store.embedding_dimension == embedding_dimension:
+        elif (
+            embedding_dimension and not store.embedding_dimension == embedding_dimension
+        ):
             raise ValueError(
                 f"Index with name {store.index_name} already exists."
                 "The provided embedding function and vector index "
@@ -1275,14 +1278,14 @@ class Neo4jVector(VectorStore):
                 "`from_existing_relationship_index` method."
             )
 
-        if not embedding_dimension:
+        if not index_type:
             raise ValueError(
                 "The specified vector index name does not exist. "
                 "Make sure to check if you spelled it correctly"
             )
 
         # Check if embedding function and vector index dimensions match
-        if not store.embedding_dimension == embedding_dimension:
+        if embedding_dimension and not store.embedding_dimension == embedding_dimension:
             raise ValueError(
                 "The provided embedding function and vector index "
                 "dimensions do not match.\n"
@@ -1337,7 +1340,7 @@ class Neo4jVector(VectorStore):
 
         embedding_dimension, index_type = store.retrieve_existing_index()
 
-        if not embedding_dimension:
+        if not index_type:
             raise ValueError(
                 "The specified vector index name does not exist. "
                 "Make sure to check if you spelled it correctly"
@@ -1351,7 +1354,7 @@ class Neo4jVector(VectorStore):
             )
 
         # Check if embedding function and vector index dimensions match
-        if not store.embedding_dimension == embedding_dimension:
+        if embedding_dimension and not store.embedding_dimension == embedding_dimension:
             raise ValueError(
                 "The provided embedding function and vector index "
                 "dimensions do not match.\n"
@@ -1464,10 +1467,12 @@ class Neo4jVector(VectorStore):
             )
 
         # If the vector index doesn't exist yet
-        if not embedding_dimension:
+        if not index_type:
             store.create_new_index()
         # If the index already exists, check if embedding dimensions match
-        elif not store.embedding_dimension == embedding_dimension:
+        elif (
+            embedding_dimension and not store.embedding_dimension == embedding_dimension
+        ):
             raise ValueError(
                 f"Index with name {store.index_name} already exists."
                 "The provided embedding function and vector index "


### PR DESCRIPTION
**Description:**

Starting from Neo4j 5.23 (22 August 2024), with vector-2.0 indexes, `vector.dimensions` is not required to be set, which will cause it the key not exist error in index config if it's not set.

Since the existence of vector.dimensions will only ensure additional checks, this commit turns embedding dimension check optional, and only do checks when it exists (not None).

https://neo4j.com/release-notes/database/neo4j-5/

**Twitter handle:** @HollowM186