### PR TITLE
community: added a method to update session id in PostgresChatMessageHistory

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/postgres.py
+++ b/libs/community/langchain_community/chat_message_histories/postgres.py
@@ -98,7 +98,7 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
         query = f"UPDATE {self.table_name} SET session_id = %s WHERE session_id = %s;"
         self.cursor.execute(query, (new_session_id, self.session_id))
         self.connection.commit()
-        self.session_id = new_session_id    
+        self.session_id = new_session_id
 
     def __del__(self) -> None:
         if self.cursor:

--- a/libs/community/langchain_community/chat_message_histories/postgres.py
+++ b/libs/community/langchain_community/chat_message_histories/postgres.py
@@ -93,6 +93,13 @@ class PostgresChatMessageHistory(BaseChatMessageHistory):
         self.cursor.execute(query, (self.session_id,))
         self.connection.commit()
 
+    def update_session_id(self, new_session_id: str) -> None:
+        "Update the session ID for the current instance and in the database"
+        query = f"UPDATE {self.table_name} SET session_id = %s WHERE session_id = %s;"
+        self.cursor.execute(query, (new_session_id, self.session_id))
+        self.connection.commit()
+        self.session_id = new_session_id    
+
     def __del__(self) -> None:
         if self.cursor:
             self.cursor.close()


### PR DESCRIPTION
**Description** : **Added a method to update session id in PostgresChatMessageHistory**

**Issue:** :  There was no method available to update the session_id of the chat history table in PostgresChatMessageHistory, which could be useful for a developer.

**Twitter handle:** @a21kanjolia

