### PR TITLE
fix:fix ChatZhipuAI tool call bug

### DIFF
--- a/libs/community/langchain_community/chat_models/zhipuai.py
+++ b/libs/community/langchain_community/chat_models/zhipuai.py
@@ -204,7 +204,7 @@ def _convert_delta_to_message_chunk(
     role = dct.get("role")
     content = dct.get("content", "")
     additional_kwargs = {}
-    tool_calls = dct.get("tool_call", None)
+    tool_calls = dct.get("tool_calls", None)
     if tool_calls is not None:
         additional_kwargs["tool_calls"] = tool_calls
 


### PR DESCRIPTION
- [ ] **PR title**: "community:fix ChatZhipuAI tool call bug"

- [ ] **Description:** ZhipuAI api response as follows:
{'id': '20240920132549e379a9152a6a4d7c', 'created': 1726809949, 'model': 'glm-4-flash', 'choices': [{'index': 0, 'finish_reason': 'tool_calls', 'delta': {'role': 'assistant', 'tool_calls': [{'id': 'call_20240920132549e379a9152a6a4d7c', 'index': 0, 'type': 'function', 'function': {'name': 'get_datetime_offline', 'arguments': '{}'}}]}}]}
so, tool_calls = dct.get("tool_call", None) in _convert_delta_to_message_chunk should be "tool_calls"

