### PR TITLE
community: use api token from Replicate constructor for service access

### DIFF
--- a/libs/community/langchain_community/llms/replicate.py
+++ b/libs/community/langchain_community/llms/replicate.py
@@ -13,14 +13,7 @@ from typing_extensions import Self
 
 if TYPE_CHECKING:
     from replicate.prediction import Prediction
-
-try:
     from replicate.client import Client
-except ImportError:
-    raise ImportError(
-        "Could not import replicate python package. "
-        "Please install it with `pip install replicate`."
-    )
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +58,7 @@ class Replicate(LLM):
     stop: List[str] = Field(default_factory=list)
     """Stop sequences to early-terminate generation."""
 
-    _client: Client = Client()
+    _client: Client = None
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -112,6 +105,13 @@ class Replicate(LLM):
     @model_validator(mode="after")
     def set_client(self) -> Self:
         """Add a client to the values."""
+        try:
+            from replicate.client import Client
+        except ImportError:
+            raise ImportError(
+                "Could not import replicate python package. "
+                "Please install it with `pip install replicate`."
+            )
         self._client = Client(api_token=self.replicate_api_token)
         return self
 

--- a/libs/community/langchain_community/llms/replicate.py
+++ b/libs/community/langchain_community/llms/replicate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
-from typing_extensions import Self
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
@@ -11,6 +10,7 @@ from langchain_core.utils import get_from_dict_or_env, pre_init
 from langchain_core.utils.pydantic import get_fields
 from pydantic import ConfigDict, Field, model_validator
 from replicate.client import Client
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from replicate.prediction import Prediction

--- a/libs/community/langchain_community/llms/replicate.py
+++ b/libs/community/langchain_community/llms/replicate.py
@@ -9,11 +9,18 @@ from langchain_core.outputs import GenerationChunk
 from langchain_core.utils import get_from_dict_or_env, pre_init
 from langchain_core.utils.pydantic import get_fields
 from pydantic import ConfigDict, Field, model_validator
-from replicate.client import Client
 from typing_extensions import Self
 
 if TYPE_CHECKING:
     from replicate.prediction import Prediction
+
+try:
+    from replicate.client import Client
+except ImportError:
+    raise ImportError(
+        "Could not import replicate python package. "
+        "Please install it with `pip install replicate`."
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/langchain_community/llms/replicate.py
+++ b/libs/community/langchain_community/llms/replicate.py
@@ -12,8 +12,8 @@ from pydantic import ConfigDict, Field, model_validator
 from typing_extensions import Self
 
 if TYPE_CHECKING:
-    from replicate.prediction import Prediction
     from replicate.client import Client
+    from replicate.prediction import Prediction
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -56,9 +56,9 @@ select = [ "E", "F", "I", "T201",]
 omit = [ "tests/*",]
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused -vv"
+addopts = "--strict-markers --strict-config --durations=5 -vv"
 markers = [ "requires: mark tests as requiring a specific library", "scheduled: mark tests to run in scheduled testing", "compile: mark placeholder test used to compile integration tests without running them",]
-asyncio_mode = "auto"
+# asyncio_mode = "auto"
 filterwarnings = [ "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning", "ignore::langchain_core._api.deprecation.LangChainDeprecationWarning:test", "ignore::langchain_core._api.deprecation.LangChainPendingDeprecationWarning:test",]
 
 [tool.poetry.group.test]

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -58,7 +58,7 @@ omit = [ "tests/*",]
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused -vv"
 markers = [ "requires: mark tests as requiring a specific library", "scheduled: mark tests to run in scheduled testing", "compile: mark placeholder test used to compile integration tests without running them",]
-# asyncio_mode = "auto"
+asyncio_mode = "auto"
 filterwarnings = [ "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning", "ignore::langchain_core._api.deprecation.LangChainDeprecationWarning:test", "ignore::langchain_core._api.deprecation.LangChainPendingDeprecationWarning:test",]
 
 [tool.poetry.group.test]

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -56,7 +56,7 @@ select = [ "E", "F", "I", "T201",]
 omit = [ "tests/*",]
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers --strict-config --durations=5 -vv"
+addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused -vv"
 markers = [ "requires: mark tests as requiring a specific library", "scheduled: mark tests to run in scheduled testing", "compile: mark placeholder test used to compile integration tests without running them",]
 # asyncio_mode = "auto"
 filterwarnings = [ "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning", "ignore::langchain_core._api.deprecation.LangChainDeprecationWarning:test", "ignore::langchain_core._api.deprecation.LangChainPendingDeprecationWarning:test",]

--- a/libs/community/tests/integration_tests/llms/test_replicate.py
+++ b/libs/community/tests/integration_tests/llms/test_replicate.py
@@ -2,6 +2,7 @@
 
 from langchain_community.llms.replicate import Replicate
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
+import os
 
 TEST_MODEL_HELLO = (
     "replicate/hello-world:"
@@ -47,3 +48,20 @@ def test_replicate_model_kwargs() -> None:
 def test_replicate_input() -> None:
     llm = Replicate(model=TEST_MODEL_LANG, input={"max_new_tokens": 10})
     assert llm.model_kwargs == {"max_new_tokens": 10}
+
+
+def test_replicate_api_key_propagation() -> None:
+    """Test that API key passed to the model is used to access the service."""
+    # Grab the api token from the environment variable.
+    api_token = os.getenv("REPLICATE_API_TOKEN")
+
+    # Reset the environment variable to ensure it's not available.
+    os.environ["REPLICATE_API_TOKEN"] = "yo"
+
+    # Pass the api token into the model.
+    llm = Replicate(model=TEST_MODEL_HELLO, replicate_api_token=api_token)
+    output = llm.invoke("What is a duck?")
+
+    assert output
+    assert isinstance(output, str)
+    

--- a/libs/community/tests/integration_tests/llms/test_replicate.py
+++ b/libs/community/tests/integration_tests/llms/test_replicate.py
@@ -1,8 +1,9 @@
 """Test Replicate API wrapper."""
 
+import os
+
 from langchain_community.llms.replicate import Replicate
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
-import os
 
 TEST_MODEL_HELLO = (
     "replicate/hello-world:"
@@ -64,4 +65,3 @@ def test_replicate_api_token_propagation() -> None:
 
     assert output
     assert isinstance(output, str)
-    

--- a/libs/community/tests/integration_tests/llms/test_replicate.py
+++ b/libs/community/tests/integration_tests/llms/test_replicate.py
@@ -50,8 +50,8 @@ def test_replicate_input() -> None:
     assert llm.model_kwargs == {"max_new_tokens": 10}
 
 
-def test_replicate_api_key_propagation() -> None:
-    """Test that API key passed to the model is used to access the service."""
+def test_replicate_api_token_propagation() -> None:
+    """Test that API token passed to the model is used to access the service."""
     # Grab the api token from the environment variable.
     api_token = os.getenv("REPLICATE_API_TOKEN")
 


### PR DESCRIPTION
**Description:**
- In the Replicate LLM, when a replicate_api_token is passed into the Replicate constructor, use it to create a private Client. Use that instead of the default Client to access the service for things like model lookups.
- Test that the api token is used by the model to access the service.

**Issue:**
https://github.com/langchain-ai/langchain/issues/27861

**Dependencies:**
N/A

**Twitter handle:**
N/A