### PR TITLE
Added mapping to fix CI for #langchain-aws:227.

### DIFF
--- a/libs/community/tests/unit_tests/load/test_serializable.py
+++ b/libs/community/tests/unit_tests/load/test_serializable.py
@@ -112,6 +112,11 @@ def test_serializable_mapping() -> None:
             "chat_models",
             "ChatGroq",
         ),
+        ("langchain_aws", "chat_models", "ChatBedrockConverse"): (
+            "langchain_aws",
+            "chat_models",
+            "ChatBedrockConverse",
+        ),
     }
     serializable_modules = import_all_modules("langchain")
 

--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -520,6 +520,11 @@ SERIALIZABLE_MAPPING: Dict[Tuple[str, ...], Tuple[str, ...]] = {
         "structured",
         "StructuredPrompt",
     ),
+    ("langchain_aws", "chat_models", "ChatBedrockConverse"): (
+        "langchain_aws",
+        "chat_models",
+        "ChatBedrockConverse",
+    ),
 }
 
 # Needed for backwards compatibility for old versions of LangChain where things


### PR DESCRIPTION
Fixes unit tests for `ChatBedrockConverse` in https://github.com/langchain-ai/langchain-aws/pull/227