### PR TITLE
Core: Handle Failed Cache Reads For Non-Serializable Objects

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -820,7 +820,11 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 # of Generation objects in this case, which is invalid
                 # for ChatResult, so we check and treat this as an
                 # uncached case.
-                if isinstance(cache_val, list) and len(cache_val) > 0 and isinstance(cache_val[0], ChatGeneration):
+                if (
+                    isinstance(cache_val, list)
+                    and len(cache_val) > 0
+                    and isinstance(cache_val[0], ChatGeneration)
+                ):
                     return ChatResult(generations=cache_val)
             elif self.cache is None:
                 pass
@@ -899,7 +903,11 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 # of Generation objects in this case, which is invalid
                 # for ChatResult, so we check and treat this as an
                 # uncached case.
-                if isinstance(cache_val, list) and len(cache_val) > 0 and isinstance(cache_val[0], ChatGeneration):
+                if (
+                    isinstance(cache_val, list)
+                    and len(cache_val) > 0
+                    and isinstance(cache_val[0], ChatGeneration)
+                ):
                     return ChatResult(generations=cache_val)
             elif self.cache is None:
                 pass

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -814,15 +814,14 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 prompt = dumps(messages)
                 cache_val = llm_cache.lookup(prompt, llm_string)
-                if isinstance(cache_val, list):
-                    # When objects that are not Serializable are cached,
-                    # they may not be succesfully serialized upon read.
-                    # Currently, many caches failover to returning a list
-                    # of Generation objects in this case, which is invalid
-                    # for ChatResult, so we check and treat this as an
-                    # uncached case.
-                    if len(cache_val) > 0 and isinstance(cache_val[0], ChatGeneration):
-                        return ChatResult(generations=cache_val)
+                # When objects that are not Serializable are cached,
+                # they may not be succesfully serialized upon read.
+                # Currently, many caches failover to returning a list
+                # of Generation objects in this case, which is invalid
+                # for ChatResult, so we check and treat this as an
+                # uncached case.
+                if isinstance(cache_val, list) and len(cache_val) > 0 and isinstance(cache_val[0], ChatGeneration):
+                    return ChatResult(generations=cache_val)
             elif self.cache is None:
                 pass
             else:
@@ -894,15 +893,14 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 prompt = dumps(messages)
                 cache_val = await llm_cache.alookup(prompt, llm_string)
-                if isinstance(cache_val, list):
-                    # When objects that are not Serializable are cached,
-                    # they may not be succesfully serialized upon read.
-                    # Currently, many caches failover to returning a list
-                    # of Generation objects in this case, which is invalid
-                    # for ChatResult, so we check and treat this as an
-                    # uncached case.
-                    if len(cache_val) > 0 and isinstance(cache_val[0], ChatGeneration):
-                        return ChatResult(generations=cache_val)
+                # When objects that are not Serializable are cached,
+                # they may not be succesfully serialized upon read.
+                # Currently, many caches failover to returning a list
+                # of Generation objects in this case, which is invalid
+                # for ChatResult, so we check and treat this as an
+                # uncached case.
+                if isinstance(cache_val, list) and len(cache_val) > 0 and isinstance(cache_val[0], ChatGeneration):
+                    return ChatResult(generations=cache_val)
             elif self.cache is None:
                 pass
             else:


### PR DESCRIPTION
This PR fixes the issue mentioned in #27264.

## Description

### Bug

Many caching implementations for chat model results (as defined in `langchain_core/caches.py`) require cached objects to be `Serializable` in order to properly perform the cache read and write. In cases where they are not, the lookup may fail when the cache attempts to de-serialize the cached data into a list of `ChatGeneration` objects. On such failure, many caches in `langchain_core\caches.py` fail over to returning a list of `Generation` objects that contain the serialized data strings.

When these are read by `BaseChatModel` in `_generate_with_cache` or `_agenerate_with_cache`, the cached result is fed into a `ChatGeneration` object, which does not accept `Generation` objects, leading to the error.

### Fix

Add a check in `_generate_with_cache` and `_agenerate_with_cache` to verify the cached results are of type `ChatGeneration[]`. If not, skip the lookup and treat the case as an uncached one.