### PR TITLE
core: Added comparison in `parse_result` method

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -290,7 +290,8 @@ class PydanticToolsParser(JsonOutputToolsParser):
                         f"{res['args']}"
                     )
                     raise ValueError(msg)
-                pydantic_objects.append(name_dict[res["type"]](**res["args"]))
+                if res["type"]:
+                    pydantic_objects.append(name_dict[res["type"]](**res["args"]))
             except (ValidationError, ValueError) as e:
                 if partial:
                     continue


### PR DESCRIPTION
Issue:
Occurring with `watsonx` implementation. 

Steps:
```
class Joke(BaseModel):
    """Joke to tell user."""

    setup: str = Field(description="question to set up a joke")
    punchline: str = Field(description="answer to resolve the joke")

chat = model.with_structured_output(Joke)

for chunk in chat.stream("Tell me a joke about cats."):
    assert isinstance(chunk, Joke)
```

Error:
```
self = PydanticToolsParser(first_tool_only=True, tools=[<class 'langchain_standard_tests.integration_tests.chat_models.Joke'>])
result = [ChatGenerationChunk(message=AIMessageChunk(content='', additional_kwargs={'tool_calls': [{'index': 0, 'id': 'chatcmpl...otal_tokens': 216}, tool_call_chunks=[{'name': None, 'args': '', 'id': None, 'index': 0, 'type': 'tool_call_chunk'}]))]

    def parse_result(self, result: list[Generation], *, partial: bool = False) -> Any:
        """Parse the result of an LLM call to a list of Pydantic objects.
    
        Args:
            result: The result of the LLM call.
            partial: Whether to parse partial JSON.
                If True, the output will be a JSON object containing
                all the keys that have been returned so far.
                If False, the output will be the full JSON object.
                Default is False.
    
        Returns:
            The parsed Pydantic objects.
    
        Raises:
            OutputParserException: If the output is not valid JSON.
        """
        json_results = super().parse_result(result, partial=partial)
        if not json_results:
            return None if self.first_tool_only else []
    
        json_results = [json_results] if self.first_tool_only else json_results
        name_dict = {tool.__name__: tool for tool in self.tools}
        pydantic_objects = []
        for res in json_results:
            try:
                if not isinstance(res["args"], dict):
                    raise ValueError(
                        f"Tool arguments must be specified as a dict, received: "
                        f"{res['args']}"
                    )
>               pydantic_objects.append(name_dict[res["type"]](**res["args"]))
E               KeyError: ''
```

Solution:
- Added key validation