### PR TITLE
Add Databricks integration to docs

### DIFF
--- a/docs/docs/integrations/providers/databricks.md
+++ b/docs/docs/integrations/providers/databricks.md
@@ -11,13 +11,22 @@ Databricks embraces the LangChain ecosystem in various ways:
 4. 🌐 **SQL Database** - [Databricks SQL](https://www.databricks.com/product/databricks-sql) is integrated with `SQLDatabase` in LangChain, allowing you to access the auto-optimizing, exceptionally performant data warehouse.
 5. 💡 **Open Models** - Databricks open sources models, such as [DBRX](https://www.databricks.com/blog/introducing-dbrx-new-state-art-open-llm), which are available through the [Hugging Face Hub](https://huggingface.co/databricks/dbrx-instruct). These models can be directly utilized with LangChain, leveraging its integration with the `transformers` library.
 
+Installation
+------------
+
+First-party Databricks integrations are available in the langchain-databricks partner package.
+
+```
+pip install langchain-databricks
+```
+
 Chat Model
 ----------
 
 `ChatDatabricks` is a Chat Model class to access chat endpoints hosted on Databricks, including state-of-the-art models such as Llama3, Mixtral, and DBRX, as well as your own fine-tuned models.
 
 ```
-from langchain_community.chat_models.databricks import ChatDatabricks
+from langchain_databricks import ChatDatabricks
 
 chat_model = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
 ```
@@ -28,6 +37,9 @@ LLM
 ---
 
 `Databricks` is an LLM class to access completion endpoints hosted on Databricks.
+
+:::caution
+Text completion models have been deprecated and the latest and most popular models are [chat completion models](/docs/concepts/#chat-models). Use `ChatDatabricks` chat model instead to use those models and advanced features such as tool calling.
 
 ```
 from langchain_community.llm.databricks import Databricks
@@ -44,7 +56,7 @@ Embeddings
 `DatabricksEmbeddings` is an Embeddings class to access text-embedding endpoints hosted on Databricks, including state-of-the-art models such as BGE, as well as your own fine-tuned models.
 
 ```
-from langchain_community.embeddings import DatabricksEmbeddings
+from langchain_databricks import DatabricksEmbeddings
 
 embeddings = DatabricksEmbeddings(endpoint="databricks-bge-large-en")
 ```
@@ -58,10 +70,15 @@ Vector Search
 Databricks Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database. With Vector Search, you can create auto-updating vector search indexes from [Delta](https://docs.databricks.com/en/introduction/delta-comparison.html) tables managed by [Unity Catalog](https://www.databricks.com/product/unity-catalog) and query them with a simple API to return the most similar vectors.
 
 ```
-from langchain_community.vectorstores import DatabricksVectorSearch
+from langchain_databricks.vectorstores import DatabricksVectorSearch
 
 dvs = DatabricksVectorSearch(
-    index, text_column="text", embedding=embeddings, columns=["source"]
+    endpoint="<YOUT_ENDPOINT_NAME>",
+    index_name="<YOUR_INDEX_NAME>",
+    index,
+    text_column="text",
+    embedding=embeddings,
+    columns=["source"]
 )
 docs = dvs.similarity_search("What is vector search?)
 ```

--- a/docs/scripts/partner_pkg_table.py
+++ b/docs/scripts/partner_pkg_table.py
@@ -15,6 +15,7 @@ EXTERNAL_PACKAGES = {
     "astradb",
     "aws",
     "cohere",
+    "databricks",
     "elasticsearch",
     "google-community",
     "google-genai",

--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -209,7 +209,7 @@ const FEATURE_TABLES = {
                 "name": "ChatDatabricks",
                 "package": "langchain-databricks",
                 "link": "databricks",
-                "structured_output": false,
+                "structured_output": true,
                 "tool_calling": true,
                 "json_mode": false, 
                 "multimodal": false,

--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -204,6 +204,17 @@ const FEATURE_TABLES = {
                 "multimodal": false,
                 "local": false,
                 "apiLink": "https://python.langchain.com/v0.2/api_reference/upstage/chat_models/langchain_upstage.chat_models.ChatUpstage.html"
+            },
+            {
+                "name": "ChatDatabricks",
+                "package": "langchain-databricks",
+                "link": "databricks",
+                "structured_output": false,
+                "tool_calling": true,
+                "json_mode": false, 
+                "multimodal": false,
+                "local": false,
+                "apiLink": "https://python.langchain.com/v0.2/api_reference/upstage/chat_models/langchain_databricks.chat_models.ChatDatabricks.html"
             }
         ],
     },
@@ -346,6 +357,12 @@ const FEATURE_TABLES = {
                 link: "cohere",
                 package: "langchain-nomic",
                 apiLink: "https://python.langchain.com/v0.2/api_reference/nomic/embeddings/langchain_nomic.embeddings.NomicEmbeddings.html"
+            },
+            {
+                name: "Databricks",
+                link: "databricks",
+                package: "langchain-databricks",
+                apiLink: "https://python.langchain.com/v0.2/api_reference/nomic/embeddings/langchain_databricks.embeddings.DatabricksEmbeddings.html"
             },
         ]
     },
@@ -943,6 +960,19 @@ const FEATURE_TABLES = {
                 passesStandardTests: false,
                 multiTenancy: false,
                 local: true,
+                idsInAddDocuments: false,
+            },
+            {
+                name: "DatabricksVectorSearch",
+                link: "databricks_vector_search",
+                deleteById: true,
+                filtering: true,
+                searchByVector: true,
+                searchWithScore: true,
+                async: true,
+                passesStandardTests: false,
+                multiTenancy: false,
+                local: false,
                 idsInAddDocuments: false,
             },
             {


### PR DESCRIPTION
Updating the gateway pages in the documentation to name the `langchain-databricks` integration.