### PR TITLE
fix(core): support `handle_tool_error=(Exception, ...)` tuple

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -18,6 +18,7 @@ def tool(
     response_format: Literal["content", "content_and_artifact"] = "content",
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
+    **kwargs: Any,
 ) -> Callable:
     """Make tools out of functions, can be used with or without arguments.
 
@@ -42,6 +43,7 @@ def tool(
         error_on_invalid_docstring: if ``parse_docstring`` is provided, configure
             whether to raise ValueError on invalid Google Style docstrings.
             Defaults to True.
+        kwargs: Additional keyword arguments to pass to BaseTool constructor.
 
     Returns:
         The tool.
@@ -186,6 +188,7 @@ def tool(
                     response_format=response_format,
                     parse_docstring=parse_docstring,
                     error_on_invalid_docstring=error_on_invalid_docstring,
+                    **kwargs,
                 )
             # If someone doesn't want a schema applied, we must treat it as
             # a simple string->string function
@@ -202,6 +205,7 @@ def tool(
                 return_direct=return_direct,
                 coroutine=coroutine,
                 response_format=response_format,
+                **kwargs,
             )
 
         return _make_tool


### PR DESCRIPTION
Current handle_tool_error functionality doesn't support handling any exceptions outside of ToolException, meaning user has very little actual control over what gets handled (if the tool implementation doesn't raise ToolException then there's not much handling they can do). This pr proposes allowing users to specify the exception types they want handled, either directly via tuple[type[Exception]] or via the signature of Callable handler.