### PR TITLE
docs: efficient rebuild

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,7 +38,7 @@ install-py-deps:
 
 generate-files:
 	mkdir -p $(INTERMEDIATE_DIR)
-	cp -r $(SOURCE_DIR)/* $(INTERMEDIATE_DIR)
+	cp -rp $(SOURCE_DIR)/* $(INTERMEDIATE_DIR)
 
 	$(PYTHON) scripts/tool_feat_table.py $(INTERMEDIATE_DIR)
 

--- a/docs/docs/contributing/how_to/integrations/standard_tests.ipynb
+++ b/docs/docs/contributing/how_to/integrations/standard_tests.ipynb
@@ -143,7 +143,8 @@
     "        This should NOT be a ToolCall dict - i.e. it should not\n",
     "        have {\"name\", \"id\", \"args\"} keys.\n",
     "        \"\"\"\n",
-    "        return {\"a\": 2, \"b\": 3}"
+    "        return {\"a\": 2, \"b\": 3}\n",
+    "    "
    ]
   },
   {

--- a/docs/docs/contributing/how_to/integrations/standard_tests.ipynb
+++ b/docs/docs/contributing/how_to/integrations/standard_tests.ipynb
@@ -143,8 +143,7 @@
     "        This should NOT be a ToolCall dict - i.e. it should not\n",
     "        have {\"name\", \"id\", \"args\"} keys.\n",
     "        \"\"\"\n",
-    "        return {\"a\": 2, \"b\": 3}\n",
-    "    "
+    "        return {\"a\": 2, \"b\": 3}"
    ]
   },
   {

--- a/docs/scripts/notebook_convert.py
+++ b/docs/scripts/notebook_convert.py
@@ -184,7 +184,18 @@ if __name__ == "__main__":
         source_paths_stripped = [p.strip() for p in source_path_strs]
         source_paths = [intermediate_docs_dir / p for p in source_paths_stripped if p]
     else:
-        source_paths = intermediate_docs_dir.glob("**/*.ipynb")
+        original_paths = list(intermediate_docs_dir.glob("**/*.ipynb"))
+        # exclude files that exist in output directory and are newer
+        relative_paths = [p.relative_to(intermediate_docs_dir) for p in original_paths]
+        out_paths = [
+            output_docs_dir / p.parent / (p.stem + ".md") for p in relative_paths
+        ]
+        source_paths = [
+            p
+            for p, o in zip(original_paths, out_paths)
+            if not o.exists() or o.stat().st_mtime < p.stat().st_mtime
+        ]
+        print(f"rebuilding {len(source_paths)}/{len(relative_paths)} notebooks")
 
     with multiprocessing.Pool() as pool:
         pool.map(


### PR DESCRIPTION
if you run `make build start` in one tab, then start editing files, you can efficient rebuild notebooks with `make generate-files md-sync render`