### PR TITLE
docs: Resolve incorrect import of AttributeInfo for self-query retriever section

### DIFF
--- a/docs/docs/integrations/retrievers/self_query/activeloop_deeplake_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/activeloop_deeplake_self_query.ipynb
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/astradb.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/astradb.ipynb
@@ -146,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/chroma_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/chroma_self_query.ipynb
@@ -164,7 +164,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/dashvector.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/dashvector.ipynb
@@ -185,7 +185,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_community.llms import Tongyi\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/databricks_vector_search.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/databricks_vector_search.ipynb
@@ -282,7 +282,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/dingo.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/dingo.ipynb
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/hanavector_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/hanavector_self_query.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_community.query_constructors.hanavector import HanaTranslator\n",
     "from langchain_openai import ChatOpenAI\n",

--- a/docs/docs/integrations/retrievers/self_query/milvus_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/milvus_self_query.ipynb
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/mongodb_atlas.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/mongodb_atlas.ipynb
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/myscale_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/myscale_self_query.ipynb
@@ -165,7 +165,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/neo4j_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/neo4j_self_query.ipynb
@@ -168,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/opensearch_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/opensearch_self_query.ipynb
@@ -135,7 +135,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/pgvector_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/pgvector_self_query.ipynb
@@ -141,7 +141,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/pinecone.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/pinecone.ipynb
@@ -190,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/qdrant_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/qdrant_self_query.ipynb
@@ -144,7 +144,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/redis_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/redis_self_query.ipynb
@@ -194,7 +194,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/supabase_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/supabase_self_query.ipynb
@@ -308,7 +308,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/tencentvectordb.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/tencentvectordb.ipynb
@@ -218,7 +218,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/timescalevector_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/timescalevector_self_query.ipynb
@@ -249,7 +249,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",

--- a/docs/docs/integrations/retrievers/self_query/vectara_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/vectara_self_query.ipynb
@@ -91,7 +91,7 @@
     "os.environ[\"VECTARA_CORPUS_ID\"] = \"<YOUR_VECTARA_CORPUS_ID>\"\n",
     "os.environ[\"VECTARA_CUSTOMER_ID\"] = \"<YOUR_VECTARA_CUSTOMER_ID>\"\n",
     "\n",
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_community.vectorstores import Vectara\n",
     "from langchain_openai.chat_models import ChatOpenAI"

--- a/docs/docs/integrations/retrievers/self_query/weaviate_self_query.ipynb
+++ b/docs/docs/integrations/retrievers/self_query/weaviate_self_query.ipynb
@@ -115,7 +115,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain.chains.query_constructor.base import AttributeInfo\n",
+    "from langchain.chains.query_constructor.schema import AttributeInfo\n",
     "from langchain.retrievers.self_query.base import SelfQueryRetriever\n",
     "from langchain_openai import OpenAI\n",
     "\n",


### PR DESCRIPTION
Most of the imports from the self-query retriever section seems to imported `AttributeInfo` from `query_constructor.base` instead of `query_constructor.schema`, found in the API reference [here](https://python.langchain.com/api_reference/langchain/chains/langchain.chains.query_constructor.schema.AttributeInfo.html)

This PR resolves the wrong imports from most of the notebooks