### PR TITLE
community: Fix a validation error for MoonshotChat

### DIFF
--- a/libs/community/langchain_community/llms/moonshot.py
+++ b/libs/community/langchain_community/llms/moonshot.py
@@ -39,7 +39,7 @@ class _MoonshotClient(BaseModel):
 class MoonshotCommon(BaseModel):
     """Common parameters for Moonshot LLMs."""
 
-    client: _MoonshotClient
+    client: Any
     base_url: str = MOONSHOT_SERVICE_URL_BASE
     moonshot_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
     """Moonshot API key. Get it here: https://platform.moonshot.cn/console/api-keys"""


### PR DESCRIPTION
- **Description:** Change `MoonshotCommon.client` type from `_MoonshotClient` to `Any`.
- **Issue:** Fix the issue #27058
- **Dependencies:** No
- **Twitter handle:** TaoWang2218

In PR #17100, the implementation for Moonshot was added, which defined two classes:

- `MoonshotChat(MoonshotCommon, ChatOpenAI)` in `langchain_community.chat_models.moonshot`;
  - Here, `validate_environment()` assigns **client** as `openai.OpenAI().chat.completions`
    - Note that **client** here is actually a member variable defined in `ChatOpenAI`;
- `MoonshotCommon` in `langchain_community.llms.moonshot`;
  - And here, `validate_environment()` assigns **_client** as `_MoonshotClient`;
    - Note that this is the underscored **_client**, which is defined within `MoonshotCommon` itself;

At this time, there was no conflict between the two, one being `client` and the other `_client`.

However, in PR #25878 which fixed #24390, `_client` in `MoonshotCommon` was changed to `client`. Since then, a conflict in the definition of `client` has arisen between `MoonshotCommon` and `MoonshotChat`, which caused `pydantic` validation error.

To fix this issue, the type of `client` in `MoonshotCommon` should be changed to `Any`.