### PR TITLE
docs: fixed typo in XML document loader

### DIFF
--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -886,7 +886,7 @@ const FEATURE_TABLES = {
                 apiLink: "https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.html_bs.BSHTMLLoader.html"
             },
             {
-                name: "UnstrucutredXMLLoader",
+                name: "UnstructuredXMLLoader",
                 link: "xml",
                 source: "XML files",
                 apiLink: "https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.xml.UnstructuredXMLLoader.html"


### PR DESCRIPTION
Fixed typo `Unstrucutred`