### PR TITLE
langchain-mistralai: fix missing tool_call_id parameter

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -353,6 +353,7 @@ def _convert_message_to_mistral_chat_message(
             "role": "tool",
             "content": message.content,
             "name": message.name,
+            "tool_call_id": message.tool_call_id,
         }
     else:
         raise ValueError(f"Got unknown type {message}")

--- a/libs/partners/mistralai/pyproject.toml
+++ b/libs/partners/mistralai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-mistralai"
-version = "0.2.1"
+version = "0.2.2"
 description = "An integration package connecting Mistral and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
First pr on langchain 🎉 

**Description**

Tool calls using langgraph fail because there is a missing `tool_call_id` in the `tool` message.

**Issue**
/

**Dependencies**
/

**Twitter handle**
/


If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
