### PR TITLE
core[patch]: Do not hard coded name for RunnableBranch

### DIFF
--- a/libs/core/langchain_core/runnables/branch.py
+++ b/libs/core/langchain_core/runnables/branch.py
@@ -138,13 +138,6 @@ class RunnableBranch(RunnableSerializable[Input, Output]):
         super().__init__(
             branches=_branches,
             default=default_,
-            # Hard-coding a name here because RunnableBranch is a generic
-            # and with pydantic 2, the class name with pydantic will capture
-            # include the parameterized type, which is not what we want.
-            # e.g., we'd get RunnableBranch[Input, Output] instead of RunnableBranch
-            # for the name. This information is already captured in the
-            # input and output types.
-            name="RunnableBranch",
         )  # type: ignore[call-arg]
 
     model_config = ConfigDict(


### PR DESCRIPTION
This is no longer necessary
