### PR TITLE
community: Reflection output parser

### DIFF
--- a/libs/community/langchain_community/output_parsers/reflection_parser.py
+++ b/libs/community/langchain_community/output_parsers/reflection_parser.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from langchain_core.exceptions import OutputParserException
+from langchain_core.output_parsers import BaseOutputParser
+
+
+class ReflectionOutputParser(BaseOutputParser[str]):
+    """Parse the output of an LLM call to extract content within <output> tags."""
+
+    @property
+    def _type(self) -> str:
+        return "reflection_output_parser"
+
+    def parse(self, text: str) -> str:
+        """Extract content within <output> tags from the input text.
+
+        Args:
+            text: The input text to parse.
+
+        Returns:
+            The extracted content within <output> tags.
+
+        Raises:
+            OutputParserException: If no <output> tags are found in the text.
+        """
+        pattern = r'<output>(.*?)</output>'
+        match = re.search(pattern, text, re.DOTALL)
+        if match:
+            return match.group(1).strip()
+        raise OutputParserException("No <output> tags found in the text.")
+
+    def get_format_instructions(self) -> str:
+        """Return instructions on how to format the output."""
+        return (
+            "Your response should be enclosed within <output> tags. "
+            "For example: <output>Your response here</output>"
+        )

--- a/libs/community/langchain_community/output_parsers/reflection_test.ipynb
+++ b/libs/community/langchain_community/output_parsers/reflection_test.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Without output parser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<thinking>\n",
+      "Let's compare these two numbers:\n",
+      "\n",
+      "9.9 and 9.11 are both decimal numbers. To determine which one is larger, we need to look at the digits after the decimal point.\n",
+      "\n",
+      "For 9.9:\n",
+      "- The tenths place has a 9\n",
+      "- The hundredths place has a 0\n",
+      "\n",
+      "For 9.11:\n",
+      "- The tenths place has a 1\n",
+      "- The hundredths place has a 1\n",
+      "\n",
+      "Since both numbers have 9 in the ones place and 9 in the tenths place, we need to compare the hundredths place.\n",
+      "\n",
+      "In the hundredths place, 9.9 has a 0 while 9.11 has a 1.\n",
+      "\n",
+      "Therefore, 9.11 is larger than 9.9.\n",
+      "\n",
+      "<reflection>\n",
+      "Wait, I made a mistake in my reasoning. When comparing decimal numbers, we don't just look at one digit after the decimal point. We need to compare all digits that differ.\n",
+      "\n",
+      "Let's correct this:\n",
+      "\n",
+      "For 9.9:\n",
+      "- The tenths place has a 9\n",
+      "- The hundredths place has a 0\n",
+      "\n",
+      "For 9.11:\n",
+      "- The tenths place has a 1\n",
+      "- The hundredths place has a 1\n",
+      "\n",
+      "The correct comparison should be:\n",
+      "9.9 = 9 + 0.9 + 0.00 (rounded to two decimal places)\n",
+      "9.11 = 9 + 0.1 + 0.01 + 0.001\n",
+      "\n",
+      "We can see that 9.9 is actually larger than 9.11.\n",
+      "</reflection>\n",
+      "</thinking>\n",
+      "\n",
+      "<output>\n",
+      "The number 9.9 is larger than 9.11.\n",
+      "\n",
+      "When comparing decimal numbers, it's important to consider all the digits after the decimal point, not just one or two places. While at first glance it might seem that 9.11 is larger due to having more non-zero digits after the decimal point, in reality, 9.9 represents a value closer to 10 than 9.11 does.\n",
+      "\n",
+      "To break it down:\n",
+      "- 9.9 is equivalent to 9 + 0.9 + 0.00 (rounded to two decimal places)\n",
+      "- 9.11 is equivalent to 9 + 0.1 + 0.01 + 0.001\n",
+      "\n",
+      "As you can see, the additional digits in 9.11 are smaller than the single digit after the decimal point in 9.9, making 9.9 the larger number.\n",
+      "</output>\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_ollama import OllamaLLM\n",
+    "\n",
+    "llm = OllamaLLM(model=\"reflection\")\n",
+    "\n",
+    "response = llm.invoke(\"Which number is larger, 9.9 or 9.11?\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# With output parser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The number 9.9 is larger than 9.11.\n",
+      "\n",
+      "This might seem counterintuitive at first glance because we're used to thinking that more decimal places mean a larger number. However, the crucial factor here is the actual value of the decimal part. In this case, 0.9 (the decimal part of 9.9) is greater than 0.11 (the decimal part of 9.11), even though 9.11 has two decimal places while 9.9 only has one.\n",
+      "\n",
+      "So, when we compare these numbers in their entirety, 9.9 proves to be the larger value.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain.prompts import PromptTemplate\n",
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from reflection_parser import ReflectionOutputParser\n",
+    "\n",
+    "# Create the LLM\n",
+    "llm = OllamaLLM(model=\"reflection\")\n",
+    "\n",
+    "# Create the prompt template\n",
+    "prompt = PromptTemplate(\n",
+    "    input_variables=[\"question\", \"format_instructions\"],\n",
+    "    template=\"Answer the following question:\\n\\n{question}\\n\\n{format_instructions}\"\n",
+    ")\n",
+    "\n",
+    "# Create the ReflectionOutputParser\n",
+    "reflection_parser = ReflectionOutputParser()\n",
+    "\n",
+    "# Create the chain\n",
+    "chain = (\n",
+    "    prompt \n",
+    "    | llm \n",
+    "    | StrOutputParser() \n",
+    "    | reflection_parser\n",
+    ")\n",
+    "\n",
+    "# Use the chain\n",
+    "response = chain.invoke({\n",
+    "    \"question\": \"Which number is larger, 9.9 or 9.11?\",\n",
+    "    \"format_instructions\": reflection_parser.get_format_instructions()\n",
+    "})\n",
+    "\n",
+    "print(response)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv-lc-test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adds a custom chain to parse the output of the Reflection 70B model. It will extract the final answer inside `<output>` and `</output>` tags, as per https://huggingface.co/mattshumer/Reflection-Llama-3.1-70B

I also added a test notebook as per feedback on #26197 