### PR TITLE
docs(create_sql_agent): fix reStructured Text Markup

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/sql/base.py
+++ b/libs/community/langchain_community/agent_toolkits/sql/base.py
@@ -107,13 +107,13 @@ def create_sql_agent(
 
         .. code-block:: python
 
-        from langchain_openai import ChatOpenAI
-        from langchain_community.agent_toolkits import create_sql_agent
-        from langchain_community.utilities import SQLDatabase
+            from langchain_openai import ChatOpenAI
+            from langchain_community.agent_toolkits import create_sql_agent
+            from langchain_community.utilities import SQLDatabase
 
-        db = SQLDatabase.from_uri("sqlite:///Chinook.db")
-        llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
-        agent_executor = create_sql_agent(llm, db=db, agent_type="tool-calling", verbose=True)
+            db = SQLDatabase.from_uri("sqlite:///Chinook.db")
+            llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+            agent_executor = create_sql_agent(llm, db=db, agent_type="tool-calling", verbose=True)
 
     """  # noqa: E501
     from langchain.agents import (


### PR DESCRIPTION
- **Description:** Lines of code must be indented beneath `.. code-block::` for proper formatting. https://devguide.python.org/documentation/markup/#showing-code-examples
- **Issue:** The example code block on the `create_sql_agent` document page is not properly rendered.
https://python.langchain.com/api_reference/community/agent_toolkits/langchain_community.agent_toolkits.sql.base.create_sql_agent.html#langchain_community.agent_toolkits.sql.base.create_sql_agent

<img width="933" alt="image" src="https://github.com/user-attachments/assets/d764bcad-e412-408b-ab0b-9a78a11188ee">
