### PR TITLE
docs[community]: Fix raw string in docstring

### DIFF
--- a/libs/community/langchain_community/document_loaders/recursive_url_loader.py
+++ b/libs/community/langchain_community/document_loaders/recursive_url_loader.py
@@ -227,7 +227,7 @@ class RecursiveUrlLoader(BaseLoader):
                 "https://docs.python.org/3.9/",
                 prevent_outside=True,
                 base_url="https://docs.python.org",
-                link_regex='<a\\s+(?:[^>]*?\\s+)?href="([^"]*(?=index)[^"]*)"',
+                link_regex=r'<a\\s+(?:[^>]*?\\s+)?href="([^"]*(?=index)[^"]*)"',
                 exclude_dirs=['https://docs.python.org/3.9/faq']
             )
             docs = loader.load()

--- a/libs/community/langchain_community/document_loaders/recursive_url_loader.py
+++ b/libs/community/langchain_community/document_loaders/recursive_url_loader.py
@@ -227,7 +227,7 @@ class RecursiveUrlLoader(BaseLoader):
                 "https://docs.python.org/3.9/",
                 prevent_outside=True,
                 base_url="https://docs.python.org",
-                link_regex=r'<a\s+(?:[^>]*?\s+)?href="([^"]*(?=index)[^"]*)"',
+                link_regex='<a\\s+(?:[^>]*?\\s+)?href="([^"]*(?=index)[^"]*)"',
                 exclude_dirs=['https://docs.python.org/3.9/faq']
             )
             docs = loader.load()


### PR DESCRIPTION
Fixes #26212: replaced the raw string with backslashes. Alternative: raw-stringif the full docstring.
