### PR TITLE
couchbase: Add document id to vector search results

### DIFF
--- a/libs/partners/couchbase/langchain_couchbase/vectorstores.py
+++ b/libs/partners/couchbase/langchain_couchbase/vectorstores.py
@@ -559,12 +559,13 @@ class CouchbaseVectorStore(VectorStore):
             # Parse the results
             for row in search_iter.rows():
                 text = row.fields.pop(self._text_key, "")
+                id = row.id
 
                 # Format the metadata from Couchbase
                 metadata = self._format_metadata(row.fields)
 
                 score = row.score
-                doc = Document(page_content=text, metadata=metadata)
+                doc = Document(id=id, page_content=text, metadata=metadata)
                 docs_with_score.append((doc, score))
 
         except Exception as e:

--- a/libs/partners/couchbase/pyproject.toml
+++ b/libs/partners/couchbase/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-couchbase"
-version = "0.2.0"
+version = "0.2.1"
 description = "An integration package connecting Couchbase and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION

**Description:** Returns the document id along with the Vector Search results

**Issue:** Fixes https://github.com/langchain-ai/langchain/issues/26860 for CouchbaseVectorStore


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. 
