### PR TITLE
feat(core): modified `RunnableWithMessageHistory` `get_input_schema` to make use of the underlying runnable input keys

### DIFF
--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 from typing_extensions import override
 
 from langchain_core.chat_history import BaseChatMessageHistory
@@ -235,6 +236,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
     output_messages_key: Optional[str] = None
     history_messages_key: Optional[str] = None
     history_factory_config: Sequence[ConfigurableFieldSpec]
+    _underlying_runnable: Runnable
 
     @classmethod
     def get_lc_namespace(cls) -> list[str]:
@@ -363,6 +365,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             **kwargs,
         )
         self._history_chain = history_chain
+        self._underlying_runnable = runnable
 
     @property
     def config_specs(self) -> list[ConfigurableFieldSpec]:
@@ -390,6 +393,25 @@ class RunnableWithMessageHistory(RunnableBindingBase):
                 module_name=self.__class__.__module__,
                 root=(Sequence[BaseMessage], ...),
             )
+
+        underlying_input_schema = self._underlying_runnable.get_input_schema()
+        for (
+            field_name,
+            field_info,
+        ) in underlying_input_schema.model_fields.items():
+            if field_info.is_required():
+                if (
+                    field_name != self.input_messages_key
+                    and field_name != self.history_messages_key
+                ):
+                    fields[field_name] = (field_info.annotation, ...)
+            else:
+                if field_info.default is not PydanticUndefined:
+                    fields[field_name] = (field_info.annotation, field_info.default)
+                else:  # Default factory
+                    # We'll skip supporting this for now
+                    continue
+
         return create_model_v2(  # type: ignore[call-overload]
             "RunnableWithChatHistoryInput",
             field_definitions=fields,

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -11,7 +11,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 from pydantic_core import PydanticUndefined
 from typing_extensions import override
 
@@ -395,6 +395,13 @@ class RunnableWithMessageHistory(RunnableBindingBase):
             )
 
         underlying_input_schema = self._underlying_runnable.get_input_schema()
+        if issubclass(underlying_input_schema, RootModel):
+            return create_model_v2(  # type: ignore[call-overload]
+                "RunnableWithChatHistoryInput",
+                field_definitions=fields,
+                module_name=self.__class__.__module__,
+            )
+
         for (
             field_name,
             field_info,

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -422,27 +422,22 @@ async def test_output_dict_async() -> None:
 
 
 def test_get_input_schema_input_dict() -> None:
-    class RunnableWithChatHistoryInput(BaseModel):
-        input: Union[str, BaseMessage, Sequence[BaseMessage]]
-
-    runnable = RunnableLambda(
-        lambda input: {
-            "output": [
-                AIMessage(
-                    content="you said: "
-                    + "\n".join(
-                        [
-                            str(m.content)
-                            for m in input["history"]
-                            if isinstance(m, HumanMessage)
-                        ]
-                        + [input["input"]]
-                    )
-                )
-            ]
-        }
+    from langchain_core.prompts import (
+        ChatPromptTemplate,
+        HumanMessagePromptTemplate,
     )
+
+    runnable = ChatPromptTemplate.from_messages(
+        messages=[
+            SystemMessage(content="You are a nice assistant."),
+            HumanMessagePromptTemplate.from_template(
+                "ability: {ability}, input:{input}, history:{history}"
+            ),
+        ]
+    )
+
     get_session_history = _get_get_session_history()
+
     with_history = RunnableWithMessageHistory(
         runnable,
         get_session_history,
@@ -450,9 +445,68 @@ def test_get_input_schema_input_dict() -> None:
         history_messages_key="history",
         output_messages_key="output",
     )
-    assert _schema(with_history.get_input_schema()) == _schema(
-        RunnableWithChatHistoryInput
-    )
+
+    assert _schema(with_history.get_input_schema()) == {
+        "properties": {
+            "input": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/definitions/BaseMessage"},
+                    {"items": {"$ref": "#/definitions/BaseMessage"}, "type": "array"},
+                ],
+                "title": "Input",
+            },
+            "ability": {"title": "Ability", "type": "string"},
+        },
+        "required": ["input", "ability"],
+        "title": "RunnableWithChatHistoryInput",
+        "type": "object",
+        "definitions": {
+            "BaseMessage": {
+                "additionalProperties": True,
+                "description": (
+                    "Base abstract message class."
+                    "\n\nMessages are the inputs and outputs of ChatModels."
+                ),
+                "properties": {
+                    "content": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {
+                                "items": {
+                                    "anyOf": [{"type": "string"}, {"type": "object"}]
+                                },
+                                "type": "array",
+                            },
+                        ],
+                        "title": "Content",
+                    },
+                    "additional_kwargs": {
+                        "title": "Additional Kwargs",
+                        "type": "object",
+                    },
+                    "response_metadata": {
+                        "title": "Response Metadata",
+                        "type": "object",
+                    },
+                    "type": {"title": "Type", "type": "string"},
+                    "name": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Name",
+                    },
+                    "id": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Id",
+                    },
+                },
+                "required": ["content", "type"],
+                "title": "BaseMessage",
+                "type": "object",
+            }
+        },
+    }
 
 
 def test_get_output_schema() -> None:


### PR DESCRIPTION
 # Description 
Modified RunnableWithMessageHistory get_input_schema to make use of the underlying runnable input keys.
This pull request a continuation of  https://github.com/langchain-ai/langchain/pull/25756 after langchain migration to pydantic v2.

## The issue it solves
The current RunnableWithMessageHistory definition only makes use of an input key from the prompt, adds it to the input schema and ignores others. 
to illustrate:
* if I replicate the following example from [RunnableWithMessageHistory](https://python.langchain.com/v0.1/docs/expression_language/how_to/message_history/) docs :
```
from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
from langchain_openai.chat_models import ChatOpenAI
from langchain_community.chat_message_histories import ChatMessageHistory
from langchain_core.chat_history import BaseChatMessageHistory
from langchain_core.runnables.history import RunnableWithMessageHistory

model = ChatOpenAI()
prompt = ChatPromptTemplate.from_messages(
    [
        (
            "system",
            "You're an assistant who's good at {ability}. Respond in 20 words or fewer",
        ),
        MessagesPlaceholder(variable_name="history"),
        ("human", "{input}"),
    ]
)
runnable = prompt | model

store = {}

def get_session_history(session_id: str) -> BaseChatMessageHistory:
    if session_id not in store:
        store[session_id] = ChatMessageHistory()
    return store[session_id]


with_message_history = RunnableWithMessageHistory(
    runnable,
    get_session_history,
    input_messages_key="input",
    history_messages_key="history",
)
```
and then run
```
with_message_history.get_input_schema().schema_json()
```
I get the following output
```
{
  "title": "RunnableWithChatHistoryInput",
  "type": "object",
  "properties": {
    "input": {
      "title": "Input",
      "anyOf": [
        {
          "type": "string"
        },
        {
          "$ref": "#/definitions/BaseMessage"
        },
        {
          "type": "array",
          "items": {
            "$ref": "#/definitions/BaseMessage"
          }
        }
      ]
    }
  },...
```
**With only one property(input)** on the input schema, **despite the prompt containing others (ability)**

## Further issue with langserve
when I try to use RunnableWithMessageHistory with langserve in the example below
```
from pydantic.v1 import BaseModel
from fastapi import FastAPI
from fastapi.responses import RedirectResponse
from langserve import add_routes
from chain import with_message_history

app = FastAPI()

@app.get("/")
async def redirect_root_to_docs():
    return RedirectResponse("/docs")

# Edit this to add the chain you want to add
add_routes(app, with_message_history)

if __name__ == "__main__":
    import uvicorn
    uvicorn.run(app, host="0.0.0.0", port=8000)
```
The fastapi docs shows the input schema without "ability" in the example above
<img width="1442" alt="Screenshot 2024-08-26 at 6 16 18 PM" src="https://github.com/user-attachments/assets/b648f851-31f2-475e-833c-2799a7518f8c">

  - **Issue:** #24370 
  - **Discussions:** 
  #22468 
  #22464
