### PR TITLE
langchain-mongodb: add asynchronous MongoDB support for chat message history

### DIFF
--- a/libs/partners/mongodb/langchain_mongodb/chat_message_histories.py
+++ b/libs/partners/mongodb/langchain_mongodb/chat_message_histories.py
@@ -123,7 +123,7 @@ class MongoDBChatMessageHistory(BaseChatMessageHistory):
         self.collection = self.db[collection_name]
 
         if _motor_available:
-            self.async_client: AsyncIOMotorClient = AsyncIOMotorClient(connection_string)
+            self.async_client = AsyncIOMotorClient(connection_string)
             self.async_db = self.async_client[database_name]
             self.async_collection = self.async_db[collection_name]
         else:
@@ -169,7 +169,8 @@ class MongoDBChatMessageHistory(BaseChatMessageHistory):
         if not _motor_available:
             logger.warning(
                 "Motor library is not installed. "
-                "Using `run_in_executor` for aget_messages, which may be less efficient."
+                "Using `run_in_executor` for aget_messages, "
+                "which may be less efficient."
             )
             return await super().aget_messages()
 
@@ -211,7 +212,8 @@ class MongoDBChatMessageHistory(BaseChatMessageHistory):
         if not _motor_available:
             logger.warning(
                 "Motor library is not installed. "
-                "Using `run_in_executor` for aadd_messages, which may be less efficient."
+                "Using `run_in_executor` for aadd_messages, "
+                "which may be less efficient."
             )
             return await super().aadd_messages(messages)
 

--- a/libs/partners/mongodb/langchain_mongodb/chat_message_histories.py
+++ b/libs/partners/mongodb/langchain_mongodb/chat_message_histories.py
@@ -19,6 +19,7 @@ DEFAULT_HISTORY_KEY = "History"
 
 try:
     from motor.motor_asyncio import AsyncIOMotorClient
+
     _motor_available = True
 except ImportError:
     AsyncIOMotorClient = None

--- a/libs/partners/mongodb/langchain_mongodb/chat_message_histories.py
+++ b/libs/partners/mongodb/langchain_mongodb/chat_message_histories.py
@@ -18,7 +18,7 @@ DEFAULT_SESSION_ID_KEY = "SessionId"
 DEFAULT_HISTORY_KEY = "History"
 
 try:
-    from motor.motor_asyncio import AsyncIOMotorClient
+    from motor.motor_asyncio import AsyncIOMotorClient  # type: ignore
 
     _motor_available = True
 except ImportError:
@@ -155,7 +155,6 @@ class MongoDBChatMessageHistory(BaseChatMessageHistory):
                 )
         except errors.OperationFailure as error:
             logger.error(error)
-            cursor = []
 
         if cursor:
             items = [json.loads(document[self.history_key]) for document in cursor]


### PR DESCRIPTION
This pull request adds asynchronous support to the MongoDBChatMessageHistory class in the langchain-mongodb package. It introduces async methods for fetching, adding, and clearing chat messages, leveraging the motor library for non-blocking operations. If motor is not installed, the implementation falls back to using run_in_executor from the parent class to ensure compatibility. This update maintains backward compatibility for users not using asynchronous operations.

Key changes:
- Added async methods: aget_messages, aadd_messages, and aclear.
- Fallback to run_in_executor when motor is unavailable.

No new dependencies are required unless you choose to install motor for async functionality.