### PR TITLE
docs: Add ApertureDB to vectorstore integrations page

### DIFF
--- a/docs/scripts/vectorstore_feat_table.py
+++ b/docs/scripts/vectorstore_feat_table.py
@@ -19,6 +19,7 @@ vectorstore_list = [
     "Redis",
     "Clickhouse",
     "InMemoryVectorStore",
+    "ApertureDB",
 ]
 
 from_partners = [
@@ -193,6 +194,17 @@ def get_vectorstore_table():
             "Passes Standard Tests": False,
             "Multi Tenancy": False,
             "Local/Cloud": "Local",
+            "IDs in add Documents": True,
+        },
+        "ApertureDB": {
+            "Delete by ID": True,
+            "Filtering": True,
+            "similarity_search_by_vector": True,
+            "similarity_search_with_score": True,
+            "asearch": True,
+            "Passes Standard Tests": True,
+            "Multi Tenancy": False,
+            "Local/Cloud": "Both",
             "IDs in add Documents": True,
         },
     }

--- a/docs/src/theme/VectorStoreTabs.js
+++ b/docs/src/theme/VectorStoreTabs.js
@@ -21,7 +21,7 @@ export default function VectorStoreTabs(props) {
         {
             value: "ApertureDB",
             label: "ApertureDB",
-            text: `from langchain_community.vectorstores import ApertureDB\n`${useFakeEmbeddings ? fakeEmbeddingsString : ""}\n${vectorStoreVarName} = ApertureDB(\n    embeddings=embeddings, \n    descriptor_set="test",\n)`,
+            text: `from langchain_community.vectorstores import ApertureDB\n${useFakeEmbeddings ? fakeEmbeddingsString : ""}\n${vectorStoreVarName} = ApertureDB(\n    embeddings=embeddings, \n    descriptor_set="test",\n)`,
             packageName: "langchain-community aperturedb",
             default: false,
         },

--- a/docs/src/theme/VectorStoreTabs.js
+++ b/docs/src/theme/VectorStoreTabs.js
@@ -19,6 +19,13 @@ export default function VectorStoreTabs(props) {
             default: true,
         },
         {
+            value: "ApertureDB",
+            label: "ApertureDB",
+            text: `from langchain_community.vectorstores import ApertureDB\n`${useFakeEmbeddings ? fakeEmbeddingsString : ""}\n${vectorStoreVarName} = ApertureDB(\n    embeddings=embeddings, \n    descriptor_set="test",\n)`,
+            packageName: "langchain-community aperturedb",
+            default: false,
+        },
+        {
             value: "AstraDB",
             label: "AstraDB",
             text: `from langchain_astradb import AstraDBVectorStore\n${useFakeEmbeddings ? fakeEmbeddingsString : ""}\n${vectorStoreVarName} = AstraDBVectorStore(\n    embedding=embeddings,\n    api_endpoint=ASTRA_DB_API_ENDPOINT,\n    collection_name="astra_vector_langchain",\n    token=ASTRA_DB_APPLICATION_TOKEN,\n    namespace=ASTRA_DB_NAMESPACE,\n)`,


### PR DESCRIPTION
- **Description:** Add ApertureDB to vectorstore integrations page
- **Issue:**none
- **Dependencies:** none
- **Twitter handle:** aperturedata

I was unable to lint or test because the development tools don't work and/or the documentation is wrong.
https://github.com/langchain-ai/langchain/discussions/28834
https://github.com/langchain-ai/langchain/discussions/28833
