### PR TITLE
mistral[patch]: Propagate tool call id

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -353,6 +353,7 @@ def _convert_message_to_mistral_chat_message(
             "role": "tool",
             "content": message.content,
             "name": message.name,
+            "tool_call_id": message.tool_call_id,
         }
     else:
         raise ValueError(f"Got unknown type {message}")


### PR DESCRIPTION
mistralai-large-2411 requires tool call id

Older models accept tool call id if its provided

mistral-large-2407 
mistral-large-2402