### PR TITLE
community: list valid values for LanceDB constructor's `mode` argument

### DIFF
--- a/libs/community/langchain_community/vectorstores/lancedb.py
+++ b/libs/community/langchain_community/vectorstores/lancedb.py
@@ -43,7 +43,8 @@ class LanceDB(VectorStore):
         table_name: Name of the table to use. Defaults to ``vectorstore``.
         api_key: API key to use for LanceDB cloud database.
         region: Region to use for LanceDB cloud database.
-        mode: Mode to use for adding data to the table. Defaults to ``overwrite``.
+        mode: Mode to use for adding data to the table. Valid values are
+              ``append`` and ``overwrite``. Defaults to ``overwrite``.
 
 
 


### PR DESCRIPTION
**Description:**

Currently, the docstring for `LanceDB.__init__()` provides the default value for `mode`, but not the list of valid values. This PR adds that list to the docstring.

**Issue:**

N/A

**Dependencies:**

N/A

**Twitter handle:**

`@metadaddy`

[Leaving as a reminder: If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.]
