### PR TITLE
Change default dimensions number in OpenAIEmbeddings class

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -177,9 +177,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     client: Any = Field(default=None, exclude=True)  #: :meta private:
     async_client: Any = Field(default=None, exclude=True)  #: :meta private:
     model: str = "text-embedding-ada-002"
-    dimensions: Optional[int] = None
+    dimensions: Optional[int] = 1536
     """The number of dimensions the resulting output embeddings should have.
-
+    By deafult equals of number of dimensions of "text-embedding-ada-002" default model
     Only supported in `text-embedding-3` and later models.
     """
     # to support Azure OpenAI Service custom deployment names


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: "partners: default dimension number in OpenAIEmbeddings class"


    - **Description:** Change default number of dims in OpenAIEmbeddings class
    - **Issue:** #25879
    - **Dependencies:** none
    - **Twitter handle:** @ValentinKovalev



- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

