### PR TITLE
partners: allow to set Prefix in AIMessage (for MistralAI)

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -345,6 +345,8 @@ def _convert_message_to_mistral_chat_message(
             message_dict["content"] = ""
         else:
             message_dict["content"] = message.content
+        if "prefix" in message.additional_kwargs:
+            message_dict["prefix"] = message.additional_kwargs["prefix"]
         return message_dict
     elif isinstance(message, SystemMessage):
         return dict(role="system", content=message.content)

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -93,6 +93,10 @@ def test_mistralai_initialization_baseurl_env(env_var_name: str) -> None:
             dict(role="assistant", content="Hello"),
         ),
         (
+            AIMessage(content="{", additional_kwargs={"prefix": True}),
+            dict(role="assistant", content="{", prefix=True),
+        ),
+        (
             ChatMessage(role="assistant", content="Hello"),
             dict(role="assistant", content="Hello"),
         ),


### PR DESCRIPTION
**Description:**

Added ability to set `prefix` attribute to prevent error : 
```
httpx.HTTPStatusError: Error response 400 while fetching https://api.mistral.ai/v1/chat/completions: {"object":"error","message":"Expected last role User or Tool (or Assistant with prefix True) for serving but got assistant","type":"invalid_request_error","param":null,"code":null}
```