### PR TITLE
community[patch]: callback before yield for friendli

### DIFF
--- a/libs/community/langchain_community/llms/friendli.py
+++ b/libs/community/langchain_community/llms/friendli.py
@@ -233,9 +233,9 @@ class Friendli(LLM, BaseFriendli):
         )
         for line in stream:
             chunk = _stream_response_to_generation_chunk(line)
-            yield chunk
             if run_manager:
                 run_manager.on_llm_new_token(line.text, chunk=chunk)
+            yield chunk
 
     async def _astream(
         self,
@@ -250,9 +250,9 @@ class Friendli(LLM, BaseFriendli):
         )
         async for line in stream:
             chunk = _stream_response_to_generation_chunk(line)
-            yield chunk
             if run_manager:
                 await run_manager.on_llm_new_token(line.text, chunk=chunk)
+            yield chunk
 
     def _generate(
         self,


### PR DESCRIPTION
**Description:** Moves yield to after callback for `_stream` and `_astream` function for the friendli model in the community package
**Issue:** #16913 