### PR TITLE
ollama[patch]: release 0.2.1

### DIFF
--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-ollama"
-version = "0.2.2"
+version = "0.2.1"
 description = "An integration package connecting Ollama and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
We inadvertently skipped 0.2.1, so release pipeline [failed](https://github.com/langchain-ai/langchain/actions/runs/12126964367/job/33810204551).