### PR TITLE
community: attach database result id to Document object when using PGVector

### DIFF
--- a/libs/community/langchain_community/vectorstores/pgvector.py
+++ b/libs/community/langchain_community/vectorstores/pgvector.py
@@ -638,6 +638,7 @@ class PGVector(VectorStore):
         docs = [
             (
                 Document(
+                    id=result.EmbeddingStore.id if result.EmbeddingStore.id else None,
                     page_content=result.EmbeddingStore.document,
                     metadata=result.EmbeddingStore.cmetadata,
                 ),


### PR DESCRIPTION
**Description**: retrieving Documents with `PGVector` its ID comes as `None` even if it has and ID on database (it will always have one id). I've changed the `_results_to_docs_and_scores` method to attach the database id into Documents