### PR TITLE
core[patch]: wrap mermaid node names w/ markdown in <p> tag

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -11,6 +11,8 @@ from langchain_core.runnables.graph import (
     NodeStyles,
 )
 
+MARKDOWN_SPECIAL_CHARS = "*_`"
+
 
 def draw_mermaid(
     nodes: Dict[str, Node],
@@ -58,13 +60,19 @@ def draw_mermaid(
         default_class_label = "default"
         format_dict = {default_class_label: "{0}({1})"}
         if first_node is not None:
-            format_dict[first_node] = "{0}([{0}]):::first"
+            format_dict[first_node] = "{0}([{1}]):::first"
         if last_node is not None:
-            format_dict[last_node] = "{0}([{0}]):::last"
+            format_dict[last_node] = "{0}([{1}]):::last"
 
         # Add nodes to the graph
         for key, node in nodes.items():
-            label = node.name.split(":")[-1]
+            node_name = node.name.split(":")[-1]
+            label = (
+                f"<p>{node_name}</p>"
+                if node_name.startswith(tuple(MARKDOWN_SPECIAL_CHARS))
+                and node_name.endswith(tuple(MARKDOWN_SPECIAL_CHARS))
+                else node_name
+            )
             if node.metadata:
                 label = (
                     f"{label}<hr/><small><em>"

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -1,31 +1,4 @@
 # serializer version: 1
-# name: test_double_nested_subgraph_mermaid[mermaid]
-  '''
-  %%{init: {'flowchart': {'curve': 'linear'}}}%%
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	parent_1(parent_1)
-  	child_child_1_grandchild_1(grandchild_1)
-  	child_child_1_grandchild_2(grandchild_2<hr/><small><em>__interrupt = before</em></small>)
-  	child_child_2(child_2)
-  	parent_2(parent_2)
-  	__end__([<p>__end__</p>]):::last
-  	__start__ --> parent_1;
-  	child_child_2 --> parent_2;
-  	parent_1 --> child_child_1_grandchild_1;
-  	parent_2 --> __end__;
-  	subgraph child
-  	child_child_1_grandchild_2 --> child_child_2;
-  	subgraph child_1
-  	child_child_1_grandchild_1 --> child_child_1_grandchild_2;
-  	end
-  	end
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
 # name: test_graph_sequence[ascii]
   '''
               +-------------+              
@@ -1090,6 +1063,63 @@
   
   '''
 # ---
+# name: test_parallel_subgraph_mermaid[mermaid]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	outer_1(outer_1)
+  	inner_1_inner_1(inner_1)
+  	inner_1_inner_2(inner_2<hr/><small><em>__interrupt = before</em></small>)
+  	inner_2_inner_1(inner_1)
+  	inner_2_inner_2(inner_2)
+  	outer_2(outer_2)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> outer_1;
+  	inner_1_inner_2 --> outer_2;
+  	inner_2_inner_2 --> outer_2;
+  	outer_1 --> inner_1_inner_1;
+  	outer_1 --> inner_2_inner_1;
+  	outer_2 --> __end__;
+  	subgraph inner_1
+  	inner_1_inner_1 --> inner_1_inner_2;
+  	end
+  	subgraph inner_2
+  	inner_2_inner_1 --> inner_2_inner_2;
+  	end
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_double_nested_subgraph_mermaid[mermaid]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	parent_1(parent_1)
+  	child_child_1_grandchild_1(grandchild_1)
+  	child_child_1_grandchild_2(grandchild_2<hr/><small><em>__interrupt = before</em></small>)
+  	child_child_2(child_2)
+  	parent_2(parent_2)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> parent_1;
+  	child_child_2 --> parent_2;
+  	parent_1 --> child_child_1_grandchild_1;
+  	parent_2 --> __end__;
+  	subgraph child
+  	child_child_1_grandchild_2 --> child_child_2;
+  	subgraph child_1
+  	child_child_1_grandchild_1 --> child_child_1_grandchild_2;
+  	end
+  	end
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
 # name: test_graph_single_runnable[ascii]
   '''
   +----------------------+   
@@ -1118,36 +1148,6 @@
   	StrOutputParserOutput([StrOutputParserOutput]):::last
   	StrOutputParserInput --> StrOutputParser;
   	StrOutputParser --> StrOutputParserOutput;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_parallel_subgraph_mermaid[mermaid]
-  '''
-  %%{init: {'flowchart': {'curve': 'linear'}}}%%
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	outer_1(outer_1)
-  	inner_1_inner_1(inner_1)
-  	inner_1_inner_2(inner_2<hr/><small><em>__interrupt = before</em></small>)
-  	inner_2_inner_1(inner_1)
-  	inner_2_inner_2(inner_2)
-  	outer_2(outer_2)
-  	__end__([<p>__end__</p>]):::last
-  	__start__ --> outer_1;
-  	inner_1_inner_2 --> outer_2;
-  	inner_2_inner_2 --> outer_2;
-  	outer_1 --> inner_1_inner_1;
-  	outer_1 --> inner_2_inner_1;
-  	outer_2 --> __end__;
-  	subgraph inner_1
-  	inner_1_inner_1 --> inner_1_inner_2;
-  	end
-  	subgraph inner_2
-  	inner_2_inner_1 --> inner_2_inner_2;
-  	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -1,4 +1,31 @@
 # serializer version: 1
+# name: test_double_nested_subgraph_mermaid[mermaid]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	parent_1(parent_1)
+  	child_child_1_grandchild_1(grandchild_1)
+  	child_child_1_grandchild_2(grandchild_2<hr/><small><em>__interrupt = before</em></small>)
+  	child_child_2(child_2)
+  	parent_2(parent_2)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> parent_1;
+  	child_child_2 --> parent_2;
+  	parent_1 --> child_child_1_grandchild_1;
+  	parent_2 --> __end__;
+  	subgraph child
+  	child_child_1_grandchild_2 --> child_child_2;
+  	subgraph child_1
+  	child_child_1_grandchild_1 --> child_child_1_grandchild_2;
+  	end
+  	end
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
 # name: test_graph_sequence[ascii]
   '''
               +-------------+              
@@ -1040,7 +1067,7 @@
   	PromptTemplate(PromptTemplate)
   	FakeListLLM(FakeListLLM)
   	Parallel_as_list_as_str_Input(Parallel<as_list,as_str>Input)
-  	Parallel_as_list_as_str_Output([Parallel_as_list_as_str_Output]):::last
+  	Parallel_as_list_as_str_Output([Parallel<as_list,as_str>Output]):::last
   	CommaSeparatedListOutputParser(CommaSeparatedListOutputParser)
   	conditional_str_parser_input(conditional_str_parser_input)
   	conditional_str_parser_output(conditional_str_parser_output)
@@ -1057,63 +1084,6 @@
   	Parallel_as_list_as_str_Input --> conditional_str_parser_input;
   	conditional_str_parser_output --> Parallel_as_list_as_str_Output;
   	FakeListLLM --> Parallel_as_list_as_str_Input;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_parallel_subgraph_mermaid[mermaid]
-  '''
-  %%{init: {'flowchart': {'curve': 'linear'}}}%%
-  graph TD;
-  	__start__([__start__]):::first
-  	outer_1(outer_1)
-  	inner_1_inner_1(inner_1)
-  	inner_1_inner_2(inner_2<hr/><small><em>__interrupt = before</em></small>)
-  	inner_2_inner_1(inner_1)
-  	inner_2_inner_2(inner_2)
-  	outer_2(outer_2)
-  	__end__([__end__]):::last
-  	__start__ --> outer_1;
-  	inner_1_inner_2 --> outer_2;
-  	inner_2_inner_2 --> outer_2;
-  	outer_1 --> inner_1_inner_1;
-  	outer_1 --> inner_2_inner_1;
-  	outer_2 --> __end__;
-  	subgraph inner_1
-  	inner_1_inner_1 --> inner_1_inner_2;
-  	end
-  	subgraph inner_2
-  	inner_2_inner_1 --> inner_2_inner_2;
-  	end
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_double_nested_subgraph_mermaid[mermaid]
-  '''
-  %%{init: {'flowchart': {'curve': 'linear'}}}%%
-  graph TD;
-  	__start__([__start__]):::first
-  	parent_1(parent_1)
-  	child_child_1_grandchild_1(grandchild_1)
-  	child_child_1_grandchild_2(grandchild_2<hr/><small><em>__interrupt = before</em></small>)
-  	child_child_2(child_2)
-  	parent_2(parent_2)
-  	__end__([__end__]):::last
-  	__start__ --> parent_1;
-  	child_child_2 --> parent_2;
-  	parent_1 --> child_child_1_grandchild_1;
-  	parent_2 --> __end__;
-  	subgraph child
-  	child_child_1_grandchild_2 --> child_child_2;
-  	subgraph child_1
-  	child_child_1_grandchild_1 --> child_child_1_grandchild_2;
-  	end
-  	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -1148,6 +1118,36 @@
   	StrOutputParserOutput([StrOutputParserOutput]):::last
   	StrOutputParserInput --> StrOutputParser;
   	StrOutputParser --> StrOutputParserOutput;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_parallel_subgraph_mermaid[mermaid]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	outer_1(outer_1)
+  	inner_1_inner_1(inner_1)
+  	inner_1_inner_2(inner_2<hr/><small><em>__interrupt = before</em></small>)
+  	inner_2_inner_1(inner_1)
+  	inner_2_inner_2(inner_2)
+  	outer_2(outer_2)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> outer_1;
+  	inner_1_inner_2 --> outer_2;
+  	inner_2_inner_2 --> outer_2;
+  	outer_1 --> inner_1_inner_1;
+  	outer_1 --> inner_2_inner_1;
+  	outer_2 --> __end__;
+  	subgraph inner_1
+  	inner_1_inner_1 --> inner_1_inner_2;
+  	end
+  	subgraph inner_2
+  	inner_2_inner_1 --> inner_2_inner_2;
+  	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc


### PR DESCRIPTION
This fixes the issue where `__start__` and `__end__` node labels are being interpreted as markdown, as of the most recent Mermaid update