### PR TITLE
ollama[patch]: support ollama 0.4

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -66,8 +66,8 @@ def _get_tool_calls_from_response(
     """Get tool calls from ollama response."""
     tool_calls = []
     if "message" in response:
-        if "tool_calls" in response["message"]:
-            for tc in response["message"]["tool_calls"]:
+        if raw_tool_calls := response["message"].get("tool_calls"):
+            for tc in raw_tool_calls:
                 tool_calls.append(
                     tool_call(
                         id=str(uuid4()),
@@ -728,6 +728,8 @@ class ChatOllama(BaseChatModel):
     def bind_tools(
         self,
         tools: Sequence[Union[Dict[str, Any], Type, Callable, BaseTool]],
+        *,
+        tool_choice: Optional[Union[dict, str, Literal["auto", "any"], bool]] = None,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, BaseMessage]:
         """Bind tool-like objects to this chat model.
@@ -738,6 +740,8 @@ class ChatOllama(BaseChatModel):
             tools: A list of tool definitions to bind to this chat model.
                 Supports any tool definition handled by
                 :meth:`langchain_core.utils.function_calling.convert_to_openai_tool`.
+            tool_choice: If provided, which tool for model to call. **This parameter
+                is currently ignored as it is not supported by Ollama.**
             kwargs: Any additional parameters are passed directly to
                 ``self.bind(**kwargs)``.
         """  # noqa: E501


### PR DESCRIPTION
v0.4 of the Python SDK is already installed via the lock file in CI, but our current implementation is not compatible with it.

This also addresses an issue introduced in https://github.com/langchain-ai/langchain/pull/28299. @RyanMagnuson would you mind explaining the motivation for that change? From what I can tell the Ollama SDK [does not support kwargs](https://github.com/ollama/ollama-python/blob/6c44bb272976b9dc8d24d3a3fd913fd39b83394b/ollama/_client.py#L286). Previously, unsupported kwargs were ignored, but they currently raise `TypeError`.

Some of LangChain's standard test suite expects `tool_choice` to be supported, so here we catch it in `bind_tools` so it is ignored and not passed through to the client.