### PR TITLE
core[patch]: support pydantic v1 annotations in tool arguments

### DIFF
--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -343,6 +343,25 @@ def test_structured_tool_types_parsed_pydantic_v1() -> None:
         assert result == expected
 
 
+def test_structured_tool_types_parsed_pydantic_mixed() -> None:
+    """Test the non-primitive types are correctly passed to structured tools."""
+
+    class SomeBaseModel(BaseModelV1):
+        foo: str
+
+    class AnotherBaseModel(BaseModel):
+        bar: str
+
+    with pytest.raises(NotImplementedError):
+
+        @tool
+        def structured_tool(
+            some_base_model: SomeBaseModel, another_base_model: AnotherBaseModel
+        ) -> None:
+            """Return the arguments directly."""
+            pass
+
+
 def test_base_tool_inheritance_base_schema() -> None:
     """Test schema is correctly inferred when inheriting from BaseTool."""
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,7 +23,6 @@ from typing import (
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
-from pydantic import BaseModel as BaseModelProper
 from typing_extensions import Annotated, TypedDict, TypeVar
 
 from langchain_core import tools
@@ -1562,7 +1561,7 @@ def test_fn_injected_arg_with_schema(tool_: Callable) -> None:
 def generate_models() -> List[Any]:
     """Generate a list of base models depending on the pydantic version."""
 
-    class FooProper(BaseModelProper):
+    class FooProper(BaseModel):
         a: int
         b: str
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -323,17 +323,20 @@ def test_structured_tool_types_parsed_pydantic_v1() -> None:
     class SomeBaseModel(BaseModelV1):
         foo: str
 
+    class AnotherBaseModel(BaseModelV1):
+        bar: str
+
     @tool
-    def structured_tool(some_base_model: SomeBaseModel) -> dict:
+    def structured_tool(some_base_model: SomeBaseModel) -> AnotherBaseModel:
         """Return the arguments directly."""
-        return {"some_base_model": some_base_model}
+        return AnotherBaseModel(bar=some_base_model.foo)
 
     assert isinstance(structured_tool, StructuredTool)
 
-    expected = {"some_base_model": SomeBaseModel(foo="bar")}
+    expected = AnotherBaseModel(bar="baz")
     for arg in [
-        SomeBaseModel(foo="bar"),
-        SomeBaseModel(foo="bar").dict(),
+        SomeBaseModel(foo="baz"),
+        SomeBaseModel(foo="baz").dict(),
     ]:
         args = {"some_base_model": arg}
         result = structured_tool.run(args)

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -330,10 +330,14 @@ def test_structured_tool_types_parsed_pydantic_v1() -> None:
 
     assert isinstance(structured_tool, StructuredTool)
 
-    args = {"some_base_model": SomeBaseModel(foo="bar").dict()}
-    result = structured_tool.run(args)
     expected = {"some_base_model": SomeBaseModel(foo="bar")}
-    assert result == expected
+    for arg in [
+        SomeBaseModel(foo="bar"),
+        SomeBaseModel(foo="bar").dict(),
+    ]:
+        args = {"some_base_model": arg}
+        result = structured_tool.run(args)
+        assert result == expected
 
 
 def test_base_tool_inheritance_base_schema() -> None:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -317,6 +317,25 @@ def test_structured_tool_types_parsed() -> None:
     assert result == expected
 
 
+def test_structured_tool_types_parsed_pydantic_v1() -> None:
+    """Test the non-primitive types are correctly passed to structured tools."""
+
+    class SomeBaseModel(BaseModelV1):
+        foo: str
+
+    @tool
+    def structured_tool(some_base_model: SomeBaseModel) -> dict:
+        """Return the arguments directly."""
+        return {"some_base_model": some_base_model}
+
+    assert isinstance(structured_tool, StructuredTool)
+
+    args = {"some_base_model": SomeBaseModel(foo="bar").dict()}
+    result = structured_tool.run(args)
+    expected = {"some_base_model": SomeBaseModel(foo="bar")}
+    assert result == expected
+
+
 def test_base_tool_inheritance_base_schema() -> None:
     """Test schema is correctly inferred when inheriting from BaseTool."""
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -344,7 +344,7 @@ def test_structured_tool_types_parsed_pydantic_v1() -> None:
 
 
 def test_structured_tool_types_parsed_pydantic_mixed() -> None:
-    """Test the non-primitive types are correctly passed to structured tools."""
+    """Test handling of tool with mixed Pydantic version arguments."""
 
     class SomeBaseModel(BaseModelV1):
         foo: str

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,6 +23,7 @@ from typing import (
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
+from pydantic.v1 import BaseModel as BaseModelV1
 from typing_extensions import Annotated, TypedDict, TypeVar
 
 from langchain_core import tools
@@ -72,6 +73,14 @@ def test_unnamed_decorator() -> None:
 
 
 class _MockSchema(BaseModel):
+    """Return the arguments directly."""
+
+    arg1: int
+    arg2: bool
+    arg3: Optional[dict] = None
+
+
+class _MockSchemaV1(BaseModelV1):
     """Return the arguments directly."""
 
     arg1: int
@@ -167,6 +176,13 @@ def test_decorator_with_specified_schema() -> None:
 
     assert isinstance(tool_func, BaseTool)
     assert tool_func.args_schema == _MockSchema
+
+    @tool(args_schema=_MockSchemaV1)
+    def tool_func_v1(arg1: int, arg2: bool, arg3: Optional[dict] = None) -> str:
+        return f"{arg1} {arg2} {arg3}"
+
+    assert isinstance(tool_func_v1, BaseTool)
+    assert tool_func_v1.args_schema == _MockSchemaV1
 
 
 def test_decorated_function_schema_equivalent() -> None:


### PR DESCRIPTION
If all pydantic annotations in function signature are V1, use V1 `validate_arguments`.