### PR TITLE
docs: Fixed mini typo

### DIFF
--- a/docs/docs/versions/v0_3/index.mdx
+++ b/docs/docs/versions/v0_3/index.mdx
@@ -132,7 +132,7 @@ should ensure that they are passing Pydantic 2 objects to these APIs rather than
 Pydantic 1 objects (created via the `pydantic.v1` namespace of pydantic 2).
 
 :::caution
-While `v1` objets may be accepted by some of these APIs, users are advised to
+While `v1` objects may be accepted by some of these APIs, users are advised to
 use Pydantic 2 objects to avoid future issues.
 :::
 


### PR DESCRIPTION
Fix mini typo from objets to objects