### PR TITLE
docs: fix docker command

### DIFF
--- a/docs/docs/integrations/memory/redis_chat_message_history.ipynb
+++ b/docs/docs/integrations/memory/redis_chat_message_history.ipynb
@@ -36,7 +36,7 @@
     "Make sure you have a Redis server running. You can start one using Docker with the following command:\n",
     "\n",
     "```\n",
-    "docker run -d -p 6379:6379 redis:latest\n",
+    "docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest\n",
     "```\n",
     "\n",
     "Or install and run Redis locally according to the instructions for your operating system."


### PR DESCRIPTION


- [ ] **docs**: "fix docker command"


  - **Description:** he Redis chat message history component requires the Redis Stack to create indexes. When using only Redis, the following error occurs: "Unknown command 'FT.INFO', with args beginning with: 'chat_history'".
  - **Twitter handle:** savar_bhasin




