### PR TITLE
docs: fixed a variable name in embeddings section

### DIFF
--- a/docs/docs/tutorials/retrievers.ipynb
+++ b/docs/docs/tutorials/retrievers.ipynb
@@ -245,7 +245,7 @@
     "\n",
     "import EmbeddingTabs from \"@theme/EmbeddingTabs\";\n",
     "\n",
-    "<EmbeddingTabs customVarName=\"embeddings_model\" />"
+    "<EmbeddingTabs customVarName=\"embeddings\" />"
    ]
   },
   {


### PR DESCRIPTION
This is a simple change for a variable name in the Embeddings section of this document: https://python.langchain.com/docs/tutorials/retrievers/#embeddings .

The variable name `embeddings_model` seems to be wrong and doesn't match what follows in the template: `embeddings`. 