### PR TITLE
core: Deprecate BaseMemory

### DIFF
--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -19,7 +19,12 @@ from langchain_core._api import deprecated
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import run_in_executor
 
-@deprecated("0.3.0", alternative="langchain_core.chat_history.BaseChatMessageHistory", removal="1.0")
+
+@deprecated(
+    "0.3.0",
+    alternative="langchain_core.chat_history.BaseChatMessageHistory",
+    removal="1.0",
+)
 class BaseMemory(Serializable, ABC):
     """Abstract base class for memory in Chains.
 

--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -15,10 +15,11 @@ from typing import Any
 
 from pydantic import ConfigDict
 
+from langchain_core._api import deprecated
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import run_in_executor
 
-
+@deprecated("0.3.0", alternative="langchain_core.chat_history.BaseChatMessageHistory", removal="1.0")
 class BaseMemory(Serializable, ABC):
     """Abstract base class for memory in Chains.
 


### PR DESCRIPTION
**Description**
Deprecate BaseMemory, because:
* LangChain developers don't recommend using it
* No other parts of the core code use it
* There is no documentation on how to use it (apart from a vague description on the docstring)
* It doesn't seem to integrate well with LCEL
* There are no tests covering it

I wonder if I can deprecate the whole `langchain.memory` package as well. If not, we can move this to `langchain.memory` and deprecate it in core.

**Issues**
* https://github.com/langchain-ai/langchain/discussions/25904#discussion-7114933
* https://www.reddit.com/r/LangChain/comments/1fju4sp/chat_history_vs_memory_whats_the_difference/