### PR TITLE
core[patch]: Lift restrictions on input variables due to pydantic

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -699,23 +699,6 @@ class _RootEventFilter:
         return include
 
 
-
-def _remap_field_definitions(field_definitions: Dict[str, Any]) -> Dict[str, Any]:
-    """This remaps fields to avoid colliding with internal pydantic fields."""
-    remapped = {}
-    for key, value in field_definitions.items():
-        if key.startswith("_"):
-            # Let's add a prefix to avoid colliding with internal pydantic fields
-            if isinstance(value, FieldInfo):
-                raise NotImplementedError(
-                    f"Remapping for fields starting with '_' is not supported if"
-                    f" the field is a pydantic Field instance. Got {key}"
-                )
-            remapped[f"private_{key}"] = Field(
-                default=value, alias=key, serialization_alias=key
-            )
-    return remapped
-
 def is_async_generator(
     func: Any,
 ) -> TypeGuard[Callable[..., AsyncIterator]]:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -54,7 +54,6 @@ PYDANTIC_MAJOR_VERSION = get_pydantic_major_version()
 
 
 if PYDANTIC_MAJOR_VERSION == 1:
-    from pydantic.fields import Field, FieldInfo
     from pydantic.fields import FieldInfo as FieldInfoV1
 
     PydanticBaseModel = pydantic.BaseModel

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -500,8 +500,8 @@ def create_model(
     )
 
 
-# Deprecated and not used by the code base.
-_OK_TO_OVERWRITE = {
+# These are reserved by pydantic.
+_RESERVED_NAMES = {
     "construct",
     "copy",
     "dict",
@@ -514,10 +514,6 @@ _OK_TO_OVERWRITE = {
     "schema_json",
     "update_forward_refs",
     "validate",
-}
-
-# These are reserved by pydantic.
-_RESERVED_NAMES = {
     "model_computed_fields",
     "model_config",
     "model_construct",
@@ -620,13 +616,7 @@ def create_model_v2(
     # No root, just field definitions
     names = set(field_definitions.keys())
 
-    # Likely common names that Pydantic will throw a run time warning about,
-    # but these names should be safe to override.
-    if _OK_TO_OVERWRITE & names:
-        # Capture warnings
-        capture_warnings = True
-    else:
-        capture_warnings = False
+    capture_warnings = False
 
     for name in names:
         # Also if any non-reserved name is used (e.g., model_id or model_name)

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -3,11 +3,24 @@
 from __future__ import annotations
 
 import inspect
-import pydantic
 import textwrap
 import warnings
 from contextlib import nullcontext
 from functools import lru_cache, wraps
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
+
+import pydantic
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -25,18 +38,6 @@ from pydantic.json_schema import (
     JsonSchemaValue,
 )
 from pydantic_core import core_schema
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
 
 
 def get_pydantic_major_version() -> int:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -3,24 +3,11 @@
 from __future__ import annotations
 
 import inspect
+import pydantic
 import textwrap
 import warnings
 from contextlib import nullcontext
 from functools import lru_cache, wraps
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
-
-import pydantic
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -38,6 +25,18 @@ from pydantic.json_schema import (
     JsonSchemaValue,
 )
 from pydantic_core import core_schema
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 
 def get_pydantic_major_version() -> int:
@@ -500,37 +499,17 @@ def create_model(
     )
 
 
-# These are reserved by pydantic.
-_RESERVED_NAMES = {
-    "construct",
-    "copy",
-    "dict",
-    "from_orm",
-    "json",
-    "parse_file",
-    "parse_obj",
-    "parse_raw",
-    "schema",
-    "schema_json",
-    "update_forward_refs",
-    "validate",
-    "model_computed_fields",
-    "model_config",
-    "model_construct",
-    "model_copy",
-    "model_dump",
-    "model_dump_json",
-    "model_extra",
-    "model_fields",
-    "model_fields_set",
-    "model_json_schema",
-    "model_parametrized_name",
-    "model_post_init",
-    "model_rebuild",
-    "model_validate",
-    "model_validate_json",
-    "model_validate_strings",
-}
+# Reserved names should capture all the `public` names / methods that are
+# used by BaseModel internally. This will keep the reserved names up-to-date.
+# For reference, the reserved names are:
+# "construct", "copy", "dict", "from_orm", "json", "parse_file", "parse_obj",
+# "parse_raw", "schema", "schema_json", "update_forward_refs", "validate",
+# "model_computed_fields", "model_config", "model_construct", "model_copy",
+# "model_dump", "model_dump_json", "model_extra", "model_fields",
+# "model_fields_set", "model_json_schema", "model_parametrized_name",
+# "model_post_init", "model_rebuild", "model_validate", "model_validate_json",
+# "model_validate_strings"
+_RESERVED_NAMES = {key for key in dir(BaseModel) if not key.startswith("_")}
 
 
 def _remap_field_definitions(field_definitions: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -893,7 +893,7 @@ def test_chat_prompt_template_variable_names() -> None:
     assert ChatPromptTemplate(
         [("system", "{_private}")]
     ).get_input_schema().model_json_schema() == {
-        "properties": {"_private": {"title": " Private", "type": "string"}},
+        "properties": {"_private": {"title": "Private", "type": "string"}},
         "required": ["_private"],
         "title": "PromptInput",
         "type": "object",

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -890,8 +890,22 @@ def test_chat_prompt_template_variable_names() -> None:
     assert list(record) == [], msg
 
     # Verify value errors raised from illegal names
-    with pytest.raises(ValueError):
-        ChatPromptTemplate([("system", "{_private}")]).get_input_schema()
+    assert ChatPromptTemplate(
+        [("system", "{_private}")]
+    ).get_input_schema().model_json_schema() == {
+        "properties": {"_private": {"title": " Private", "type": "string"}},
+        "required": ["_private"],
+        "title": "PromptInput",
+        "type": "object",
+    }
 
-    with pytest.raises(ValueError):
-        ChatPromptTemplate([("system", "{model_json_schema}")]).get_input_schema()
+    assert ChatPromptTemplate(
+        [("system", "{model_json_schema}")]
+    ).get_input_schema().model_json_schema() == {
+        "properties": {
+            "model_json_schema": {"title": "Model Json Schema", "type": "string"}
+        },
+        "required": ["model_json_schema"],
+        "title": "PromptInput",
+        "type": "object",
+    }

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5399,13 +5399,15 @@ def test_schema_for_prompt_and_chat_model() -> None:
 
     that collide with pydantic attributes.
     """
-    prompt = ChatPromptTemplate([("system", "{model_json_schema}, {_private}")])
+    prompt = ChatPromptTemplate([("system", "{model_json_schema}, {_private}, {json}")])
     chat_res = "i'm a chatbot"
     # sleep to better simulate a real stream
     chat = FakeListChatModel(responses=[chat_res], sleep=0.01)
     chain = prompt | chat
     assert (
-        chain.invoke({"model_json_schema": "hello", "_private": "goodbye"}).content
+        chain.invoke(
+            {"model_json_schema": "hello", "_private": "goodbye", "json": "json"}
+        ).content
         == chat_res
     )
 
@@ -5413,8 +5415,13 @@ def test_schema_for_prompt_and_chat_model() -> None:
         "properties": {
             "model_json_schema": {"title": "Model Json Schema", "type": "string"},
             "_private": {"title": "Private", "type": "string"},
+            "json": {"title": "Json", "type": "string"},
         },
-        "required": ["_private", "model_json_schema"],
+        "required": [
+            "_private",
+            "json",
+            "model_json_schema",
+        ],
         "title": "PromptInput",
         "type": "object",
     }

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5392,3 +5392,29 @@ def test_pydantic_protected_namespaces() -> None:
 
         class CustomChatModel(RunnableSerializable):
             model_kwargs: Dict[str, Any] = Field(default_factory=dict)
+
+
+def test_schema_for_prompt_and_chat_model() -> None:
+    """Testing that schema is generated properly when using variable names
+
+    that collide with pydantic attributes.
+    """
+    prompt = ChatPromptTemplate([("system", "{model_json_schema}, {_private}")])
+    chat_res = "i'm a chatbot"
+    # sleep to better simulate a real stream
+    chat = FakeListChatModel(responses=[chat_res], sleep=0.01)
+    chain = prompt | chat
+    assert (
+        chain.invoke({"model_json_schema": "hello", "_private": "goodbye"}).content
+        == chat_res
+    )
+
+    assert chain.get_input_jsonschema() == {
+        "properties": {
+            "model_json_schema": {"title": "Model Json Schema", "type": "string"},
+            "_private": {"title": "Private", "type": "string"},
+        },
+        "required": ["_private", "model_json_schema"],
+        "title": "PromptInput",
+        "type": "object",
+    }

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -220,15 +220,6 @@ def test_create_model_v2() -> None:
 
     assert list(record) == []
 
-    # Used by pydantic, not OK to re-use
-    with pytest.raises(ValueError):
-        create_model_v2("Foo", field_definitions={"model_json_schema": (int, None)})
-
-    # Private attributes raise an error for now since pydantic 2 considers them
-    # to be private attributes.
-    with pytest.raises(ValueError):
-        create_model_v2("Foo", field_definitions={"_a": (int, None)})
-
     with pytest.warns(None) as record:  # type: ignore
         # Verify that we can use non-English characters
         field_name = "もしもし"


### PR DESCRIPTION
This PR lifts the restrictions by pydantic by remapping the fields.

We could do a bit more work if we wanted to better catch issues if any users are intentionally trying to create field collisions