### PR TITLE
docs: Correct thread_id consistency for conversation history example

### DIFF
--- a/docs/docs/tutorials/chatbot.ipynb
+++ b/docs/docs/tutorials/chatbot.ipynb
@@ -847,7 +847,7 @@
     }
    ],
    "source": [
-    "config = {\"configurable\": {\"thread_id\": \"abc678\"}}\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc567\"}}\n",
     "query = \"What math problem did I ask?\"\n",
     "language = \"English\"\n",
     "\n",


### PR DESCRIPTION
Thank you for contributing to LangChain!

**Description:** Updated the documentation to ensure that both queries in the conversation history example share the same thread_id, reflecting a single conversation context. This change aligns with the intended behavior where the model should discard the context for query1 after trimming the chat history and retain the context for query2. 

**Issue:** DOC: Managing Conversation History #28450

**Dependencies:** No additional dependencies required for this change.
