### PR TITLE
docs: Adds the langchain-neo4j package to the API docs

### DIFF
--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -147,3 +147,6 @@ packages:
   - name: langchain-tests
     repo: langchain-ai/langchain
     path: libs/standard-tests
+  - name: langchain-neo4j
+    repo: langchain-ai/langchain-neo4j
+    path: libs/neo4j


### PR DESCRIPTION
This PR adds the `langchain-neo4j` package to the `libs/packages.yml` so the API docs can be built.