### PR TITLE
docs: Update ChatModelTabs.js to fix the label "AWS" to "Amazon Bedrock"

### DIFF
--- a/docs/src/theme/ChatModelTabs.js
+++ b/docs/src/theme/ChatModelTabs.js
@@ -121,7 +121,7 @@ export default function ChatModelTabs(props) {
     },
     {
       value: "AWS",
-      label: "AWS",
+      label: "Amazon Bedrock",
       text: `from langchain_aws import ChatBedrock\n\n${llmVarName} = ChatBedrock(${awsBedrockParamsOrDefault})`,
       apiKeyText: "# Ensure your AWS credentials are configured",
       packageName: "langchain-aws",


### PR DESCRIPTION
- [ ] **PR message**: 
    - **Description:** Update ChatModelTabs.js to fix the label "AWS" to "Amazon Bedrock"
    - **Note:** The order of the tab is not changed as this ChatModelTab's items does not seem to follow alphabetic order.
    - **Issue:** https://github.com/langchain-ai/langchain/issues/27661
    - **Dependencies:** NA
