### PR TITLE
docs: Completed sentence under the heading  "Instantiating a Browser …

### DIFF
--- a/docs/docs/integrations/tools/playwright.ipynb
+++ b/docs/docs/integrations/tools/playwright.ipynb
@@ -101,7 +101,7 @@
    "source": [
     "## Instantiating a Browser Toolkit\n",
     "\n",
-    "It's always recommended to instantiate using the `from_browser` method so that the "
+    "It's always recommended to instantiate using the from_browser method so that the browser context is properly initialized and managed, ensuring seamless interaction and resource optimization."
    ]
   },
   {


### PR DESCRIPTION
…Toolkit" in "playwright.ipynb" integration.

- Completed the incomplete sentence in the Langchain Playwright documentation.

- Enhanced documentation clarity to guide users on best practices for instantiating browser instances with Langchain Playwright.

Example before:
> "It's always recommended to instantiate using the from_browser method so that the 

Example after:
> "It's always recommended to instantiate using the `from_browser` method so that the browser context is properly initialized and managed, ensuring seamless interaction and resource optimization."


