### PR TITLE
Fix strict parameter usage in convert_to_openai_function (Generated by Ana - AI SDE)

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -386,8 +386,8 @@ def convert_to_openai_function(
             " either be in OpenAI function format or valid JSON schema with top-level"
             " 'title' and 'description' keys."
         )
-
-    if strict is not None:
+    # Only include the strict parameter if the function is being converted to a tool
+    if isinstance(function, BaseTool) and strict is not None:
         oai_function["strict"] = strict
         if strict:
             # As of 08/06/24, OpenAI requires that additionalProperties be supplied and


### PR DESCRIPTION
This patch addresses the issue with the `strict` parameter being used in unsupported contexts when converting functions to OpenAI function format. The fix ensures that the `strict` parameter is only included when the function is being converted to a tool (instance of `BaseTool`).

Changes made:
- Modified the condition in `convert_to_openai_function` to check if the function is an instance of `BaseTool` before applying the `strict` parameter.
- Added a comment explaining the new condition.

This change prevents the error \"Invalid function definition for 'GerichtlicheAnerkennung': the 'strict' parameter is only permitted in 'tools'\" from occurring in non-tool contexts.

This patch was generated by [Ana - AI SDE](https://openana.ai/), an AI-powered software development assistant.

This is a fix for [Issue 25842](https://github.com/langchain-ai/langchain/issues/25842)