### PR TITLE
langchain-chroma: mark `test_chroma_async` properly

### DIFF
--- a/libs/partners/chroma/tests/integration_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/integration_tests/test_vectorstores.py
@@ -36,7 +36,7 @@ def test_chroma() -> None:
 
     assert output == [Document(page_content="foo")]
 
-
+@pytest.mark.asyncio
 async def test_chroma_async() -> None:
     """Test end to end construction and search."""
     texts = ["foo", "bar", "baz"]


### PR DESCRIPTION
Thank you for contributing to LangChain!

**Description**

`test_chroma_async` was giving `PytestUnhandledCoroutineWarning` and `test_chroma_update_document` was failing with a bad assertion on Darwin (MacOS) 10.5.

The fix is to mark the async test as async.

**Issue**

Fixes #27034

**Xitter Handle**

@a_bowl_of_stars 

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
