### PR TITLE
community[patch]: callback before yield for _astream (gigachat)

### DIFF
--- a/libs/community/langchain_community/chat_models/gigachat.py
+++ b/libs/community/langchain_community/chat_models/gigachat.py
@@ -268,6 +268,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 dict(finish_reason=finish_reason) if finish_reason is not None else None
             )
 
-            yield ChatGenerationChunk(message=chunk, generation_info=generation_info)
             if run_manager:
                 await run_manager.on_llm_new_token(content)
+            
+            yield ChatGenerationChunk(message=chunk, generation_info=generation_info)

--- a/libs/community/langchain_community/chat_models/gigachat.py
+++ b/libs/community/langchain_community/chat_models/gigachat.py
@@ -270,5 +270,5 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
 
             if run_manager:
                 await run_manager.on_llm_new_token(content)
-            
+
             yield ChatGenerationChunk(message=chunk, generation_info=generation_info)


### PR DESCRIPTION
Description: Moves yield to after callback for _astream for gigachat in the community package
Issue: #16913 
    

