### PR TITLE
Update passthrough.ipynb --  Grammar correction

### DIFF
--- a/docs/docs/how_to/passthrough.ipynb
+++ b/docs/docs/how_to/passthrough.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "## Next steps\n",
     "\n",
-    "Now you've learned how to pass data through your chains to help to help format the data flowing through your chains.\n",
+    "Now you've learned how to pass data through your chains to help format the data flowing through your chains.\n",
     "\n",
     "To learn more, see the other how-to guides on runnables in this section."
    ]


### PR DESCRIPTION
Grammar correction needed in passthrough.ipynb
The sentence is:

"Now you've learned how to pass data through your chains to help to help format the data flowing through your chains."

There's a redundant "to help", and it could be more succinctly written as:

"Now you've learned how to pass data through your chains to help format the data flowing through your chains."
