### PR TITLE
partners: update version header for Pinecone integration

### DIFF
--- a/libs/partners/pinecone/langchain_pinecone/embeddings.py
+++ b/libs/partners/pinecone/langchain_pinecone/embeddings.py
@@ -73,7 +73,7 @@ class PineconeEmbeddings(BaseModel, Embeddings):
                 headers={
                     "Api-Key": self.pinecone_api_key.get_secret_value(),
                     "Content-Type": "application/json",
-                    "X-Pinecone-API-Version": "2024-07",
+                    "X-Pinecone-API-Version": "2024-10",
                 }
             )
         return self._async_client


### PR DESCRIPTION
Just need to update the version header used with Pinecone in recently-merged method (from [this PR](https://github.com/langchain-ai/langchain/pull/28320/files#r1867820929)).
