### PR TITLE
how to trim messages: add explanation about what the chat history should end with

### DIFF
--- a/docs/docs/how_to/trim_messages.ipynb
+++ b/docs/docs/how_to/trim_messages.ipynb
@@ -27,11 +27,12 @@
     "\n",
     "If passing the trimmed chat history back into a chat model directly, the trimmed chat history should satisfy the following properties:\n",
     "\n",
-    "1. The resulting chat history should be **valid**. Most chat models expect that chat\n",
-    "   history starts with either (1) a `HumanMessage` or (2) a [SystemMessage](/docs/concepts/#systemmessage) followed\n",
-    "   by a `HumanMessage`. In addition, generally a `ToolMessage` can only appear after an `AIMessage`\n",
-    "   that involved a tool call. This can be achieved by setting `start_on=\"human\"`.\n",
-    "2. It includes recent messages and drops old messages in the chat history.\n",
+    "1. The resulting chat history should be **valid**. Usually this means that the following properties should be satisfied:\n",
+    "   - The chat history **starts** with either (1) a `HumanMessage` or (2) a [SystemMessage](/docs/concepts/#systemmessage) followed by a `HumanMessage`.\n",
+    "   - The chat history **ends** with either a `HumanMessage` or a `ToolMessage`.\n",
+    "   - A `ToolMessage` can only appear after an `AIMessage` that involved a tool call. \n",
+    "   This can be achieved by setting `start_on=\"human\"` and `ends_on=(\"human\", \"tool\")`.\n",
+    "3. It includes recent messages and drops old messages in the chat history.\n",
     "   This can be achieved by setting `strategy=\"last\"`.\n",
     "4. Usually, the new chat history should include the `SystemMessage` if it\n",
     "   was present in the original chat history since the `SystemMessage` includes\n",
@@ -97,6 +98,7 @@
     "    AIMessage,\n",
     "    HumanMessage,\n",
     "    SystemMessage,\n",
+    "    ToolMessage,\n",
     "    trim_messages,\n",
     ")\n",
     "from langchain_openai import ChatOpenAI\n",
@@ -135,8 +137,11 @@
     "    # Most chat models expect that chat history starts with either:\n",
     "    # (1) a HumanMessage or\n",
     "    # (2) a SystemMessage followed by a HumanMessage\n",
-    "    # start_on=\"human\" makes sure we produce a valid chat history\n",
     "    start_on=\"human\",\n",
+    "    # Most chat models expect that chat history ends with either:\n",
+    "    # (1) a HumanMessage or\n",
+    "    # (2) a ToolMessage\n",
+    "    end_on=(\"human\", \"tool\"),\n",
     "    # Usually, we want to keep the SystemMessage\n",
     "    # if it's present in the original history.\n",
     "    # The SystemMessage has special instructions for the model.\n",
@@ -194,8 +199,11 @@
     "    # Most chat models expect that chat history starts with either:\n",
     "    # (1) a HumanMessage or\n",
     "    # (2) a SystemMessage followed by a HumanMessage\n",
-    "    # start_on=\"human\" makes sure we produce a valid chat history\n",
     "    start_on=\"human\",\n",
+    "    # Most chat models expect that chat history ends with either:\n",
+    "    # (1) a HumanMessage or\n",
+    "    # (2) a ToolMessage\n",
+    "    end_on=(\"human\", \"tool\"),\n",
     "    # Usually, we want to keep the SystemMessage\n",
     "    # if it's present in the original history.\n",
     "    # The SystemMessage has special instructions for the model.\n",
@@ -328,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 7,
    "id": "d930c089-e8e6-4980-9d39-11d41e794772",
    "metadata": {},
    "outputs": [
@@ -346,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "1c1c3b1e-2ece-49e7-a3b6-e69877c1633b",
    "metadata": {},
    "outputs": [
@@ -357,7 +365,7 @@
        " HumanMessage(content='what do you call a speechless parrot', additional_kwargs={}, response_metadata={})]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,8 +426,11 @@
     "    # Most chat models expect that chat history starts with either:\n",
     "    # (1) a HumanMessage or\n",
     "    # (2) a SystemMessage followed by a HumanMessage\n",
-    "    # start_on=\"human\" makes sure we produce a valid chat history\n",
     "    start_on=\"human\",\n",
+    "    # Most chat models expect that chat history ends with either:\n",
+    "    # (1) a HumanMessage or\n",
+    "    # (2) a ToolMessage\n",
+    "    end_on=(\"human\", \"tool\"),\n",
     "    # Usually, we want to keep the SystemMessage\n",
     "    # if it's present in the original history.\n",
     "    # The SystemMessage has special instructions for the model.\n",
@@ -439,17 +450,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 9,
    "id": "96aa29b2-01e0-437c-a1ab-02fb0141cb57",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='A \"polygon!\"', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 4, 'prompt_tokens': 32, 'total_tokens': 36, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4o-2024-05-13', 'system_fingerprint': 'fp_3537616b13', 'finish_reason': 'stop', 'logprobs': None}, id='run-995342be-0443-4e33-9b54-153f5c8771d3-0', usage_metadata={'input_tokens': 32, 'output_tokens': 4, 'total_tokens': 36})"
+       "AIMessage(content='A polygon! Because it\\'s a \"poly-gone\" quiet!', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 13, 'prompt_tokens': 32, 'total_tokens': 45, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4o-2024-05-13', 'system_fingerprint': 'fp_057232b607', 'finish_reason': 'stop', 'logprobs': None}, id='run-4fa026e7-9137-4fef-b596-54243615e3b3-0', usage_metadata={'input_tokens': 32, 'output_tokens': 13, 'total_tokens': 45})"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,18 +471,25 @@
     "# Notice we don't pass in messages. This creates\n",
     "# a RunnableLambda that takes messages as input\n",
     "trimmer = trim_messages(\n",
-    "    max_tokens=45,\n",
-    "    strategy=\"last\",\n",
     "    token_counter=llm,\n",
+    "    # Keep the last <= n_count tokens of the messages.\n",
+    "    strategy=\"last\",\n",
+    "    # When token_counter=len, each message\n",
+    "    # will be counted as a single token.\n",
+    "    # Remember to adjust for your use case\n",
+    "    max_tokens=45,\n",
+    "    # Most chat models expect that chat history starts with either:\n",
+    "    # (1) a HumanMessage or\n",
+    "    # (2) a SystemMessage followed by a HumanMessage\n",
+    "    start_on=\"human\",\n",
+    "    # Most chat models expect that chat history ends with either:\n",
+    "    # (1) a HumanMessage or\n",
+    "    # (2) a ToolMessage\n",
+    "    end_on=(\"human\", \"tool\"),\n",
     "    # Usually, we want to keep the SystemMessage\n",
     "    # if it's present in the original history.\n",
     "    # The SystemMessage has special instructions for the model.\n",
     "    include_system=True,\n",
-    "    # Most chat models expect that chat history starts with either:\n",
-    "    # (1) a HumanMessage or\n",
-    "    # (2) a SystemMessage followed by a HumanMessage\n",
-    "    # start_on=\"human\" makes sure we produce a valid chat history\n",
-    "    start_on=\"human\",\n",
     ")\n",
     "\n",
     "chain = trimmer | llm\n",
@@ -490,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 10,
    "id": "1ff02d0a-353d-4fac-a77c-7c2c5262abd9",
    "metadata": {},
    "outputs": [
@@ -501,7 +519,7 @@
        " HumanMessage(content='what do you call a speechless parrot', additional_kwargs={}, response_metadata={})]"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -522,17 +540,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "a9517858-fc2f-4dc3-898d-bf98a0e905a0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='A polygon! (Because it\\'s a \"poly-gone\" quiet!)', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 14, 'prompt_tokens': 32, 'total_tokens': 46, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4o-2024-05-13', 'system_fingerprint': 'fp_e375328146', 'finish_reason': 'stop', 'logprobs': None}, id='run-8569a119-ca02-4232-bee1-20caea61cd6d-0', usage_metadata={'input_tokens': 32, 'output_tokens': 14, 'total_tokens': 46})"
+       "AIMessage(content='A \"polygon\"!', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 4, 'prompt_tokens': 32, 'total_tokens': 36, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4o-2024-05-13', 'system_fingerprint': 'fp_c17d3befe7', 'finish_reason': 'stop', 'logprobs': None}, id='run-71d9fce6-bb0c-4bb3-acc8-d5eaee6ae7bc-0', usage_metadata={'input_tokens': 32, 'output_tokens': 4, 'total_tokens': 36})"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
A valid chat history should end with human message or tool message if being fed back to a chat model