### PR TITLE
docs: Fixed broken link to the Luminous model family introduction

### DIFF
--- a/docs/docs/integrations/llms/aleph_alpha.ipynb
+++ b/docs/docs/integrations/llms/aleph_alpha.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Aleph Alpha\n",
     "\n",
-    "[The Luminous series](https://docs.aleph-alpha.com/docs/introduction/luminous/) is a family of large language models.\n",
+    "[The Luminous series](https://docs.aleph-alpha.com/docs/category/luminous/) is a family of large language models.\n",
     "\n",
     "This example goes over how to use LangChain to interact with Aleph Alpha models"
    ]


### PR DESCRIPTION
The Luminous Model hyperlink at the start of the model is broken.
Fixed it to update it with the latest link used by the integration