### PR TITLE
docs: fix typo in how-to guides

### DIFF
--- a/docs/docs/how_to/installation.mdx
+++ b/docs/docs/how_to/installation.mdx
@@ -31,7 +31,7 @@ By default, the dependencies needed to do that are NOT installed. You will need 
 ## Ecosystem packages
 
 With the exception of the `langsmith` SDK, all packages in the LangChain ecosystem depend on `langchain-core`, which contains base
-classes and abstractions that other packages use. The dependency graph below shows how the difference packages are related.
+classes and abstractions that other packages use. The dependency graph below shows how the different packages are related.
 A directed arrow indicates that the source package depends on the target package:
 
 ![](/img/ecosystem_packages.png)


### PR DESCRIPTION
This PR is to correct a simple typo in how-to guides section.