### PR TITLE
core/langchain: fix version used in deprecation

### DIFF
--- a/libs/core/langchain_core/memory.py
+++ b/libs/core/langchain_core/memory.py
@@ -18,7 +18,7 @@ from langchain_core.runnables import run_in_executor
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/buffer.py
+++ b/libs/langchain/langchain/memory/buffer.py
@@ -9,7 +9,7 @@ from langchain.memory.utils import get_prompt_input_key
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -88,7 +88,7 @@ class ConversationBufferMemory(BaseChatMemory):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/buffer.py
+++ b/libs/langchain/langchain/memory/buffer.py
@@ -9,7 +9,7 @@ from langchain.memory.utils import get_prompt_input_key
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -88,7 +88,7 @@ class ConversationBufferMemory(BaseChatMemory):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/buffer_window.py
+++ b/libs/langchain/langchain/memory/buffer_window.py
@@ -7,7 +7,7 @@ from langchain.memory.chat_memory import BaseChatMemory
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/buffer_window.py
+++ b/libs/langchain/langchain/memory/buffer_window.py
@@ -7,7 +7,7 @@ from langchain.memory.chat_memory import BaseChatMemory
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -15,7 +15,7 @@ from langchain.memory.utils import get_prompt_input_key
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/chat_memory.py
+++ b/libs/langchain/langchain/memory/chat_memory.py
@@ -15,7 +15,7 @@ from langchain.memory.utils import get_prompt_input_key
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/entity.py
+++ b/libs/langchain/langchain/memory/entity.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -60,7 +60,7 @@ class BaseEntityStore(BaseModel, ABC):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -89,7 +89,7 @@ class InMemoryEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -175,7 +175,7 @@ class UpstashRedisEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -274,7 +274,7 @@ class RedisEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -379,7 +379,7 @@ class SQLiteEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/entity.py
+++ b/libs/langchain/langchain/memory/entity.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -60,7 +60,7 @@ class BaseEntityStore(BaseModel, ABC):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -89,7 +89,7 @@ class InMemoryEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -175,7 +175,7 @@ class UpstashRedisEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -274,7 +274,7 @@ class RedisEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "
@@ -379,7 +379,7 @@ class SQLiteEntityStore(BaseEntityStore):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/summary.py
+++ b/libs/langchain/langchain/memory/summary.py
@@ -58,7 +58,7 @@ class SummarizerMixin(BaseModel):
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/summary.py
+++ b/libs/langchain/langchain/memory/summary.py
@@ -58,7 +58,7 @@ class SummarizerMixin(BaseModel):
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/summary_buffer.py
+++ b/libs/langchain/langchain/memory/summary_buffer.py
@@ -9,7 +9,7 @@ from langchain.memory.summary import SummarizerMixin
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/summary_buffer.py
+++ b/libs/langchain/langchain/memory/summary_buffer.py
@@ -9,7 +9,7 @@ from langchain.memory.summary import SummarizerMixin
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/token_buffer.py
+++ b/libs/langchain/langchain/memory/token_buffer.py
@@ -8,7 +8,7 @@ from langchain.memory.chat_memory import BaseChatMemory
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/token_buffer.py
+++ b/libs/langchain/langchain/memory/token_buffer.py
@@ -8,7 +8,7 @@ from langchain.memory.chat_memory import BaseChatMemory
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/vectorstore.py
+++ b/libs/langchain/langchain/memory/vectorstore.py
@@ -12,7 +12,7 @@ from langchain.memory.utils import get_prompt_input_key
 
 
 @deprecated(
-    since="0.3.4",
+    since="0.3.3",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "

--- a/libs/langchain/langchain/memory/vectorstore.py
+++ b/libs/langchain/langchain/memory/vectorstore.py
@@ -12,7 +12,7 @@ from langchain.memory.utils import get_prompt_input_key
 
 
 @deprecated(
-    since="0.3.3",
+    since="0.3.1",
     removal="1.0.0",
     message=(
         "Please see the migration guide at: "


### PR DESCRIPTION
in core deprecation should be version 0.3.3 instead of 0.3.4
in langchain deprecation should be version 0.3.1 instead of 0.3.4