### PR TITLE
docs: Update VectorStoreTabs.js

### DIFF
--- a/docs/src/theme/VectorStoreTabs.js
+++ b/docs/src/theme/VectorStoreTabs.js
@@ -56,7 +56,7 @@ export default function VectorStoreTabs(props) {
         {
             value: "PGVector",
             label: "PGVector",
-            text: `from langchain_postgres import PGVector\n${useFakeEmbeddings ? fakeEmbeddingsString : ""}\n${vectorStoreVarName} = PGVector(\n    embedding=embeddings,\n    collection_name="my_docs",\n    connection="postgresql+psycopg://...",\n)`,
+            text: `from langchain_postgres import PGVector\n${useFakeEmbeddings ? fakeEmbeddingsString : ""}\n${vectorStoreVarName} = PGVector(\n    embeddings=embeddings,\n    collection_name="my_docs",\n    connection="postgresql+psycopg://...",\n)`,
             packageName: "langchain-postgres",
             default: false,
         },


### PR DESCRIPTION
- Title: Fix typo to correct "embedding" to "embeddings" in PGVector initialization example

- Problem: There is a typo in the example code for initializing the PGVector class. The current parameter "embedding" is incorrect as the class expects "embeddings".

- Correction: The corrected code snippet is:

vector_store = PGVector(
    embeddings=embeddings,
    collection_name="my_docs",
    connection="postgresql+psycopg://...",
)