### PR TITLE
Update qa_chat_history.ipynb

### DIFF
--- a/docs/docs/tutorials/qa_chat_history.ipynb
+++ b/docs/docs/tutorials/qa_chat_history.ipynb
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "import bs4\n",
-    "from langchain.chains import create_retrieval_chain\n",
+    "from langchain.chains.retrieval import create_retrieval_chain\n",
     "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
     "from langchain_community.document_loaders import WebBaseLoader\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",


### PR DESCRIPTION

**PR Title**: `docs: use correct module path for create_retrieval_chain import`

**Description**:  
Updated the import path for `create_retrieval_chain` in the documentation to reflect its correct module location. Changed:
```python
from langchain.chains import create_retrieval_chain
```
to 
```python
from langchain.chains.retrieval import create_retrieval_chain
```
