### PR TITLE
Community: Marqo Index Setting GET Request Updated according to `2.x` API version while keep backward compatability for 1.5.x

### DIFF
--- a/libs/community/langchain_community/vectorstores/marqo.py
+++ b/libs/community/langchain_community/vectorstores/marqo.py
@@ -109,9 +109,19 @@ class Marqo(VectorStore):
             List[str]: The list of ids that were added.
         """
 
-        if self._client.index(self._index_name).get_settings()["index_defaults"][
-            "treat_urls_and_pointers_as_images"
-        ]:
+        if (
+            "index_defaults" in self._client.index(self._index_name).get_settings()
+            and self._client.index(self._index_name).get_settings()["index_defaults"][
+                "treat_urls_and_pointers_as_images"
+            ]
+            or (
+                "treat_urls_and_pointers_as_images"
+                in self._client.index(self._index_name).get_settings()
+                and self._client.index(self._index_name).get_settings()[
+                    "treat_urls_and_pointers_as_images"
+                ]
+            )
+        ):
             raise ValueError(
                 "Marqo.add_texts is disabled for multimodal indexes. To add documents "
                 "with a multimodal index use the Python client for Marqo directly."

--- a/libs/community/langchain_community/vectorstores/marqo.py
+++ b/libs/community/langchain_community/vectorstores/marqo.py
@@ -113,7 +113,7 @@ class Marqo(VectorStore):
         if (
             "index_defaults" in settings
             and settings["index_defaults"]["treat_urls_and_pointers_as_images"]
-            or settings.get("treat_urls_and_pointers_as_images"):
+            or settings.get("treat_urls_and_pointers_as_images")
         ):
             raise ValueError(
                 "Marqo.add_texts is disabled for multimodal indexes. To add documents "

--- a/libs/community/langchain_community/vectorstores/marqo.py
+++ b/libs/community/langchain_community/vectorstores/marqo.py
@@ -109,18 +109,11 @@ class Marqo(VectorStore):
             List[str]: The list of ids that were added.
         """
 
+        settings = self._client.index(self._index_name).get_settings()
         if (
-            "index_defaults" in self._client.index(self._index_name).get_settings()
-            and self._client.index(self._index_name).get_settings()["index_defaults"][
-                "treat_urls_and_pointers_as_images"
-            ]
-            or (
-                "treat_urls_and_pointers_as_images"
-                in self._client.index(self._index_name).get_settings()
-                and self._client.index(self._index_name).get_settings()[
-                    "treat_urls_and_pointers_as_images"
-                ]
-            )
+            "index_defaults" in settings
+            and settings["index_defaults"]["treat_urls_and_pointers_as_images"]
+            or settings.get("treat_urls_and_pointers_as_images"):
         ):
             raise ValueError(
                 "Marqo.add_texts is disabled for multimodal indexes. To add documents "


### PR DESCRIPTION
  - **Description:** `add_texts` was using `get_setting` for marqo client which was being used according to 1.5.x API version. However, this PR updates the `add_text` accounting for updated response payload for 2.x and later while maintaining backward compatibility. Plus I have verified this was the only place where marqo client was not accounting for updated API version.
  - **Issue:** #28323
 