### PR TITLE
docs: update API Reference Link in /docs/how_to/vectorstore_retriever/

### DIFF
--- a/docs/docs/how_to/vectorstore_retriever.ipynb
+++ b/docs/docs/how_to/vectorstore_retriever.ipynb
@@ -77,7 +77,7 @@
    "id": "08f8b820-5912-49c1-9d76-40be0571dffb",
    "metadata": {},
    "source": [
-    "This creates a retriever (specifically a [VectorStoreRetriever](https://python.langchain.com/api_reference/core/vectorstores/langchain_core.vectorstores.VectorStoreRetriever.html)), which we can use in the usual way:"
+    "This creates a retriever (specifically a [VectorStoreRetriever](https://python.langchain.com/api_reference/core/vectorstores/langchain_core.vectorstores.base.VectorStoreRetriever.html)), which we can use in the usual way:"
    ]
   },
   {


### PR DESCRIPTION
Description: updated docs [here](https://python.langchain.com/docs/how_to/vectorstore_retriever/#:~:text=VectorStoreRetriever) for creating VectorStoreRetrievers. The URL was missing a `.base`, and now works as expected. 

This was a fix for Issue #27196 