### PR TITLE
community: add score to PineconeHybridSearchRetriever

### DIFF
--- a/libs/community/langchain_community/retrievers/pinecone_hybrid_search.py
+++ b/libs/community/langchain_community/retrievers/pinecone_hybrid_search.py
@@ -172,11 +172,9 @@ class PineconeHybridSearchRetriever(BaseRetriever):
         final_result = []
         for res in result["matches"]:
             context = res["metadata"].pop("context")
-            final_result.append(
-                Document(
-                    page_content=context,
-                    metadata=res["metadata"] | {"score": res["score"]},
-                )
-            )
+            metadata = res["metadata"]
+            if "score" not in metadata and "score" in res:
+                metadata["score"] = res["score"]
+            final_result.append(Document(page_content=context, metadata=metadata))
         # return search results as json
         return final_result

--- a/libs/community/langchain_community/retrievers/pinecone_hybrid_search.py
+++ b/libs/community/langchain_community/retrievers/pinecone_hybrid_search.py
@@ -173,7 +173,10 @@ class PineconeHybridSearchRetriever(BaseRetriever):
         for res in result["matches"]:
             context = res["metadata"].pop("context")
             final_result.append(
-                Document(page_content=context, metadata=res["metadata"])
+                Document(
+                    page_content=context,
+                    metadata=res["metadata"] | {"score": res["score"]},
+                )
             )
         # return search results as json
         return final_result


### PR DESCRIPTION
**Description:**

Adds the 'score' returned by Pinecone to the `PineconeHybridSearchRetriever` list of returned Documents.

There is currently no way to return the score when using Pinecone hybrid search, so in this PR I include it by default.