### PR TITLE
Generate vectors with only positive values:langchain_community.embeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/fake.py
+++ b/libs/community/langchain_community/embeddings/fake.py
@@ -13,7 +13,7 @@ class FakeEmbeddings(Embeddings, BaseModel):
     """The size of the embedding vector."""
 
     def _get_embedding(self) -> List[float]:
-        return list(np.random.normal(size=self.size))
+        return list(abs(np.random.normal(size=self.size)))
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         return [self._get_embedding() for _ in texts]


### PR DESCRIPTION
**Description:** 
Generate vectors for which cosine distance will always be between 0 and 1, to comply with similarity_search_with_relevance_scores requirement of returning only values between 0 and 1

**Issue:** 
N/A

**Dependencies:** 
None
