### PR TITLE
Fix typo (missing letter) in elasticsearch_retriever.ipynb

### DIFF
--- a/docs/docs/integrations/retrievers/elasticsearch_retriever.ipynb
+++ b/docs/docs/integrations/retrievers/elasticsearch_retriever.ipynb
@@ -563,7 +563,7 @@
    "source": [
     "### Custom document mapper\n",
     "\n",
-    "It is possible to cusomize the function tha maps an Elasticsearch result (hit) to a LangChain document."
+    "It is possible to cusomize the function that maps an Elasticsearch result (hit) to a LangChain document."
    ]
   },
   {


### PR DESCRIPTION
Fixed a small typo (added a missing "t" in ElasticsearchRetriever docs page)

https://python.langchain.com/docs/integrations/retrievers/elasticsearch_retriever/#:~:text=It%20is%20possible%20to%20cusomize%20the%20function%20tha%20maps%20an%20Elasticsearch%20result%20(hit)%20to%20a%20LangChain%20document.