### PR TITLE
core[patch]: Ignore ASYNC110 to upgrade to newest ruff version

### DIFF
--- a/libs/core/langchain_core/rate_limiters.py
+++ b/libs/core/langchain_core/rate_limiters.py
@@ -249,7 +249,13 @@ class InMemoryRateLimiter(BaseRateLimiter):
             return self._consume()
 
         while not self._consume():
-            await asyncio.sleep(self.check_every_n_seconds)
+            # This code ignores the ASYNC110 warning which is a false positive in this
+            # case.
+            # There is no external actor that can mark that the Event is done
+            # since the tokens are managed by the rate limiter itself.
+            # It needs to wake up to re-fill the tokens.
+            # https://docs.astral.sh/ruff/rules/async-busy-wait/
+            await asyncio.sleep(self.check_every_n_seconds)  # ruff: noqa: ASYNC110
         return True
 
 


### PR DESCRIPTION
Ignoring ASYNC110 with explanation