### PR TITLE
Docs: Add langgraph to installation section for Rag tutorial

### DIFF
--- a/docs/docs/tutorials/rag.ipynb
+++ b/docs/docs/tutorials/rag.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet --upgrade langchain-text-splitters langchain-community"
+    "%pip install --quiet --upgrade langchain-text-splitters langchain-community langgraph"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "source": [
     "  </TabItem>\n",
     "  <TabItem value=\"conda\" label=\"Conda\">\n",
-    "    <CodeBlock language=\"bash\">conda install langchain-text-splitters langchain-community -c conda-forge</CodeBlock>\n",
+    "    <CodeBlock language=\"bash\">conda install langchain-text-splitters langchain-community langgraph -c conda-forge</CodeBlock>\n",
     "  </TabItem>\n",
     "</Tabs>\n",
     "\n",


### PR DESCRIPTION
**Issue**:
This tutorial depends on langgraph, however Langgraph is not mentioned on the installation section for the tutorial, which raises an error when copying and pasting the code snippets as following:
![image](https://github.com/user-attachments/assets/829c9118-fcf8-4f17-9abb-32e005ebae07)

**Solution**:
Just adding langgraph package to installation section, for both pip and Conda tabs as this tutorial requires it. 
