### PR TITLE
community: fix an issue with deepinfra integration

### DIFF
--- a/libs/community/langchain_community/chat_models/deepinfra.py
+++ b/libs/community/langchain_community/chat_models/deepinfra.py
@@ -207,6 +207,10 @@ class ChatDeepInfra(BaseChatModel):
     # client: Any  #: :meta private:
     model_name: str = Field(default="meta-llama/Llama-2-70b-chat-hf", alias="model")
     """Model name to use."""
+
+    url: Optional[str] = "https://api.deepinfra.com/v1/openai/chat/completions"
+    """URL to use for the API call."""
+
     deepinfra_api_token: Optional[str] = None
     request_timeout: Optional[float] = Field(default=None, alias="timeout")
     temperature: Optional[float] = 1
@@ -469,7 +473,7 @@ class ChatDeepInfra(BaseChatModel):
             )
 
     def _url(self) -> str:
-        return "https://stage.api.deepinfra.com/v1/openai/chat/completions"
+        return self.url
 
     def _headers(self) -> Dict:
         return {

--- a/libs/community/langchain_community/chat_models/deepinfra.py
+++ b/libs/community/langchain_community/chat_models/deepinfra.py
@@ -208,7 +208,7 @@ class ChatDeepInfra(BaseChatModel):
     model_name: str = Field(default="meta-llama/Llama-2-70b-chat-hf", alias="model")
     """Model name to use."""
 
-    url: Optional[str] = "https://api.deepinfra.com/v1/openai/chat/completions"
+    url: str = "https://api.deepinfra.com/v1/openai/chat/completions"
     """URL to use for the API call."""
 
     deepinfra_api_token: Optional[str] = None


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: langchain: add URL parameter to ChatDeepInfra class

- [x] **PR message**: add URL parameter to ChatDeepInfra class
    - **Description:** This PR introduces a url parameter to the ChatDeepInfra class in LangChain, allowing users to specify a custom URL. Previously, the URL for the DeepInfra API was hardcoded to "https://stage.api.deepinfra.com/v1/openai/chat/completions", which caused issues when the staging endpoint was not functional. The _url method was updated to return the value from the url parameter, enabling greater flexibility and addressing the problem. out!
