### PR TITLE
Fix typo & updated link to be imbued to "API Reference"

### DIFF
--- a/docs/docs/integrations/chat/google_generative_ai.ipynb
+++ b/docs/docs/integrations/chat/google_generative_ai.ipynb
@@ -247,7 +247,7 @@
    "source": [
     "## Safety Settings\n",
     "\n",
-    "Gemini models have default safety settings that can be overridden. If you are receiving lots of \"Safety Warnings\" from your models, you can try tweaking the `safety_settings` attribute of the model. For example, to turn off safety blocking for dangerous content, you can construct your LLM as follows:"
+    "Gemini models have default safety settings that can be overwritten. If you are receiving lots of \"Safety Warnings\" from your models, you can try tweaking the `safety_settings` attribute of the model. For example, to turn off safety blocking for dangerous content, you can construct your LLM as follows:"
    ]
   },
   {
@@ -286,7 +286,7 @@
    "source": [
     "## API reference\n",
     "\n",
-    "For detailed documentation of all ChatGoogleGenerativeAI features and configurations head to the API reference: https://python.langchain.com/api_reference/google_genai/chat_models/langchain_google_genai.chat_models.ChatGoogleGenerativeAI.html"
+    "For detailed documentation of all ChatGoogleGenerativeAI features and configurations head to the [API reference](https://python.langchain.com/api_reference/google_genai/chat_models/langchain_google_genai.chat_models.ChatGoogleGenerativeAI.html")
    ]
   }
  ],


### PR DESCRIPTION
Fix a small typo and imbued the long link for the API Reference documentation to be a hyperlink