### PR TITLE
community: chore warn deprecate the wandb callback handler

### DIFF
--- a/libs/community/langchain_community/callbacks/wandb_callback.py
+++ b/libs/community/langchain_community/callbacks/wandb_callback.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
+from langchain_core._api import warn_deprecated
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
@@ -206,6 +207,22 @@ class WandbCallbackHandler(BaseMetadataCallbackHandler, BaseCallbackHandler):
         self.complexity_metrics = complexity_metrics
         self.visualize = visualize
         self.nlp = spacy.load("en_core_web_sm")
+        warn_deprecated(
+            "0.3.8",
+            pending=False,
+            message=(
+                "Please use the WeaveTracer instead of the WandbCallbackHandler. "
+                "The WeaveTracer is a more flexible and powerful tool for logging "
+                "and tracing your LangChain callables."
+                "Find more information at https://weave-docs.wandb.ai/guides/integrations/langchain"
+            ),
+            alternative=(
+                "Please instantiate the WeaveTracer from "
+                "weave.integrations.langchain import WeaveTracer ."
+                "For autologging simply use weave.init() and log all traces "
+                "from your LangChain callables."
+            ),
+        )
 
     def _init_resp(self) -> Dict:
         return {k: None for k in self.callback_columns}


### PR DESCRIPTION
- **Description:**: This PR deprecates the wandb callback handler in favor of the new [WeaveTracer](https://weave-docs.wandb.ai/guides/integrations/langchain#using-weavetracer) in W&B
- **Dependencies:** No dependencies, just a deprecation warning.
- **Twitter handle:** @parambharat


@baskaryan 
