### PR TITLE
langchain[patch]: fix extended tests

### DIFF
--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -102,7 +102,7 @@ def test_configurable() -> None:
         "bound": {
             "name": None,
             "cache": None,
-            "disable_streaming": False,
+            "disable_streaming": False,  #
             "model_name": "gpt-4o",
             "temperature": 0.7,
             "model_kwargs": {},

--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -102,7 +102,8 @@ def test_configurable() -> None:
         "bound": {
             "name": None,
             "cache": None,
-            "disable_streaming": False,  #
+            "disable_streaming": False,
+            "disabled_params": None,
             "model_name": "gpt-4o",
             "temperature": 0.7,
             "model_kwargs": {},


### PR DESCRIPTION
Broken by addition of `disabled_params`