### PR TITLE
fix: Correct typo in 'PromptTemplate' documentation

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1161,7 +1161,7 @@ class Runnable(Generic[Input, Output], ABC):
         - ``data``: **Dict[str, Any]**
 
 
-        Below is a table that illustrates some evens that might be emitted by various
+        Below is a table that illustrates some events that might be emitted by various
         chains. Metadata fields have been omitted from the table for brevity.
         Chain definitions have been included after the table.
 


### PR DESCRIPTION
This commit addresses a typographical error in the documentation for the async astream_events method. The word 'evens' was incorrectly used in the introductory sentence for the reference table, which could lead to confusion for users.\n\n### Changes Made:\n- Corrected 'Below is a table that illustrates some evens that might be emitted by various chains.' to 'Below is a table that illustrates some events that might be emitted by various chains.'\n\nThis enhancement improves the clarity of the documentation and ensures accurate terminology is used throughout the reference material.\n\nIssue Reference: #27107