### PR TITLE
community[patch]: Add protected_namespace=() to models that use model namespace

### DIFF
--- a/libs/community/langchain_community/cross_encoders/huggingface.py
+++ b/libs/community/langchain_community/cross_encoders/huggingface.py
@@ -45,9 +45,7 @@ class HuggingFaceCrossEncoder(BaseModel, BaseCrossEncoder):
             self.model_name, **self.model_kwargs
         )
 
-    model_config = ConfigDict(
-        extra="forbid",
-    )
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     def score(self, text_pairs: List[Tuple[str, str]]) -> List[float]:
         """Compute similarity scores using a HuggingFace transformer model.

--- a/libs/community/langchain_community/cross_encoders/sagemaker_endpoint.py
+++ b/libs/community/langchain_community/cross_encoders/sagemaker_endpoint.py
@@ -90,8 +90,7 @@ class SagemakerEndpointCrossEncoder(BaseModel, BaseCrossEncoder):
    """
 
     model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        extra="forbid",
+        arbitrary_types_allowed=True, extra="forbid", protected_namespaces=()
     )
 
     @model_validator(mode="before")

--- a/libs/community/langchain_community/document_compressors/llmlingua_filter.py
+++ b/libs/community/langchain_community/document_compressors/llmlingua_filter.py
@@ -76,6 +76,7 @@ class LLMLinguaCompressor(BaseDocumentCompressor):
         arbitrary_types_allowed=True,
         extra="forbid",
         populate_by_name=True,
+        protected_namespaces=(),
     )
 
     @staticmethod

--- a/libs/community/langchain_community/llms/moonshot.py
+++ b/libs/community/langchain_community/llms/moonshot.py
@@ -50,9 +50,7 @@ class MoonshotCommon(BaseModel):
     temperature: float = 0.3
     """Temperature parameter (higher values make the model more creative)."""
 
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
+    model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
 
     @property
     def lc_secrets(self) -> dict:

--- a/libs/community/langchain_community/llms/oci_generative_ai.py
+++ b/libs/community/langchain_community/llms/oci_generative_ai.py
@@ -101,8 +101,7 @@ class OCIGenAIBase(BaseModel, ABC):
     """Whether to stream back partial progress"""
 
     model_config = ConfigDict(
-        extra="forbid",
-        arbitrary_types_allowed=True,
+        extra="forbid", arbitrary_types_allowed=True, protected_namespaces=()
     )
 
     @pre_init

--- a/libs/community/langchain_community/llms/solar.py
+++ b/libs/community/langchain_community/llms/solar.py
@@ -53,6 +53,7 @@ class SolarCommon(BaseModel):
         populate_by_name=True,
         arbitrary_types_allowed=True,
         extra="ignore",
+        protected_namespaces=(),
     )
 
     @property

--- a/libs/community/langchain_community/utilities/dalle_image_generator.py
+++ b/libs/community/langchain_community/utilities/dalle_image_generator.py
@@ -73,9 +73,7 @@ class DallEAPIWrapper(BaseModel):
     http_client: Union[Any, None] = None
     """Optional httpx.Client."""
 
-    model_config = ConfigDict(
-        extra="forbid",
-    )
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
Add protected_namespaces=() for existing implementations that use the pydantic
reserved model namespace.

