### PR TITLE
docs: Fixed broken link for AI models introduction

### DIFF
--- a/docs/docs/integrations/llms/forefrontai.ipynb
+++ b/docs/docs/integrations/llms/forefrontai.ipynb
@@ -7,7 +7,7 @@
     "# ForefrontAI\n",
     "\n",
     "\n",
-    "The `Forefront` platform gives you the ability to fine-tune and use [open-source large language models](https://docs.forefront.ai/forefront/master/models).\n",
+    "The `Forefront` platform gives you the ability to fine-tune and use [open-source large language models](https://docs.forefront.ai/get-started/models).\n",
     "\n",
     "This notebook goes over how to use Langchain with [ForefrontAI](https://www.forefront.ai/).\n"
    ]


### PR DESCRIPTION
Fixed broken redirect to the introduction to AI models in the Forefront platform