### PR TITLE
docs: correct variable name from formatted_docs to docs_content

### DIFF
--- a/docs/docs/tutorials/rag.ipynb
+++ b/docs/docs/tutorials/rag.ipynb
@@ -706,7 +706,7 @@
     "\n",
     "retrieved_docs = vector_store.similarity_search(question)\n",
     "docs_content = \"\\n\\n\".join(doc.page_content for doc in retrieved_docs)\n",
-    "prompt = prompt.invoke({\"question\": question, \"context\": formatted_docs})\n",
+    "prompt = prompt.invoke({\"question\": question, \"context\": docs_content})\n",
     "answer = llm.invoke(prompt)\n",
     "```\n",
     "\n",


### PR DESCRIPTION
- **Description:** Fixed incorrect variable name formatted_docs, replacing it with docs_content to ensure correct functionality.
