### PR TITLE
text-splitter: support for trust_remote_code and not loading model in SentenceTransformersTokenTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
+++ b/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
@@ -1,41 +1,47 @@
 from __future__ import annotations
 
 from typing import Any, List, Optional, cast
-
 from langchain_text_splitters.base import TextSplitter, Tokenizer, split_text_on_tokens
 
-
 class SentenceTransformersTokenTextSplitter(TextSplitter):
-    """Splitting text to tokens using sentence model tokenizer."""
+    """Splitting text into tokens using a SentenceTransformer model tokenizer."""
 
     def __init__(
         self,
         chunk_overlap: int = 50,
         model_name: str = "sentence-transformers/all-mpnet-base-v2",
         tokens_per_chunk: Optional[int] = None,
+        trust_remote_code: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Create a new TextSplitter."""
-        super().__init__(**kwargs, chunk_overlap=chunk_overlap)
+        """Create a new SentenceTransformersTokenTextSplitter instance.
+
+        Args:
+            chunk_overlap (int): The number of overlapping tokens between chunks.
+            model_name (str): The name of the SentenceTransformer model.
+            tokens_per_chunk (Optional[int]): Maximum tokens per chunk.
+            trust_remote_code (bool): Whether to trust remote code when loading the model.
+            **kwargs (Any): Additional keyword arguments.
+        """
 
         try:
-            from sentence_transformers import SentenceTransformer
+            from transformers import AutoTokenizer
         except ImportError:
             raise ImportError(
-                "Could not import sentence_transformer python package. "
-                "This is needed in order to for SentenceTransformersTokenTextSplitter. "
-                "Please install it with `pip install sentence-transformers`."
+                "Could not import the transformers package. "
+                "Install it with `pip install transformers`."
             )
+            
+        super().__init__(**kwargs, chunk_overlap=chunk_overlap)
 
         self.model_name = model_name
-        self._model = SentenceTransformer(self.model_name)
-        self.tokenizer = self._model.tokenizer
+
+        self.tokenizer = tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=trust_remote_code)
         self._initialize_chunk_configuration(tokens_per_chunk=tokens_per_chunk)
 
-    def _initialize_chunk_configuration(
-        self, *, tokens_per_chunk: Optional[int]
-    ) -> None:
-        self.maximum_tokens_per_chunk = cast(int, self._model.max_seq_length)
+    def _initialize_chunk_configuration(self, *, tokens_per_chunk: Optional[int]) -> None:
+        """Initialize chunk-related configuration based on the model's limits."""
+        self.maximum_tokens_per_chunk = cast(int, self.tokenizer.model_max_length)
 
         if tokens_per_chunk is None:
             self.tokens_per_chunk = self.maximum_tokens_per_chunk
@@ -44,28 +50,15 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
 
         if self.tokens_per_chunk > self.maximum_tokens_per_chunk:
             raise ValueError(
-                f"The token limit of the models '{self.model_name}'"
-                f" is: {self.maximum_tokens_per_chunk}."
-                f" Argument tokens_per_chunk={self.tokens_per_chunk}"
-                f" > maximum token limit."
+                f"The token limit of the model '{self.model_name}' is: {self.maximum_tokens_per_chunk}. "
+                f"Argument tokens_per_chunk={self.tokens_per_chunk} exceeds this limit."
             )
 
     def split_text(self, text: str) -> List[str]:
-        """Splits the input text into smaller components by splitting text on tokens.
-
-        This method encodes the input text using a private `_encode` method, then
-        strips the start and stop token IDs from the encoded result. It returns the
-        processed segments as a list of strings.
-
-        Args:
-            text (str): The input text to be split.
-
-        Returns:
-            List[str]: A list of string components derived from the input text after
-            encoding and processing.
-        """
+        """Split the input text into smaller chunks based on the tokenizer configuration."""
 
         def encode_strip_start_and_stop_token_ids(text: str) -> List[int]:
+            """Encode text and strip start and stop token IDs."""
             return self._encode(text)[1:-1]
 
         tokenizer = Tokenizer(
@@ -78,25 +71,15 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
         return split_text_on_tokens(text=text, tokenizer=tokenizer)
 
     def count_tokens(self, *, text: str) -> int:
-        """Counts the number of tokens in the given text.
-
-        This method encodes the input text using a private `_encode` method and
-        calculates the total number of tokens in the encoded result.
-
-        Args:
-            text (str): The input text for which the token count is calculated.
-
-        Returns:
-            int: The number of tokens in the encoded text.
-        """
+        """Count the number of tokens in the input text."""
         return len(self._encode(text))
 
     _max_length_equal_32_bit_integer: int = 2**32
 
     def _encode(self, text: str) -> List[int]:
-        token_ids_with_start_and_end_token_ids = self.tokenizer.encode(
+        """Encode text into a list of token IDs."""
+        return self.tokenizer.encode(
             text,
             max_length=self._max_length_equal_32_bit_integer,
             truncation="do_not_truncate",
         )
-        return token_ids_with_start_and_end_token_ids


### PR DESCRIPTION
Thank you for contributing to LangChain!

- **Description:** Trust remote code parameter was not there due to which we could not load external models, also there is no need to load the model and increase the memory footprint.
- **Dependencies:** Transformers
- **Twitter handle:** @anchit2000


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
