### PR TITLE
Fixed typo sql_rag.storage to sql_community.storage

### DIFF
--- a/libs/community/langchain_community/storage/sql.py
+++ b/libs/community/langchain_community/storage/sql.py
@@ -95,7 +95,7 @@ class SQLStore(BaseStore[str, bytes]):
 
         .. code-block:: python
 
-            from langchain_rag.storage import SQLStore
+            from langchain_community.storage import SQLStore
 
             # Instantiate the SQLStore with the root path
             sql_store = SQLStore(namespace="test", db_url="sqlite://:memory:")


### PR DESCRIPTION
- [x] **PR title**: 
  - docs: fix typo in SQLStore import path

- [x] **PR message**: 
    - **Description:** This PR corrects a typo in the docstrings for the class SQLStore(BaseStore[str, bytes]). The import path in the docstring currently reads from lanchain_rag.storage import SQLStore, which should be changed to from langchain_community.storage import SQLStore. This typo is also reflected in the official documentation.
    - **Issue:** N/A
    - **Dependencies:** None
    - **Twitter handle:** N/A
