### PR TITLE
docs: fix GOOGLE_API_KEY typo

### DIFF
--- a/libs/community/langchain_community/chat_models/google_palm.py
+++ b/libs/community/langchain_community/chat_models/google_palm.py
@@ -219,7 +219,7 @@ class ChatGooglePalm(BaseChatModel, BaseModel):
     To use you must have the google.generativeai Python package installed and
     either:
 
-        1. The ``GOOGLE_API_KEY``` environment variable set with your API key, or
+        1. The ``GOOGLE_API_KEY`` environment variable set with your API key, or
         2. Pass your API key using the google_api_key kwarg to the ChatGoogle
            constructor.
 


### PR DESCRIPTION
fix small GOOGLE_API_KEY markdown formatting typo