### PR TITLE
docs: Update Milvus documentation to correctly show how to filter in similarity_search

### DIFF
--- a/docs/docs/integrations/vectorstores/milvus.ipynb
+++ b/docs/docs/integrations/vectorstores/milvus.ipynb
@@ -314,7 +314,7 @@
     "results = vector_store.similarity_search(\n",
     "    \"LangChain provides abstractions to make working with LLMs easy\",\n",
     "    k=2,\n",
-    "    filter={\"source\": \"tweet\"},\n",
+    "    expr="source == 'tweet'"},\n",
     ")\n",
     "for res in results:\n",
     "    print(f\"* {res.page_content} [{res.metadata}]\")"
@@ -346,7 +346,7 @@
    ],
    "source": [
     "results = vector_store.similarity_search_with_score(\n",
-    "    \"Will it be hot tomorrow?\", k=1, filter={\"source\": \"news\"}\n",
+    "    \"Will it be hot tomorrow?\", k=1, expr="source == 'news'"}\n",
     ")\n",
     "for res, score in results:\n",
     "    print(f\"* [SIM={score:3f}] {res.page_content} [{res.metadata}]\")"

--- a/docs/docs/integrations/vectorstores/milvus.ipynb
+++ b/docs/docs/integrations/vectorstores/milvus.ipynb
@@ -314,7 +314,7 @@
     "results = vector_store.similarity_search(\n",
     "    \"LangChain provides abstractions to make working with LLMs easy\",\n",
     "    k=2,\n",
-    "    expr="source == 'tweet'"},\n",
+    "    expr='source == \"tweet\"',\n",
     ")\n",
     "for res in results:\n",
     "    print(f\"* {res.page_content} [{res.metadata}]\")"
@@ -346,7 +346,7 @@
    ],
    "source": [
     "results = vector_store.similarity_search_with_score(\n",
-    "    \"Will it be hot tomorrow?\", k=1, expr="source == 'news'"}\n",
+    "    \"Will it be hot tomorrow?\", k=1, expr='source == \"news\"'\n",
     ")\n",
     "for res, score in results:\n",
     "    print(f\"* [SIM={score:3f}] {res.page_content} [{res.metadata}]\")"


### PR DESCRIPTION
### Description/Issue:

I had problems filtering when setting up a local Milvus db and noticed that the  `filter` option in the `similarity_search` and `similarity_search_with_score` appeared to do nothing. Instead, the `expr` option should be used.

The `expr` option is correctly used in the retriever example further down in the documentation.

The `expr` option seems to be correctly passed on, for example [here](https://github.com/langchain-ai/langchain/blob/447c0dd2f051157a3ccdac49a8d5ca6c06ea1401/libs/community/langchain_community/vectorstores/milvus.py#L701)

### Solution:

Update the documentation for the functions mentioned to show intended behavior.
