### PR TITLE
Update FeatureTables.js to reflect Cohere's support for JSON mode

### DIFF
--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -123,7 +123,7 @@ const FEATURE_TABLES = {
                 "link": "cohere/",
                 "structured_output": true,
                 "tool_calling": true,
-                "json_mode": false,
+                "json_mode": true,
                 "multimodal": false,
                 "local": false,
                 "apiLink": "https://python.langchain.com/v0.2/api_reference/cohere/chat_models/langchain_cohere.chat_models.ChatCohere.html"


### PR DESCRIPTION
- [ ] **PR title**: "docs: update FeatureTables.js to reflect Cohere's support for JSON mode"
- [ ] **PR message**: Update FeatureTables.js to reflect Cohere's support for JSON mode

- [ ] **Description:** updated Cohere's record in the Featured Providers table [1].  Set "json_mode" to true as Cohere's models support JSON mode [2].

[1] source table: https://python.langchain.com/v0.2/docs/integrations/chat/#featured-providers

[2] Cohere's api reference showing support for JSON mode  i.e. response_format={ "type": "json_object" }
https://docs.cohere.com/docs/structured-outputs-json

- **Twitter handle:** @ryanchase1