### PR TITLE
docs: Fix missing space between the words API Reference

### DIFF
--- a/docs/docs/how_to/custom_chat_model.ipynb
+++ b/docs/docs/how_to/custom_chat_model.ipynb
@@ -503,7 +503,7 @@
     "\n",
     "Documentation:\n",
     "\n",
-    "* The model contains doc-strings for all initialization arguments, as these will be surfaced in the [APIReference](https://python.langchain.com/api_reference/langchain/index.html).\n",
+    "* The model contains doc-strings for all initialization arguments, as these will be surfaced in the [API Reference](https://python.langchain.com/api_reference/langchain/index.html).\n",
     "* The class doc-string for the model contains a link to the model API if the model is powered by a service.\n",
     "\n",
     "Tests:\n",


### PR DESCRIPTION
Added an expected space between the words APIReference