### PR TITLE
core: Simplify pydantic version constraints

### DIFF
--- a/libs/core/poetry.lock
+++ b/libs/core/poetry.lock
@@ -3053,4 +3053,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "7d516cb9978fab31edd2a9568c7e24556cd7a63c7a0b627fa513f08c99a6001c"
+content-hash = "b64871f84ca286a52214d52134d1e3401a35ae4f0595b8acc7f6696e69b17001"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -30,13 +30,7 @@ jsonpatch = "^1.33"
 PyYAML = ">=5.3"
 packaging = ">=23.2,<25"
 typing-extensions = ">=4.7"
-[[tool.poetry.dependencies.pydantic]]
-version = "^2.5.2"
-python = "<3.12.4"
-
-[[tool.poetry.dependencies.pydantic]]
-version = "^2.7.4"
-python = ">=3.12.4"
+pydantic = "^2.7.4"
 
 [tool.poetry.extras]
 


### PR DESCRIPTION
Or is there an interest in keeping these constraints ?