### PR TITLE
docs: fix typo on friendli.ipynb

### DIFF
--- a/docs/docs/integrations/chat/friendli.ipynb
+++ b/docs/docs/integrations/chat/friendli.ipynb
@@ -29,7 +29,7 @@
     "Ensure the `langchain_community` and `friendli-client` are installed.\n",
     "\n",
     "```sh\n",
-    "pip install -U langchain-comminity friendli-client.\n",
+    "pip install -U langchain-community friendli-client.\n",
     "```\n",
     "\n",
     "Sign in to [Friendli Suite](https://suite.friendli.ai/) to create a Personal Access Token, and set it as the `FRIENDLI_TOKEN` environment."

--- a/docs/docs/integrations/llms/friendli.ipynb
+++ b/docs/docs/integrations/llms/friendli.ipynb
@@ -29,7 +29,7 @@
     "Ensure the `langchain_community` and `friendli-client` are installed.\n",
     "\n",
     "```sh\n",
-    "pip install -U langchain-comminity friendli-client.\n",
+    "pip install -U langchain-community friendli-client.\n",
     "```\n",
     "\n",
     "Sign in to [Friendli Suite](https://suite.friendli.ai/) to create a Personal Access Token, and set it as the `FRIENDLI_TOKEN` environment."


### PR DESCRIPTION
This PR fixes typos in `chat/friendli.ipynb` and `llms/friendli.ipynb` docs.