### PR TITLE
Draft: community: add pull_md tool for converting URLs to Markdown

### DIFF
--- a/docs/docs/integrations/tools/pull_md.ipynb
+++ b/docs/docs/integrations/tools/pull_md.ipynb
@@ -1,121 +1,408 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "intro-markdown",
-   "metadata": {},
-   "source": [
-    "# Pull-md Tool Usage\n",
-    "\n",
-    "This guide shows how to use the PullMd component for converting URLs into Markdown.\n",
-    "\n",
-    "## Installation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "installation-code",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -qU pull-md langchain-community"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "api-wrapper-introduction",
-   "metadata": {},
-   "source": [
-    "## Using PullMdAPIWrapper"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "api-wrapper-usage",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "# Example Domain\nThis domain is established to be used for illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
+      "cell_type": "markdown",
+      "id": "overview",
+      "metadata": {},
+      "source": [
+        "# PullMd Tool Usage\n",
+        "## Overview\n",
+        "\n",
+        "This guide demonstrates how to use the `pull_md` tool within the Langchain framework to convert URLs into Markdown. `pull_md` is capable of handling web pages built with dynamic JavaScript frameworks like React, Angular, and Vue.js, efficiently retrieving fully rendered Markdown without consuming local server resources."
       ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from langchain_community.utilities import PullMdAPIWrapper\n",
-    "\n",
-    "pull_md = PullMdAPIWrapper()\n",
-    "markdown = pull_md.convert_url_to_markdown(\"http://example.com\")\n",
-    "print(markdown)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "tool-usage-introduction",
-   "metadata": {},
-   "source": [
-    "## Using PullMdQueryRun Tool"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "tool-usage-code",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "# Example Domain\nThis domain is established to be used for illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
+      "cell_type": "markdown",
+      "id": "setup",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "\n",
+        "First, install the necessary packages using pip:"
       ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "installation-code",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -qU pull-md langchain-community"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "instantiation",
+      "metadata": {},
+      "source": [
+        "## Instantiation\n",
+        "\n",
+        "Import the necessary classes and instantiate the `PullMdAPIWrapper` and `PullMdQueryRun` tools:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "instantiation-code",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_community.utilities import PullMdAPIWrapper\n",
+        "from langchain_community.tools import PullMdQueryRun\n",
+        "\n",
+        "# Instantiate the API Wrapper\n",
+        "pull_md_wrapper = PullMdAPIWrapper()\n",
+        "\n",
+        "# Instantiate the Query Run Tool\n",
+        "pull_md_tool = PullMdQueryRun()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "invocation",
+      "metadata": {},
+      "source": [
+        "## Invocation\n",
+        "\n",
+        "Use the `PullMdAPIWrapper` to convert a URL to Markdown directly, or use the `PullMdQueryRun` tool within Langchain to handle the conversion process internally."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "invocation-api-wrapper",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "# Example Domain\nThis domain is established to be used for illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Using PullMdAPIWrapper to convert a URL to Markdown\n",
+        "markdown = pull_md_wrapper.convert_url_to_markdown(\"http://example.com\")\n",
+        "print(markdown)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "invocation-tool",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "# Example Domain\nThis domain is established to be used for illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Using PullMdQueryRun Tool to convert a URL to Markdown\n",
+        "markdown_tool = pull_md_tool.invoke({\"url\": \"http://example.com\"})\n",
+        "print(markdown_tool)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "chaining",
+      "metadata": {},
+      "source": [
+        "## Chaining\n",
+        "\n",
+        "You can chain the `PullMdQueryRun` tool with other Langchain components to create complex workflows. Below is an example of how to use `PullMdQueryRun` to fetch and summarize an article using a chain with a language model (here, Mistral via Ollama as an example)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "chaining-code",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_core.output_parsers import StrOutputParser\n",
+        "from langchain_core.prompts import ChatPromptTemplate\n",
+        "from langchain_core.runnables import RunnablePassthrough, chain\n",
+        "from langchain_ollama import ChatOllama\n",
+        "from langchain_community.tools import PullMdQueryRun\n",
+        "\n",
+        "# Instantiate the PullMdQueryRun tool (already done above, repeating here for clarity)\n",
+        "pull_md_tool = PullMdQueryRun()\n",
+        "\n",
+        "# Create a template to embed the article content in the prompt\n",
+        "prompt = ChatPromptTemplate.from_template(\n",
+        "    \"\"\"\n",
+        "    The following article may come in handy for answering the question:\n",
+        "    {context}\n",
+        "    Question:\n",
+        "    {question}\n",
+        "    \"\"\"\n",
+        ")\n",
+        "\n",
+        "@chain\n",
+        "def custom_chain(inputs: dict) -> str:\n",
+        "    return (\n",
+        "        prompt\n",
+        "        | ChatOllama(model=\"mistral\")  # Choose your LLM\n",
+        "        | StrOutputParser()\n",
+        "    ).invoke({\"context\": pull_md_tool.invoke({\"url\": inputs[\"url\"]}), \"question\": inputs[\"question\"]})\n",
+        "\n",
+        "# Example usage\n",
+        "response = custom_chain.invoke({\n",
+        "    \"url\": \"https://en.wikipedia.org/wiki/Cambridge\",\n",
+        "    \"question\": \"Write a summary of the provided article.\"\n",
+        "})\n",
+        "print(response)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "chaining-result",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "The article provides information about Cambridge, a city in England and the county town of Cambridgeshire.\n",
+              "It is known for its historic university, which is one of the oldest and most prestigious in the world.\n",
+              "The city's rich history dates back to Roman times, with significant contributions from the Saxons, Vikings, and Normans.\n",
+              "Its architecture reflects a blend of styles ranging from Gothic to Baroque, including iconic structures like King's College Chapel and the Fitzwilliam Museum.\n",
+              "\n",
+              "Cambridge is also known for the 'Cambridge Phenomenon', referring to the high concentration of innovative technology businesses around the university, contributing significantly to the UK economy.\n",
+              "The city hosts annual events such as the world-renowned Cambridge University Boat Races and the Cambridge Folk Festival.\n",
+              "Despite its growth and modernization, Cambridge has managed to preserve much of its historic charm, making it a popular tourist destination.\n",
+              "The article also provides coordinates for locating the city on maps."
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# This cell just shows a final example result after the chain runs.\n",
+        "# It's reusing the same usage of pull_md_wrapper from above, with a different URL or scenario.\n",
+        "markdown = pull_md_wrapper.convert_url_to_markdown(\"http://example.com\")\n",
+        "print(markdown)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "another-example-code",
+      "metadata": {},
+      "source": [
+        "### Using as a Tool\n",
+        "\n",
+        "Here's an example of how you might integrate `PullMdQueryRun` with a language model, passing the URL to the tool and then continuing the conversation with the text it returns:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "another-example",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_core.messages import ToolMessage\n",
+        "from langchain_ollama import ChatOllama\n",
+        "from langchain_community.tools import PullMdQueryRun\n",
+        "\n",
+        "# Instantiate the PullMdQueryRun tool\n",
+        "pull_md_tool_for_react = PullMdQueryRun()\n",
+        "\n",
+        "# Instantiate the LLM\n",
+        "llm = ChatOllama(model=\"mistral\")\n",
+        "\n",
+        "# Bind the PullMd tool to the LLM\n",
+        "llm_with_tools = llm.bind_tools([pull_md_tool_for_react])\n",
+        "\n",
+        "# Define the query\n",
+        "query = \"Convert https://react.dev to markdown.\"\n",
+        "\n",
+        "# Invoke the LLM with the query\n",
+        "response = llm_with_tools.invoke(query)\n",
+        "\n",
+        "# Process tool calls and generate messages\n",
+        "messages = []\n",
+        "if response.tool_calls:\n",
+        "    for tool_call in response.tool_calls:\n",
+        "        tool_response = pull_md_tool_for_react.invoke(tool_call[\"args\"])\n",
+        "        tool_msg = llm_with_tools.invoke([\n",
+        "            ToolMessage(content=str(tool_response), tool_call_id=tool_call[\"id\"])\n",
+        "        ])\n",
+        "        messages.append(tool_msg)\n",
+        "\n",
+        "print(messages)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "tools-result",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[AIMessage(content=\" Here is the text you provided, which appears to be the content for a webpage about the React library:\n",
+              "\n---\n",
+              "Title: Welcome to the React community!\n",
+              "Content:\n",
+              "Welcome to the world of React! Here, you'll find everything you need to get started with this versatile JavaScript library.\n",
+              "Whether you're new to React or an experienced developer, our community is here to help you learn, grow, and create amazing user interfaces.\n",
+              "**What is React?**\n",
+              "React is a popular open-source JavaScript library used for building user interfaces, primarily for web applications.\n",
+              "It allows developers to design modular and reusable UI components that can be easily managed and updated.\n",
+              "**Getting Started with React**\n",
+              "To get started with React, follow our quick start guide:\n",
+              "1. [Quick Start](/learn)\n",
+              "2. [Installation](/learn/installation)\n",
+              "3. [Describing the UI](/learn/describing-the-ui)\n",
+              "4. [Adding Interactivity](/learn/adding-interactivity)\n",
+              "5. [Managing State](/learn/managing-state)\n",
+              "6. [Escape Hatches](/learn/escape-hatches)\n",
+              "For a complete reference of the React API, check out our [API Reference](/reference/react).\n",
+              "**The React Community**\n",
+              "React is more than just a library or an ecosystem; it's a vibrant community.\n",
+              "Here, you'll find developers and designers, beginners, experts, researchers, artists, teachers, and students from all around the world collaborating to create user interfaces together.\n",
+              "Our diverse backgrounds make us stronger, and React empowers us to work seamlessly as a team.\n",
+              "Join our community today and:\n",
+              "- Ask for help with your projects\n",
+              "- Find opportunities to grow your skills\n",
+              "- Meet new friends from all over the world\n",
+              "**Resources**\n",
+              "For more information about React, check out these resources:\n",
+              "* [Blog](/blog)\n",
+              "* [React Native](https://reactnative.dev/)\n",
+              "* [Privacy Policy](https://opensource.facebook.com/legal/privacy)\n",
+              "* [Terms of Service](https://opensource.fb.com/legal/terms/)\n",
+              "Follow us on:\n",
+              "* [Facebook](https://www.facebook.com/react)\n",
+              "* [Twitter](https://twitter.com/reactjs)\n",
+              "* [Brand Social Account (Bsky)](https://bsky.app/profile/react.dev)\n",
+              "* [GitHub](https://github.com/facebook/react)\n",
+              "**Join the React Community Today!**\n",
+              "Ready to dive in and start creating amazing user interfaces with React? Click here to get started: [Get Started](/learn)\n",
+              "---\n",
+              "This webpage provides an introduction to React, a quick start guide for getting started with the library, and resources for learning more about it.\n",
+              "It also highlights the vibrant community surrounding React and encourages visitors to join the community and get involved.\",\n",
+              "additional_kwargs={}, response_metadata={'model': 'mistral', 'created_at': '2025-01-03T16:57:33.930219Z',\n",
+              "'done': True, 'done_reason': 'stop', 'total_duration': 35859683750, 'load_duration': 20255000, 'prompt_eval_count': 2048,\n",
+              "'prompt_eval_duration': 8906000000, 'eval_count': 672, 'eval_duration': 26931000000,\n",
+              "'message': Message(role='assistant', content=\" Here is the text you provided, which appears to be the content for a webpage about the React library:\n",
+              "---\n",
+              "Title: Welcome to the React community!\n",
+              "Content:\n",
+              "Welcome to the world of React! Here, you'll find everything you need to get started with this versatile JavaScript library.\n",
+              "Whether you're new to React or an experienced developer, our community is here to help you learn, grow, and create amazing user interfaces.\n",
+              "**What is React?**\n",
+              "React is a popular open-source JavaScript library used for building user interfaces, primarily for web applications.\n",
+              "It allows developers to design modular and reusable UI components that can be easily managed and updated.\n",
+              "**Getting Started with React**\n",
+              "To get started with React, follow our quick start guide:\n",
+              "1. [Quick Start](/learn)\n",
+              "2. [Installation](/learn/installation)\n",
+              "3. [Describing the UI](/learn/describing-the-ui)\n",
+              "4. [Adding Interactivity](/learn/adding-interactivity)\n",
+              "5. [Managing State](/learn/managing-state)\n",
+              "6. [Escape Hatches](/learn/escape-hatches)\n",
+              "For a complete reference of the React API, check out our [API Reference](/reference/react).\n",
+              "**The React Community**\n",
+              "React is more than just a library or an ecosystem; it's a vibrant community.\n",
+              "Here, you'll find developers and designers, beginners, experts, researchers, artists, teachers, and students from all around the world collaborating to create user interfaces together.\n",
+              "Our diverse backgrounds make us stronger, and React empowers us to work seamlessly as a team.\n",
+              "Join our community today and:\n",
+              "- Ask for help with your projects\n",
+              "- Find opportunities to grow your skills\n",
+              "- Meet new friends from all over the world\n",
+              "**Resources**\n",
+              "For more information about React, check out these resources:\n",
+              "* [Blog](/blog)\n",
+              "* [React Native](https://reactnative.dev/)\n",
+              "* [Privacy Policy](https://opensource.facebook.com/legal/privacy)\n",
+              "* [Terms of Service](https://opensource.fb.com/legal/terms/)\n",
+              "Follow us on:\n",
+              "* [Facebook](https://www.facebook.com/react)\n",
+              "* [Twitter](https://twitter.com/reactjs)\n",
+              "* [Brand Social Account (Bsky)](https://bsky.app/profile/react.dev)\n",
+              "* [GitHub](https://github.com/facebook/react)\n",
+              "**Join the React Community Today!**\n",
+              "Ready to dive in and start creating amazing user interfaces with React? Click here to get started: [Get Started](/learn)\n",
+              "---\n",
+              "This webpage provides an introduction to React, a quick start guide for getting started with the library, and resources for learning more about it.\n",
+              "It also highlights the vibrant community surrounding React and encourages visitors to join the community and get involved.\",\n",
+              "images=None, tool_calls=None)}, id='run-aa7da287-8be7-42c8-bfc8-27f10d84d352-0', usage_metadata={'input_tokens': 2048, 'output_tokens': 672, 'total_tokens': 2720})]"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# This cell just shows a final example result after the chain runs.\n",
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "api-reference",
+      "metadata": {},
+      "source": [
+        "## API reference\n",
+        "\n",
+        "For a complete description of all arguments, head to the API reference: [PullMdQueryRun](https://python.langchain.com/api_reference/community/tools/langchain_community.tools.pull_md.tool.PullMdQueryRun.html)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "additional-information",
+      "metadata": {},
+      "source": [
+        "You can directly pass the URL to the tool, and it will handle the conversion process internally, simplifying integration into larger workflows."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "related",
+      "metadata": {},
+      "source": [
+        "## Related\n",
+        "\n",
+        "- [How to use a chat model to call tools](https://python.langchain.com/docs/how_to/tool_calling/)"
+      ]
     }
-   ],
-   "source": [
-    "from langchain_community.tools import PullMdQueryRun\n",
-    "\n",
-    "pull_md_tool = PullMdQueryRun()\n",
-    "markdown = pull_md_tool.invoke({'url': 'http://example.com'})\n",
-    "print(markdown)"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "additional-information",
-   "metadata": {},
-   "source": [
-    "You can directly pass the URL to the tool, and it will handle the conversion process internally, simplifying integration into larger workflows."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/docs/docs/integrations/tools/pull_md.ipynb
+++ b/docs/docs/integrations/tools/pull_md.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-markdown",
+   "metadata": {},
+   "source": [
+    "# Pull-md Tool Usage\n",
+    "\n",
+    "This guide shows how to use the PullMd component for converting URLs into Markdown.\n",
+    "\n",
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "installation-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU pull-md langchain-community"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "api-wrapper-introduction",
+   "metadata": {},
+   "source": [
+    "## Using PullMdAPIWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "api-wrapper-usage",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "# Example Domain\nThis domain is established to be used for illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain_community.utilities import PullMdAPIWrapper\n",
+    "\n",
+    "pull_md = PullMdAPIWrapper()\n",
+    "markdown = pull_md.convert_url_to_markdown(\"http://example.com\")\n",
+    "print(markdown)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tool-usage-introduction",
+   "metadata": {},
+   "source": [
+    "## Using PullMdQueryRun Tool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "tool-usage-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "# Example Domain\nThis domain is established to be used for illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain_community.tools import PullMdQueryRun\n",
+    "\n",
+    "pull_md_tool = PullMdQueryRun()\n",
+    "markdown = pull_md_tool.invoke({'url': 'http://example.com'})\n",
+    "print(markdown)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "additional-information",
+   "metadata": {},
+   "source": [
+    "You can directly pass the URL to the tool, and it will handle the conversion process internally, simplifying integration into larger workflows."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/community/langchain_community/agent_toolkits/load_tools.py
+++ b/libs/community/langchain_community/agent_toolkits/load_tools.py
@@ -51,6 +51,7 @@ from langchain_community.tools.merriam_webster.tool import MerriamWebsterQueryRu
 from langchain_community.tools.metaphor_search.tool import MetaphorSearchResults
 from langchain_community.tools.openweathermap.tool import OpenWeatherMapQueryRun
 from langchain_community.tools.pubmed.tool import PubmedQueryRun
+from langchain_community.tools.pull_md.tool import PullMdQueryRun
 from langchain_community.tools.reddit_search.tool import RedditSearchRun
 from langchain_community.tools.requests.tool import (
     RequestsDeleteTool,
@@ -90,6 +91,7 @@ from langchain_community.utilities.merriam_webster import MerriamWebsterAPIWrapp
 from langchain_community.utilities.metaphor_search import MetaphorSearchAPIWrapper
 from langchain_community.utilities.openweathermap import OpenWeatherMapAPIWrapper
 from langchain_community.utilities.pubmed import PubMedAPIWrapper
+from langchain_community.utilities.pull_md import PullMdAPIWrapper
 from langchain_community.utilities.reddit_search import RedditSearchAPIWrapper
 from langchain_community.utilities.requests import TextRequestsWrapper
 from langchain_community.utilities.searchapi import SearchApiAPIWrapper
@@ -333,6 +335,8 @@ def _get_golden_query(**kwargs: Any) -> BaseTool:
 def _get_pubmed(**kwargs: Any) -> BaseTool:
     return PubmedQueryRun(api_wrapper=PubMedAPIWrapper(**kwargs))
 
+def _get_pull_md(**kwargs: Any) -> BaseTool:
+    return PullMdQueryRun(api_wrapper=PullMdAPIWrapper(**kwargs))
 
 def _get_google_books(**kwargs: Any) -> BaseTool:
     from langchain_community.tools.google_books import GoogleBooksQueryRun
@@ -537,6 +541,7 @@ _EXTRA_OPTIONAL_TOOLS: Dict[str, Tuple[Callable[[KwArg(Any)], BaseTool], List[st
     ),
     "golden-query": (_get_golden_query, ["golden_api_key"]),
     "pubmed": (_get_pubmed, ["top_k_results"]),
+    "pull-md": (_get_pull_md, []),
     "human": (_get_human_tool, ["prompt_func", "input_func"]),
     "awslambda": (
         _get_lambda_api,

--- a/libs/community/langchain_community/tools/__init__.py
+++ b/libs/community/langchain_community/tools/__init__.py
@@ -248,6 +248,9 @@ if TYPE_CHECKING:
     from langchain_community.tools.pubmed.tool import (
         PubmedQueryRun,
     )
+    from langchain_community.tools.pull_md.tool import (
+        PullMdQueryRun,
+    )
     from langchain_community.tools.reddit_search.tool import (
         RedditSearchRun,
         RedditSearchSchema,
@@ -451,6 +454,7 @@ __all__ = [
     "PolygonLastQuote",
     "PolygonTickerNews",
     "PubmedQueryRun",
+    "PullMdQueryRun",
     "QueryCheckerTool",
     "QueryPowerBITool",
     "QuerySQLCheckerTool",
@@ -605,6 +609,7 @@ _module_lookup = {
     "PolygonLastQuote": "langchain_community.tools.polygon.last_quote",
     "PolygonTickerNews": "langchain_community.tools.polygon.ticker_news",
     "PubmedQueryRun": "langchain_community.tools.pubmed.tool",
+    "PullMdQueryRun": "langchain_community.tools.pull_md.tool",
     "QueryCheckerTool": "langchain_community.tools.spark_sql.tool",
     "QueryPowerBITool": "langchain_community.tools.powerbi.tool",
     "QuerySQLCheckerTool": "langchain_community.tools.sql_database.tool",

--- a/libs/community/langchain_community/tools/pull_md/__init__.py
+++ b/libs/community/langchain_community/tools/pull_md/__init__.py
@@ -1,0 +1,3 @@
+from langchain_community.tools.pull_md.tool import PullMdQueryRun
+
+__all__ = ["PullMdQueryRun"]

--- a/libs/community/langchain_community/tools/pull_md/tool.py
+++ b/libs/community/langchain_community/tools/pull_md/tool.py
@@ -1,0 +1,33 @@
+"""Tool for the Pull.md API."""
+
+from typing import Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from langchain_community.utilities.pull_md import PullMdAPIWrapper
+
+class PullMdInput(BaseModel):
+    """Input for the Pull.md tool."""
+    url: str = Field(description="URL to convert to markdown")
+
+class PullMdQueryRun(BaseTool):
+    """Tool that uses Pull.md API to convert URLs to Markdown."""
+
+    name: str = "pull_md"
+    description: str = (
+        "A wrapper around Pull.md service. "
+        "Useful for converting web pages to Markdown format. "
+        "Input should be a valid URL."
+    )
+    api_wrapper: PullMdAPIWrapper = Field(default_factory=PullMdAPIWrapper)
+    args_schema: Type[BaseModel] = PullMdInput
+
+    def _run(
+        self,
+        url: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Use the Pull.md tool."""
+        return self.api_wrapper.convert_url_to_markdown(url)

--- a/libs/community/langchain_community/utilities/__init__.py
+++ b/libs/community/langchain_community/utilities/__init__.py
@@ -125,6 +125,9 @@ if TYPE_CHECKING:
     from langchain_community.utilities.pubmed import (
         PubMedAPIWrapper,
     )
+    from langchain_community.utilities.pull_md import (
+        PullMdAPIWrapper,
+    )
     from langchain_community.utilities.rememberizer import RememberizerAPIWrapper
     from langchain_community.utilities.requests import (
         Requests,
@@ -216,6 +219,7 @@ __all__ = [
     "Portkey",
     "PowerBIDataset",
     "PubMedAPIWrapper",
+    "PullMdAPIWrapper",
     "RememberizerAPIWrapper",
     "Requests",
     "RequestsWrapper",
@@ -280,6 +284,7 @@ _module_lookup = {
     "Portkey": "langchain_community.utilities.portkey",
     "PowerBIDataset": "langchain_community.utilities.powerbi",
     "PubMedAPIWrapper": "langchain_community.utilities.pubmed",
+    "PullMdAPIWrapper": "langchain_community.utilities.pull_md",
     "RememberizerAPIWrapper": "langchain_community.utilities.rememberizer",
     "Requests": "langchain_community.utilities.requests",
     "RequestsWrapper": "langchain_community.utilities.requests",

--- a/libs/community/langchain_community/utilities/pull_md.py
+++ b/libs/community/langchain_community/utilities/pull_md.py
@@ -1,7 +1,6 @@
 """Utility that calls the Pull.md API for markdown conversion."""
 
 import logging
-from typing import Any, Dict
 
 from pydantic import BaseModel
 import requests

--- a/libs/community/langchain_community/utilities/pull_md.py
+++ b/libs/community/langchain_community/utilities/pull_md.py
@@ -1,0 +1,41 @@
+"""Utility that calls the Pull.md API for markdown conversion."""
+
+import logging
+from typing import Any, Dict
+
+from pydantic import BaseModel
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class PullMdAPIWrapper(BaseModel):
+    """Wrapper around PullMdAPI to convert URLs to Markdown.
+
+    This utility provides a method to convert a given URL to Markdown format using
+    the Pull.md service.
+    """
+
+    def convert_url_to_markdown(self, url: str) -> str:
+        """Converts a URL to Markdown using the Pull.md service.
+
+        Args:
+            url: A string representing the URL to be converted.
+
+        Returns:
+            A string containing the Markdown version of the URL's content.
+
+        Raises:
+            HTTPError: An error from the requests library for bad HTTP responses.
+        """
+        try:
+            from pull_md import pull_markdown  # Assuming pull_md is installed in the environment
+            return pull_markdown(url)
+        except ImportError:
+            raise ImportError("pull_md package is not installed. Install it with `pip install pull-md`")
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Request to Pull.md API failed: {e}")
+            raise
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/libs/community/tests/unit_tests/utilities/test_pull_md.py
+++ b/libs/community/tests/unit_tests/utilities/test_pull_md.py
@@ -1,0 +1,23 @@
+import pytest
+
+from utilities.pull_md import PullMdAPIWrapper
+
+
+def test_convert_url_to_markdown_success(mocker):
+    """Test successful URL conversion to Markdown."""
+    expected_markdown = "# Example Domain"
+    mocker.patch('pull_md.pull_markdown', return_value=expected_markdown)
+
+    pull_md = PullMdAPIWrapper()
+    result = pull_md.convert_url_to_markdown("http://example.com")
+    assert result == expected_markdown
+
+
+def test_convert_url_to_markdown_failure(mocker):
+    """Test failure in URL conversion to Markdown."""
+    mocker.patch('pull_md.pull_markdown', side_effect=Exception("Failed to convert"))
+
+    pull_md = PullMdAPIWrapper()
+    with pytest.raises(Exception) as excinfo:
+        pull_md.convert_url_to_markdown("http://example.com")
+    assert "Failed to convert" in str(excinfo.value)


### PR DESCRIPTION
- [x] **PR title**: community: add `pull_md` tool for converting URLs to Markdown

- [x] **PR message**:
    - **Description:** This pull request adds the `pull_md` tool to the Langchain community package, enabling the conversion of URLs to Markdown format. It's particularly effective for processing web pages built with dynamic JavaScript frameworks like React, Angular, and Vue.js. By leveraging the pull.md service, `pull_md` retrieves fully rendered Markdown without using local server resources, simplifying the conversion of complex web pages into Markdown for documentation and educational projects. The tool enhances Langchain's functionality.
    - **Dependencies:** Requires the [`pull_md`](https://pypi.org/project/pull-md/) package from PyPI.
    - **Twitter handle:** https://x.com/eugeneevstafev?s=21

- [x] **Add tests and docs**: 
  1. Added unit tests that do not rely on network access.
  2. Included an example notebook demonstrating its use, located in the `docs/docs/integrations` directory.

- [ ] **Lint and test**: Ran `make format`, `make lint`, and `make test` from the root of the package(s) I've modified. All checks pass as per the [contribution guidelines](https://python.langchain.com/docs/contributing/).

