### PR TITLE
langchain_community: Add default value 0.0 to min_score_confidence in AmazonKendraRetriever

### DIFF
--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -355,11 +355,10 @@ class AmazonKendraRetriever(BaseRetriever):
 
         user_context: Provides information about the user context
             See: https://docs.aws.amazon.com/kendra/latest/APIReference
-        
-        min_score_confidence: The minimum confidence score threshold for 
-            filtering documents. Documents with a confidence score 
-            below this value will be excluded from the results. 
 
+        min_score_confidence: The minimum confidence score threshold for
+            filtering documents. Documents with a confidence score
+            below this value will be excluded from the results.
     Example:
         .. code-block:: python
 

--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -357,8 +357,8 @@ class AmazonKendraRetriever(BaseRetriever):
             See: https://docs.aws.amazon.com/kendra/latest/APIReference
         
         min_score_confidence: The minimum confidence score threshold for 
-            filtering documents. 
-            Documents with a confidence score below this value will be excluded from the results. 
+            filtering documents. Documents with a confidence score 
+            below this value will be excluded from the results. 
 
     Example:
         .. code-block:: python

--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -366,7 +366,6 @@ class AmazonKendraRetriever(BaseRetriever):
             retriever = AmazonKendraRetriever(
                 index_id="c0806df7-e76b-4bce-9b5c-d5582f6b1a03"
             )
-
     """
 
     index_id: str

--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -355,6 +355,9 @@ class AmazonKendraRetriever(BaseRetriever):
 
         user_context: Provides information about the user context
             See: https://docs.aws.amazon.com/kendra/latest/APIReference
+        
+        min_score_confidence: The minimum confidence score threshold for filtering documents. 
+            Documents with a confidence score below this value will be excluded from the results. 
 
     Example:
         .. code-block:: python
@@ -374,7 +377,7 @@ class AmazonKendraRetriever(BaseRetriever):
     page_content_formatter: Callable[[ResultItem], str] = combined_text
     client: Any
     user_context: Optional[Dict] = None
-    min_score_confidence: Annotated[Optional[float], Field(ge=0.0, le=1.0)]
+    min_score_confidence: Annotated[Optional[float], Field(ge=0.0, le=1.0)] = 0.0
 
     @validator("top_k")
     def validate_top_k(cls, value: int) -> int:

--- a/libs/community/langchain_community/retrievers/kendra.py
+++ b/libs/community/langchain_community/retrievers/kendra.py
@@ -356,7 +356,8 @@ class AmazonKendraRetriever(BaseRetriever):
         user_context: Provides information about the user context
             See: https://docs.aws.amazon.com/kendra/latest/APIReference
         
-        min_score_confidence: The minimum confidence score threshold for filtering documents. 
+        min_score_confidence: The minimum confidence score threshold for 
+            filtering documents. 
             Documents with a confidence score below this value will be excluded from the results. 
 
     Example:


### PR DESCRIPTION
**Description**:
This PR introduces a default value of 0.0 for the min_score_confidence parameter in the AmazonKendraRetriever class. Previously, min_score_confidence did not have a default value, and it was not documented, requiring developers to read the code to understand how to use the class effectively. This caused confusion and made it difficult to execute AmazonKendraRetriever without prior knowledge of the parameter.

**With this change**:

A default value of 0.0 ensures that all documents, regardless of their confidence score, are included in the results unless a stricter threshold is explicitly specified.
The min_score_confidence parameter is now easier to understand and use, improving the developer experience.


**Rationale**:

Setting a default of 0.0 maintains backward compatibility and aligns with the behavior where no confidence filtering is applied.
Clearly documenting the default behavior ensures developers can utilize AmazonKendraRetriever without needing to dig into the codebase.
Changes Made:

Added min_score_confidence: Annotated[Optional[float], Field(ge=0.0, le=1.0)] = 0.0 to the AmazonKendraRetriever class.
Updated comments to explain the purpose and default value of min_score_confidence.

**Checklist**:
 Verified that AmazonKendraRetriever works as expected with the default value of min_score_confidence=0.0.
