### PR TITLE
core: typo `Utilities for tests.` -> `Utilities for pydantic.`

### DIFF
--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -1,4 +1,4 @@
-"""Utilities for tests."""
+"""Utilities for pydantic."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
**Description:** typo