### PR TITLE
community[patch]: callback before yield for mlx pipeline

### DIFF
--- a/libs/community/langchain_community/llms/mlx_pipeline.py
+++ b/libs/community/langchain_community/llms/mlx_pipeline.py
@@ -232,9 +232,9 @@ class MLXPipeline(LLM):
             # yield text, if any
             if text:
                 chunk = GenerationChunk(text=text)
-                yield chunk
                 if run_manager:
                     run_manager.on_llm_new_token(chunk.text)
+                yield chunk
 
             # break if stop sequence found
             if token == eos_token_id or (stop is not None and text in stop):


### PR DESCRIPTION
**Description:** Moves yield to after callback for `_stream` function for the MLX pipeline model in the community llm package
**Issue:** #16913 