### PR TITLE
community:  Add Cloudflare AI Gateway option for Cloudflare workers-ai LLM

### DIFF
--- a/libs/community/langchain_community/llms/cloudflare_workersai.py
+++ b/libs/community/langchain_community/llms/cloudflare_workersai.py
@@ -29,12 +29,14 @@ class CloudflareWorkersAI(LLM):
             cf_ai = CloudflareWorkersAI(
                 account_id=my_account_id,
                 api_token=my_api_token,
+                ai_gateway=my_cfai_gateway_token,
                 model=llm_model
             )
     """  # noqa: E501
 
     account_id: str
     api_token: str
+    ai_gateway: str = ""
     model: str = "@cf/meta/llama-2-7b-chat-int8"
     base_url: str = "https://api.cloudflare.com/client/v4/accounts"
     streaming: bool = False
@@ -43,8 +45,10 @@ class CloudflareWorkersAI(LLM):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the Cloudflare Workers AI class."""
         super().__init__(**kwargs)
-
-        self.endpoint_url = f"{self.base_url}/{self.account_id}/ai/run/{self.model}"
+        if self.gateway:
+            self.endpoint_url = f"{self.base_url}/{self.account_id}/{self.gateway}/workers-ai/run/{self.model}"
+        else:
+            self.endpoint_url = f"{self.base_url}/{self.account_id}/ai/run/{self.model}"
 
     @property
     def _llm_type(self) -> str:

--- a/libs/community/langchain_community/llms/cloudflare_workersai.py
+++ b/libs/community/langchain_community/llms/cloudflare_workersai.py
@@ -39,6 +39,7 @@ class CloudflareWorkersAI(LLM):
     ai_gateway: str = ""
     model: str = "@cf/meta/llama-2-7b-chat-int8"
     base_url: str = "https://api.cloudflare.com/client/v4/accounts"
+    gateway_url: str = "https://gateway.ai.cloudflare.com/v1"
     streaming: bool = False
     endpoint_url: str = ""
 
@@ -46,7 +47,7 @@ class CloudflareWorkersAI(LLM):
         """Initialize the Cloudflare Workers AI class."""
         super().__init__(**kwargs)
         if self.gateway:
-            self.endpoint_url = f"{self.base_url}/{self.account_id}/{self.gateway}/workers-ai/run/{self.model}"
+            self.endpoint_url = f"{self.gateway_url}/{self.account_id}/{self.ai_gateway}/workers-ai/run/{self.model}"
         else:
             self.endpoint_url = f"{self.base_url}/{self.account_id}/ai/run/{self.model}"
 


### PR DESCRIPTION
**Description:**
Added support for Cloudflare AI Gateway in the Cloudflare workers-ai integration. This enables users to call Cloudflare AI models through their AI Gateway endpoint, providing more flexibility for analytics, caching, and managing AI requests.

Before:

```python
self.endpoint_url = f"{self.base_url}/{self.account_id}/ai/run/{self.model}"
```

After:

```python
...

ai_gateway: str = ""
gateway_url: str = "https://gateway.ai.cloudflare.com/v1"

...

if self.ai_gateway:
    self.endpoint_url = f"{self.gateway_url}/{self.account_id}/{self.ai_gateway}/workers-ai/run/{self.model}"
else:
    self.endpoint_url = f"{self.base_url}/{self.account_id}/ai/run/{self.model}"
```


- **Dependencies:** N/A

- **Twitter handle:** @YimingShen5