### PR TITLE
docs: Fix typo in Build a Retrieval Augmented Generation Part 1 section

### DIFF
--- a/docs/docs/tutorials/rag.ipynb
+++ b/docs/docs/tutorials/rag.ipynb
@@ -22,7 +22,7 @@
     "complexity.\n",
     "\n",
     "If you're already familiar with basic retrieval, you might also be interested in\n",
-    "this [high-level overview of different retrieval techinques](/docs/concepts/retrieval).\n",
+    "this [high-level overview of different retrieval techniques](/docs/concepts/retrieval).\n",
     "\n",
     "**Note**: Here we focus on Q&A for unstructured data. If you are interested for RAG over structured data, check out our tutorial on doing [question/answering over SQL data](/docs/tutorials/sql_qa).\n",
     "\n",


### PR DESCRIPTION
This PR fixes a typo in [Build a Retrieval Augmented Generation (RAG) App: Part 1](https://python.langchain.com/docs/tutorials/rag/)