### PR TITLE
community: add support for HANA dialect when setting schema in SQLDatabase

### DIFF
--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -457,6 +457,11 @@ class SQLDatabase:
                         (self._schema,),
                         execution_options=execution_options,
                     )
+                elif self.dialect == "hana":
+                    connection.exec_driver_sql(
+                        f"SET SCHEMA {self._schema}",
+                        execution_options=execution_options,
+                    )
 
             if isinstance(command, str):
                 command = text(command)


### PR DESCRIPTION
Add HANA dialect to enable setting default schema before executing a SQL in SQLDatabase. 

Reference:
- [SET SCHEMA Statement (Session Management)](https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20fd550375191014b886a338afb4cd5f.html)
