### PR TITLE
docs: Update langserve to 0.3 and pydantic to 2+ in cli project template

### DIFF
--- a/libs/cli/langchain_cli/project_template/pyproject.toml
+++ b/libs/cli/langchain_cli/project_template/pyproject.toml
@@ -11,8 +11,8 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.11"
 uvicorn = "^0.23.2"
-langserve = {extras = ["server"], version = ">=0.0.30"}
-pydantic = "<2"
+langserve = {extras = ["server"], version = ">=0.3.0"}
+pydantic = ">2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: **docs: Update langserve to 0.3 and pydantic to 2+ in cli project template**

- [x] **PR message**: 
    - **Description:** Update langserve to 0.3 and pydantic to 2+ in cli project template
    - **Issue:** **when using poetry to install something after new an app, it will run into conflicts as the pydantic version required by the template app is too old.**

- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
