### PR TITLE
community: AzureSearch: fix reranking for empty lists

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -1769,6 +1769,8 @@ def _reorder_results_with_maximal_marginal_relevance(
         )
         for result in results
     ]
+    if not docs:
+        return []
     documents, scores, vectors = map(list, zip(*docs))
 
     # Get the new order of results.


### PR DESCRIPTION
**Description:** 
  Fix reranking for empty lists 

**Issue:** 
```
ValueError: not enough values to unpack (expected 3, got 0)
    documents, scores, vectors = map(list, zip(*docs))
  File langchain_community/vectorstores/azuresearch.py", line 1680, in _reorder_results_with_maximal_marginal_relevance
```