### PR TITLE
community: chroma add id to Document result

### DIFF
--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -41,8 +41,12 @@ def _results_to_docs_and_scores(results: Any) -> List[Tuple[Document, float]]:
     return [
         # TODO: Chroma can do batch querying,
         # we shouldn't hard code to the 1st result
-        (Document(page_content=result[0], metadata=result[1] or {}), result[2])
+        (
+            Document(id=result[0], page_content=result[1], metadata=result[2] or {}),
+            result[3],
+        )
         for result in zip(
+            results["ids"][0],
             results["documents"][0],
             results["metadatas"][0],
             results["distances"][0],

--- a/libs/community/tests/unit_tests/vectorstores/test_chroma.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_chroma.py
@@ -1,0 +1,31 @@
+from langchain_core.documents import Document
+
+from langchain_community.vectorstores.chroma import _results_to_docs_and_scores
+
+_PAGE_CONTENT = """This is a page about LangChain.
+
+It is a really cool framework.
+
+What isn't there to love about langchain?
+
+Made in 2022."""
+
+
+def test_results_to_docs_and_scores():
+    """Test the results for correct document information."""
+    input_data = {
+        "ids": [["1"]],
+        "embeddings": None,
+        "documents": [[_PAGE_CONTENT]],
+        "metadatas": [[{"source": "1"}]],
+        "distances": [[0.1111]],
+    }
+
+    results = _results_to_docs_and_scores(input_data)
+
+    expected_results = (
+        Document(id="1", page_content=_PAGE_CONTENT, metadata={"source": "1"}),
+        0.1111,
+    )
+
+    assert results[0] == expected_results


### PR DESCRIPTION
  - **Description:** I add `id` property when create Document class. But after the search, the `id` property is missing. The reason is that the `_results_to_docs_and_scores` function does not return the `id` property. 
  - **Issue:**  You can reproduce the issue by the blow script
  - **Dependencies:** N/A
  - **Twitter handle:** @BrambleXu


```python
from langchain_chroma import Chroma
from langchain.schema import Document
from langchain_openai import OpenAIEmbeddings


data = [
    "LangChain is a framework for developing applications powered by language models.",
    "LangChain provides a standard interface for chains, enabling developers to create complex applications.",
    "LangChain supports both OpenAI and Hugging Face models, making it versatile for various use cases."
]

documents = []
count = 1
for sentence in data:
    documents.append(Document(page_content=sentence, metadata={"source": str(count)}, id=str(count)))
    count += 1

EMBEDDING_MODEL = "text-embedding-3-small"
embeddings = OpenAIEmbeddings(api_key=os.getenv("OPENAI_API_KEY"), model=EMBEDDING_MODEL)

vector_store = Chroma(
    collection_name="sample_collection",
    embedding_function=embeddings,
)

ids = [doc.id for doc in documents]
vector_store.add_documents(documents, ids=ids)

query = "What kind of models LangChain supports?"

results = vector_store.similarity_search_with_score(query=query, k=1)
print(results)
# [(Document(metadata={'source': '1'}, page_content='LangChain is a framework for developing applications powered by language models.'), 0.7262518405914307)]
```