### PR TITLE
fix(community): Add support for Bedrock cross-region inference models

### DIFF
--- a/libs/community/langchain_community/llms/bedrock.py
+++ b/libs/community/langchain_community/llms/bedrock.py
@@ -37,6 +37,18 @@ ASSISTANT_PROMPT = "\n\nAssistant:"
 ALTERNATION_ERROR = (
     "Error: Prompt must alternate between '\n\nHuman:' and '\n\nAssistant:'."
 )
+AWS_REGIONS = [
+    "us",
+    "sa",
+    "me",
+    "il",
+    "eu",
+    "cn",
+    "ca",
+    "ap",
+    "af",
+    "us-gov",
+]
 
 
 def _add_newlines_before_ha(input_text: str) -> str:
@@ -447,6 +459,12 @@ class BedrockBase(BaseModel, ABC):
             **{"model_kwargs": _model_kwargs},
         }
 
+    @property
+    def _model_is_inference(self) -> bool:
+        parts = self.model_id.split(".")
+
+        return True if parts[0] in AWS_REGIONS else False
+
     def _get_provider(self) -> str:
         if self.provider:
             return self.provider
@@ -456,7 +474,9 @@ class BedrockBase(BaseModel, ABC):
                 "model_id"
             )
 
-        return self.model_id.split(".")[0]
+        parts = self.model_id.split(".")
+
+        return parts[1] if self._model_is_inference else parts[0]
 
     @property
     def _model_is_anthropic(self) -> bool:


### PR DESCRIPTION
Merged for langchainjs: https://github.com/langchain-ai/langchainjs/pull/6682

Hey, I recently I switched to Bedrock Inference models.

Basically, I've introduced a property to check if the `modelId` belongs to an inference model or not.

With Inference models, Amazon introduced a new prefix which is a region code. If `modelId` previously was `anthropic.claude-3-5-sonnet-20240620-v1:0` now, with the change it's `eu.anthropic.claude-3-5-sonnet-20240620-v1:0`

Fixes langchain-ai/langchainjs#6690 