### PR TITLE
core: [env.py/get_from_env] change default value None -> sentinel object

### DIFF
--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -59,6 +59,7 @@ def get_from_dict_or_env(
     else:
         return get_from_env(key_for_err, env_key, default=default)
 
+
 def get_from_env(
         key: str,
         env_key: str,

--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -55,15 +55,17 @@ def get_from_dict_or_env(
     return get_from_env(key_for_err, env_key, default=default)
 
 
-def get_from_env(key: str, env_key: str, default: Optional[str] = None) -> str:
-    """Get a value from a dictionary or an environment variable.
+_get_from_env_default_sentinel = object()
 
+
+def get_from_env(key: str, env_key: str, default: Optional[Union[str, object]] = _get_from_env_default_sentinel) -> str:
+    """Get a value from a dictionary or an environment variable.
     Args:
         key: The key to look up in the dictionary.
         env_key: The environment variable to look up if the key is not
             in the dictionary.
         default: The default value to return if the key is not in the dictionary
-            or the environment. Defaults to None.
+            or the environment. Defaults to object() as a sentinel. https://peps.python.org/pep-0661/
 
     Returns:
         str: The value of the key.
@@ -74,7 +76,7 @@ def get_from_env(key: str, env_key: str, default: Optional[str] = None) -> str:
     """
     if env_key in os.environ and os.environ[env_key]:
         return os.environ[env_key]
-    elif default is not None:
+    elif default is not _get_from_env_default_sentinel:
         return default
     else:
         raise ValueError(

--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -28,7 +28,7 @@ def get_from_dict_or_env(
     data: Dict[str, Any],
     key: Union[str, List[str]],
     env_key: str,
-        default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
+    default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
 ) -> str:
     """Get a value from a dictionary or an environment variable.
 
@@ -61,9 +61,9 @@ def get_from_dict_or_env(
 
 
 def get_from_env(
-        key: str,
-        env_key: str,
-        default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
+    key: str,
+    env_key: str,
+    default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
 ) -> str:
     """Get a value from a dictionary or an environment variable.
     Args:

--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -29,7 +29,7 @@ def get_from_dict_or_env(
     key: Union[str, List[str]],
     env_key: str,
         default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
-) -> Union[str, object, None]:
+) -> str:
     """Get a value from a dictionary or an environment variable.
 
     Args:
@@ -54,15 +54,16 @@ def get_from_dict_or_env(
         key_for_err = key[0]
     else:
         key_for_err = key
-
-    return get_from_env(key_for_err, env_key, default=default)
-
+    if default is _get_from_env_default_sentinel:
+        return get_from_env(key_for_err, env_key)
+    else:
+        return get_from_env(key_for_err, env_key, default=default)
 
 def get_from_env(
         key: str,
         env_key: str,
         default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
-) -> Union[str, object, None]:
+) -> str:
     """Get a value from a dictionary or an environment variable.
     Args:
         key: The key to look up in the dictionary.
@@ -81,7 +82,7 @@ def get_from_env(
     if env_key in os.environ and os.environ[env_key]:
         return os.environ[env_key]
     elif default is not _get_from_env_default_sentinel:
-        return default
+        return str(default)
     else:
         raise ValueError(
             f"Did not find {key}, please add an environment variable"

--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -21,12 +21,15 @@ def env_var_is_set(env_var: str) -> bool:
     )
 
 
+_get_from_env_default_sentinel = object()
+
+
 def get_from_dict_or_env(
     data: Dict[str, Any],
     key: Union[str, List[str]],
     env_key: str,
-    default: Optional[str] = None,
-) -> str:
+        default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
+) -> Union[str, object, None]:
     """Get a value from a dictionary or an environment variable.
 
     Args:
@@ -35,8 +38,8 @@ def get_from_dict_or_env(
             in order.
         env_key: The environment variable to look up if the key is not
             in the dictionary.
-        default: The default value to return if the key is not in the dictionary
-            or the environment. Defaults to None.
+         default: The default value to return if the key is not in the dictionary
+            or the environment. Defaults to object() as a sentinel. https://peps.python.org/pep-0661/
     """
     if isinstance(key, (list, tuple)):
         for k in key:
@@ -55,10 +58,11 @@ def get_from_dict_or_env(
     return get_from_env(key_for_err, env_key, default=default)
 
 
-_get_from_env_default_sentinel = object()
-
-
-def get_from_env(key: str, env_key: str, default: Optional[Union[str, object]] = _get_from_env_default_sentinel) -> str:
+def get_from_env(
+        key: str,
+        env_key: str,
+        default: Optional[Union[str, object]] = _get_from_env_default_sentinel,
+) -> Union[str, object, None]:
     """Get a value from a dictionary or an environment variable.
     Args:
         key: The key to look up in the dictionary.


### PR DESCRIPTION
**Description**
   Install sentinel value by default in get_from_env and get_from_dict_and_env function in env.py for let's None value by default and not raise ValueError in this case.

**Issue :**
[ [Partners-HuggingFace] Breaking Change - impossible to skip login after PR #23309 #26085](https://github.com/langchain-ai/langchain/issues/26085)