### PR TITLE
community[minor]: [Pebblo] Fix URL construction in newer Python versions

### DIFF
--- a/libs/community/langchain_community/chains/pebblo_retrieval/utilities.py
+++ b/libs/community/langchain_community/chains/pebblo_retrieval/utilities.py
@@ -125,7 +125,9 @@ class PebbloRetrievalAPIWrapper(BaseModel):
         if self.classifier_location == "local":
             # Send app details to local classifier
             headers = self._make_headers()
-            app_discover_url = f"{self.classifier_url}{Routes.retrieval_app_discover}"
+            app_discover_url = (
+                f"{self.classifier_url}{Routes.retrieval_app_discover.value}"
+            )
             pebblo_resp = self.make_request("POST", app_discover_url, headers, payload)
 
         if self.api_key:
@@ -138,7 +140,7 @@ class PebbloRetrievalAPIWrapper(BaseModel):
                 payload.update({"pebblo_server_version": pebblo_server_version})
 
             payload.update({"pebblo_client_version": PLUGIN_VERSION})
-            pebblo_cloud_url = f"{self.cloud_url}{Routes.retrieval_app_discover}"
+            pebblo_cloud_url = f"{self.cloud_url}{Routes.retrieval_app_discover.value}"
             _ = self.make_request("POST", pebblo_cloud_url, headers, payload)
 
     def send_prompt(
@@ -184,7 +186,7 @@ class PebbloRetrievalAPIWrapper(BaseModel):
         if self.classifier_location == "local":
             # Send prompt to local classifier
             headers = self._make_headers()
-            prompt_url = f"{self.classifier_url}{Routes.prompt}"
+            prompt_url = f"{self.classifier_url}{Routes.prompt.value}"
             pebblo_resp = self.make_request("POST", prompt_url, headers, payload)
 
         if self.api_key:
@@ -196,7 +198,7 @@ class PebbloRetrievalAPIWrapper(BaseModel):
                 self.update_cloud_payload(payload, pebblo_resp)
 
             headers = self._make_headers(cloud_request=True)
-            pebblo_cloud_prompt_url = f"{self.cloud_url}{Routes.prompt}"
+            pebblo_cloud_prompt_url = f"{self.cloud_url}{Routes.prompt.value}"
             _ = self.make_request("POST", pebblo_cloud_prompt_url, headers, payload)
         elif self.classifier_location == "pebblo-cloud":
             logger.warning("API key is missing for sending prompt to Pebblo cloud.")
@@ -222,7 +224,9 @@ class PebbloRetrievalAPIWrapper(BaseModel):
         is_valid_prompt: bool = True
         if self.classifier_location == "local":
             headers = self._make_headers()
-            prompt_gov_api_url = f"{self.classifier_url}{Routes.prompt_governance}"
+            prompt_gov_api_url = (
+                f"{self.classifier_url}{Routes.prompt_governance.value}"
+            )
             pebblo_resp = self.make_request(
                 "POST", prompt_gov_api_url, headers, prompt_payload
             )

--- a/libs/community/langchain_community/utilities/pebblo.py
+++ b/libs/community/langchain_community/utilities/pebblo.py
@@ -69,9 +69,6 @@ class Routes(str, Enum):
 
     loader_doc = "/v1/loader/doc"
     loader_app_discover = "/v1/app/discover"
-    retrieval_app_discover = "/v1/app/discover"
-    prompt = "/v1/prompt"
-    prompt_governance = "/v1/prompt/governance"
 
 
 class IndexedDocument(Document):
@@ -452,7 +449,9 @@ class PebbloLoaderAPIWrapper(BaseModel):
         if self.classifier_location == "local":
             # Send app details to local classifier
             headers = self._make_headers()
-            app_discover_url = f"{self.classifier_url}{Routes.loader_app_discover}"
+            app_discover_url = (
+                f"{self.classifier_url}{Routes.loader_app_discover.value}"
+            )
             pebblo_resp = self.make_request("POST", app_discover_url, headers, payload)
 
         if self.api_key:
@@ -465,7 +464,7 @@ class PebbloLoaderAPIWrapper(BaseModel):
                 payload.update({"pebblo_server_version": pebblo_server_version})
 
             payload.update({"pebblo_client_version": PLUGIN_VERSION})
-            pebblo_cloud_url = f"{self.cloud_url}{Routes.loader_app_discover}"
+            pebblo_cloud_url = f"{self.cloud_url}{Routes.loader_app_discover.value}"
             _ = self.make_request("POST", pebblo_cloud_url, headers, payload)
 
     def classify_documents(
@@ -500,7 +499,7 @@ class PebbloLoaderAPIWrapper(BaseModel):
         if self.classifier_location == "local":
             # Send docs to local classifier
             headers = self._make_headers()
-            load_doc_url = f"{self.classifier_url}{Routes.loader_doc}"
+            load_doc_url = f"{self.classifier_url}{Routes.loader_doc.value}"
             try:
                 pebblo_resp = self.make_request(
                     "POST", load_doc_url, headers, payload, 300
@@ -536,7 +535,7 @@ class PebbloLoaderAPIWrapper(BaseModel):
             payload (dict): The payload containing documents to be sent.
         """
         headers = self._make_headers(cloud_request=True)
-        pebblo_cloud_url = f"{self.cloud_url}{Routes.loader_doc}"
+        pebblo_cloud_url = f"{self.cloud_url}{Routes.loader_doc.value}"
         try:
             _ = self.make_request("POST", pebblo_cloud_url, headers, payload)
         except Exception as e:


### PR DESCRIPTION
- **PR message**: **Fix URL construction in newer Python versions**
- **Description:** 
  - Update the URL construction logic to use the .value attribute for Routes enum members. 
  - This adjustment resolves an issue where the code worked correctly in Python 3.9 but failed in Python 3.11. 
  - Clean up unused routes.
- **Issue:** NA
- **Dependencies:** NA

