### PR TITLE
community: fix compatibility issue in kinetica chat model integration for Pydantic 2

### DIFF
--- a/libs/community/langchain_community/chat_models/kinetica.py
+++ b/libs/community/langchain_community/chat_models/kinetica.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2024, Chad Juliano, Kinetica DB Inc.
 ##
 """Kinetica SQL generation LLM API."""
-
 import json
 import logging
 import os
@@ -78,7 +77,7 @@ class _KdtSuggestContext(BaseModel):
 class _KdtSuggestPayload(BaseModel):
     """pydantic API request type"""
 
-    question: Optional[str]
+    question: Optional[str] = None
     context: List[_KdtSuggestContext]
 
     def get_system_str(self) -> str:
@@ -410,17 +409,21 @@ class ChatKinetica(BaseChatModel):
 
         # query kinetica for the prompt
         sql = f"GENERATE PROMPT WITH OPTIONS (CONTEXT_NAMES = '{context_name}')"
+
         result = self._execute_sql(sql)
         prompt = result["Prompt"]
         prompt_json = json.loads(prompt)
 
         # convert the prompt to messages
         # request = SuggestRequest.model_validate(prompt_json) # pydantic v2
+
         request = _KdtoSuggestRequest.model_validate(prompt_json)
         payload = request.payload
+      
 
         dict_messages = []
         dict_messages.append(dict(role="system", content=payload.get_system_str()))
+       
         dict_messages.extend(payload.get_messages())
         messages = [self._convert_message_from_dict(m) for m in dict_messages]
         return messages

--- a/libs/community/langchain_community/chat_models/kinetica.py
+++ b/libs/community/langchain_community/chat_models/kinetica.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024, Chad Juliano, Kinetica DB Inc.
 ##
 """Kinetica SQL generation LLM API."""
+
 import json
 import logging
 import os
@@ -419,11 +420,10 @@ class ChatKinetica(BaseChatModel):
 
         request = _KdtoSuggestRequest.model_validate(prompt_json)
         payload = request.payload
-      
 
         dict_messages = []
         dict_messages.append(dict(role="system", content=payload.get_system_str()))
-       
+
         dict_messages.extend(payload.get_messages())
         messages = [self._convert_message_from_dict(m) for m in dict_messages]
         return messages


### PR DESCRIPTION
Fixed a compatibility issue in the `load_messages_from_context()` function for the Kinetica chat model integration. The issue was caused by stricter validation introduced in Pydantic 2.