### PR TITLE
community[patch]: update gpt-4o cost

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -15,11 +15,11 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4o-mini-completion": 0.0006,
     "gpt-4o-mini-2024-07-18-completion": 0.0006,
     # GPT-4o input
-    "gpt-4o": 0.005,
+    "gpt-4o": 0.0025,
     "gpt-4o-2024-05-13": 0.005,
     "gpt-4o-2024-08-06": 0.0025,
     # GPT-4o output
-    "gpt-4o-completion": 0.015,
+    "gpt-4o-completion": 0.01,
     "gpt-4o-2024-05-13-completion": 0.015,
     "gpt-4o-2024-08-06-completion": 0.01,
     # GPT-4 input


### PR DESCRIPTION
updated OpenAI cost definition according to the following:
https://openai.com/api/pricing/