### PR TITLE
community: add bm25 retriever model save and load method

### DIFF
--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import joblib
 import pickle
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
@@ -110,6 +109,14 @@ class BM25Retriever(BaseRetriever):
         folder_path: str,
         file_name: str = "bm25_vectorizer",
     ) -> None:
+        
+        try:
+            import joblib
+        except ImportError:
+            raise ImportError(
+                "Could not import joblib, please install with `pip install joblib`."
+            )
+        
         path = Path(folder_path)
         path.mkdir(exist_ok=True, parents=True)
 
@@ -138,6 +145,14 @@ class BM25Retriever(BaseRetriever):
         Returns:
             BM25Retriever: Loaded retriever.
         """
+
+        try:
+            import joblib
+        except ImportError:
+            raise ImportError(
+                "Could not import joblib, please install with `pip install joblib`."
+            )
+        
         if not allow_dangerous_deserialization:
             raise ValueError(
                 "The de-serialization of this retriever is based on .joblib and "

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -129,7 +129,7 @@ class BM25Retriever(BaseRetriever):
         allow_dangerous_deserialization: bool = False,
         file_name: str = "bm25_vectorizer",
     ) -> BM25Retriever:
-        """Load the retriever from local storage with enhancements.
+        """Load the retriever from local storage.
 
         Args:
             folder_path: Folder path to load from.
@@ -137,7 +137,7 @@ class BM25Retriever(BaseRetriever):
             file_name: File name to load from.
 
         Returns:
-            EnhancedBM25Retriever: Loaded retriever with enhancements.
+            BM25Retriever: Loaded retriever.
         """
         if not allow_dangerous_deserialization:
             raise ValueError(

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import joblib
 import pickle
 from pathlib import Path
-
-from __future__ import annotations
-
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -172,6 +172,8 @@ class BM25Retriever(BaseRetriever):
 
         # Load docs and preprocess_func as pickle.
         with open(path / f"{file_name}.pkl", "rb") as f:
-            docs, preprocess_func = pickle.load(f)
+            # This code path can only be triggered if the user
+            # passed allow_dangerous_deserialization=True
+            docs, preprocess_func = pickle.load(f)  # ignore[pickle]: explicit-opt-in
 
         return cls(vectorizer=vectorizer, docs=docs, preprocess_func=preprocess_func)

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -103,7 +103,7 @@ class BM25Retriever(BaseRetriever):
         processed_query = self.preprocess_func(query)
         return_docs = self.vectorizer.get_top_n(processed_query, self.docs, n=self.k)
         return return_docs
-    
+
     def save_local(
         self,
         folder_path: str,
@@ -115,7 +115,7 @@ class BM25Retriever(BaseRetriever):
             raise ImportError(
                 "Could not import joblib, please install with `pip install joblib`."
             )
-        
+
         path = Path(folder_path)
         path.mkdir(exist_ok=True, parents=True)
 

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -109,7 +109,6 @@ class BM25Retriever(BaseRetriever):
         folder_path: str,
         file_name: str = "bm25_vectorizer",
     ) -> None:
-        
         try:
             import joblib
         except ImportError:
@@ -145,14 +144,12 @@ class BM25Retriever(BaseRetriever):
         Returns:
             BM25Retriever: Loaded retriever.
         """
-
         try:
             import joblib
         except ImportError:
             raise ImportError(
                 "Could not import joblib, please install with `pip install joblib`."
             )
-        
         if not allow_dangerous_deserialization:
             raise ValueError(
                 "The de-serialization of this retriever is based on .joblib and "

--- a/libs/community/tests/unit_tests/retrievers/test_bm25.py
+++ b/libs/community/tests/unit_tests/retrievers/test_bm25.py
@@ -48,6 +48,7 @@ def test_repr() -> None:
     bm25_retriever = BM25Retriever.from_documents(documents=input_docs)
     assert "I have a pen" not in repr(bm25_retriever)
 
+
 @pytest.mark.requires("sklearn")
 def test_save_local_load_local() -> None:
     input_texts = ["I have a pen.", "Do you have a pen?", "I have a bag."]
@@ -69,3 +70,4 @@ def test_save_local_load_local() -> None:
             allow_dangerous_deserialization=True,
         )
     assert len(loaded_bm25_retriever.docs) == 3
+    assert loaded_bm25_retriever.vectorizer.doc_len == [4, 5, 4]

--- a/libs/community/tests/unit_tests/retrievers/test_bm25.py
+++ b/libs/community/tests/unit_tests/retrievers/test_bm25.py
@@ -66,6 +66,7 @@ def test_save_local_load_local() -> None:
         loaded_bm25_retriever = BM25Retriever.load_local(
             folder_path=temp_folder,
             file_name=file_name,
+            allow_dangerous_deserialization=True,
         )
     assert len(loaded_bm25_retriever.docs) == 3
     assert loaded_bm25_retriever.bm25_array.toarray().shape == (3, 5)

--- a/libs/community/tests/unit_tests/retrievers/test_bm25.py
+++ b/libs/community/tests/unit_tests/retrievers/test_bm25.py
@@ -69,4 +69,3 @@ def test_save_local_load_local() -> None:
             allow_dangerous_deserialization=True,
         )
     assert len(loaded_bm25_retriever.docs) == 3
-    assert loaded_bm25_retriever.bm25_array.toarray().shape == (3, 5)


### PR DESCRIPTION
Description
This PR adds functionality for saving and loading retrievers to the` BM25Retriever` class. This feature, already present in the `TFIDFRetriever`, is extremely useful and necessary for the `BM25Retriever` as well.

https://api.python.langchain.com/en/latest/_modules/langchain_community/retrievers/tfidf.html#TFIDFRetriever:~:text=docs%5D%20%20%20%20%40classmethod-,def%20load_local(,-cls%2C%0A%20%20%20%20%20%20%20%20folder_path

Dependencies
No additional dependencies are required for this change.

Twitter handle
@i_w__a