### PR TITLE
core: impl DocumentCompressorSequence

### DIFF
--- a/libs/core/langchain_core/documents/compressor.py
+++ b/libs/core/langchain_core/documents/compressor.py
@@ -64,3 +64,69 @@ class BaseDocumentCompressor(BaseModel, ABC):
         return await run_in_executor(
             None, self.compress_documents, documents, query, callbacks
         )
+
+    def __or__(self, other: BaseDocumentCompressor) -> BaseDocumentCompressor:
+        return DocumentCompressorSequence(self, other)
+
+
+class DocumentCompressorSequence(BaseDocumentCompressor):
+    """Sequence of Compressors, which will be executed in order.
+
+    A DocumentCompressorSequence can be instantiated directly or more commonly by using
+    the `|` operator where both the left and right operands be a BaseDocumentCompressor.
+    """
+
+    _compressor_list: Sequence[BaseDocumentCompressor] = []
+    """The Sequence of Compressors to execute."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        arbitrary_types_allowed = True
+        extra = "forbid"
+
+    def __init__(
+        self,
+        first_compressor: BaseDocumentCompressor,
+        second_compressor: BaseDocumentCompressor,
+        *compressor_list: BaseDocumentCompressor,
+    ):
+        """Create a new DocumentCompressorSequence.
+
+        Args:
+            first_compressor: The first BaseDocumentCompressor in the sequence.
+            second_compressor: The second BaseDocumentCompressor in the sequence.
+            compressor_list: The rest BaseDocumentCompressor in the sequence.
+
+        first_compressor and second_compressor are place holder to make sure
+        that the sequence has least two compressors.
+        """
+        super().__init__()
+        self._compressor_list = [first_compressor, second_compressor, *compressor_list]
+
+    def compress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Optional[Callbacks] = None,
+    ) -> Sequence[Document]:
+        """
+        Compress documents using the compressors in the chain.
+
+        Args:
+            documents: The retrieved documents.
+            query: The query context.
+            callbacks: Optional callbacks to run during compression.
+
+        Returns:
+            The compressed documents.
+        """
+
+        for compressor in self._compressor_list:
+            # avoid meaningless compression
+            if len(documents) == 0:
+                break
+            documents = compressor.compress_documents(
+                documents, query, callbacks=callbacks
+            )
+        return documents

--- a/libs/core/tests/unit_tests/documents/test_compressor.py
+++ b/libs/core/tests/unit_tests/documents/test_compressor.py
@@ -1,0 +1,51 @@
+from collections.abc import Sequence
+
+from langchain_core.callbacks import Callbacks
+from langchain_core.documents import BaseDocumentCompressor, Document
+
+
+class FakeDocumentCompressorA(BaseDocumentCompressor):
+    def compress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Callbacks = None,
+    ) -> Sequence[Document]:
+        if len(documents) > 0:
+            return documents[1:]
+        return []
+
+
+class FakeDocumentCompressorB(BaseDocumentCompressor):
+    def compress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Callbacks = None,
+    ) -> Sequence[Document]:
+        return [Document(page_content=doc.page_content.upper()) for doc in documents]
+
+
+def test_fake_compressor() -> None:
+    assert (
+        len(
+            FakeDocumentCompressorA().compress_documents(
+                [Document(page_content="Hello, World!")] * 2, "query"
+            )
+        )
+        == 1
+    )
+    assert (
+        FakeDocumentCompressorB()
+        .compress_documents([Document(page_content="Hello, World!")], "query")[0]
+        .page_content.isupper()
+    )
+
+
+def test_compressor_sequence() -> None:
+    compressor_sequence = FakeDocumentCompressorA() | FakeDocumentCompressorB()
+    compress_result = compressor_sequence.compress_documents(
+        [Document(page_content="Hello, World!")] * 2, "query"
+    )
+    assert len(compress_result) == 1
+    assert compress_result[0].page_content.isupper()


### PR DESCRIPTION
## Description

Implement the `DocumentCompressorSequence` class and add the `__or__` method to `BaseDocumentCompressor`.

This change allows for chaining different compressors. For example, this PR enables combining `BCERerank` with `LLMLinguaCompressor`, allowing documents to be filtered and streamlined simultaneously.

## Issue

Not applicable

## Dependencies

No dependencies are required for this change.

## Twitter Handle

Not applicable