### PR TITLE
core[major]: Upgrade langchain-core to pydantic 2

### DIFF
--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -39,7 +39,6 @@ lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test
 
 lint lint_diff lint_package lint_tests:
-	./scripts/check_pydantic.sh .
 	./scripts/lint_imports.sh
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff check $(PYTHON_FILES)
 	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES) --diff

--- a/libs/core/langchain_core/beta/runnables/context.py
+++ b/libs/core/langchain_core/beta/runnables/context.py
@@ -18,6 +18,8 @@ from typing import (
     Union,
 )
 
+from pydantic import ConfigDict
+
 from langchain_core._api.beta_decorator import beta
 from langchain_core.runnables.base import (
     Runnable,
@@ -229,8 +231,9 @@ class ContextSet(RunnableSerializable):
 
     keys: Mapping[str, Optional[Runnable]]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     def __init__(
         self,

--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Sequence, Union
 
+from pydantic import BaseModel, Field
+
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     HumanMessage,
     get_buffer_string,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 
 
 class BaseChatMessageHistory(ABC):

--- a/libs/core/langchain_core/documents/compressor.py
+++ b/libs/core/langchain_core/documents/compressor.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks import Callbacks
 from langchain_core.documents import Document
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import run_in_executor
 
 

--- a/libs/core/langchain_core/embeddings/fake.py
+++ b/libs/core/langchain_core/embeddings/fake.py
@@ -4,8 +4,9 @@
 import hashlib
 from typing import List
 
+from pydantic import BaseModel
+
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class FakeEmbeddings(Embeddings, BaseModel):

--- a/libs/core/langchain_core/example_selectors/length_based.py
+++ b/libs/core/langchain_core/example_selectors/length_based.py
@@ -3,9 +3,10 @@
 import re
 from typing import Callable, Dict, List
 
+from pydantic import BaseModel, validator
+
 from langchain_core.example_selectors.base import BaseExampleSelector
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, validator
 
 
 def _get_length_based(text: str) -> int:

--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
-from pydantic import BaseModel, ConfigDict, Extra
+from pydantic import BaseModel, ConfigDict
 
 from langchain_core.documents import Document
 from langchain_core.example_selectors.base import BaseExampleSelector
@@ -45,7 +45,7 @@ class _VectorStoreExampleSelector(BaseExampleSelector, BaseModel, ABC):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
-        extra=Extra.forbid,
+        extra="forbid",
     )
 
     @staticmethod

--- a/libs/core/langchain_core/example_selectors/semantic_similarity.py
+++ b/libs/core/langchain_core/example_selectors/semantic_similarity.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
+from pydantic import BaseModel, ConfigDict, Extra
+
 from langchain_core.documents import Document
 from langchain_core.example_selectors.base import BaseExampleSelector
-from langchain_core.pydantic_v1 import BaseModel, Extra
 from langchain_core.vectorstores import VectorStore
 
 if TYPE_CHECKING:
@@ -42,9 +43,10 @@ class _VectorStoreExampleSelector(BaseExampleSelector, BaseModel, ABC):
     vectorstore_kwargs: Optional[Dict[str, Any]] = None
     """Extra arguments passed to similarity_search function of the vectorstore."""
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra=Extra.forbid,
+    )
 
     @staticmethod
     def _example_to_text(

--- a/libs/core/langchain_core/graph_vectorstores/base.py
+++ b/libs/core/langchain_core/graph_vectorstores/base.py
@@ -12,6 +12,8 @@ from typing import (
     Optional,
 )
 
+from pydantic import Field
+
 from langchain_core._api import beta
 from langchain_core.callbacks import (
     AsyncCallbackManagerForRetrieverRun,
@@ -20,7 +22,6 @@ from langchain_core.callbacks import (
 from langchain_core.documents import Document
 from langchain_core.graph_vectorstores.links import METADATA_LINKS_KEY, Link
 from langchain_core.load import Serializable
-from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import run_in_executor
 from langchain_core.vectorstores import VectorStore, VectorStoreRetriever
 

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -25,10 +25,11 @@ from typing import (
     cast,
 )
 
+from pydantic import model_validator
+
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 from langchain_core.indexing.base import DocumentIndex, RecordManager
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.vectorstores import VectorStore
 
 # Magic UUID to use as a namespace for hashing.
@@ -68,8 +69,9 @@ class _HashedDocument(Document):
     def is_lc_serializable(cls) -> bool:
         return False
 
-    @root_validator(pre=True)
-    def calculate_hashes(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def calculate_hashes(cls, values: Dict[str, Any]) -> Any:
         """Root validator to calculate content and metadata hash."""
         content = values.get("page_content", "")
         metadata = values.get("metadata", {})

--- a/libs/core/langchain_core/indexing/in_memory.py
+++ b/libs/core/langchain_core/indexing/in_memory.py
@@ -1,12 +1,13 @@
 import uuid
 from typing import Any, Dict, List, Optional, Sequence, cast
 
+from pydantic import Field
+
 from langchain_core._api import beta
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.indexing import UpsertResponse
 from langchain_core.indexing.base import DeleteResponse, DocumentIndex
-from langchain_core.pydantic_v1 import Field
 
 
 @beta(message="Introduced in version 0.2.29. Underlying abstraction subject to change.")

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel, ConfigDict, Field, validator
 from typing_extensions import TypeAlias, TypedDict
 
 from langchain_core._api import deprecated
@@ -28,7 +29,6 @@ from langchain_core.messages import (
     get_buffer_string,
 )
 from langchain_core.prompt_values import PromptValue
-from langchain_core.pydantic_v1 import BaseModel, Field, validator
 from langchain_core.runnables import Runnable, RunnableSerializable
 from langchain_core.utils import get_pydantic_field_names
 
@@ -113,7 +113,11 @@ class BaseLanguageModel(
     
     Caching is not currently supported for streaming methods of models.
     """
-    verbose: bool = Field(default_factory=_get_verbosity)
+    # Repr = False is consistent with pydantic 1 if verbose = False
+    # We can relax this for pydantic 2?
+    # TODO(Team): decide what to do here.
+    # Modified just to get unit tests to pass.
+    verbose: bool = Field(default_factory=_get_verbosity, exclude=True, repr=False)
     """Whether to print out response text."""
     callbacks: Callbacks = Field(default=None, exclude=True)
     """Callbacks to add to the run trace."""
@@ -125,6 +129,10 @@ class BaseLanguageModel(
         default=None, exclude=True
     )
     """Optional encoder to use for counting tokens."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @validator("verbose", pre=True, always=True, allow_reuse=True)
     def set_verbose(cls, verbose: Optional[bool]) -> bool:

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -115,7 +115,7 @@ class BaseLanguageModel(
     """
     # Repr = False is consistent with pydantic 1 if verbose = False
     # We can relax this for pydantic 2?
-    # TODO(Team): decide what to do here.
+    # TODO(0.3): Resolve repr for verbose
     # Modified just to get unit tests to pass.
     verbose: bool = Field(default_factory=_get_verbosity, exclude=True, repr=False)
     """Whether to print out response text."""

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import yaml
+from pydantic import ConfigDict, Field, model_validator
 from tenacity import (
     RetryCallState,
     before_sleep_log,
@@ -62,7 +63,6 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult, RunInfo
 from langchain_core.prompt_values import ChatPromptValue, PromptValue, StringPromptValue
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables import RunnableConfig, ensure_config, get_config_list
 from langchain_core.runnables.config import run_in_executor
 
@@ -300,11 +300,13 @@ class BaseLLM(BaseLanguageModel[str], ABC):
     callback_manager: Optional[BaseCallbackManager] = Field(default=None, exclude=True)
     """[DEPRECATED]"""
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
-    @root_validator(pre=True)
-    def raise_deprecation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def raise_deprecation(cls, values: Dict) -> Any:
         """Raise deprecation warning if callback_manager is used."""
         if values.get("callback_manager") is not None:
             warnings.warn(

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -10,7 +10,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel, ConfigDict  # pydantic: ignore
+from pydantic import BaseModel, ConfigDict  
 from typing_extensions import NotRequired
 
 from langchain_core.utils.pydantic import v1_repr

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -10,9 +10,10 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict  # pydantic: ignore
 from typing_extensions import NotRequired
 
-from langchain_core.pydantic_v1 import BaseModel
+from langchain_core.utils.pydantic import v1_repr
 
 
 class BaseSerialized(TypedDict):
@@ -80,7 +81,7 @@ def try_neq_default(value: Any, key: str, model: BaseModel) -> bool:
         Exception: If the key is not in the model.
     """
     try:
-        return model.__fields__[key].get_default() != value
+        return model.model_fields[key].get_default() != value
     except Exception:
         return True
 
@@ -161,16 +162,25 @@ class Serializable(BaseModel, ABC):
         For example, for the class `langchain.llms.openai.OpenAI`, the id is
         ["langchain", "llms", "openai", "OpenAI"].
         """
-        return [*cls.get_lc_namespace(), cls.__name__]
+        # Pydantic generics change the class name. So we need to do the following
+        if (
+            "origin" in cls.__pydantic_generic_metadata__
+            and cls.__pydantic_generic_metadata__["origin"] is not None
+        ):
+            original_name = cls.__pydantic_generic_metadata__["origin"].__name__
+        else:
+            original_name = cls.__name__
+        return [*cls.get_lc_namespace(), original_name]
 
-    class Config:
-        extra = "ignore"
+    model_config = ConfigDict(
+        extra="ignore",
+    )
 
     def __repr_args__(self) -> Any:
         return [
             (k, v)
             for k, v in super().__repr_args__()
-            if (k not in self.__fields__ or try_neq_default(v, k, self))
+            if (k not in self.model_fields or try_neq_default(v, k, self))
         ]
 
     def to_json(self) -> Union[SerializedConstructor, SerializedNotImplemented]:
@@ -184,12 +194,15 @@ class Serializable(BaseModel, ABC):
 
         secrets = dict()
         # Get latest values for kwargs if there is an attribute with same name
-        lc_kwargs = {
-            k: getattr(self, k, v)
-            for k, v in self
-            if not (self.__exclude_fields__ or {}).get(k, False)  # type: ignore
-            and _is_field_useful(self, k, v)
-        }
+        lc_kwargs = {}
+        for k, v in self:
+            if not _is_field_useful(self, k, v):
+                continue
+            # Do nothing if the field is excluded
+            if k in self.model_fields and self.model_fields[k].exclude:
+                continue
+
+            lc_kwargs[k] = getattr(self, k, v)
 
         # Merge the lc_secrets and lc_attributes from every class in the MRO
         for cls in [None, *self.__class__.mro()]:
@@ -221,8 +234,10 @@ class Serializable(BaseModel, ABC):
             # that are not present in the fields.
             for key in list(secrets):
                 value = secrets[key]
-                if key in this.__fields__:
-                    secrets[this.__fields__[key].alias] = value
+                if key in this.model_fields:
+                    alias = this.model_fields[key].alias
+                    if alias is not None:
+                        secrets[alias] = value
             lc_kwargs.update(this.lc_attributes)
 
         # include all secrets, even if not specified in kwargs
@@ -244,6 +259,10 @@ class Serializable(BaseModel, ABC):
     def to_json_not_implemented(self) -> SerializedNotImplemented:
         return to_json_not_implemented(self)
 
+    def __repr__(self) -> str:
+        # TODO(0.3): Remove this override after confirming unit tests!
+        return v1_repr(self)
+
 
 def _is_field_useful(inst: Serializable, key: str, value: Any) -> bool:
     """Check if a field is useful as a constructor argument.
@@ -259,15 +278,30 @@ def _is_field_useful(inst: Serializable, key: str, value: Any) -> bool:
         If the field is not required and the value is None, it is useful if the
         default value is different from the value.
     """
-    field = inst.__fields__.get(key)
+    field = inst.model_fields.get(key)
     if not field:
         return False
+
+    if field.is_required():
+        return True
+
     # Handle edge case: a value cannot be converted to a boolean (e.g. a
     # Pandas DataFrame).
     try:
         value_is_truthy = bool(value)
     except Exception as _:
         value_is_truthy = False
+
+    if value_is_truthy:
+        return True
+
+    # Value is still falsy here!
+    if field.default_factory is dict and isinstance(value, dict):
+        return False
+
+    # Value is still falsy here!
+    if field.default_factory is list and isinstance(value, list):
+        return False
 
     # Handle edge case: inequality of two objects does not evaluate to a bool (e.g. two
     # Pandas DataFrames).
@@ -282,7 +316,8 @@ def _is_field_useful(inst: Serializable, key: str, value: Any) -> bool:
             except Exception as _:
                 value_neq_default = False
 
-    return field.required is True or value_is_truthy or value_neq_default
+    # If value is falsy and does not match the default
+    return value_is_truthy or value_neq_default
 
 
 def _replace_secrets(

--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
+from pydantic import ConfigDict
+
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import run_in_executor
 
@@ -47,8 +49,9 @@ class BaseMemory(Serializable, ABC):
                     pass
     """  # noqa: E501
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     @abstractmethod

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, cast
 
+from pydantic import ConfigDict, Extra, Field
+
 from langchain_core.load.serializable import Serializable
-from langchain_core.pydantic_v1 import Extra, Field
 from langchain_core.utils import get_bolded_text
 from langchain_core.utils._merge import merge_dicts, merge_lists
 from langchain_core.utils.interactive_env import is_interactive_env
+from langchain_core.utils.pydantic import v1_repr
 
 if TYPE_CHECKING:
     from langchain_core.prompts.chat import ChatPromptTemplate
@@ -51,8 +53,9 @@ class BaseMessage(Serializable):
     """An optional unique identifier for the message. This should ideally be
     provided by the provider/model which created the message."""
 
-    class Config:
-        extra = Extra.allow
+    model_config = ConfigDict(
+        extra=Extra.allow,
+    )
 
     def __init__(
         self, content: Union[str, List[Union[str, Dict]]], **kwargs: Any
@@ -107,6 +110,10 @@ class BaseMessage(Serializable):
 
     def pretty_print(self) -> None:
         print(self.pretty_repr(html=is_interactive_env()))  # noqa: T201
+
+    def __repr__(self) -> str:
+        # TODO(0.3): Remove this override after confirming unit tests!
+        return v1_repr(self)
 
 
 def merge_content(

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, cast
 
-from pydantic import ConfigDict, Extra, Field
+from pydantic import ConfigDict, Field
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.utils import get_bolded_text
@@ -54,7 +54,7 @@ class BaseMessage(Serializable):
     provided by the provider/model which created the message."""
 
     model_config = ConfigDict(
-        extra=Extra.allow,
+        extra="allow",
     )
 
     def __init__(

--- a/libs/core/langchain_core/messages/chat.py
+++ b/libs/core/langchain_core/messages/chat.py
@@ -25,7 +25,7 @@ class ChatMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-ChatMessage.update_forward_refs()
+ChatMessage.model_rebuild()
 
 
 class ChatMessageChunk(ChatMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/function.py
+++ b/libs/core/langchain_core/messages/function.py
@@ -32,7 +32,7 @@ class FunctionMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-FunctionMessage.update_forward_refs()
+FunctionMessage.model_rebuild()
 
 
 class FunctionMessageChunk(FunctionMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/human.py
+++ b/libs/core/langchain_core/messages/human.py
@@ -56,7 +56,7 @@ class HumanMessage(BaseMessage):
         super().__init__(content=content, **kwargs)
 
 
-HumanMessage.update_forward_refs()
+HumanMessage.model_rebuild()
 
 
 class HumanMessageChunk(HumanMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/modifier.py
+++ b/libs/core/langchain_core/messages/modifier.py
@@ -33,4 +33,4 @@ class RemoveMessage(BaseMessage):
         return ["langchain", "schema", "messages"]
 
 
-RemoveMessage.update_forward_refs()
+RemoveMessage.model_rebuild()

--- a/libs/core/langchain_core/messages/system.py
+++ b/libs/core/langchain_core/messages/system.py
@@ -50,7 +50,7 @@ class SystemMessage(BaseMessage):
         super().__init__(content=content, **kwargs)
 
 
-SystemMessage.update_forward_refs()
+SystemMessage.model_rebuild()
 
 
 class SystemMessageChunk(SystemMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
+from pydantic import Field
 from typing_extensions import NotRequired, TypedDict
 
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk, merge_content
@@ -70,6 +71,11 @@ class ToolMessage(BaseMessage):
     .. versionadded:: 0.2.24
     """
 
+    additional_kwargs: dict = Field(default_factory=dict, repr=False)
+    """Currently inherited from BaseMessage, but not used."""
+    response_metadata: dict = Field(default_factory=dict, repr=False)
+    """Currently inherited from BaseMessage, but not used."""
+
     @classmethod
     def get_lc_namespace(cls) -> List[str]:
         """Get the namespace of the langchain object.
@@ -88,7 +94,7 @@ class ToolMessage(BaseMessage):
         super().__init__(content=content, **kwargs)
 
 
-ToolMessage.update_forward_refs()
+ToolMessage.model_rebuild()
 
 
 class ToolMessageChunk(ToolMessage, BaseMessageChunk):

--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -13,8 +13,6 @@ from typing import (
     Union,
 )
 
-from typing_extensions import get_args
-
 from langchain_core.language_models import LanguageModelOutput
 from langchain_core.messages import AnyMessage, BaseMessage
 from langchain_core.outputs import ChatGeneration, Generation
@@ -166,10 +164,11 @@ class BaseOutputParser(
         Raises:
             TypeError: If the class doesn't have an inferable OutputType.
         """
-        for cls in self.__class__.__orig_bases__:  # type: ignore[attr-defined]
-            type_args = get_args(cls)
-            if type_args and len(type_args) == 1:
-                return type_args[0]
+        for base in self.__class__.mro():
+            if hasattr(base, "__pydantic_generic_metadata__"):
+                metadata = base.__pydantic_generic_metadata__
+                if "args" in metadata and len(metadata["args"]) > 0:
+                    return metadata["args"][0]
 
         raise TypeError(
             f"Runnable {self.__class__.__name__} doesn't have an inferable OutputType. "

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -5,8 +5,8 @@ from json import JSONDecodeError
 from typing import Any, List, Optional, Type, TypeVar, Union
 
 import jsonpatch  # type: ignore[import]
-import pydantic  # pydantic: ignore
-from pydantic import SkipValidation  # pydantic: ignore
+import pydantic  
+from pydantic import SkipValidation  
 from typing_extensions import Annotated
 
 from langchain_core.exceptions import OutputParserException
@@ -24,7 +24,7 @@ if PYDANTIC_MAJOR_VERSION < 2:
     PydanticBaseModel = pydantic.BaseModel
 
 else:
-    from pydantic.v1 import BaseModel  # pydantic: ignore
+    from pydantic.v1 import BaseModel  
 
     # Union type needs to be last assignment to PydanticBaseModel to make mypy happy.
     PydanticBaseModel = Union[BaseModel, pydantic.BaseModel]  # type: ignore

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import json
 from json import JSONDecodeError
-from typing import Any, List, Optional, Type, TypeVar, Union
+from typing import Annotated, Any, List, Optional, Type, TypeVar, Union
 
 import jsonpatch  # type: ignore[import]
 import pydantic  # pydantic: ignore
+from pydantic import SkipValidation  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers.format_instructions import JSON_FORMAT_INSTRUCTIONS
@@ -40,7 +41,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
     describing the difference between the previous and the current object.
     """
 
-    pydantic_object: Optional[Type[TBaseModel]] = None  # type: ignore
+    pydantic_object: Annotated[Optional[Type[TBaseModel]], SkipValidation()] = None  # type: ignore
     """The Pydantic object to use for validation. 
     If None, no validation is performed."""
 

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 from json import JSONDecodeError
-from typing import Annotated, Any, List, Optional, Type, TypeVar, Union
+from typing import Any, List, Optional, Type, TypeVar, Union
 
 import jsonpatch  # type: ignore[import]
 import pydantic  # pydantic: ignore
 from pydantic import SkipValidation  # pydantic: ignore
+from typing_extensions import Annotated
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers.format_instructions import JSON_FORMAT_INSTRUCTIONS

--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -4,6 +4,7 @@ import re
 from abc import abstractmethod
 from collections import deque
 from typing import AsyncIterator, Deque, Iterator, List, TypeVar, Union
+from typing import Optional as Optional
 
 from langchain_core.messages import BaseMessage
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
@@ -120,6 +121,9 @@ class ListOutputParser(BaseTransformOutputParser[List[str]]):
         # yield the last part
         for part in self.parse(buffer):
             yield [part]
+
+
+ListOutputParser.model_rebuild()
 
 
 class CommaSeparatedListOutputParser(ListOutputParser):

--- a/libs/core/langchain_core/output_parsers/openai_functions.py
+++ b/libs/core/langchain_core/output_parsers/openai_functions.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Dict, List, Optional, Type, Union
 
 import jsonpatch  # type: ignore[import]
+from pydantic import BaseModel, model_validator
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import (
@@ -11,7 +12,6 @@ from langchain_core.output_parsers import (
 )
 from langchain_core.output_parsers.json import parse_partial_json
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import BaseModel, root_validator
 
 
 class OutputFunctionsParser(BaseGenerationOutputParser[Any]):
@@ -230,8 +230,9 @@ class PydanticOutputFunctionsParser(OutputFunctionsParser):
     determine which schema to use.
     """
 
-    @root_validator(pre=True)
-    def validate_schema(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def validate_schema(cls, values: Dict) -> Any:
         """Validate the pydantic schema.
 
         Args:
@@ -267,11 +268,17 @@ class PydanticOutputFunctionsParser(OutputFunctionsParser):
         """
         _result = super().parse_result(result)
         if self.args_only:
-            pydantic_args = self.pydantic_schema.parse_raw(_result)  # type: ignore
+            if hasattr(self.pydantic_schema, "model_validate_json"):
+                pydantic_args = self.pydantic_schema.model_validate_json(_result)
+            else:
+                pydantic_args = self.pydantic_schema.parse_raw(_result)  # type: ignore
         else:
             fn_name = _result["name"]
             _args = _result["arguments"]
-            pydantic_args = self.pydantic_schema[fn_name].parse_raw(_args)  # type: ignore
+            if hasattr(self.pydantic_schema, "model_validate_json"):
+                pydantic_args = self.pydantic_schema[fn_name].model_validate_json(_args)  # type: ignore
+            else:
+                pydantic_args = self.pydantic_schema[fn_name].parse_raw(_args)  # type: ignore
         return pydantic_args
 
 

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -1,7 +1,9 @@
 import copy
 import json
 from json import JSONDecodeError
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
+
+from pydantic import SkipValidation, ValidationError  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, InvalidToolCall
@@ -9,7 +11,6 @@ from langchain_core.messages.tool import invalid_tool_call
 from langchain_core.messages.tool import tool_call as create_tool_call
 from langchain_core.output_parsers.transform import BaseCumulativeTransformOutputParser
 from langchain_core.outputs import ChatGeneration, Generation
-from langchain_core.pydantic_v1 import ValidationError
 from langchain_core.utils.json import parse_partial_json
 from langchain_core.utils.pydantic import TypeBaseModel
 
@@ -252,7 +253,7 @@ class JsonOutputKeyToolsParser(JsonOutputToolsParser):
 class PydanticToolsParser(JsonOutputToolsParser):
     """Parse tools from OpenAI response."""
 
-    tools: List[TypeBaseModel]
+    tools: Annotated[List[TypeBaseModel], SkipValidation()]
     """The tools to parse."""
 
     # TODO: Support more granular streaming of objects. Currently only streams once all

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -1,9 +1,10 @@
 import copy
 import json
 from json import JSONDecodeError
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import SkipValidation, ValidationError  # pydantic: ignore
+from typing_extensions import Annotated
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, InvalidToolCall

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -3,7 +3,7 @@ import json
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional
 
-from pydantic import SkipValidation, ValidationError  # pydantic: ignore
+from pydantic import SkipValidation, ValidationError  
 from typing_extensions import Annotated
 
 from langchain_core.exceptions import OutputParserException

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,7 +1,8 @@
 import json
-from typing import Generic, List, Optional, Type
+from typing import Annotated, Generic, List, Optional, Type
 
 import pydantic  # pydantic: ignore
+from pydantic import SkipValidation  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser
@@ -16,7 +17,7 @@ from langchain_core.utils.pydantic import (
 class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
     """Parse an output using a pydantic model."""
 
-    pydantic_object: Type[TBaseModel]  # type: ignore
+    pydantic_object: Annotated[Type[TBaseModel], SkipValidation()]  # type: ignore
     """The pydantic model to parse."""
 
     def _parse_obj(self, obj: dict) -> TBaseModel:
@@ -109,6 +110,9 @@ class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
     def OutputType(self) -> Type[TBaseModel]:
         """Return the pydantic model."""
         return self.pydantic_object
+
+
+PydanticOutputParser.model_rebuild()
 
 
 _PYDANTIC_FORMAT_INSTRUCTIONS = """The output should be formatted as a JSON instance that conforms to the JSON schema below.

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,8 +1,9 @@
 import json
-from typing import Annotated, Generic, List, Optional, Type
+from typing import Generic, List, Optional, Type
 
 import pydantic  # pydantic: ignore
 from pydantic import SkipValidation  # pydantic: ignore
+from typing_extensions import Annotated
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import JsonOutputParser

--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -1,8 +1,8 @@
 import json
 from typing import Generic, List, Optional, Type
 
-import pydantic  # pydantic: ignore
-from pydantic import SkipValidation  # pydantic: ignore
+import pydantic  
+from pydantic import SkipValidation  
 from typing_extensions import Annotated
 
 from langchain_core.exceptions import OutputParserException

--- a/libs/core/langchain_core/output_parsers/string.py
+++ b/libs/core/langchain_core/output_parsers/string.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import Optional as Optional
 
 from langchain_core.output_parsers.transform import BaseTransformOutputParser
 
@@ -24,3 +25,6 @@ class StrOutputParser(BaseTransformOutputParser[str]):
     def parse(self, text: str) -> str:
         """Returns the input text with no changes."""
         return text
+
+
+StrOutputParser.model_rebuild()

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Union
+from typing import List, Literal, Union
+
+from pydantic import model_validator
+from typing_extensions import Self
 
 from langchain_core.messages import BaseMessage, BaseMessageChunk
 from langchain_core.outputs.generation import Generation
-from langchain_core.pydantic_v1 import root_validator
 from langchain_core.utils._merge import merge_dicts
 
 
@@ -30,8 +32,8 @@ class ChatGeneration(Generation):
     type: Literal["ChatGeneration"] = "ChatGeneration"  # type: ignore[assignment]
     """Type is used exclusively for serialization purposes."""
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="after")
+    def set_text(self) -> Self:
         """Set the text attribute to be the contents of the message.
 
         Args:
@@ -45,12 +47,12 @@ class ChatGeneration(Generation):
         """
         try:
             text = ""
-            if isinstance(values["message"].content, str):
-                text = values["message"].content
+            if isinstance(self.message.content, str):
+                text = self.message.content
             # HACK: Assumes text in content blocks in OpenAI format.
             # Uses first text block.
-            elif isinstance(values["message"].content, list):
-                for block in values["message"].content:
+            elif isinstance(self.message.content, list):
+                for block in self.message.content:
                     if isinstance(block, str):
                         text = block
                         break
@@ -61,10 +63,10 @@ class ChatGeneration(Generation):
                         pass
             else:
                 pass
-            values["text"] = text
+            self.text = text
         except (KeyError, AttributeError) as e:
             raise ValueError("Error while initializing ChatGeneration") from e
-        return values
+        return self
 
     @classmethod
     def get_lc_namespace(cls) -> List[str]:

--- a/libs/core/langchain_core/outputs/chat_result.py
+++ b/libs/core/langchain_core/outputs/chat_result.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
+from pydantic import BaseModel
+
 from langchain_core.outputs.chat_generation import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class ChatResult(BaseModel):

--- a/libs/core/langchain_core/outputs/llm_result.py
+++ b/libs/core/langchain_core/outputs/llm_result.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from langchain_core.outputs.generation import Generation
+from pydantic import BaseModel
+
+from langchain_core.outputs.chat_generation import ChatGeneration, ChatGenerationChunk
+from langchain_core.outputs.generation import Generation, GenerationChunk
 from langchain_core.outputs.run_info import RunInfo
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class LLMResult(BaseModel):
@@ -16,7 +18,9 @@ class LLMResult(BaseModel):
     wants to return.
     """
 
-    generations: List[List[Generation]]
+    generations: List[
+        List[Union[Generation, ChatGeneration, GenerationChunk, ChatGenerationChunk]]
+    ]
     """Generated outputs.
     
     The first dimension of the list represents completions for different input

--- a/libs/core/langchain_core/outputs/run_info.py
+++ b/libs/core/langchain_core/outputs/run_info.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class RunInfo(BaseModel):

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
+    Annotated,
     Any,
     Dict,
     List,
@@ -19,6 +20,13 @@ from typing import (
     Union,
     cast,
     overload,
+)
+
+from pydantic import (
+    Field,
+    PositiveInt,
+    SkipValidation,
+    model_validator,
 )
 
 from langchain_core._api import deprecated
@@ -38,7 +46,6 @@ from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.image import ImagePromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import StringPromptTemplate, get_template_variables
-from langchain_core.pydantic_v1 import Field, PositiveInt, root_validator
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.interactive_env import is_interactive_env
 
@@ -207,8 +214,14 @@ class MessagesPlaceholder(BaseMessagePromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "chat"]
 
-    def __init__(self, variable_name: str, *, optional: bool = False, **kwargs: Any):
-        super().__init__(variable_name=variable_name, optional=optional, **kwargs)
+    def __init__(
+        self, variable_name: str, *, optional: bool = False, **kwargs: Any
+    ) -> None:
+        # mypy can't detect the init which is defined in the parent class
+        # b/c these are BaseModel classes.
+        super().__init__(  # type: ignore
+            variable_name=variable_name, optional=optional, **kwargs
+        )
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format messages from kwargs.
@@ -922,7 +935,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
 
     """  # noqa: E501
 
-    messages: List[MessageLike]
+    messages: Annotated[List[MessageLike], SkipValidation]
     """List of messages consisting of either message prompt templates or messages."""
     validate_template: bool = False
     """Whether or not to try validating the template."""
@@ -1038,8 +1051,9 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         else:
             raise NotImplementedError(f"Unsupported operand type for +: {type(other)}")
 
-    @root_validator(pre=True)
-    def validate_input_variables(cls, values: dict) -> dict:
+    @model_validator(mode="before")
+    @classmethod
+    def validate_input_variables(cls, values: dict) -> Any:
         """Validate input variables.
 
         If input_variables is not set, it will be set to the union of

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -935,7 +935,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
 
     """  # noqa: E501
 
-    messages: Annotated[List[MessageLike], SkipValidation]
+    messages: Annotated[List[MessageLike], SkipValidation()]
     """List of messages consisting of either message prompt templates or messages."""
     validate_template: bool = False
     """Whether or not to try validating the template."""

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
-    Annotated,
     Any,
     Dict,
     List,
@@ -28,6 +27,7 @@ from pydantic import (
     SkipValidation,
     model_validator,
 )
+from typing_extensions import Annotated
 
 from langchain_core._api import deprecated
 from langchain_core.load import Serializable

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import (
     BaseModel,
     ConfigDict,
-    Extra,
     Field,
     model_validator,
 )
@@ -42,7 +41,7 @@ class _FewShotPromptTemplateMixin(BaseModel):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
-        extra=Extra.forbid,
+        extra="forbid",
     )
 
     @model_validator(mode="before")
@@ -170,7 +169,7 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
-        extra=Extra.forbid,
+        extra="forbid",
     )
 
     def format(self, **kwargs: Any) -> str:
@@ -378,7 +377,7 @@ class FewShotChatMessagePromptTemplate(
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
-        extra=Extra.forbid,
+        extra="forbid",
     )
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:

--- a/libs/core/langchain_core/prompts/few_shot.py
+++ b/libs/core/langchain_core/prompts/few_shot.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Extra,
+    Field,
+    model_validator,
+)
+from typing_extensions import Self
+
 from langchain_core.example_selectors import BaseExampleSelector
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.prompts.chat import (
@@ -18,7 +27,6 @@ from langchain_core.prompts.string import (
     check_valid_template,
     get_template_variables,
 )
-from langchain_core.pydantic_v1 import BaseModel, Extra, Field, root_validator
 
 
 class _FewShotPromptTemplateMixin(BaseModel):
@@ -32,12 +40,14 @@ class _FewShotPromptTemplateMixin(BaseModel):
     """ExampleSelector to choose the examples to format into the prompt.
     Either this or examples should be provided."""
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra=Extra.forbid,
+    )
 
-    @root_validator(pre=True)
-    def check_examples_and_selector(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def check_examples_and_selector(cls, values: Dict) -> Any:
         """Check that one and only one of examples/example_selector are provided.
 
         Args:
@@ -139,28 +149,29 @@ class FewShotPromptTemplate(_FewShotPromptTemplateMixin, StringPromptTemplate):
             kwargs["input_variables"] = kwargs["example_prompt"].input_variables
         super().__init__(**kwargs)
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def template_is_valid(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def template_is_valid(self) -> Self:
         """Check that prefix, suffix, and input variables are consistent."""
-        if values["validate_template"]:
+        if self.validate_template:
             check_valid_template(
-                values["prefix"] + values["suffix"],
-                values["template_format"],
-                values["input_variables"] + list(values["partial_variables"]),
+                self.prefix + self.suffix,
+                self.template_format,
+                self.input_variables + list(self.partial_variables),
             )
-        elif values.get("template_format"):
-            values["input_variables"] = [
+        elif self.template_format or None:
+            self.input_variables = [
                 var
                 for var in get_template_variables(
-                    values["prefix"] + values["suffix"], values["template_format"]
+                    self.prefix + self.suffix, self.template_format
                 )
-                if var not in values["partial_variables"]
+                if var not in self.partial_variables
             ]
-        return values
+        return self
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra=Extra.forbid,
+    )
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with inputs generating a string.
@@ -365,9 +376,10 @@ class FewShotChatMessagePromptTemplate(
         """Return whether or not the class is serializable."""
         return False
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra=Extra.forbid,
+    )
 
     def format_messages(self, **kwargs: Any) -> List[BaseMessage]:
         """Format kwargs into a list of messages.

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -3,12 +3,14 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from pydantic import ConfigDict, Extra, model_validator
+from typing_extensions import Self
+
 from langchain_core.prompts.prompt import PromptTemplate
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     StringPromptTemplate,
 )
-from langchain_core.pydantic_v1 import Extra, root_validator
 
 
 class FewShotPromptWithTemplates(StringPromptTemplate):
@@ -45,8 +47,9 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "few_shot_with_templates"]
 
-    @root_validator(pre=True)
-    def check_examples_and_selector(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def check_examples_and_selector(cls, values: Dict) -> Any:
         """Check that one and only one of examples/example_selector are provided."""
         examples = values.get("examples", None)
         example_selector = values.get("example_selector", None)
@@ -62,15 +65,15 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
 
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def template_is_valid(cls, values: Dict) -> Dict:
+    @model_validator(mode="after")
+    def template_is_valid(self) -> Self:
         """Check that prefix, suffix, and input variables are consistent."""
-        if values["validate_template"]:
-            input_variables = values["input_variables"]
-            expected_input_variables = set(values["suffix"].input_variables)
-            expected_input_variables |= set(values["partial_variables"])
-            if values["prefix"] is not None:
-                expected_input_variables |= set(values["prefix"].input_variables)
+        if self.validate_template:
+            input_variables = self.input_variables
+            expected_input_variables = set(self.suffix.input_variables)
+            expected_input_variables |= set(self.partial_variables)
+            if self.prefix is not None:
+                expected_input_variables |= set(self.prefix.input_variables)
             missing_vars = expected_input_variables.difference(input_variables)
             if missing_vars:
                 raise ValueError(
@@ -78,16 +81,17 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
                     f"prefix/suffix expected {expected_input_variables}"
                 )
         else:
-            values["input_variables"] = sorted(
-                set(values["suffix"].input_variables)
-                | set(values["prefix"].input_variables if values["prefix"] else [])
-                - set(values["partial_variables"])
+            self.input_variables = sorted(
+                set(self.suffix.input_variables)
+                | set(self.prefix.input_variables if self.prefix else [])
+                - set(self.partial_variables)
             )
-        return values
+        return self
 
-    class Config:
-        arbitrary_types_allowed = True
-        extra = Extra.forbid
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra=Extra.forbid,
+    )
 
     def _get_examples(self, **kwargs: Any) -> List[dict]:
         if self.examples is not None:

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import ConfigDict, Extra, model_validator
+from pydantic import ConfigDict, model_validator
 from typing_extensions import Self
 
 from langchain_core.prompts.prompt import PromptTemplate
@@ -90,7 +90,7 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
-        extra=Extra.forbid,
+        extra="forbid",
     )
 
     def _get_examples(self, **kwargs: Any) -> List[dict]:

--- a/libs/core/langchain_core/prompts/image.py
+++ b/libs/core/langchain_core/prompts/image.py
@@ -1,8 +1,9 @@
 from typing import Any, List
 
+from pydantic import Field
+
 from langchain_core.prompt_values import ImagePromptValue, ImageURL, PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
-from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import run_in_executor
 from langchain_core.utils import image as image_utils
 

--- a/libs/core/langchain_core/prompts/pipeline.py
+++ b/libs/core/langchain_core/prompts/pipeline.py
@@ -1,9 +1,11 @@
 from typing import Any, Dict, List, Tuple
+from typing import Optional as Optional
+
+from pydantic import model_validator
 
 from langchain_core.prompt_values import PromptValue
 from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.chat import BaseChatPromptTemplate
-from langchain_core.pydantic_v1 import root_validator
 
 
 def _get_inputs(inputs: dict, input_variables: List[str]) -> dict:
@@ -34,8 +36,9 @@ class PipelinePromptTemplate(BasePromptTemplate):
         """Get the namespace of the langchain object."""
         return ["langchain", "prompts", "pipeline"]
 
-    @root_validator(pre=True)
-    def get_input_variables(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def get_input_variables(cls, values: Dict) -> Any:
         """Get input variables."""
         created_variables = set()
         all_variables = set()
@@ -106,3 +109,6 @@ class PipelinePromptTemplate(BasePromptTemplate):
     @property
     def _prompt_type(self) -> str:
         raise ValueError
+
+
+PipelinePromptTemplate.model_rebuild()

--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -6,6 +6,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from pydantic import BaseModel, model_validator
+
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     StringPromptTemplate,
@@ -13,7 +15,6 @@ from langchain_core.prompts.string import (
     get_template_variables,
     mustache_schema,
 )
-from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.runnables.config import RunnableConfig
 
 
@@ -73,8 +74,9 @@ class PromptTemplate(StringPromptTemplate):
     validate_template: bool = False
     """Whether or not to try validating the template."""
 
-    @root_validator(pre=True)
-    def pre_init_validation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def pre_init_validation(cls, values: Dict) -> Any:
         """Check that template and input variables are consistent."""
         if values.get("template") is None:
             # Will let pydantic fail with a ValidationError if template

--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -7,10 +7,11 @@ from abc import ABC
 from string import Formatter
 from typing import Any, Callable, Dict, List, Set, Tuple, Type
 
+from pydantic import BaseModel, create_model
+
 import langchain_core.utils.mustache as mustache
 from langchain_core.prompt_values import PromptValue, StringPromptValue
 from langchain_core.prompts.base import BasePromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, create_model
 from langchain_core.utils import get_colored_text
 from langchain_core.utils.formatting import formatter
 from langchain_core.utils.interactive_env import is_interactive_env

--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -11,13 +11,14 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel, Field
+
 from langchain_core._api.beta_decorator import beta
 from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.prompts.chat import (
     ChatPromptTemplate,
     MessageLikeRepresentation,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables.base import (
     Other,
     Runnable,

--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -26,6 +26,7 @@ from abc import ABC, abstractmethod
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from pydantic import ConfigDict
 from typing_extensions import TypedDict
 
 from langchain_core._api import deprecated
@@ -126,8 +127,9 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
                     return [self.docs[i] for i in results.argsort()[-self.k :][::-1]]
     """  # noqa: E501
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     _new_arg_supported: bool = False
     _expects_other_args: bool = False

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -35,7 +35,8 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Literal, get_args
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+from typing_extensions import Literal, get_args, get_type_hints
 
 from langchain_core._api import beta_decorator
 from langchain_core.load.dump import dumpd
@@ -44,7 +45,6 @@ from langchain_core.load.serializable import (
     SerializedConstructor,
     SerializedNotImplemented,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables.config import (
     RunnableConfig,
     _set_config_context,
@@ -83,7 +83,6 @@ from langchain_core.runnables.utils import (
 )
 from langchain_core.utils.aiter import aclosing, atee, py_anext
 from langchain_core.utils.iter import safetee
-from langchain_core.utils.pydantic import is_basemodel_subclass
 
 if TYPE_CHECKING:
     from langchain_core.callbacks.manager import (
@@ -236,25 +235,56 @@ class Runnable(Generic[Input, Output], ABC):
     For a UI (and much more) checkout LangSmith: https://docs.smith.langchain.com/
     """  # noqa: E501
 
-    name: Optional[str] = None
+    name: Optional[str]
     """The name of the Runnable. Used for debugging and tracing."""
 
     def get_name(
         self, suffix: Optional[str] = None, *, name: Optional[str] = None
     ) -> str:
         """Get the name of the Runnable."""
-        name = name or self.name or self.__class__.__name__
-        if suffix:
-            if name[0].isupper():
-                return name + suffix.title()
-            else:
-                return name + "_" + suffix.lower()
+        if name:
+            name_ = name
+        elif hasattr(self, "name") and self.name:
+            name_ = self.name
         else:
-            return name
+            # Here we handle a case where the runnable subclass is also a pydantic
+            # model.
+            cls = self.__class__
+            # Then it's a pydantic sub-class, and we have to check
+            # whether it's a generic, and if so recover the original name.
+            if (
+                hasattr(
+                    cls,
+                    "__pydantic_generic_metadata__",
+                )
+                and "origin" in cls.__pydantic_generic_metadata__
+                and cls.__pydantic_generic_metadata__["origin"] is not None
+            ):
+                name_ = cls.__pydantic_generic_metadata__["origin"].__name__
+            else:
+                name_ = cls.__name__
+
+        if suffix:
+            if name_[0].isupper():
+                return name_ + suffix.title()
+            else:
+                return name_ + "_" + suffix.lower()
+        else:
+            return name_
 
     @property
     def InputType(self) -> Type[Input]:
         """The type of input this Runnable accepts specified as a type annotation."""
+        # First loop through bases -- this will help generic
+        # any pydantic models.
+        for base in self.__class__.mro():
+            if hasattr(base, "__pydantic_generic_metadata__"):
+                metadata = base.__pydantic_generic_metadata__
+                if "args" in metadata and len(metadata["args"]) == 2:
+                    return metadata["args"][0]
+
+        # then loop through __orig_bases__ -- this will Runnables that do not inherit
+        # from pydantic
         for cls in self.__class__.__orig_bases__:  # type: ignore[attr-defined]
             type_args = get_args(cls)
             if type_args and len(type_args) == 2:
@@ -268,6 +298,14 @@ class Runnable(Generic[Input, Output], ABC):
     @property
     def OutputType(self) -> Type[Output]:
         """The type of output this Runnable produces specified as a type annotation."""
+        # First loop through bases -- this will help generic
+        # any pydantic models.
+        for base in self.__class__.mro():
+            if hasattr(base, "__pydantic_generic_metadata__"):
+                metadata = base.__pydantic_generic_metadata__
+                if "args" in metadata and len(metadata["args"]) == 2:
+                    return metadata["args"][1]
+
         for cls in self.__class__.__orig_bases__:  # type: ignore[attr-defined]
             type_args = get_args(cls)
             if type_args and len(type_args) == 2:
@@ -302,12 +340,12 @@ class Runnable(Generic[Input, Output], ABC):
         """
         root_type = self.InputType
 
-        if inspect.isclass(root_type) and is_basemodel_subclass(root_type):
+        if inspect.isclass(root_type) and issubclass(root_type, BaseModel):
             return root_type
 
         return create_model(
             self.get_name("Input"),
-            __root__=(root_type, None),
+            __root__=root_type,
         )
 
     @property
@@ -334,12 +372,12 @@ class Runnable(Generic[Input, Output], ABC):
         """
         root_type = self.OutputType
 
-        if inspect.isclass(root_type) and is_basemodel_subclass(root_type):
+        if inspect.isclass(root_type) and issubclass(root_type, BaseModel):
             return root_type
 
         return create_model(
             self.get_name("Output"),
-            __root__=(root_type, None),
+            __root__=root_type,
         )
 
     @property
@@ -381,15 +419,19 @@ class Runnable(Generic[Input, Output], ABC):
             else None
         )
 
-        return create_model(  # type: ignore[call-overload]
-            self.get_name("Config"),
+        # Many need to create a typed dict instead to implement NotRequired!
+        all_fields = {
             **({"configurable": (configurable, None)} if configurable else {}),
             **{
                 field_name: (field_type, None)
-                for field_name, field_type in RunnableConfig.__annotations__.items()
+                for field_name, field_type in get_type_hints(RunnableConfig).items()
                 if field_name in [i for i in include if i != "configurable"]
             },
+        }
+        model = create_model(  # type: ignore[call-overload]
+            self.get_name("Config"), **all_fields
         )
+        return model
 
     def get_graph(self, config: Optional[RunnableConfig] = None) -> Graph:
         """Return a graph representation of this Runnable."""
@@ -579,7 +621,7 @@ class Runnable(Generic[Input, Output], ABC):
         """
         from langchain_core.runnables.passthrough import RunnableAssign
 
-        return self | RunnableAssign(RunnableParallel(kwargs))
+        return self | RunnableAssign(RunnableParallel[Dict[str, Any]](kwargs))
 
     """ --- Public API --- """
 
@@ -2129,7 +2171,6 @@ class Runnable(Generic[Input, Output], ABC):
             name=config.get("run_name") or self.get_name(),
             run_id=config.pop("run_id", None),
         )
-        iterator_ = None
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())
             if accepts_config(transformer):
@@ -2314,7 +2355,6 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
     """Runnable that can be serialized to JSON."""
 
     name: Optional[str] = None
-    """The name of the Runnable. Used for debugging and tracing."""
 
     def to_json(self) -> Union[SerializedConstructor, SerializedNotImplemented]:
         """Serialize the Runnable to JSON.
@@ -2369,10 +2409,10 @@ class RunnableSerializable(Serializable, Runnable[Input, Output]):
         from langchain_core.runnables.configurable import RunnableConfigurableFields
 
         for key in kwargs:
-            if key not in self.__fields__:
+            if key not in self.model_fields:
                 raise ValueError(
                     f"Configuration key {key} not found in {self}: "
-                    f"available keys are {self.__fields__.keys()}"
+                    f"available keys are {self.model_fields.keys()}"
                 )
 
         return RunnableConfigurableFields(default=self, fields=kwargs)
@@ -2447,13 +2487,13 @@ def _seq_input_schema(
         return first.get_input_schema(config)
     elif isinstance(first, RunnableAssign):
         next_input_schema = _seq_input_schema(steps[1:], config)
-        if not next_input_schema.__custom_root_type__:
+        if not issubclass(next_input_schema, RootModel):
             # it's a dict as expected
             return create_model(  # type: ignore[call-overload]
                 "RunnableSequenceInput",
                 **{
                     k: (v.annotation, v.default)
-                    for k, v in next_input_schema.__fields__.items()
+                    for k, v in next_input_schema.model_fields.items()
                     if k not in first.mapper.steps__
                 },
             )
@@ -2474,36 +2514,36 @@ def _seq_output_schema(
     elif isinstance(last, RunnableAssign):
         mapper_output_schema = last.mapper.get_output_schema(config)
         prev_output_schema = _seq_output_schema(steps[:-1], config)
-        if not prev_output_schema.__custom_root_type__:
+        if not issubclass(prev_output_schema, RootModel):
             # it's a dict as expected
             return create_model(  # type: ignore[call-overload]
                 "RunnableSequenceOutput",
                 **{
                     **{
                         k: (v.annotation, v.default)
-                        for k, v in prev_output_schema.__fields__.items()
+                        for k, v in prev_output_schema.model_fields.items()
                     },
                     **{
                         k: (v.annotation, v.default)
-                        for k, v in mapper_output_schema.__fields__.items()
+                        for k, v in mapper_output_schema.model_fields.items()
                     },
                 },
             )
     elif isinstance(last, RunnablePick):
         prev_output_schema = _seq_output_schema(steps[:-1], config)
-        if not prev_output_schema.__custom_root_type__:
+        if not issubclass(prev_output_schema, RootModel):
             # it's a dict as expected
             if isinstance(last.keys, list):
                 return create_model(  # type: ignore[call-overload]
                     "RunnableSequenceOutput",
                     **{
                         k: (v.annotation, v.default)
-                        for k, v in prev_output_schema.__fields__.items()
+                        for k, v in prev_output_schema.model_fields.items()
                         if k in last.keys
                     },
                 )
             else:
-                field = prev_output_schema.__fields__[last.keys]
+                field = prev_output_schema.model_fields[last.keys]
                 return create_model(  # type: ignore[call-overload]
                     "RunnableSequenceOutput",
                     __root__=(field.annotation, field.default),
@@ -2665,8 +2705,9 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
         """
         return True
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def InputType(self) -> Type[Input]:
@@ -3402,8 +3443,9 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
         """Get the namespace of the langchain object."""
         return ["langchain", "schema", "runnable"]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     def get_name(
         self, suffix: Optional[str] = None, *, name: Optional[str] = None
@@ -3450,7 +3492,7 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
                 **{
                     k: (v.annotation, v.default)
                     for step in self.steps__.values()
-                    for k, v in step.get_input_schema(config).__fields__.items()
+                    for k, v in step.get_input_schema(config).model_fields.items()
                     if k != "__root__"
                 },
             )
@@ -3468,11 +3510,8 @@ class RunnableParallel(RunnableSerializable[Input, Dict[str, Any]]):
         Returns:
             The output schema of the Runnable.
         """
-        # This is correct, but pydantic typings/mypy don't think so.
-        return create_model(  # type: ignore[call-overload]
-            self.get_name("Output"),
-            **{k: (v.OutputType, None) for k, v in self.steps__.items()},
-        )
+        fields = {k: (v.OutputType, ...) for k, v in self.steps__.items()}
+        return create_model(self.get_name("Output"), **fields)
 
     @property
     def config_specs(self) -> List[ConfigurableFieldSpec]:
@@ -3882,6 +3921,8 @@ class RunnableGenerator(Runnable[Input, Output]):
         atransform: Optional[
             Callable[[AsyncIterator[Input]], AsyncIterator[Output]]
         ] = None,
+        *,
+        name: Optional[str] = None,
     ) -> None:
         """Initialize a RunnableGenerator.
 
@@ -3909,9 +3950,9 @@ class RunnableGenerator(Runnable[Input, Output]):
             )
 
         try:
-            self.name = func_for_name.__name__
+            self.name = name or func_for_name.__name__
         except AttributeError:
-            pass
+            self.name = "RunnableGenerator"
 
     @property
     def InputType(self) -> Any:
@@ -4183,15 +4224,13 @@ class RunnableLambda(Runnable[Input, Output]):
             if all(
                 item[0] == "'" and item[-1] == "'" and len(item) > 2 for item in items
             ):
+                fields = {item[1:-1]: (Any, ...) for item in items}
                 # It's a dict, lol
-                return create_model(
-                    self.get_name("Input"),
-                    **{item[1:-1]: (Any, None) for item in items},  # type: ignore
-                )
+                return create_model(self.get_name("Input"), **fields)
             else:
                 return create_model(
                     self.get_name("Input"),
-                    __root__=(List[Any], None),
+                    __root__=List[Any],
                 )
 
         if self.InputType != Any:
@@ -4200,7 +4239,7 @@ class RunnableLambda(Runnable[Input, Output]):
         if dict_keys := get_function_first_arg_dict_keys(func):
             return create_model(
                 self.get_name("Input"),
-                **{key: (Any, None) for key in dict_keys},  # type: ignore
+                **{key: (Any, ...) for key in dict_keys},  # type: ignore
             )
 
         return super().get_input_schema(config)
@@ -4728,8 +4767,9 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
 
     bound: Runnable[Input, Output]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def InputType(self) -> Any:
@@ -4756,10 +4796,7 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
         schema = self.bound.get_output_schema(config)
         return create_model(
             self.get_name("Output"),
-            __root__=(
-                List[schema],  # type: ignore
-                None,
-            ),
+            __root__=List[schema],  # type: ignore[valid-type]
         )
 
     @property
@@ -4979,8 +5016,9 @@ class RunnableBindingBase(RunnableSerializable[Input, Output]):
     The type can be a pydantic model, or a type annotation (e.g., `List[str]`).
     """
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     def __init__(
         self,
@@ -5316,7 +5354,7 @@ class RunnableBindingBase(RunnableSerializable[Input, Output]):
             yield item
 
 
-RunnableBindingBase.update_forward_refs(RunnableConfig=RunnableConfig)
+RunnableBindingBase.model_rebuild()
 
 
 class RunnableBinding(RunnableBindingBase[Input, Output]):

--- a/libs/core/langchain_core/runnables/branch.py
+++ b/libs/core/langchain_core/runnables/branch.py
@@ -14,8 +14,9 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict
+
 from langchain_core.load.dump import dumpd
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import (
     Runnable,
     RunnableLike,
@@ -134,10 +135,21 @@ class RunnableBranch(RunnableSerializable[Input, Output]):
             runnable = coerce_to_runnable(runnable)
             _branches.append((condition, runnable))
 
-        super().__init__(branches=_branches, default=default_)  # type: ignore[call-arg]
+        super().__init__(
+            branches=_branches,
+            default=default_,
+            # Hard-coding a name here because RunnableBranch is a generic
+            # and with pydantic 2, the class name with pydantic will capture
+            # include the parameterized type, which is not what we want.
+            # e.g., we'd get RunnableBranch[Input, Output] instead of RunnableBranch
+            # for the name. This information is already captured in the
+            # input and output types.
+            name="RunnableBranch",
+        )  # type: ignore[call-arg]
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/configurable.py
+++ b/libs/core/langchain_core/runnables/configurable.py
@@ -20,7 +20,8 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel, ConfigDict
+
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
     RunnableConfig,
@@ -58,8 +59,9 @@ class DynamicRunnable(RunnableSerializable[Input, Output]):
 
     config: Optional[RunnableConfig] = None
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @classmethod
     def is_lc_serializable(cls) -> bool:
@@ -373,28 +375,33 @@ class RunnableConfigurableFields(DynamicRunnable[Input, Output]):
         Returns:
             List[ConfigurableFieldSpec]: The configuration specs.
         """
-        return get_unique_config_specs(
-            [
-                (
+        # TODO(0.3): This change removes field_info which isn't needed in pydantic 2
+        config_specs = []
+
+        for field_name, spec in self.fields.items():
+            if isinstance(spec, ConfigurableField):
+                config_specs.append(
                     ConfigurableFieldSpec(
                         id=spec.id,
                         name=spec.name,
                         description=spec.description
-                        or self.default.__fields__[field_name].field_info.description,
+                        or self.default.model_fields[field_name].description,
                         annotation=spec.annotation
-                        or self.default.__fields__[field_name].annotation,
+                        or self.default.model_fields[field_name].annotation,
                         default=getattr(self.default, field_name),
                         is_shared=spec.is_shared,
                     )
-                    if isinstance(spec, ConfigurableField)
-                    else make_options_spec(
-                        spec, self.default.__fields__[field_name].field_info.description
+                )
+            else:
+                config_specs.append(
+                    make_options_spec(
+                        spec, self.default.model_fields[field_name].description
                     )
                 )
-                for field_name, spec in self.fields.items()
-            ]
-            + list(self.default.config_specs)
-        )
+
+        config_specs.extend(self.default.config_specs)
+
+        return get_unique_config_specs(config_specs)
 
     def configurable_fields(
         self, **kwargs: AnyConfigurableField
@@ -436,7 +443,7 @@ class RunnableConfigurableFields(DynamicRunnable[Input, Output]):
             init_params = {
                 k: v
                 for k, v in self.default.__dict__.items()
-                if k in self.default.__fields__
+                if k in self.default.model_fields
             }
             return (
                 self.default.__class__(**{**init_params, **configurable}),

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -18,8 +18,9 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict
+
 from langchain_core.load.dump import dumpd
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableSerializable
 from langchain_core.runnables.config import (
     RunnableConfig,
@@ -107,8 +108,9 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         will not be passed to fallbacks. If used, the base Runnable and its fallbacks 
         must accept a dictionary as input."""
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def InputType(self) -> Type[Input]:

--- a/libs/core/langchain_core/runnables/graph.py
+++ b/libs/core/langchain_core/runnables/graph.py
@@ -22,8 +22,9 @@ from typing import (
 )
 from uuid import UUID, uuid4
 
-from langchain_core.pydantic_v1 import BaseModel
-from langchain_core.utils.pydantic import is_basemodel_subclass
+from pydantic import BaseModel
+
+from langchain_core.utils.pydantic import _IgnoreUnserializable, is_basemodel_subclass
 
 if TYPE_CHECKING:
     from langchain_core.runnables.base import Runnable as RunnableType
@@ -235,7 +236,9 @@ def node_data_json(
         json = (
             {
                 "type": "schema",
-                "data": node.data.schema(),
+                "data": node.data.model_json_schema(
+                    schema_generator=_IgnoreUnserializable
+                ),
             }
             if with_schemas
             else {

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -13,9 +13,10 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel
+
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.load.load import load
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableBindingBase, RunnableLambda
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (
@@ -372,28 +373,25 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     def get_input_schema(
         self, config: Optional[RunnableConfig] = None
     ) -> Type[BaseModel]:
-        super_schema = super().get_input_schema(config)
-        if super_schema.__custom_root_type__ or not super_schema.schema().get(
-            "properties"
-        ):
-            from langchain_core.messages import BaseMessage
+        # TODO(0.3): Verify that this change was correct
+        # Not enough tests and unclear on why the previous implementation was
+        # necessary.
+        from langchain_core.messages import BaseMessage
 
-            fields: Dict = {}
-            if self.input_messages_key and self.history_messages_key:
-                fields[self.input_messages_key] = (
-                    Union[str, BaseMessage, Sequence[BaseMessage]],
-                    ...,
-                )
-            elif self.input_messages_key:
-                fields[self.input_messages_key] = (Sequence[BaseMessage], ...)
-            else:
-                fields["__root__"] = (Sequence[BaseMessage], ...)
-            return create_model(  # type: ignore[call-overload]
-                "RunnableWithChatHistoryInput",
-                **fields,
+        fields: Dict = {}
+        if self.input_messages_key and self.history_messages_key:
+            fields[self.input_messages_key] = (
+                Union[str, BaseMessage, Sequence[BaseMessage]],
+                ...,
             )
+        elif self.input_messages_key:
+            fields[self.input_messages_key] = (Sequence[BaseMessage], ...)
         else:
-            return super_schema
+            fields["__root__"] = (Sequence[BaseMessage], ...)
+        return create_model(  # type: ignore[call-overload]
+            "RunnableWithChatHistoryInput",
+            **fields,
+        )
 
     def _is_not_async(self, *args: Sequence[Any], **kwargs: Dict[str, Any]) -> bool:
         return False

--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -21,7 +21,8 @@ from typing import (
     cast,
 )
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel, RootModel
+
 from langchain_core.runnables.base import (
     Other,
     Runnable,
@@ -227,7 +228,7 @@ class RunnablePassthrough(RunnableSerializable[Other, Other]):
             A Runnable that merges the Dict input with the output produced by the
             mapping argument.
         """
-        return RunnableAssign(RunnableParallel(kwargs))
+        return RunnableAssign(RunnableParallel[Dict[str, Any]](kwargs))
 
     def invoke(
         self, input: Other, config: Optional[RunnableConfig] = None, **kwargs: Any
@@ -419,7 +420,7 @@ class RunnableAssign(RunnableSerializable[Dict[str, Any], Dict[str, Any]]):
         self, config: Optional[RunnableConfig] = None
     ) -> Type[BaseModel]:
         map_input_schema = self.mapper.get_input_schema(config)
-        if not map_input_schema.__custom_root_type__:
+        if not issubclass(map_input_schema, RootModel):
             # ie. it's a dict
             return map_input_schema
 
@@ -430,20 +431,22 @@ class RunnableAssign(RunnableSerializable[Dict[str, Any], Dict[str, Any]]):
     ) -> Type[BaseModel]:
         map_input_schema = self.mapper.get_input_schema(config)
         map_output_schema = self.mapper.get_output_schema(config)
-        if (
-            not map_input_schema.__custom_root_type__
-            and not map_output_schema.__custom_root_type__
+        if not issubclass(map_input_schema, RootModel) and not issubclass(
+            map_output_schema, RootModel
         ):
-            # ie. both are dicts
+            fields = {}
+
+            for name, field_info in map_input_schema.model_fields.items():
+                fields[name] = (field_info.annotation, field_info.default)
+
+            for name, field_info in map_output_schema.model_fields.items():
+                fields[name] = (field_info.annotation, field_info.default)
+
             return create_model(  # type: ignore[call-overload]
                 "RunnableAssignOutput",
-                **{
-                    k: (v.type_, v.default)
-                    for s in (map_input_schema, map_output_schema)
-                    for k, v in s.__fields__.items()
-                },
+                **fields,
             )
-        elif not map_output_schema.__custom_root_type__:
+        elif not issubclass(map_output_schema, RootModel):
             # ie. only map output is a dict
             # ie. input type is either unknown or inferred incorrectly
             return map_output_schema

--- a/libs/core/langchain_core/runnables/router.py
+++ b/libs/core/langchain_core/runnables/router.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
 )
 
+from pydantic import ConfigDict
 from typing_extensions import TypedDict
 
 from langchain_core.runnables.base import (
@@ -83,8 +84,9 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
             runnables={key: coerce_to_runnable(r) for key, r in runnables.items()}
         )
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -31,7 +31,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel, ConfigDict, RootModel  # pydantic: ignore
+from pydantic import BaseModel, ConfigDict, RootModel  
 from pydantic import create_model as _create_model_base  # pydantic :ignore
 from pydantic.json_schema import (
     DEFAULT_REF_TEMPLATE,

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, List, Optional, Sequence, Union
 
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 
 class Visitor(ABC):
@@ -127,7 +127,8 @@ class Comparison(FilterDirective):
     def __init__(
         self, comparator: Comparator, attribute: str, value: Any, **kwargs: Any
     ) -> None:
-        super().__init__(
+        # super exists from BaseModel
+        super().__init__(  # type: ignore[call-arg]
             comparator=comparator, attribute=attribute, value=value, **kwargs
         )
 
@@ -145,8 +146,11 @@ class Operation(FilterDirective):
 
     def __init__(
         self, operator: Operator, arguments: List[FilterDirective], **kwargs: Any
-    ):
-        super().__init__(operator=operator, arguments=arguments, **kwargs)
+    ) -> None:
+        # super exists from BaseModel
+        super().__init__(  # type: ignore[call-arg]
+            operator=operator, arguments=arguments, **kwargs
+        )
 
 
 class StructuredQuery(Expr):
@@ -165,5 +169,8 @@ class StructuredQuery(Expr):
         filter: Optional[FilterDirective],
         limit: Optional[int] = None,
         **kwargs: Any,
-    ):
-        super().__init__(query=query, filter=filter, limit=limit, **kwargs)
+    ) -> None:
+        # super exists from BaseModel
+        super().__init__(  # type: ignore[call-arg]
+            query=query, filter=filter, limit=limit, **kwargs
+        )

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -10,7 +10,6 @@ from abc import ABC, abstractmethod
 from contextvars import copy_context
 from inspect import signature
 from typing import (
-    Annotated,
     Any,
     Callable,
     Dict,
@@ -38,6 +37,7 @@ from pydantic import (
     model_validator,
     validate_arguments,
 )
+from typing_extensions import Annotated
 
 from langchain_core._api import deprecated
 from langchain_core.callbacks import (

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from contextvars import copy_context
 from inspect import signature
 from typing import (
+    Annotated,
     Any,
     Callable,
     Dict,
@@ -19,12 +20,24 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
+    get_args,
+    get_origin,
     get_type_hints,
 )
 
-from typing_extensions import Annotated, TypeVar, get_args, get_origin
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Extra,
+    Field,
+    SkipValidation,
+    ValidationError,
+    model_validator,
+    validate_arguments,
+)
 
 from langchain_core._api import deprecated
 from langchain_core.callbacks import (
@@ -33,16 +46,7 @@ from langchain_core.callbacks import (
     CallbackManager,
     Callbacks,
 )
-from langchain_core.load import Serializable
-from langchain_core.messages import ToolCall, ToolMessage
-from langchain_core.pydantic_v1 import (
-    BaseModel,
-    Extra,
-    Field,
-    ValidationError,
-    root_validator,
-    validate_arguments,
-)
+from langchain_core.messages.tool import ToolCall, ToolMessage
 from langchain_core.runnables import (
     RunnableConfig,
     RunnableSerializable,
@@ -59,6 +63,7 @@ from langchain_core.utils.function_calling import (
 from langchain_core.utils.pydantic import (
     TypeBaseModel,
     _create_subset_model,
+    get_fields,
     is_basemodel_subclass,
     is_pydantic_v1_subclass,
     is_pydantic_v2_subclass,
@@ -204,20 +209,64 @@ def create_schema_from_function(
     """
     # https://docs.pydantic.dev/latest/usage/validation_decorator/
     validated = validate_arguments(func, config=_SchemaConfig)  # type: ignore
+
+    sig = inspect.signature(func)
+
+    # Let's ignore `self` and `cls` arguments for class and instance methods
+    if func.__qualname__ and "." in func.__qualname__:
+        # Then it likely belongs in a class namespace
+        in_class = True
+    else:
+        in_class = False
+
+    has_args = False
+    has_kwargs = False
+
+    for param in sig.parameters.values():
+        if param.kind == param.VAR_POSITIONAL:
+            has_args = True
+        elif param.kind == param.VAR_KEYWORD:
+            has_kwargs = True
+
     inferred_model = validated.model  # type: ignore
-    filter_args = filter_args if filter_args is not None else FILTERED_ARGS
-    for arg in filter_args:
-        if arg in inferred_model.__fields__:
-            del inferred_model.__fields__[arg]
+
+    if filter_args:
+        filter_args_ = filter_args
+    else:
+        # Handle classmethods and instance methods
+        existing_params: List[str] = list(sig.parameters.keys())
+        if existing_params and existing_params[0] in ("self", "cls") and in_class:
+            filter_args_ = [existing_params[0]] + list(FILTERED_ARGS)
+        else:
+            filter_args_ = list(FILTERED_ARGS)
+
+        for existing_param in existing_params:
+            if not include_injected and _is_injected_arg_type(
+                sig.parameters[existing_param].annotation
+            ):
+                filter_args_.append(existing_param)
+
     description, arg_descriptions = _infer_arg_descriptions(
         func,
         parse_docstring=parse_docstring,
         error_on_invalid_docstring=error_on_invalid_docstring,
     )
     # Pydantic adds placeholder virtual fields we need to strip
-    valid_properties = _get_filtered_args(
-        inferred_model, func, filter_args=filter_args, include_injected=include_injected
-    )
+    valid_properties = []
+    for field in get_fields(inferred_model):
+        if not has_args:
+            if field == "args":
+                continue
+        if not has_kwargs:
+            if field == "kwargs":
+                continue
+
+        if field == "v__duplicate_kwargs":  # Internal pydantic field
+            continue
+
+        if field not in filter_args_:
+            valid_properties.append(field)
+
     return _create_subset_model(
         f"{model_name}Schema",
         inferred_model,
@@ -274,7 +323,10 @@ class ChildTool(BaseTool):
     
     You can provide few-shot examples as a part of the description.
     """
-    args_schema: Optional[TypeBaseModel] = None
+
+    args_schema: Annotated[Optional[TypeBaseModel], SkipValidation()] = Field(
+        default=None, description="The tool schema."
+    )
     """Pydantic model class to validate and parse the tool's input arguments.
     
     Args schema should be either: 
@@ -345,8 +397,9 @@ class ChildTool(BaseTool):
                 )
         super().__init__(**kwargs)
 
-    class Config(Serializable.Config):
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
     @property
     def is_single_input(self) -> bool:
@@ -416,7 +469,7 @@ class ChildTool(BaseTool):
         input_args = self.args_schema
         if isinstance(tool_input, str):
             if input_args is not None:
-                key_ = next(iter(input_args.__fields__.keys()))
+                key_ = next(iter(get_fields(input_args).keys()))
                 input_args.validate({key_: tool_input})
             return tool_input
         else:
@@ -429,8 +482,9 @@ class ChildTool(BaseTool):
                 }
             return tool_input
 
-    @root_validator(pre=True)
-    def raise_deprecation(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def raise_deprecation(cls, values: Dict) -> Any:
         """Raise deprecation warning if callback_manager is used.
 
         Args:

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -1,8 +1,9 @@
 import inspect
 from typing import Any, Callable, Dict, Literal, Optional, Type, Union, get_type_hints
 
+from pydantic import BaseModel, Field, create_model
+
 from langchain_core.callbacks import Callbacks
-from langchain_core.pydantic_v1 import BaseModel, Field, create_model
 from langchain_core.runnables import Runnable
 from langchain_core.tools.base import BaseTool
 from langchain_core.tools.simple import Tool

--- a/libs/core/langchain_core/tools/retriever.py
+++ b/libs/core/langchain_core/tools/retriever.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from functools import partial
 from typing import Optional
 
+from pydantic import BaseModel, Field
+
 from langchain_core.callbacks import Callbacks
 from langchain_core.prompts import (
     BasePromptTemplate,
@@ -10,7 +12,6 @@ from langchain_core.prompts import (
     aformat_document,
     format_document,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.tools.simple import Tool
 

--- a/libs/core/langchain_core/tools/simple.py
+++ b/libs/core/langchain_core/tools/simple.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 from inspect import signature
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+
+from pydantic import BaseModel
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
 from langchain_core.messages import ToolCall
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import RunnableConfig, run_in_executor
 from langchain_core.tools.base import (
     BaseTool,
@@ -155,3 +165,6 @@ class Tool(BaseTool):
             args_schema=args_schema,
             **kwargs,
         )
+
+
+Tool.model_rebuild()

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -2,14 +2,26 @@ from __future__ import annotations
 
 import textwrap
 from inspect import signature
-from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import (
+    Annotated,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
+
+from pydantic import BaseModel, Field, SkipValidation
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
 from langchain_core.messages import ToolCall
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import RunnableConfig, run_in_executor
 from langchain_core.tools.base import (
     FILTERED_ARGS,
@@ -24,7 +36,9 @@ class StructuredTool(BaseTool):
     """Tool that can operate on any number of inputs."""
 
     description: str = ""
-    args_schema: TypeBaseModel = Field(..., description="The tool schema.")
+    args_schema: Annotated[TypeBaseModel, SkipValidation()] = Field(
+        ..., description="The tool schema."
+    )
     """The input arguments' schema."""
     func: Optional[Callable[..., Any]]
     """The function to run when the tool is called."""

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import textwrap
 from inspect import signature
 from typing import (
-    Annotated,
     Any,
     Awaitable,
     Callable,
@@ -16,6 +15,7 @@ from typing import (
 )
 
 from pydantic import BaseModel, Field, SkipValidation
+from typing_extensions import Annotated
 
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,

--- a/libs/core/langchain_core/tracers/schemas.py
+++ b/libs/core/langchain_core/tracers/schemas.py
@@ -11,7 +11,6 @@ from langsmith.schemas import RunBase as BaseRunV2
 from langsmith.schemas import RunTypeEnum as RunTypeEnumDep
 
 from langchain_core._api import deprecated
-from langchain_core.outputs import LLMResult
 from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
 
 
@@ -83,7 +82,8 @@ class LLMRun(BaseRun):
     """Class for LLMRun."""
 
     prompts: List[str]
-    response: Optional[LLMResult] = None
+    # Temporarily, remove but we will completely remove LLMRun
+    # response: Optional[LLMResult] = None
 
 
 @deprecated("0.1.0", alternative="Run", removal="1.0")

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -196,7 +196,7 @@ def convert_python_function_to_openai_function(
 
 def _convert_typed_dict_to_openai_function(typed_dict: Type) -> FunctionDescription:
     visited: Dict = {}
-    from pydantic.v1 import BaseModel  # pydantic: ignore
+    from pydantic.v1 import BaseModel  
 
     model = cast(
         Type[BaseModel],
@@ -214,8 +214,8 @@ def _convert_any_typed_dicts_to_pydantic(
     visited: Dict,
     depth: int = 0,
 ) -> Type:
-    from pydantic.v1 import Field as Field_v1  # pydantic: ignore
-    from pydantic.v1 import create_model as create_model_v1  # pydantic: ignore
+    from pydantic.v1 import Field as Field_v1  
+    from pydantic.v1 import create_model as create_model_v1  
 
     if type_ in visited:
         return visited[type_]

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -23,11 +23,11 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel
 from typing_extensions import Annotated, TypedDict, get_args, get_origin, is_typeddict
 
 from langchain_core._api import deprecated
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
-from langchain_core.pydantic_v1 import BaseModel, Field, create_model
 from langchain_core.utils.json_schema import dereference_refs
 from langchain_core.utils.pydantic import is_basemodel_subclass
 
@@ -85,7 +85,7 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
     removal="1.0",
 )
 def convert_pydantic_to_openai_function(
-    model: Type[BaseModel],
+    model: Type,
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
@@ -109,7 +109,10 @@ def convert_pydantic_to_openai_function(
     else:
         schema = model.schema()  # Pydantic 1
     schema = dereference_refs(schema)
-    schema.pop("definitions", None)
+    if "definitions" in schema:  # pydantic 1
+        schema.pop("definitions", None)
+    if "$defs" in schema:  # pydantic 2
+        schema.pop("$defs", None)
     title = schema.pop("title", "")
     default_description = schema.pop("description", "")
     return {
@@ -193,11 +196,13 @@ def convert_python_function_to_openai_function(
 
 def _convert_typed_dict_to_openai_function(typed_dict: Type) -> FunctionDescription:
     visited: Dict = {}
+    from pydantic.v1 import BaseModel  # pydantic: ignore
+
     model = cast(
         Type[BaseModel],
         _convert_any_typed_dicts_to_pydantic(typed_dict, visited=visited),
     )
-    return convert_pydantic_to_openai_function(model)
+    return convert_pydantic_to_openai_function(model)  # type: ignore
 
 
 _MAX_TYPED_DICT_RECURSION = 25
@@ -209,6 +214,9 @@ def _convert_any_typed_dicts_to_pydantic(
     visited: Dict,
     depth: int = 0,
 ) -> Type:
+    from pydantic.v1 import Field as Field_v1  # pydantic: ignore
+    from pydantic.v1 import create_model as create_model_v1  # pydantic: ignore
+
     if type_ in visited:
         return visited[type_]
     elif depth >= _MAX_TYPED_DICT_RECURSION:
@@ -242,7 +250,7 @@ def _convert_any_typed_dicts_to_pydantic(
                     field_kwargs["description"] = arg_desc
                 else:
                     pass
-                fields[arg] = (new_arg_type, Field(**field_kwargs))
+                fields[arg] = (new_arg_type, Field_v1(**field_kwargs))
             else:
                 new_arg_type = _convert_any_typed_dicts_to_pydantic(
                     arg_type, depth=depth + 1, visited=visited
@@ -250,8 +258,8 @@ def _convert_any_typed_dicts_to_pydantic(
                 field_kwargs = {"default": ...}
                 if arg_desc := arg_descriptions.get(arg):
                     field_kwargs["description"] = arg_desc
-                fields[arg] = (new_arg_type, Field(**field_kwargs))
-        model = create_model(typed_dict.__name__, **fields)
+                fields[arg] = (new_arg_type, Field_v1(**field_kwargs))
+        model = create_model_v1(typed_dict.__name__, **fields)
         model.__doc__ = description
         visited[typed_dict] = model
         return model

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -7,10 +7,10 @@ import textwrap
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, overload
 
-import pydantic  # pydantic: ignore
-from pydantic import BaseModel, root_validator  # pydantic: ignore
-from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue  # pydantic: ignore
-from pydantic_core import core_schema  # pydantic: ignore
+import pydantic  
+from pydantic import BaseModel, root_validator  
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue  
+from pydantic_core import core_schema  
 
 
 def get_pydantic_major_version() -> int:
@@ -77,13 +77,13 @@ def is_basemodel_subclass(cls: Type) -> bool:
         return False
 
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV1Proper  
 
         if issubclass(cls, BaseModelV1Proper):
             return True
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
-        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV2  
+        from pydantic.v1 import BaseModel as BaseModelV1  
 
         if issubclass(cls, BaseModelV2):
             return True
@@ -105,13 +105,13 @@ def is_basemodel_instance(obj: Any) -> bool:
     * pydantic.v1.BaseModel in Pydantic 2.x
     """
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV1Proper  
 
         if isinstance(obj, BaseModelV1Proper):
             return True
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
-        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV2  
+        from pydantic.v1 import BaseModel as BaseModelV1  
 
         if isinstance(obj, BaseModelV2):
             return True
@@ -222,9 +222,9 @@ def _create_subset_model_v1(
 ) -> Type[BaseModel]:
     """Create a pydantic model with only a subset of model's fields."""
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import create_model  # pydantic: ignore
+        from pydantic import create_model  
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic.v1 import create_model  # type: ignore # pydantic: ignore
+        from pydantic.v1 import create_model  # type: ignore 
     else:
         raise NotImplementedError(
             f"Unsupported pydantic version: {PYDANTIC_MAJOR_VERSION}"
@@ -259,8 +259,8 @@ def _create_subset_model_v2(
     fn_description: Optional[str] = None,
 ) -> Type[pydantic.BaseModel]:
     """Create a pydantic model with a subset of the model fields."""
-    from pydantic import create_model  # pydantic: ignore
-    from pydantic.fields import FieldInfo  # pydantic: ignore
+    from pydantic import create_model  
+    from pydantic.fields import FieldInfo  
 
     descriptions_ = descriptions or {}
     fields = {}
@@ -299,7 +299,7 @@ def _create_subset_model(
             fn_description=fn_description,
         )
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic.v1 import BaseModel as BaseModelV1  
 
         if issubclass(model, BaseModelV1):
             return _create_subset_model_v1(

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -8,8 +8,9 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, overload
 
 import pydantic  # pydantic: ignore
-
-from langchain_core.pydantic_v1 import BaseModel, root_validator
+from pydantic import BaseModel, root_validator  # pydantic: ignore
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue  # pydantic: ignore
+from pydantic_core import core_schema  # pydantic: ignore
 
 
 def get_pydantic_major_version() -> int:
@@ -146,7 +147,7 @@ def pre_init(func: Callable) -> Any:
             Dict[str, Any]: The values to initialize the model with.
         """
         # Insert default values
-        fields = cls.__fields__
+        fields = cls.model_fields
         for name, field_info in fields.items():
             # Check if allow_population_by_field_name is enabled
             # If yes, then set the field name to the alias
@@ -155,9 +156,13 @@ def pre_init(func: Callable) -> Any:
                     if cls.Config.allow_population_by_field_name:
                         if field_info.alias in values:
                             values[name] = values.pop(field_info.alias)
+            if hasattr(cls, "model_config"):
+                if cls.model_config.get("populate_by_name"):
+                    if field_info.alias in values:
+                        values[name] = values.pop(field_info.alias)
 
             if name not in values or values[name] is None:
-                if not field_info.required:
+                if not field_info.is_required():
                     if field_info.default_factory is not None:
                         values[name] = field_info.default_factory()
                     else:
@@ -169,6 +174,44 @@ def pre_init(func: Callable) -> Any:
     return wrapper
 
 
+class _IgnoreUnserializable(GenerateJsonSchema):
+    """A JSON schema generator that ignores unknown types.
+
+    https://docs.pydantic.dev/latest/concepts/json_schema/#customizing-the-json-schema-generation-process
+    """
+
+    def handle_invalid_for_json_schema(
+        self, schema: core_schema.CoreSchema, error_info: str
+    ) -> JsonSchemaValue:
+        return {}
+
+
+def v1_repr(obj: BaseModel) -> str:
+    """Return the schema of the object as a string.
+
+    Get a repr for the pydantic object which is consistent with pydantic.v1.
+    """
+    if not is_basemodel_instance(obj):
+        raise TypeError(f"Expected a pydantic BaseModel, got {type(obj)}")
+    repr_ = []
+    for name, field in get_fields(obj).items():
+        value = getattr(obj, name)
+
+        if isinstance(value, BaseModel):
+            repr_.append(f"{name}={v1_repr(value)}")
+        else:
+            if not field.is_required():
+                if not value:
+                    continue
+                if field.default == value:
+                    continue
+
+            repr_.append(f"{name}={repr(value)}")
+
+    args = ", ".join(repr_)
+    return f"{obj.__class__.__name__}({args})"
+
+
 def _create_subset_model_v1(
     name: str,
     model: Type[BaseModel],
@@ -178,12 +221,20 @@ def _create_subset_model_v1(
     fn_description: Optional[str] = None,
 ) -> Type[BaseModel]:
     """Create a pydantic model with only a subset of model's fields."""
-    from langchain_core.pydantic_v1 import create_model
+    if PYDANTIC_MAJOR_VERSION == 1:
+        from pydantic import create_model  # pydantic: ignore
+    elif PYDANTIC_MAJOR_VERSION == 2:
+        from pydantic.v1 import create_model  # type: ignore # pydantic: ignore
+    else:
+        raise NotImplementedError(
+            f"Unsupported pydantic version: {PYDANTIC_MAJOR_VERSION}"
+        )
 
     fields = {}
 
     for field_name in field_names:
-        field = model.__fields__[field_name]
+        # Using pydantic v1 so can access __fields__ as a dict.
+        field = model.__fields__[field_name]  # type: ignore
         t = (
             # this isn't perfect but should work for most functions
             field.outer_type_

--- a/libs/core/langchain_core/utils/utils.py
+++ b/libs/core/langchain_core/utils/utils.py
@@ -10,9 +10,9 @@ from importlib.metadata import version
 from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, Union, overload
 
 from packaging.version import parse
+from pydantic import SecretStr
 from requests import HTTPError, Response
 
-from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils.pydantic import (
     is_pydantic_v1_subclass,
 )

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -42,8 +42,9 @@ from typing import (
     TypeVar,
 )
 
+from pydantic import ConfigDict, Field, model_validator
+
 from langchain_core.embeddings import Embeddings
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.retrievers import BaseRetriever, LangSmithRetrieverParams
 from langchain_core.runnables.config import run_in_executor
 
@@ -984,11 +985,13 @@ class VectorStoreRetriever(BaseRetriever):
         "mmr",
     )
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
-    @root_validator(pre=True)
-    def validate_search_type(cls, values: Dict) -> Dict:
+    @model_validator(mode="before")
+    @classmethod
+    def validate_search_type(cls, values: Dict) -> Any:
         """Validate search type.
 
         Args:

--- a/libs/core/langchain_core/vectorstores/utils.py
+++ b/libs/core/langchain_core/vectorstores/utils.py
@@ -51,7 +51,7 @@ def _cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
             f"and Y has shape {Y.shape}."
         )
     try:
-        import simsimd as simd
+        import simsimd as simd  # type: ignore[import-not-found]
 
         X = np.array(X, dtype=np.float32)
         Y = np.array(Y, dtype=np.float32)

--- a/libs/core/tests/unit_tests/_api/test_beta_decorator.py
+++ b/libs/core/tests/unit_tests/_api/test_beta_decorator.py
@@ -3,9 +3,9 @@ import warnings
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core._api.beta_decorator import beta, warn_beta
-from langchain_core.pydantic_v1 import BaseModel
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/_api/test_deprecation.py
+++ b/libs/core/tests/unit_tests/_api/test_deprecation.py
@@ -3,13 +3,13 @@ import warnings
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core._api.deprecation import (
     deprecated,
     rename_parameter,
     warn_deprecated,
 )
-from langchain_core.pydantic_v1 import BaseModel
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/fake/callbacks.py
+++ b/libs/core/tests/unit_tests/fake/callbacks.py
@@ -4,9 +4,10 @@ from itertools import chain
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
+from pydantic import BaseModel
+
 from langchain_core.callbacks.base import AsyncCallbackHandler, BaseCallbackHandler
 from langchain_core.messages import BaseMessage
-from langchain_core.pydantic_v1 import BaseModel
 
 
 class BaseFakeCallbackHandler(BaseModel):
@@ -256,7 +257,8 @@ class FakeCallbackHandler(BaseCallbackHandler, BaseFakeCallbackHandlerMixin):
     ) -> Any:
         self.on_retriever_error_common()
 
-    def __deepcopy__(self, memo: dict) -> "FakeCallbackHandler":
+    # Overriding since BaseModel has __deepcopy__ method as well
+    def __deepcopy__(self, memo: dict) -> "FakeCallbackHandler":  # type: ignore
         return self
 
 
@@ -390,5 +392,6 @@ class FakeAsyncCallbackHandler(AsyncCallbackHandler, BaseFakeCallbackHandlerMixi
     ) -> None:
         self.on_text_common()
 
-    def __deepcopy__(self, memo: dict) -> "FakeAsyncCallbackHandler":
+    # Overriding since BaseModel has __deepcopy__ method as well
+    def __deepcopy__(self, memo: dict) -> "FakeAsyncCallbackHandler":  # type: ignore
         return self

--- a/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
+++ b/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
@@ -9,7 +9,6 @@ from langchain_core.language_models import GenericFakeChatModel, ParrotFakeChatM
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 from tests.unit_tests.stubs import (
-    AnyStr,
     _AnyIdAIMessage,
     _AnyIdAIMessageChunk,
     _AnyIdHumanMessage,
@@ -70,8 +69,8 @@ async def test_generic_fake_chat_model_stream() -> None:
     model = GenericFakeChatModel(messages=cycle([message]))
     chunks = [chunk async for chunk in model.astream("meow")]
     assert chunks == [
-        AIMessageChunk(content="", additional_kwargs={"foo": 42}, id=AnyStr()),
-        AIMessageChunk(content="", additional_kwargs={"bar": 24}, id=AnyStr()),
+        _AnyIdAIMessageChunk(content="", additional_kwargs={"foo": 42}),
+        _AnyIdAIMessageChunk(content="", additional_kwargs={"bar": 24}),
     ]
     assert len({chunk.id for chunk in chunks}) == 1
 
@@ -89,29 +88,23 @@ async def test_generic_fake_chat_model_stream() -> None:
     chunks = [chunk async for chunk in model.astream("meow")]
 
     assert chunks == [
-        AIMessageChunk(
-            content="",
-            additional_kwargs={"function_call": {"name": "move_file"}},
-            id=AnyStr(),
+        _AnyIdAIMessageChunk(
+            content="", additional_kwargs={"function_call": {"name": "move_file"}}
         ),
-        AIMessageChunk(
+        _AnyIdAIMessageChunk(
             content="",
             additional_kwargs={
                 "function_call": {"arguments": '{\n  "source_path": "foo"'},
             },
-            id=AnyStr(),
         ),
-        AIMessageChunk(
-            content="",
-            additional_kwargs={"function_call": {"arguments": ","}},
-            id=AnyStr(),
+        _AnyIdAIMessageChunk(
+            content="", additional_kwargs={"function_call": {"arguments": ","}}
         ),
-        AIMessageChunk(
+        _AnyIdAIMessageChunk(
             content="",
             additional_kwargs={
                 "function_call": {"arguments": '\n  "destination_path": "bar"\n}'},
             },
-            id=AnyStr(),
         ),
     ]
     assert len({chunk.id for chunk in chunks}) == 1

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional as Optional
 
 from langchain_core.caches import InMemoryCache
 from langchain_core.language_models import GenericFakeChatModel
@@ -218,6 +219,9 @@ class SerializableModel(GenericFakeChatModel):
     @classmethod
     def is_lc_serializable(cls) -> bool:
         return True
+
+
+SerializableModel.model_rebuild()
 
 
 def test_serialization_with_rate_limiter() -> None:

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -1,8 +1,9 @@
 from typing import Dict
 
+from pydantic import ConfigDict, Field
+
 from langchain_core.load import Serializable, dumpd
 from langchain_core.load.serializable import _is_field_useful
-from langchain_core.pydantic_v1 import Field
 
 
 def test_simple_serialization() -> None:
@@ -40,8 +41,9 @@ def test_simple_serialization_is_serializable() -> None:
 
 def test_simple_serialization_secret() -> None:
     """Test handling of secrets."""
+    from pydantic import SecretStr
+
     from langchain_core.load import Serializable
-    from langchain_core.pydantic_v1 import SecretStr
 
     class Foo(Serializable):
         bar: int
@@ -97,8 +99,9 @@ def test__is_field_useful() -> None:
         # Make sure works for fields without default.
         z: ArrayObj
 
-        class Config:
-            arbitrary_types_allowed = True
+        model_config = ConfigDict(
+            arbitrary_types_allowed=True,
+        )
 
     foo = Foo(x=ArrayObj(), y=NonBoolObj(), z=ArrayObj())
     assert _is_field_useful(foo, "x", foo.x)

--- a/libs/core/tests/unit_tests/output_parsers/test_base_parsers.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_base_parsers.py
@@ -1,6 +1,7 @@
 """Module to test base parser implementations."""
 
 from typing import List
+from typing import Optional as Optional
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import GenericFakeChatModel
@@ -45,6 +46,8 @@ def test_base_generation_parser() -> None:
             content = generation.message.content
             assert isinstance(content, str)
             return content.swapcase()  # type: ignore
+
+    StrInvertCase.model_rebuild()
 
     model = GenericFakeChatModel(messages=iter([AIMessage(content="hEllo")]))
     chain = model | StrInvertCase()

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -2,12 +2,12 @@ import json
 from typing import Any, AsyncIterator, Iterator, Tuple
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers.json import (
     SimpleJsonOutputParser,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.utils.function_calling import convert_to_openai_function
 from langchain_core.utils.json import parse_json_markdown, parse_partial_json
 from tests.unit_tests.pydantic_utils import _schema

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_functions.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_functions.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -10,7 +11,6 @@ from langchain_core.output_parsers.openai_functions import (
     PydanticOutputFunctionsParser,
 )
 from langchain_core.outputs import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel
 
 
 def test_json_output_function_parser() -> None:

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -1,6 +1,7 @@
 from typing import Any, AsyncIterator, Iterator, List
 
 import pytest
+from pydantic import BaseModel, Field
 
 from langchain_core.messages import (
     AIMessage,
@@ -14,7 +15,6 @@ from langchain_core.output_parsers.openai_tools import (
     PydanticToolsParser,
 )
 from langchain_core.outputs import ChatGeneration
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION
 
 STREAMED_MESSAGES: list = [

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -531,7 +531,7 @@ async def test_partial_pydantic_output_parser_async() -> None:
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="This test is for pydantic 2")
 def test_parse_with_different_pydantic_2_v1() -> None:
     """Test with pydantic.v1.BaseModel from pydantic 2."""
-    import pydantic  # pydantic: ignore
+    import pydantic  
 
     class Forecast(pydantic.v1.BaseModel):
         temperature: int
@@ -566,7 +566,7 @@ def test_parse_with_different_pydantic_2_v1() -> None:
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="This test is for pydantic 2")
 def test_parse_with_different_pydantic_2_proper() -> None:
     """Test with pydantic.BaseModel from pydantic 2."""
-    import pydantic  # pydantic: ignore
+    import pydantic  
 
     class Forecast(pydantic.BaseModel):
         temperature: int
@@ -601,7 +601,7 @@ def test_parse_with_different_pydantic_2_proper() -> None:
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 1, reason="This test is for pydantic 1")
 def test_parse_with_different_pydantic_1_proper() -> None:
     """Test with pydantic.BaseModel from pydantic 1."""
-    import pydantic  # pydantic: ignore
+    import pydantic  
 
     class Forecast(pydantic.BaseModel):
         temperature: int

--- a/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -5,20 +5,15 @@ from typing import Literal, Optional
 
 import pydantic  # pydantic: ignore
 import pytest
+from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel as V1BaseModel  # pydantic: ignore
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import ParrotFakeChatModel
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.output_parsers.json import JsonOutputParser
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, Field
-from langchain_core.utils.pydantic import PYDANTIC_MAJOR_VERSION, TBaseModel
-
-V1BaseModel = pydantic.BaseModel
-if PYDANTIC_MAJOR_VERSION == 2:
-    from pydantic.v1 import BaseModel  # pydantic: ignore
-
-    V1BaseModel = BaseModel  # type: ignore
+from langchain_core.utils.pydantic import TBaseModel
 
 
 class ForecastV2(pydantic.BaseModel):
@@ -194,7 +189,7 @@ def test_pydantic_output_parser_type_inference() -> None:
 
 def test_format_instructions_preserves_language() -> None:
     """Test format instructions does not attempt to encode into ascii."""
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     description = (
         "你好, こんにちは, नमस्ते, Bonjour, Hola, "

--- a/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_pydantic_parser.py
@@ -3,10 +3,10 @@
 from enum import Enum
 from typing import Literal, Optional
 
-import pydantic  # pydantic: ignore
+import pydantic  
 import pytest
 from pydantic import BaseModel, Field
-from pydantic.v1 import BaseModel as V1BaseModel  # pydantic: ignore
+from pydantic.v1 import BaseModel as V1BaseModel  
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import ParrotFakeChatModel

--- a/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
+++ b/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
@@ -3,6 +3,7 @@
   dict({
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -44,8 +45,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -57,8 +66,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -74,6 +91,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -82,7 +100,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -92,6 +118,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -120,12 +147,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -136,6 +179,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -152,6 +196,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -189,8 +234,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -201,6 +254,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -217,6 +271,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -273,18 +328,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -300,24 +372,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -335,6 +442,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -386,18 +494,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -413,20 +538,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -443,6 +592,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -513,12 +663,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -538,6 +704,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -554,6 +721,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -620,6 +802,7 @@
   dict({
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -661,8 +844,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -674,8 +865,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -691,6 +890,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -699,7 +899,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -709,6 +917,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -737,12 +946,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -753,6 +978,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -769,6 +995,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -806,8 +1033,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -818,6 +1053,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -834,6 +1070,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -890,18 +1127,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -917,24 +1171,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -952,6 +1241,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -1003,18 +1293,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -1030,20 +1337,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -1060,6 +1391,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -1130,12 +1462,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -1155,6 +1503,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -1171,6 +1520,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -1436,7 +1800,7 @@
     'type': 'constructor',
   })
 # ---
-# name: test_chat_prompt_w_msgs_placeholder_ser_des[placholder]
+# name: test_chat_prompt_w_msgs_placeholder_ser_des[placeholder]
   dict({
     'id': list([
       'langchain',

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -4,9 +4,12 @@ from pathlib import Path
 from typing import Any, List, Tuple, Union, cast
 
 import pytest
+from pydantic import ValidationError
 from syrupy import SnapshotAssertion
 
-from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
+from langchain_core._api.deprecation import (
+    LangChainPendingDeprecationWarning,
+)
 from langchain_core.load import dumpd, load
 from langchain_core.messages import (
     AIMessage,
@@ -28,7 +31,6 @@ from langchain_core.prompts.chat import (
     SystemMessagePromptTemplate,
     _convert_to_message,
 )
-from langchain_core.pydantic_v1 import ValidationError
 from tests.unit_tests.pydantic_utils import _schema
 
 
@@ -808,7 +810,7 @@ def test_chat_prompt_w_msgs_placeholder_ser_des(snapshot: SnapshotAssertion) -> 
     prompt = ChatPromptTemplate.from_messages(
         [("system", "foo"), MessagesPlaceholder("bar"), ("human", "baz")]
     )
-    assert dumpd(MessagesPlaceholder("bar")) == snapshot(name="placholder")
+    assert dumpd(MessagesPlaceholder("bar")) == snapshot(name="placeholder")
     assert load(dumpd(MessagesPlaceholder("bar"))) == MessagesPlaceholder("bar")
     assert dumpd(prompt) == snapshot(name="chat_prompt")
     assert load(dumpd(prompt)) == prompt

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -1,12 +1,14 @@
 from functools import partial
 from inspect import isclass
 from typing import Any, Dict, Type, Union, cast
+from typing import Optional as Optional
+
+from pydantic import BaseModel
 
 from langchain_core.language_models import FakeListChatModel
 from langchain_core.load.dump import dumps
 from langchain_core.load.load import loads
 from langchain_core.prompts.structured import StructuredPrompt
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableLambda
 from langchain_core.utils.pydantic import is_basemodel_subclass
 
@@ -32,6 +34,9 @@ class FakeStructuredChatModel(FakeListChatModel):
     @property
     def _llm_type(self) -> str:
         return "fake-messages-list-chat-model"
+
+
+FakeStructuredChatModel.model_rebuild()
 
 
 def test_structured_prompt_pydantic() -> None:

--- a/libs/core/tests/unit_tests/pydantic_utils.py
+++ b/libs/core/tests/unit_tests/pydantic_utils.py
@@ -1,20 +1,10 @@
-"""Helper utilities for pydantic.
-
-This module includes helper utilities to ease the migration from pydantic v1 to v2.
-
-They're meant to be used in the following way:
-
-1) Use utility code to help (selected) unit tests pass without modifications
-2) Upgrade the unit tests to match pydantic 2
-3) Stop using the utility code
-"""
-
 from typing import Any
+
+from langchain_core.utils.pydantic import is_basemodel_subclass
 
 
 # Function to replace allOf with $ref
-def _replace_all_of_with_ref(schema: Any) -> None:
-    """Replace allOf with $ref in the schema."""
+def replace_all_of_with_ref(schema: Any) -> None:
     if isinstance(schema, dict):
         # If the schema has an allOf key with a single item that contains a $ref
         if (
@@ -30,13 +20,13 @@ def _replace_all_of_with_ref(schema: Any) -> None:
             # Recursively process nested schemas
             for value in schema.values():
                 if isinstance(value, (dict, list)):
-                    _replace_all_of_with_ref(value)
+                    replace_all_of_with_ref(value)
     elif isinstance(schema, list):
         for item in schema:
-            _replace_all_of_with_ref(item)
+            replace_all_of_with_ref(item)
 
 
-def _remove_bad_none_defaults(schema: Any) -> None:
+def remove_all_none_default(schema: Any) -> None:
     """Removing all none defaults.
 
     Pydantic v1 did not generate these, but Pydantic v2 does.
@@ -56,39 +46,48 @@ def _remove_bad_none_defaults(schema: Any) -> None:
                             break  # Null type explicitly defined
                     else:
                         del value["default"]
-                _remove_bad_none_defaults(value)
+                remove_all_none_default(value)
             elif isinstance(value, list):
                 for item in value:
-                    _remove_bad_none_defaults(item)
+                    remove_all_none_default(item)
     elif isinstance(schema, list):
         for item in schema:
-            _remove_bad_none_defaults(item)
+            remove_all_none_default(item)
+
+
+def _remove_enum_description(obj: Any) -> None:
+    """Remove the description from enums."""
+    if isinstance(obj, dict):
+        if "enum" in obj:
+            if "description" in obj and obj["description"] == "An enumeration.":
+                del obj["description"]
+        for value in obj.values():
+            _remove_enum_description(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            _remove_enum_description(item)
 
 
 def _schema(obj: Any) -> dict:
-    """Get the schema of a pydantic model in the pydantic v1 style.
-
-    This will attempt to map the schema as close as possible to the pydantic v1 schema.
-    """
+    """Return the schema of the object."""
     # Remap to old style schema
+    if not is_basemodel_subclass(obj):
+        raise TypeError(
+            f"Object must be a Pydantic BaseModel subclass. Got {type(obj)}"
+        )
     if not hasattr(obj, "model_json_schema"):  # V1 model
         return obj.schema()
-
-    # Then we're using V2 models internally.
-    raise AssertionError(
-        "Hi there! Looks like you're attempting to upgrade to Pydantic v2. If so: \n"
-        "1) remove this exception\n"
-        "2) confirm that the old unit tests pass, and if not look for difference\n"
-        "3) update the unit tests to match the new schema\n"
-        "4) remove this utility function\n"
-    )
 
     schema_ = obj.model_json_schema(ref_template="#/definitions/{model}")
     if "$defs" in schema_:
         schema_["definitions"] = schema_["$defs"]
         del schema_["$defs"]
 
-    _replace_all_of_with_ref(schema_)
-    _remove_bad_none_defaults(schema_)
+    if "default" in schema_ and schema_["default"] is None:
+        del schema_["default"]
+
+    replace_all_of_with_ref(schema_)
+    remove_all_none_default(schema_)
+    _remove_enum_description(schema_)
 
     return schema_

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -334,31 +334,9 @@
       }),
       dict({
         'data': dict({
-          'anyOf': list([
-            dict({
-              'type': 'string',
-            }),
-            dict({
-              '$ref': '#/definitions/AIMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/HumanMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ChatMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/SystemMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/FunctionMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ToolMessage',
-            }),
-          ]),
-          'definitions': dict({
+          '$defs': dict({
             'AIMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message from an AI.
                 
@@ -400,21 +378,37 @@
                   'type': 'boolean',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'invalid_tool_calls': dict({
                   'default': list([
                   ]),
                   'items': dict({
-                    '$ref': '#/definitions/InvalidToolCall',
+                    '$ref': '#/$defs/InvalidToolCall',
                   }),
                   'title': 'Invalid Tool Calls',
                   'type': 'array',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
@@ -424,12 +418,13 @@
                   'default': list([
                   ]),
                   'items': dict({
-                    '$ref': '#/definitions/ToolCall',
+                    '$ref': '#/$defs/ToolCall',
                   }),
                   'title': 'Tool Calls',
                   'type': 'array',
                 }),
                 'type': dict({
+                  'const': 'ai',
                   'default': 'ai',
                   'enum': list([
                     'ai',
@@ -438,7 +433,15 @@
                   'type': 'string',
                 }),
                 'usage_metadata': dict({
-                  '$ref': '#/definitions/UsageMetadata',
+                  'anyOf': list([
+                    dict({
+                      '$ref': '#/$defs/UsageMetadata',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                 }),
               }),
               'required': list([
@@ -448,6 +451,7 @@
               'type': 'object',
             }),
             'ChatMessage': dict({
+              'additionalProperties': True,
               'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
               'properties': dict({
                 'additional_kwargs': dict({
@@ -476,12 +480,28 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
@@ -492,6 +512,7 @@
                   'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'chat',
                   'default': 'chat',
                   'enum': list([
                     'chat',
@@ -508,6 +529,7 @@
               'type': 'object',
             }),
             'FunctionMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message for passing the result of executing a tool back to a model.
                 
@@ -545,8 +567,16 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
                   'title': 'Name',
@@ -557,6 +587,7 @@
                   'type': 'object',
                 }),
                 'type': dict({
+                  'const': 'function',
                   'default': 'function',
                   'enum': list([
                     'function',
@@ -573,6 +604,7 @@
               'type': 'object',
             }),
             'HumanMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message from a human.
                 
@@ -629,18 +661,35 @@
                   'type': 'boolean',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
                   'type': 'object',
                 }),
                 'type': dict({
+                  'const': 'human',
                   'default': 'human',
                   'enum': list([
                     'human',
@@ -656,24 +705,59 @@
               'type': 'object',
             }),
             'InvalidToolCall': dict({
+              'description': '''
+                Allowance for errors made by LLM.
+                
+                Here we add an `error` key to surface errors made during generation
+                (e.g., invalid JSON arguments.)
+              ''',
               'properties': dict({
                 'args': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Args',
-                  'type': 'string',
                 }),
                 'error': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Error',
-                  'type': 'string',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'invalid_tool_call',
                   'enum': list([
                     'invalid_tool_call',
                   ]),
@@ -691,6 +775,7 @@
               'type': 'object',
             }),
             'SystemMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message for priming AI behavior.
                 
@@ -742,18 +827,35 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
                   'type': 'object',
                 }),
                 'type': dict({
+                  'const': 'system',
                   'default': 'system',
                   'enum': list([
                     'system',
@@ -769,20 +871,44 @@
               'type': 'object',
             }),
             'ToolCall': dict({
+              'description': '''
+                Represents a request to call a tool.
+                
+                Example:
+                
+                    .. code-block:: python
+                
+                        {
+                            "name": "foo",
+                            "args": {"a": 1},
+                            "id": "123"
+                        }
+                
+                    This represents a request to call the tool named "foo" with arguments {"a": 1}
+                    and an identifier of "123".
+              ''',
               'properties': dict({
                 'args': dict({
                   'title': 'Args',
                   'type': 'object',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
                   'title': 'Name',
                   'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'tool_call',
                   'enum': list([
                     'tool_call',
                   ]),
@@ -799,6 +925,7 @@
               'type': 'object',
             }),
             'ToolMessage': dict({
+              'additionalProperties': True,
               'description': '''
                 Message for passing the result of executing a tool back to a model.
                 
@@ -845,6 +972,7 @@
                   'type': 'object',
                 }),
                 'artifact': dict({
+                  'default': None,
                   'title': 'Artifact',
                 }),
                 'content': dict({
@@ -869,12 +997,28 @@
                   'title': 'Content',
                 }),
                 'id': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Id',
-                  'type': 'string',
                 }),
                 'name': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
                   'title': 'Name',
-                  'type': 'string',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
@@ -894,6 +1038,7 @@
                   'type': 'string',
                 }),
                 'type': dict({
+                  'const': 'tool',
                   'default': 'tool',
                   'enum': list([
                     'tool',
@@ -910,6 +1055,21 @@
               'type': 'object',
             }),
             'UsageMetadata': dict({
+              'description': '''
+                Usage metadata for a message, such as token counts.
+                
+                This is a standard representation of token usage that is consistent across models.
+                
+                Example:
+                
+                    .. code-block:: python
+                
+                        {
+                            "input_tokens": 10,
+                            "output_tokens": 20,
+                            "total_tokens": 30
+                        }
+              ''',
               'properties': dict({
                 'input_tokens': dict({
                   'title': 'Input Tokens',
@@ -933,6 +1093,29 @@
               'type': 'object',
             }),
           }),
+          'anyOf': list([
+            dict({
+              'type': 'string',
+            }),
+            dict({
+              '$ref': '#/$defs/AIMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/HumanMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/ChatMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/SystemMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/FunctionMessage',
+            }),
+            dict({
+              '$ref': '#/$defs/ToolMessage',
+            }),
+          ]),
           'title': 'RunnableParallel<as_list,as_str>Input',
         }),
         'id': 3,
@@ -952,6 +1135,10 @@
               'title': 'As Str',
             }),
           }),
+          'required': list([
+            'as_list',
+            'as_str',
+          ]),
           'title': 'RunnableParallel<as_list,as_str>Output',
           'type': 'object',
         }),

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -5176,3910 +5176,11 @@
   }
   '''
 # ---
-# name: test_schemas
-  dict({
-    'anyOf': list([
-      dict({
-        'type': 'string',
-      }),
-      dict({
-        '$ref': '#/definitions/StringPromptValue',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatPromptValueConcrete',
-      }),
-      dict({
-        'items': dict({
-          'anyOf': list([
-            dict({
-              '$ref': '#/definitions/AIMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/HumanMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ChatMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/SystemMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/FunctionMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ToolMessage',
-            }),
-          ]),
-        }),
-        'type': 'array',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'FakeListLLMInput',
-  })
-# ---
-# name: test_schemas.1
-  dict({
-    'anyOf': list([
-      dict({
-        'type': 'string',
-      }),
-      dict({
-        '$ref': '#/definitions/StringPromptValue',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatPromptValueConcrete',
-      }),
-      dict({
-        'items': dict({
-          'anyOf': list([
-            dict({
-              '$ref': '#/definitions/AIMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/HumanMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ChatMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/SystemMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/FunctionMessage',
-            }),
-            dict({
-              '$ref': '#/definitions/ToolMessage',
-            }),
-          ]),
-        }),
-        'type': 'array',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'FakeListChatModelInput',
-  })
-# ---
-# name: test_schemas.2
-  dict({
-    'anyOf': list([
-      dict({
-        '$ref': '#/definitions/AIMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/HumanMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/SystemMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/FunctionMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ToolMessage',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'FakeListChatModelOutput',
-  })
-# ---
-# name: test_schemas.5
-  dict({
-    'anyOf': list([
-      dict({
-        '$ref': '#/definitions/StringPromptValue',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatPromptValueConcrete',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'PromptTemplateOutput',
-  })
-# ---
-# name: test_schemas.6
-  dict({
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'ChatPromptValueConcrete': dict({
-        'description': '''
-          Chat prompt value which explicitly lists out the message types it accepts.
-          For use in external schemas.
-        ''',
-        'properties': dict({
-          'messages': dict({
-            'items': dict({
-              'anyOf': list([
-                dict({
-                  '$ref': '#/definitions/AIMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/HumanMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ChatMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/SystemMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/FunctionMessage',
-                }),
-                dict({
-                  '$ref': '#/definitions/ToolMessage',
-                }),
-              ]),
-            }),
-            'title': 'Messages',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ChatPromptValueConcrete',
-            'enum': list([
-              'ChatPromptValueConcrete',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'messages',
-        ]),
-        'title': 'ChatPromptValueConcrete',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'PromptTemplateOutput': dict({
-        'anyOf': list([
-          dict({
-            '$ref': '#/definitions/StringPromptValue',
-          }),
-          dict({
-            '$ref': '#/definitions/ChatPromptValueConcrete',
-          }),
-        ]),
-        'title': 'PromptTemplateOutput',
-      }),
-      'StringPromptValue': dict({
-        'description': 'String prompt value.',
-        'properties': dict({
-          'text': dict({
-            'title': 'Text',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'StringPromptValue',
-            'enum': list([
-              'StringPromptValue',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'text',
-        ]),
-        'title': 'StringPromptValue',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'items': dict({
-      '$ref': '#/definitions/PromptTemplateOutput',
-    }),
-    'title': 'RunnableEach<PromptTemplate>Output',
-    'type': 'array',
-  })
-# ---
-# name: test_schemas.7
-  dict({
-    'anyOf': list([
-      dict({
-        'type': 'string',
-      }),
-      dict({
-        '$ref': '#/definitions/AIMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/HumanMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ChatMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/SystemMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/FunctionMessage',
-      }),
-      dict({
-        '$ref': '#/definitions/ToolMessage',
-      }),
-    ]),
-    'definitions': dict({
-      'AIMessage': dict({
-        'description': '''
-          Message from an AI.
-          
-          AIMessage is returned from a chat model as a response to a prompt.
-          
-          This message represents the output of the model and consists of both
-          the raw output as returned by the model together standardized fields
-          (e.g., tool calls, usage metadata) added by the LangChain framework.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'invalid_tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/InvalidToolCall',
-            }),
-            'title': 'Invalid Tool Calls',
-            'type': 'array',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'tool_calls': dict({
-            'default': list([
-            ]),
-            'items': dict({
-              '$ref': '#/definitions/ToolCall',
-            }),
-            'title': 'Tool Calls',
-            'type': 'array',
-          }),
-          'type': dict({
-            'default': 'ai',
-            'enum': list([
-              'ai',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-          'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'AIMessage',
-        'type': 'object',
-      }),
-      'ChatMessage': dict({
-        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'role': dict({
-            'title': 'Role',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'chat',
-            'enum': list([
-              'chat',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'role',
-        ]),
-        'title': 'ChatMessage',
-        'type': 'object',
-      }),
-      'FunctionMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          FunctionMessage are an older version of the ToolMessage schema, and
-          do not contain the tool_call_id field.
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'function',
-            'enum': list([
-              'function',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'name',
-        ]),
-        'title': 'FunctionMessage',
-        'type': 'object',
-      }),
-      'HumanMessage': dict({
-        'description': '''
-          Message from a human.
-          
-          HumanMessages are messages that are passed in from a human to the model.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Instantiate a chat model and invoke it with the messages
-                  model = ...
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'example': dict({
-            'default': False,
-            'title': 'Example',
-            'type': 'boolean',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'human',
-            'enum': list([
-              'human',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'HumanMessage',
-        'type': 'object',
-      }),
-      'InvalidToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'string',
-          }),
-          'error': dict({
-            'title': 'Error',
-            'type': 'string',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'invalid_tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-          'error',
-        ]),
-        'title': 'InvalidToolCall',
-        'type': 'object',
-      }),
-      'SystemMessage': dict({
-        'description': '''
-          Message for priming AI behavior.
-          
-          The system message is usually passed in as the first of a sequence
-          of input messages.
-          
-          Example:
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import HumanMessage, SystemMessage
-          
-                  messages = [
-                      SystemMessage(
-                          content="You are a helpful assistant! Your name is Bob."
-                      ),
-                      HumanMessage(
-                          content="What is your name?"
-                      )
-                  ]
-          
-                  # Define a chat model and invoke it with the messages
-                  print(model.invoke(messages))
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'type': dict({
-            'default': 'system',
-            'enum': list([
-              'system',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-        ]),
-        'title': 'SystemMessage',
-        'type': 'object',
-      }),
-      'ToolCall': dict({
-        'properties': dict({
-          'args': dict({
-            'title': 'Args',
-            'type': 'object',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'type': dict({
-            'enum': list([
-              'tool_call',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-          'args',
-          'id',
-        ]),
-        'title': 'ToolCall',
-        'type': 'object',
-      }),
-      'ToolMessage': dict({
-        'description': '''
-          Message for passing the result of executing a tool back to a model.
-          
-          ToolMessages contain the result of a tool invocation. Typically, the result
-          is encoded inside the `content` field.
-          
-          Example: A ToolMessage representing a result of 42 from a tool call with id
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
-          
-          
-          Example: A ToolMessage where only part of the tool output is sent to the model
-              and the full output is passed in to artifact.
-          
-              .. versionadded:: 0.2.17
-          
-              .. code-block:: python
-          
-                  from langchain_core.messages import ToolMessage
-          
-                  tool_output = {
-                      "stdout": "From the graph we can see that the correlation between x and y is ...",
-                      "stderr": None,
-                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
-                  }
-          
-                  ToolMessage(
-                      content=tool_output["stdout"],
-                      artifact=tool_output,
-                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
-                  )
-          
-          The tool_call_id field is used to associate the tool call request with the
-          tool call response. This is useful in situations where a chat model is able
-          to request multiple tool calls in parallel.
-        ''',
-        'properties': dict({
-          'additional_kwargs': dict({
-            'title': 'Additional Kwargs',
-            'type': 'object',
-          }),
-          'artifact': dict({
-            'title': 'Artifact',
-          }),
-          'content': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'items': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'string',
-                    }),
-                    dict({
-                      'type': 'object',
-                    }),
-                  ]),
-                }),
-                'type': 'array',
-              }),
-            ]),
-            'title': 'Content',
-          }),
-          'id': dict({
-            'title': 'Id',
-            'type': 'string',
-          }),
-          'name': dict({
-            'title': 'Name',
-            'type': 'string',
-          }),
-          'response_metadata': dict({
-            'title': 'Response Metadata',
-            'type': 'object',
-          }),
-          'status': dict({
-            'default': 'success',
-            'enum': list([
-              'success',
-              'error',
-            ]),
-            'title': 'Status',
-            'type': 'string',
-          }),
-          'tool_call_id': dict({
-            'title': 'Tool Call Id',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'tool',
-            'enum': list([
-              'tool',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'content',
-          'tool_call_id',
-        ]),
-        'title': 'ToolMessage',
-        'type': 'object',
-      }),
-      'UsageMetadata': dict({
-        'properties': dict({
-          'input_tokens': dict({
-            'title': 'Input Tokens',
-            'type': 'integer',
-          }),
-          'output_tokens': dict({
-            'title': 'Output Tokens',
-            'type': 'integer',
-          }),
-          'total_tokens': dict({
-            'title': 'Total Tokens',
-            'type': 'integer',
-          }),
-        }),
-        'required': list([
-          'input_tokens',
-          'output_tokens',
-          'total_tokens',
-        ]),
-        'title': 'UsageMetadata',
-        'type': 'object',
-      }),
-    }),
-    'title': 'CommaSeparatedListOutputParserInput',
-  })
-# ---
 # name: test_schemas[chat_prompt_input_schema]
   dict({
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -9121,8 +5222,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -9134,8 +5243,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9151,6 +5268,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -9159,7 +5277,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -9169,6 +5295,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -9197,12 +5324,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9213,6 +5356,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -9229,6 +5373,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -9266,8 +5411,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -9278,6 +5431,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -9294,6 +5448,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -9350,18 +5505,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -9377,24 +5549,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -9412,6 +5619,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -9463,18 +5671,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -9490,20 +5715,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -9520,6 +5769,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -9590,12 +5840,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9615,6 +5881,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -9631,6 +5898,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -9701,6 +5983,7 @@
     ]),
     'definitions': dict({
       'AIMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from an AI.
           
@@ -9742,8 +6025,16 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'invalid_tool_calls': dict({
             'default': list([
@@ -9755,8 +6046,16 @@
             'type': 'array',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9772,6 +6071,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ai',
             'default': 'ai',
             'enum': list([
               'ai',
@@ -9780,7 +6080,15 @@
             'type': 'string',
           }),
           'usage_metadata': dict({
-            '$ref': '#/definitions/UsageMetadata',
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
         }),
         'required': list([
@@ -9790,6 +6098,7 @@
         'type': 'object',
       }),
       'ChatMessage': dict({
+        'additionalProperties': True,
         'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
         'properties': dict({
           'additional_kwargs': dict({
@@ -9818,12 +6127,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -9834,6 +6159,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'chat',
             'default': 'chat',
             'enum': list([
               'chat',
@@ -9882,6 +6208,7 @@
             'type': 'array',
           }),
           'type': dict({
+            'const': 'ChatPromptValueConcrete',
             'default': 'ChatPromptValueConcrete',
             'enum': list([
               'ChatPromptValueConcrete',
@@ -9897,6 +6224,7 @@
         'type': 'object',
       }),
       'FunctionMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -9934,8 +6262,16 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
@@ -9946,6 +6282,7 @@
             'type': 'object',
           }),
           'type': dict({
+            'const': 'function',
             'default': 'function',
             'enum': list([
               'function',
@@ -9962,6 +6299,7 @@
         'type': 'object',
       }),
       'HumanMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message from a human.
           
@@ -10018,18 +6356,35 @@
             'type': 'boolean',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'human',
             'default': 'human',
             'enum': list([
               'human',
@@ -10045,24 +6400,59 @@
         'type': 'object',
       }),
       'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
         'properties': dict({
           'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Args',
-            'type': 'string',
           }),
           'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Error',
-            'type': 'string',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Name',
-            'type': 'string',
           }),
           'type': dict({
+            'const': 'invalid_tool_call',
             'enum': list([
               'invalid_tool_call',
             ]),
@@ -10087,6 +6477,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'StringPromptValue',
             'default': 'StringPromptValue',
             'enum': list([
               'StringPromptValue',
@@ -10102,6 +6493,7 @@
         'type': 'object',
       }),
       'SystemMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for priming AI behavior.
           
@@ -10153,18 +6545,35 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
           }),
           'type': dict({
+            'const': 'system',
             'default': 'system',
             'enum': list([
               'system',
@@ -10180,20 +6589,44 @@
         'type': 'object',
       }),
       'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
             'type': 'object',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool_call',
             'enum': list([
               'tool_call',
             ]),
@@ -10210,6 +6643,7 @@
         'type': 'object',
       }),
       'ToolMessage': dict({
+        'additionalProperties': True,
         'description': '''
           Message for passing the result of executing a tool back to a model.
           
@@ -10280,12 +6714,28 @@
             'title': 'Content',
           }),
           'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Id',
-            'type': 'string',
           }),
           'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
             'title': 'Name',
-            'type': 'string',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -10305,6 +6755,7 @@
             'type': 'string',
           }),
           'type': dict({
+            'const': 'tool',
             'default': 'tool',
             'enum': list([
               'tool',
@@ -10321,6 +6772,21 @@
         'type': 'object',
       }),
       'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
         'properties': dict({
           'input_tokens': dict({
             'title': 'Input Tokens',
@@ -10347,10 +6813,5010 @@
     'title': 'ChatPromptTemplateOutput',
   })
 # ---
+# name: test_schemas[fake_chat_input_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        'type': 'string',
+      }),
+      dict({
+        '$ref': '#/definitions/StringPromptValue',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatPromptValueConcrete',
+      }),
+      dict({
+        'items': dict({
+          'anyOf': list([
+            dict({
+              '$ref': '#/definitions/AIMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/HumanMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ChatMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/SystemMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/FunctionMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ToolMessage',
+            }),
+          ]),
+        }),
+        'type': 'array',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'FakeListChatModelInput',
+  })
+# ---
+# name: test_schemas[fake_chat_output_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        '$ref': '#/definitions/AIMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/HumanMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/SystemMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/FunctionMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ToolMessage',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'FakeListChatModelOutput',
+  })
+# ---
+# name: test_schemas[fake_llm_input_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        'type': 'string',
+      }),
+      dict({
+        '$ref': '#/definitions/StringPromptValue',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatPromptValueConcrete',
+      }),
+      dict({
+        'items': dict({
+          'anyOf': list([
+            dict({
+              '$ref': '#/definitions/AIMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/HumanMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ChatMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/SystemMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/FunctionMessage',
+            }),
+            dict({
+              '$ref': '#/definitions/ToolMessage',
+            }),
+          ]),
+        }),
+        'type': 'array',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'FakeListLLMInput',
+  })
+# ---
+# name: test_schemas[list_parser_input_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        'type': 'string',
+      }),
+      dict({
+        '$ref': '#/definitions/AIMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/HumanMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/SystemMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/FunctionMessage',
+      }),
+      dict({
+        '$ref': '#/definitions/ToolMessage',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'CommaSeparatedListOutputParserInput',
+  })
+# ---
+# name: test_schemas[prompt_mapper_output_schema]
+  dict({
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'PromptTemplateOutput': dict({
+        'anyOf': list([
+          dict({
+            '$ref': '#/definitions/StringPromptValue',
+          }),
+          dict({
+            '$ref': '#/definitions/ChatPromptValueConcrete',
+          }),
+        ]),
+        'title': 'PromptTemplateOutput',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'items': dict({
+      '$ref': '#/definitions/PromptTemplateOutput',
+    }),
+    'title': 'RunnableEach<PromptTemplate>Output',
+    'type': 'array',
+  })
+# ---
+# name: test_schemas[prompt_output_schema]
+  dict({
+    'anyOf': list([
+      dict({
+        '$ref': '#/definitions/StringPromptValue',
+      }),
+      dict({
+        '$ref': '#/definitions/ChatPromptValueConcrete',
+      }),
+    ]),
+    'definitions': dict({
+      'AIMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from an AI.
+          
+          AIMessage is returned from a chat model as a response to a prompt.
+          
+          This message represents the output of the model and consists of both
+          the raw output as returned by the model together standardized fields
+          (e.g., tool calls, usage metadata) added by the LangChain framework.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'invalid_tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/InvalidToolCall',
+            }),
+            'title': 'Invalid Tool Calls',
+            'type': 'array',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'tool_calls': dict({
+            'default': list([
+            ]),
+            'items': dict({
+              '$ref': '#/definitions/ToolCall',
+            }),
+            'title': 'Tool Calls',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ai',
+            'default': 'ai',
+            'enum': list([
+              'ai',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+          'usage_metadata': dict({
+            'anyOf': list([
+              dict({
+                '$ref': '#/definitions/UsageMetadata',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'AIMessage',
+        'type': 'object',
+      }),
+      'ChatMessage': dict({
+        'additionalProperties': True,
+        'description': 'Message that can be assigned an arbitrary speaker (i.e. role).',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'role': dict({
+            'title': 'Role',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'chat',
+            'default': 'chat',
+            'enum': list([
+              'chat',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'role',
+        ]),
+        'title': 'ChatMessage',
+        'type': 'object',
+      }),
+      'ChatPromptValueConcrete': dict({
+        'description': '''
+          Chat prompt value which explicitly lists out the message types it accepts.
+          For use in external schemas.
+        ''',
+        'properties': dict({
+          'messages': dict({
+            'items': dict({
+              'anyOf': list([
+                dict({
+                  '$ref': '#/definitions/AIMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/HumanMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ChatMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/SystemMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/FunctionMessage',
+                }),
+                dict({
+                  '$ref': '#/definitions/ToolMessage',
+                }),
+              ]),
+            }),
+            'title': 'Messages',
+            'type': 'array',
+          }),
+          'type': dict({
+            'const': 'ChatPromptValueConcrete',
+            'default': 'ChatPromptValueConcrete',
+            'enum': list([
+              'ChatPromptValueConcrete',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'messages',
+        ]),
+        'title': 'ChatPromptValueConcrete',
+        'type': 'object',
+      }),
+      'FunctionMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          FunctionMessage are an older version of the ToolMessage schema, and
+          do not contain the tool_call_id field.
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'function',
+            'default': 'function',
+            'enum': list([
+              'function',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'name',
+        ]),
+        'title': 'FunctionMessage',
+        'type': 'object',
+      }),
+      'HumanMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message from a human.
+          
+          HumanMessages are messages that are passed in from a human to the model.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Instantiate a chat model and invoke it with the messages
+                  model = ...
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'example': dict({
+            'default': False,
+            'title': 'Example',
+            'type': 'boolean',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'human',
+            'default': 'human',
+            'enum': list([
+              'human',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'HumanMessage',
+        'type': 'object',
+      }),
+      'InvalidToolCall': dict({
+        'description': '''
+          Allowance for errors made by LLM.
+          
+          Here we add an `error` key to surface errors made during generation
+          (e.g., invalid JSON arguments.)
+        ''',
+        'properties': dict({
+          'args': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Args',
+          }),
+          'error': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Error',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Name',
+          }),
+          'type': dict({
+            'const': 'invalid_tool_call',
+            'enum': list([
+              'invalid_tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+          'error',
+        ]),
+        'title': 'InvalidToolCall',
+        'type': 'object',
+      }),
+      'StringPromptValue': dict({
+        'description': 'String prompt value.',
+        'properties': dict({
+          'text': dict({
+            'title': 'Text',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'StringPromptValue',
+            'default': 'StringPromptValue',
+            'enum': list([
+              'StringPromptValue',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'text',
+        ]),
+        'title': 'StringPromptValue',
+        'type': 'object',
+      }),
+      'SystemMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for priming AI behavior.
+          
+          The system message is usually passed in as the first of a sequence
+          of input messages.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import HumanMessage, SystemMessage
+          
+                  messages = [
+                      SystemMessage(
+                          content="You are a helpful assistant! Your name is Bob."
+                      ),
+                      HumanMessage(
+                          content="What is your name?"
+                      )
+                  ]
+          
+                  # Define a chat model and invoke it with the messages
+                  print(model.invoke(messages))
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'type': dict({
+            'const': 'system',
+            'default': 'system',
+            'enum': list([
+              'system',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+        ]),
+        'title': 'SystemMessage',
+        'type': 'object',
+      }),
+      'ToolCall': dict({
+        'description': '''
+          Represents a request to call a tool.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "name": "foo",
+                      "args": {"a": 1},
+                      "id": "123"
+                  }
+          
+              This represents a request to call the tool named "foo" with arguments {"a": 1}
+              and an identifier of "123".
+        ''',
+        'properties': dict({
+          'args': dict({
+            'title': 'Args',
+            'type': 'object',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'title': 'Id',
+          }),
+          'name': dict({
+            'title': 'Name',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool_call',
+            'enum': list([
+              'tool_call',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'name',
+          'args',
+          'id',
+        ]),
+        'title': 'ToolCall',
+        'type': 'object',
+      }),
+      'ToolMessage': dict({
+        'additionalProperties': True,
+        'description': '''
+          Message for passing the result of executing a tool back to a model.
+          
+          ToolMessages contain the result of a tool invocation. Typically, the result
+          is encoded inside the `content` field.
+          
+          Example: A ToolMessage representing a result of 42 from a tool call with id
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  ToolMessage(content='42', tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL')
+          
+          
+          Example: A ToolMessage where only part of the tool output is sent to the model
+              and the full output is passed in to artifact.
+          
+              .. versionadded:: 0.2.17
+          
+              .. code-block:: python
+          
+                  from langchain_core.messages import ToolMessage
+          
+                  tool_output = {
+                      "stdout": "From the graph we can see that the correlation between x and y is ...",
+                      "stderr": None,
+                      "artifacts": {"type": "image", "base64_data": "/9j/4gIcSU..."},
+                  }
+          
+                  ToolMessage(
+                      content=tool_output["stdout"],
+                      artifact=tool_output,
+                      tool_call_id='call_Jja7J89XsjrOLA5r!MEOW!SL',
+                  )
+          
+          The tool_call_id field is used to associate the tool call request with the
+          tool call response. This is useful in situations where a chat model is able
+          to request multiple tool calls in parallel.
+        ''',
+        'properties': dict({
+          'additional_kwargs': dict({
+            'title': 'Additional Kwargs',
+            'type': 'object',
+          }),
+          'artifact': dict({
+            'title': 'Artifact',
+          }),
+          'content': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'items': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'string',
+                    }),
+                    dict({
+                      'type': 'object',
+                    }),
+                  ]),
+                }),
+                'type': 'array',
+              }),
+            ]),
+            'title': 'Content',
+          }),
+          'id': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Id',
+          }),
+          'name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Name',
+          }),
+          'response_metadata': dict({
+            'title': 'Response Metadata',
+            'type': 'object',
+          }),
+          'status': dict({
+            'default': 'success',
+            'enum': list([
+              'success',
+              'error',
+            ]),
+            'title': 'Status',
+            'type': 'string',
+          }),
+          'tool_call_id': dict({
+            'title': 'Tool Call Id',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'tool',
+            'default': 'tool',
+            'enum': list([
+              'tool',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'content',
+          'tool_call_id',
+        ]),
+        'title': 'ToolMessage',
+        'type': 'object',
+      }),
+      'UsageMetadata': dict({
+        'description': '''
+          Usage metadata for a message, such as token counts.
+          
+          This is a standard representation of token usage that is consistent across models.
+          
+          Example:
+          
+              .. code-block:: python
+          
+                  {
+                      "input_tokens": 10,
+                      "output_tokens": 20,
+                      "total_tokens": 30
+                  }
+        ''',
+        'properties': dict({
+          'input_tokens': dict({
+            'title': 'Input Tokens',
+            'type': 'integer',
+          }),
+          'output_tokens': dict({
+            'title': 'Output Tokens',
+            'type': 'integer',
+          }),
+          'total_tokens': dict({
+            'title': 'Total Tokens',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'input_tokens',
+          'output_tokens',
+          'total_tokens',
+        ]),
+        'title': 'UsageMetadata',
+        'type': 'object',
+      }),
+    }),
+    'title': 'PromptTemplateOutput',
+  })
+# ---
 # name: test_seq_dict_prompt_llm
   '''
   {
-    question: RunnablePassthrough()
+    question: RunnablePassthrough[str]()
               | RunnableLambda(...),
     documents: RunnableLambda(...)
                | FakeRetriever(),

--- a/libs/core/tests/unit_tests/runnables/test_configurable.py
+++ b/libs/core/tests/unit_tests/runnables/test_configurable.py
@@ -1,8 +1,9 @@
 from typing import Any, Dict, Optional
 
 import pytest
+from pydantic import ConfigDict, Field, model_validator
+from typing_extensions import Self
 
-from langchain_core.pydantic_v1 import Field, root_validator
 from langchain_core.runnables import (
     ConfigurableField,
     RunnableConfig,
@@ -14,19 +15,21 @@ class MyRunnable(RunnableSerializable[str, str]):
     my_property: str = Field(alias="my_property_alias")
     _my_hidden_property: str = ""
 
-    class Config:
-        allow_population_by_field_name = True
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
 
-    @root_validator(pre=True)
-    def my_error(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    @model_validator(mode="before")
+    @classmethod
+    def my_error(cls, values: Dict[str, Any]) -> Any:
         if "_my_hidden_property" in values:
             raise ValueError("Cannot set _my_hidden_property")
         return values
 
-    @root_validator(pre=False, skip_on_failure=True)
-    def build_extra(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        values["_my_hidden_property"] = values["my_property"]
-        return values
+    @model_validator(mode="after")
+    def build_extra(self) -> Self:
+        self._my_hidden_property = self.my_property
+        return self
 
     def invoke(self, input: str, config: Optional[RunnableConfig] = None) -> Any:
         return input + self._my_hidden_property

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel
 from syrupy import SnapshotAssertion
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
@@ -25,7 +26,6 @@ from langchain_core.load import dumps
 from langchain_core.messages import BaseMessage
 from langchain_core.outputs import ChatResult
 from langchain_core.prompts import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import (
     Runnable,
     RunnableBinding,

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from pydantic import BaseModel
 from syrupy import SnapshotAssertion
 
 from langchain_core.language_models import FakeListLLM
@@ -7,7 +8,6 @@ from langchain_core.output_parsers.list import CommaSeparatedListOutputParser
 from langchain_core.output_parsers.string import StrOutputParser
 from langchain_core.output_parsers.xml import XMLOutputParser
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables.base import Runnable, RunnableConfig
 from langchain_core.runnables.graph import Edge, Graph, Node
 from langchain_core.runnables.graph_mermaid import _escape_node_label

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
@@ -9,7 +10,6 @@ from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.runnables import Runnable
 from langchain_core.runnables.base import RunnableBinding, RunnableLambda
 from langchain_core.runnables.config import RunnableConfig
@@ -455,8 +455,9 @@ def test_get_input_schema_input_dict() -> None:
 
 
 def test_get_input_schema_input_messages() -> None:
-    class RunnableWithChatHistoryInput(BaseModel):
-        __root__: Sequence[BaseMessage]
+    from pydantic import RootModel  # pydantic: ignore
+
+    RunnableWithMessageHistoryInput = RootModel[Sequence[BaseMessage]]
 
     runnable = RunnableLambda(
         lambda messages: {
@@ -478,9 +479,9 @@ def test_get_input_schema_input_messages() -> None:
     with_history = RunnableWithMessageHistory(
         runnable, get_session_history, output_messages_key="output"
     )
-    assert _schema(with_history.get_input_schema()) == _schema(
-        RunnableWithChatHistoryInput
-    )
+    expected_schema = _schema(RunnableWithMessageHistoryInput)
+    expected_schema["title"] = "RunnableWithChatHistoryInput"
+    assert _schema(with_history.get_input_schema()) == expected_schema
 
 
 def test_using_custom_config_specs() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -455,7 +455,7 @@ def test_get_input_schema_input_dict() -> None:
 
 
 def test_get_input_schema_input_messages() -> None:
-    from pydantic import RootModel  # pydantic: ignore
+    from pydantic import RootModel  
 
     RunnableWithMessageHistoryInput = RootModel[Sequence[BaseMessage]]
 

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
+from pydantic import BaseModel
 from pytest_mock import MockerFixture
 from syrupy import SnapshotAssertion
 from typing_extensions import TypedDict
@@ -57,7 +58,6 @@ from langchain_core.prompts import (
     PromptTemplate,
     SystemMessagePromptTemplate,
 )
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     AddableDict,
@@ -89,7 +89,7 @@ from langchain_core.tracers import (
     RunLogPatch,
 )
 from langchain_core.tracers.context import collect_runs
-from tests.unit_tests.pydantic_utils import _schema
+from tests.unit_tests.pydantic_utils import _schema, replace_all_of_with_ref
 from tests.unit_tests.stubs import AnyStr, _AnyIdAIMessage, _AnyIdAIMessageChunk
 
 
@@ -313,12 +313,14 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                     "metadata": {"title": "Metadata", "type": "object"},
                     "id": {
                         "title": "Id",
-                        "type": "string",
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
                     },
                     "type": {
                         "title": "Type",
                         "enum": ["Document"],
                         "default": "Document",
+                        "const": "Document",
                         "type": "string",
                     },
                 },
@@ -329,7 +331,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
 
     fake_llm = FakeListLLM(responses=["a"])  # str -> List[List[str]]
 
-    assert _schema(fake_llm.input_schema) == snapshot
+    assert _schema(fake_llm.input_schema) == snapshot(name="fake_llm_input_schema")
     assert _schema(fake_llm.output_schema) == {
         "title": "FakeListLLMOutput",
         "type": "string",
@@ -337,8 +339,8 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
 
     fake_chat = FakeListChatModel(responses=["a"])  # str -> List[List[str]]
 
-    assert _schema(fake_chat.input_schema) == snapshot
-    assert _schema(fake_chat.output_schema) == snapshot
+    assert _schema(fake_chat.input_schema) == snapshot(name="fake_chat_input_schema")
+    assert _schema(fake_chat.output_schema) == snapshot(name="fake_chat_output_schema")
 
     chat_prompt = ChatPromptTemplate.from_messages(
         [
@@ -362,7 +364,7 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
         "properties": {"name": {"title": "Name", "type": "string"}},
         "required": ["name"],
     }
-    assert _schema(prompt.output_schema) == snapshot
+    assert _schema(prompt.output_schema) == snapshot(name="prompt_output_schema")
 
     prompt_mapper = PromptTemplate.from_template("Hello, {name}!").map()
 
@@ -379,11 +381,15 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
         "type": "array",
         "title": "RunnableEach<PromptTemplate>Input",
     }
-    assert _schema(prompt_mapper.output_schema) == snapshot
+    assert _schema(prompt_mapper.output_schema) == snapshot(
+        name="prompt_mapper_output_schema"
+    )
 
     list_parser = CommaSeparatedListOutputParser()
 
-    assert _schema(list_parser.input_schema) == snapshot
+    assert _schema(list_parser.input_schema) == snapshot(
+        name="list_parser_input_schema"
+    )
     assert _schema(list_parser.output_schema) == {
         "title": "CommaSeparatedListOutputParserOutput",
         "type": "array",
@@ -407,19 +413,26 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
     router: Runnable = RouterRunnable({})
 
     assert _schema(router.input_schema) == {
-        "title": "RouterRunnableInput",
         "$ref": "#/definitions/RouterInput",
         "definitions": {
             "RouterInput": {
-                "title": "RouterInput",
-                "type": "object",
+                "description": "Router input.\n"
+                "\n"
+                "Attributes:\n"
+                "    key: The key to route "
+                "on.\n"
+                "    input: The input to pass "
+                "to the selected Runnable.",
                 "properties": {
-                    "key": {"title": "Key", "type": "string"},
                     "input": {"title": "Input"},
+                    "key": {"title": "Key", "type": "string"},
                 },
                 "required": ["key", "input"],
+                "title": "RouterInput",
+                "type": "object",
             }
         },
+        "title": "RouterRunnableInput",
     }
     assert _schema(router.output_schema) == {"title": "RouterRunnableOutput"}
 
@@ -451,6 +464,20 @@ def test_schemas(snapshot: SnapshotAssertion) -> None:
                 "items": {"type": "string"},
             },
         },
+        "required": ["original", "as_list", "length"],
+    }
+
+    # Add a test for schema of runnable assign
+    def foo(x: int) -> int:
+        return x
+
+    foo_ = RunnableLambda(foo)
+
+    assert foo_.assign(bar=lambda x: "foo").get_output_schema().schema() == {
+        "properties": {"bar": {"title": "Bar"}, "root": {"title": "Root"}},
+        "required": ["root", "bar"],
+        "title": "RunnableAssignOutput",
+        "type": "object",
     }
 
 
@@ -469,6 +496,7 @@ def test_passthrough_assign_schema() -> None:
         "properties": {"question": {"title": "Question", "type": "string"}},
         "title": "RunnableSequenceInput",
         "type": "object",
+        "required": ["question"],
     }
     assert _schema(seq_w_assign.output_schema) == {
         "title": "FakeListLLMOutput",
@@ -486,6 +514,7 @@ def test_passthrough_assign_schema() -> None:
         "properties": {"question": {"title": "Question"}},
         "title": "RunnableParallel<context>Input",
         "type": "object",
+        "required": ["question"],
     }
 
 
@@ -498,6 +527,7 @@ def test_lambda_schemas() -> None:
         "title": "RunnableLambdaInput",
         "type": "object",
         "properties": {"hello": {"title": "Hello"}},
+        "required": ["hello"],
     }
 
     second_lambda = lambda x, y: (x["hello"], x["bye"], y["bah"])  # noqa: E731
@@ -505,6 +535,7 @@ def test_lambda_schemas() -> None:
         "title": "RunnableLambdaInput",
         "type": "object",
         "properties": {"hello": {"title": "Hello"}, "bye": {"title": "Bye"}},
+        "required": ["bye", "hello"],
     }
 
     def get_value(input):  # type: ignore[no-untyped-def]
@@ -514,6 +545,7 @@ def test_lambda_schemas() -> None:
         "title": "get_value_input",
         "type": "object",
         "properties": {"variable_name": {"title": "Variable Name"}},
+        "required": ["variable_name"],
     }
 
     async def aget_value(input):  # type: ignore[no-untyped-def]
@@ -526,6 +558,7 @@ def test_lambda_schemas() -> None:
             "another": {"title": "Another"},
             "variable_name": {"title": "Variable Name"},
         },
+        "required": ["another", "variable_name"],
     }
 
     async def aget_values(input):  # type: ignore[no-untyped-def]
@@ -542,6 +575,7 @@ def test_lambda_schemas() -> None:
             "variable_name": {"title": "Variable Name"},
             "yo": {"title": "Yo"},
         },
+        "required": ["variable_name", "yo"],
     }
 
     class InputType(TypedDict):
@@ -622,6 +656,25 @@ def test_with_types_with_type_generics() -> None:
     )
 
 
+def test_schema_with_itemgetter() -> None:
+    """Test runnable with itemgetter."""
+    foo = RunnableLambda(itemgetter("hello"))
+    assert _schema(foo.input_schema) == {
+        "properties": {"hello": {"title": "Hello"}},
+        "required": ["hello"],
+        "title": "RunnableLambdaInput",
+        "type": "object",
+    }
+    prompt = ChatPromptTemplate.from_template("what is {language}?")
+    chain: Runnable = {"language": itemgetter("language")} | prompt
+    assert _schema(chain.input_schema) == {
+        "properties": {"language": {"title": "Language"}},
+        "required": ["language"],
+        "title": "RunnableParallel<language>Input",
+        "type": "object",
+    }
+
+
 def test_schema_complex_seq() -> None:
     prompt1 = ChatPromptTemplate.from_template("what is the city {person} is from?")
     prompt2 = ChatPromptTemplate.from_template(
@@ -650,6 +703,7 @@ def test_schema_complex_seq() -> None:
             "person": {"title": "Person", "type": "string"},
             "language": {"title": "Language"},
         },
+        "required": ["person", "language"],
     }
 
     assert _schema(chain2.output_schema) == {
@@ -953,66 +1007,69 @@ def test_configurable_fields_prefix_keys() -> None:
     chain = prompt | fake_llm
 
     assert _schema(chain.config_schema()) == {
-        "title": "RunnableSequenceConfig",
-        "type": "object",
-        "properties": {"configurable": {"$ref": "#/definitions/Configurable"}},
         "definitions": {
-            "LLM": {
-                "title": "LLM",
-                "description": "An enumeration.",
-                "enum": ["chat", "default"],
-                "type": "string",
-            },
             "Chat_Responses": {
-                "title": "Chat Responses",
-                "description": "An enumeration.",
                 "enum": ["hello", "bye", "helpful"],
-                "type": "string",
-            },
-            "Prompt_Template": {
-                "title": "Prompt Template",
-                "description": "An enumeration.",
-                "enum": ["hello", "good_morning"],
+                "title": "Chat Responses",
                 "type": "string",
             },
             "Configurable": {
-                "title": "Configurable",
-                "type": "object",
                 "properties": {
-                    "prompt_template": {
-                        "title": "Prompt Template",
-                        "description": "The prompt template for this chain",
-                        "default": "hello",
-                        "allOf": [{"$ref": "#/definitions/Prompt_Template"}],
+                    "chat_sleep": {
+                        "anyOf": [{"type": "number"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Chat " "Sleep",
                     },
                     "llm": {
-                        "title": "LLM",
+                        "$ref": "#/definitions/LLM",
                         "default": "default",
-                        "allOf": [{"$ref": "#/definitions/LLM"}],
+                        "title": "LLM",
                     },
-                    # not prefixed because marked as shared
-                    "chat_sleep": {
-                        "title": "Chat Sleep",
-                        "type": "number",
-                    },
-                    # prefixed for "chat" option
                     "llm==chat/responses": {
-                        "title": "Chat Responses",
                         "default": ["hello", "bye"],
-                        "type": "array",
                         "items": {"$ref": "#/definitions/Chat_Responses"},
-                    },
-                    # prefixed for "default" option
-                    "llm==default/responses": {
-                        "title": "LLM Responses",
-                        "description": "A list of fake responses for this LLM",
-                        "default": ["a"],
+                        "title": "Chat " "Responses",
                         "type": "array",
+                    },
+                    "llm==default/responses": {
+                        "default": ["a"],
+                        "description": "A "
+                        "list "
+                        "of "
+                        "fake "
+                        "responses "
+                        "for "
+                        "this "
+                        "LLM",
                         "items": {"type": "string"},
+                        "title": "LLM " "Responses",
+                        "type": "array",
+                    },
+                    "prompt_template": {
+                        "$ref": "#/definitions/Prompt_Template",
+                        "default": "hello",
+                        "description": "The "
+                        "prompt "
+                        "template "
+                        "for "
+                        "this "
+                        "chain",
+                        "title": "Prompt " "Template",
                     },
                 },
+                "title": "Configurable",
+                "type": "object",
+            },
+            "LLM": {"enum": ["chat", "default"], "title": "LLM", "type": "string"},
+            "Prompt_Template": {
+                "enum": ["hello", "good_morning"],
+                "title": "Prompt Template",
+                "type": "string",
             },
         },
+        "properties": {"configurable": {"$ref": "#/definitions/Configurable"}},
+        "title": "RunnableSequenceConfig",
+        "type": "object",
     }
 
 
@@ -1061,26 +1118,22 @@ def test_configurable_fields_example() -> None:
     chain_configurable = prompt | fake_llm | (lambda x: {"name": x}) | prompt | fake_llm
 
     assert chain_configurable.invoke({"name": "John"}) == "a"
-
-    assert _schema(chain_configurable.config_schema()) == {
+    expected = {
         "title": "RunnableSequenceConfig",
         "type": "object",
         "properties": {"configurable": {"$ref": "#/definitions/Configurable"}},
         "definitions": {
             "LLM": {
                 "title": "LLM",
-                "description": "An enumeration.",
                 "enum": ["chat", "default"],
                 "type": "string",
             },
             "Chat_Responses": {
-                "description": "An enumeration.",
                 "enum": ["hello", "bye", "helpful"],
                 "title": "Chat Responses",
                 "type": "string",
             },
             "Prompt_Template": {
-                "description": "An enumeration.",
                 "enum": ["hello", "good_morning"],
                 "title": "Prompt Template",
                 "type": "string",
@@ -1117,6 +1170,10 @@ def test_configurable_fields_example() -> None:
             },
         },
     }
+
+    replace_all_of_with_ref(expected)
+
+    assert _schema(chain_configurable.config_schema()) == expected
 
     assert (
         chain_configurable.with_config(configurable={"llm": "chat"}).invoke(
@@ -3176,6 +3233,7 @@ def test_map_stream() -> None:
             "hello": {"title": "Hello", "type": "string"},
             "llm": {"title": "Llm", "type": "string"},
         },
+        "required": ["llm", "hello"],
     }
 
     stream = chain_pick_two.stream({"question": "What is your name?"})
@@ -3193,6 +3251,12 @@ def test_map_stream() -> None:
         {"llm": "i"},
         {"chat": _AnyIdAIMessageChunk(content="i")},
     ]
+    if not (  # TODO(Rewrite properly) statement above
+        streamed_chunks[0] == {"llm": "i"}
+        or {"chat": _AnyIdAIMessageChunk(content="i")}
+    ):
+        raise AssertionError(f"Got an unexpected chunk: {streamed_chunks[0]}")
+
     assert len(streamed_chunks) == len(llm_res) + len(chat_res)
 
 
@@ -3547,6 +3611,7 @@ def test_deep_stream_assign() -> None:
             "str": {"title": "Str", "type": "string"},
             "hello": {"title": "Hello", "type": "string"},
         },
+        "required": ["str", "hello"],
     }
 
     chunks = []
@@ -3598,6 +3663,7 @@ def test_deep_stream_assign() -> None:
             "str": {"title": "Str"},
             "hello": {"title": "Hello", "type": "string"},
         },
+        "required": ["str", "hello"],
     }
 
     chunks = []
@@ -3673,6 +3739,7 @@ async def test_deep_astream_assign() -> None:
             "str": {"title": "Str", "type": "string"},
             "hello": {"title": "Hello", "type": "string"},
         },
+        "required": ["str", "hello"],
     }
 
     chunks = []
@@ -3724,6 +3791,7 @@ async def test_deep_astream_assign() -> None:
             "str": {"title": "Str"},
             "hello": {"title": "Hello", "type": "string"},
         },
+        "required": ["str", "hello"],
     }
 
     chunks = []
@@ -4365,7 +4433,10 @@ def test_runnable_branch_init_coercion(branches: Sequence[Any]) -> None:
         assert isinstance(body, Runnable)
 
     assert isinstance(runnable.default, Runnable)
-    assert _schema(runnable.input_schema) == {"title": "RunnableBranchInput"}
+    assert _schema(runnable.input_schema) == {
+        "title": "RunnableBranchInput",
+        "type": "integer",
+    }
 
 
 def test_runnable_branch_invoke_call_counts(mocker: MockerFixture) -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -3,8 +3,10 @@
 import sys
 from itertools import cycle
 from typing import Any, AsyncIterator, Dict, List, Sequence, cast
+from typing import Optional as Optional
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -19,7 +21,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     ConfigurableField,
@@ -1174,6 +1175,9 @@ class HardCodedRetriever(BaseRetriever):
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> List[Document]:
         return self.documents
+
+
+HardCodedRetriever.model_rebuild()
 
 
 async def test_event_stream_with_retriever() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import pytest
+from pydantic import BaseModel
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -33,7 +34,6 @@ from langchain_core.messages import (
 )
 from langchain_core.prompt_values import ChatPromptValue
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.runnables import (
     ConfigurableField,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,7 +23,7 @@ from typing import (
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
-from pydantic import BaseModel as BaseModelProper  # pydantic: ignore
+from pydantic import BaseModel as BaseModelProper  
 from typing_extensions import Annotated, TypedDict, TypeVar
 
 from langchain_core import tools
@@ -1572,7 +1572,7 @@ def generate_models() -> List[Any]:
 
 def generate_backwards_compatible_v1() -> List[Any]:
     """Generate a model with pydantic 2 from the v1 namespace."""
-    from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+    from pydantic.v1 import BaseModel as BaseModelV1  
 
     class FooV1Namespace(BaseModelV1):
         a: int
@@ -1629,7 +1629,7 @@ def test_args_schema_explicitly_typed() -> None:
     is a pydantic 1 model!
     """
     # Check with whatever pydantic model is passed in and not via v1 namespace
-    from pydantic import BaseModel  # pydantic: ignore
+    from pydantic import BaseModel  
 
     class Foo(BaseModel):
         a: int
@@ -1873,9 +1873,9 @@ def test__get_all_basemodel_annotations_v1() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="Testing pydantic v2.")
 def test_tool_args_schema_pydantic_v2_with_metadata() -> None:
-    from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
-    from pydantic import Field as FieldV2  # pydantic: ignore
-    from pydantic import ValidationError as ValidationErrorV2  # pydantic: ignore
+    from pydantic import BaseModel as BaseModelV2  
+    from pydantic import Field as FieldV2  
+    from pydantic import ValidationError as ValidationErrorV2  
 
     class Foo(BaseModelV2):
         x: List[int] = FieldV2(

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -34,8 +34,9 @@ try:
 except ImportError:
     TypingAnnotated = ExtensionsAnnotated
 
+from pydantic import BaseModel, Field
+
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import Runnable, RunnableLambda
 from langchain_core.tools import BaseTool, tool
 from langchain_core.utils.function_calling import (
@@ -450,17 +451,17 @@ def test_multiple_tool_calls() -> None:
         {
             "id": messages[2].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall1"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall1"}'},
         },
         {
             "id": messages[3].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall2"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall2"}'},
         },
         {
             "id": messages[4].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall3"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall3"}'},
         },
     ]
 
@@ -481,7 +482,7 @@ def test_tool_outputs() -> None:
         {
             "id": messages[2].tool_call_id,
             "type": "function",
-            "function": {"name": "FakeCall", "arguments": '{"data": "ToolCall1"}'},
+            "function": {"name": "FakeCall", "arguments": '{"data":"ToolCall1"}'},
         },
     ]
     assert messages[2].content == "Output1"
@@ -737,8 +738,9 @@ def test__convert_typed_dict_to_openai_function(
 @pytest.mark.parametrize("typed_dict", [ExtensionsTypedDict, TypingTypedDict])
 def test__convert_typed_dict_to_openai_function_fail(typed_dict: Type) -> None:
     class Tool(typed_dict):
-        arg1: MutableSet  # Pydantic doesn't support
+        arg1: MutableSet  # Pydantic 2 supports this, but pydantic v1 does not.
 
+    # Error should be raised since we're using v1 code path here
     with pytest.raises(TypeError):
         _convert_typed_dict_to_openai_function(Tool)
 

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -94,12 +94,12 @@ def test_with_aliases() -> None:
 def test_is_basemodel_subclass() -> None:
     """Test pydantic."""
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV1Proper  
 
         assert is_basemodel_subclass(BaseModelV1Proper)
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
-        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV2  
+        from pydantic.v1 import BaseModel as BaseModelV1  
 
         assert is_basemodel_subclass(BaseModelV2)
 
@@ -111,15 +111,15 @@ def test_is_basemodel_subclass() -> None:
 def test_is_basemodel_instance() -> None:
     """Test pydantic."""
     if PYDANTIC_MAJOR_VERSION == 1:
-        from pydantic import BaseModel as BaseModelV1Proper  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV1Proper  
 
         class FooV1(BaseModelV1Proper):
             x: int
 
         assert is_basemodel_instance(FooV1(x=5))
     elif PYDANTIC_MAJOR_VERSION == 2:
-        from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
-        from pydantic.v1 import BaseModel as BaseModelV1  # pydantic: ignore
+        from pydantic import BaseModel as BaseModelV2  
+        from pydantic.v1 import BaseModel as BaseModelV1  
 
         class Foo(BaseModelV2):
             x: int
@@ -137,8 +137,8 @@ def test_is_basemodel_instance() -> None:
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="Only tests Pydantic v2")
 def test_with_field_metadata() -> None:
     """Test pydantic with field metadata"""
-    from pydantic import BaseModel as BaseModelV2  # pydantic: ignore
-    from pydantic import Field as FieldV2  # pydantic: ignore
+    from pydantic import BaseModel as BaseModelV2  
+    from pydantic import Field as FieldV2  
 
     class Foo(BaseModelV2):
         x: List[int] = FieldV2(
@@ -165,7 +165,7 @@ def test_with_field_metadata() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 1, reason="Only tests Pydantic v1")
 def test_fields_pydantic_v1() -> None:
-    from pydantic import BaseModel  # pydantic: ignore
+    from pydantic import BaseModel  
 
     class Foo(BaseModel):
         x: int
@@ -176,7 +176,7 @@ def test_fields_pydantic_v1() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="Only tests Pydantic v2")
 def test_fields_pydantic_v2_proper() -> None:
-    from pydantic import BaseModel  # pydantic: ignore
+    from pydantic import BaseModel  
 
     class Foo(BaseModel):
         x: int
@@ -187,7 +187,7 @@ def test_fields_pydantic_v2_proper() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="Only tests Pydantic v2")
 def test_fields_pydantic_v1_from_2() -> None:
-    from pydantic.v1 import BaseModel  # pydantic: ignore
+    from pydantic.v1 import BaseModel  
 
     class Foo(BaseModel):
         x: int

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional
 
 import pytest
+from pydantic import ConfigDict
 
 from langchain_core.utils.pydantic import (
     PYDANTIC_MAJOR_VERSION,
@@ -15,7 +16,7 @@ from langchain_core.utils.pydantic import (
 
 
 def test_pre_init_decorator() -> None:
-    from langchain_core.pydantic_v1 import BaseModel
+    from pydantic import BaseModel
 
     class Foo(BaseModel):
         x: int = 5
@@ -34,7 +35,7 @@ def test_pre_init_decorator() -> None:
 
 
 def test_pre_init_decorator_with_more_defaults() -> None:
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         a: int = 1
@@ -56,14 +57,15 @@ def test_pre_init_decorator_with_more_defaults() -> None:
 
 
 def test_with_aliases() -> None:
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         x: int = Field(default=1, alias="y")
         z: int
 
-        class Config:
-            allow_population_by_field_name = True
+        model_config = ConfigDict(
+            populate_by_name=True,
+        )
 
         @pre_init
         def validator(cls, v: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -221,8 +221,8 @@ def test_guard_import_failure(
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="Requires pydantic 2")
 def test_get_pydantic_field_names_v1_in_2() -> None:
-    from pydantic.v1 import BaseModel as PydanticV1BaseModel  # pydantic: ignore
-    from pydantic.v1 import Field  # pydantic: ignore
+    from pydantic.v1 import BaseModel as PydanticV1BaseModel  
+    from pydantic.v1 import Field  
 
     class PydanticV1Model(PydanticV1BaseModel):
         field1: str
@@ -236,7 +236,7 @@ def test_get_pydantic_field_names_v1_in_2() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 2, reason="Requires pydantic 2")
 def test_get_pydantic_field_names_v2_in_2() -> None:
-    from pydantic import BaseModel, Field  # pydantic: ignore
+    from pydantic import BaseModel, Field  
 
     class PydanticModel(BaseModel):
         field1: str
@@ -250,7 +250,7 @@ def test_get_pydantic_field_names_v2_in_2() -> None:
 
 @pytest.mark.skipif(PYDANTIC_MAJOR_VERSION != 1, reason="Requires pydantic 1")
 def test_get_pydantic_field_names_v1() -> None:
-    from pydantic import BaseModel, Field  # pydantic: ignore
+    from pydantic import BaseModel, Field  
 
     class PydanticModel(BaseModel):
         field1: str

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -6,9 +6,9 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 from langchain_core import utils
-from langchain_core.pydantic_v1 import SecretStr
 from langchain_core.utils import (
     check_package_version,
     from_env,
@@ -365,7 +365,7 @@ def test_secret_from_env_with_custom_error_message(
 def test_using_secret_from_env_as_default_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from langchain_core.pydantic_v1 import BaseModel, Field
+    from pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         secret: SecretStr = Field(default_factory=secret_from_env("TEST_KEY"))

--- a/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
@@ -10,7 +10,7 @@ from langchain_standard_tests.integration_tests.vectorstores import (
 from langchain_core.documents import Document
 from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 from langchain_core.vectorstores import InMemoryVectorStore
-from tests.unit_tests.stubs import AnyStr, _AnyIdDocument
+from tests.unit_tests.stubs import _AnyIdDocument
 
 
 class TestInMemoryReadWriteTestSuite(ReadWriteTestSuite):
@@ -117,7 +117,7 @@ async def test_inmemory_filter() -> None:
 
     # Check sync version
     output = store.similarity_search("fee", filter=lambda doc: doc.metadata["id"] == 1)
-    assert output == [Document(page_content="foo", metadata={"id": 1}, id=AnyStr())]
+    assert output == [_AnyIdDocument(page_content="foo", metadata={"id": 1})]
 
     # filter with not stored document id
     output = await store.asimilarity_search(


### PR DESCRIPTION
This PR upgrades core to pydantic 2.

It involves a combination of manual changes together with automated code mods using gritql.

Changes and known issues:

1. Current models override __repr__ to be consistent with pydantic 1 (this will be removed in a follow up PR)
Related: https://github.com/langchain-ai/langchain/pull/25986/files#diff-e5bd296179b7a72fcd4ea5cfa28b145beaf787da057e6d122aa76ee0bb8132c9R74
2. Issue with decorator for BaseChatModel (https://github.com/langchain-ai/langchain/pull/25986/files#diff-932bf3b314b268754ef640a5b8f52da96f9024fb81dd388dcd166b5713ecdf66R202) -- cc @baskaryan 
3. `name` attribute in Base Runnable does not have a default -- was raising a pydantic warning due to override. We need to see if there's a way to fix to avoid making a breaking change for folks with custom runnables. (https://github.com/langchain-ai/langchain/pull/25986/files#diff-836773d27f8565f4dd45e9d6cf828920f89991a880c098b7511e0d3bb78a8a0dR238)
4. Likely can remove hard-coded RunnableBranch name (https://github.com/langchain-ai/langchain/pull/25986/files#diff-72894b94f70b1bfc908eb4d53f5ff90bb33bf8a4240a5e34cae48ddc62ac313aR147)
5. `model_*` namespace is reserved in pydantic. We'll need to specify `protected_namespaces`
6. create_model does not have a cached path yet
7. get_input_schema() in many places has been updated to be explicit about whether parameters are required or optional
8. injected tool args aren't picked up properly (losing type annotation)

For posterity the following gritql migrations were used:

```
engine marzano(0.1)
language python

or {
    `from $IMPORT import $...` where {
        $IMPORT <: contains `pydantic_v1`,
        $IMPORT => `pydantic`
    },
    `$X.update_forward_refs` => `$X.model_rebuild`,
  // This pattern still needs fixing as it fails (populate_by_name vs.
  // allow_populate_by_name)
  class_definition($name, $body) as $C where {
      $name <: `Config`,
      $body <: block($statements),
      $t = "",
      $statements <: some bubble($t) assignment(left=$x, right=$y) as $A where {    
        or {
            $x <: `allow_population_by_field_name` where {
                $t += `populate_by_name=$y,`
            },
            $t += `$x=$y,`
        }
      },
      $C => `model_config = ConfigDict($t)`,
      add_import(source="pydantic", name="ConfigDict")
  }
}

```



```
engine marzano(0.1)
language python

`@root_validator(pre=True)` as $decorator where {
    $decorator <: before function_definition($body, $return_type),
    $decorator => `@model_validator(mode="before")\n@classmethod`,
    add_import(source="pydantic", name="model_validator"),
    $return_type => `Any`
}
```

```
engine marzano(0.1)
language python

`@root_validator(pre=False, skip_on_failure=True)` as $decorator where {
    $decorator <: before function_definition($body, $parameters, $return_type) where {
        $body <: contains bubble or {
            `values["$Q"]` => `self.$Q`,
            `values.get("$Q")` => `(self.$Q or None)`,
            `values.get($Q, $...)` as $V where {
                $Q <: contains `"$QName"`,
                $V => `self.$QName`,
            },
            `return $Q` => `return self`
        }
    },
    $decorator => `@model_validator(mode="after")`,
    // Silly work around a bug in grit
    // Adding Self to pydantic and then will replace it with one from typing
    add_import(source="pydantic", name="model_validator"),
    $parameters => `self`,
    $return_type => `Self`
}

```

```
grit apply --language python '`Self` where { add_import(source="typing_extensions", name="Self")}'
```
