### PR TITLE
core[minor]: change how tool error handling works

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -663,7 +663,7 @@ class ChildTool(BaseTool):
             except ToolException as e:
                 raise e
             except Exception as e:
-                raise ToolException(str(e)) from e
+                raise ToolException(repr(e)) from e
             except KeyboardInterrupt as e:
                 error_to_raise = e
                 status = "error"
@@ -786,7 +786,7 @@ class ChildTool(BaseTool):
             except ToolException as e:
                 raise e
             except Exception as e:
-                raise ToolException(str(e)) from e
+                raise ToolException(repr(e)) from e
         except ToolException as e:
             if not self.handle_tool_error:
                 error_to_raise = e

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -90,26 +90,6 @@ def _get_annotation_description(arg_type: Type) -> str | None:
                 return annotation
     return None
 
-
-def _get_filtered_args(
-    inferred_model: Type[BaseModel],
-    func: Callable,
-    *,
-    filter_args: Sequence[str],
-    include_injected: bool = True,
-) -> dict:
-    """Get the arguments from a function's signature."""
-    schema = inferred_model.model_json_schema()["properties"]
-    valid_keys = signature(func).parameters
-    return {
-        k: schema[k]
-        for i, (k, param) in enumerate(valid_keys.items())
-        if k not in filter_args
-        and (i > 0 or param.name not in ("self", "cls"))
-        and (include_injected or not _is_injected_arg_type(param.annotation))
-    }
-
-
 def _parse_python_function_docstring(
     function: Callable, annotations: dict, error_on_invalid_docstring: bool = False
 ) -> Tuple[str, dict]:

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -649,42 +649,49 @@ class ChildTool(BaseTool):
         artifact = None
         error_to_raise: Union[Exception, KeyboardInterrupt, None] = None
         try:
-            child_config = patch_config(config, callbacks=run_manager.get_child())
-            context = copy_context()
-            context.run(_set_config_context, child_config)
-            tool_args, tool_kwargs = self._to_args_and_kwargs(tool_input)
-            if signature(self._run).parameters.get("run_manager"):
-                tool_kwargs["run_manager"] = run_manager
+            try:
+                child_config = patch_config(config, callbacks=run_manager.get_child())
+                context = copy_context()
+                context.run(_set_config_context, child_config)
+                tool_args, tool_kwargs = self._to_args_and_kwargs(tool_input)
+                if signature(self._run).parameters.get("run_manager"):
+                    tool_kwargs["run_manager"] = run_manager
 
-            if config_param := _get_runnable_config_param(self._run):
-                tool_kwargs[config_param] = config
-            response = context.run(self._run, *tool_args, **tool_kwargs)
-            if self.response_format == "content_and_artifact":
-                if not isinstance(response, tuple) or len(response) != 2:
-                    raise ValueError(
-                        "Since response_format='content_and_artifact' "
-                        "a two-tuple of the message content and raw tool output is "
-                        f"expected. Instead generated response of type: "
-                        f"{type(response)}."
+                if config_param := _get_runnable_config_param(self._run):
+                    tool_kwargs[config_param] = config
+                response = context.run(self._run, *tool_args, **tool_kwargs)
+                if self.response_format == "content_and_artifact":
+                    if not isinstance(response, tuple) or len(response) != 2:
+                        raise ValueError(
+                            "Since response_format='content_and_artifact' "
+                            "a two-tuple of the message content and raw tool output is "
+                            f"expected. Instead generated response of type: "
+                            f"{type(response)}."
+                        )
+                    content, artifact = response
+                else:
+                    content = response
+                status = "success"
+            except ValidationError as e:
+                if not self.handle_validation_error:
+                    error_to_raise = e
+                else:
+                    content = _handle_validation_error(
+                        e, flag=self.handle_validation_error
                     )
-                content, artifact = response
-            else:
-                content = response
-            status = "success"
-        except ValidationError as e:
-            if not self.handle_validation_error:
+                status = "error"
+            except ToolException as e:
+                raise e
+            except Exception as e:
+                raise ToolException(str(e)) from e
+            except KeyboardInterrupt as e:
                 error_to_raise = e
-            else:
-                content = _handle_validation_error(e, flag=self.handle_validation_error)
-            status = "error"
+                status = "error"
         except ToolException as e:
             if not self.handle_tool_error:
                 error_to_raise = e
             else:
                 content = _handle_tool_error(e, flag=self.handle_tool_error)
-            status = "error"
-        except (Exception, KeyboardInterrupt) as e:
-            error_to_raise = e
             status = "error"
 
         if error_to_raise:
@@ -758,49 +765,53 @@ class ChildTool(BaseTool):
         artifact = None
         error_to_raise: Optional[Union[Exception, KeyboardInterrupt]] = None
         try:
-            tool_args, tool_kwargs = self._to_args_and_kwargs(tool_input)
-            child_config = patch_config(config, callbacks=run_manager.get_child())
-            context = copy_context()
-            context.run(_set_config_context, child_config)
-            func_to_check = (
-                self._run if self.__class__._arun is BaseTool._arun else self._arun
-            )
-            if signature(func_to_check).parameters.get("run_manager"):
-                tool_kwargs["run_manager"] = run_manager
-            if config_param := _get_runnable_config_param(func_to_check):
-                tool_kwargs[config_param] = config
+            try:
+                tool_args, tool_kwargs = self._to_args_and_kwargs(tool_input)
+                child_config = patch_config(config, callbacks=run_manager.get_child())
+                context = copy_context()
+                context.run(_set_config_context, child_config)
+                func_to_check = (
+                    self._run if self.__class__._arun is BaseTool._arun else self._arun
+                )
+                if signature(func_to_check).parameters.get("run_manager"):
+                    tool_kwargs["run_manager"] = run_manager
+                if config_param := _get_runnable_config_param(func_to_check):
+                    tool_kwargs[config_param] = config
 
-            coro = context.run(self._arun, *tool_args, **tool_kwargs)
-            if asyncio_accepts_context():
-                response = await asyncio.create_task(coro, context=context)  # type: ignore
-            else:
-                response = await coro
-            if self.response_format == "content_and_artifact":
-                if not isinstance(response, tuple) or len(response) != 2:
-                    raise ValueError(
-                        "Since response_format='content_and_artifact' "
-                        "a two-tuple of the message content and raw tool output is "
-                        f"expected. Instead generated response of type: "
-                        f"{type(response)}."
+                coro = context.run(self._arun, *tool_args, **tool_kwargs)
+                if asyncio_accepts_context():
+                    response = await asyncio.create_task(coro, context=context)  # type: ignore
+                else:
+                    response = await coro
+                if self.response_format == "content_and_artifact":
+                    if not isinstance(response, tuple) or len(response) != 2:
+                        raise ValueError(
+                            "Since response_format='content_and_artifact' "
+                            "a two-tuple of the message content and raw tool output is "
+                            f"expected. Instead generated response of type: "
+                            f"{type(response)}."
+                        )
+                    content, artifact = response
+                else:
+                    content = response
+                status = "success"
+            except ValidationError as e:
+                if not self.handle_validation_error:
+                    error_to_raise = e
+                else:
+                    content = _handle_validation_error(
+                        e, flag=self.handle_validation_error
                     )
-                content, artifact = response
-            else:
-                content = response
-            status = "success"
-        except ValidationError as e:
-            if not self.handle_validation_error:
-                error_to_raise = e
-            else:
-                content = _handle_validation_error(e, flag=self.handle_validation_error)
-            status = "error"
+                status = "error"
+            except ToolException as e:
+                raise e
+            except Exception as e:
+                raise ToolException(str(e)) from e
         except ToolException as e:
             if not self.handle_tool_error:
                 error_to_raise = e
             else:
                 content = _handle_tool_error(e, flag=self.handle_tool_error)
-            status = "error"
-        except (Exception, KeyboardInterrupt) as e:
-            error_to_raise = e
             status = "error"
 
         if error_to_raise:


### PR DESCRIPTION
- error handling can now be passed through decorator
- all errors thrown will be ValidationErrors (tool call was formatted incorrectly) or ToolExceptions (any error that occurs while running the tool)