### PR TITLE
docs: Fixed broken link in the warning message to @tool API Reference…

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -294,7 +294,7 @@
    "metadata": {},
    "source": [
     ":::caution\n",
-    "By default, `@tool(parse_docstring=True)` will raise `ValueError` if the docstring does not parse correctly. See [API Reference](https://python.langchain.com/api_reference/core/tools/langchain_core.tools.tool.html) for detail and examples.\n",
+    "By default, `@tool(parse_docstring=True)` will raise `ValueError` if the docstring does not parse correctly. See [API Reference](https://python.langchain.com/api_reference/core/tools/langchain_core.tools.convert.tool.html) for detail and examples.\n",
     ":::"
    ]
   },


### PR DESCRIPTION
Fixed the broken hyperlink in the warning of docstring section to the correct `@tool` API reference