### PR TITLE
docs: deprecated styling

### DIFF
--- a/docs/api_reference/_static/css/custom.css
+++ b/docs/api_reference/_static/css/custom.css
@@ -80,6 +80,8 @@
 html {
     --pst-font-family-base: 'Inter';
     --pst-font-family-heading: 'Inter Tight', sans-serif;
+
+    --pst-icon-versionmodified-deprecated: var(--pst-icon-exclamation-triangle);
 }
 
 /*******************************************************************************
@@ -408,4 +410,13 @@ dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.
 p {
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
+}
+
+div.deprecated {
+  background-color: var(--pst-color-warning-bg);
+  border-color: var(--pst-color-warning);
+}
+
+span.versionmodified.deprecated:before {
+  color: var(--pst-color-warning);
 }


### PR DESCRIPTION
from
![image](https://github.com/user-attachments/assets/52565861-618b-407c-8bb4-f16dce3b5718)

to
![image](https://github.com/user-attachments/assets/fafeef00-6101-42cd-a8c6-ca15808d1e7c)
