### PR TITLE
core: use ruff.target-version instead

### DIFF
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -40,6 +40,9 @@ python = ">=3.12.4"
 
 [tool.poetry.extras]
 
+[tool.ruff]
+target-version = "py39"
+
 [tool.ruff.lint]
 select = ["B", "E", "F", "I", "T201", "UP"]
 ignore = ["UP007"]


### PR DESCRIPTION
tested on one of the replacement cases and seems to work! 
![ScreenShot 2024-09-18 at 02 02 43PM](https://github.com/user-attachments/assets/7170975a-2542-43ed-a203-d4126c6a2c81)
