### PR TITLE
community[pathch]: Add missing custom content_key handling in Redis vector store

### DIFF
--- a/libs/community/langchain_community/vectorstores/redis/base.py
+++ b/libs/community/langchain_community/vectorstores/redis/base.py
@@ -866,7 +866,8 @@ class Redis(VectorStore):
                 metadata = {"id": result.id}
                 metadata.update(self._collect_metadata(result))
 
-            doc = Document(page_content=result.content, metadata=metadata)
+            content_key = self._schema.content_key
+            doc = Document(page_content=getattr(result, content_key), metadata=metadata)
             distance = self._calculate_fp_distance(result.distance)
             docs_with_scores.append((doc, distance))
 


### PR DESCRIPTION
This fix an error caused by missing custom content_key handling in Redis vector store in function similarity_search_with_score.