### PR TITLE
docs: Updated incorrected type used for the `multiply_by_max` function

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -162,7 +162,7 @@
     "\n",
     "@tool\n",
     "def multiply_by_max(\n",
-    "    a: Annotated[str, \"scale factor\"],\n",
+    "    a: Annotated[int, \"scale factor\"],\n",
     "    b: Annotated[List[int], \"list of ints over which to take maximum\"],\n",
     ") -> int:\n",
     "    \"\"\"Multiply a by the maximum of b.\"\"\"\n",


### PR DESCRIPTION
In the `multiply_by_max()` tool, `a` is a scale factor but it is annotated with a string type.