### PR TITLE
[community] [feature]: Implementation of excel parser and including it in o365 loader

### DIFF
--- a/libs/community/langchain_community/document_loaders/base_o365.py
+++ b/libs/community/langchain_community/document_loaders/base_o365.py
@@ -50,6 +50,7 @@ class _FileType(str, Enum):
     DOC = "doc"
     DOCX = "docx"
     PDF = "pdf"
+    XLSX = "xlsx"
 
 
 def fetch_mime_types(file_types: Sequence[_FileType]) -> Dict[str, str]:
@@ -59,11 +60,15 @@ def fetch_mime_types(file_types: Sequence[_FileType]) -> Dict[str, str]:
         if file_type.value == "doc":
             mime_types_mapping[file_type.value] = "application/msword"
         elif file_type.value == "docx":
-            mime_types_mapping[file_type.value] = (
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"  # noqa: E501
-            )
+            mime_types_mapping[
+                file_type.value
+            ] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"  # noqa: E501
         elif file_type.value == "pdf":
             mime_types_mapping[file_type.value] = "application/pdf"
+        elif file_type.value == "xlsx":
+            mime_types_mapping[
+                file_type.value
+            ] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     return mime_types_mapping
 
 

--- a/libs/community/langchain_community/document_loaders/base_o365.py
+++ b/libs/community/langchain_community/document_loaders/base_o365.py
@@ -60,15 +60,15 @@ def fetch_mime_types(file_types: Sequence[_FileType]) -> Dict[str, str]:
         if file_type.value == "doc":
             mime_types_mapping[file_type.value] = "application/msword"
         elif file_type.value == "docx":
-            mime_types_mapping[
-                file_type.value
-            ] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"  # noqa: E501
+            mime_types_mapping[file_type.value] = (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"  # noqa: E501
+            )
         elif file_type.value == "pdf":
             mime_types_mapping[file_type.value] = "application/pdf"
         elif file_type.value == "xlsx":
-            mime_types_mapping[
-                file_type.value
-            ] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            mime_types_mapping[file_type.value] = (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
     return mime_types_mapping
 
 

--- a/libs/community/langchain_community/document_loaders/parsers/excel.py
+++ b/libs/community/langchain_community/document_loaders/parsers/excel.py
@@ -1,0 +1,72 @@
+from typing import Iterator, Sequence
+
+from langchain_core.documents import Document
+
+from langchain_community.document_loaders.base import BaseBlobParser
+from langchain_community.document_loaders.blob_loaders import Blob
+
+
+class ExcelParser(BaseBlobParser):
+    """Parse the Microsoft Excel documents from a blob."""
+
+    def post_process_unstructured_elements(
+        self, elements: Sequence[str], source: str
+    ) -> Iterator[Document]:
+        try:
+            import htmltabletomd
+        except ImportError as e:
+            raise ImportError(
+                "Could not import htmltabletomd, please install with `pip install "
+                "htmltabletomd`."
+            ) from e
+        last_page = None
+        for element in elements:
+            if element.metadata.page_number != last_page:
+                if last_page:
+                    metadata = {"source": source, "title": element.metadata.page_name}  # type: ignore[attr-defined]
+                    yield Document(page_content=page_text, metadata=metadata)
+                page_text = f"# {element.metadata.page_name}\n"
+                last_page = element.metadata.page_number
+
+            if type(element).__name__ == "Title":
+                page_text += f"## {element.text}\n"
+            elif type(element).__name__ == "Table":
+                page_text += (
+                    htmltabletomd.convert_table(element.metadata.text_as_html) + "\n"
+                )
+            else:
+                page_text += f"{element.text}\n"
+        # yield last page
+        metadata = {"source": source, "title": element.metadata.page_name}  # type: ignore[attr-defined]
+        yield Document(page_content=page_text, metadata=metadata)
+
+    def lazy_parse(self, blob: Blob) -> Iterator[Document]:  # type: ignore[valid-type]
+        """Parse a Microsoft Excel document into the Document iterator.
+
+        Args:
+            blob: The blob to parse.
+
+        Returns: An iterator of Documents.
+
+        """
+        try:
+            from unstructured.partition.xlsx import partition_xlsx
+        except ImportError as e:
+            raise ImportError(
+                "Could not import unstructured, please install with `pip install "
+                "unstructured`."
+            ) from e
+
+        # TODO: add pre-2007 .xls support
+        mime_type_parser = {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": (
+                partition_xlsx
+            ),
+        }
+        if blob.mimetype not in (  # type: ignore[attr-defined]
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ):
+            raise ValueError("This blob type is not supported for this parser.")
+        with blob.as_bytes_io() as excel_document:  # type: ignore[attr-defined]
+            elements = mime_type_parser[blob.mimetype](file=excel_document)  # type: ignore[attr-defined]
+            yield from self.post_process_unstructured_elements(elements, blob.source)

--- a/libs/community/langchain_community/document_loaders/parsers/excel.py
+++ b/libs/community/langchain_community/document_loaders/parsers/excel.py
@@ -20,13 +20,14 @@ class ExcelParser(BaseBlobParser):
                 "htmltabletomd`."
             ) from e
         last_page = None
+        page_text: str = ""
         for element in elements:
             if element.metadata.page_number != last_page:
                 if last_page:
                     metadata = {"source": source, "title": element.metadata.page_name}  # type: ignore[attr-defined]
-                    yield Document(page_content=page_text, metadata=metadata)
-                page_text = f"# {element.metadata.page_name}\n"
-                last_page = element.metadata.page_number
+                    yield Document(page_content=page_text, metadata=metadata)  # type: ignore[attr-defined]
+                page_text: str = f"# {element.metadata.page_name}\n"
+                last_page: int = element.metadata.page_number
 
             if type(element).__name__ == "Title":
                 page_text += f"## {element.text}\n"

--- a/libs/community/langchain_community/document_loaders/parsers/registry.py
+++ b/libs/community/langchain_community/document_loaders/parsers/registry.py
@@ -1,6 +1,7 @@
 """Module includes a registry of default parser configurations."""
 
 from langchain_community.document_loaders.base import BaseBlobParser
+from langchain_community.document_loaders.parsers.excel import ExcelParser
 from langchain_community.document_loaders.parsers.generic import MimeTypeBasedParser
 from langchain_community.document_loaders.parsers.msword import MsWordParser
 from langchain_community.document_loaders.parsers.pdf import PyMuPDFParser
@@ -16,6 +17,9 @@ def _get_default_parser() -> BaseBlobParser:
             "application/msword": MsWordParser(),
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
                 MsWordParser()
+            ),
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": (
+                ExcelParser()
             ),
         },
         fallback_parser=None,

--- a/libs/community/langchain_community/document_loaders/sharepoint.py
+++ b/libs/community/langchain_community/document_loaders/sharepoint.py
@@ -42,7 +42,7 @@ class SharePointLoader(O365BaseLoader, BaseLoader):
         Returns:
             A sequence of supported file types.
         """
-        return _FileType.DOC, _FileType.DOCX, _FileType.PDF
+        return _FileType.DOC, _FileType.DOCX, _FileType.PDF, _FileType.XLSX
 
     @property
     def _scopes(self) -> List[str]:


### PR DESCRIPTION
# Description
Currently there is no implementation of `.xlsx` parser and consequently `FileSystemBlobLoader` as well as all loaders derived from `O365BaseLoader` are limited to `.doc`, `.docx`, `.pdf` and `.txt`. This PR uses _unstructured_ to implement `ExcelParser` parser very similar to `MsWordParser` (with just an extra bit of post processing).

## Dependencies: 
- *htmltabletomd*

## Tests
I've implemented a unit test for the `.xlsx` parser however it depends on `unstructured` module and I have a problem getting any version of unstructured to `pyproject.toml` that would work and didn't break something somewhere. Please let me know if anyone is willing to help me with that.

**Twitter handle: @martintriska1**

Is anyone willing to review this please? Thanks! @baskaryan, @eyurtsev, @ccurme
