### PR TITLE
docs: Fixed wrong link redirect from JS ToolMessage to Python ToolMes…

### DIFF
--- a/docs/docs/troubleshooting/errors/INVALID_TOOL_RESULTS.ipynb
+++ b/docs/docs/troubleshooting/errors/INVALID_TOOL_RESULTS.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# INVALID_TOOL_RESULTS\n",
     "\n",
-    "You are passing too many, too few, or mismatched [`ToolMessages`](https://api.js.langchain.com/classes/_langchain_core.messages_tool.ToolMessage.html) to a model.\n",
+    "You are passing too many, too few, or mismatched [`ToolMessages`](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.tool.ToolMessage.html#toolmessage) to a model.\n",
     "\n",
     "When [using a model to call tools](/docs/concepts/tool_calling), the [`AIMessage`](https://api.js.langchain.com/classes/_langchain_core.messages.AIMessage.html)\n",
     "the model responds with will contain a `tool_calls` array. To continue the flow, the next messages you pass back to the model must\n",


### PR DESCRIPTION
Fixed the link to ToolMessage from the JS documentation to Python documentation