### PR TITLE
Community: Updated Chat Ollama `_get_tool_calls_from_response` to check for Nullability for `tool_calls` in return message

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -66,7 +66,7 @@ def _get_tool_calls_from_response(
     """Get tool calls from ollama response."""
     tool_calls = []
     if "message" in response:
-        if "tool_calls" in response["message"]:
+        if "tool_calls" in response["message"] and response["message"]["tool_calls"]:
             for tc in response["message"]["tool_calls"]:
                 tool_calls.append(
                     tool_call(


### PR DESCRIPTION
- **Description:** Checking if `response["message"]["tool_calls"]` is Null or not to avoid `NoneType` Error as pointed in the issue
- **Issue:** #28312
