### PR TITLE
[rfc] core: make tool_call_id optional

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -50,7 +50,7 @@ class ToolMessage(BaseMessage):
     to request multiple tool calls in parallel.
     """  # noqa: E501
 
-    tool_call_id: str
+    tool_call_id: Optional[str] = None
     """Tool call that this message is responding to."""
 
     type: Literal["tool"] = "tool"
@@ -119,7 +119,7 @@ class ToolMessage(BaseMessage):
         else:
             pass
 
-        tool_call_id = values["tool_call_id"]
+        tool_call_id = values.get("tool_call_id")
         if isinstance(tool_call_id, (UUID, int, float)):
             values["tool_call_id"] = str(tool_call_id)
         return values

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -892,6 +892,9 @@ def _format_output(
     content: Any, artifact: Any, tool_call_id: Optional[str], name: str, status: str
 ) -> Union[ToolMessage, Any]:
     if tool_call_id:
+        if isinstance(content, ToolMessage):
+            content.tool_call_id = tool_call_id
+            return content
         if not _is_message_content_type(content):
             content = _stringify(content)
         return ToolMessage(


### PR DESCRIPTION
This would allow tools to return `ToolMessage` directly from the tools, and populate it with additional fields. For example, this would allow tools to return control flow information in langgraph.

Simple example:

```python
from langchain_core.tools import tool
from langchain_core.messages import ToolMessage

@tool
def multiply(a: int, b: int):
    """Multiplies two numbers"""
    result = a * b
    return ToolMessage(content=str(result))

multiply.invoke({"args": {"a": 13, "b": 2}, "type": "tool_call", "id": "1"})

@tool
def transfer_to_agent_a():
    """Routes to agent A."""
    return ToolMessage(content="Transferred to agent A!", command=GraphCommand(goto="agent_a")))

transfer_to_agent_a.invoke({"args": {}, "type": "tool_call", "id": "1"})
```