### PR TITLE
community: improve Neo4j connection lifecycle management

### DIFF
--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -410,6 +410,20 @@ class Neo4jGraph(GraphStore):
         """Returns the structured schema of the Graph"""
         return self.structured_schema
 
+    def close(self) -> None:
+        """Close all the active resources."""
+        if hasattr(self, '_driver'):
+            self._driver.close()
+            delattr(self, '_driver')  # Remove the driver to prevent usage after close
+
+    def __enter__(self) -> "Neo4jGraph":
+        """Enter context manager by returning self."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close all active resources when exiting context manager."""
+        self.close()
+
     def query(
         self,
         query: str,
@@ -423,9 +437,15 @@ class Neo4jGraph(GraphStore):
 
         Returns:
             List[Dict[str, Any]]: The list of dictionaries containing the query results.
+
+        Raises:
+            RuntimeError: If attempting to query after the connection is closed.
         """
         from neo4j import Query
         from neo4j.exceptions import Neo4jError
+
+        if not hasattr(self, '_driver'):
+            raise RuntimeError("Cannot query Neo4j - connection has been closed")
 
         try:
             data, _, _ = self._driver.execute_query(
@@ -674,10 +694,7 @@ class Neo4jGraph(GraphStore):
                         )
                     )
                     return_clauses.append(
-                        (
-                            f"values:`{prop_name}_values`[..{DISTINCT_VALUE_LIMIT}],"
-                            f" distinct_count: size(`{prop_name}_values`)"
-                        )
+                        f"values:`{prop_name}_values`[..{DISTINCT_VALUE_LIMIT}], distinct_count: size(`{prop_name}_values`)"
                     )
                 elif prop_type in [
                     "INTEGER",
@@ -692,11 +709,7 @@ class Neo4jGraph(GraphStore):
                         f"count(distinct n.`{prop_name}`) AS `{prop_name}_distinct`"
                     )
                     return_clauses.append(
-                        (
-                            f"min: toString(`{prop_name}_min`), "
-                            f"max: toString(`{prop_name}_max`), "
-                            f"distinct_count: `{prop_name}_distinct`"
-                        )
+                        f"min: toString(`{prop_name}_min`), max: toString(`{prop_name}_max`), distinct_count: `{prop_name}_distinct`"
                     )
                 elif prop_type == "LIST":
                     with_clauses.append(
@@ -706,8 +719,7 @@ class Neo4jGraph(GraphStore):
                         )
                     )
                     return_clauses.append(
-                        f"min_size: `{prop_name}_size_min`, "
-                        f"max_size: `{prop_name}_size_max`"
+                        f"min_size: `{prop_name}_size_min`, max_size: `{prop_name}_size_max`"
                     )
                 elif prop_type in ["BOOLEAN", "POINT", "DURATION"]:
                     continue
@@ -738,10 +750,7 @@ class Neo4jGraph(GraphStore):
                             f"'{label_or_type}', '{prop_name}') YIELD value"
                         )[0]["value"]
                         return_clauses.append(
-                            (
-                                f"values: {distinct_values},"
-                                f" distinct_count: {len(distinct_values)}"
-                            )
+                            f"values: {distinct_values}, distinct_count: {len(distinct_values)}"
                         )
                     else:
                         with_clauses.append(
@@ -775,11 +784,7 @@ class Neo4jGraph(GraphStore):
                             f"count(distinct n.`{prop_name}`) AS `{prop_name}_distinct`"
                         )
                         return_clauses.append(
-                            (
-                                f"min: toString(`{prop_name}_min`), "
-                                f"max: toString(`{prop_name}_max`), "
-                                f"distinct_count: `{prop_name}_distinct`"
-                            )
+                            f"min: toString(`{prop_name}_min`), max: toString(`{prop_name}_max`), distinct_count: `{prop_name}_distinct`"
                         )
 
                 elif prop_type == "LIST":
@@ -790,10 +795,7 @@ class Neo4jGraph(GraphStore):
                         )
                     )
                     return_clauses.append(
-                        (
-                            f"min_size: `{prop_name}_size_min`, "
-                            f"max_size: `{prop_name}_size_max`"
-                        )
+                        f"min_size: `{prop_name}_size_min`, max_size: `{prop_name}_size_max`"
                     )
                 elif prop_type in ["BOOLEAN", "POINT", "DURATION"]:
                     continue

--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -412,9 +412,9 @@ class Neo4jGraph(GraphStore):
 
     def close(self) -> None:
         """Close all the active resources."""
-        if hasattr(self, '_driver'):
+        if hasattr(self, "_driver"):
             self._driver.close()
-            delattr(self, '_driver')  # Remove the driver to prevent usage after close
+            delattr(self, "_driver")  # Remove the driver to prevent usage after close
 
     def __enter__(self) -> "Neo4jGraph":
         """Enter context manager by returning self."""
@@ -444,7 +444,7 @@ class Neo4jGraph(GraphStore):
         from neo4j import Query
         from neo4j.exceptions import Neo4jError
 
-        if not hasattr(self, '_driver'):
+        if not hasattr(self, "_driver"):
             raise RuntimeError("Cannot query Neo4j - connection has been closed")
 
         try:
@@ -694,7 +694,8 @@ class Neo4jGraph(GraphStore):
                         )
                     )
                     return_clauses.append(
-                        f"values:`{prop_name}_values`[..{DISTINCT_VALUE_LIMIT}], distinct_count: size(`{prop_name}_values`)"
+                        f"values:`{prop_name}_values`[..{DISTINCT_VALUE_LIMIT}], "
+                        f"distinct_count: size(`{prop_name}_values`)"
                     )
                 elif prop_type in [
                     "INTEGER",
@@ -709,7 +710,9 @@ class Neo4jGraph(GraphStore):
                         f"count(distinct n.`{prop_name}`) AS `{prop_name}_distinct`"
                     )
                     return_clauses.append(
-                        f"min: toString(`{prop_name}_min`), max: toString(`{prop_name}_max`), distinct_count: `{prop_name}_distinct`"
+                        f"min: toString(`{prop_name}_min`), "
+                        f"max: toString(`{prop_name}_max`), "
+                        f"distinct_count: `{prop_name}_distinct`"
                     )
                 elif prop_type == "LIST":
                     with_clauses.append(
@@ -719,7 +722,8 @@ class Neo4jGraph(GraphStore):
                         )
                     )
                     return_clauses.append(
-                        f"min_size: `{prop_name}_size_min`, max_size: `{prop_name}_size_max`"
+                        f"min_size: `{prop_name}_size_min`, "
+                        f"max_size: `{prop_name}_size_max`"
                     )
                 elif prop_type in ["BOOLEAN", "POINT", "DURATION"]:
                     continue
@@ -750,7 +754,8 @@ class Neo4jGraph(GraphStore):
                             f"'{label_or_type}', '{prop_name}') YIELD value"
                         )[0]["value"]
                         return_clauses.append(
-                            f"values: {distinct_values}, distinct_count: {len(distinct_values)}"
+                            f"values: {distinct_values}, "
+                            f"distinct_count: {len(distinct_values)}"
                         )
                     else:
                         with_clauses.append(
@@ -784,7 +789,9 @@ class Neo4jGraph(GraphStore):
                             f"count(distinct n.`{prop_name}`) AS `{prop_name}_distinct`"
                         )
                         return_clauses.append(
-                            f"min: toString(`{prop_name}_min`), max: toString(`{prop_name}_max`), distinct_count: `{prop_name}_distinct`"
+                            f"min: toString(`{prop_name}_min`), "
+                            f"max: toString(`{prop_name}_max`), "
+                            f"distinct_count: `{prop_name}_distinct`"
                         )
 
                 elif prop_type == "LIST":
@@ -795,7 +802,8 @@ class Neo4jGraph(GraphStore):
                         )
                     )
                     return_clauses.append(
-                        f"min_size: `{prop_name}_size_min`, max_size: `{prop_name}_size_max`"
+                        f"min_size: `{prop_name}_size_min`, "
+                        f"max_size: `{prop_name}_size_max`"
                     )
                 elif prop_type in ["BOOLEAN", "POINT", "DURATION"]:
                     continue

--- a/libs/community/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/community/tests/integration_tests/graphs/test_neo4j.py
@@ -398,3 +398,191 @@ def test_backticks() -> None:
 
     assert nodes == expected_nodes
     assert rels == expected_rels
+
+
+def test_neo4j_context_manager() -> None:
+    """Test that Neo4jGraph works correctly with context manager."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    with Neo4jGraph(url=url, username=username, password=password) as graph:
+        # Test that the connection is working
+        graph.query("RETURN 1 as n")
+
+    # Test that the connection is closed after exiting context
+    try:
+        graph.query("RETURN 1 as n")
+        assert False, "Expected RuntimeError when using closed connection"
+    except RuntimeError:
+        pass
+
+
+def test_neo4j_explicit_close() -> None:
+    """Test that Neo4jGraph can be explicitly closed."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    graph = Neo4jGraph(url=url, username=username, password=password)
+    # Test that the connection is working
+    graph.query("RETURN 1 as n")
+
+    # Close the connection
+    graph.close()
+
+    # Test that the connection is closed
+    try:
+        graph.query("RETURN 1 as n")
+        assert False, "Expected RuntimeError when using closed connection"
+    except RuntimeError:
+        pass
+
+
+def test_neo4j_error_after_close() -> None:
+    """Test that Neo4jGraph operations raise proper errors after closing."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    graph = Neo4jGraph(url=url, username=username, password=password)
+    graph.close()
+
+    # Test various operations after close
+    try:
+        graph.refresh_schema()
+        assert False, "Expected RuntimeError when refreshing schema on closed connection"
+    except RuntimeError as e:
+        assert "connection has been closed" in str(e)
+    
+    try:
+        graph.query("RETURN 1")
+        assert False, "Expected RuntimeError when querying closed connection"
+    except RuntimeError as e:
+        assert "connection has been closed" in str(e)
+    
+    try:
+        graph.add_graph_documents([test_data[0]])
+        assert False, "Expected RuntimeError when adding documents to closed connection"
+    except RuntimeError as e:
+        assert "connection has been closed" in str(e)
+
+
+def test_neo4j_concurrent_connections() -> None:
+    """Test that multiple Neo4jGraph instances can be used independently."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    graph1 = Neo4jGraph(url=url, username=username, password=password)
+    graph2 = Neo4jGraph(url=url, username=username, password=password)
+
+    # Both connections should work independently
+    assert graph1.query("RETURN 1 as n") == [{"n": 1}]
+    assert graph2.query("RETURN 2 as n") == [{"n": 2}]
+
+    # Closing one shouldn't affect the other
+    graph1.close()
+    try:
+        graph1.query("RETURN 1")
+        assert False, "Expected RuntimeError when using closed connection"
+    except RuntimeError:
+        pass
+    assert graph2.query("RETURN 2 as n") == [{"n": 2}]
+
+    graph2.close()
+
+
+def test_neo4j_nested_context_managers() -> None:
+    """Test that nested context managers work correctly."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    with Neo4jGraph(url=url, username=username, password=password) as graph1:
+        with Neo4jGraph(url=url, username=username, password=password) as graph2:
+            # Both connections should work
+            assert graph1.query("RETURN 1 as n") == [{"n": 1}]
+            assert graph2.query("RETURN 2 as n") == [{"n": 2}]
+        
+        # Inner connection should be closed, outer still works
+        try:
+            graph2.query("RETURN 2")
+            assert False, "Expected RuntimeError when using closed connection"
+        except RuntimeError:
+            pass
+        assert graph1.query("RETURN 1 as n") == [{"n": 1}]
+    
+    # Both connections should be closed
+    try:
+        graph1.query("RETURN 1")
+        assert False, "Expected RuntimeError when using closed connection"
+    except RuntimeError:
+        pass
+    try:
+        graph2.query("RETURN 2")
+        assert False, "Expected RuntimeError when using closed connection"
+    except RuntimeError:
+        pass
+
+
+def test_neo4j_multiple_close() -> None:
+    """Test that Neo4jGraph can be closed multiple times without error."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    graph = Neo4jGraph(url=url, username=username, password=password)
+    # Test that multiple closes don't raise errors
+    graph.close()
+    graph.close()  # This should not raise an error
+
+
+def test_neo4j_error_after_close() -> None:
+    """Test that Neo4jGraph operations raise proper errors after closing."""
+    url = os.environ.get("NEO4J_URI")
+    username = os.environ.get("NEO4J_USERNAME")
+    password = os.environ.get("NEO4J_PASSWORD")
+    assert url is not None
+    assert username is not None
+    assert password is not None
+
+    graph = Neo4jGraph(url=url, username=username, password=password)
+    graph.close()
+
+    # Test various operations after close
+    try:
+        graph.refresh_schema()
+        assert False, "Expected RuntimeError when refreshing schema on closed connection"
+    except RuntimeError as e:
+        assert "connection has been closed" in str(e)
+    
+    try:
+        graph.query("RETURN 1")
+        assert False, "Expected RuntimeError when querying closed connection"
+    except RuntimeError as e:
+        assert "connection has been closed" in str(e)
+    
+    try:
+        graph.add_graph_documents([test_data[0]])
+        assert False, "Expected RuntimeError when adding documents to closed connection"
+    except RuntimeError as e:
+        assert "connection has been closed" in str(e)

--- a/libs/community/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/community/tests/integration_tests/graphs/test_neo4j.py
@@ -455,21 +455,24 @@ def test_neo4j_error_after_close() -> None:
     assert password is not None
 
     graph = Neo4jGraph(url=url, username=username, password=password)
+    graph.query("RETURN 1")  # Should work
     graph.close()
 
     # Test various operations after close
     try:
         graph.refresh_schema()
-        assert False, "Expected RuntimeError when refreshing schema on closed connection"
+        assert (
+            False
+        ), "Expected RuntimeError when refreshing schema on closed connection"
     except RuntimeError as e:
         assert "connection has been closed" in str(e)
-    
+
     try:
         graph.query("RETURN 1")
         assert False, "Expected RuntimeError when querying closed connection"
     except RuntimeError as e:
         assert "connection has been closed" in str(e)
-    
+
     try:
         graph.add_graph_documents([test_data[0]])
         assert False, "Expected RuntimeError when adding documents to closed connection"
@@ -519,7 +522,7 @@ def test_neo4j_nested_context_managers() -> None:
             # Both connections should work
             assert graph1.query("RETURN 1 as n") == [{"n": 1}]
             assert graph2.query("RETURN 2 as n") == [{"n": 2}]
-        
+
         # Inner connection should be closed, outer still works
         try:
             graph2.query("RETURN 2")
@@ -527,7 +530,7 @@ def test_neo4j_nested_context_managers() -> None:
         except RuntimeError:
             pass
         assert graph1.query("RETURN 1 as n") == [{"n": 1}]
-    
+
     # Both connections should be closed
     try:
         graph1.query("RETURN 1")
@@ -554,35 +557,3 @@ def test_neo4j_multiple_close() -> None:
     # Test that multiple closes don't raise errors
     graph.close()
     graph.close()  # This should not raise an error
-
-
-def test_neo4j_error_after_close() -> None:
-    """Test that Neo4jGraph operations raise proper errors after closing."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
-    graph = Neo4jGraph(url=url, username=username, password=password)
-    graph.close()
-
-    # Test various operations after close
-    try:
-        graph.refresh_schema()
-        assert False, "Expected RuntimeError when refreshing schema on closed connection"
-    except RuntimeError as e:
-        assert "connection has been closed" in str(e)
-    
-    try:
-        graph.query("RETURN 1")
-        assert False, "Expected RuntimeError when querying closed connection"
-    except RuntimeError as e:
-        assert "connection has been closed" in str(e)
-    
-    try:
-        graph.add_graph_documents([test_data[0]])
-        assert False, "Expected RuntimeError when adding documents to closed connection"
-    except RuntimeError as e:
-        assert "connection has been closed" in str(e)


### PR DESCRIPTION
**Description:**
This PR improves the Neo4j graph integration by implementing proper connection lifecycle management. The changes ensure that Neo4j database connections are properly managed and cleaned up, preventing resource leaks and improving the robustness of the integration.

Key improvements:
- Add explicit `close()` method to terminate Neo4j connections
- Implement context manager support with `__enter__` and `__exit__`
- Add runtime checks to prevent operations on closed connections
- Add comprehensive lifecycle tests

These changes align with Neo4j driver best practices and provide users with clear patterns for managing database connections.

**Dependencies:**
- No new dependencies required
- Existing dependency: neo4j>=5.0

**Testing:**
- Added comprehensive test suite in `test_neo4j.py`
- Tests cover:
  - Context manager usage
  - Explicit connection closing
  - Error handling for closed connections
  - Connection state validation

Few unrelated test failures with `make test`: 
======================================================================================================== short test summary info ========================================================================================================
FAILED tests/unit_tests/llms/test_llamafile.py::test_call_raises_exception_on_missing_server - pytest_socket.SocketBlockedError: A test tried to use socket.socket.
FAILED tests/unit_tests/tools/playwright/test_all.py::test_playwright_tools_schemas - ModuleNotFoundError: No module named 'playwright'
====================================================================================== 2 failed, 1068 passed, 531 skipped, 695 warnings in 13.71s =======================================================================================
Failed to batch ingest runs: langsmith.utils.LangSmithError: Failed to POST https://api.smith.langchain.com/runs/batch in LangSmith API. HTTPError('403 Client Error: Forbidden for url: https://api.smith.langchain.com/runs/batch', '{"detail":"Forbidden"}')
make: *** [test] Error 1

NOTE: I saw a separate [PR](https://github.com/langchain-ai/langchain/pull/28130) referencing community neo4j deprecation, but not really informed on the details of this. Either way, this provides a more graceful shutdown for clients still using this lib and aligns with neo4j driver expectations.  