### PR TITLE
experimental: Handle possible KeyError in 'convert_to_graph_documents' in llm.py

### DIFF
--- a/libs/experimental/langchain_experimental/graph_transformers/llm.py
+++ b/libs/experimental/langchain_experimental/graph_transformers/llm.py
@@ -749,6 +749,9 @@ class LLMGraphTransformer:
             if isinstance(parsed_json, dict):
                 parsed_json = [parsed_json]
             for rel in parsed_json:
+                # It's possible some returned dicts don't have the "head" or "tail_type" key, ignore these as well as those who have `head` as "".
+                if ("head" not in rel) or (rel["head"] == "") or ("tail_type" not in rel):
+                    continue
                 # Nodes need to be deduplicated using a set
                 nodes_set.add((rel["head"], rel["head_type"]))
                 nodes_set.add((rel["tail"], rel["tail_type"]))


### PR DESCRIPTION
It's possible some returned dicts don't have the "head" or "tail_type" key which results in a KeyError if not handled (which it currently isn't). So, ignore dicts returned that displays this behaviour, as well as those who have `head` as "". I noticed `rel` dicts that have `head` as "" (empty string) are usually dicts which are text duplicates of a **previous** `rel`, hence why they can be safely ignored.