### PR TITLE
(Community): `DuckDuckGoSearchAPIWrapper` backend changed from `api` to `auto`

### DIFF
--- a/libs/community/langchain_community/utilities/duckduckgo_search.py
+++ b/libs/community/langchain_community/utilities/duckduckgo_search.py
@@ -28,9 +28,9 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
     Options: d, w, m, y
     """
     max_results: int = 5
-    backend: str = "api"
+    backend: str = "auto"
     """
-    Options: api, html, lite
+    Options: auto, html, lite
     """
     source: str = "text"
     """


### PR DESCRIPTION

- **Description:** `DuckDuckGoSearchAPIWrapper` default value for backend has been changed to avoid User Warning
- **Issue:** #28957
 