### PR TITLE
Update chroma.ipynb, Add langchain openai to the pip install in the chroma docs

### DIFF
--- a/docs/docs/integrations/vectorstores/chroma.ipynb
+++ b/docs/docs/integrations/vectorstores/chroma.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pip install -qU \"langchain-chroma>=0.1.2\""
+    "pip install -qU \"langchain-chroma>=0.1.2\" langchain_openai"
    ]
   },
   {


### PR DESCRIPTION
Description: added langchain openai to the pip
Issue: Example notebook will not run without this added
Dependencies: langchain openai
