### PR TITLE
community: Fix missing protected_namespaces().

### DIFF
--- a/libs/community/langchain_community/embeddings/ascend.py
+++ b/libs/community/langchain_community/embeddings/ascend.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class AscendEmbeddings(Embeddings, BaseModel):
@@ -32,6 +32,8 @@ class AscendEmbeddings(Embeddings, BaseModel):
     pooling_method: Optional[str] = "cls"
     model: Any
     tokenizer: Any
+
+    model_config = ConfigDict(protected_namespaces=())
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/libs/community/langchain_community/embeddings/baidu_qianfan_endpoint.py
+++ b/libs/community/langchain_community/embeddings/baidu_qianfan_endpoint.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env, pre_init
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +80,8 @@ class QianfanEmbeddingsEndpoint(BaseModel, Embeddings):
 
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
     """extra params for model invoke using with `do`."""
+
+    model_config = ConfigDict(protected_namespaces=())
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/bookend.py
+++ b/libs/community/langchain_community/embeddings/bookend.py
@@ -5,7 +5,7 @@ from typing import Any, List
 
 import requests
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 API_URL = "https://api.bookend.ai/"
 DEFAULT_TASK = "embeddings"
@@ -41,6 +41,8 @@ class BookendEmbeddings(BaseModel, Embeddings):
     model_id: str
     """Embeddings model ID to use."""
     auth_header: dict = Field(default_factory=dict)
+
+    model_config = ConfigDict(protected_namespaces=())
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)

--- a/libs/community/langchain_community/embeddings/ernie.py
+++ b/libs/community/langchain_community/embeddings/ernie.py
@@ -8,7 +8,7 @@ from langchain_core._api.deprecation import deprecated
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.utils import get_from_dict_or_env, pre_init
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,8 @@ class ErnieEmbeddings(BaseModel, Embeddings):
     model_name: str = "ErnieBot-Embedding-V1"
 
     _lock = threading.Lock()
+
+    model_config = ConfigDict(protected_namespaces=())
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/google_palm.py
+++ b/libs/community/langchain_community/embeddings/google_palm.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_dict_or_env, pre_init
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from tenacity import (
     before_sleep_log,
     retry,
@@ -61,6 +61,8 @@ class GooglePalmEmbeddings(BaseModel, Embeddings):
     """Model name to use."""
     show_progress_bar: bool = False
     """Whether to show a tqdm progress bar. Must have `tqdm` installed."""
+
+    model_config = ConfigDict(protected_namespaces=())
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/gpt4all.py
+++ b/libs/community/langchain_community/embeddings/gpt4all.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class GPT4AllEmbeddings(BaseModel, Embeddings):
@@ -27,6 +27,8 @@ class GPT4AllEmbeddings(BaseModel, Embeddings):
     device: Optional[str] = "cpu"
     gpt4all_kwargs: Optional[dict] = {}
     client: Any  #: :meta private:
+
+    model_config = ConfigDict(protected_namespaces=())
 
     @model_validator(mode="before")
     @classmethod

--- a/libs/community/langchain_community/embeddings/infinity_local.py
+++ b/libs/community/langchain_community/embeddings/infinity_local.py
@@ -60,6 +60,7 @@ class InfinityEmbeddingsLocal(BaseModel, Embeddings):
     # LLM call kwargs
     model_config = ConfigDict(
         extra="forbid",
+        protected_namespaces=(),
     )
 
     @model_validator(mode="after")

--- a/libs/community/langchain_community/embeddings/itrex.py
+++ b/libs/community/langchain_community/embeddings/itrex.py
@@ -120,6 +120,7 @@ class QuantizedBgeEmbeddings(BaseModel, Embeddings):
 
     model_config = ConfigDict(
         extra="allow",
+        protected_namespaces=(),
     )
 
     def _embed(self, inputs: Any) -> Any:

--- a/libs/community/langchain_community/embeddings/jina.py
+++ b/libs/community/langchain_community/embeddings/jina.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import requests
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import convert_to_secret_str, get_from_dict_or_env
-from pydantic import BaseModel, SecretStr, model_validator
+from pydantic import BaseModel, ConfigDict, SecretStr, model_validator
 
 JINA_API_URL: str = "https://api.jina.ai/v1/embeddings"
 
@@ -45,6 +45,8 @@ class JinaEmbeddings(BaseModel, Embeddings):
     session: Any  #: :meta private:
     model_name: str = "jina-embeddings-v2-base-en"
     jina_api_key: Optional[SecretStr] = None
+
+    model_config = ConfigDict(protected_namespaces=())
 
     @model_validator(mode="before")
     @classmethod

--- a/libs/community/langchain_community/embeddings/llamacpp.py
+++ b/libs/community/langchain_community/embeddings/llamacpp.py
@@ -63,6 +63,7 @@ class LlamaCppEmbeddings(BaseModel, Embeddings):
 
     model_config = ConfigDict(
         extra="forbid",
+        protected_namespaces=(),
     )
 
     @model_validator(mode="after")

--- a/libs/community/langchain_community/embeddings/nlpcloud.py
+++ b/libs/community/langchain_community/embeddings/nlpcloud.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_dict_or_env, pre_init
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class NLPCloudEmbeddings(BaseModel, Embeddings):
@@ -21,6 +21,8 @@ class NLPCloudEmbeddings(BaseModel, Embeddings):
     model_name: str  # Define model_name as a class attribute
     gpu: bool  # Define gpu as a class attribute
     client: Any  #: :meta private:
+
+    model_config = ConfigDict(protected_namespaces=())
 
     def __init__(
         self,

--- a/libs/community/langchain_community/embeddings/optimum_intel.py
+++ b/libs/community/langchain_community/embeddings/optimum_intel.py
@@ -102,6 +102,7 @@ For more information, please visit:
 
     model_config = ConfigDict(
         extra="allow",
+        protected_namespaces=(),
     )
 
     def _embed(self, inputs: Any) -> Any:

--- a/libs/community/langchain_community/embeddings/sambanova.py
+++ b/libs/community/langchain_community/embeddings/sambanova.py
@@ -4,7 +4,7 @@ from typing import Dict, Generator, List, Optional
 import requests
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_dict_or_env, pre_init
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class SambaStudioEmbeddings(BaseModel, Embeddings):
@@ -63,6 +63,8 @@ class SambaStudioEmbeddings(BaseModel, Embeddings):
 
     batch_size: int = 32
     """Batch size for the embedding models"""
+
+    model_config = ConfigDict(protected_namespaces=())
 
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/community/langchain_community/embeddings/tensorflow_hub.py
+++ b/libs/community/langchain_community/embeddings/tensorflow_hub.py
@@ -45,6 +45,7 @@ class TensorflowHubEmbeddings(BaseModel, Embeddings):
 
     model_config = ConfigDict(
         extra="forbid",
+        protected_namespaces=(),
     )
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:

--- a/libs/community/langchain_community/embeddings/text2vec.py
+++ b/libs/community/langchain_community/embeddings/text2vec.py
@@ -3,7 +3,7 @@
 from typing import Any, List, Optional
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class Text2vecEmbeddings(Embeddings, BaseModel):
@@ -32,6 +32,8 @@ class Text2vecEmbeddings(Embeddings, BaseModel):
     max_seq_length: int = 256
     device: Optional[str] = None
     model: Any = None
+
+    model_config = ConfigDict(protected_namespaces=())
 
     def __init__(
         self,


### PR DESCRIPTION
- [x] **PR message**:
    - **Description:** Fixes warning messages raised due to missing `protected_namespaces` parameter in `ConfigDict`.
    - **Issue:** https://github.com/langchain-ai/langchain/issues/27609
    - **Dependencies:** No dependencies
    - **Twitter handle:** @gawbul