### PR TITLE
Fixed broken link for TokenTextSplitter

### DIFF
--- a/docs/docs/how_to/split_by_token.ipynb
+++ b/docs/docs/how_to/split_by_token.ipynb
@@ -27,7 +27,7 @@
     "1. How the text is split: by character passed in.\n",
     "2. How the chunk size is measured: by `tiktoken` tokenizer.\n",
     "\n",
-    "[CharacterTextSplitter](https://python.langchain.com/api_reference/text_splitters/character/langchain_text_splitters.character.CharacterTextSplitter.html), [RecursiveCharacterTextSplitter](https://python.langchain.com/api_reference/text_splitters/character/langchain_text_splitters.character.RecursiveCharacterTextSplitter.html), and [TokenTextSplitter](https://python.langchain.com/api_reference/langchain_text_splitters/base/langchain_text_splitters.base.TokenTextSplitter.html) can be used with `tiktoken` directly."
+    "[CharacterTextSplitter](https://python.langchain.com/api_reference/text_splitters/character/langchain_text_splitters.character.CharacterTextSplitter.html), [RecursiveCharacterTextSplitter](https://python.langchain.com/api_reference/text_splitters/character/langchain_text_splitters.character.RecursiveCharacterTextSplitter.html), and [TokenTextSplitter](https://python.langchain.com/api_reference/text_splitters/base/langchain_text_splitters.base.TokenTextSplitter.html) can be used with `tiktoken` directly."
    ]
   },
   {


### PR DESCRIPTION
Fixed the broken redirect link for `TokenTextSplitter` section