### PR TITLE
feat: pass tool call id to tool runs

### DIFF
--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -1444,6 +1444,7 @@ class AgentExecutor(Chain):
                 verbose=self.verbose,
                 color=color,
                 callbacks=run_manager.get_child() if run_manager else None,
+                tool_call_id=agent_action.tool_call_id,
                 **tool_run_kwargs,
             )
         else:


### PR DESCRIPTION
Passes `tool_call_id` to the tools run during agent's execution. Without this, due to [this check](https://github.com/langchain-ai/langchain/blob/7a07196df683582c783edf164bfb6fe813135169/libs/core/langchain_core/tools/base.py#L884C5-L884C20), one can't access to the artifacts (if provided) from the result of the tool run.