### PR TITLE
Changed docker command of redis to stack redis

### DIFF
--- a/docs/docs/integrations/memory/redis_chat_message_history.ipynb
+++ b/docs/docs/integrations/memory/redis_chat_message_history.ipynb
@@ -36,7 +36,7 @@
     "Make sure you have a Redis server running. You can start one using Docker with the following command:\n",
     "\n",
     "```\n",
-    "docker run -d -p 6379:6379 redis:latest\n",
+    "docker run -d --name redis-stack -p 6379:6379 redis/redis-stack-server:latest\n",
     "```\n",
     "\n",
     "Or install and run Redis locally according to the instructions for your operating system."


### PR DESCRIPTION
Thank you for contributing to LangChain!


changed the docker command from normal redis to stack redis 
When i tried to follow the example faced an issue but with stack redis it worked as expected


    - **Description:** Docker command changed : Langchain
    - **Issue:**  With normal redis it is not working as expected so replaced with stack redis
    - **Twitter handle:** https://x.com/VpkPrasanna