### PR TITLE
community: Change ChatOpenAI import in OctoAI chat model

### DIFF
--- a/libs/community/langchain_community/chat_models/octoai.py
+++ b/libs/community/langchain_community/chat_models/octoai.py
@@ -5,7 +5,7 @@ from typing import Dict
 from langchain_core.pydantic_v1 import Field, SecretStr
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
 
-from langchain_community.chat_models.openai import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain_community.utils.openai import is_openai_v1
 
 DEFAULT_API_BASE = "https://text.octoai.run/v1/"


### PR DESCRIPTION
OctoAI model was importing OpenAI from a langchain_community object that doesn't have `bind_tool` defined so the model wasn't allowing tool choosing.