### PR TITLE
openai[patch]: release 0.2.0.dev2

### DIFF
--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-openai"
-version = "0.2.0.dev1"
+version = "0.2.0.dev2"
 description = "An integration package connecting OpenAI and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
To fix warnings stemming from OpenAIEmbeddings.