### PR TITLE
community[patch]: Fix `tool_calls` parsing when streaming from DeepInfra

### DIFF
--- a/libs/community/langchain_community/chat_models/deepinfra.py
+++ b/libs/community/langchain_community/chat_models/deepinfra.py
@@ -144,13 +144,12 @@ def _convert_delta_to_message_chunk(
 ) -> BaseMessageChunk:
     role = _dict.get("role")
     content = _dict.get("content") or ""
+    tool_calls = _dict.get("tool_calls") or []
 
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content)
     elif role == "assistant" or default_class == AIMessageChunk:
-        tool_calls = [
-            _parse_tool_calling(tool_call) for tool_call in _dict.get("tool_calls", [])
-        ]
+        tool_calls = [_parse_tool_calling(tool_call) for tool_call in tool_calls]
         return AIMessageChunk(content=content, tool_calls=tool_calls)
     elif role == "system" or default_class == SystemMessageChunk:
         return SystemMessageChunk(content=content)


### PR DESCRIPTION
- **Description:** This PR fixes the response parsing logic for `ChatDeepInfra`, more specifially `_convert_delta_to_message_chunk()`, which is invoked when streaming via `ChatDeepInfra`.
- **Issue:** Streaming from DeepInfra via `ChatDeepInfra` is currently broken because the response parsing logic doesn't handle that `tool_calls` can be `None`. (There is no GitHub issue for this problem yet.)
- **Dependencies:** –
- **Twitter handle:** –

Keeping this here as a reminder:
> If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.