### PR TITLE
core,langchain: deprecated pydantic_v1 namespace to raise import error

### DIFF
--- a/libs/community/tests/unit_tests/load/test_serializable.py
+++ b/libs/community/tests/unit_tests/load/test_serializable.py
@@ -45,6 +45,12 @@ def import_all_modules(package_name: str) -> dict:
     for importer, modname, ispkg in pkgutil.walk_packages(
         package.__path__, package.__name__ + "."
     ):
+        if modname.startswith("langchain_core.pydantic_v1") or modname.startswith(
+            "langchain.pydantic_v1"
+        ):
+            # These are deprecated and should not be imported as they
+            # intentionally raise an import error
+            continue
         try:
             module = importlib.import_module(modname)
         except ModuleNotFoundError:
@@ -138,8 +144,15 @@ def test_serializable_mapping() -> None:
 
     for k, import_path in serializable_modules.items():
         import_dir, import_obj = import_path[:-1], import_path[-1]
+        module = ".".join(import_dir)
+        if module.startswith("langchain_core.pydantic_v1") or module.startswith(
+            "langchain.pydantic_v1"
+        ):
+            # These are deprecated and should not be imported as they
+            # intentionally raise an import error
+            continue
         # Import module
-        mod = importlib.import_module(".".join(import_dir))
+        mod = importlib.import_module(module)
         # Import class
         cls = getattr(mod, import_obj)
         assert list(k) == cls.lc_id()

--- a/libs/core/langchain_core/pydantic_v1/__init__.py
+++ b/libs/core/langchain_core/pydantic_v1/__init__.py
@@ -1,7 +1,7 @@
 def _raise_import_error() -> None:
     """Raise ImportError with a helpful message."""
     raise ImportError(
-        "Please do not import from langchain_core.pydantic_v1.*."
+        "Please do not import from langchain_core.pydantic_v1. "
         "This module was a compatibility shim for pydantic v1, and should "
         "no longer be used "
         "Please update the code to import from Pydantic directly. "

--- a/libs/core/langchain_core/pydantic_v1/__init__.py
+++ b/libs/core/langchain_core/pydantic_v1/__init__.py
@@ -1,43 +1,14 @@
-from importlib import metadata
-
-from langchain_core._api.deprecation import warn_deprecated
-
-## Create namespaces for pydantic v1 and v2.
-# This code must stay at the top of the file before other modules may
-# attempt to import pydantic since it adds pydantic_v1 and pydantic_v2 to sys.modules.
-#
-# This hack is done for the following reasons:
-# * Langchain will attempt to remain compatible with both pydantic v1 and v2 since
-#   both dependencies and dependents may be stuck on either version of v1 or v2.
-# * Creating namespaces for pydantic v1 and v2 should allow us to write code that
-#   unambiguously uses either v1 or v2 API.
-# * This change is easier to roll out and roll back.
-
-try:
-    from pydantic.v1 import *  # noqa: F403
-except ImportError:
-    from pydantic import *  # type: ignore # noqa: F403
-
-
-try:
-    _PYDANTIC_MAJOR_VERSION: int = int(metadata.version("pydantic").split(".")[0])
-except metadata.PackageNotFoundError:
-    _PYDANTIC_MAJOR_VERSION = 0
-
-warn_deprecated(
-    "0.3.0",
-    removal="1.0.0",
-    alternative="pydantic.v1 or pydantic",
-    message=(
-        "As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. "
-        "The langchain_core.pydantic_v1 module was a "
-        "compatibility shim for pydantic v1, and should no longer be used. "
-        "Please update the code to import from Pydantic directly.\n\n"
+def _raise_import_error() -> None:
+    """Raise ImportError with a helpful message."""
+    raise ImportError(
+        "Please do not import from langchain_core.pydantic_v1.*."
+        "This module was a compatibility shim for pydantic v1, and should "
+        "no longer be used "
+        "Please update the code to import from Pydantic directly. "
         "For example, replace imports like: "
         "`from langchain_core.pydantic_v1 import BaseModel`\n"
         "with: `from pydantic import BaseModel`\n"
-        "or the v1 compatibility namespace if you are working in a code base "
-        "that has not been fully upgraded to pydantic 2 yet. "
-        "\tfrom pydantic.v1 import BaseModel\n"
-    ),
-)
+    )
+
+
+_raise_import_error()

--- a/libs/core/langchain_core/pydantic_v1/dataclasses.py
+++ b/libs/core/langchain_core/pydantic_v1/dataclasses.py
@@ -1,7 +1,7 @@
 def _raise_import_error() -> None:
     """Raise ImportError with a helpful message."""
     raise ImportError(
-        "Please do not import from langchain_core.pydantic_v1.*."
+        "Please do not import from langchain_core.pydantic_v1. "
         "This module was a compatibility shim for pydantic v1, and should "
         "no longer be used "
         "Please update the code to import from Pydantic directly. "

--- a/libs/core/langchain_core/pydantic_v1/dataclasses.py
+++ b/libs/core/langchain_core/pydantic_v1/dataclasses.py
@@ -1,24 +1,14 @@
-from langchain_core._api import warn_deprecated
-
-try:
-    from pydantic.v1.dataclasses import *  # noqa: F403
-except ImportError:
-    from pydantic.dataclasses import *  # type: ignore # noqa: F403
-
-warn_deprecated(
-    "0.3.0",
-    removal="1.0.0",
-    alternative="pydantic.v1 or pydantic",
-    message=(
-        "As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. "
-        "The langchain_core.pydantic_v1 module was a "
-        "compatibility shim for pydantic v1, and should no longer be used. "
-        "Please update the code to import from Pydantic directly.\n\n"
+def _raise_import_error() -> None:
+    """Raise ImportError with a helpful message."""
+    raise ImportError(
+        "Please do not import from langchain_core.pydantic_v1.*."
+        "This module was a compatibility shim for pydantic v1, and should "
+        "no longer be used "
+        "Please update the code to import from Pydantic directly. "
         "For example, replace imports like: "
         "`from langchain_core.pydantic_v1 import BaseModel`\n"
         "with: `from pydantic import BaseModel`\n"
-        "or the v1 compatibility namespace if you are working in a code base "
-        "that has not been fully upgraded to pydantic 2 yet. "
-        "\tfrom pydantic.v1 import BaseModel\n"
-    ),
-)
+    )
+
+
+_raise_import_error()

--- a/libs/core/langchain_core/pydantic_v1/main.py
+++ b/libs/core/langchain_core/pydantic_v1/main.py
@@ -1,7 +1,7 @@
 def _raise_import_error() -> None:
     """Raise ImportError with a helpful message."""
     raise ImportError(
-        "Please do not import from langchain_core.pydantic_v1.*."
+        "Please do not import from langchain_core.pydantic_v1. "
         "This module was a compatibility shim for pydantic v1, and should "
         "no longer be used "
         "Please update the code to import from Pydantic directly. "

--- a/libs/core/langchain_core/pydantic_v1/main.py
+++ b/libs/core/langchain_core/pydantic_v1/main.py
@@ -1,24 +1,14 @@
-from langchain_core._api import warn_deprecated
-
-try:
-    from pydantic.v1.main import *  # noqa: F403
-except ImportError:
-    from pydantic.main import *  # type: ignore # noqa: F403
-
-warn_deprecated(
-    "0.3.0",
-    removal="1.0.0",
-    alternative="pydantic.v1 or pydantic",
-    message=(
-        "As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. "
-        "The langchain_core.pydantic_v1 module was a "
-        "compatibility shim for pydantic v1, and should no longer be used. "
-        "Please update the code to import from Pydantic directly.\n\n"
+def _raise_import_error() -> None:
+    """Raise ImportError with a helpful message."""
+    raise ImportError(
+        "Please do not import from langchain_core.pydantic_v1.*."
+        "This module was a compatibility shim for pydantic v1, and should "
+        "no longer be used "
+        "Please update the code to import from Pydantic directly. "
         "For example, replace imports like: "
         "`from langchain_core.pydantic_v1 import BaseModel`\n"
         "with: `from pydantic import BaseModel`\n"
-        "or the v1 compatibility namespace if you are working in a code base "
-        "that has not been fully upgraded to pydantic 2 yet. "
-        "\tfrom pydantic.v1 import BaseModel\n"
-    ),
-)
+    )
+
+
+_raise_import_error()

--- a/libs/core/tests/unit_tests/test_imports.py
+++ b/libs/core/tests/unit_tests/test_imports.py
@@ -12,6 +12,8 @@ def test_importable_all() -> None:
         if relative_path.endswith(".typed"):
             continue
         module_name = relative_path.split(".")[0]
+        if module_name.startswith("pydantic_v1"):
+            continue
         module = importlib.import_module("langchain_core." + module_name)
         all_ = getattr(module, "__all__", [])
         for cls_ in all_:
@@ -41,6 +43,10 @@ def test_importable_all_via_subprocess() -> None:
     for path in glob.glob("../core/langchain_core/*"):
         relative_path = Path(path).parts[-1]
         if relative_path.endswith(".typed"):
+            continue
+        # pydantic_v1 has been deprecated and intentionally
+        # raises an ImportError when imported.
+        if relative_path.startswith("pydantic_v1"):
             continue
         module_name = relative_path.split(".")[0]
         module_names.append(module_name)

--- a/libs/langchain/langchain/pydantic_v1/__init__.py
+++ b/libs/langchain/langchain/pydantic_v1/__init__.py
@@ -1,43 +1,14 @@
-from importlib import metadata
-
-from langchain_core._api import warn_deprecated
-
-## Create namespaces for pydantic v1 and v2.
-# This code must stay at the top of the file before other modules may
-# attempt to import pydantic since it adds pydantic_v1 and pydantic_v2 to sys.modules.
-#
-# This hack is done for the following reasons:
-# * Langchain will attempt to remain compatible with both pydantic v1 and v2 since
-#   both dependencies and dependents may be stuck on either version of v1 or v2.
-# * Creating namespaces for pydantic v1 and v2 should allow us to write code that
-#   unambiguously uses either v1 or v2 API.
-# * This change is easier to roll out and roll back.
-
-try:
-    from pydantic.v1 import *  # noqa: F403
-except ImportError:
-    from pydantic import *  # type: ignore # noqa: F403
-
-
-try:
-    _PYDANTIC_MAJOR_VERSION: int = int(metadata.version("pydantic").split(".")[0])
-except metadata.PackageNotFoundError:
-    _PYDANTIC_MAJOR_VERSION = 0
-
-warn_deprecated(
-    "0.3.0",
-    removal="1.0.0",
-    alternative="pydantic.v1 or pydantic",
-    message=(
-        "As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. "
-        "The langchain.pydantic_v1 module was a "
-        "compatibility shim for pydantic v1, and should no longer be used. "
-        "Please update the code to import from Pydantic directly.\n\n"
+def _raise_import_error() -> None:
+    """Raise ImportError with a helpful message."""
+    raise ImportError(
+        "Please do not import from langchain.pydantic_v1.*."
+        "This module was a compatibility shim for pydantic v1, and should "
+        "no longer be used "
+        "Please update the code to import from Pydantic directly. "
         "For example, replace imports like: "
         "`from langchain.pydantic_v1 import BaseModel`\n"
         "with: `from pydantic import BaseModel`\n"
-        "or the v1 compatibility namespace if you are working in a code base "
-        "that has not been fully upgraded to pydantic 2 yet. "
-        "\tfrom pydantic.v1 import BaseModel\n"
-    ),
-)
+    )
+
+
+_raise_import_error()

--- a/libs/langchain/langchain/pydantic_v1/__init__.py
+++ b/libs/langchain/langchain/pydantic_v1/__init__.py
@@ -1,7 +1,7 @@
 def _raise_import_error() -> None:
     """Raise ImportError with a helpful message."""
     raise ImportError(
-        "Please do not import from langchain.pydantic_v1.*."
+        "Please do not import from langchain.pydantic_v1. "
         "This module was a compatibility shim for pydantic v1, and should "
         "no longer be used "
         "Please update the code to import from Pydantic directly. "

--- a/libs/langchain/langchain/pydantic_v1/dataclasses.py
+++ b/libs/langchain/langchain/pydantic_v1/dataclasses.py
@@ -1,24 +1,14 @@
-from langchain_core._api import warn_deprecated
-
-try:
-    from pydantic.v1.dataclasses import *  # noqa: F403
-except ImportError:
-    from pydantic.dataclasses import *  # type: ignore # noqa: F403
-
-warn_deprecated(
-    "0.3.0",
-    removal="1.0.0",
-    alternative="pydantic.v1 or pydantic",
-    message=(
-        "As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. "
-        "The langchain.pydantic_v1 module was a "
-        "compatibility shim for pydantic v1, and should no longer be used. "
-        "Please update the code to import from Pydantic directly.\n\n"
+def _raise_import_error() -> None:
+    """Raise ImportError with a helpful message."""
+    raise ImportError(
+        "Please do not import from langchain.pydantic_v1.*."
+        "This module was a compatibility shim for pydantic v1, and should "
+        "no longer be used "
+        "Please update the code to import from Pydantic directly. "
         "For example, replace imports like: "
         "`from langchain.pydantic_v1 import BaseModel`\n"
         "with: `from pydantic import BaseModel`\n"
-        "or the v1 compatibility namespace if you are working in a code base "
-        "that has not been fully upgraded to pydantic 2 yet. "
-        "\tfrom pydantic.v1 import BaseModel\n"
-    ),
-)
+    )
+
+
+_raise_import_error()

--- a/libs/langchain/langchain/pydantic_v1/main.py
+++ b/libs/langchain/langchain/pydantic_v1/main.py
@@ -1,7 +1,7 @@
 def _raise_import_error() -> None:
     """Raise ImportError with a helpful message."""
     raise ImportError(
-        "Please do not import from langchain.pydantic_v1.*."
+        "Please do not import from langchain.pydantic_v1. "
         "This module was a compatibility shim for pydantic v1, and should "
         "no longer be used "
         "Please update the code to import from Pydantic directly. "

--- a/libs/langchain/langchain/pydantic_v1/main.py
+++ b/libs/langchain/langchain/pydantic_v1/main.py
@@ -1,24 +1,14 @@
-from langchain_core._api import warn_deprecated
-
-try:
-    from pydantic.v1.main import *  # noqa: F403
-except ImportError:
-    from pydantic.main import *  # type: ignore # noqa: F403
-
-warn_deprecated(
-    "0.3.0",
-    removal="1.0.0",
-    alternative="pydantic.v1 or pydantic",
-    message=(
-        "As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. "
-        "The langchain.pydantic_v1 module was a "
-        "compatibility shim for pydantic v1, and should no longer be used. "
-        "Please update the code to import from Pydantic directly.\n\n"
+def _raise_import_error() -> None:
+    """Raise ImportError with a helpful message."""
+    raise ImportError(
+        "Please do not import from langchain.pydantic_v1.*."
+        "This module was a compatibility shim for pydantic v1, and should "
+        "no longer be used "
+        "Please update the code to import from Pydantic directly. "
         "For example, replace imports like: "
         "`from langchain.pydantic_v1 import BaseModel`\n"
         "with: `from pydantic import BaseModel`\n"
-        "or the v1 compatibility namespace if you are working in a code base "
-        "that has not been fully upgraded to pydantic 2 yet. "
-        "\tfrom pydantic.v1 import BaseModel\n"
-    ),
-)
+    )
+
+
+_raise_import_error()

--- a/libs/langchain/tests/unit_tests/test_imports.py
+++ b/libs/langchain/tests/unit_tests/test_imports.py
@@ -24,6 +24,11 @@ def test_import_all() -> None:
                 # Without init
                 module_name = module_name.rsplit(".", 1)[0]
 
+            # pydantic_v1 name space is deprecated and will intentionally raise an
+            # ImportError
+            if module_name.startswith("langchain.pydantic_v1"):
+                continue
+
             mod = importlib.import_module(module_name)
 
             all = getattr(mod, "__all__", [])
@@ -59,6 +64,11 @@ def test_import_all_using_dir() -> None:
             module_name = module_name.rsplit(".", 1)[0]
 
         if module_name.startswith("langchain_community.") and COMMUNITY_NOT_INSTALLED:
+            continue
+
+        # pydantic_v1 name space is deprecated and will intentionally raise an
+        # ImportError
+        if module_name.startswith("langchain.pydantic_v1"):
             continue
 
         try:


### PR DESCRIPTION
Raise error from the langchain_core.pydantic_v1 and langchain.pydantic_v1 namespaces