### PR TITLE
docs: Fix outdated doc as no templates on master

### DIFF
--- a/libs/cli/langchain_cli/project_template/README.md
+++ b/libs/cli/langchain_cli/project_template/README.md
@@ -11,9 +11,10 @@ pip install -U langchain-cli
 ## Adding packages
 
 ```bash
-# adding packages from 
-# https://github.com/langchain-ai/langchain/tree/master/templates
-langchain app add $PROJECT_NAME
+# adding packages from v0.2 templates
+# https://github.com/langchain-ai/langchain/tree/v0.2/templates
+langchain app add $PROJECT_NAME --branch v0.2
+# langchain app add pirate-speak --branch v0.2
 
 # adding custom GitHub repo packages
 langchain app add --repo $OWNER/$REPO


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: **docs: update project_template readme as no templates dir on master**
  - Where "package" is whichever of langchain, community, core, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


- [x] **PR message**: 
    - **Description:** 
    templates dir is only keeped on v0.2 branch. Master has removed it. However our master branch still has the outdated readme to let user add those templates packages. It's failed of course.
    - **Solution**: update the lines and tell user to use them on v0.2
  

- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
