### PR TITLE
community: fix Cypher query generation for node names with spaces

### DIFF
--- a/libs/community/langchain_community/chains/graph_qa/cypher.py
+++ b/libs/community/langchain_community/chains/graph_qa/cypher.py
@@ -65,7 +65,15 @@ def extract_cypher(text: str) -> str:
     # Find all matches in the input text
     matches = re.findall(pattern, text, re.DOTALL)
 
-    return matches[0] if matches else text
+    # Extracted Cypher query
+    cypher_query = matches[0] if matches else text
+
+    # Replace node labels with backticks if they contain spaces
+    cypher_query = re.sub(
+        r":\s(\s*)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(\s*)", 
+        r": `\1\2\3`", cypher_query)
+
+    return cypher_query
 
 
 @deprecated(

--- a/libs/community/langchain_community/chains/graph_qa/cypher.py
+++ b/libs/community/langchain_community/chains/graph_qa/cypher.py
@@ -70,8 +70,10 @@ def extract_cypher(text: str) -> str:
 
     # Replace node labels with backticks if they contain spaces
     cypher_query = re.sub(
-        r":\s(\s*)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(\s*)", 
-        r": `\1\2\3`", cypher_query)
+        r":\s(\s*)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(\s*)",
+        r": `\1\2\3`",
+        cypher_query,
+    )
 
     return cypher_query
 

--- a/libs/community/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/community/tests/unit_tests/chains/test_graph_qa.py
@@ -209,19 +209,29 @@ def test_extract_cypher_with_backticks() -> None:
     assert output == "MATCH (n) RETURN n"
 
 
+def test_extract_cypher_with_node_name_with_backticks() -> None:
+    """Test if there are backticks in the node name.
+    The original text should be returned."""
+    query = "MATCH (n: `Node Name`) RETURN n"
+    output = extract_cypher(query)
+    assert output == "MATCH (n: `Node Name`) RETURN n"
+
+
 def test_extract_cypher_with_node_name_with_one_space() -> None:
     """Test if there is one space in the node name.
-    node name should be wrapped in backticks."""
+    Node name should be wrapped in backticks."""
     query = "MATCH (n: Node Name) RETURN n"
     output = extract_cypher(query)
     assert output == "MATCH (n: `Node Name`) RETURN n"
 
+
 def test_extract_cypher_with_node_name_with_multi_spaces() -> None:
     """Test if there are multiple spaces in the node name.
-    node name should be wrapped in backticks."""
+    Node name should be wrapped in backticks."""
     query = "MATCH (n: Node Name With Multiple Spaces) RETURN n"
     output = extract_cypher(query)
     assert output == "MATCH (n: `Node Name With Multiple Spaces`) RETURN n"
+
 
 def test_exclude_types() -> None:
     structured_schema = {

--- a/libs/community/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/community/tests/unit_tests/chains/test_graph_qa.py
@@ -195,19 +195,33 @@ def test_graph_cypher_qa_chain() -> None:
     assert True
 
 
-def test_no_backticks() -> None:
+def test_extract_cypher_with_no_backticks() -> None:
     """Test if there are no backticks, so the original text should be returned."""
     query = "MATCH (n) RETURN n"
     output = extract_cypher(query)
     assert output == query
 
 
-def test_backticks() -> None:
+def test_extract_cypher_with_backticks() -> None:
     """Test if there are backticks. Query from within backticks should be returned."""
     query = "You can use the following query: ```MATCH (n) RETURN n```"
     output = extract_cypher(query)
     assert output == "MATCH (n) RETURN n"
 
+
+def test_extract_cypher_with_node_name_with_one_space() -> None:
+    """Test if there is one space in the node name.
+    node name should be wrapped in backticks."""
+    query = "MATCH (n: Node Name) RETURN n"
+    output = extract_cypher(query)
+    assert output == "MATCH (n: `Node Name`) RETURN n"
+
+def test_extract_cypher_with_node_name_with_multi_spaces() -> None:
+    """Test if there are multiple spaces in the node name.
+    node name should be wrapped in backticks."""
+    query = "MATCH (n: Node Name With Multiple Spaces) RETURN n"
+    output = extract_cypher(query)
+    assert output == "MATCH (n: `Node Name With Multiple Spaces`) RETURN n"
 
 def test_exclude_types() -> None:
     structured_schema = {


### PR DESCRIPTION
**Description:**  
This PR fixes an issue in `GraphCypherQAChain` where node names containing spaces (e.g., "Medical Condition") resulted in a `Neo.ClientError.Statement.SyntaxError` when generating Cypher queries. The issue was caused by node names with spaces not being wrapped in backticks, which are required for correct Cypher syntax.
- Modified the `extract_cypher` function to wrap node names containing spaces in backticks.

**Issue:**  
Fixes #28375

**Dependencies:**  N/A

**Test Coverage:**  
- Unit tests have been added to ensure that node names with single and multiple spaces are correctly wrapped in backticks. Additionally, queries with already backtick-wrapped node names remain unaffected.

**Lint and Test:**  
- Ran `make format`, `make lint`, and `make test` to ensure all tests pass and the code adheres to the formatting standards.

**Twitter handle:**  N/A