### PR TITLE
community: Cap AzureOpenAIEmbeddings chunk_size at 2048 instead of 16.

### DIFF
--- a/libs/community/langchain_community/embeddings/azure_openai.py
+++ b/libs/community/langchain_community/embeddings/azure_openai.py
@@ -91,10 +91,10 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):
         values["azure_ad_token"] = values.get("azure_ad_token") or os.getenv(
             "AZURE_OPENAI_AD_TOKEN"
         )
-        # Azure OpenAI embedding models allow a maximum of 16 texts
+        # Azure OpenAI embedding models allow a maximum of 2048 texts
         # at a time in each batch
         # See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#embeddings
-        values["chunk_size"] = min(values["chunk_size"], 16)
+        values["chunk_size"] = min(values["chunk_size"], 2048)
         try:
             import openai  # noqa: F401
         except ImportError:

--- a/libs/community/langchain_community/embeddings/openai.py
+++ b/libs/community/langchain_community/embeddings/openai.py
@@ -307,10 +307,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         )
         if values["openai_api_type"] in ("azure", "azure_ad", "azuread"):
             default_api_version = "2023-05-15"
-            # Azure OpenAI embedding models allow a maximum of 16 texts
-            # at a time in each batch
+            # Azure OpenAI embedding models allow a maximum of 2048
+            # texts at a time in each batch
             # See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#embeddings
-            values["chunk_size"] = min(values["chunk_size"], 16)
+            values["chunk_size"] = min(values["chunk_size"], 2048)
         else:
             default_api_version = ""
         values["openai_api_version"] = get_from_dict_or_env(


### PR DESCRIPTION
**Description:** Within AzureOpenAIEmbeddings there is a validation to cap `chunk_size` at 16. The value of 16 is either an old limitation or was erroneously chosen. I have checked all of the `preview` and `stable` releases to ensure that the `embeddings` endpoint can handle 2048 entries [Azure/azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference). I have also found many locations that confirm this limit should be 2048:
- https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#embeddings
- https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits

**Issue:** fixes #25462
