### PR TITLE
docs: Resolve incorrect import for `AttributeInfo`

### DIFF
--- a/docs/docs/how_to/self_query.ipynb
+++ b/docs/docs/how_to/self_query.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",


### PR DESCRIPTION
`AttributeInfo` is incorrectly imported from `langchain.chains.query_constructor.base` instead of `langchain.chains.query_constructor.schema`