### PR TITLE
Set api_key param to litellm client based on providers api keys

### DIFF
--- a/libs/community/langchain_community/chat_models/litellm.py
+++ b/libs/community/langchain_community/chat_models/litellm.py
@@ -225,6 +225,8 @@ class ChatLiteLLM(BaseChatModel):
     replicate_api_key: Optional[str] = None
     cohere_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None
+    together_ai_api_key: Optional[str] = None
+    huggingface_api_key: Optional[str] = None
     streaming: bool = False
     api_base: Optional[str] = None
     organization: Optional[str] = None
@@ -264,6 +266,19 @@ class ChatLiteLLM(BaseChatModel):
             **self.model_kwargs,
         }
 
+    def get_api_key(self) -> str:
+        return (
+            self.openai_api_key
+            or self.azure_api_key
+            or self.anthropic_api_key
+            or self.replicate_api_key
+            or self.openrouter_api_key
+            or self.cohere_api_key
+            or self.huggingface_api_key
+            or self.together_ai_api_key
+            or ""
+        )
+
     @property
     def _client_params(self) -> Dict[str, Any]:
         """Get the parameters used for the openai client."""
@@ -271,6 +286,7 @@ class ChatLiteLLM(BaseChatModel):
         if self.model_name is not None:
             set_model_value = self.model_name
         self.client.api_base = self.api_base
+        self.client.api_key = self.get_api_key()
         self.client.organization = self.organization
         creds: Dict[str, Any] = {
             "model": set_model_value,

--- a/libs/community/langchain_community/chat_models/litellm.py
+++ b/libs/community/langchain_community/chat_models/litellm.py
@@ -266,7 +266,8 @@ class ChatLiteLLM(BaseChatModel):
             **self.model_kwargs,
         }
 
-    def get_api_key(self) -> str:
+    @property
+    def _api_key(self) -> str:
         return (
             self.openai_api_key
             or self.azure_api_key
@@ -286,7 +287,7 @@ class ChatLiteLLM(BaseChatModel):
         if self.model_name is not None:
             set_model_value = self.model_name
         self.client.api_base = self.api_base
-        self.client.api_key = self.get_api_key()
+        self.client.api_key = self._api_key
         self.client.organization = self.organization
         creds: Dict[str, Any] = {
             "model": set_model_value,


### PR DESCRIPTION
- **PR title**: "ChatLiteLLM: set api_key to litellm client"

-  **PR message**:
    - **Description:** The litellm client requires an api_key parameter, but it currently does not take any provider-specific API keys. I propose using the available provider API key as the api_key for litellm.
    - **Issue:** the issue #27826

