### PR TITLE
docs: Remove deprecated `schema()` usage in examples

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -169,7 +169,7 @@
     "    return a * max(b)\n",
     "\n",
     "\n",
-    "multiply_by_max.args_schema.schema()"
+    "print(multiply_by_max.args_schema.model_json_schema())"
    ]
   },
   {

--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -285,7 +285,7 @@
     "    return bar\n",
     "\n",
     "\n",
-    "foo.args_schema.schema()"
+    "print(foo.args_schema.model_json_schema())"
    ]
   },
   {


### PR DESCRIPTION
This pull request updates the documentation in `docs/docs/how_to/custom_tools.ipynb` to reflect the recommended approach for generating JSON schemas in Pydantic. Specifically, it replaces instances of the deprecated `schema()` method with the newer and more versatile `model_json_schema()`.