### PR TITLE
langchain_community.chat_models.oci_generative_ai: Fix a bug when using optional parameters in tools

### DIFF
--- a/libs/community/langchain_community/chat_models/oci_generative_ai.py
+++ b/libs/community/langchain_community/chat_models/oci_generative_ai.py
@@ -61,6 +61,7 @@ JSON_TO_PYTHON_TYPES = {
     "integer": "int",
     "array": "List",
     "object": "Dict",
+    "any": "any",
 }
 
 
@@ -323,7 +324,7 @@ class CohereProvider(Provider):
                         if "description" in p_def
                         else "",
                         type=JSON_TO_PYTHON_TYPES.get(
-                            p_def.get("type"), p_def.get("type")
+                            p_def.get("type"), p_def.get("type", "any")
                         ),
                         is_required="default" not in p_def,
                     )
@@ -342,7 +343,7 @@ class CohereProvider(Provider):
                     p_name: self.oci_tool_param(
                         description=p_def.get("description"),
                         type=JSON_TO_PYTHON_TYPES.get(
-                            p_def.get("type"), p_def.get("type")
+                            p_def.get("type"), p_def.get("type", "any")
                         ),
                         is_required="default" not in p_def,
                     )
@@ -363,7 +364,7 @@ class CohereProvider(Provider):
                     p_name: self.oci_tool_param(
                         description=p_def.get("description"),
                         type=JSON_TO_PYTHON_TYPES.get(
-                            p_def.get("type"), p_def.get("type")
+                            p_def.get("type"), p_def.get("type", "any")
                         ),
                         is_required=p_name in parameters.get("required", []),
                     )


### PR DESCRIPTION
When using tools with optional parameters, the parameter `type` is not longer available since langchain update to 0.3 (because of the pydantic upgrade?) and there is now an `anyOf` field instead. This results in the `type` being `None` in the chat request for the tool parameter, and the LLM call fails with the error:

```
oci.exceptions.ServiceError: {'target_service': 'generative_ai_inference', 
'status': 400, 'code': '400', 
'opc-request-id': '...', 
'message': 'Parameter definition must have a type.', 
'operation_name': 'chat'
...
}
```

Example code that fails:

```
from langchain_community.chat_models.oci_generative_ai import ChatOCIGenAI
from langchain_core.tools import tool
from typing import Optional

llm = ChatOCIGenAI(
        model_id="cohere.command-r-plus",
        service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
        compartment_id="ocid1.compartment.oc1...",
        auth_profile="your_profile",
        auth_type="API_KEY",
        model_kwargs={"temperature": 0, "max_tokens": 3000},
)

@tool
def test(example: Optional[str] = None):
    """This is the tool to use to test things

    Args:
        example: example variable, defaults to None
    """
    return "this is a test"

llm_with_tools = llm.bind_tools([test])

result = llm_with_tools.invoke("can you make a test for g")
```

This PR sets the param type to `any` in that case, and fixes the problem.

