### PR TITLE
[Docs] Correct the admonition explaining min langchain-anthropic version in doc

### DIFF
--- a/docs/docs/integrations/chat/anthropic_functions.ipynb
+++ b/docs/docs/integrations/chat/anthropic_functions.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "::: {.callout-warning}\n",
     "\n",
-    "The Anthropic API officially supports tool-calling so this workaround is no longer needed. Please use [ChatAnthropic](/docs/integrations/chat/anthropic) with `langchain-anthropic>=0.1.5`.\n",
+    "The Anthropic API officially supports tool-calling so this workaround is no longer needed. Please use [ChatAnthropic](/docs/integrations/chat/anthropic) with `langchain-anthropic>=0.1.15`.\n",
     "\n",
     ":::\n",
     "\n",


### PR DESCRIPTION
0.1.15 instead of just 0.1.5