### PR TITLE
core[patch]: Propagate module name to create model

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -348,6 +348,7 @@ class Runnable(Generic[Input, Output], ABC):
         return create_model(
             self.get_name("Input"),
             __root__=root_type,
+            __module_name=self.__class__.__module__,
         )
 
     def get_input_jsonschema(
@@ -408,6 +409,7 @@ class Runnable(Generic[Input, Output], ABC):
         return create_model(
             self.get_name("Output"),
             __root__=root_type,
+            __module_name=self.__class__.__module__,
         )
 
     def get_output_jsonschema(
@@ -4864,6 +4866,7 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
                 List[self.bound.get_input_schema(config)],  # type: ignore
                 None,
             ),
+            __module_name=self.__class__.__module__,
         )
 
     @property
@@ -4877,6 +4880,7 @@ class RunnableEachBase(RunnableSerializable[List[Input], List[Output]]):
         return create_model(
             self.get_name("Output"),
             __root__=List[schema],  # type: ignore[valid-type]
+            __module_name=self.__class__.__module__,
         )
 
     @property

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from concurrent.futures import FIRST_COMPLETED, wait
-
 import asyncio
 import collections
 import functools
 import inspect
 import threading
 from abc import ABC, abstractmethod
+from concurrent.futures import FIRST_COMPLETED, wait
 from contextvars import copy_context
 from functools import wraps
 from itertools import groupby, tee
 from operator import itemgetter
-from pydantic import BaseModel, ConfigDict, Field, RootModel
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -36,6 +34,8 @@ from typing import (
     cast,
     overload,
 )
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 from typing_extensions import Literal, get_args, get_type_hints
 
 from langchain_core._api import beta_decorator

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -391,7 +391,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
         else:
             fields["__root__"] = (Sequence[BaseMessage], ...)
         return create_model(  # type: ignore[call-overload]
-            "RunnableWithMessageHistoryInput",
+            "RunnableWithChatHistoryInput",
             **fields,
         )
 
@@ -423,7 +423,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             return root_type
 
         return create_model(
-            "RunnableWithMessageHistoryOutput",
+            "RunnableWithChatHistoryOutput",
             __root__=root_type,
             __module_name=self.__class__.__module__,
         )

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -393,7 +393,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
         else:
             fields["__root__"] = (Sequence[BaseMessage], ...)
         return create_model(  # type: ignore[call-overload]
-            self.get_name("Input"),
+            "RunnableWithMessageHistoryInput",
             **fields,
         )
 

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -257,7 +257,6 @@ class RunnableWithMessageHistory(RunnableBindingBase):
         output_messages_key: Optional[str] = None,
         history_messages_key: Optional[str] = None,
         history_factory_config: Optional[Sequence[ConfigurableFieldSpec]] = None,
-        name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize RunnableWithMessageHistory.
@@ -362,7 +361,6 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             bound=bound,
             history_messages_key=history_messages_key,
             history_factory_config=_config_specs,
-            name=name or "RunnableWithMessageHistory",
             **kwargs,
         )
         self._history_chain = history_chain

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -21,6 +21,7 @@ from langchain_core.runnables.base import Runnable, RunnableBindingBase, Runnabl
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (
     ConfigurableFieldSpec,
+    Output,
     create_model,
     get_unique_config_specs,
 )
@@ -256,6 +257,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
         output_messages_key: Optional[str] = None,
         history_messages_key: Optional[str] = None,
         history_factory_config: Optional[Sequence[ConfigurableFieldSpec]] = None,
+        name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize RunnableWithMessageHistory.
@@ -360,8 +362,10 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             bound=bound,
             history_messages_key=history_messages_key,
             history_factory_config=_config_specs,
+            name=name or "RunnableWithMessageHistory",
             **kwargs,
         )
+        self._history_chain = history_chain
 
     @property
     def config_specs(self) -> List[ConfigurableFieldSpec]:
@@ -389,8 +393,41 @@ class RunnableWithMessageHistory(RunnableBindingBase):
         else:
             fields["__root__"] = (Sequence[BaseMessage], ...)
         return create_model(  # type: ignore[call-overload]
-            "RunnableWithChatHistoryInput",
+            self.get_name("Input"),
             **fields,
+        )
+
+    @property
+    def OutputType(self) -> Type[Output]:
+        output_type = self._history_chain.OutputType
+        return output_type
+
+    def get_output_schema(
+        self, config: Optional[RunnableConfig] = None
+    ) -> Type[BaseModel]:
+        """Get a pydantic model that can be used to validate output to the Runnable.
+
+        Runnables that leverage the configurable_fields and configurable_alternatives
+        methods will have a dynamic output schema that depends on which
+        configuration the Runnable is invoked with.
+
+        This method allows to get an output schema for a specific configuration.
+
+        Args:
+            config: A config to use when generating the schema.
+
+        Returns:
+            A pydantic model that can be used to validate output.
+        """
+        root_type = self.OutputType
+
+        if inspect.isclass(root_type) and issubclass(root_type, BaseModel):
+            return root_type
+
+        return create_model(
+            "RunnableWithMessageHistoryOutput",
+            __root__=root_type,
+            __module_name=self.__class__.__module__,
         )
 
     def _is_not_async(self, *args: Sequence[Any], **kwargs: Dict[str, Any]) -> bool:

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -43,7 +43,6 @@ from pydantic.v1 import BaseModel as BaseModelV1
 from typing_extensions import TypeGuard
 
 from langchain_core.runnables.schema import StreamEvent
-from langchain_core.utils.pydantic import _IgnoreUnserializable
 
 Input = TypeVar("Input", contravariant=True)
 # Output type should implement __concat__, as eg str, list, dict do
@@ -737,8 +736,7 @@ def _create_root_model(
         cls: Type[BaseModel],
         by_alias: bool = True,
         ref_template: str = DEFAULT_REF_TEMPLATE,
-        # Using a default schema generator that ignores unserializable types
-        schema_generator: type[GenerateJsonSchema] = _IgnoreUnserializable,
+        schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
         mode: JsonSchemaMode = "validation",
     ) -> Dict[str, Any]:
         # Complains about model_json_schema not being defined in superclass

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -715,8 +715,8 @@ NO_DEFAULT = object()
 def _create_root_model(
     name: str,
     type_: Any,
+    module_name: Optional[str] = None,
     default_: object = NO_DEFAULT,
-    __module_name: Optional[str] = None,
 ) -> Type[BaseModel]:
     """Create a base class."""
 
@@ -754,7 +754,7 @@ def _create_root_model(
         "model_config": ConfigDict(arbitrary_types_allowed=True),
         "schema": classmethod(schema),
         "model_json_schema": classmethod(model_json_schema),
-        "__module__": __module_name or "langchain_core.runnables.utils",
+        "__module__": module_name or "langchain_core.runnables.utils",
     }
 
     if default_ is not NO_DEFAULT:
@@ -773,10 +773,10 @@ def _create_root_model_cached(
     __model_name: str,
     type_: Any,
     default_: object = NO_DEFAULT,
-    __module_name: Optional[str] = None,
+    module_name: Optional[str] = None,
 ) -> Type[BaseModel]:
     return _create_root_model(
-        __model_name, type_, default_=default_, __module_name=__module_name
+        __model_name, type_, default_=default_, module_name=module_name
     )
 
 
@@ -789,6 +789,8 @@ def create_model(
 
     Args:
         __model_name: The name of the model.
+        __module_name: The name of the module where the model is defined.
+            This is used by Pydantic to resolve any forward references.
         **field_definitions: The field definitions for the model.
 
     Returns:
@@ -811,12 +813,14 @@ def create_model(
 
         try:
             named_root_model = _create_root_model_cached(
-                __model_name, __module_name=__module_name, **kwargs
+                __model_name, module_name=__module_name, **kwargs
             )
         except TypeError:
             # something in the arguments into _create_root_model_cached is not hashable
             named_root_model = _create_root_model(
-                __model_name, __module_name=__module_name, **kwargs
+                __model_name,
+                module_name=__module_name,
+                **kwargs,
             )
         return named_root_model
     try:

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -454,6 +454,37 @@ def test_get_input_schema_input_dict() -> None:
     )
 
 
+def test_get_output_schema() -> None:
+    """Test get output schema."""
+    runnable = RunnableLambda(
+        lambda input: {
+            "output": [
+                AIMessage(
+                    content="you said: "
+                    + "\n".join(
+                        [
+                            str(m.content)
+                            for m in input["history"]
+                            if isinstance(m, HumanMessage)
+                        ]
+                        + [input["input"]]
+                    )
+                )
+            ]
+        }
+    )
+    get_session_history = _get_get_session_history()
+    with_history = RunnableWithMessageHistory(
+        runnable,
+        get_session_history,
+        input_messages_key="input",
+        history_messages_key="history",
+        output_messages_key="output",
+    )
+    output_type = with_history.get_output_schema()
+    assert _schema(output_type) == {"title": "_call_runnable_sync_output"}
+
+
 def test_get_input_schema_input_messages() -> None:
     from pydantic import RootModel
 

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -482,8 +482,9 @@ def test_get_output_schema() -> None:
         output_messages_key="output",
     )
     output_type = with_history.get_output_schema()
+
     assert _schema(output_type) == {
-        "title": "RunnableWithMessageHistoryOutput",
+        "title": "RunnableWithChatHistoryOutput",
         "type": "object",
     }
 

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -482,7 +482,10 @@ def test_get_output_schema() -> None:
         output_messages_key="output",
     )
     output_type = with_history.get_output_schema()
-    assert _schema(output_type) == {"title": "_call_runnable_sync_output"}
+    assert _schema(output_type) == {
+        "title": "RunnableWithMessageHistoryOutput",
+        "type": "object",
+    }
 
 
 def test_get_input_schema_input_messages() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -652,13 +652,6 @@ def test_lambda_schemas(snapshot: SnapshotAssertion) -> None:
             RunnableLambda(aget_values_typed).get_output_jsonschema()  # type: ignore
         ) == snapshot(name="schema8")
 
-    def foo(x: int) -> Runnable:
-        raise NotImplementedError()
-
-    assert RunnableLambda(foo).get_output_schema().model_json_schema() == {
-        "title": "foo_output"
-    }
-
 
 def test_with_types_with_type_generics() -> None:
     """Verify that with_types works if we use things like List[int]"""

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -652,6 +652,13 @@ def test_lambda_schemas(snapshot: SnapshotAssertion) -> None:
             RunnableLambda(aget_values_typed).get_output_jsonschema()  # type: ignore
         ) == snapshot(name="schema8")
 
+    def foo(x: int) -> Runnable:
+        raise NotImplementedError()
+
+    assert RunnableLambda(foo).get_output_schema().model_json_schema() == {
+        "title": "foo_output"
+    }
+
 
 def test_with_types_with_type_generics() -> None:
     """Verify that with_types works if we use things like List[int]"""


### PR DESCRIPTION
* This allows pydantic to correctly resolve annotations necessary for building pydantic models dynamically.
* Makes a small fix for RunnableWithMessageHistory which was fetching the OutputType from the  RunnableLambda that was yielding another RunnableLambda. This doesn't propagate the output of the RunnableAssign fully (i.e., with concrete type information etc.)

Resolves issue: https://github.com/langchain-ai/langchain/issues/26250
