### PR TITLE
docs: `integrations/providers/More`

### DIFF
--- a/docs/docs/integrations/providers/all.mdx
+++ b/docs/docs/integrations/providers/all.mdx
@@ -1,0 +1,125 @@
+---
+hide_table_of_contents: true
+---
+# Providers
+
+:::info
+If you'd like to write your own integration, see [Extending LangChain](/docs/how_to/#custom).
+
+If you'd like to contribute an integration, see [Contributing integrations](/docs/contributing/how_to/integrations/).
+
+:::
+
+[0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i) | [J](#j) | [K](#k) | [L](#l) | [M](#m) | [N](#n) | [O](#o) | [P](#p) | [Q](#q) | [R](#r) | [S](#s) | [T](#t) | [U](#u) | [V](#v) | [W](#w) | [X](#x) | [Y](#y) | [Z](#z)
+
+
+---
+
+### 0-9
+
+[01.AI](/docs/integrations/providers/yi) | [2Markdown](/docs/integrations/providers/tomarkdown)
+
+### A
+
+[Acreom](/docs/integrations/providers/acreom) | [Activeloop Deep Lake](/docs/integrations/providers/activeloop_deeplake) | [Aerospike](/docs/integrations/providers/aerospike) | [AI21 Labs](/docs/integrations/providers/ai21) | [Aim](/docs/integrations/providers/aim_tracking) | [AINetwork](/docs/integrations/providers/ainetwork) | [Airbyte](/docs/integrations/providers/airbyte) | [Airtable](/docs/integrations/providers/airtable) | [Alchemy](/docs/integrations/providers/alchemy) | [Aleph Alpha](/docs/integrations/providers/aleph_alpha) | [Alibaba Cloud](/docs/integrations/providers/alibaba_cloud) | [AnalyticDB](/docs/integrations/providers/analyticdb) | [Annoy](/docs/integrations/providers/annoy) | [Anthropic](/docs/integrations/providers/anthropic) | [Anyscale](/docs/integrations/providers/anyscale) | [Apache Doris](/docs/integrations/providers/apache_doris) | [Apache Software Foundation](/docs/integrations/providers/apache) | [Apify](/docs/integrations/providers/apify) | [Apple](/docs/integrations/providers/apple) | [ArangoDB](/docs/integrations/providers/arangodb) | [Arcee](/docs/integrations/providers/arcee) | [ArcGIS](/docs/integrations/providers/arcgis) | [Argilla](/docs/integrations/providers/argilla) | [Arize](/docs/integrations/providers/arize) | [Arthur](/docs/integrations/providers/arthur_tracking) | [Arxiv](/docs/integrations/providers/arxiv) | [Ascend](/docs/integrations/providers/ascend) | [AskNews](/docs/integrations/providers/asknews) | [AssemblyAI](/docs/integrations/providers/assemblyai) | [Astra DB](/docs/integrations/providers/astradb) | [Atlas](/docs/integrations/providers/atlas) | [AwaDB](/docs/integrations/providers/awadb) | [AWS](/docs/integrations/providers/aws) | [AZLyrics](/docs/integrations/providers/azlyrics)
+
+### B
+
+[BAAI](/docs/integrations/providers/baai) | [Bagel](/docs/integrations/providers/bagel) | [BagelDB](/docs/integrations/providers/bageldb) | [Baichuan](/docs/integrations/providers/baichuan) | [Baidu](/docs/integrations/providers/baidu) | [Banana](/docs/integrations/providers/bananadev) | [Baseten](/docs/integrations/providers/baseten) | [Beam](/docs/integrations/providers/beam) | [Beautiful Soup](/docs/integrations/providers/beautiful_soup) | [BibTeX](/docs/integrations/providers/bibtex) | [BiliBili](/docs/integrations/providers/bilibili) | [Bittensor](/docs/integrations/providers/bittensor) | [Blackboard](/docs/integrations/providers/blackboard) | [bookend.ai](/docs/integrations/providers/bookendai) | [Box](/docs/integrations/providers/box) | [Brave Search](/docs/integrations/providers/brave_search) | [Breebs (Open Knowledge)](/docs/integrations/providers/breebs) | [Browserbase](/docs/integrations/providers/browserbase) | [Browserless](/docs/integrations/providers/browserless) | [ByteDance](/docs/integrations/providers/byte_dance)
+
+### C
+
+[C Transformers](/docs/integrations/providers/ctransformers) | [Cassandra](/docs/integrations/providers/cassandra) | [Cerebras](/docs/integrations/providers/cerebras) | [CerebriumAI](/docs/integrations/providers/cerebriumai) | [Chaindesk](/docs/integrations/providers/chaindesk) | [Chroma](/docs/integrations/providers/chroma) | [Clarifai](/docs/integrations/providers/clarifai) | [ClearML](/docs/integrations/providers/clearml_tracking) | [ClickHouse](/docs/integrations/providers/clickhouse) | [ClickUp](/docs/integrations/providers/clickup) | [Cloudflare](/docs/integrations/providers/cloudflare) | [Clova](/docs/integrations/providers/clova) | [CnosDB](/docs/integrations/providers/cnosdb) | [CogniSwitch](/docs/integrations/providers/cogniswitch) | [Cohere](/docs/integrations/providers/cohere) | [College Confidential](/docs/integrations/providers/college_confidential) | [Comet](/docs/integrations/providers/comet_tracking) | [Confident AI](/docs/integrations/providers/confident) | [Confluence](/docs/integrations/providers/confluence) | [Connery](/docs/integrations/providers/connery) | [Context](/docs/integrations/providers/context) | [Couchbase](/docs/integrations/providers/couchbase) | [Coze](/docs/integrations/providers/coze) | [CTranslate2](/docs/integrations/providers/ctranslate2) | [Cube](/docs/integrations/providers/cube)
+
+### D
+
+[Dappier AI](/docs/integrations/providers/dappierai) | [DashVector](/docs/integrations/providers/dashvector) | [Datadog Logs](/docs/integrations/providers/datadog_logs) | [Datadog Tracing](/docs/integrations/providers/datadog) | [DataForSEO](/docs/integrations/providers/dataforseo) | [Dataherald](/docs/integrations/providers/dataherald) | [Dedoc](/docs/integrations/providers/dedoc) | [DeepInfra](/docs/integrations/providers/deepinfra) | [DeepSparse](/docs/integrations/providers/deepsparse) | [Diffbot](/docs/integrations/providers/diffbot) | [DingoDB](/docs/integrations/providers/dingo) | [Discord](/docs/integrations/providers/discord) | [DocArray](/docs/integrations/providers/docarray) | [Doctran](/docs/integrations/providers/doctran) | [Docugami](/docs/integrations/providers/docugami) | [Docusaurus](/docs/integrations/providers/docusaurus) | [Dria](/docs/integrations/providers/dria) | [Dropbox](/docs/integrations/providers/dropbox) | [DSPy](/docs/integrations/providers/dspy) | [DuckDB](/docs/integrations/providers/duckdb) | [DuckDuckGo Search](/docs/integrations/providers/duckduckgo_search)
+
+### E
+
+[E2B](/docs/integrations/providers/e2b) | [Eden AI](/docs/integrations/providers/edenai) | [Elasticsearch](/docs/integrations/providers/elasticsearch) | [ElevenLabs](/docs/integrations/providers/elevenlabs) | [Embedchain](/docs/integrations/providers/embedchain) | [Epsilla](/docs/integrations/providers/epsilla) | [Etherscan](/docs/integrations/providers/etherscan) | [Everly AI](/docs/integrations/providers/everlyai) | [EverNote](/docs/integrations/providers/evernote) | [Exa](/docs/integrations/providers/exa_search)
+
+### F
+
+[Facebook - Meta](/docs/integrations/providers/facebook) | [FalkorDB](/docs/integrations/providers/falkordb) | [Fauna](/docs/integrations/providers/fauna) | [Fiddler](/docs/integrations/providers/fiddler) | [Figma](/docs/integrations/providers/figma) | [FireCrawl](/docs/integrations/providers/firecrawl) | [Fireworks AI](/docs/integrations/providers/fireworks) | [Flyte](/docs/integrations/providers/flyte) | [Forefront AI](/docs/integrations/providers/forefrontai) | [Friendli AI](/docs/integrations/providers/friendli) | [Friendli AI](/docs/integrations/providers/friendly)
+
+### G
+
+[Geopandas](/docs/integrations/providers/geopandas) | [Git](/docs/integrations/providers/git) | [GitBook](/docs/integrations/providers/gitbook) | [GitHub](/docs/integrations/providers/github) | [GitLab](/docs/integrations/providers/gitlab) | [Golden](/docs/integrations/providers/golden) | [Google](/docs/integrations/providers/google) | [GooseAI](/docs/integrations/providers/gooseai) | [GPT4All](/docs/integrations/providers/gpt4all) | [Gradient](/docs/integrations/providers/gradient) | [Graphsignal](/docs/integrations/providers/graphsignal) | [Grobid](/docs/integrations/providers/grobid) | [Groq](/docs/integrations/providers/groq) | [Gutenberg](/docs/integrations/providers/gutenberg)
+
+### H
+
+[Hacker News](/docs/integrations/providers/hacker_news) | [Hazy Research](/docs/integrations/providers/hazy_research) | [Helicone](/docs/integrations/providers/helicone) | [Hologres](/docs/integrations/providers/hologres) | [HTML to text](/docs/integrations/providers/html2text) | [Huawei](/docs/integrations/providers/huawei) | [Hugging Face](/docs/integrations/providers/huggingface)
+
+### I
+
+[IBM](/docs/integrations/providers/ibm) | [IEIT Systems](/docs/integrations/providers/ieit_systems) | [iFixit](/docs/integrations/providers/ifixit) | [iFlytek](/docs/integrations/providers/iflytek) | [IMSDb](/docs/integrations/providers/imsdb) | [Infinispan VS](/docs/integrations/providers/infinispanvs) | [Infinity](/docs/integrations/providers/infinity) | [Infino](/docs/integrations/providers/infino) | [Intel](/docs/integrations/providers/intel) | [Iugu](/docs/integrations/providers/iugu)
+
+### J
+
+[Jaguar](/docs/integrations/providers/jaguar) | [Javelin AI Gateway](/docs/integrations/providers/javelin_ai_gateway) | [Jina AI](/docs/integrations/providers/jina) | [Johnsnowlabs](/docs/integrations/providers/johnsnowlabs) | [Joplin](/docs/integrations/providers/joplin)
+
+### K
+
+[KDB.AI](/docs/integrations/providers/kdbai) | [Kinetica](/docs/integrations/providers/kinetica) | [KoboldAI](/docs/integrations/providers/koboldai) | [Konko](/docs/integrations/providers/konko) | [KoNLPY](/docs/integrations/providers/konlpy) | [Kùzu](/docs/integrations/providers/kuzu)
+
+### L
+
+[Label Studio](/docs/integrations/providers/labelstudio) | [lakeFS](/docs/integrations/providers/lakefs) | [LanceDB](/docs/integrations/providers/lancedb) | [LangChain Decorators ✨](/docs/integrations/providers/langchain_decorators) | [Lantern](/docs/integrations/providers/lantern) | [Linkup](/docs/integrations/providers/linkup) | [LiteLLM](/docs/integrations/providers/littlellm) | [Llama.cpp](/docs/integrations/providers/llamacpp) | [LlamaEdge](/docs/integrations/providers/llamaedge) | [llamafile](/docs/integrations/providers/llamafile) | [LlamaIndex](/docs/integrations/providers/llama_index) | [LLMonitor](/docs/integrations/providers/llmonitor) | [LocalAI](/docs/integrations/providers/localai) | [Log10](/docs/integrations/providers/log10)
+
+### M
+
+[MariTalk](/docs/integrations/providers/maritalk) | [Marqo](/docs/integrations/providers/marqo) | [MediaWikiDump](/docs/integrations/providers/mediawikidump) | [Meilisearch](/docs/integrations/providers/meilisearch) | [Memcached](/docs/integrations/providers/memcached) | [Metal](/docs/integrations/providers/metal) | [Microsoft](/docs/integrations/providers/microsoft) | [Milvus](/docs/integrations/providers/milvus) | [MindsDB](/docs/integrations/providers/mindsdb) | [Minimax](/docs/integrations/providers/minimax) | [MistralAI](/docs/integrations/providers/mistralai) | [MLflow AI Gateway for LLMs](/docs/integrations/providers/mlflow) | [MLflow](/docs/integrations/providers/mlflow_tracking) | [MLX](/docs/integrations/providers/mlx) | [Modal](/docs/integrations/providers/modal) | [ModelScope](/docs/integrations/providers/modelscope) | [Modern Treasury](/docs/integrations/providers/modern_treasury) | [Momento](/docs/integrations/providers/momento) | [MongoDB Atlas](/docs/integrations/providers/mongodb_atlas) | [MongoDB](/docs/integrations/providers/mongodb) | [Motherduck](/docs/integrations/providers/motherduck) | [Motörhead](/docs/integrations/providers/motorhead) | [MyScale](/docs/integrations/providers/myscale)
+
+### N
+
+[NAVER](/docs/integrations/providers/naver) | [Nebula](/docs/integrations/providers/symblai_nebula) | [Neo4j](/docs/integrations/providers/neo4j) | [NLPCloud](/docs/integrations/providers/nlpcloud) | [Nomic](/docs/integrations/providers/nomic) | [Notion DB](/docs/integrations/providers/notion) | [Nuclia](/docs/integrations/providers/nuclia) | [NVIDIA](/docs/integrations/providers/nvidia)
+
+### O
+
+[Obsidian](/docs/integrations/providers/obsidian) | [OctoAI](/docs/integrations/providers/octoai) | [Ollama](/docs/integrations/providers/ollama) | [Ontotext GraphDB](/docs/integrations/providers/ontotext_graphdb) | [OpenAI](/docs/integrations/providers/openai) | [OpenLLM](/docs/integrations/providers/openllm) | [OpenSearch](/docs/integrations/providers/opensearch) | [OpenWeatherMap](/docs/integrations/providers/openweathermap) | [Oracle Cloud Infrastructure (OCI)](/docs/integrations/providers/oci) | [OracleAI Vector Search](/docs/integrations/providers/oracleai) | [Outline](/docs/integrations/providers/outline) | [Outlines](/docs/integrations/providers/outlines)
+
+### P
+
+[Pandas](/docs/integrations/providers/pandas) | [Perplexity](/docs/integrations/providers/perplexity) | [Petals](/docs/integrations/providers/petals) | [PGVector](/docs/integrations/providers/pgvector) | [Pinecone](/docs/integrations/providers/pinecone) | [PipelineAI](/docs/integrations/providers/pipelineai) | [Postgres Embedding](/docs/integrations/providers/pg_embedding) | [Predibase](/docs/integrations/providers/predibase) | [Prediction Guard](/docs/integrations/providers/predictionguard) | [PremAI](/docs/integrations/providers/premai) | [PromptLayer](/docs/integrations/providers/promptlayer) | [Psychic](/docs/integrations/providers/psychic) | [PubMed](/docs/integrations/providers/pubmed) | [PygmalionAI](/docs/integrations/providers/pygmalionai)
+
+### Q
+
+[Qdrant](/docs/integrations/providers/qdrant)
+
+### R
+
+[RAGatouille](/docs/integrations/providers/ragatouille) | [rank_bm25](/docs/integrations/providers/rank_bm25) | [Ray Serve](/docs/integrations/providers/ray_serve) | [Rebuff](/docs/integrations/providers/rebuff) | [Reddit](/docs/integrations/providers/reddit) | [Redis](/docs/integrations/providers/redis) | [Remembrall](/docs/integrations/providers/remembrall) | [Replicate](/docs/integrations/providers/replicate) | [Roam](/docs/integrations/providers/roam) | [Robocorp](/docs/integrations/providers/robocorp) | [Rockset](/docs/integrations/providers/rockset) | [Runhouse](/docs/integrations/providers/runhouse) | [RWKV-4](/docs/integrations/providers/rwkv)
+
+### S
+
+[Salute Devices](/docs/integrations/providers/salute_devices) | [SAP](/docs/integrations/providers/sap) | [scikit-learn](/docs/integrations/providers/sklearn) | [ScrapeGraph AI](/docs/integrations/providers/scrapegraph) | [SearchApi](/docs/integrations/providers/searchapi) | [SearxNG Search API](/docs/integrations/providers/searx) | [SemaDB](/docs/integrations/providers/semadb) | [SerpAPI](/docs/integrations/providers/serpapi) | [Serper - Google Search API](/docs/integrations/providers/google_serper) | [Shale Protocol](/docs/integrations/providers/shaleprotocol) | [SingleStoreDB](/docs/integrations/providers/singlestoredb) | [Slack](/docs/integrations/providers/slack) | [Snowflake](/docs/integrations/providers/snowflake) | [spaCy](/docs/integrations/providers/spacy) | [Spark](/docs/integrations/providers/spark) | [SparkLLM](/docs/integrations/providers/sparkllm) | [Spreedly](/docs/integrations/providers/spreedly) | [SQLite](/docs/integrations/providers/sqlite) | [Stack Exchange](/docs/integrations/providers/stackexchange) | [StarRocks](/docs/integrations/providers/starrocks) | [StochasticAI](/docs/integrations/providers/stochasticai) | [Streamlit](/docs/integrations/providers/streamlit) | [Stripe](/docs/integrations/providers/stripe) | [Supabase (Postgres)](/docs/integrations/providers/supabase)
+
+### T
+
+[Tair](/docs/integrations/providers/tair) | [Telegram](/docs/integrations/providers/telegram) | [Tencent](/docs/integrations/providers/tencent) | [TensorFlow Datasets](/docs/integrations/providers/tensorflow_datasets) | [TiDB](/docs/integrations/providers/tidb) | [TigerGraph](/docs/integrations/providers/tigergraph) | [Tigris](/docs/integrations/providers/tigris) | [Together AI](/docs/integrations/providers/together) | [Transwarp](/docs/integrations/providers/transwarp) | [Trello](/docs/integrations/providers/trello) | [Trubrics](/docs/integrations/providers/trubrics) | [TruLens](/docs/integrations/providers/trulens) | [Twitter](/docs/integrations/providers/twitter) | [Typesense](/docs/integrations/providers/typesense)
+
+### U
+
+[Unstructured](/docs/integrations/providers/unstructured) | [Upstage](/docs/integrations/providers/upstage) | [Upstash Vector](/docs/integrations/providers/upstash) | [UpTrain](/docs/integrations/providers/uptrain) | [USearch](/docs/integrations/providers/usearch)
+
+### V
+
+[VDMS](/docs/integrations/providers/vdms) | [Vearch](/docs/integrations/providers/vearch) | [Vespa](/docs/integrations/providers/vespa) | [vlite](/docs/integrations/providers/vlite) | [VoyageAI](/docs/integrations/providers/voyageai)
+
+### W
+
+[Weather](/docs/integrations/providers/weather) | [Weaviate](/docs/integrations/providers/weaviate) | [Weights & Biases tracing](/docs/integrations/providers/wandb_tracing) | [Weights & Biases tracking](/docs/integrations/providers/wandb_tracking) | [Weights & Biases](/docs/integrations/providers/wandb) | [WhatsApp](/docs/integrations/providers/whatsapp) | [WhyLabs](/docs/integrations/providers/whylabs_profiling) | [Wikipedia](/docs/integrations/providers/wikipedia) | [Wolfram Alpha](/docs/integrations/providers/wolfram_alpha) | [Writer](/docs/integrations/providers/writer)
+
+### X
+
+[xAI](/docs/integrations/providers/xai) | [Xata](/docs/integrations/providers/xata) | [Xorbits Inference (Xinference)](/docs/integrations/providers/xinference)
+
+### Y
+
+[Yahoo](/docs/integrations/providers/yahoo) | [Yandex](/docs/integrations/providers/yandex) | [Yeager.ai](/docs/integrations/providers/yeagerai) | [Yellowbrick](/docs/integrations/providers/yellowbrick) | [You](/docs/integrations/providers/you) | [YouTube](/docs/integrations/providers/youtube)
+
+### Z
+
+[Zep](/docs/integrations/providers/zep) | [Zhipu AI](/docs/integrations/providers/zhipuai) | [Zilliz](/docs/integrations/providers/zilliz)
+

--- a/docs/docs/integrations/providers/wandb.mdx
+++ b/docs/docs/integrations/providers/wandb.mdx
@@ -1,0 +1,42 @@
+# Weights & Biases
+
+>[Weights & Biases](https://wandb.ai/) is provider of the AI developer platform to train and 
+> fine-tune AI models and develop AI applications.
+ 
+`Weights & Biase` products can be used to log metrics and artifacts during training, 
+and to trace the execution of your code.
+
+There are several main ways to use `Weights & Biases` products within LangChain:
+- with `wandb_tracing_enabled`
+- with `Weave` lightweight toolkit
+- with `WandbCallbackHandler` (deprecated)
+
+
+## wandb_tracing_enabled
+
+See a [usage example](/docs/integrations/providers/wandb_tracing).
+
+See in the [W&B documentation](https://docs.wandb.ai/guides/integrations/langchain).
+
+```python
+from langchain_community.callbacks import wandb_tracing_enabled
+```
+
+## Weave
+
+See in the [W&B documentation](https://weave-docs.wandb.ai/guides/integrations/langchain).
+
+
+## WandbCallbackHandler
+
+**Note:** the `WandbCallbackHandler` is being deprecated in favour of the `wandb_tracing_enabled`.
+
+See a [usage example](/docs/integrations/providers/wandb_tracking).
+
+See in the [W&B documentation](https://docs.wandb.ai/guides/integrations/langchain).
+
+```python
+from langchain_community.callbacks import WandbCallbackHandler
+```
+
+

--- a/docs/docs/integrations/providers/wandb_tracing.ipynb
+++ b/docs/docs/integrations/providers/wandb_tracing.ipynb
@@ -5,7 +5,7 @@
    "id": "5371a9bb",
    "metadata": {},
    "source": [
-    "# WandB Tracing\n",
+    "# Weights & Biases tracing\n",
     "\n",
     "There are two recommended ways to trace your LangChains:\n",
     "\n",
@@ -165,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/providers/wandb_tracking.ipynb
+++ b/docs/docs/integrations/providers/wandb_tracking.ipynb
@@ -6,19 +6,24 @@
    "id": "e43f4ea0",
    "metadata": {},
    "source": [
-    "# Weights & Biases\n",
+    "# Weights & Biases tracking\n",
     "\n",
-    "This notebook goes over how to track your LangChain experiments into one centralized Weights and Biases dashboard. To learn more about prompt engineering and the callback please refer to this Report which explains both alongside the resultant dashboards you can expect to see.\n",
+    "This notebook goes over how to track your LangChain experiments into one centralized `Weights and Biases` dashboard. \n",
     "\n",
+    "To learn more about prompt engineering and the callback please refer to this notebook which explains both alongside the resultant dashboards you can expect to see:\n",
     "\n",
     "<a href=\"https://colab.research.google.com/drive/1DXH4beT4HFaRKy_Vm4PoxhXVDRf7Ym8L?usp=sharing\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
     "\n",
-    "[View Report](https://wandb.ai/a-sh0ts/langchain_callback_demo/reports/Prompt-Engineering-LLMs-with-LangChain-and-W-B--VmlldzozNjk1NTUw#👋-how-to-build-a-callback-in-langchain-for-better-prompt-engineering\n",
-    ") \n",
+    "View a detailed description and examples in the [W&B article](https://wandb.ai/a-sh0ts/langchain_callback_demo/reports/Prompt-Engineering-LLMs-with-LangChain-and-W-B--VmlldzozNjk1NTUw#👋-how-to-build-a-callback-in-langchain-for-better-prompt-engineering\n",
+    "). \n",
     "\n",
     "\n",
-    "**Note**: _the `WandbCallbackHandler` is being deprecated in favour of the `WandbTracer`_ . In future please use the `WandbTracer` as it is more flexible and allows for more granular logging. To know more about the `WandbTracer` refer to the [agent_with_wandb_tracing](/docs/integrations/providers/wandb_tracing) notebook or use the following [colab notebook](http://wandb.me/prompts-quickstart). To know more about Weights & Biases Prompts refer to the following [prompts documentation](https://docs.wandb.ai/guides/prompts)."
+    "**Note**: _the `WandbCallbackHandler` is being deprecated in favour of the `WandbTracer`_ . In future please use the `WandbTracer` as it is more flexible and allows for more granular logging. \n",
+    "\n",
+    "To know more about the `WandbTracer` refer to the [agent_with_wandb_tracing](/docs/integrations/providers/wandb_tracing) notebook or use the following [colab notebook](http://wandb.me/prompts-quickstart). \n",
+    "\n",
+    "To know more about Weights & Biases Prompts refer to the following [prompts documentation](https://docs.wandb.ai/guides/prompts)."
    ]
   },
   {
@@ -249,6 +254,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "483eefd4-633e-4686-8730-944705fe8a80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T18:20:31.003316Z",
+     "iopub.status.busy": "2024-11-12T18:20:31.003152Z",
+     "iopub.status.idle": "2024-11-12T18:20:31.006033Z",
+     "shell.execute_reply": "2024-11-12T18:20:31.005546Z",
+     "shell.execute_reply.started": "2024-11-12T18:20:31.003303Z"
+    }
+   },
+   "source": [
+    "## Usage Scenarios"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "066adc04-8180-4936-8d75-5c3660b61de7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T18:20:45.826326Z",
+     "iopub.status.busy": "2024-11-12T18:20:45.825714Z",
+     "iopub.status.idle": "2024-11-12T18:20:45.830483Z",
+     "shell.execute_reply": "2024-11-12T18:20:45.830037Z",
+     "shell.execute_reply.started": "2024-11-12T18:20:45.826279Z"
+    }
+   },
+   "source": [
+    "### With LLM"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "d68750d5",
@@ -371,6 +408,14 @@
     "# SCENARIO 1 - LLM\n",
     "llm_result = llm.generate([\"Tell me a joke\", \"Tell me a poem\"] * 3)\n",
     "wandb_callback.flush_tracker(llm, name=\"simple_sequential\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dcfc24b-f0b0-48ec-89ce-beeb2fb763d5",
+   "metadata": {},
+   "source": [
+    "### Within Chains"
    ]
   },
   {
@@ -525,6 +570,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "533cd4c9-56e2-4ad9-a83e-4653bfcf322f",
+   "metadata": {},
+   "source": [
+    "### With Agents"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "0c609071",
@@ -646,7 +699,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/scripts/providers_index.py
+++ b/docs/scripts/providers_index.py
@@ -1,0 +1,112 @@
+import json
+import os
+import re
+import string
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def extract_titles(input_dir: str) -> list[dict[str, str]]:
+    titles = []
+    title_pattern = re.compile(r"^# (.+)")  # Pattern to match '# Title' format
+
+    # Traverse all files in the directory
+    for filename in os.listdir(input_dir):
+        if filename == "all.mdx":
+            continue  # Skip the output file
+        file_path = os.path.join(input_dir, filename)
+
+        if filename.endswith((".md", ".mdx")):
+            # Open markdown files and extract title
+            with open(file_path, "r", encoding="utf-8") as file:
+                for line in file:
+                    match = title_pattern.match(line)
+                    if match:
+                        title = match.group(1)
+                        titles.append({"file": filename, "title": title})
+                        break  # Stop after the first title line
+
+        elif filename.endswith(".ipynb"):
+            # Open Jupyter Notebook files and extract title
+            with open(file_path, "r", encoding="utf-8") as file:
+                notebook_data = json.load(file)
+                # Search in notebook cells for the title
+                for cell in notebook_data.get("cells", []):
+                    if cell.get("cell_type") == "markdown":
+                        for line in cell.get("source", []):
+                            match = title_pattern.match(line)
+                            if match:
+                                title = match.group(1)
+                                titles.append({"file": filename, "title": title})
+                                break
+                    if titles and titles[-1]["file"] == filename:
+                        break  # Stop after finding the first title in the notebook
+
+    return titles
+
+
+def transform_to_links(titles: list[dict[str, str]], prefix: str) -> list[str]:
+    return [
+        f"[{title['title']}]({prefix}{title['file'].split('.')[0]})" for title in titles
+    ]
+
+
+def generate_index_page(items: list[str], num_columns: int = 5) -> str:
+    # Group items by their starting letter (the second character in the string)
+    grouped_items = defaultdict(list)
+    for item in items:
+        first_letter = item[1].upper()
+        if first_letter in string.ascii_uppercase:
+            grouped_items[first_letter].append(item)
+        else:
+            grouped_items["0-9"].append(item)  # Non-alphabetical characters go here
+
+    # Sort groups by letters A-Z
+    sorted_groups = sorted(grouped_items.items())
+
+    # Generate Markdown content
+    content = [
+        """---
+hide_table_of_contents: true
+---
+# Providers
+
+:::info
+If you'd like to write your own integration, see [Extending LangChain](/docs/how_to/#custom).
+
+If you'd like to contribute an integration, see [Contributing integrations](/docs/contributing/how_to/integrations/).
+
+:::
+
+""",
+    ]
+    # First part: Menu with links
+    menu_links = " | ".join(
+        f"[{letter}](#{letter.lower()})" for letter, _ in sorted_groups
+    )
+    content.append(menu_links + "\n\n")
+    content.append("\n---\n\n")
+
+    # Second part: Grouped items in a single line with separators
+    for letter, items in sorted_groups:
+        content.append(f"### {letter}\n\n")
+        # Sort items within each group and join them in a single line with " | " separator
+        items_line = " | ".join(sorted(items, key=str.casefold))
+        content.append(items_line + "\n\n")
+
+    return "".join(content)
+
+
+if __name__ == "__main__":
+    DOCS_DIR = Path(__file__).parents[1]
+    providers_dir = DOCS_DIR / "docs" / "integrations" / "providers"
+    # "all.mdx" is used for `providers` root directory menu
+    output_file = providers_dir / "all.mdx"
+
+    titles = extract_titles(providers_dir)
+    links = transform_to_links(titles=titles, prefix="/docs/integrations/providers/")
+    mdx_page = generate_index_page(items=links)
+    with open(output_file, "w") as f:
+        f.write(mdx_page)
+        print(f"{output_file} generated successfully")

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -171,8 +171,8 @@ module.exports = {
             },
           ],
           link: {
-            type: "generated-index",
-            slug: "integrations/providers/all",
+            type: "doc",
+            id: "integrations/providers/all",
           },
         },
       ],


### PR DESCRIPTION
The current [`integration/providers/all`](https://python.langchain.com/docs/integrations/providers/all/) page is not readable. It has too many items.
I've generated it with A-Z menu. Now it is much easier to navigate.
See the [result page](https://langchain-j3ziuc88w-langchain.vercel.app/docs/integrations/providers/all/).
