### PR TITLE
community: rename method 'similarity_search_by_vector_with_relevance_scores' for clarity

### DIFF
--- a/libs/community/langchain_community/vectorstores/chroma.py
+++ b/libs/community/langchain_community/vectorstores/chroma.py
@@ -377,7 +377,7 @@ class Chroma(VectorStore):
         )
         return _results_to_docs(results)
 
-    def similarity_search_by_vector_with_relevance_scores(
+    def similarity_search_by_vector_with_scores(
         self,
         embedding: List[float],
         k: int = DEFAULT_K,
@@ -557,7 +557,7 @@ class Chroma(VectorStore):
         image_embedding = self._embedding_function.embed_image(uris=[uri])
 
         # Perform similarity search based on the obtained embedding
-        results = self.similarity_search_by_vector_with_relevance_scores(
+        results = self.similarity_search_by_vector_with_scores(
             embedding=image_embedding,
             k=k,
             filter=filter,


### PR DESCRIPTION
**Description:**

In the current version, the `similarity_search_by_vector_with_relevance_scores` method in `langchain_chroma.vectorstores.Chroma` returns scores where "lower score represents more similarity". However, the `similarity_search_with_relevance_scores` method in the parent class `langchain_core.vectorstores.base.VectorStore` returns scores where "0 is dissimilar, and 1 is most similar" ([source](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/vectorstores/base.py#L538)).

This discrepancy between the two methods' score conventions can confuse developers and lead to errors. Developers may mix up the relevance_scores in vector and text searches, resulting in opposite outcomes.

To resolve this issue and avoid confusion, I propose renaming Chroma’s `similarity_search_by_vector_with_relevance_scores` method to `similarity_search_by_vector_with_scores`. This change aligns with the scoring convention of the `similarity_search_with_score` method in the `VectorStore` class ([source](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/vectorstores/base.py#L450)), where the score represents distance.

**Issue:** 
https://github.com/langchain-ai/langchain/issues/24545

**Dependencies:**
No new dependencies

**Twitter handle:** N/A