### PR TITLE
docs: added caution notes on Jina and LocalAI docs about openai sdk version compatibility

### DIFF
--- a/docs/docs/integrations/providers/jina.mdx
+++ b/docs/docs/integrations/providers/jina.mdx
@@ -2,6 +2,10 @@
 
 >[Jina AI](https://jina.ai/about-us) is a search AI company. `Jina` helps businesses and developers unlock multimodal data with a better search.
 
+:::caution
+For proper compatibility, please ensure you are using the `openai` SDK at version **0.x**.
+:::
+
 ## Installation and Setup
 - Get a Jina AI API token from [here](https://jina.ai/embeddings/) and set it as an environment variable (`JINA_API_TOKEN`)
 

--- a/docs/docs/integrations/providers/localai.mdx
+++ b/docs/docs/integrations/providers/localai.mdx
@@ -6,6 +6,10 @@
 > audio (and not only) locally or on-prem with consumer grade hardware, 
 > supporting multiple model families and architectures.
 
+:::caution
+For proper compatibility, please ensure you are using the `openai` SDK at version **0.x**.
+:::
+
 ## Installation and Setup
 
 We have to install several python packages: 


### PR DESCRIPTION
- [ ] Main note
    - **Description:** I added notes on the Jina and LocalAI pages telling users that they must be using this integrations with openai sdk version 0.x, because if they dont they will get an error saying that "openai has no attribute error". This PR was recommended by @efriis 
    - **Issue:** warns people about the issue in #28529 
    - **Dependencies:** None
    - **Twitter handle:** JoaqCore



- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
