### PR TITLE
core: Add encoding config to json for load_prompt()

### DIFF
--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -51,9 +51,13 @@ def _load_template(var_name: str, config: dict) -> dict:
             )
         # Pop the template path from the config.
         template_path = Path(config.pop(f"{var_name}_path"))
+        if f"{var_name}_encoding" in config:
+            encoding = config.pop(f"{var_name}_encoding")
+        else:
+            encoding = None
         # Load the template.
         if template_path.suffix == ".txt":
-            with open(template_path) as f:
+            with open(template_path, encoding=encoding) as f:
                 template = f.read()
         else:
             raise ValueError

--- a/libs/core/tests/unit_tests/examples/simple_prompt_with_template_file_cp932.json
+++ b/libs/core/tests/unit_tests/examples/simple_prompt_with_template_file_cp932.json
@@ -1,0 +1,6 @@
+{
+    "_type": "prompt",
+    "input_variables": ["adjective", "content"],
+    "template_path": "simple_template_cp932.txt",
+    "template_encoding": "cp932"
+}

--- a/libs/core/tests/unit_tests/examples/simple_prompt_with_template_file_utf8.json
+++ b/libs/core/tests/unit_tests/examples/simple_prompt_with_template_file_utf8.json
@@ -1,0 +1,6 @@
+{
+    "_type": "prompt",
+    "input_variables": ["adjective", "content"],
+    "template_path": "simple_template_utf8.txt",
+    "template_encoding": "utf-8"
+}

--- a/libs/core/tests/unit_tests/examples/simple_template_cp932.txt
+++ b/libs/core/tests/unit_tests/examples/simple_template_cp932.txt
@@ -1,0 +1,1 @@
+Tell me a {adjective} joke about {content}. SJIS日本語テスト

--- a/libs/core/tests/unit_tests/examples/simple_template_utf8.txt
+++ b/libs/core/tests/unit_tests/examples/simple_template_utf8.txt
@@ -1,0 +1,1 @@
+Tell me a {adjective} joke about {content}. AÁĂȀ🐌😁

--- a/libs/core/tests/unit_tests/prompts/test_loading.py
+++ b/libs/core/tests/unit_tests/prompts/test_loading.py
@@ -99,6 +99,28 @@ def test_loading_with_template_as_file() -> None:
         assert prompt == expected_prompt
 
 
+def test_loading_from_json_utf8() -> None:
+    """Test loading when the template is a file."""
+    with change_directory(EXAMPLE_DIR):
+        prompt = load_prompt("simple_prompt_with_template_file_utf8.json")
+        expected_prompt = PromptTemplate(
+            input_variables=["adjective", "content"],
+            template="Tell me a {adjective} joke about {content}. AÁĂȀ🐌😁",
+        )
+        assert prompt == expected_prompt
+
+
+def test_loading_from_json_cp932() -> None:
+    """Test loading when the template is a file."""
+    with change_directory(EXAMPLE_DIR):
+        prompt = load_prompt("simple_prompt_with_template_file_cp932.json")
+        expected_prompt = PromptTemplate(
+            input_variables=["adjective", "content"],
+            template="Tell me a {adjective} joke about {content}. SJIS日本語テスト",
+        )
+        assert prompt == expected_prompt
+
+
 def test_loading_few_shot_prompt_from_yaml() -> None:
     """Test loading few shot prompt from yaml."""
     with change_directory(EXAMPLE_DIR):


### PR DESCRIPTION
- **Description:**

This PR lets you specify file encoding of "*_path" in the config.
If an encoding is set in the config, it will be used when opening the file.
Otherwise, the default encoding will be applied.

The default encoding in Python differs depending on the environment.
On Windows, it is the ANSI code page (ex: "cp932").

- **Issue:** https://github.com/langchain-ai/langchain/issues/6900
- **Twitter handle:** https://x.com/k_matsuzaki


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/
