### PR TITLE
langchain: add missing punctuation in react_single_input.py

### DIFF
--- a/libs/langchain/langchain/agents/output_parsers/react_single_input.py
+++ b/libs/langchain/langchain/agents/output_parsers/react_single_input.py
@@ -9,7 +9,7 @@ from langchain.agents.mrkl.prompt import FORMAT_INSTRUCTIONS
 
 FINAL_ANSWER_ACTION = "Final Answer:"
 MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE = (
-    "Invalid Format: Missing 'Action:' after 'Thought:"
+    "Invalid Format: Missing 'Action:' after 'Thought:'"
 )
 MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE = (
     "Invalid Format: Missing 'Action Input:' after 'Action:'"


### PR DESCRIPTION
- [x] **PR title**: "langchain: add missing punctuation in react_single_input.py"

- [x] **PR message**: 
    - **Description:** Add missing single quote to line 12: "Invalid Format: Missing 'Action:' after 'Thought:"
