### PR TITLE
core: Run LangChainTracer inline

### DIFF
--- a/libs/core/langchain_core/tracers/langchain.py
+++ b/libs/core/langchain_core/tracers/langchain.py
@@ -84,6 +84,8 @@ def _run_to_dict(run: Run) -> dict:
 class LangChainTracer(BaseTracer):
     """Implementation of the SharedTracer that POSTS to the LangChain endpoint."""
 
+    run_inline = True
+
     def __init__(
         self,
         example_id: Optional[Union[UUID, str]] = None,


### PR DESCRIPTION
- this flag ensures the tracer always runs in the same thread as the run being traced for both sync and async runs
- pro: less chance for ordering bugs and other oddities
- blocking the event loop is not a concern given all code in the tracer holds the GIL anyway

