### PR TITLE
[Community]: Fixed `ArxivAPIWrapper` (corrected fitz attribute and not using `load_max_docs`)

### DIFF
--- a/libs/community/langchain_community/utilities/arxiv.py
+++ b/libs/community/langchain_community/utilities/arxiv.py
@@ -182,7 +182,7 @@ class ArxivAPIWrapper(BaseModel):
         Args:
             query: a plaintext search query
         """
-        return list(self.lazy_load(query))
+        return list(self.lazy_load(query))[: self.load_max_docs]
 
     def lazy_load(self, query: str) -> Iterator[Document]:
         """
@@ -220,7 +220,7 @@ class ArxivAPIWrapper(BaseModel):
                 doc_file_name: str = result.download_pdf()
                 with fitz.open(doc_file_name) as doc_file:
                     text: str = "".join(page.get_text() for page in doc_file)
-            except (FileNotFoundError, fitz.fitz.FileDataError) as f_ex:
+            except (FileNotFoundError, fitz.FileDataError) as f_ex:
                 logger.debug(f_ex)
                 continue
             except Exception as e:


### PR DESCRIPTION
- **Description:** `ArxivAPIWrapper` was not using `load_max_docs` which have been fixed, and also fitz.fitz was raising an attribute error which has also been fixed in this PR.