### PR TITLE
core[patch]: Ignore pydantic deprecation warnings in validate_arguments

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -9,6 +9,16 @@ import warnings
 from abc import ABC, abstractmethod
 from contextvars import copy_context
 from inspect import signature
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SkipValidation,
+    ValidationError,
+    model_validator,
+    validate_arguments,
+)
+from pydantic import PydanticDeprecationWarning
 from typing import (
     Any,
     Callable,
@@ -25,16 +35,6 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
-)
-
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    SkipValidation,
-    ValidationError,
-    model_validator,
-    validate_arguments,
 )
 from typing_extensions import Annotated
 
@@ -207,7 +207,12 @@ def create_schema_from_function(
         A pydantic model with the same arguments as the function.
     """
     # https://docs.pydantic.dev/latest/usage/validation_decorator/
-    validated = validate_arguments(func, config=_SchemaConfig)  # type: ignore
+    with warnings.catch_warnings():
+        # We are using deprecated functionality here.
+        # This code should be re-written to simply construct a pydantic model
+        # using inspect.signature and create_model.
+        warnings.simplefilter("ignore", category=PydanticDeprecationWarning)
+        validated = validate_arguments(func, config=_SchemaConfig)  # type: ignore
 
     sig = inspect.signature(func)
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -9,16 +9,6 @@ import warnings
 from abc import ABC, abstractmethod
 from contextvars import copy_context
 from inspect import signature
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    SkipValidation,
-    ValidationError,
-    model_validator,
-    validate_arguments,
-)
-from pydantic import PydanticDeprecationWarning
 from typing import (
     Any,
     Callable,
@@ -35,6 +25,17 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PydanticDeprecationWarning,
+    SkipValidation,
+    ValidationError,
+    model_validator,
+    validate_arguments,
 )
 from typing_extensions import Annotated
 


### PR DESCRIPTION
For now, we'll use the deprecation functionality which is present until pydantic 3.
