### PR TITLE
DOC: Fixed conflicting info on ChatOllama structured output support

### DIFF
--- a/docs/docs/integrations/chat/ollama.ipynb
+++ b/docs/docs/integrations/chat/ollama.ipynb
@@ -34,8 +34,8 @@
     "\n",
     "### Model features\n",
     "| [Tool calling](/docs/how_to/tool_calling/) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
-    "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
-    "| ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | \n",
+    "| :---: |:----------------------------------------------------:| :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
+    "| ✅ |                          ✅                           | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |\n",
     "\n",
     "## Setup\n",
     "\n",
@@ -95,6 +95,20 @@
    "source": [
     "%pip install -qU langchain-ollama"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Make sure you're using the latest Ollama version for structured outputs. Update by running:",
+   "id": "b18bd692076f7cf7"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "%pip install -U ollama",
+   "id": "b7a05cba95644c2e"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR resolves the conflicting information in the Chat models documentation regarding structured output support for ChatOllama. 

- The Featured Providers table has been updated to reflect the correct status.  
- Structured output support for ChatOllama was introduced on Dec 6, 2024.
- A note has been added to ensure users update to the latest Ollama version for structured outputs.

**Issue:** Fixes #28691 