### PR TITLE
core: fix tool_call function

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -210,17 +210,18 @@ class ToolCall(TypedDict):
 
 
 def tool_call(*, name: str, args: dict[str, Any], id: Optional[str]) -> ToolCall:
-    if isinstance(args, str):
-        try:
-            # Extract JSON-like dictionary from string using regex
-            match = re.search(r'\{.*\}', args)
-            if match:
+    try:
+        return ToolCall(name=name, args=args, id=id, type="tool_call")
+    except:
+        # Attempt to extract JSON-like dictionary from string using regex
+        match = re.search(r'\{.*\}', args)
+        if match:
+            try:
                 args = json.loads(match.group())
-            else:
-                raise ValueError("No valid JSON object found in args string")
-        except json.JSONDecodeError:
-            raise ValueError("Invalid JSON string for args")
-    return ToolCall(name=name, args=args, id=id, type="tool_call")
+            except json.JSONDecodeError:
+                pass
+        return ToolCall(name=name, args=args, id=id, type="tool_call")
+    
 
 
 class ToolCallChunk(TypedDict):

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -7,7 +7,6 @@ from typing_extensions import NotRequired, TypedDict
 
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk, merge_content
 from langchain_core.utils._merge import merge_dicts, merge_obj
-import re
 
 
 class ToolOutputMixin:
@@ -210,6 +209,7 @@ class ToolCall(TypedDict):
 
 
 def tool_call(*, name: str, args: dict[str, Any], id: Optional[str]) -> ToolCall:
+    import re
     if isinstance(args, str):
         try:
             # Extract JSON-like dictionary from string using regex

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -7,6 +7,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk, merge_content
 from langchain_core.utils._merge import merge_dicts, merge_obj
+import re
 
 
 class ToolOutputMixin:
@@ -209,6 +210,16 @@ class ToolCall(TypedDict):
 
 
 def tool_call(*, name: str, args: dict[str, Any], id: Optional[str]) -> ToolCall:
+    if isinstance(args, str):
+        try:
+            # Extract JSON-like dictionary from string using regex
+            match = re.search(r'\{.*\}', args)
+            if match:
+                args = json.loads(match.group())
+            else:
+                raise ValueError("No valid JSON object found in args string")
+        except json.JSONDecodeError:
+            raise ValueError("Invalid JSON string for args")
     return ToolCall(name=name, args=args, id=id, type="tool_call")
 
 

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -7,6 +7,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk, merge_content
 from langchain_core.utils._merge import merge_dicts, merge_obj
+import re
 
 
 class ToolOutputMixin:
@@ -209,7 +210,6 @@ class ToolCall(TypedDict):
 
 
 def tool_call(*, name: str, args: dict[str, Any], id: Optional[str]) -> ToolCall:
-    import re
     if isinstance(args, str):
         try:
             # Extract JSON-like dictionary from string using regex


### PR DESCRIPTION

  - **Description:** For some LLM APIs, the current tool_call function is too vulnerable, causing validation errors within the chain or graph invocation, such as `tool_calls=[ { "name": "function_name", "args": '{}', "id": "tool_call_id", "type": "tool_call", } ]`, where args here is a string that resembles a dictionary, rather than the standard dictionary type. This issue is encountered when using the Qwen2.5 API and cannot be resolved by adding exception handling within the user-constructed chain or graph, as it is an error within LangChain itself. This update proactively catches dictionary-like structures in args if they are strings, which resolves the issue.
