### PR TITLE
Add Support for Additional Clova Embedding Models

### DIFF
--- a/docs/docs/integrations/text_embedding/clova.ipynb
+++ b/docs/docs/integrations/text_embedding/clova.ipynb
@@ -1,86 +1,210 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Clova Embeddings\n",
-    "[Clova](https://api.ncloud-docs.com/docs/ai-naver-clovastudio-summary) offers an embeddings service\n",
-    "\n",
-    "This example goes over how to use LangChain to interact with Clova inference for text embedding.\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-Bew9J94GaF9"
+      },
+      "source": [
+        "# Clova Embeddings\n",
+        "\n",
+        "Clova offers two versions of embedding services: V1 and V2.  \n",
+        "For more details, please check the [official documentation](https://guide.ncloud-docs.com/docs/clovastudio-explorer03) and [API guide](https://api.ncloud-docs.com/docs/clovastudio-embedding).\n",
+        "\n",
+        "\n",
+        "<div style=\"margin-bottom: 30px;\"> <!-- 위쪽 공백 -->\n",
+        "    <p style=\"font-size: 16px; line-height: 1.6; margin-bottom: 20px;\">\n",
+        "        This table illustrates the details of the Clova embedding models and their specifications.\n",
+        "        The embedding services are categorized based on their versions and capabilities.\n",
+        "    </p>\n",
+        "</div>\n",
+        "\n",
+        "<table style=\"width:100%; border-collapse: collapse; font-size: 18px; margin-bottom: 30px;\">\n",
+        "  <tr style=\"background-color: #f2f2f2;\">\n",
+        "    <th style=\"border: 1px solid black; padding: 15px; text-align: center;\">Tool Name</th>\n",
+        "    <th style=\"border: 1px solid black; padding: 15px; text-align: center;\">Model Name</th>\n",
+        "    <th style=\"border: 1px solid black; padding: 15px; text-align: center;\">Max Token Count</th>\n",
+        "    <th style=\"border: 1px solid black; padding: 15px; text-align: center;\">Vector Dimension</th>\n",
+        "    <th style=\"border: 1px solid black; padding: 15px; text-align: center;\">Recommended Distance Metric</th>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">EmbeddingV1</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">clir-emb-dolphin</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">500 tokens</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">1024</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">IP (Inner Product/Dot Product/Scalar Product)</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">EmbeddingV1</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">clir-sts-dolphin</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">500 tokens</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">1024</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">Cosine Similarity</td>\n",
+        "  </tr>\n",
+        "  <tr>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">EmbeddingV2</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">bge-m3</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">8,192 tokens</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">1024</td>\n",
+        "    <td style=\"border: 1px solid black; padding: 15px; text-align: center;\">Cosine Similarity</td>\n",
+        "  </tr>\n",
+        "</table>\n",
+        "\n",
+        "<div style=\"margin-top: 30px;\"> <!-- 아래쪽 공백 -->\n",
+        "    <p style=\"font-size: 16px; line-height: 1.6; margin-top: 20px;\">\n",
+        "        This notebook demonstrates how to interact with Clova's inference for text embeddings using LangChain.\n",
+        "    </p>\n",
+        "</div>\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "y22R9n0kGWkO"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "os.environ[\"CLOVA_EMB_API_KEY\"] = \"\"\n",
+        "os.environ[\"CLOVA_EMB_APIGW_API_KEY\"] = \"\"\n",
+        "os.environ[\"CLOVA_EMB_APP_ID_V1\"] = \"\"\n",
+        "os.environ[\"CLOVA_EMB_APP_ID_V2\"] = \"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kMArQZyCKKmN"
+      },
+      "outputs": [],
+      "source": [
+        "from langchain_community.embeddings import ClovaEmbeddingsV1, ClovaEmbeddingsV2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "uWRA-V1RKLYw"
+      },
+      "outputs": [],
+      "source": [
+        "query_text = \"This is a test query.\"\n",
+        "document_texts = [\"This is a test doc1.\", \"This is a test doc2.\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PoOxjbd8Yuvd"
+      },
+      "source": [
+        "Define embedding test function"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "8eAcCbqGKTOU"
+      },
+      "outputs": [],
+      "source": [
+        "def test_embeddings(embeddings_instance, query_text, document_texts):\n",
+        "    query_result = embeddings_instance.embed_query(query_text)\n",
+        "    document_result = embeddings_instance.embed_documents(document_texts)\n",
+        "    return query_result, document_result"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ikdtDnVLYzIN"
+      },
+      "source": [
+        "Test ClovaEmbeddingsV1 with 'clir-emb-dolphin' model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "r2_P1-nSKlaH"
+      },
+      "outputs": [],
+      "source": [
+        "embeddings_v1_emb = ClovaEmbeddingsV1(model=\"clir-emb-dolphin\")\n",
+        "query_result_v1_emb, document_result_v1_emb = test_embeddings(embeddings_v1_emb, query_text, document_texts)\n",
+        "\n",
+        "print(\"V1 (clir-emb-dolphin) Query Embedding Result:\", query_result_v1_emb[:5])\n",
+        "print(\"V1 (clir-emb-dolphin) Document Embedding Results:\", [doc[:5] for doc in document_result_v1_emb])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zrAViS5tY1o4"
+      },
+      "source": [
+        "Test ClovaEmbeddingsV1 with 'clir-sts-dolphin' model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ut2Aq7gCKwAe"
+      },
+      "outputs": [],
+      "source": [
+        "embeddings_v1_sts = ClovaEmbeddingsV1(model=\"clir-sts-dolphin\")\n",
+        "query_result_v1_sts, document_result_v1_sts = test_embeddings(embeddings_v1_sts, query_text, document_texts)\n",
+        "\n",
+        "print(\"V1 (clir-sts-dolphin) Query Embedding Result:\", query_result_v1_sts[:5])\n",
+        "print(\"V1 (clir-sts-dolphin) Document Embedding Results:\", [doc[:5] for doc in document_result_v1_sts])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LT3FtNfqY3ve"
+      },
+      "source": [
+        "Test ClovaEmbeddingsV2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Or8LQrNnUjMX"
+      },
+      "outputs": [],
+      "source": [
+        "embeddings_v2 = ClovaEmbeddingsV2()\n",
+        "query_result_v2, document_result_v2 = test_embeddings(embeddings_v2, query_text, document_texts)\n",
+        "\n",
+        "print(\"V2 Query Embedding Result:\", query_result_v2[:5])\n",
+        "print(\"V2 Document Embedding Results:\", [doc[:5] for doc in document_result_v2])"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "os.environ[\"CLOVA_EMB_API_KEY\"] = \"\"\n",
-    "os.environ[\"CLOVA_EMB_APIGW_API_KEY\"] = \"\"\n",
-    "os.environ[\"CLOVA_EMB_APP_ID\"] = \"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain_community.embeddings import ClovaEmbeddings"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "embeddings = ClovaEmbeddings()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "query_text = \"This is a test query.\"\n",
-    "query_result = embeddings.embed_query(query_text)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "document_text = [\"This is a test doc1.\", \"This is a test doc2.\"]\n",
-    "document_result = embeddings.embed_documents(document_text)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.1"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/libs/community/langchain_community/embeddings/clova.py
+++ b/libs/community/langchain_community/embeddings/clova.py
@@ -1,66 +1,44 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, cast
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, cast
 
 import requests
-from langchain_core.embeddings import Embeddings
-from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 from pydantic import BaseModel, ConfigDict, SecretStr, model_validator
 
+from langchain_core.embeddings import Embeddings
+from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
 
-class ClovaEmbeddings(BaseModel, Embeddings):
+class BaseClovaEmbeddings(BaseModel, Embeddings, ABC):
     """
-    Clova's embedding service.
+    Base class for Clova's embedding services.
 
-    To use this service,
-
-    you should have the following environment variables
+    To use this service, you should have the following environment variables
     set with your API tokens and application ID,
     or pass them as named parameters to the constructor:
 
     - ``CLOVA_EMB_API_KEY``: API key for accessing Clova's embedding service.
     - ``CLOVA_EMB_APIGW_API_KEY``: API gateway key for enhanced security.
-    - ``CLOVA_EMB_APP_ID``: Application ID for identifying your application.
-
-    Example:
-        .. code-block:: python
-
-            from langchain_community.embeddings import ClovaEmbeddings
-            embeddings = ClovaEmbeddings(
-                clova_emb_api_key='your_clova_emb_api_key',
-                clova_emb_apigw_api_key='your_clova_emb_apigw_api_key',
-                app_id='your_app_id'
-            )
-
-            query_text = "This is a test query."
-            query_result = embeddings.embed_query(query_text)
-
-            document_text = "This is a test document."
-            document_result = embeddings.embed_documents([document_text])
-
+    - ``CLOVA_EMB_APP_ID_V1``: Application ID for V1 models.
+    - ``CLOVA_EMB_APP_ID_V2``: Application ID for V2 model. 
     """
 
-    endpoint_url: str = (
-        "https://clovastudio.apigw.ntruss.com/testapp/v1/api-tools/embedding"
-    )
+    endpoint_url: str
     """Endpoint URL to use."""
-    model: str = "clir-emb-dolphin"
-    """Embedding model name to use."""
-    clova_emb_api_key: Optional[SecretStr] = None
+    clova_emb_api_key: SecretStr
     """API key for accessing Clova's embedding service."""
-    clova_emb_apigw_api_key: Optional[SecretStr] = None
+    clova_emb_apigw_api_key: SecretStr
     """API gateway key for enhanced security."""
-    app_id: Optional[SecretStr] = None
+    app_id: SecretStr
     """Application ID for identifying your application."""
+    model: Optional[str] = None
+    """Embedding model name to use (optional)."""
 
-    model_config = ConfigDict(
-        extra="forbid",
-    )
+    model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="before")
-    @classmethod
-    def validate_environment(cls, values: Dict) -> Any:
-        """Validate api key exists in environment."""
+    def validate_environment(cls, values: Dict) -> Dict:
+        """Validate that API keys and app ID are set."""
         values["clova_emb_api_key"] = convert_to_secret_str(
             get_from_dict_or_env(values, "clova_emb_api_key", "CLOVA_EMB_API_KEY")
         )
@@ -70,24 +48,45 @@ class ClovaEmbeddings(BaseModel, Embeddings):
             )
         )
         values["app_id"] = convert_to_secret_str(
-            get_from_dict_or_env(values, "app_id", "CLOVA_EMB_APP_ID")
+            get_from_dict_or_env(values, "app_id", cls.get_app_id_env_var())
         )
+        if cls.requires_model():
+            values["model"] = get_from_dict_or_env(
+                values, "model", cls.get_model_env_var(), default="clir-emb-dolphin"
+            )
         return values
+
+    @classmethod
+    @abstractmethod
+    def requires_model(cls) -> bool:
+        """Indicates whether the model parameter is required."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_app_id_env_var(cls) -> str:
+        """Provides the environment variable name for the app ID."""
+        pass
+
+    @classmethod
+    def get_model_env_var(cls) -> str:
+        """Provides the environment variable name for the model."""
+        return "CLOVA_EMB_MODEL"
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """
         Embed a list of texts and return their embeddings.
 
         Args:
-            texts: The list of texts to embed.
+            texts: List of texts to embed.
 
         Returns:
-            List of embeddings, one for each text.
+            A list of embeddings, one for each text.
+
+        Raises:
+            ValueError: If embeddings cannot be retrieved.
         """
-        embeddings = []
-        for text in texts:
-            embeddings.append(self._embed_text(text))
-        return embeddings
+        return [self._embed_text(text) for text in texts]
 
     def embed_query(self, text: str) -> List[float]:
         """
@@ -97,40 +96,116 @@ class ClovaEmbeddings(BaseModel, Embeddings):
             text: The text to embed.
 
         Returns:
-            Embeddings for the text.
+            A list of floats representing the text embedding.
+
+        Raises:
+            ValueError: If embedding cannot be retrieved.
         """
         return self._embed_text(text)
 
     def _embed_text(self, text: str) -> List[float]:
         """
         Internal method to call the embedding API and handle the response.
+
+        Args:
+            text: The text to embed.
+
+        Returns:
+            A list of floats representing the embedding.
+
+        Raises:
+            ValueError: If the API request fails or the response is invalid.
         """
         payload = {"text": text}
-
-        # HTTP headers for authorization
         headers = {
-            "X-NCP-CLOVASTUDIO-API-KEY": cast(
-                SecretStr, self.clova_emb_api_key
-            ).get_secret_value(),
-            "X-NCP-APIGW-API-KEY": cast(
-                SecretStr, self.clova_emb_apigw_api_key
-            ).get_secret_value(),
+            "X-NCP-CLOVASTUDIO-API-KEY": self.clova_emb_api_key.get_secret_value(),
+            "X-NCP-APIGW-API-KEY": self.clova_emb_apigw_api_key.get_secret_value(),
             "Content-Type": "application/json",
         }
 
-        # send request
-        app_id = cast(SecretStr, self.app_id).get_secret_value()
-        response = requests.post(
-            f"{self.endpoint_url}/{self.model}/{app_id}",
-            headers=headers,
-            json=payload,
-        )
+        response_data = self._send_request(headers, payload)
+        try:
+            return response_data["result"]["embedding"]
+        except KeyError:
+            raise ValueError(
+                "Invalid response format: 'embedding' not found in response."
+            )
 
-        # check for errors
-        if response.status_code == 200:
-            response_data = response.json()
-            if "result" in response_data and "embedding" in response_data["result"]:
-                return response_data["result"]["embedding"]
-        raise ValueError(
-            f"API request failed with status {response.status_code}: {response.text}"
-        )
+    @abstractmethod
+    def _send_request(self, headers: Dict[str, str], payload: Dict[str, str]) -> Dict:
+        """
+        Send the request to the embedding API.
+
+        Args:
+            headers: HTTP headers for authentication.
+            payload: JSON payload for the request.
+
+        Returns:
+            The API response as a dictionary.
+
+        Raises:
+            ConnectionError: If the API request fails.
+        """
+        pass
+
+class ClovaEmbeddingsV1(BaseClovaEmbeddings):
+    """
+    Clova's embedding service V1.
+    """
+
+    endpoint_url: str = (
+        "https://clovastudio.apigw.ntruss.com/testapp/v1/api-tools/embedding"
+    )
+    """Endpoint URL to use."""
+
+    @classmethod
+    def get_app_id_env_var(cls) -> str:
+        """Provides the environment variable name for the app ID."""
+        return "CLOVA_EMB_APP_ID_V1"
+
+    @classmethod
+    def requires_model(cls) -> bool:
+        """Indicates whether the model parameter is required."""
+        return True
+
+    def _send_request(self, headers: Dict[str, str], payload: Dict[str, str]) -> Dict:
+        request_url = f"{self.endpoint_url}/{self.model}/{self.app_id.get_secret_value()}"
+        try:
+            response = requests.post(
+                request_url, headers=headers, json=payload, timeout=10
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise ConnectionError(f"Error connecting to Clova API: {e}") from e
+
+class ClovaEmbeddingsV2(BaseClovaEmbeddings):
+    """
+    Clova's embedding service V2.
+    """
+
+    endpoint_url: str = (
+        "https://clovastudio.apigw.ntruss.com/testapp/v1/api-tools/embedding/v2"
+    )
+    """Endpoint URL to use."""
+
+    @classmethod
+    def get_app_id_env_var(cls) -> str:
+        """Provides the environment variable name for the app ID."""
+        return "CLOVA_EMB_APP_ID_V2"
+
+    @classmethod
+    def requires_model(cls) -> bool:
+        """Indicates whether the model parameter is required."""
+        return False
+
+    def _send_request(self, headers: Dict[str, str], payload: Dict[str, str]) -> Dict:
+        request_url = f"{self.endpoint_url}/{self.app_id.get_secret_value()}"
+        try:
+            response = requests.post(
+                request_url, headers=headers, json=payload, timeout=10
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise ConnectionError(f"Error connecting to Clova API: {e}") from e


### PR DESCRIPTION
- [ ] **PR title**: "Add Support for Additional Clova Embedding Models"
  - Previously, the Clova embeddings supported only the V1 clir-emb-dolphin model.
  - Changes Made:
     - Added support for both clir-emb-dolphin and clir-sts-dolphin models in V1.
     - Added support for the new V2 model.
  - Improvements:Updated code for compatibility with Pydantic v2.
  
- [ ] **Details**: 
    - Existing Clova Embeddings Support
       - Only supported the V1 clir-emb-dolphin model.
    - Modifications
       - V1 Model Enhancements:
         - Now supports both clir-emb-dolphin and clir-sts-dolphin models.
       - V2 Model Support:
          - Implemented support for the new V2 embedding model.
     - Pydantic v2 Compatibility
        - Import Updates:
           - Changed imports from deprecated langchain_core.pydantic_v1 to use Pydantic v2 directly.
              ```
              from pydantic import BaseModel, Extra, SecretStr, model_validator, ConfigDict
              ```
         - Validator Changes:
            - Replaced @root_validator(pre=True, allow_reuse=True) with @model_validator(mode='before') as per Pydantic v2 requirements.
         - Config Adjustments:
            - Updated configuration settings to use ConfigDict(extra="forbid") instead of the old Config class.

- [ ] **Additional guidelines**: 
   - [official documentation](https://guide.ncloud-docs.com/docs/clovastudio-explorer03) 
   - [API guide](https://api.ncloud-docs.com/docs/clovastudio-embedding)

