### PR TITLE
core[patch],langchain[patch]: deprecate memory and entity abstractions and implementations

### DIFF
--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -1,11 +1,8 @@
 """**Memory** maintains Chain state, incorporating context from past runs.
 
-**Class hierarchy for Memory:**
+This module contains memory abstractions from LangChain v0.0.x.
 
-.. code-block::
-
-    BaseMemory --> <name>Memory --> <name>Memory  # Examples: BaseChatMemory -> MotorheadMemory
-
+These abstractions are now deprecated and will be removed in LangChain v1.0.0.
 """  # noqa: E501
 
 from __future__ import annotations
@@ -15,10 +12,19 @@ from typing import Any
 
 from pydantic import ConfigDict
 
+from langchain_core._api import deprecated
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import run_in_executor
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class BaseMemory(Serializable, ABC):
     """Abstract base class for memory in Chains.
 

--- a/libs/langchain/langchain/memory/buffer.py
+++ b/libs/langchain/langchain/memory/buffer.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.utils import pre_init
 
@@ -7,8 +8,23 @@ from langchain.memory.chat_memory import BaseChatMemory, BaseMemory
 from langchain.memory.utils import get_prompt_input_key
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationBufferMemory(BaseChatMemory):
-    """Buffer for storing conversation memory."""
+    """A basic memory implementation that simply stores the conversation history.
+
+    This stores the entire conversation history in memory without any
+    additional processing.
+
+    Note that additional processing may be required in some situations when the
+    conversation history is too large to fit in the context window of the model.
+    """
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"
@@ -71,8 +87,26 @@ class ConversationBufferMemory(BaseChatMemory):
         return {self.memory_key: buffer}
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationStringBufferMemory(BaseMemory):
-    """Buffer for storing conversation memory."""
+    """A basic memory implementation that simply stores the conversation history.
+
+    This stores the entire conversation history in memory without any
+    additional processing.
+
+    Equivalent to ConversationBufferMemory but tailored more specifically
+    for string-based conversations rather than chat models.
+
+    Note that additional processing may be required in some situations when the
+    conversation history is too large to fit in the context window of the model.
+    """
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"

--- a/libs/langchain/langchain/memory/buffer_window.py
+++ b/libs/langchain/langchain/memory/buffer_window.py
@@ -1,12 +1,25 @@
 from typing import Any, Dict, List, Union
 
+from langchain_core._api import deprecated
 from langchain_core.messages import BaseMessage, get_buffer_string
 
 from langchain.memory.chat_memory import BaseChatMemory
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationBufferWindowMemory(BaseChatMemory):
-    """Buffer for storing conversation memory inside a limited size window."""
+    """Use to keep track of the last k turns of a conversation.
+
+    If the number of messages in the conversation is more than the maximum number
+    of messages to keep, the oldest messages are dropped.
+    """
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"

--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -2,6 +2,7 @@ import warnings
 from abc import ABC
 from typing import Any, Dict, Optional, Tuple
 
+from langchain_core._api import deprecated
 from langchain_core.chat_history import (
     BaseChatMessageHistory,
     InMemoryChatMessageHistory,
@@ -13,8 +14,24 @@ from pydantic import Field
 from langchain.memory.utils import get_prompt_input_key
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class BaseChatMemory(BaseMemory, ABC):
-    """Abstract base class for chat memory."""
+    """Abstract base class for chat memory.
+
+    **ATTENTION** This abstraction was created prior to when chat models had
+        native tool calling capabilities.
+        It does **NOT** support native tool calling capabilities for chat models and
+        will fail SILENTLY if used with a chat model that has native tool calling.
+
+    DO NOT USE THIS ABSTRACTION FOR NEW CODE.
+    """
 
     chat_memory: BaseChatMessageHistory = Field(
         default_factory=InMemoryChatMessageHistory

--- a/libs/langchain/langchain/memory/entity.py
+++ b/libs/langchain/langchain/memory/entity.py
@@ -1,8 +1,11 @@
+"""Deprecated as of LangChain v0.3.4 and will be removed in LangChain v1.0.0."""
+
 import logging
 from abc import ABC, abstractmethod
 from itertools import islice
 from typing import Any, Dict, Iterable, List, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.prompts import BasePromptTemplate
@@ -19,6 +22,14 @@ from langchain.memory.utils import get_prompt_input_key
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class BaseEntityStore(BaseModel, ABC):
     """Abstract base class for Entity store."""
 
@@ -48,6 +59,14 @@ class BaseEntityStore(BaseModel, ABC):
         pass
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class InMemoryEntityStore(BaseEntityStore):
     """In-memory Entity store."""
 
@@ -69,6 +88,14 @@ class InMemoryEntityStore(BaseEntityStore):
         return self.store.clear()
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class UpstashRedisEntityStore(BaseEntityStore):
     """Upstash Redis backed Entity store.
 
@@ -147,6 +174,14 @@ class UpstashRedisEntityStore(BaseEntityStore):
             scan_and_delete(cursor)
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class RedisEntityStore(BaseEntityStore):
     """Redis-backed Entity store.
 
@@ -238,6 +273,14 @@ class RedisEntityStore(BaseEntityStore):
             self.redis_client.delete(*keybatch)
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class SQLiteEntityStore(BaseEntityStore):
     """SQLite-backed Entity store"""
 
@@ -335,6 +378,14 @@ class SQLiteEntityStore(BaseEntityStore):
             self.conn.execute(query)
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationEntityMemory(BaseChatMemory):
     """Entity extractor & summarizer memory.
 

--- a/libs/langchain/langchain/memory/summary.py
+++ b/libs/langchain/langchain/memory/summary.py
@@ -57,8 +57,21 @@ class SummarizerMixin(BaseModel):
         return await chain.apredict(summary=existing_summary, new_lines=new_lines)
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
-    """Conversation summarizer to chat memory."""
+    """Continually summarizes the conversation history.
+
+    The summary is updated after each conversation turn.
+    The implementations returns a summary of the conversation history which
+    can be used to provide context to the model.
+    """
 
     buffer: str = ""
     memory_key: str = "history"  #: :meta private:

--- a/libs/langchain/langchain/memory/summary_buffer.py
+++ b/libs/langchain/langchain/memory/summary_buffer.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Union
 
+from langchain_core._api import deprecated
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.utils import pre_init
 
@@ -7,8 +8,21 @@ from langchain.memory.chat_memory import BaseChatMemory
 from langchain.memory.summary import SummarizerMixin
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationSummaryBufferMemory(BaseChatMemory, SummarizerMixin):
-    """Buffer with summarizer for storing conversation memory."""
+    """Buffer with summarizer for storing conversation memory.
+
+    Provides a running summary of the conversation together with the most recent
+    messages in the conversation under the constraint that the total number of
+    tokens in the conversation does not exceed a certain limit.
+    """
 
     max_token_limit: int = 2000
     moving_summary_buffer: str = ""

--- a/libs/langchain/langchain/memory/token_buffer.py
+++ b/libs/langchain/langchain/memory/token_buffer.py
@@ -1,13 +1,26 @@
 from typing import Any, Dict, List
 
+from langchain_core._api import deprecated
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.messages import BaseMessage, get_buffer_string
 
 from langchain.memory.chat_memory import BaseChatMemory
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class ConversationTokenBufferMemory(BaseChatMemory):
-    """Conversation chat memory with token limit."""
+    """Conversation chat memory with token limit.
+
+    Keeps only the most recent messages in the conversation under the constraint
+    that the total number of tokens in the conversation does not exceed a certain limit.
+    """
 
     human_prefix: str = "Human"
     ai_prefix: str = "AI"

--- a/libs/langchain/langchain/memory/vectorstore.py
+++ b/libs/langchain/langchain/memory/vectorstore.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional, Sequence, Union
 
+from langchain_core._api import deprecated
 from langchain_core.documents import Document
 from langchain_core.vectorstores import VectorStoreRetriever
 from pydantic import Field
@@ -10,8 +11,18 @@ from langchain.memory.chat_memory import BaseMemory
 from langchain.memory.utils import get_prompt_input_key
 
 
+@deprecated(
+    since="0.3.4",
+    removal="1.0.0",
+    message=(
+        "Please see the migration guide at: "
+        "https://python.langchain.com/docs/versions/migrating_memory/"
+    ),
+)
 class VectorStoreRetrieverMemory(BaseMemory):
-    """VectorStoreRetriever-backed memory."""
+    """Store the conversation history in a vector store and retrieves the relevant
+    parts of past conversation based on the input.
+    """
 
     retriever: VectorStoreRetriever = Field(exclude=True)
     """VectorStoreRetriever object to connect to."""


### PR DESCRIPTION
This PR deprecates the old memory, entity abstractions and implementations