### PR TITLE
core: Rectify json decode error in core/output_parser/json.py

### DIFF
--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -82,7 +82,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
                 return None
         else:
             try:
-                return parse_json_markdown(text)
+                return parse_json_markdown(json.dumps(text))
             except JSONDecodeError as e:
                 msg = f"Invalid json output: {text}"
                 raise OutputParserException(msg, llm_output=text) from e

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -77,7 +77,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
         text = text.strip()
         if partial:
             try:
-                return parse_json_markdown(json.dumps(text))
+                return parse_json_markdown(text)
             except JSONDecodeError:
                 return None
         else:

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -77,7 +77,7 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
         text = text.strip()
         if partial:
             try:
-                return parse_json_markdown(text)
+                return parse_json_markdown(json.dumps(text))
             except JSONDecodeError:
                 return None
         else:


### PR DESCRIPTION

- [ ] **PR title**: "core: Rectify issue in parsing json in langchain_core/output_parser/json.py"

- [ ] **PR message**: 
    - **Description:** Added json.dumps in the return statement of the parse_result method. This ensures that it does not throw an exception if the dictionary contains escape characters.
    - **Issue:** #26655 
    - **Dependencies:** No dependencies
    - **Twitter handle:**@AshvinA001