### PR TITLE
core: make sure tool input keys won't be modified during following process

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -528,7 +528,8 @@ class ChildTool(BaseTool):
                     for k, v in result_dict.items()
                     if k in tool_input
                 }
-            return tool_input
+            # make sure tool input keys won't be modified during following process
+            return tool_input.copy()
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
- **Description:** When the tool has an empty `args_schema` field, it throws a `TypeError('Object of type CallbackManagerForToolRun is not JSON serializable')` error during execution. This error occurs because `tool_input` is not copied in this case, leading to unintended modifications to its keys, unlike scenarios where the `args_schema` field is populated. This fix ensures that `tool_input` remains unchanged throughout the process, resolving the issue.


- **Issue:** Fixes [https://github.com/langchain-ai/langchain/issues/24621](https://github.com/langchain-ai/langchain/issues/24621), [https://github.com/langchain-ai/langchain/issues/24614](https://github.com/langchain-ai/langchain/issues/24614)

- **Dependencies:** None
