### PR TITLE
docs: fixed syntax error in ChatAnthropic Example - rag app tutorial notebook 

### DIFF
--- a/docs/docs/tutorials/rag.ipynb
+++ b/docs/docs/tutorials/rag.ipynb
@@ -607,7 +607,7 @@
     "```{=mdx}\n",
     "<ChatModelTabs\n",
     "  customVarName=\"llm\"\n",
-    "  anthropicParams={`\"model=\"claude-3-sonnet-20240229\", temperature=0.2, max_tokens=1024\"`}\n",
+    "  anthropicParams={`model=\"claude-3-sonnet-20240229\", temperature=0.2, max_tokens=1024`}\n",
     "/>\n",
     "```\n",
     "\n",
@@ -957,7 +957,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**:  docs: fixed syntax error in ChatAnthropic Example - rag app tutorial notebook - generation


- [ ] **PR message**: 
    - **Description:**  Fixed a syntax error in the ChatAnthropic initialization example in the RAG tutorial notebook. The original code had an extra set of quotation marks around the model parameter, which would cause a Python syntax error. The corrected version removes these unnecessary quotes.
 
    - **Dependencies:** No new dependencies required for this documentation fix.
I've verified that the corrected code is syntactically valid and matches the expected format for initializing a ChatAnthropic instance in LangChain.
    - **Twitter handle:** madhu_shantan


- [ ] **Add tests and docs**: the error in Jupyter notebook: 
<img width="1189" alt="Screenshot 2024-08-29 at 12 43 47 AM" src="https://github.com/user-attachments/assets/07148a93-300f-40e2-ad4a-ac219cbb56a4">

the corrected cell: 
<img width="983" alt="Screenshot 2024-08-29 at 12 44 18 AM" src="https://github.com/user-attachments/assets/75b1455a-3671-454e-ac16-8ca77c049dbd">



- [ ] **Lint and test**: As this is a documentation-only change, I have not run the full test suite. However, I have verified that the corrected code example is syntactically valid and matches the expected usage of the ChatAnthropic class.
 
the error in the docs is here -  
<img width="1020" alt="Screenshot 2024-08-29 at 12 48 36 AM" src="https://github.com/user-attachments/assets/812ccb20-b411-4a5b-afc1-41742efb32a7">


