### PR TITLE
community[patch]: [SharePointLoader] Fix validation error in _O365Settings due to extra fields in .env file

### DIFF
--- a/libs/community/langchain_community/document_loaders/base_o365.py
+++ b/libs/community/langchain_community/document_loaders/base_o365.py
@@ -38,7 +38,7 @@ class _O365Settings(BaseSettings):
     client_secret: SecretStr = Field(..., alias="O365_CLIENT_SECRET")
 
     model_config = SettingsConfigDict(
-        case_sensitive=False, env_file=".env", env_prefix=""
+        case_sensitive=False, env_file=".env", env_prefix="", extra="ignore"
     )
 
 


### PR DESCRIPTION
**Description:** Fix validation error in _O365Settings by ignoring extra fields in .env file
**Issue:** https://github.com/langchain-ai/langchain/issues/26850
**Dependencies:** NA