### PR TITLE
qdrant: Updated class check in Self-Query Retriever factory

### DIFF
--- a/libs/community/langchain_community/retrievers/qdrant_sparse_vector_retriever.py
+++ b/libs/community/langchain_community/retrievers/qdrant_sparse_vector_retriever.py
@@ -13,6 +13,7 @@ from typing import (
     cast,
 )
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
@@ -21,6 +22,16 @@ from langchain_core.utils import pre_init
 from langchain_community.vectorstores.qdrant import Qdrant, QdrantException
 
 
+@deprecated(
+    since="0.2.16",
+    alternative=(
+        "Qdrant vector store now supports sparse retrievals natively. "
+        "Use langchain_qdrant.QdrantVectorStore#as_retriever() instead. "
+        "Reference: "
+        "https://python.langchain.com/v0.2/docs/integrations/vectorstores/qdrant/#sparse-vector-search"
+    ),
+    removal="0.5.0",
+)
 class QdrantSparseVectorRetriever(BaseRetriever):
     """Qdrant sparse vector retriever."""
 

--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -114,8 +114,6 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
     }
     if isinstance(vectorstore, DatabricksVectorSearch):
         return DatabricksVectorSearchTranslator()
-    if isinstance(vectorstore, Qdrant):
-        return QdrantTranslator(metadata_key=vectorstore.metadata_payload_key)
     elif isinstance(vectorstore, MyScale):
         return MyScaleTranslator(metadata_key=vectorstore.metadata_column)
     elif isinstance(vectorstore, Redis):
@@ -176,6 +174,14 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
         else:
             if isinstance(vectorstore, PGVector):
                 return NewPGVectorTranslator()
+
+        try:
+            from langchain_qdrant import QdrantVectorStore
+        except ImportError:
+            pass
+        else:
+            if isinstance(vectorstore, QdrantVectorStore):
+                return QdrantTranslator(metadata_key=vectorstore.metadata_payload_key)
 
         try:
             # Added in langchain-community==0.2.11


### PR DESCRIPTION
## Description

- Updates the self-query retriever factory to check for the new Qdrant vector store class. i.e. `langchain_qdrant.QdrantVectorstore`.
- Deprecates `QdrantSparseVectorRetriever`, since the vector store implementation natively supports it now.

Resolves #25798