### PR TITLE
docs: Fix typo in _action_agent docs section

### DIFF
--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -1182,7 +1182,7 @@ class AgentExecutor(Chain):
     def _action_agent(self) -> Union[BaseSingleActionAgent, BaseMultiActionAgent]:
         """Type cast self.agent.
 
-        The .agent attribute type includes Runnable, but is converted to one of
+        The self.agent attribute type includes Runnable, but is converted to one of
         RunnableAgentType in the validate_runnable_agent root_validator.
 
         To support instantiating with a Runnable, here we explicitly cast the type

--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -1182,7 +1182,7 @@ class AgentExecutor(Chain):
     def _action_agent(self) -> Union[BaseSingleActionAgent, BaseMultiActionAgent]:
         """Type cast self.agent.
 
-        The self.agent attribute type includes Runnable, but is converted to one of
+        The `agent` attribute type includes Runnable, but is converted to one of
         RunnableAgentType in the validate_runnable_agent root_validator.
 
         To support instantiating with a Runnable, here we explicitly cast the type

--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -1182,7 +1182,7 @@ class AgentExecutor(Chain):
     def _action_agent(self) -> Union[BaseSingleActionAgent, BaseMultiActionAgent]:
         """Type cast self.agent.
 
-        The `agent` attribute type includes Runnable, but is converted to one of
+        If the `agent` attribute is a Runnable, it will be converted one of
         RunnableAgentType in the validate_runnable_agent root_validator.
 
         To support instantiating with a Runnable, here we explicitly cast the type


### PR DESCRIPTION
PR Title: docs: Fix typo in _action_agent function docs section

Description: In line 1185, _action_agent function's docs, changing **".agent"** to **"self.agent"**.

Issue: N/A

Dependencies: None