### PR TITLE
community: optimize xinference llm import

### DIFF
--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -15,7 +15,13 @@ class Xinference(LLM):
 
     .. code-block:: bash
 
-       pip install "xinference[all]"
+       pip install "xinference[all]"    
+       
+    If you're simply using the services provided by Xinference, you can utilize the xinference_client package:
+
+    .. code-block:: bash
+
+        pip install xinference_client
 
     Check out: https://github.com/xorbitsai/inference
     To run, you need to start a Xinference supervisor on one server and Xinference workers on the other servers
@@ -91,11 +97,14 @@ class Xinference(LLM):
     ):
         try:
             from xinference.client import RESTfulClient
-        except ImportError as e:
-            raise ImportError(
-                "Could not import RESTfulClient from xinference. Please install it"
-                " with `pip install xinference`."
-            ) from e
+        except ImportError:
+            try:
+                from xinference_client import RESTfulClient
+            except ImportError as e:
+                raise ImportError(
+                    "Could not import RESTfulClient from xinference. Please install it"
+                    " with `pip install xinference` or `pip install xinference_client`."
+                ) from e
 
         model_kwargs = model_kwargs or {}
 

--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -15,8 +15,8 @@ class Xinference(LLM):
 
     .. code-block:: bash
 
-       pip install "xinference[all]"    
-       
+       pip install "xinference[all]"
+
     If you're simply using the services provided by Xinference, you can utilize the xinference_client package:
 
     .. code-block:: bash


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: "community: optimize xinference llm import"

- [ ] **PR message**: 
    - **Description:** from xinferece_client import  RESTfulClient when there is no importing xinference.
    - **Dependencies:** xinferece_client
    - **Why do so:** the total xinference(pip install xinference[all]) is too heavy for installing, let alone it is useless for langchain user except RESTfulClient. The modification has maintained consistency with the xinference embeddings [embeddings/xinference](../blob/master/libs/community/langchain_community/embeddings/xinference.py#L89).
