### PR TITLE
docs: Fixed broken link for Cloudfare docs for the models available

### DIFF
--- a/docs/docs/integrations/llms/cloudflare_workersai.ipynb
+++ b/docs/docs/integrations/llms/cloudflare_workersai.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Cloudflare Workers AI\n",
     "\n",
-    "[Cloudflare AI documentation](https://developers.cloudflare.com/workers-ai/models/text-generation/) listed all generative text models available.\n",
+    "[Cloudflare AI documentation](https://developers.cloudflare.com/workers-ai/models/) listed all generative text models available.\n",
     "\n",
     "Both Cloudflare account ID and API token are required. Find how to obtain them from [this document](https://developers.cloudflare.com/workers-ai/get-started/rest-api/)."
    ]


### PR DESCRIPTION
Fixed the broken redirect to see all the cloudfare models