### PR TITLE
docs: fix typo in `callbacks_custom_events`

### DIFF
--- a/docs/docs/how_to/callbacks_custom_events.ipynb
+++ b/docs/docs/how_to/callbacks_custom_events.ipynb
@@ -15,7 +15,7 @@
     "- [Astream Events API](/docs/concepts/streaming/#astream_events) the `astream_events` method will surface custom callback events.\n",
     ":::\n",
     "\n",
-    "In some situations, you may want to dipsatch a custom callback event from within a [Runnable](/docs/concepts/runnables) so it can be surfaced\n",
+    "In some situations, you may want to dispatch a custom callback event from within a [Runnable](/docs/concepts/runnables) so it can be surfaced\n",
     "in a custom callback handler or via the [Astream Events API](/docs/concepts/streaming/#astream_events).\n",
     "\n",
     "For example, if you have a long running tool with multiple steps, you can dispatch custom events between the steps and use these custom events to monitor progress.\n",


### PR DESCRIPTION
This PR is to correct a simple typo (dipsatch -> dispatch) in how-to guide.