### PR TITLE
partners[pinecone]: Prevent race condition in `add_texts()` method

### DIFF
--- a/libs/partners/pinecone/langchain_pinecone/vectorstores.py
+++ b/libs/partners/pinecone/langchain_pinecone/vectorstores.py
@@ -294,6 +294,8 @@ class PineconeVectorStore(VectorStore):
         for metadata, text in zip(metadatas, texts):
             metadata[self._text_key] = text
 
+        initial_vector_count = self._get_vector_count()
+
         # For loops to avoid memory issues and optimize when using HTTP based embeddings
         # The first loop runs the embeddings, it benefits when using OpenAI embeddings
         # The second loops runs the pinecone upsert asynchronously.
@@ -322,6 +324,8 @@ class PineconeVectorStore(VectorStore):
                     async_req=async_req,
                     **kwargs,
                 )
+
+        asyncio.run(self._wait_on_index(len(texts) + initial_vector_count))
 
         return ids
 

--- a/libs/partners/pinecone/tests/integration_tests/test_vectorstores.py
+++ b/libs/partners/pinecone/tests/integration_tests/test_vectorstores.py
@@ -89,7 +89,6 @@ class TestPinecone:
             index_name=INDEX_NAME,
             namespace=NAMESPACE_NAME,
         )
-        time.sleep(DEFAULT_SLEEP)  # prevent race condition
         output = docsearch.similarity_search(unique_id, k=1, namespace=NAMESPACE_NAME)
         output[0].id = None  # overwrite ID for ease of comparison
         assert output == [Document(page_content=needs)]
@@ -113,7 +112,6 @@ class TestPinecone:
             metadatas=metadatas,
             namespace=namespace,
         )
-        time.sleep(DEFAULT_SLEEP)  # prevent race condition
         output = docsearch.similarity_search(needs, k=1, namespace=namespace)
 
         output[0].id = None
@@ -133,7 +131,6 @@ class TestPinecone:
             namespace=NAMESPACE_NAME,
         )
         print(texts)  # noqa: T201
-        time.sleep(DEFAULT_SLEEP)  # prevent race condition
         output = docsearch.similarity_search_with_score(
             "foo", k=3, namespace=NAMESPACE_NAME
         )
@@ -178,8 +175,6 @@ class TestPinecone:
             namespace=f"{INDEX_NAME}-2",
         )
 
-        time.sleep(DEFAULT_SLEEP)  # prevent race condition
-
         # Search with namespace
         docsearch = PineconeVectorStore.from_existing_index(
             index_name=INDEX_NAME,
@@ -203,7 +198,6 @@ class TestPinecone:
             index_name=INDEX_NAME,
             namespace=NAMESPACE_NAME,
         )
-        time.sleep(DEFAULT_SLEEP)  # prevent race condition
         index_stats = self.index.describe_index_stats()
         assert index_stats["namespaces"][NAMESPACE_NAME]["vector_count"] == len(texts)
 
@@ -215,7 +209,6 @@ class TestPinecone:
             index_name=INDEX_NAME,
             namespace=NAMESPACE_NAME,
         )
-        time.sleep(DEFAULT_SLEEP)  # prevent race condition
         index_stats = self.index.describe_index_stats()
         assert (
             index_stats["namespaces"][NAMESPACE_NAME]["vector_count"] == len(texts) * 2
@@ -234,8 +227,6 @@ class TestPinecone:
             index_name=INDEX_NAME,
             metadatas=metadatas,
         )
-        # wait for the index to be ready
-        time.sleep(DEFAULT_SLEEP)
         output = docsearch.similarity_search_with_relevance_scores("foo", k=3)
         print(output)  # noqa: T201
         assert all(


### PR DESCRIPTION
### Problem
When invoking the add_texts() method on the vector store, subsequent actions that depend on the existence of the newly added documents may result in errors or unexpected behavior. For example:

```python
from langchain_pinecone import PineconeVectorStore

# Example code demonstrating the problem
vectore_store = PineconeVectorStore.from_texts(["Document 1", "Document 2"], ...)

# Immediately trying to retrieve the added documents
retrieved_docs = vector_store.similarity_search("Document 1")
# This may raise an error or return unexpected results if the documents are not yet indexed.
```

### Solution

This pull request introduces a mechanism to block the addition of text to the index until the expected number of documents has been reached. The added code ensures that all insertions are completed only when the vector count in the index matches the anticipated document count.

### Considerations

I have implemented this solution based on the assumption that no additional updates will occur on the index during this process. However, I am open to feedback regarding this interpretation of the problem and any alternative approaches that may be more effective.