### PR TITLE
reka model integration

### DIFF
--- a/docs/docs/integrations/chat/reka.ipynb
+++ b/docs/docs/integrations/chat/reka.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.chat_models import ChatReka"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = ChatReka()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_url = \"https://v0.docs.reka.ai/_images/000000245576.jpg\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: Reka\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ChatReka\n",
+    "\n",
+    "This notebook provides a quick overview for getting started with Reka [chat models](/docs/concepts/#chat-models). \n",
+    "\n",
+    "Reka has several chat models. You can find information about their latest models and their costs, context windows, and supported input types in the [Reka docs](https://docs.reka.ai/available-models).\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "| Class | Package | Local | Serializable | JS support | Package downloads | Package latest |\n",
+    "| :--- | :--- | :---: | :---: |  :---: | :---: | :---: |\n",
+    "| [ChatReka] | [langchain_community](https://python.langchain.com/v0.2/api_reference/community/index.html) | ✅ | ❌ | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain_community?style=flat-square&label=%20) |\n",
+    "\n",
+    "### Model features\n",
+    "| [Tool calling](/docs/how_to/tool_calling) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
+    "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
+    "| ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | \n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To access Reka models you'll need to create an Reka developer account, get an API key, and install the `langchain_community` integration package and the reka python package via 'pip install reka-api'.\n",
+    "\n",
+    "### Credentials\n",
+    "\n",
+    "Head to https://platform.reka.ai/ to sign up for Reka and generate an API key. Once you've done this set the REKA_API_KEY environment variable:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "The LangChain __ModuleName__ integration lives in the `langchain_community` package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain_community"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Initialize a client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "# os.environ[\"REKA_API_KEY\"] = getpass.getpass(\"Enter your Reka API key: \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain_community"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.chat_models import ChatReka\n",
+    "# This \n",
+    "model = ChatReka()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Single turn text message"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content=' Hello! How can I help you today? If you have any questions or need assistance with something, feel free to ask.\\n\\n', id='run-492dcda9-79b8-4e16-a81f-2f77b7d4e23a-0')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.invoke('hi')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Images input "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " The image you've uploaded is an indoor shot, and therefore, it does not provide any information about the weather outside. Since there are no windows or outdoor views depicted, it's not possible to determine the weather conditions at the time the photo was taken. If you need information about the weather, you should check a weather app, website, or news source based on your location or the location where the image was captured.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_community.chat_models import ChatReka\n",
+    "import httpx\n",
+    "\n",
+    "model = ChatReka()\n",
+    "image_url = \"https://v0.docs.reka.ai/_images/000000245576.jpg\"\n",
+    "from langchain_core.messages import HumanMessage\n",
+    "\n",
+    "message = HumanMessage(\n",
+    "    content=[\n",
+    "        {\"type\": \"text\", \"text\": \"describe the weather in this image\"},\n",
+    "        {\n",
+    "            \"type\": \"image_url\",\n",
+    "            \"image_url\": {\"url\": image_url},\n",
+    "        },\n",
+    "    ],\n",
+    ")\n",
+    "response = model.invoke([message])\n",
+    "print(response.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multiple images as input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " The two images are quite different in several ways. \n",
+      "\n",
+      "Firstly, the subjects of the images are different. The first image features a cat, while the second image features two German Shepherds, an adult and a puppy.\n",
+      "\n",
+      "Secondly, the actions depicted are different. In the first image, the cat is sitting still and looking directly at the camera. In contrast, the second image captures the two dogs in motion, running across a grassy field with a stick in the mouth of the adult dog.\n",
+      "\n",
+      "Lastly, the setting of the images is different. The first image has a neutral, blurred background, providing no specific context about the location. The second image, on the other hand, is set in an outdoor environment with a grassy field and trees in the background.\n",
+      "\n",
+      "These differences highlight the distinct characteristics and behaviors of the animals as well as the varying contexts in which they are photographed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "message = HumanMessage(\n",
+    "    content=[\n",
+    "        {\"type\": \"text\", \"text\": \"What are the difference between the two images? \"},\n",
+    "        {\n",
+    "            \"type\": \"image_url\",\n",
+    "            \"image_url\": {\"url\": \"https://cdn.pixabay.com/photo/2019/07/23/13/51/shepherd-dog-4357790_1280.jpg\"},\n",
+    "        },\n",
+    "        {\n",
+    "            \"type\": \"image_url\",\n",
+    "            \"image_url\": {\"url\": \"https://cdn.pixabay.com/photo/2024/02/17/00/18/cat-8578562_1280.jpg\"},\n",
+    "        },\n",
+    "    ],\n",
+    ")\n",
+    "response = model.invoke([message])\n",
+    "print(response.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain_reka",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -72,6 +72,7 @@ rapidfuzz>=3.1.1,<4
 rapidocr-onnxruntime>=1.3.2,<2
 rdflib==7.0.0
 requests-toolbelt>=1.0.0,<2
+reka-api>=3.2.0
 rspace_client>=2.5.0,<3
 scikit-learn>=1.2.2,<2
 simsimd>=5.0.0,<6

--- a/libs/community/langchain_community/chat_models/__init__.py
+++ b/libs/community/langchain_community/chat_models/__init__.py
@@ -149,7 +149,10 @@ if TYPE_CHECKING:
     )
     from langchain_community.chat_models.sambanova import (
         ChatSambaNovaCloud,
-        ChatSambaStudio,
+        ChatSambaStudio
+    )
+    from langchain_community.chat_models.reka import (
+        ChatReka,
     )
     from langchain_community.chat_models.snowflake import (
         ChatSnowflakeCortex,
@@ -214,6 +217,7 @@ __all__ = [
     "ChatOllama",
     "ChatOpenAI",
     "ChatPerplexity",
+    "ChatReka",
     "ChatPremAI",
     "ChatSambaNovaCloud",
     "ChatSambaStudio",
@@ -274,6 +278,7 @@ _module_lookup = {
     "ChatOCIGenAI": "langchain_community.chat_models.oci_generative_ai",
     "ChatOllama": "langchain_community.chat_models.ollama",
     "ChatOpenAI": "langchain_community.chat_models.openai",
+    "ChatReka": "langchain_community.chat_models.reka",
     "ChatPerplexity": "langchain_community.chat_models.perplexity",
     "ChatSambaNovaCloud": "langchain_community.chat_models.sambanova",
     "ChatSambaStudio": "langchain_community.chat_models.sambanova",

--- a/libs/community/langchain_community/chat_models/reka.py
+++ b/libs/community/langchain_community/chat_models/reka.py
@@ -1,0 +1,188 @@
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models.chat_models import (
+    BaseChatModel,
+    agenerate_from_stream,
+    generate_from_stream,
+)
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    ChatMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.pydantic_v1 import Field, PrivateAttr
+from langchain_core.utils import get_from_dict_or_env
+
+try:
+    from reka.client import Reka, AsyncReka
+except ImportError:
+    raise ValueError(
+        "Reka is not installed. Please install it with `pip install reka-api`."
+    )
+
+REKA_MODELS = [
+    "reka-edge",
+    "reka-flash",
+    "reka-core",
+    "reka-core-20240501",
+]
+
+DEFAULT_REKA_MODEL = "reka-core-20240501"
+
+def get_role(message: BaseMessage) -> str:
+    """Get the role of the message."""
+    if isinstance(message, (ChatMessage, HumanMessage)):
+        return "user"
+    elif isinstance(message, AIMessage):
+        return "assistant"
+    elif isinstance(message, SystemMessage):
+        return "system"
+    else:
+        raise ValueError(f"Got unknown type {message}")
+
+def process_messages_for_reka(messages: List[BaseMessage]) -> List[Dict[str, str]]:
+    """Process messages for Reka format."""
+    reka_messages = []
+    system_message = None
+
+    for message in messages:
+        if isinstance(message, SystemMessage):
+            if system_message is None:
+                system_message = message.content
+            else:
+                raise ValueError("Multiple system messages are not supported.")
+        else:
+            content = message.content
+            if system_message and isinstance(message, HumanMessage):
+                content = f"{system_message}\n{content}"
+                system_message = None
+            reka_messages.append({"role": get_role(message), "content": content})
+
+    return reka_messages
+
+class ChatReka(BaseChatModel):
+    """Reka chat large language models."""
+
+    model: str = Field(default=DEFAULT_REKA_MODEL, description="The Reka model to use.")
+    temperature: float = Field(default=0.7, description="The sampling temperature.")
+    max_tokens: int = Field(default=512, description="The maximum number of tokens to generate.")
+    api_key: str = Field(default=None, description="The API key for Reka.")
+    streaming: bool = Field(default=False, description="Whether to stream the response.")
+
+    _client: Reka = PrivateAttr()
+    _aclient: AsyncReka = PrivateAttr()
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        api_key = get_from_dict_or_env(kwargs, "api_key", "REKA_API_KEY")
+        self._client = Reka(api_key=api_key)
+        self._aclient = AsyncReka(api_key=api_key)
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of chat model."""
+        return "reka-chat"
+
+    @property
+    def _default_params(self) -> Dict[str, Any]:
+        """Get the default parameters for calling Reka API."""
+        return {
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        reka_messages = process_messages_for_reka(messages)
+        params = {**self._default_params, **kwargs}
+        if stop:
+            params["stop"] = stop
+
+        stream = self._client.chat.create_stream(messages=reka_messages, **params)
+
+        for chunk in stream:
+            content = chunk.responses[0].chunk.content
+            chunk = ChatGenerationChunk(message=AIMessageChunk(content=content))
+            yield chunk
+            if run_manager:
+                run_manager.on_llm_new_token(content, chunk=chunk)
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        reka_messages = process_messages_for_reka(messages)
+        params = {**self._default_params, **kwargs}
+        if stop:
+            params["stop"] = stop
+
+        stream = await self._aclient.chat.create_stream(messages=reka_messages, **params)
+
+        async for chunk in stream:
+            content = chunk.responses[0].chunk.content
+            chunk = ChatGenerationChunk(message=AIMessageChunk(content=content))
+            yield chunk
+            if run_manager:
+                await run_manager.on_llm_new_token(content, chunk=chunk)
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.streaming:
+            return generate_from_stream(
+                self._stream(messages, stop=stop, run_manager=run_manager, **kwargs)
+            )
+
+        reka_messages = process_messages_for_reka(messages)
+        params = {**self._default_params, **kwargs}
+        if stop:
+            params["stop"] = stop
+        response = self._client.chat.create(messages=reka_messages, **params)
+
+        message = AIMessage(content=response.responses[0].message.content)
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self.streaming:
+            return await agenerate_from_stream(
+                self._astream(messages, stop=stop, run_manager=run_manager, **kwargs)
+            )
+
+        reka_messages = process_messages_for_reka(messages)
+        params = {**self._default_params, **kwargs}
+        if stop:
+            params["stop"] = stop
+        response = await self._aclient.chat.create(messages=reka_messages, **params)
+
+        message = AIMessage(content=response.responses[0].message.content)
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def get_num_tokens(self, text: str) -> int:
+        """Calculate number of tokens."""
+        raise NotImplementedError("Token counting is not implemented for Reka models.")

--- a/libs/community/langchain_community/chat_models/reka.py
+++ b/libs/community/langchain_community/chat_models/reka.py
@@ -1,4 +1,5 @@
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -21,7 +22,7 @@ from langchain_core.pydantic_v1 import Field, PrivateAttr
 from langchain_core.utils import get_from_dict_or_env
 
 try:
-    from reka.client import Reka, AsyncReka
+    from reka.client import AsyncReka, Reka
 except ImportError:
     raise ValueError(
         "Reka is not installed. Please install it with `pip install reka-api`."
@@ -70,11 +71,26 @@ def process_messages_for_reka(messages: List[BaseMessage]) -> List[Dict[str, str
 class ChatReka(BaseChatModel):
     """Reka chat large language models."""
 
-    model: str = Field(default=DEFAULT_REKA_MODEL, description="The Reka model to use.")
-    temperature: float = Field(default=0.7, description="The sampling temperature.")
-    max_tokens: int = Field(default=512, description="The maximum number of tokens to generate.")
-    api_key: str = Field(default=None, description="The API key for Reka.")
-    streaming: bool = Field(default=False, description="Whether to stream the response.")
+    model: str = Field(
+        default=DEFAULT_REKA_MODEL, 
+        description="The Reka model to use."
+    )
+    temperature: float = Field(
+        default=0.7, 
+        description="The sampling temperature."
+    )
+    max_tokens: int = Field(
+        default=512, 
+        description="The maximum number of tokens to generate."
+    )
+    api_key: str = Field(
+        default=None, 
+        description="The API key for Reka."
+    )
+    streaming: bool = Field(
+        default=False, 
+        description="Whether to stream the response."
+    )
 
     _client: Reka = PrivateAttr()
     _aclient: AsyncReka = PrivateAttr()
@@ -132,7 +148,10 @@ class ChatReka(BaseChatModel):
         if stop:
             params["stop"] = stop
 
-        stream = await self._aclient.chat.create_stream(messages=reka_messages, **params)
+        stream = await self._aclient.chat.create_stream(
+            messages=reka_messages, 
+            **params
+        )
 
         async for chunk in stream:
             content = chunk.responses[0].chunk.content

--- a/libs/community/tests/integration_tests/chat_models/test_reka.py
+++ b/libs/community/tests/integration_tests/chat_models/test_reka.py
@@ -10,6 +10,7 @@ from langchain_core.outputs import ChatGeneration, LLMResult
 from langchain_community.chat_models.reka import ChatReka
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
 
+
 @pytest.mark.scheduled
 def test_reka_call() -> None:
     """Test valid call to Reka."""

--- a/libs/community/tests/integration_tests/chat_models/test_reka.py
+++ b/libs/community/tests/integration_tests/chat_models/test_reka.py
@@ -20,6 +20,7 @@ def test_reka_call() -> None:
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
 
+
 @pytest.mark.scheduled
 def test_reka_generate() -> None:
     """Test generate method of Reka."""
@@ -36,6 +37,7 @@ def test_reka_generate() -> None:
         assert response.text == response.message.content
     assert chat_messages == messages_copy
 
+
 @pytest.mark.scheduled
 def test_reka_streaming() -> None:
     """Test streaming tokens from Reka."""
@@ -44,6 +46,7 @@ def test_reka_streaming() -> None:
     response = chat.invoke([message])
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
+
 
 @pytest.mark.scheduled
 def test_reka_streaming_callback() -> None:
@@ -59,6 +62,7 @@ def test_reka_streaming_callback() -> None:
     message = HumanMessage(content="Write me a sentence with 10 words.")
     chat.invoke([message])
     assert callback_handler.llm_streams > 1
+
 
 @pytest.mark.scheduled
 async def test_reka_async_streaming_callback() -> None:

--- a/libs/community/tests/integration_tests/chat_models/test_reka.py
+++ b/libs/community/tests/integration_tests/chat_models/test_reka.py
@@ -1,0 +1,82 @@
+"""Test Reka API wrapper."""
+
+from typing import List
+
+import pytest
+from langchain_core.callbacks import CallbackManager
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from langchain_community.chat_models.reka import ChatReka
+from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
+
+@pytest.mark.scheduled
+def test_reka_call() -> None:
+    """Test valid call to Reka."""
+    chat = ChatReka(model="reka-flash")
+    message = HumanMessage(content="Hello")
+    response = chat.invoke([message])
+    assert isinstance(response, AIMessage)
+    assert isinstance(response.content, str)
+
+@pytest.mark.scheduled
+def test_reka_generate() -> None:
+    """Test generate method of Reka."""
+    chat = ChatReka(model="reka-flash")
+    chat_messages: List[List[BaseMessage]] = [
+        [HumanMessage(content="How many toes do dogs have?")]
+    ]
+    messages_copy = [messages.copy() for messages in chat_messages]
+    result: LLMResult = chat.generate(chat_messages)
+    assert isinstance(result, LLMResult)
+    for response in result.generations[0]:
+        assert isinstance(response, ChatGeneration)
+        assert isinstance(response.text, str)
+        assert response.text == response.message.content
+    assert chat_messages == messages_copy
+
+@pytest.mark.scheduled
+def test_reka_streaming() -> None:
+    """Test streaming tokens from Reka."""
+    chat = ChatReka(model="reka-flash", streaming=True)
+    message = HumanMessage(content="Hello")
+    response = chat.invoke([message])
+    assert isinstance(response, AIMessage)
+    assert isinstance(response.content, str)
+
+@pytest.mark.scheduled
+def test_reka_streaming_callback() -> None:
+    """Test that streaming correctly invokes on_llm_new_token callback."""
+    callback_handler = FakeCallbackHandler()
+    callback_manager = CallbackManager([callback_handler])
+    chat = ChatReka(
+        model="reka-flash",
+        streaming=True,
+        callback_manager=callback_manager,
+        verbose=True,
+    )
+    message = HumanMessage(content="Write me a sentence with 10 words.")
+    chat.invoke([message])
+    assert callback_handler.llm_streams > 1
+
+@pytest.mark.scheduled
+async def test_reka_async_streaming_callback() -> None:
+    """Test that streaming correctly invokes on_llm_new_token callback."""
+    callback_handler = FakeCallbackHandler()
+    callback_manager = CallbackManager([callback_handler])
+    chat = ChatReka(
+        model="reka-flash",
+        streaming=True,
+        callback_manager=callback_manager,
+        verbose=True,
+    )
+    chat_messages: List[BaseMessage] = [
+        HumanMessage(content="How many toes do dogs have?")
+    ]
+    result: LLMResult = await chat.agenerate([chat_messages])
+    assert callback_handler.llm_streams > 1
+    assert isinstance(result, LLMResult)
+    for response in result.generations[0]:
+        assert isinstance(response, ChatGeneration)
+        assert isinstance(response.text, str)
+        assert response.text == response.message.content

--- a/libs/community/tests/unit_tests/chat_models/test_reka.py
+++ b/libs/community/tests/unit_tests/chat_models/test_reka.py
@@ -1,0 +1,123 @@
+"""Test Reka Chat API wrapper."""
+
+import os
+from typing import List
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+from langchain_community.chat_models import ChatReka
+from langchain_community.chat_models.reka import process_messages_for_reka
+
+os.environ["REKA_API_KEY"] = "dummy_key"
+
+
+@pytest.mark.requires("reka")
+def test_reka_model_name_param() -> None:
+    llm = ChatReka(model_name="reka-flash")
+    assert llm.model == "reka-flash"
+
+
+@pytest.mark.requires("reka")
+def test_reka_model_param() -> None:
+    llm = ChatReka(model="reka-flash")
+    assert llm.model == "reka-flash"
+
+
+@pytest.mark.requires("reka")
+def test_reka_model_kwargs() -> None:
+    llm = ChatReka(model_kwargs={"foo": "bar"})
+    assert llm.model_kwargs == {"foo": "bar"}
+
+
+@pytest.mark.requires("reka")
+def test_reka_invalid_model_kwargs() -> None:
+    with pytest.raises(ValueError):
+        ChatReka(model_kwargs={"max_tokens": "invalid"})
+
+
+@pytest.mark.requires("reka")
+def test_reka_incorrect_field() -> None:
+    with pytest.warns(match="not default parameter"):
+        llm = ChatReka(foo="bar")
+    assert llm.model_kwargs == {"foo": "bar"}
+
+
+@pytest.mark.requires("reka")
+def test_reka_initialization() -> None:
+    """Test Reka initialization."""
+    # Verify that ChatReka can be initialized using a secret key provided
+    # as a parameter rather than an environment variable.
+    ChatReka(model="reka-flash", reka_api_key="test_key")
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected"),
+    [
+        ([HumanMessage(content="Hello")], [{"role": "user", "content": "Hello"}]),
+        (
+            [HumanMessage(content="Hello"), AIMessage(content="Hi there!")],
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+        ),
+        (
+            [
+                SystemMessage(content="You're an assistant"),
+                HumanMessage(content="Hello"),
+                AIMessage(content="Hi there!"),
+            ],
+            [
+                {"role": "user", "content": "You're an assistant\nHello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+        ),
+    ],
+)
+def test_message_processing(messages: List[BaseMessage], expected: List[dict]) -> None:
+    result = process_messages_for_reka(messages)
+    assert result == expected
+
+
+@pytest.mark.requires("reka")
+def test_reka_streaming() -> None:
+    llm = ChatReka(streaming=True)
+    assert llm.streaming is True
+
+
+@pytest.mark.requires("reka")
+def test_reka_temperature() -> None:
+    llm = ChatReka(temperature=0.5)
+    assert llm.temperature == 0.5
+
+
+@pytest.mark.requires("reka")
+def test_reka_max_tokens() -> None:
+    llm = ChatReka(max_tokens=100)
+    assert llm.max_tokens == 100
+
+
+@pytest.mark.requires("reka")
+def test_reka_default_params() -> None:
+    llm = ChatReka()
+    assert llm._default_params == {
+        "max_tokens": 256,
+        "model": "reka-flash",
+    }
+
+
+@pytest.mark.requires("reka")
+def test_reka_identifying_params() -> None:
+    llm = ChatReka(temperature=0.7)
+    assert llm._identifying_params == {
+        "max_tokens": 256,
+        "model": "reka-flash",
+        "temperature": 0.7,
+    }
+
+
+@pytest.mark.requires("reka")
+def test_reka_llm_type() -> None:
+    llm = ChatReka()
+    assert llm._llm_type == "reka-chat"


### PR DESCRIPTION
community: add Reka chat model integration

**Description:** This PR adds support for the Reka chat model to the LangChain community package. It includes the implementation of `ChatReka` class, which allows users to interact with Reka's API for chat completions. The integration supports both text and image inputs, streaming responses, and async operations.

**Dependencies:** This integration inside langchain-community requires the `reka-api` package to be installed. Users will need to install it separately with `pip install reka-api`.

**Added features:**
- `ChatReka` class for interacting with Reka chat models
- Support for text and image inputs
- Streaming and non-streaming response handling
- Synchronous and asynchronous methods
- Unit and integration tests
- Example notebook demonstrating usage

**Testing:**
- Unit tests have been added in `tests/unit_tests/chat_models/test_reka.py`
- Integration tests have been added in `tests/integration_tests/chat_models/test_reka.py`
- An example notebook has been created in `docs/docs/integrations/chat/reka.ipynb`

I have run `make format`, `make lint`, and `make test` from the root of the community package, and all checks pass.

X/Twitter handle: @RekaAILabs
