### PR TITLE
community: Replace pypdf2 import with pypdf

### DIFF
--- a/libs/community/langchain_community/document_loaders/googledrive.py
+++ b/libs/community/langchain_community/document_loaders/googledrive.py
@@ -335,7 +335,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             return docs
 
         else:
-            from PyPDF2 import PdfReader
+            from pypdf import PdfReader
 
             content = fh.getvalue()
             pdf_reader = PdfReader(BytesIO(content))


### PR DESCRIPTION
Replace the dependency PyPDF2 with PyPDF. PyPDF2 is an old fork from PyPDF which hasn't been updated for 11years.