### PR TITLE
community[patch]: callback before yield for textgen

### DIFF
--- a/libs/community/langchain_community/llms/textgen.py
+++ b/libs/community/langchain_community/llms/textgen.py
@@ -342,7 +342,6 @@ class TextGen(LLM):
                 websocket_client.close()
                 return
 
-
     async def _astream(
         self,
         prompt: str,
@@ -414,4 +413,3 @@ class TextGen(LLM):
             elif result["event"] == "stream_end":  # type: ignore[call-overload, index]
                 websocket_client.close()
                 return
-

--- a/libs/community/langchain_community/llms/textgen.py
+++ b/libs/community/langchain_community/llms/textgen.py
@@ -335,13 +335,13 @@ class TextGen(LLM):
                     text=result["text"],  # type: ignore[call-overload, index]
                     generation_info=None,
                 )
+                if run_manager:
+                    run_manager.on_llm_new_token(token=chunk.text)
                 yield chunk
             elif result["event"] == "stream_end":  # type: ignore[call-overload, index]
                 websocket_client.close()
                 return
 
-            if run_manager:
-                run_manager.on_llm_new_token(token=chunk.text)
 
     async def _astream(
         self,
@@ -408,10 +408,10 @@ class TextGen(LLM):
                     text=result["text"],  # type: ignore[call-overload, index]
                     generation_info=None,
                 )
+                if run_manager:
+                    await run_manager.on_llm_new_token(token=chunk.text)
                 yield chunk
             elif result["event"] == "stream_end":  # type: ignore[call-overload, index]
                 websocket_client.close()
                 return
 
-            if run_manager:
-                await run_manager.on_llm_new_token(token=chunk.text)


### PR DESCRIPTION
**Description:** Moves callback to before yield for `_stream` and `_astream` function for the textgen model in the community llm package
**Issue:** #16913 