### PR TITLE
Community : Add cost information for missing OpenAI model

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -41,6 +41,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4o-2024-08-06": 0.0025,
     "gpt-4o-2024-08-06-cached": 0.00125,
     "gpt-4o-2024-11-20": 0.0025,
+    "gpt-4o-2024-11-20-cached": 0.00125,
     # GPT-4o output
     "gpt-4o-completion": 0.01,
     "gpt-4o-2024-05-13-completion": 0.015,


### PR DESCRIPTION
In the previous commit, the cached model key for this model was omitted.
When using the "gpt-4o-2024-11-20" model, the token count in the callback appeared as 0, and the cost was recorded as 0.

We add model and cost information so that the token count and cost can be displayed for the respective model.

- The message before modification is as follows.
```
Tokens Used: 0
Prompt Tokens: 0
Prompt Tokens Cached: 0 
Completion Tokens: 0  
Reasoning Tokens: 0
Successful Requests: 0
Total Cost (USD): $0.0
```

- The message after modification is as follows.
```
Tokens Used: 3783 
Prompt Tokens: 3625
Prompt Tokens Cached: 2560
Completion Tokens: 158
Reasoning Tokens: 0
Successful Requests: 1
Total Cost (USD): $0.010642500000000001
```