### PR TITLE
docs: canonical url fix

### DIFF
--- a/docs/src/theme/SiteMetadata/index.js
+++ b/docs/src/theme/SiteMetadata/index.js
@@ -62,6 +62,9 @@ function useDefaultCanonicalUrl() {
   const canonicalPathnameNoVersion = canonicalPathname.startsWith('/v0.') ? "/"+canonicalPathname.split('/').slice(2).join('/') : canonicalPathname;
   const suggestedLookup = suggestedLinks[canonicalPathnameNoVersion];
   const finalPathname = suggestedLookup?.canonical || canonicalPathname;
+  if (finalPathname.startsWith("https://")) {
+    return finalPathname;
+  }
   return siteUrl + finalPathname;
 }
 


### PR DESCRIPTION
canonical wrong on e.g. https://python.langchain.com/v0.1/docs/modules/agents/concepts/