### PR TITLE
docs: fix typo in embedding vectors documentation

### DIFF
--- a/docs/docs/concepts/embedding_models.mdx
+++ b/docs/docs/concepts/embedding_models.mdx
@@ -25,7 +25,7 @@ Embeddings allow search system to find relevant documents not just based on keyw
 
 (1) **Embed text as a vector**: Embeddings transform text into a numerical vector representation.
 
-(2) **Measure similarity**: Embedding vectors can be comparing using simple mathematical operations.
+(2) **Measure similarity**: Embedding vectors can be compared using simple mathematical operations.
 
 ## Embedding 
 


### PR DESCRIPTION
**Description:** Fixed a grammatical error in the documentation section on embedding vectors. Replaced "Embedding vectors can be comparing" with "Embedding vectors can be compared."

**Issue:** N/A (This is a minor documentation fix with no linked issue.)

**Dependencies:** None.