### PR TITLE
docs: Fix the broken documentation link of Vertex AI Embeddings API reference

### DIFF
--- a/docs/docs/integrations/text_embedding/google_vertex_ai_palm.ipynb
+++ b/docs/docs/integrations/text_embedding/google_vertex_ai_palm.ipynb
@@ -18,14 +18,14 @@
    "source": [
     "# Google Vertex AI Embeddings \n",
     "\n",
-    "This will help you get started with Google Vertex AI Embeddings models using LangChain. For detailed documentation on `Google Vertex AI Embeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/google_vertexai/embeddings/langchain_google_vertexai.embeddings.VertexAIEmbeddings.html).\n",
+    "This will help you get started with Google Vertex AI Embeddings models using LangChain. For detailed documentation on `Google Vertex AI Embeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.vertexai.VertexAIEmbeddings.html).\n",
     "\n",
     "## Overview\n",
     "### Integration details\n",
     "\n",
     "| Provider | Package |\n",
     "|:--------:|:-------:|\n",
-    "| [Google](https://python.langchain.com/docs/integrations/providers/google/) | [langchain-google-vertexai](https://python.langchain.com/api_reference/google_vertexai/embeddings/langchain_google_vertexai.embeddings.VertexAIEmbeddings.html) |\n",
+    "| [Google](https://python.langchain.com/docs/integrations/providers/google/) | [langchain-google-vertexai](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.vertexai.VertexAIEmbeddings.html) |\n",
     "\n",
     "## Setup\n",
     "\n",
@@ -289,7 +289,7 @@
     "## API Reference\n",
     "\n",
     "For detailed documentation on `Google Vertex AI Embeddings\n",
-    "` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/google_vertexai/embeddings/langchain_google_vertexai.embeddings.VertexAIEmbeddings.html).\n"
+    "` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.vertexai.VertexAIEmbeddings.html).\n"
    ]
   }
  ],


### PR DESCRIPTION

- [ ] **PR message**: 
    - **Description:** Fix the broken documentation link of Vertex AI Embeddings API reference
    - **Issue:** #28359 
    - **Dependencies:** NA

