### PR TITLE
docs: replace invoke with run for PubMed query execution 

### DIFF
--- a/docs/docs/integrations/tools/pubmed.ipynb
+++ b/docs/docs/integrations/tools/pubmed.ipynb
@@ -60,7 +60,7 @@
     }
    ],
    "source": [
-    "tool.invoke(\"What causes lung cancer?\")"
+    "tool.run(\"What causes lung cancer?\")"
    ]
   },
   {


### PR DESCRIPTION
Updated to use run instead of invoke in PubmedQueryRun to prevent execution errors like "object has no attribute 'invoke'"" and ensure compatibility with the latest API syntax.