### PR TITLE
fix: HuggingFaceEmbeddings add trust_remote_code of SentenceTransformer #27142

### DIFF
--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -90,7 +90,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
             ) from exc
 
         self.client = sentence_transformers.SentenceTransformer(
-            self.model_name, cache_folder=self.cache_folder, **self.model_kwargs
+            self.model_name, trust_remote_code=True, cache_folder=self.cache_folder, **self.model_kwargs
         )
 
     model_config = ConfigDict(extra="forbid", protected_namespaces=())


### PR DESCRIPTION
# Sentence Transformer trust_remote_code did not include in HuggingFaceEmbeddings from langchain_community.embedding.

## Description

Add `trust_remote_code=True` in `SentenceTransformer()` in file 'libs/community/langchain_community/embeddings/huggingface.py' line 92.

## Issue

Fixes #27142 
