### PR TITLE
fix: HuggingFacePipeline model_id parameter

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -54,7 +54,7 @@ class HuggingFacePipeline(BaseLLM):
     """
 
     pipeline: Any  #: :meta private:
-    model_id: str = DEFAULT_MODEL_ID
+    model_id: str = pipeline.model.name_or_path if pipeline else DEFAULT_MODEL_ID
     """Model name to use."""
     model_kwargs: Optional[dict] = None
     """Keyword arguments passed to the model."""


### PR DESCRIPTION
**PR title**: "Fixes issue with model parameter not getting initialized correctly when passing transformers pipeline"
- Package: "langchain_huggingface"

- **Issue:** #25915
- **Dependencies:** None


The current version of the [code](https://github.com/langchain-ai/langchain/blob/master/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py) contains default parameter of `model_id` in `HuggingFacePipeline` class. If the user passes a transformers pipeline object, ideally the default value should get overridden, but it doesn't. This PR fixes it.

Cheers!