### PR TITLE
langchain_community: updated query constructor for Databricks Vector Search due to  LangChainDeprecationWarning: `filters` was deprecated since langchain-community 0.2.11 and will be removed in 0.3. Please use `filter` instead.

### DIFF
--- a/libs/community/langchain_community/query_constructors/databricks_vector_search.py
+++ b/libs/community/langchain_community/query_constructors/databricks_vector_search.py
@@ -76,10 +76,7 @@ class DatabricksVectorSearchTranslator(Visitor):
             return self._visit_not_operation(operation)
         else:
             raise NotImplementedError(
-                f'Operator "{operation.operator}" is not supported. \
-                Allowable operators for Databricks Vector Search are: {[str(item) for item in self.allowed_operators]}. \
-                Be sure to pass this via the allowed_operators parameter for associated functions \
-                ( i.e. get_query_constructor_prompt() )'
+                f'Operator "{operation.operator}" is not supported'
             )
 
     def visit_comparison(self, comparison: Comparison) -> Dict:

--- a/libs/community/langchain_community/query_constructors/databricks_vector_search.py
+++ b/libs/community/langchain_community/query_constructors/databricks_vector_search.py
@@ -76,7 +76,10 @@ class DatabricksVectorSearchTranslator(Visitor):
             return self._visit_not_operation(operation)
         else:
             raise NotImplementedError(
-                f'Operator "{operation.operator}" is not supported'
+                f'Operator "{operation.operator}" is not supported. \
+                Allowable operators for Databricks Vector Search are: {[str(item) for item in self.allowed_operators]}. \
+                Be sure to pass this via the allowed_operators parameter for associated functions \
+                ( i.e. get_query_constructor_prompt() )'
             )
 
     def visit_comparison(self, comparison: Comparison) -> Dict:
@@ -90,5 +93,5 @@ class DatabricksVectorSearchTranslator(Visitor):
         if structured_query.filter is None:
             kwargs = {}
         else:
-            kwargs = {"filters": structured_query.filter.accept(self)}
+            kwargs = {"filter": structured_query.filter.accept(self)}
         return structured_query.query, kwargs


### PR DESCRIPTION
Thank you for contributing to LangChain!

    - **Description:** Updated the kwargs for the structured query from filters to filter due to deprecation of 'filters' for Databricks Vector Search. Also changed the error messages as the allowed operators and comparators are different which can cause issues with functions such as get_query_constructor_prompt()

    - **Issue:** Fixes the Key Error for filters due to deprecation in favor for 'filter': 
    
    LangChainDeprecationWarning: DatabricksVectorSearch received a key `filters` in search_kwargs. `filters` was deprecated since langchain-community 0.2.11 and will be removed in 0.3. Please use `filter` instead.
    
    - **Dependencies:** N/A
    - **Twitter handle:** No twitter handle, only github! 
