### PR TITLE
docs: Grammar fix in concepts.mdx

### DIFF
--- a/docs/docs/concepts.mdx
+++ b/docs/docs/concepts.mdx
@@ -611,7 +611,7 @@ Read more about [defining tools that return artifacts here](/docs/how_to/tool_ar
 When designing tools to be used by a model, it is important to keep in mind that:
 
 - Chat models that have explicit [tool-calling APIs](/docs/concepts/#functiontool-calling) will be better at tool calling than non-fine-tuned models.
-- Models will perform better if the tools have well-chosen names, descriptions, and JSON schemas. This another form of prompt engineering.
+- Models will perform better if the tools have well-chosen names, descriptions, and JSON schemas. This is another form of prompt engineering.
 - Simple, narrowly scoped tools are easier for models to use than complex tools.
 
 #### Related


### PR DESCRIPTION
Missing "is" in a sentence about the Tool usage.

