### PR TITLE
feat(core): Allow nested prompt templates

### DIFF
--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Union
 
 from pydantic import BaseModel, model_validator
 
+from langchain_core.prompts import BasePromptTemplate
 from langchain_core.prompts.string import (
     DEFAULT_FORMATTER_MAPPING,
     PromptTemplateFormat,
@@ -104,12 +105,24 @@ class PromptTemplate(StringPromptTemplate):
             )
 
         if values["template_format"]:
+            # Collect nested partial variables from
+            # BasePromptTemplate instances in partial_variables
+            nested_partial_vars = {
+                key
+                for partial_var in values["partial_variables"].values()
+                if isinstance(partial_var, BasePromptTemplate)
+                for key in partial_var.partial_variables
+            }
+
+            # Filter template variables based on
+            # partial_variables and nested_partial_vars
             values["input_variables"] = [
                 var
                 for var in get_template_variables(
                     values["template"], values["template_format"]
                 )
                 if var not in values["partial_variables"]
+                and var not in nested_partial_vars
             ]
 
         return values


### PR DESCRIPTION
This PR allows to use nested prompt templates. 
* `partial` now checks if the partial variable is a `PromptTemplate` and it will propagate partial variables to it
* `format` will first format the nested prompts and the root prompt

In my application, we allow users to write part of prompts (i.e. specific instructions), which may contain input variables. After this change, it will be possible for us to instantiate those instructions as `PromptTemplate`, and pass them to the main prompts as partial variables. 

N.B. I know that there is PipelinePromptTemplate that does something similar, but it doesn't support partial prompts as of now, and imo it should not be needed if the `PromptTemplate` itself can handle nested prompts.

Thanks for your feedback!

@hwchase17 @baskaryan 
