### PR TITLE
community: [docai] Fix docai online_process IndividualPageSelector import

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/docai.py
+++ b/libs/community/langchain_community/document_loaders/parsers/docai.py
@@ -137,7 +137,6 @@ class DocAIParser(BaseBlobParser):
         try:
             from google.cloud import documentai
             from google.cloud.documentai_v1.types import (
-                IndividualPageSelector,
                 OcrConfig,
                 ProcessOptions,
             )
@@ -159,7 +158,7 @@ class DocAIParser(BaseBlobParser):
             else None
         )
         individual_page_selector = (
-            IndividualPageSelector(pages=page_range) if page_range else None
+            ProcessOptions.IndividualPageSelector(pages=page_range) if page_range else None
         )
 
         response = self._client.process_document(


### PR DESCRIPTION
Fixes the import of IndividualPageSelector which is a subclass of ProcessOptions, visible from https://github.com/googleapis/google-cloud-python/blob/5e3f4aebeb2f79efb1992ae623eb1aea86de2b0c/packages/google-cloud-documentai/google/cloud/documentai_v1/types/document_processor_service.py#L167
