### PR TITLE
docs: fix typo in migration guide: migrate_agent.ipynb

### DIFF
--- a/docs/docs/how_to/migrate_agent.ipynb
+++ b/docs/docs/how_to/migrate_agent.ipynb
@@ -331,7 +331,7 @@
    "metadata": {},
    "source": [
     "We can also pass in an arbitrary function. This function should take in a list of messages and output a list of messages.\n",
-    "We can do all types of arbitrary formatting of messages here. In this cases, let's just add a SystemMessage to the start of the list of messages."
+    "We can do all types of arbitrary formatting of messages here. In this case, let's just add a SystemMessage to the start of the list of messages."
    ]
   },
   {


### PR DESCRIPTION
PR Title: `docs: fix typo in migration guide`

PR Message:
- **Description**: This PR fixes a small typo in the "How to Migrate from Legacy LangChain Agents to LangGraph" guide. "In this cases" -> "In this case"
- **Issue**: N/A (no issue linked for this typo fix)
- **Dependencies**: None
- **Twitter handle**: N/A
