### PR TITLE
community: Add `@mozilla/readability` document transformer

### DIFF
--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -70,6 +70,7 @@ pymupdf>=1.22.3,<2
 pypdf>=3.4.0,<5
 pypdfium2>=4.10.0,<5
 pyspark>=3.4.0,<4
+python-readability>=0.1.2
 rank-bm25>=0.2.2,<0.3
 rapidfuzz>=3.1.1,<4
 rapidocr-onnxruntime>=1.3.2,<2

--- a/libs/community/langchain_community/document_transformers/__init__.py
+++ b/libs/community/langchain_community/document_transformers/__init__.py
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
     from langchain_community.document_transformers.markdownify import (
         MarkdownifyTransformer,
     )
+    from langchain_community.document_transformers.mozilla_readability import (
+        ReadabilityTransformer,
+    )
     from langchain_community.document_transformers.nuclia_text_transform import (
         NucliaTextTransformer,
     )
@@ -66,6 +69,7 @@ __all__ = [
     "Html2TextTransformer",
     "LongContextReorder",
     "MarkdownifyTransformer",
+    "ReadabilityTransformer",
     "NucliaTextTransformer",
     "OpenAIMetadataTagger",
     "get_stateful_documents",
@@ -82,6 +86,7 @@ _module_lookup = {
     "Html2TextTransformer": "langchain_community.document_transformers.html2text",
     "LongContextReorder": "langchain_community.document_transformers.long_context_reorder",  # noqa: E501
     "MarkdownifyTransformer": "langchain_community.document_transformers.markdownify",
+    "ReadabilityTransformer": "langchain_community.document_transformers.mozilla_readability",  # noqa: E501
     "NucliaTextTransformer": "langchain_community.document_transformers.nuclia_text_transform",  # noqa: E501
     "OpenAIMetadataTagger": "langchain_community.document_transformers.openai_functions",  # noqa: E501
     "get_stateful_documents": "langchain_community.document_transformers.embeddings_redundant_filter",  # noqa: E501

--- a/libs/community/langchain_community/document_transformers/__init__.py
+++ b/libs/community/langchain_community/document_transformers/__init__.py
@@ -69,9 +69,9 @@ __all__ = [
     "Html2TextTransformer",
     "LongContextReorder",
     "MarkdownifyTransformer",
-    "ReadabilityTransformer",
     "NucliaTextTransformer",
     "OpenAIMetadataTagger",
+    "ReadabilityTransformer",
     "get_stateful_documents",
 ]
 
@@ -86,9 +86,9 @@ _module_lookup = {
     "Html2TextTransformer": "langchain_community.document_transformers.html2text",
     "LongContextReorder": "langchain_community.document_transformers.long_context_reorder",  # noqa: E501
     "MarkdownifyTransformer": "langchain_community.document_transformers.markdownify",
-    "ReadabilityTransformer": "langchain_community.document_transformers.mozilla_readability",  # noqa: E501
     "NucliaTextTransformer": "langchain_community.document_transformers.nuclia_text_transform",  # noqa: E501
     "OpenAIMetadataTagger": "langchain_community.document_transformers.openai_functions",  # noqa: E501
+    "ReadabilityTransformer": "langchain_community.document_transformers.mozilla_readability",  # noqa: E501
     "get_stateful_documents": "langchain_community.document_transformers.embeddings_redundant_filter",  # noqa: E501
 }
 

--- a/libs/community/langchain_community/document_transformers/mozilla_readability.py
+++ b/libs/community/langchain_community/document_transformers/mozilla_readability.py
@@ -26,9 +26,7 @@ class ReadabilityTransformer(BaseDocumentTransformer):
         self.target = target
         self.options = readability_options
 
-    def transform_document(
-        self, document: Document, **override_options: Any
-    ) -> Document:
+    def transform_document(self, document: Document, **kwargs: Any) -> Document:
         try:
             from readability import parse
         except ImportError:
@@ -37,9 +35,11 @@ class ReadabilityTransformer(BaseDocumentTransformer):
                 "please install it with `pip install python-readability`"
             )
 
-        article = parse(document.page_content, **{**self.options, **override_options})
+        target: Literal["text", "html"] = kwargs.pop("target", self.target)
 
-        result = article.text_content if self.target == "html" else article.content
+        article = parse(document.page_content, **{**self.options, **kwargs})
+
+        result = article.text_content if target == "html" else article.content
 
         return Document(page_content=result or "", **document.metadata)
 

--- a/libs/community/langchain_community/document_transformers/mozilla_readability.py
+++ b/libs/community/langchain_community/document_transformers/mozilla_readability.py
@@ -40,7 +40,7 @@ class ReadabilityTransformer(BaseDocumentTransformer):
 
         article = parse(document.page_content, **{**self.options, **kwargs})
 
-        result = article.text_content if target == "html" else article.content
+        result = article.content if target == "html" else article.text_content
 
         metadata = {**document.metadata, **asdict(article)}
 

--- a/libs/community/langchain_community/document_transformers/mozilla_readability.py
+++ b/libs/community/langchain_community/document_transformers/mozilla_readability.py
@@ -1,0 +1,47 @@
+from typing import Any, Literal, Sequence
+
+from langchain_core.documents import BaseDocumentTransformer, Document
+
+
+class ReadabilityTransformer(BaseDocumentTransformer):
+    """A transformer that uses the Mozilla Readability library
+    to extract the main contentfrom a web page.
+
+    Arguments:
+        target: The target format of the extracted content; defaults to "text".
+        **readability_options: Additional options to pass to the readability parser.
+
+    Example:
+        .. code-block:: python
+            from langchain_community.document_transformers import ReadabilityTransformer
+            html2text = Html2TextTransformer()
+            docs_transform = html2text.transform_documents(docs)
+    """
+
+    def __init__(
+        self,
+        target: Literal["text", "html"] = "text",
+        **readability_options: Any,
+    ) -> None:
+        self.target = target
+        self.options = readability_options
+
+    def transform_document(self, document: Document) -> Document:
+        try:
+            from readability import parse
+        except ImportError:
+            raise ImportError(
+                "readability module not found, "
+                "please install it with `pip install python-readability`"
+            )
+
+        article = parse(document.page_content, **self.options)
+
+        result = article.text_content if self.target == "html" else article.content
+
+        return Document(page_content=result or "", **document.metadata)
+
+    def transform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        return list(map(self.transform_document, documents))

--- a/libs/community/langchain_community/document_transformers/mozilla_readability.py
+++ b/libs/community/langchain_community/document_transformers/mozilla_readability.py
@@ -26,7 +26,9 @@ class ReadabilityTransformer(BaseDocumentTransformer):
         self.target = target
         self.options = readability_options
 
-    def transform_document(self, document: Document) -> Document:
+    def transform_document(
+        self, document: Document, **override_options: Any
+    ) -> Document:
         try:
             from readability import parse
         except ImportError:
@@ -35,7 +37,7 @@ class ReadabilityTransformer(BaseDocumentTransformer):
                 "please install it with `pip install python-readability`"
             )
 
-        article = parse(document.page_content, **self.options)
+        article = parse(document.page_content, **{**self.options, **override_options})
 
         result = article.text_content if self.target == "html" else article.content
 
@@ -44,4 +46,4 @@ class ReadabilityTransformer(BaseDocumentTransformer):
     def transform_documents(
         self, documents: Sequence[Document], **kwargs: Any
     ) -> Sequence[Document]:
-        return list(map(self.transform_document, documents))
+        return [self.transform_document(doc, **kwargs) for doc in documents]

--- a/libs/community/langchain_community/document_transformers/mozilla_readability.py
+++ b/libs/community/langchain_community/document_transformers/mozilla_readability.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from typing import Any, Literal, Sequence
 
 from langchain_core.documents import BaseDocumentTransformer, Document
@@ -41,7 +42,9 @@ class ReadabilityTransformer(BaseDocumentTransformer):
 
         result = article.text_content if target == "html" else article.content
 
-        return Document(page_content=result or "", **document.metadata)
+        metadata = {**document.metadata, **asdict(article)}
+
+        return Document(page_content=result or "", **metadata)
 
     def transform_documents(
         self, documents: Sequence[Document], **kwargs: Any

--- a/libs/community/tests/unit_tests/document_transformers/test_imports.py
+++ b/libs/community/tests/unit_tests/document_transformers/test_imports.py
@@ -12,6 +12,7 @@ EXPECTED_ALL = [
     "LongContextReorder",
     "NucliaTextTransformer",
     "OpenAIMetadataTagger",
+    "ReadabilityTransformer",
     "Html2TextTransformer",
     "MarkdownifyTransformer",
 ]

--- a/libs/community/tests/unit_tests/document_transformers/test_mozilla_readability_transformer.py
+++ b/libs/community/tests/unit_tests/document_transformers/test_mozilla_readability_transformer.py
@@ -1,0 +1,28 @@
+"""Unit tests for mozilla readability document transformer."""
+
+import pytest
+from langchain_core.documents import Document
+
+from langchain_community.document_transformers import ReadabilityTransformer
+
+
+@pytest.mark.requires("python-readability")
+def test_empty_html() -> None:
+    readability = ReadabilityTransformer()
+    documents = [Document(page_content="<html></html>")]
+    [document] = readability.transform_documents(documents)
+    assert document.page_content == "", document.page_content
+
+
+@pytest.mark.requires("python-readability")
+def test_transform_non_empty_html() -> None:
+    readability = ReadabilityTransformer()
+    documents = [Document(page_content="<html><body><div>123</div></body></html>")]
+    [document] = readability.transform_documents(documents)
+    assert document.page_content == "123"
+
+    [document] = readability.transform_documents(documents, target="html")
+    assert (
+        document.page_content
+        == '<div id="readability-page-1" class="page"><p>123</p></div>'
+    ), document.page_content

--- a/libs/community/tests/unit_tests/document_transformers/test_mozilla_readability_transformer.py
+++ b/libs/community/tests/unit_tests/document_transformers/test_mozilla_readability_transformer.py
@@ -6,7 +6,7 @@ from langchain_core.documents import Document
 from langchain_community.document_transformers import ReadabilityTransformer
 
 
-@pytest.mark.requires("python-readability")
+@pytest.mark.requires("readability")
 def test_empty_html() -> None:
     readability = ReadabilityTransformer()
     documents = [Document(page_content="<html></html>")]
@@ -14,7 +14,7 @@ def test_empty_html() -> None:
     assert document.page_content == "", document.page_content
 
 
-@pytest.mark.requires("python-readability")
+@pytest.mark.requires("readability")
 def test_transform_non_empty_html() -> None:
     readability = ReadabilityTransformer()
     documents = [Document(page_content="<html><body><div>123</div></body></html>")]


### PR DESCRIPTION
### Description

`langchain-js` already has a useful document transformer that use `@mozilla/readability` to extract main content of a web page heuristically. [[docs]](https://js.langchain.com/docs/integrations/document_transformers/mozilla_readability/) [[source]](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-community/src/document_transformers/mozilla_readability.ts)

This PR introduces a new `ReadabilityTransformer` class to the `langchain_community/document_transformers`, which class leverages the `python-readability` library to do the same thing.

### Dependencies:

[`python-readability`](https://pypi.org/project/python-readability/) — a Standalone Python wrapper for `@mozilla/readability`

Mention that no nodejs environment is needed. In regular CPython distributions, [python-readability](https://github.com/CNSeniorious000/python-readability) requires [PythonMonkey](https://github.com/Distributive-Network/PythonMonkey) to interpret JavaScript, and in [Pyodide](https://github.com/pyodide/pyodide), it uses the native JavaScript environment. So this package is available even if the user deploys langchain apps on [Cloudflare Workers](https://developers.cloudflare.com/workers/languages/python/).
