### PR TITLE
docs: Updated link to ensure reference to the correct header for ToolNode

### DIFF
--- a/docs/docs/concepts/tool_calling.mdx
+++ b/docs/docs/concepts/tool_calling.mdx
@@ -128,7 +128,7 @@ For more details on usage, see our [how-to guides](/docs/how_to/#tools)!
 
 [Tools](/docs/concepts/tools/) implement the [Runnable](/docs/concepts/runnables/) interface, which means that they can be invoked (e.g., `tool.invoke(args)`) directly.
 
-[LangGraph](https://langchain-ai.github.io/langgraph/) offers pre-built components (e.g., [`ToolNode`](https://langchain-ai.github.io/langgraph/reference/prebuilt/#toolnode)) that will often invoke the tool in behalf of the user.
+[LangGraph](https://langchain-ai.github.io/langgraph/) offers pre-built components (e.g., [`ToolNode`](https://langchain-ai.github.io/langgraph/reference/prebuilt/#langgraph.prebuilt.tool_node.ToolNode)) that will often invoke the tool in behalf of the user.
 
 :::info[Further reading]
 


### PR DESCRIPTION
When `ToolNode` hyperlink is clicked, it does not automatically scroll to the section due to incorrect reference to the heading / id in the LangGraph documentation