### PR TITLE
DOCS: Fixed import of langchain instead of langchain_nvidia_ai_endpoints for ChatNVIDIA

### DIFF
--- a/docs/src/theme/ChatModelTabs.js
+++ b/docs/src/theme/ChatModelTabs.js
@@ -131,7 +131,7 @@ export default function ChatModelTabs(props) {
     {
       value: "NVIDIA",
       label: "NVIDIA",
-      text: `from langchain import ChatNVIDIA\n\n${llmVarName} = ChatNVIDIA(${nvidiaParamsOrDefault})`,
+      text: `from langchain_nvidia_ai_endpoints import ChatNVIDIA\n\n${llmVarName} = ChatNVIDIA(${nvidiaParamsOrDefault})`,
       apiKeyName: "NVIDIA_API_KEY",
       packageName: "langchain-nvidia-ai-endpoints",
       default: false,


### PR DESCRIPTION
* **PR title**: "docs: Replaced langchain import with langchain-nvidia-ai-endpoints in NVIDIA Endpoints Tab"

* **PR message**:
	+ **Description:** Replaced the import of `langchain` with `langchain-nvidia-ai-endpoints` in the NVIDIA Endpoints Tab to resolve an error caused by the documentation attempting to import the generic `langchain` module despite the targeted import.
	+ **Issue:** 
	+ **Dependencies:** No additional dependencies introduced; simply updated the existing import to a more specific module.
	+ **Twitter handle:** https://x.com/nawaz0x1

* **Add tests and docs**:
	+ **Applicability:** Not applicable in this case, as the change is a fix to an existing integration rather than the addition of a new one.
	+ **Rationale:** No new functionality or integrations are introduced, only a corrective import change.

* **Lint and test**:
	+ **Status:** Completed
	+ **Outcome:** 
		- `make format`: **Passed**
		- `make lint`: **Passed**
		- `make test`: **Passed**

![image](https://github.com/user-attachments/assets/fbc1b597-5083-4461-875a-d32ab8ed933c)
