### PR TITLE
docs: Migrate Makefile to Compose V2 syntax

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,9 +4,9 @@ build_graphdb:
 	docker build --tag graphdb ./graphdb
 
 start_graphdb:
-	docker-compose up -d graphdb
+	docker compose up -d graphdb
 
 down:
-	docker-compose down -v --remove-orphans
+	docker compose down -v --remove-orphans
 
 .PHONY: build_graphdb start_graphdb down


### PR DESCRIPTION
docs: Migrate Makefile to Compose V2 syntax
Description：The Makefile now reflects the change from using Compose V1 (docker-compose) to Compose V2 (docker compose).
