### PR TITLE
core[patch]: Remove some usage of .copy() in favor of .model_copy()

### DIFF
--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -23,11 +23,11 @@ from langchain_core.messages.utils import (
 @pytest.mark.parametrize("msg_cls", [HumanMessage, AIMessage, SystemMessage])
 def test_merge_message_runs_str(msg_cls: Type[BaseMessage]) -> None:
     messages = [msg_cls("foo"), msg_cls("bar"), msg_cls("baz")]
-    messages_copy = [m.copy(deep=True) for m in messages]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
     expected = [msg_cls("foo\nbar\nbaz")]
     actual = merge_message_runs(messages)
     assert actual == expected
-    assert messages == messages_copy
+    assert messages == messages_model_copy
 
 
 @pytest.mark.parametrize("msg_cls", [HumanMessage, AIMessage, SystemMessage])
@@ -35,11 +35,11 @@ def test_merge_message_runs_str_with_specified_separator(
     msg_cls: Type[BaseMessage],
 ) -> None:
     messages = [msg_cls("foo"), msg_cls("bar"), msg_cls("baz")]
-    messages_copy = [m.copy(deep=True) for m in messages]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
     expected = [msg_cls("foo<sep>bar<sep>baz")]
     actual = merge_message_runs(messages, chunk_separator="<sep>")
     assert actual == expected
-    assert messages == messages_copy
+    assert messages == messages_model_copy
 
 
 @pytest.mark.parametrize("msg_cls", [HumanMessage, AIMessage, SystemMessage])
@@ -47,11 +47,11 @@ def test_merge_message_runs_str_without_separator(
     msg_cls: Type[BaseMessage],
 ) -> None:
     messages = [msg_cls("foo"), msg_cls("bar"), msg_cls("baz")]
-    messages_copy = [m.copy(deep=True) for m in messages]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
     expected = [msg_cls("foobarbaz")]
     actual = merge_message_runs(messages, chunk_separator="")
     assert actual == expected
-    assert messages == messages_copy
+    assert messages == messages_model_copy
 
 
 def test_merge_message_runs_content() -> None:
@@ -75,7 +75,7 @@ def test_merge_message_runs_content() -> None:
             id="3",
         ),
     ]
-    messages_copy = [m.copy(deep=True) for m in messages]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
     expected = [
         AIMessage(
             [
@@ -95,7 +95,7 @@ def test_merge_message_runs_content() -> None:
     assert actual == expected
     invoked = merge_message_runs().invoke(messages)
     assert actual == invoked
-    assert messages == messages_copy
+    assert messages == messages_model_copy
 
 
 def test_merge_messages_tool_messages() -> None:
@@ -103,10 +103,10 @@ def test_merge_messages_tool_messages() -> None:
         ToolMessage("foo", tool_call_id="1"),
         ToolMessage("bar", tool_call_id="2"),
     ]
-    messages_copy = [m.copy(deep=True) for m in messages]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
     actual = merge_message_runs(messages)
     assert actual == messages
-    assert messages == messages_copy
+    assert messages == messages_model_copy
 
 
 @pytest.mark.parametrize(
@@ -132,13 +132,13 @@ def test_filter_message(filters: Dict) -> None:
         SystemMessage("foo", name="blah", id="1"),
         HumanMessage("bar", name="blur", id="2"),
     ]
-    messages_copy = [m.copy(deep=True) for m in messages]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
     expected = messages[1:2]
     actual = filter_messages(messages, **filters)
     assert expected == actual
     invoked = filter_messages(**filters).invoke(messages)
     assert invoked == actual
-    assert messages == messages_copy
+    assert messages == messages_model_copy
 
 
 _MESSAGES_TO_TRIM = [
@@ -154,7 +154,7 @@ _MESSAGES_TO_TRIM = [
     HumanMessage("This is a 4 token text.", id="third"),
     AIMessage("This is a 4 token text.", id="fourth"),
 ]
-_MESSAGES_TO_TRIM_COPY = [m.copy(deep=True) for m in _MESSAGES_TO_TRIM]
+_MESSAGES_TO_TRIM_COPY = [m.model_copy(deep=True) for m in _MESSAGES_TO_TRIM]
 
 
 def test_trim_messages_first_30() -> None:


### PR DESCRIPTION
Address under place where deprecated functionality is used.