### PR TITLE
core: improve performance of InMemoryVectorStore

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -351,7 +351,7 @@ class InMemoryVectorStore(VectorStore):
             top_k_idx = top_k_idx[:prefilter_k]
 
         result = [
-            (doc, similarity[idx], doc_dict["vector"])
+            (doc, float(similarity[idx].item()), doc_dict["vector"])
             for idx in top_k_idx
             for doc_dict in [docs[idx]]
             for doc in [

--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -326,45 +326,40 @@ class InMemoryVectorStore(VectorStore):
         self,
         embedding: list[float],
         k: int = 4,
-        prefilter_k_multiplier: Optional[int] = 10,
         filter: Optional[Callable[[Document], bool]] = None,
         **kwargs: Any,
     ) -> list[tuple[Document, float, list[float]]]:
         # get all docs with fixed order in list
         docs = list(self.store.values())
+
+        if filter is not None:
+            docs = [
+                doc
+                for doc in docs
+                if filter(Document(page_content=doc["text"], metadata=doc["metadata"]))
+            ]
+
         if not docs:
             return []
 
         similarity = cosine_similarity([embedding], [doc["vector"] for doc in docs])[0]
 
         # get the indices ordered by similarity score
-        top_k_idx = similarity.argsort()[::-1]
+        top_k_idx = similarity.argsort()[::-1][:k]
 
-        # prefilter to speed up for list comprehension below
-        if filter is not None:
-            # we can safely filter to top k if no filter is set
-            top_k_idx = top_k_idx[:k]
-        elif prefilter_k_multiplier is not None:
-            # Filter to top k * prefilter_k_multiplier
-            # We keep more than k to avoid returning less than k after filtering
-            prefilter_k = k * prefilter_k_multiplier
-            top_k_idx = top_k_idx[:prefilter_k]
-
-        result = [
-            (doc, float(similarity[idx].item()), doc_dict["vector"])
-            for idx in top_k_idx
-            for doc_dict in [docs[idx]]
-            for doc in [
+        return [
+            (
                 Document(
                     id=doc_dict["id"],
                     page_content=doc_dict["text"],
                     metadata=doc_dict["metadata"],
-                )
-            ]
-            if filter is None or filter(doc)
+                ),
+                float(similarity[idx].item()),
+                doc_dict["vector"],
+            )
+            for idx in top_k_idx
+            for doc_dict in [docs[idx]]
         ]
-
-        return result[:k]
 
     def similarity_search_with_score_by_vector(
         self,

--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -358,7 +358,8 @@ class InMemoryVectorStore(VectorStore):
                 doc_dict["vector"],
             )
             for idx in top_k_idx
-            for doc_dict in [docs[idx]]
+            # Assign using walrus operator to avoid multiple lookups
+            if (doc_dict := docs[idx])
         ]
 
     def similarity_search_with_score_by_vector(


### PR DESCRIPTION
**Description:** We improve the performance of the InMemoryVectorStore.
**Isue:** Originally, similarity was computed document by document:
```
for doc in self.store.values():
            vector = doc["vector"]
            similarity = float(cosine_similarity([embedding], [vector]).item(0))
```
This is inefficient and does not make use of numpy vectorization.
This PR computes the similarity in one vectorized go:
```
docs = list(self.store.values())
similarity = cosine_similarity([embedding], [doc["vector"] for doc in docs])
```
**Dependencies:** None
**Twitter handle:** @b12_consulting, @Vincent_Min