### PR TITLE
Add Steel loader for Langchain

### DIFF
--- a/libs/community/langchain_community/document_loaders/__init__.py
+++ b/libs/community/langchain_community/document_loaders/__init__.py
@@ -531,6 +531,9 @@ if TYPE_CHECKING:
     from langchain_community.document_loaders.yuque import (
         YuqueLoader,
     )
+    from langchain_community.document_loaders.steel import (
+        SteelLoader,
+    )
 
 
 _module_lookup = {
@@ -730,6 +733,7 @@ _module_lookup = {
     "YoutubeAudioLoader": "langchain_community.document_loaders.blob_loaders",
     "YoutubeLoader": "langchain_community.document_loaders.youtube",
     "YuqueLoader": "langchain_community.document_loaders.yuque",
+    "SteelLoader": "langchain_community.document_loaders.steel",
 }
 
 
@@ -937,4 +941,5 @@ __all__ = [
     "YoutubeAudioLoader",
     "YoutubeLoader",
     "YuqueLoader",
+    "SteelLoader",
 ]

--- a/libs/community/langchain_community/document_loaders/steel.py
+++ b/libs/community/langchain_community/document_loaders/steel.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Iterator, List, Optional, Union
+
+import requests
+from langchain_core.documents import Document
+
+from langchain_community.document_loaders.base import BaseLoader
+
+logger = logging.getLogger(__name__)
+
+class SteelLoader(BaseLoader):
+    """Load webpages with Steel."""
+
+    def __init__(
+        self, api_token: str, urls: Union[str, List[str]], text_content: bool = True
+    ):
+        """Initialize with API token and the URLs to scrape"""
+        self.api_token = api_token
+        """Steel API token."""
+        self.urls = urls
+        """List of URLs to scrape."""
+        self.text_content = text_content
+
+    def lazy_load(self) -> Iterator[Document]:
+        """Lazy load Documents from URLs."""
+
+        for url in self.urls:
+            try:
+                if self.text_content:
+                    response = requests.post(
+                        "https://api.steel.dev/scrape",
+                        headers={
+                            "Authorization": f"Bearer {self.api_token}",
+                        },
+                        json={
+                            "url": url,
+                            "elements": [
+                                {
+                                    "selector": "body",
+                                }
+                            ],
+                        },
+                    )
+                    response.raise_for_status()
+                    yield Document(
+                        page_content=response.json()["data"][0]["results"][0]["text"],
+                        metadata={
+                            "source": url,
+                        },
+                    )
+                else:
+                    response = requests.post(
+                        "https://api.steel.dev/content",
+                        headers={
+                            "Authorization": f"Bearer {self.api_token}",
+                        },
+                        json={
+                            "url": url,
+                        },
+                    )
+                    response.raise_for_status()
+                    yield Document(
+                        page_content=response.text,
+                        metadata={
+                            "source": url,
+                        },
+                    )
+            except requests.RequestException as e:
+                logger.error(f"Error fetching {url}: {e}")
+                continue

--- a/libs/community/langchain_community/document_loaders/tests/test_steel_loader.py
+++ b/libs/community/langchain_community/document_loaders/tests/test_steel_loader.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, Mock
+from requests.exceptions import RequestException
+from langchain_core.documents import Document
+from langchain_community.document_loaders.steel import SteelLoader
+
+class TestSteelLoader(unittest.TestCase):
+
+    @patch('requests.post')
+    def test_lazy_load_success_text_content(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [{"results": [{"text": "Sample text content"}]}]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        loader = SteelLoader(api_token="fake_token", urls=["http://example.com"], text_content=True)
+        documents = list(loader.lazy_load())
+
+        self.assertEqual(len(documents), 1)
+        self.assertEqual(documents[0].page_content, "Sample text content")
+        self.assertEqual(documents[0].metadata["source"], "http://example.com")
+
+    @patch('requests.post')
+    def test_lazy_load_success_html_content(self, mock_post):
+        mock_response = Mock()
+        mock_response.text = "<html>Sample HTML content</html>"
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        loader = SteelLoader(api_token="fake_token", urls=["http://example.com"], text_content=False)
+        documents = list(loader.lazy_load())
+
+        self.assertEqual(len(documents), 1)
+        self.assertEqual(documents[0].page_content, "<html>Sample HTML content</html>")
+        self.assertEqual(documents[0].metadata["source"], "http://example.com")
+
+    @patch('requests.post')
+    def test_lazy_load_invalid_api_token(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = RequestException("Invalid API token")
+        mock_post.return_value = mock_response
+
+        loader = SteelLoader(api_token="invalid_token", urls=["http://example.com"], text_content=True)
+        documents = list(loader.lazy_load())
+
+        self.assertEqual(len(documents), 0)
+
+    @patch('requests.post')
+    def test_lazy_load_unreachable_url(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = RequestException("URL unreachable")
+        mock_post.return_value = mock_response
+
+        loader = SteelLoader(api_token="fake_token", urls=["http://unreachable-url.com"], text_content=True)
+        documents = list(loader.lazy_load())
+
+        self.assertEqual(len(documents), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add SteelLoader for Langchain to load web pages.

* **New SteelLoader Class**
  - Create `SteelLoader` class in `libs/community/langchain_community/document_loaders/steel.py`.
  - Implement proper error handling and logging in `SteelLoader`.
  - Ensure `SteelLoader` works with both Self-hosted Steel and Steel Cloud.

* **Update Init File**
  - Import `SteelLoader` class in `libs/community/langchain_community/document_loaders/__init__.py`.
  - Add `SteelLoader` to `__all__` list in `libs/community/langchain_community/document_loaders/__init__.py`.

