### PR TITLE
community: Add instructions in InfinityEmbeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/infinity.py
+++ b/libs/community/langchain_community/embeddings/infinity.py
@@ -43,6 +43,11 @@ class InfinityEmbeddings(BaseModel, Embeddings):
     client: Any = None  #: :meta private:
     """Infinity client."""
 
+    embed_instruction: str = "passage: "
+    """Instruction used to embed documents."""
+    query_instruction: str = "query: "
+    """Instruction used to embed the query."""
+
     # LLM call kwargs
     model_config = ConfigDict(
         extra="forbid",
@@ -73,7 +78,7 @@ class InfinityEmbeddings(BaseModel, Embeddings):
         """
         embeddings = self.client.embed(
             model=self.model,
-            texts=texts,
+            texts=[self.embed_instruction + text for text in texts],
         )
         return embeddings
 
@@ -88,7 +93,7 @@ class InfinityEmbeddings(BaseModel, Embeddings):
         """
         embeddings = await self.client.aembed(
             model=self.model,
-            texts=texts,
+            texts=[self.embed_instruction + text for text in texts],
         )
         return embeddings
 
@@ -101,7 +106,9 @@ class InfinityEmbeddings(BaseModel, Embeddings):
         Returns:
             Embeddings for the text.
         """
-        return self.embed_documents([text])[0]
+        return self.client.embed(
+            model=self.model, texts=[self.query_instruction + text]
+        )[0]
 
     async def aembed_query(self, text: str) -> List[float]:
         """Async call out to Infinity's embedding endpoint.
@@ -112,7 +119,9 @@ class InfinityEmbeddings(BaseModel, Embeddings):
         Returns:
             Embeddings for the text.
         """
-        embeddings = await self.aembed_documents([text])
+        embeddings = await self.client.aembed(
+            model=self.model, texts=[self.query_instruction + text]
+        )
         return embeddings[0]
 
 

--- a/libs/community/langchain_community/embeddings/infinity.py
+++ b/libs/community/langchain_community/embeddings/infinity.py
@@ -43,9 +43,9 @@ class InfinityEmbeddings(BaseModel, Embeddings):
     client: Any = None  #: :meta private:
     """Infinity client."""
 
-    embed_instruction: str = "passage: "
+    embed_instruction: str = ""
     """Instruction used to embed documents."""
-    query_instruction: str = "query: "
+    query_instruction: str = ""
     """Instruction used to embed the query."""
 
     # LLM call kwargs

--- a/libs/community/tests/unit_tests/embeddings/test_infinity.py
+++ b/libs/community/tests/unit_tests/embeddings/test_infinity.py
@@ -44,7 +44,7 @@ def mocked_requests_post(
             v = [0.0, 0.9, 0.0]
         else:
             v = [0.0, 0.0, -1.0]
-        if len(inp) > 10:
+        if len(inp) > 19:  # 10 + 9 for "passage: "
             v[2] += 0.1
         embeddings.append({"embedding": v})
 

--- a/libs/community/tests/unit_tests/embeddings/test_infinity.py
+++ b/libs/community/tests/unit_tests/embeddings/test_infinity.py
@@ -44,7 +44,7 @@ def mocked_requests_post(
             v = [0.0, 0.9, 0.0]
         else:
             v = [0.0, 0.0, -1.0]
-        if len(inp) > 19:  # 10 + 9 for "passage: "
+        if len(inp) > 10:
             v[2] += 0.1
         embeddings.append({"embedding": v})
 


### PR DESCRIPTION
**Description:**

Add instructions for embedding with Infinity:

```python
embed_instruction: str = ""
query_instruction: str = ""
```

Allows to pass instructions like "passage: " or "query: ". Defaults to "" (no instructions)