### PR TITLE
partners/milvus: multi-vector support

### DIFF
--- a/libs/partners/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
+++ b/libs/partners/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
@@ -146,6 +146,16 @@ class MilvusCollectionHybridSearchRetriever(BaseRetriever):
             documents.append(doc)
         return documents
 
+    def hybrid_search(
+        self,
+        query: str,
+    ) -> List[SearchResult]:
+        requests = self._build_ann_search_requests(query)
+        search_result = self.collection.hybrid_search(
+            requests, self.rerank, limit=self.top_k, output_fields=self.output_fields
+        )
+        return search_result
+
     def _get_relevant_documents(
         self,
         query: str,
@@ -153,9 +163,6 @@ class MilvusCollectionHybridSearchRetriever(BaseRetriever):
         run_manager: CallbackManagerForRetrieverRun,
         **kwargs: Any,
     ) -> List[Document]:
-        requests = self._build_ann_search_requests(query)
-        search_result = self.collection.hybrid_search(
-            requests, self.rerank, limit=self.top_k, output_fields=self.output_fields
-        )
+        search_result = self.hybrid_search(query)
         documents = self._process_search_result(search_result)
         return documents

--- a/libs/partners/milvus/langchain_milvus/vectorstores/zilliz.py
+++ b/libs/partners/milvus/langchain_milvus/vectorstores/zilliz.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Union
 
-from langchain_core.embeddings import Embeddings
-
-from langchain_milvus.utils.sparse import BaseSparseEmbedding
-from langchain_milvus.vectorstores.milvus import Milvus
+from langchain_milvus.vectorstores.milvus import EmbeddingType, Milvus
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +98,7 @@ class Zilliz(Milvus):
             try:
                 # If no index params, use a default AutoIndex based one
                 if self.index_params is None:
-                    self.index_params = {
+                    self.index_params: Dict[str, Any] = {
                         "metric_type": "L2",
                         "index_type": "AUTOINDEX",
                         "params": {},
@@ -142,13 +139,13 @@ class Zilliz(Milvus):
     def from_texts(
         cls,
         texts: List[str],
-        embedding: Union[Embeddings, BaseSparseEmbedding],
+        embedding: Union[EmbeddingType, List[EmbeddingType]],  # type: ignore
         metadatas: Optional[List[dict]] = None,
         collection_name: str = "LangChainCollection",
         connection_args: Optional[Dict[str, Any]] = None,
         consistency_level: str = "Session",
-        index_params: Optional[dict] = None,
-        search_params: Optional[dict] = None,
+        index_params: Optional[Union[dict, List[dict]]] = None,
+        search_params: Optional[Union[dict, List[dict]]] = None,
         drop_old: bool = False,
         *,
         ids: Optional[List[str]] = None,

--- a/libs/partners/milvus/tests/integration_tests/utils.py
+++ b/libs/partners/milvus/tests/integration_tests/utils.py
@@ -28,6 +28,20 @@ class FakeEmbeddings(Embeddings):
         return self.embed_query(text)
 
 
+class FixedValuesEmbeddings(Embeddings):
+    """Fake embeddings class with fixed values for document and query embeddings"""
+
+    def __init__(self, *, documents_base_val: float = 1.0, query_val: float = 1.0):
+        self.documents_val = documents_base_val
+        self.query_val = query_val
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [[self.documents_val + i] * 10 for i in range(len(texts))]
+
+    def embed_query(self, text: str) -> List[float]:
+        return [float(self.query_val)] * 10
+
+
 def assert_docs_equal_without_pk(
     docs1: List[Document], docs2: List[Document], pk_field: str = "pk"
 ) -> None:


### PR DESCRIPTION
## Description

This PR introduces  multi-vector support in a fully backward-compatible way!

Milvus 2.4 introduced the option for [multi-vector support](https://milvus.io/blog/milvus-2-4-nvidia-cagra-gpu-index-multivector-search-sparse-vector-support.md), which is becoming increasingly popular, especially for use cases like hybrid search (dense + sparse embeddings).

Lately, @ohadeytan  introduced the option to use sparse embeddings in [this PR](https://github.com/langchain-ai/langchain/pull/25284).

Additionally, @zc277584121 already introduced the `MilvusCollectionHybridSearchRetriever`, which enables hybrid search against pre-defined collections directly via pymilvus.

However, this method doesn't take full advantage of the many useful features offered by `langchain_milvus` when building a collection: automatic schema creation, indexing and search parameter creation etc.

This PR intend to make developers life easier, by allowing them to use single-vector or multi-vector with a single `langchain` interface, that create, connect, and search `Milvus`. For example, at IBM and IBM Research this feature is requested by many of our developers and researchers and will be very useful for us.

## Changes

This PR addresses the limitations described above by introducing the following changes:

1. Allows passing multiple embedding functions with optional matching indexing parameters, search parameters, and vector field names.
2. Dynamically creates the collection using these functions, similar to how it's done for a single embedding function.
3. Adds multiple tests to validate this new feature.

If more tests or changes are required, we will be happy to add those as needed!
Twitter handle: @EliyahuOmri, @ohadeytan