### PR TITLE
docs: Update sql-query doc by fixing spelling mistake of chinhook.db to chinook.db

### DIFF
--- a/docs/docs/how_to/sql_large_db.ipynb
+++ b/docs/docs/how_to/sql_large_db.ipynb
@@ -55,7 +55,7 @@
     "* Run `.read Chinook_Sqlite.sql`\n",
     "* Test `SELECT * FROM Artist LIMIT 10;`\n",
     "\n",
-    "Now, `Chinhook.db` is in our directory and we can interface with it using the SQLAlchemy-driven [SQLDatabase](https://python.langchain.com/api_reference/community/utilities/langchain_community.utilities.sql_database.SQLDatabase.html) class:"
+    "Now, `Chinook.db` is in our directory and we can interface with it using the SQLAlchemy-driven [SQLDatabase](https://python.langchain.com/api_reference/community/utilities/langchain_community.utilities.sql_database.SQLDatabase.html) class:"
    ]
   },
   {

--- a/docs/docs/how_to/sql_prompting.ipynb
+++ b/docs/docs/how_to/sql_prompting.ipynb
@@ -51,7 +51,7 @@
     "* Run `.read Chinook_Sqlite.sql`\n",
     "* Test `SELECT * FROM Artist LIMIT 10;`\n",
     "\n",
-    "Now, `Chinhook.db` is in our directory and we can interface with it using the SQLAlchemy-driven `SQLDatabase` class:"
+    "Now, `Chinook.db` is in our directory and we can interface with it using the SQLAlchemy-driven `SQLDatabase` class:"
    ]
   },
   {

--- a/docs/docs/how_to/sql_query_checking.ipynb
+++ b/docs/docs/how_to/sql_query_checking.ipynb
@@ -54,7 +54,7 @@
     "* Run `.read Chinook_Sqlite.sql`\n",
     "* Test `SELECT * FROM Artist LIMIT 10;`\n",
     "\n",
-    "Now, `Chinhook.db` is in our directory and we can interface with it using the SQLAlchemy-driven `SQLDatabase` class:"
+    "Now, `Chinook.db` is in our directory and we can interface with it using the SQLAlchemy-driven `SQLDatabase` class:"
    ]
   },
   {


### PR DESCRIPTION
Link (of doc with mistake): https://python.langchain.com/v0.1/docs/use_cases/sql/quickstart/#:~:text=Now%2C-,Chinhook.db,-is%20in%20our

  - **Description:** speeling mistake in how-to docs of sql-db 
  - **Issue:** just a spelling mistake.
  - **Dependencies:** NA
