### PR TITLE
ollama[patch]: bump core dep and increment version to 0.2.0.dev1

### DIFF
--- a/libs/partners/ollama/poetry.lock
+++ b/libs/partners/ollama/poetry.lock
@@ -291,7 +291,7 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.0.dev2"
+version = "0.3.0.dev4"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.9,<4.0"
@@ -300,7 +300,7 @@ develop = true
 
 [package.dependencies]
 jsonpatch = "^1.33"
-langsmith = "^0.1.75"
+langsmith = "^0.1.112"
 packaging = ">=23.2,<25"
 pydantic = "^2.7.4"
 PyYAML = ">=5.3"
@@ -345,8 +345,8 @@ files = [
 httpx = ">=0.23.0,<1"
 orjson = ">=3.9.14,<4.0.0"
 pydantic = [
-    {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
     {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
+    {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
 ]
 requests = ">=2,<3"
 
@@ -529,8 +529,8 @@ files = [
 annotated-types = ">=0.4.0"
 pydantic-core = "2.23.2"
 typing-extensions = [
-    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
     {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
+    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
 ]
 tzdata = {version = "*", markers = "python_version >= \"3.9\""}
 
@@ -951,4 +951,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "039acc4a60607f0e709081b1021ff3d776c3e862a2589dbef40bc91e6359a97e"
+content-hash = "a0611f4b7d9f7a6405a5dfa0347ae7208902ff11ec9dae22c601e381a9fa5253"

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-ollama"
-version = "0.1.3"
+version = "0.2.0.dev1"
 description = "An integration package connecting Ollama and LangChain"
 authors = []
 readme = "README.md"
@@ -21,8 +21,7 @@ disallow_untyped_defs = "True"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 ollama = ">=0.3.0,<1"
-langchain-core = "^0.3.0.dev"
-pydantic = ">=2,<3"
+langchain-core = { version = "^0.3.0.dev4", allow-prereleases = true }
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]


### PR DESCRIPTION
Confirmed no pydantic warnings in unit or integration tests.