### PR TITLE
core[patch]: Support non ASCII characters in tool output if user doesn't output string

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -822,7 +822,7 @@ def _is_message_content_block(obj: Any) -> bool:
 
 def _stringify(content: Any) -> str:
     try:
-        return json.dumps(content)
+        return json.dumps(content, ensure_ascii=False)
     except Exception:
         return str(content)
 


### PR DESCRIPTION
### simple modify
core: add supporting non english character

target issue is #26315 
same issue on langgraph - https://github.com/langchain-ai/langgraph/issues/1504