### PR TITLE
community: improve retrieval speed of BM25Retriever

### DIFF
--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -11,6 +11,79 @@ from pydantic import ConfigDict, Field
 def default_preprocessing_func(text: str) -> List[str]:
     return text.split()
 
+def create_bm25_vectorizer(corpus, **bm25_params):
+    try:
+        from rank_bm25 import BM25Okapi
+    except ImportError:
+        raise ImportError(
+            "Could not import rank_bm25, please install with `pip install "
+            "rank_bm25`."
+        )
+    
+    class BM25Vectorizer(BM25Okapi):
+        def __init__(self, corpus, **bm25_params):            
+            super().__init__(corpus, **bm25_params)
+            self.vocabulary = list(self.idf.keys())
+            self.word_to_id = {word: i for i, word in enumerate(self.vocabulary)}
+        
+        def transform(self, queries: list[list[str]]) -> scipy.sparse.csr_matrix:
+            try:
+                from scipy.sparse import csr_matrix
+            except ImportError:
+                raise ImportError(
+                    "Could not import scipy, please install with `pip install "
+                    "scipy`."
+                )
+            
+            rows = []
+            cols = []
+            data = []
+            
+            for i, query in enumerate(queries):
+                query_len = len(query)
+                
+                for word in set(query):
+                    if word in self.word_to_id:
+                        word_id = self.word_to_id[word]
+                        tf = query.count(word)
+                        idf = self.idf.get(word, 0)
+                        
+                        # BM25 scoring formula
+                        numerator = idf * tf * (self.k1 + 1)
+                        denominator = tf + self.k1 * (1 - self.b + self.b * query_len / self.avgdl)
+                        
+                        score = numerator / denominator
+                        
+                        rows.append(i)
+                        cols.append(word_id)
+                        data.append(score)
+            
+            return csr_matrix((data, (rows, cols)), shape=(len(queries), len(self.vocabulary)))
+        
+        def count_transform(self, queries: list[list[str]]) -> scipy.sparse.csr_matrix:
+            try:
+                from scipy.sparse import csr_matrix
+            except ImportError:
+                raise ImportError(
+                    "Could not import scipy, please install with `pip install "
+                    "scipy`."
+                )
+            
+            rows = []
+            cols = []
+            data = []
+            
+            for i, query in enumerate(queries):
+                for word in query:
+                    if word in self.word_to_id:
+                        word_id = self.word_to_id[word]
+                        rows.append(i)
+                        cols.append(word_id)
+                        data.append(1)  # Count is always 1 for each occurrence
+            
+            return csr_matrix((data, (rows, cols)), shape=(len(queries), len(self.vocabulary)))
+    
+    return BM25Vectorizer(corpus, **bm25_params)
 
 class BM25Retriever(BaseRetriever):
     """`BM25` retriever without Elasticsearch."""
@@ -19,6 +92,8 @@ class BM25Retriever(BaseRetriever):
     """ BM25 vectorizer."""
     docs: List[Document] = Field(repr=False)
     """ List of documents."""
+    bm25_array: Any = None
+    """BM25 array."""
     k: int = 4
     """ Number of documents to return."""
     preprocess_func: Callable[[str], List[str]] = default_preprocessing_func
@@ -49,21 +124,14 @@ class BM25Retriever(BaseRetriever):
         Returns:
             A BM25Retriever instance.
         """
-        try:
-            from rank_bm25 import BM25Okapi
-        except ImportError:
-            raise ImportError(
-                "Could not import rank_bm25, please install with `pip install "
-                "rank_bm25`."
-            )
-
         texts_processed = [preprocess_func(t) for t in texts]
         bm25_params = bm25_params or {}
-        vectorizer = BM25Okapi(texts_processed, **bm25_params)
+        vectorizer = create_bm25_vectorizer(texts_processed, **bm25_params)
+        bm25_array = vectorizer.transform(texts_processed)
         metadatas = metadatas or ({} for _ in texts)
         docs = [Document(page_content=t, metadata=m) for t, m in zip(texts, metadatas)]
         return cls(
-            vectorizer=vectorizer, docs=docs, preprocess_func=preprocess_func, **kwargs
+            vectorizer=vectorizer, docs=docs, bm25_array=bm25_array, preprocess_func=preprocess_func, **kwargs
         )
 
     @classmethod
@@ -99,5 +167,7 @@ class BM25Retriever(BaseRetriever):
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> List[Document]:
         processed_query = self.preprocess_func(query)
-        return_docs = self.vectorizer.get_top_n(processed_query, self.docs, n=self.k)
+        query_vec = self.vectorizer.count_transform([processed_query])
+        results = query_vec.dot(self.bm25_array.T).toarray()[0]
+        return_docs = [self.docs[i] for i in results.argsort()[-self.k :][::-1]]
         return return_docs

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -20,12 +20,14 @@ def create_bm25_vectorizer(corpus: Iterable[Iterable[str]], **bm25_params: Any) 
     Create a BM25 vectorizer from the given corpus.
 
     Args:
-        corpus: An iterable of tokenized documents, where each document is an iterable of strings.
-        **bm25_params: Additional parameters to be passed to the BM25Okapi constructor.
+        corpus: An iterable of tokenized documents, where each document is
+                an iterable of strings.
+        **bm25_params: Additional parameters to be passed to the BM25Okapi
+                constructor.
 
     Returns:
-        Any: A BM25Vectorizer instance, which is a custom class that extends BM25Okapi
-             with additional functionality for vectorization.
+        Any: A BM25Vectorizer instance, which is a custom class that extends
+             BM25Okapi with additional functionality for vectorization.
     """
     try:
         from rank_bm25 import BM25Okapi


### PR DESCRIPTION
# PR Message

## Overview
- Significantly improved search speed of BM25Retriever (approximately 50 times faster for 100k documents retrieval).
- Initialization time increases by 2-3 times, but this is a one-time cost.
- Slight differences in search results may occur, but these are negligible for practical use.
- No API changes, so existing code can be used as-is.
- The scipy library is now required as an additional dependency, which can be installed via pip.

If this modification aligns with the principles of langchain, I would be grateful if it could be merged.

## Cause
In rank_bm25 used by BM25Retriever, BM25 scores are calculated using dictionary operations for each query, which may be causing the slow speed.

## Solution and Implementation
TFIDFRetriever is fast because it pre-computes weight matrices for the corpus and uses matrix operations to calculate similarities during searches.
I implemented a similar approach for BM25Retriever. Specifically, I made the following changes:
- Extended rank_bm25.BM25Okapi to add a method for converting sentences into weight vectors
  - Scipy library (installable via pip) is additionally used for efficient storage and computation of sparse matrices.
- In BM25Retriever.from_texts, created BM25 weight vectors for each document in the corpus and saved them as properties
- In BM25Retriever._get_relevant_documents, calculated BM25 scores as the dot product of the query word frequency vector and the corpus document weight vectors.

## Evaluation
When evaluated on a corpus of 100,000 documents, initialization became 2-3 times slower, but searching became about 50 times faster.
Since initialization can be completed before the user starts, search speed is more likely to affect user experience. Therefore, this improvement is considered useful for many use cases.

As the search process was changed, the BM25 scores no longer completely match those from before the change, but the difference was very small. Specifically, while the average value of the top 100 BM25 scores was around 30, the absolute difference in BM25 scores between the conventional method and the improved method was on the order of 10 to the minus 16th power.
There was also a slight impact on search results, but it seems to be at a negligible level for practical use. Specifically, when comparing the top 100 search results of BM25Retriever.invoke for 100 queries between the conventional and improved methods, 94 queries had completely matching top 100 search results. Of the remaining 6 queries, one had a difference in the 6th place result, and the other 5 all had differences in the 50th place result. Therefore, for applications like RAG that prioritize top search results, this difference appears to have minimal impact.

The source code used for evaluation, detailed results, and analysis are available for viewing at the following repository:
https://github.com/jiroshimaya/fast-langchain-sparse-retriever

# Checklist
- [x] **PR title**: "package: description"
- [x] **PR message**
  - PR message was written considering guidelines. 
- [x] **Add tests and docs**: If you're adding a new integration, please include
  - no tests and docs added 
- [x] **Lint and test**

---
twitter handle: @shimajiroxyz