### PR TITLE
chroma[patch]: (nit) simplify test

### DIFF
--- a/libs/partners/chroma/tests/integration_tests/test_standard.py
+++ b/libs/partners/chroma/tests/integration_tests/test_standard.py
@@ -1,7 +1,6 @@
 from typing import AsyncGenerator, Generator
 
 import pytest
-from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 from langchain_core.vectorstores import VectorStore
 from langchain_tests.integration_tests.vectorstores import (
     AsyncReadWriteTestSuite,
@@ -15,8 +14,7 @@ class TestSync(ReadWriteTestSuite):
     @pytest.fixture()
     def vectorstore(self) -> Generator[VectorStore, None, None]:  # type: ignore
         """Get an empty vectorstore for unit tests."""
-        embeddings = DeterministicFakeEmbedding(size=10)
-        store = Chroma(embedding_function=embeddings)
+        store = Chroma(embedding_function=self.get_embeddings())
         try:
             yield store
         finally:
@@ -28,8 +26,7 @@ class TestAsync(AsyncReadWriteTestSuite):
     @pytest.fixture()
     async def vectorstore(self) -> AsyncGenerator[VectorStore, None]:  # type: ignore
         """Get an empty vectorstore for unit tests."""
-        embeddings = DeterministicFakeEmbedding(size=10)
-        store = Chroma(embedding_function=embeddings)
+        store = Chroma(embedding_function=self.get_embeddings())
         try:
             yield store
         finally:


### PR DESCRIPTION
Use `self.get_embeddings` on test class instead of importing embeddings separately.