### PR TITLE
community[patch]: Switch language parsers tree-sitter languages library, robustness [DRAFT]

### DIFF
--- a/docs/docs/integrations/document_loaders/source_code.ipynb
+++ b/docs/docs/integrations/document_loaders/source_code.ipynb
@@ -30,7 +30,7 @@
     "- Scala (*)\n",
     "- TypeScript (*)\n",
     "\n",
-    "Items marked with (*) require the packages `tree_sitter` and `tree_sitter_languages`.\n",
+    "Items marked with (*) require the packages `tree_sitter` and `tree_sitter_language_pack`.\n",
     "It is straightforward to add support for additional languages using `tree_sitter`,\n",
     "although this currently requires modifying LangChain.\n",
     "\n",
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -qU esprima esprima tree_sitter tree_sitter_languages"
+    "%pip install -qU esprima esprima tree_sitter tree_sitter_language_pack"
    ]
   },
   {

--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -85,7 +85,7 @@ tidb-vector>=0.0.3,<1.0.0
 timescale-vector==0.0.1
 tqdm>=4.48.0
 tree-sitter>=0.20.2,<0.21
-tree-sitter-languages>=1.8.0,<2
+tree-sitter-language-pack>=0.2.0,<0.3
 upstash-redis>=1.1.0,<2
 upstash-ratelimit>=1.1.0,<2
 vdms>=0.0.20

--- a/libs/community/langchain_community/document_loaders/parsers/language/c.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/c.py
@@ -25,7 +25,7 @@ class CSegmenter(TreeSitterSegmenter):
     """Code segmenter for C."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("c")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/cpp.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/cpp.py
@@ -25,7 +25,7 @@ class CPPSegmenter(TreeSitterSegmenter):
     """Code segmenter for C++."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("cpp")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/csharp.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/csharp.py
@@ -25,7 +25,7 @@ class CSharpSegmenter(TreeSitterSegmenter):
     """Code segmenter for C#."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("c_sharp")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/elixir.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/elixir.py
@@ -24,7 +24,7 @@ class ElixirSegmenter(TreeSitterSegmenter):
     """Code segmenter for Elixir."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("elixir")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/go.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/go.py
@@ -20,7 +20,7 @@ class GoSegmenter(TreeSitterSegmenter):
     """Code segmenter for Go."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("go")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/java.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/java.py
@@ -21,7 +21,7 @@ class JavaSegmenter(TreeSitterSegmenter):
     """Code segmenter for Java."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("java")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/kotlin.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/kotlin.py
@@ -20,7 +20,7 @@ class KotlinSegmenter(TreeSitterSegmenter):
     """Code segmenter for Kotlin."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("kotlin")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/language_parser.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/language_parser.py
@@ -126,7 +126,7 @@ class LanguageParser(BaseBlobParser):
     - TypeScript: "ts" (*)
 
     Items marked with (*) require the packages `tree_sitter` and
-    `tree_sitter_languages`. It is straightforward to add support for additional
+    `tree_sitter_language_pack`. It is straightforward to add support for additional
     languages using `tree_sitter`, although this currently requires modifying LangChain.
 
     The language used for parsing can be configured, along with the minimum number of

--- a/libs/community/langchain_community/document_loaders/parsers/language/lua.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/lua.py
@@ -22,7 +22,7 @@ class LuaSegmenter(TreeSitterSegmenter):
     """Code segmenter for Lua."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("lua")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/perl.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/perl.py
@@ -19,7 +19,7 @@ class PerlSegmenter(TreeSitterSegmenter):
     """Code segmenter for Perl."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("perl")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/php.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/php.py
@@ -24,7 +24,7 @@ class PHPSegmenter(TreeSitterSegmenter):
     """Code segmenter for PHP."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("php")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/ruby.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/ruby.py
@@ -21,7 +21,7 @@ class RubySegmenter(TreeSitterSegmenter):
     """Code segmenter for Ruby."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("ruby")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/rust.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/rust.py
@@ -23,7 +23,7 @@ class RustSegmenter(TreeSitterSegmenter):
     """Code segmenter for Rust."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("rust")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/scala.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/scala.py
@@ -22,7 +22,7 @@ class ScalaSegmenter(TreeSitterSegmenter):
     """Code segmenter for Scala."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("scala")
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/tree_sitter_segmenter.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/tree_sitter_segmenter.py
@@ -77,12 +77,14 @@ class TreeSitterSegmenter(CodeSegmenter):
             if any(line in processed_lines for line in lines):
                 continue
 
-            simplified_lines[start_line] = self.make_line_comment(
-                f"Code for: {self.source_lines[start_line]}"
-            )
+            if start_line < len(simplified_lines):
+                simplified_lines[start_line] = self.make_line_comment(
+                    f"Code for: {self.source_lines[start_line]}"
+                )
 
             for line_num in range(start_line + 1, end_line + 1):
-                simplified_lines[line_num] = None  # type: ignore
+                if line_num < len(simplified_lines):
+                    simplified_lines[line_num] = None  # type: ignore
 
             processed_lines.update(lines)
 

--- a/libs/community/langchain_community/document_loaders/parsers/language/tree_sitter_segmenter.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/tree_sitter_segmenter.py
@@ -18,12 +18,12 @@ class TreeSitterSegmenter(CodeSegmenter):
 
         try:
             import tree_sitter  # noqa: F401
-            import tree_sitter_languages  # noqa: F401
+            import tree_sitter_language_pack  # noqa: F401
         except ImportError:
             raise ImportError(
-                "Could not import tree_sitter/tree_sitter_languages Python packages. "
-                "Please install them with "
-                "`pip install tree-sitter tree-sitter-languages`."
+                "Could not import tree_sitter/tree_sitter_language_pack Python "
+                "packages. Please install them with "
+                "`pip install tree-sitter tree-sitter-language-pack`."
             )
 
     def is_valid(self) -> bool:

--- a/libs/community/langchain_community/document_loaders/parsers/language/typescript.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/typescript.py
@@ -22,7 +22,7 @@ class TypeScriptSegmenter(TreeSitterSegmenter):
     """Code segmenter for TypeScript."""
 
     def get_language(self) -> "Language":
-        from tree_sitter_languages import get_language
+        from tree_sitter_language_pack import get_language
 
         return get_language("typescript")
 

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_c.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_c.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.c import CSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestCSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """int main() {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_cpp.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_cpp.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.cpp import CPPSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestCPPSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """int foo() {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_csharp.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_csharp.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.csharp import CSharpSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestCSharpSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """namespace World

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_elixir.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_elixir.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.elixir import ElixirSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestElixirSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """@doc "some comment"

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_go.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_go.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.go import GoSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestGoSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """func foo(a int) int {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_java.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_java.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.java import JavaSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestJavaSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """class Hello

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_kotlin.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_kotlin.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.kotlin import KotlinSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestKotlinSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """fun foo(a: Int): Int {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_lua.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_lua.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.lua import LuaSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestLuaSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """function F()

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_perl.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_perl.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.perl import PerlSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestPerlSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """sub Hello {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_php.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_php.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.php import PHPSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestPHPSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """<?php

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_ruby.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_ruby.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.ruby import RubySegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestRubySegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """def foo

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_rust.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_rust.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.rust import RustSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestRustSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """fn foo() -> i32 {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_scala.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_scala.py
@@ -5,7 +5,7 @@ import pytest
 from langchain_community.document_loaders.parsers.language.scala import ScalaSegmenter
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestScalaSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """def foo() {

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_typescript.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_typescript.py
@@ -7,7 +7,7 @@ from langchain_community.document_loaders.parsers.language.typescript import (
 )
 
 
-@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+@pytest.mark.requires("tree_sitter", "tree_sitter_language_pack")
 class TestTypeScriptSegmenter(unittest.TestCase):
     def setUp(self) -> None:
         self.example_code = """function foo(): number


### PR DESCRIPTION
Please see commit messages, I was not able to get going with `tree-sitter-languages`.

Four of the languages don't make it through the tests (CSharp, Perl, PHP, TypeScript). If this PR is welcome in general, I can have a look at those.

So for now this is a “works for me” patch, it might be helpful to other people.

My original error message, for the Googlez:

```
Traceback (most recent call last):
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
             ^^^^^^
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 579, in code_to_exec
    exec(code, module.__dict__)
  File "/Users/self/Documents/hacking/carag/carag.py", line 49, in <module>
    st.session_state.docs = loader.load()
                            ^^^^^^^^^^^^^
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/langchain_core/document_loaders/base.py", line 31, in load
    return list(self.lazy_load())
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/langchain_community/document_loaders/generic.py", line 116, in lazy_load
    yield from self.blob_parser.lazy_parse(blob)
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/langchain_community/document_loaders/parsers/language/language_parser.py", line 220, in lazy_parse
    if not segmenter.is_valid():
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/langchain_community/document_loaders/parsers/language/tree_sitter_segmenter.py", line 30, in is_valid
    language = self.get_language()
               ^^^^^^^^^^^^^^^^^^^
  File "/Users/self/Documents/hacking/carag/.venv/lib/python3.11/site-packages/langchain_community/document_loaders/parsers/language/elixir.py", line 29, in get_language
    return get_language("elixir")
           ^^^^^^^^^^^^^^^^^^^^^^
  File "tree_sitter_languages/core.pyx", line 14, in tree_sitter_languages.core.get_language
TypeError: __init__() takes exactly 1 argument (2 given)
```