### PR TITLE
Add save and load functionality for BM25 sparse embedding model

### DIFF
--- a/libs/partners/milvus/langchain_milvus/utils/sparse.py
+++ b/libs/partners/milvus/langchain_milvus/utils/sparse.py
@@ -53,3 +53,9 @@ class BM25SparseEmbedding(BaseSparseEmbedding):
         for col_index, value in zip(col_indices, non_zero_values):
             result_dict[col_index] = value
         return result_dict
+
+    def load(self, path: str):
+        self.bm25_ef.load(path)
+
+    def save(self, path: str):
+        self.bm25_ef.save(path)


### PR DESCRIPTION
- [ ] **PR title**: "community: add save and load functionality for BM25 sparse embedding model"

- [ ] **PR message**:
    - **Description:** This pull request adds `save` and `load` methods to the `BM25SparseEmbedding` class. These methods provide the ability to save and load the trained BM25 model from a specified file path, enhancing model persistence capabilities.
    - **Issue:** N/A
    - **Dependencies:** No new dependencies introduced. The change leverages existing functionality from the `pymilvus.model` package.

- [ ] **Add tests and docs**:
  - No existing test file for this functionality, so unit tests have not been added in this PR.
  - Documentation updates for this feature are not included due to the absence of pre-existing documentation for the `BM25SparseEmbedding` class.