### PR TITLE
LangChain-Community - AzureCosmos Mongo vCore: Bug Fix when the data doesn't contain metadata field

### DIFF
--- a/libs/community/langchain_community/vectorstores/azure_cosmos_db.py
+++ b/libs/community/langchain_community/vectorstores/azure_cosmos_db.py
@@ -460,7 +460,7 @@ class AzureCosmosDBVectorSearch(VectorStore):
                 continue
             document_object_field = res.pop("document")
             text = document_object_field.pop(self._text_key)
-            metadata = document_object_field.pop("metadata")
+            metadata = document_object_field.pop("metadata", {})
             if with_embedding:
                 metadata[self._embedding_key] = document_object_field.pop(
                     self._embedding_key


### PR DESCRIPTION
Thank you for contributing to LangChain!
- **Description:** Adding an empty metadata field when metadata is not present in the data
- **Issue:** This PR fixes the issue when the data items doesn't contain the metadata field. This happens when there is already data in the container, or cx uses CosmosDB Python SDK to insert data.
- **Dependencies:** No dependencies required

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
