### PR TITLE
docs: Fix wrong import of `AttributeInfo`

### DIFF
--- a/docs/docs/integrations/retrievers/self_query/elasticsearch_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/elasticsearch_self_query.ipynb
@@ -136,7 +136,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",


### PR DESCRIPTION
Fix wrong import of `AttributeInfo` from `langchain.chains.query_constructor.base` to `langchain.chains.query_constructor.schema`