### PR TITLE
anthropic[patch]: increase timeouts for integration tests

### DIFF
--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -8,7 +8,7 @@ TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests integration_test integration_tests:
-	poetry run pytest -vvv --timeout 20 $(TEST_FILE)
+	poetry run pytest -vvv --timeout 30 $(TEST_FILE)
 
 test_watch:
 	poetry run ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -8,7 +8,7 @@ TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests integration_test integration_tests:
-	poetry run pytest -vvv --timeout 10 $(TEST_FILE)
+	poetry run pytest -vvv --timeout 20 $(TEST_FILE)
 
 test_watch:
 	poetry run ptw --snapshot-update --now . -- -vv $(TEST_FILE)


### PR DESCRIPTION
Some tests consistently ran into the 10s limit in CI.