### PR TITLE
openai: fix json_schema mode in AzureChatOpenAI.with_structured_output

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -716,14 +716,12 @@ class BaseChatOpenAI(BaseChatModel):
             "system_fingerprint": response_dict.get("system_fingerprint", ""),
         }
 
-        if isinstance(response, openai.BaseModel) and getattr(
-            response, "choices", None
-        ):
-            message = response.choices[0].message  # type: ignore[attr-defined]
-            if hasattr(message, "parsed"):
-                generations[0].message.additional_kwargs["parsed"] = message.parsed
-            if hasattr(message, "refusal"):
-                generations[0].message.additional_kwargs["refusal"] = message.refusal
+        if response_dict.get("choices"):
+            message = response_dict["choices"][0]["message"]
+            if "parsed" in message:
+                generations[0].message.additional_kwargs["parsed"] = message["parsed"]
+            if "refusal" in message:
+                generations[0].message.additional_kwargs["refusal"] = message["refusal"]
 
         return ChatResult(generations=generations, llm_output=llm_output)
 


### PR DESCRIPTION
This PR fixes an issue with `json_schema` mode in `AzureChatOpenAI.with_structured_output`.

Following the release of [structured output support in Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/structured-outputs?tabs=python), I was able to test #25591 where the main proposed change is to use  `BaseChatOpenAI.with_structured_output` and not override it in `AzureChatOpenAI.with_structured_output` like currently implemented. When testing `json_schema` mode with those proposed changes, I was getting `ValueError: Structured Output response does not have a 'parsed' field nor a 'refusal' field.`. 

After some investigation, here is an analysis of the issue:
- In `BaseChatOpenAI._create_chat_result`, the `parsed` and `refusal` properties of the completion generated by  `BaseChatOpenAI._generate` are correctly added as `additional_kwargs` to the generation.
- In that case, `BaseChatOpenAI._create_chat_result` is called with the argument `response` of type `openai.BaseModel`. 
- However, `AzureChatOpenAI._create_chat_result` overrides `BaseChatOpenAI._create_chat_result` like so
https://github.com/langchain-ai/langchain/blob/de97d5064437c98f34dae0b0afa3b61162790726/libs/partners/openai/langchain_openai/chat_models/azure.py#L985-L993
- `BaseChatOpenAI._create_chat_result` is thus called with the argument `response` of type `dict` (following `response.model_dump()`). 
- It follows that the condition below in the implementation of `BaseChatOpenAI._create_chat_result` is not satisfied and thus `parsed` and `refusal` are not added to the generation.
https://github.com/langchain-ai/langchain/blob/de97d5064437c98f34dae0b0afa3b61162790726/libs/partners/openai/langchain_openai/chat_models/base.py#L719-L726

I propose to change the implementation of that check so that it works on the `response_dict` that is created anyways in `BaseChatOpenAI._create_chat_result` so that the `parsed` and `refusal` properties of the completion are correctly added as `additional_kwargs` to the generation whatever the type of `response`.

@baskaryan I believe it would be valuable for you to review to avoid any regression and confirm that this PR should be merged at the same time as #25591 to avoid introducing a bug.