### PR TITLE
core[major]: Remove "Schema" suffix from tool name

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -307,7 +307,7 @@ def create_schema_from_function(
             valid_properties.append(field)
 
     return _create_subset_model(
-        f"{model_name}Schema",
+        model_name,
         inferred_model,
         list(valid_properties),
         descriptions=arg_descriptions,

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -87,7 +87,7 @@ def tool(
         .. code-block:: python
 
             {
-                "title": "fooSchema",
+                "title": "foo",
                 "description": "The foo.",
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Remove the automatically appended "Schema" suffix to tool names.