### PR TITLE
Patch enable to use Amazon OpenSearch Serverless(aoss) for Semantic Cache store 

### DIFF
--- a/libs/community/langchain_community/cache.py
+++ b/libs/community/langchain_community/cache.py
@@ -2283,7 +2283,7 @@ class OpenSearchSemanticCache(BaseCache):
         opensearch_url: str,
         embedding: Embeddings,
         score_threshold: float = 0.2,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         """
         Args:

--- a/libs/community/langchain_community/cache.py
+++ b/libs/community/langchain_community/cache.py
@@ -2279,7 +2279,11 @@ class OpenSearchSemanticCache(BaseCache):
     """Cache that uses OpenSearch vector store backend"""
 
     def __init__(
-        self, opensearch_url: str, embedding: Embeddings, score_threshold: float = 0.2
+        self,
+        opensearch_url: str,
+        embedding: Embeddings,
+        score_threshold: float = 0.2,
+        **kwargs: Any
     ):
         """
         Args:
@@ -2300,6 +2304,7 @@ class OpenSearchSemanticCache(BaseCache):
         self.opensearch_url = opensearch_url
         self.embedding = embedding
         self.score_threshold = score_threshold
+        self.connection_kwargs = kwargs
 
     def _index_name(self, llm_string: str) -> str:
         hashed_index = _hash(llm_string)
@@ -2317,6 +2322,7 @@ class OpenSearchSemanticCache(BaseCache):
             opensearch_url=self.opensearch_url,
             index_name=index_name,
             embedding_function=self.embedding,
+            **self.connection_kwargs,
         )
 
         # create index for the vectorstore


### PR DESCRIPTION
- [x] **PR title**: "community: Patch enable to use Amazon OpenSearch Serverless for Semantic Cache store"

- [x] **PR message**: 
    - **Description:** OpenSearchSemanticCache class support Amazon OpenSearch Serverless for Semantic Cache store, it's only required to pass auth(http_auth) parameter to initializer
    - **Dependencies:** none

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.