### PR TITLE
core: Handle arguments returned by Text Generation Inference's Messages API

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -39,25 +39,35 @@ def parse_tool_call(
     """
     if "function" not in raw_tool_call:
         return None
-    if partial:
-        try:
-            function_args = parse_partial_json(
-                raw_tool_call["function"]["arguments"], strict=strict
-            )
-        except (JSONDecodeError, TypeError):  # None args raise TypeError
-            return None
+    if isinstance(raw_tool_call["function"]["arguments"], str):  # OpenAI returns arguments as str
+        if partial:
+            try:
+                function_args = parse_partial_json(
+                    raw_tool_call["function"]["arguments"], strict=strict
+                )
+            except (JSONDecodeError, TypeError):  # None args raise TypeError
+                return None
+        else:
+            try:
+                function_args = json.loads(
+                    raw_tool_call["function"]["arguments"], strict=strict
+                )
+            except JSONDecodeError as e:
+                msg = (
+                    f"Function {raw_tool_call['function']['name']} arguments:\n\n"
+                    f"{raw_tool_call['function']['arguments']}\n\nare not valid JSON. "
+                    f"Received JSONDecodeError {e}"
+                )
+                raise OutputParserException(msg) from e
+    elif isinstance(raw_tool_call["function"]["arguments"], dict): # TGI returns arguments as dict
+        function_args = raw_tool_call["function"]["arguments"]
     else:
-        try:
-            function_args = json.loads(
-                raw_tool_call["function"]["arguments"], strict=strict
+        msg = (
+            f"Function {raw_tool_call['function']['name']} arguments:\n\n",
+            f"Arguments passed as {type(raw_tool_call['function']['name'])}. Must be str or dict."
             )
-        except JSONDecodeError as e:
-            msg = (
-                f"Function {raw_tool_call['function']['name']} arguments:\n\n"
-                f"{raw_tool_call['function']['arguments']}\n\nare not valid JSON. "
-                f"Received JSONDecodeError {e}"
-            )
-            raise OutputParserException(msg) from e
+        raise OutputParserException(msg)
+
     parsed = {
         "name": raw_tool_call["function"]["name"] or "",
         "args": function_args or {},

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -65,7 +65,7 @@ def parse_tool_call(
         function_args = raw_tool_call["function"]["arguments"]
     else:
         msg = (
-            f"Function {raw_tool_call['function']['name']} arguments:\n\n",
+            f"Function {raw_tool_call['function']['name']} arguments:\n\n"
             f"Arguments passed as {type(raw_tool_call['function']['name'])}. "
             "Must be str or dict."
             )

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -68,7 +68,7 @@ def parse_tool_call(
             f"Function {raw_tool_call['function']['name']} arguments:\n\n"
             f"Arguments passed as {type(raw_tool_call['function']['name'])}. "
             "Must be str or dict."
-            )
+        )
         raise OutputParserException(msg)
 
     parsed = {

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -39,7 +39,8 @@ def parse_tool_call(
     """
     if "function" not in raw_tool_call:
         return None
-    if isinstance(raw_tool_call["function"]["arguments"], str):  # OpenAI returns arguments as str
+    if isinstance(raw_tool_call["function"]["arguments"], str):
+        # OpenAI returns arguments as str
         if partial:
             try:
                 function_args = parse_partial_json(
@@ -59,12 +60,14 @@ def parse_tool_call(
                     f"Received JSONDecodeError {e}"
                 )
                 raise OutputParserException(msg) from e
-    elif isinstance(raw_tool_call["function"]["arguments"], dict): # TGI returns arguments as dict
+    elif isinstance(raw_tool_call["function"]["arguments"], dict):
+        # TGI returns arguments as dict
         function_args = raw_tool_call["function"]["arguments"]
     else:
         msg = (
             f"Function {raw_tool_call['function']['name']} arguments:\n\n",
-            f"Arguments passed as {type(raw_tool_call['function']['name'])}. Must be str or dict."
+            f"Arguments passed as {type(raw_tool_call['function']['name'])}. "
+            "Must be str or dict."
             )
         raise OutputParserException(msg)
 


### PR DESCRIPTION
core: Handle tool arguments returned by Text Generation Inference's messages API

- **Description:** The parser for OpenAI tool calls expects the function arguments to be returned as a string. This is true for OpenAI's own API, but not necessarily for OpenAI-compatible APIs like Text Generation Inference's (TGI) Messages API. TGI returns the arguments as a dictionary. Since some OpenAI-compatible tools refer to OpenAI's client library (which handles TGI's tool response correctly), it makes sense to also support them through LangChain's OpenAI wrappers. This PR checks the type of the returned arguments and correctly processes them accordingly.
- **Issue:** #26777 