### PR TITLE
community: Fix validation error in SettingsConfigDict across multiple Langchain modules

### DIFF
--- a/libs/community/langchain_community/document_loaders/onenote.py
+++ b/libs/community/langchain_community/document_loaders/onenote.py
@@ -26,6 +26,7 @@ class _OneNoteGraphSettings(BaseSettings):
         populate_by_name=True,
         env_file=".env",
         env_prefix="MS_GRAPH_",
+        extra="ignore",
     )
 
 

--- a/libs/community/langchain_community/vectorstores/apache_doris.py
+++ b/libs/community/langchain_community/vectorstores/apache_doris.py
@@ -62,7 +62,10 @@ class ApacheDorisSettings(BaseSettings):
         return getattr(self, item)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", env_prefix="apache_doris_"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="apache_doris_",
+        extra="ignore",
     )
 
 

--- a/libs/community/langchain_community/vectorstores/clickhouse.py
+++ b/libs/community/langchain_community/vectorstores/clickhouse.py
@@ -96,7 +96,10 @@ class ClickhouseSettings(BaseSettings):
         return getattr(self, item)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", env_prefix="clickhouse_"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="clickhouse_",
+        extra="ignore",
     )
 
 

--- a/libs/community/langchain_community/vectorstores/kinetica.py
+++ b/libs/community/langchain_community/vectorstores/kinetica.py
@@ -80,7 +80,10 @@ class KineticaSettings(BaseSettings):
         return getattr(self, item)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", env_prefix="kinetica_"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="kinetica_",
+        extra="ignore",
     )
 
 

--- a/libs/community/langchain_community/vectorstores/manticore_search.py
+++ b/libs/community/langchain_community/vectorstores/manticore_search.py
@@ -57,7 +57,10 @@ class ManticoreSearchSettings(BaseSettings):
         return getattr(self, item)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", env_prefix="manticore_"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="manticore_",
+        extra="ignore",
     )
 
 

--- a/libs/community/langchain_community/vectorstores/myscale.py
+++ b/libs/community/langchain_community/vectorstores/myscale.py
@@ -86,7 +86,10 @@ class MyScaleSettings(BaseSettings):
         return getattr(self, item)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", env_prefix="myscale_"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="myscale_",
+        extra="ignore",
     )
 
 

--- a/libs/community/langchain_community/vectorstores/starrocks.py
+++ b/libs/community/langchain_community/vectorstores/starrocks.py
@@ -113,7 +113,10 @@ class StarRocksSettings(BaseSettings):
         return getattr(self, item)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", env_prefix="starrocks_"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        env_prefix="starrocks_",
+        extra="ignore",
     )
 
 


### PR DESCRIPTION
- **Description:** This pull request addresses the validation error in `SettingsConfigDict` due to extra fields in the `.env` file. The issue is prevalent across multiple Langchain modules. This fix ensures that extra fields in the `.env` file are ignored, preventing validation errors.
  **Changes include:**
    - Applied fixes to modules using `SettingsConfigDict`.

- **Issue:** NA, similar https://github.com/langchain-ai/langchain/issues/26850
- **Dependencies:** NA

