### PR TITLE
langchain_ollama: Check for None tool_calls object

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -66,7 +66,8 @@ def _get_tool_calls_from_response(
     """Get tool calls from ollama response."""
     tool_calls = []
     if "message" in response:
-        if "tool_calls" in response["message"] and response["message"]["tool_calls"] is not None:
+        if "tool_calls" in response["message"] \
+        and response["message"]["tool_calls"] is not None:
             for tc in response["message"]["tool_calls"]:
                 tool_calls.append(
                     tool_call(

--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -66,7 +66,7 @@ def _get_tool_calls_from_response(
     """Get tool calls from ollama response."""
     tool_calls = []
     if "message" in response:
-        if "tool_calls" in response["message"]:
+        if "tool_calls" in response["message"] and response["message"]["tool_calls"] is not None:
             for tc in response["message"]["tool_calls"]:
                 tool_calls.append(
                     tool_call(

--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -66,8 +66,10 @@ def _get_tool_calls_from_response(
     """Get tool calls from ollama response."""
     tool_calls = []
     if "message" in response:
-        if "tool_calls" in response["message"] \
-        and response["message"]["tool_calls"] is not None:
+        if (
+            "tool_calls" in response["message"]
+            and response["message"]["tool_calls"] is not None
+        ):
             for tc in response["message"]["tool_calls"]:
                 tool_calls.append(
                     tool_call(


### PR DESCRIPTION
- **Description:** Handle `None` `tool_calls` object in chat model
- **Issue:** NA, see below
- **Dependencies:** NA
- **Twitter handle:** NA

I just started encountering this problem:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[<ipython-input-8-7e68218630b0>](https://localhost:8080/#) in <cell line: 10>()
      8 ollama_model = ChatOllama(model=ollama_model_name)
      9 
---> 10 zero_temp_ollama_model.invoke("what")
     11 
     12 response=zero_temp_ollama_model.invoke("Hi!  What is your name?").content

7 frames
[/usr/local/lib/python3.10/dist-packages/langchain_ollama/chat_models.py](https://localhost:8080/#) in _get_tool_calls_from_response(response)
     68     if "message" in response:
     69         if "tool_calls" in response["message"]:
---> 70             print(response["message"])
     71             for tc in response["message"]["tool_calls"]:
     72                 tool_calls.append(

TypeError: 'NoneType' object is not iterable
```

ollama version 0.4.3, langchain_ollama-0.2.0 ollama-0.4.0 langchain-0.3.7

I think it's probably from a recent ollama change.