### PR TITLE
docs: Makes the phrasing more smooth and reasoning more clear

### DIFF
--- a/docs/docs/versions/migrating_memory/index.mdx
+++ b/docs/docs/versions/migrating_memory/index.mdx
@@ -108,9 +108,8 @@ And specific backend implementations of abstractions:
 | `SQLiteEntityStore`       | A specific implementation of `BaseEntityStore` that uses SQLite as the backend.                          |
 | `UpstashRedisEntityStore` | A specific implementation of `BaseEntityStore` that uses Upstash as the backend.                         |
 
-These abstractions have not received much development since their initial release. The reason
-is that for these abstractions to be useful they typically require a lot of specialization for a particular application, so these
-abstractions are not as widely used as the conversation history management abstractions.
+These abstractions have received limited development since their initial release. The is because they generally require significant customization for a specific application to be effective , making
+them less widely used than the conversation history management abstractions.
 
 For this reason, there are no migration guides for these abstractions. If you're struggling to migrate an application
 that relies on these abstractions, please:

--- a/docs/docs/versions/migrating_memory/index.mdx
+++ b/docs/docs/versions/migrating_memory/index.mdx
@@ -108,7 +108,7 @@ And specific backend implementations of abstractions:
 | `SQLiteEntityStore`       | A specific implementation of `BaseEntityStore` that uses SQLite as the backend.                          |
 | `UpstashRedisEntityStore` | A specific implementation of `BaseEntityStore` that uses Upstash as the backend.                         |
 
-These abstractions have received limited development since their initial release. The is because they generally require significant customization for a specific application to be effective , making
+These abstractions have received limited development since their initial release. This is because they generally require significant customization for a specific application to be effective, making
 them less widely used than the conversation history management abstractions.
 
 For this reason, there are no migration guides for these abstractions. If you're struggling to migrate an application


### PR DESCRIPTION
Updated the phrasing and reasoning on the "abstraction not receiving much development" part of the documentation
