### PR TITLE
docs: fix undefined 'data' variable in document_loader_csv.ipynb

### DIFF
--- a/docs/docs/how_to/document_loader_csv.ipynb
+++ b/docs/docs/how_to/document_loader_csv.ipynb
@@ -157,7 +157,7 @@
     "    temp_file_path = temp_file.name\n",
     "\n",
     "loader = CSVLoader(file_path=temp_file_path)\n",
-    "loader.load()\n",
+    "data = loader.load()\n",
     "for record in data[:2]:\n",
     "    print(record)"
    ]


### PR DESCRIPTION
**Description:** 
This PR addresses an issue in the CSVLoader example where data is not defined, causing a NameError. The line `data = loader.load()` is added to correctly assign the output of loader.load() to the data variable.
