### PR TITLE
docs: Fix Firecrawl v0 version

### DIFF
--- a/docs/docs/integrations/document_loaders/firecrawl.ipynb
+++ b/docs/docs/integrations/document_loaders/firecrawl.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -qU firecrawl-py langchain_community"
+    "%pip install -qU firecrawl-py==0.0.20 langchain_community"
    ]
   },
   {

--- a/docs/docs/integrations/providers/firecrawl.mdx
+++ b/docs/docs/integrations/providers/firecrawl.mdx
@@ -10,7 +10,7 @@
 Install the python SDK:
 
 ```bash
-pip install firecrawl-py
+pip install firecrawl-py==0.0.20
 ```
 
 ## Document loader


### PR DESCRIPTION
Firecrawl integration is currently on v0 - which is supported until version 0.0.20.

@rafaelsideguide is working on a pr for v1 but meanwhile we should fix the docs.