### PR TITLE
fix the grammar and markdown component

### DIFF
--- a/docs/docs/contributing/reference/review_process.mdx
+++ b/docs/docs/contributing/reference/review_process.mdx
@@ -46,7 +46,7 @@ by the submitter.
    - These are reviewed and closed aggressively, similar to core PRs.
    - New feature requests should be discussed with the core maintainer team beforehand in an issue.
 
-3. **PRs that touch /libs/partners/**\**:
+3. **PRs that touch /libs/partners/**:
    - PRs involving integration packages.
    - **Triage Guideline**: most PRs should either go straight to `In Review` or closed.
    - The review may be conducted by our team or handed off to the partner's development team, depending on the PR's content.

--- a/docs/docs/contributing/reference/review_process.mdx
+++ b/docs/docs/contributing/reference/review_process.mdx
@@ -36,7 +36,7 @@ by the submitter.
    - PRs that directly impact core code and are likely to affect end users.
    - **Triage Guideline**: most PRs should either go straight to `In Review` or closed.
    - These PRs are given top priority and are reviewed the fastest.
-   - PRs that don't have a **concise** descriptions of their motivation (either in PR summary of in a linked issue) are likely to be closed without an in-depth review. Please do not generate verbose PR descriptions with an LLM.
+   - PRs that don't have a **concise** descriptions of their motivation (either in PR summary or in a linked issue) are likely to be closed without an in-depth review. Please do not generate verbose PR descriptions with an LLM.
    - PRs that don't have unit tests are likely to be closed.
    - Feature requests should first be opened as a GitHub issue and discussed with the LangChain maintainers. Large PRs submitted without prior discussion are likely to be closed.
 
@@ -46,7 +46,7 @@ by the submitter.
    - These are reviewed and closed aggressively, similar to core PRs.
    - New feature requests should be discussed with the core maintainer team beforehand in an issue.
 
-3. **PRs that touch /libs/partners/****:
+3. **PRs that touch /libs/partners/**\**:
    - PRs involving integration packages.
    - **Triage Guideline**: most PRs should either go straight to `In Review` or closed.
    - The review may be conducted by our team or handed off to the partner's development team, depending on the PR's content.


### PR DESCRIPTION
## Before

![Screenshot from 2024-10-26 08-47-29](https://github.com/user-attachments/assets/d8ccead1-3ba3-4f67-a29f-ef8b352341cf)

## After

![image](https://github.com/user-attachments/assets/78f36d54-b2d7-4164-b334-8ac41000711e)

## Typo
`(either in PR summary of in a linked issue)` => `either in PR summary or in a linked issue`