### PR TITLE
anthropic[patch]: remove retired model from tests

### DIFF
--- a/libs/partners/anthropic/tests/integration_tests/test_llms.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_llms.py
@@ -24,14 +24,14 @@ def test_anthropic_model_param() -> None:
 
 def test_anthropic_call() -> None:
     """Test valid call to anthropic."""
-    llm = Anthropic(model="claude-instant-1")  # type: ignore[call-arg]
+    llm = Anthropic(model="claude-2.1")  # type: ignore[call-arg]
     output = llm.invoke("Say foo:")
     assert isinstance(output, str)
 
 
 def test_anthropic_streaming() -> None:
     """Test streaming tokens from anthropic."""
-    llm = Anthropic(model="claude-instant-1")  # type: ignore[call-arg]
+    llm = Anthropic(model="claude-2.1")  # type: ignore[call-arg]
     generator = llm.stream("I'm Pickle Rick")
 
     assert isinstance(generator, Generator)


### PR DESCRIPTION
`claude-instant` was [retired yesterday](https://docs.anthropic.com/en/docs/resources/model-deprecations).