### PR TITLE
DOC: Consistent thread_id for conversation history retention

### DIFF
--- a/docs/docs/tutorials/chatbot.ipynb
+++ b/docs/docs/tutorials/chatbot.ipynb
@@ -306,7 +306,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "Hi Bob! How can I assist you today?\n"
      ]
@@ -329,7 +329,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "Your name is Bob! How can I help you today, Bob?\n"
      ]
@@ -359,7 +359,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "I'm sorry, but I don't have access to personal information about you unless you've shared it in this conversation. How can I assist you today?\n"
      ]
@@ -389,7 +389,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "Your name is Bob. What would you like to discuss today?\n"
      ]
@@ -513,7 +513,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "Ahoy there, Jim! What brings ye to these waters today? Be ye seekin' treasure, knowledge, or perhaps a good tale from the high seas? Arrr!\n"
      ]
@@ -537,7 +537,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "Ye be called Jim, matey! A fine name fer a swashbuckler such as yerself! What else can I do fer ye? Arrr!\n"
      ]
@@ -628,7 +628,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "¡Hola, Bob! ¿Cómo puedo ayudarte hoy?\n"
      ]
@@ -664,7 +664,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "Tu nombre es Bob. ¿Hay algo más en lo que pueda ayudarte?\n"
      ]
@@ -804,7 +804,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "==================================\u001B[1m Ai Message \u001B[0m==================================\n",
       "\n",
       "I don't know your name. You haven't told me yet!\n"
      ]
@@ -832,22 +832,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 26,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "\n",
-      "You asked what 2 + 2 equals.\n"
-     ]
-    }
-   ],
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "config = {\"configurable\": {\"thread_id\": \"abc678\"}}\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc567\"}}\n",
     "query = \"What math problem did I ask?\"\n",
     "language = \"English\"\n",
     "\n",


### PR DESCRIPTION
**Description:** This PR ensures that the `thread_id` is consistent across queries to accurately reflect context retention within a single conversation thread. This fix addresses an issue where different `thread_id` values were used for queries that should belong to the same conversation.

**Issue:** Fixes #28450 - Ensures consistent thread_id for conversation history retention

**Dependencies:** None

