### PR TITLE
community: Add "headers" parameter support to OpenAPI tools

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/openapi/planner.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/planner.py
@@ -87,7 +87,10 @@ class RequestsGetToolWithParsing(BaseRequestsTool, BaseTool):  # type: ignore[ov
             raise e
         data_params = data.get("params")
         response: str = cast(
-            str, self.requests_wrapper.get(data["url"], params=data_params)
+            str,
+            self.requests_wrapper.get(
+                data["url"], data.get("headers", {}), params=data_params
+            ),
         )
         response = response[: self.response_length]
         return self.llm_chain.predict(

--- a/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/planner_prompt.py
@@ -151,6 +151,7 @@ REQUESTS_GET_TOOL_DESCRIPTION = """Use this to GET content from a website.
 Input to the tool should be a json string with 3 keys: "url", "params" and "output_instructions".
 The value of "url" should be a string. 
 The value of "params" should be a dict of the needed and available parameters from the OpenAPI spec related to the endpoint. 
+The value of "headers" should be a dict of the needed (e.g. if required only in certain case based on description) and available parameters from the OpenAPI spec related to the endpoint.
 If parameters are not needed, or not available, leave it empty.
 The value of "output_instructions" should be instructions on what information to extract from the response, 
 for example the id(s) for a resource(s) that the GET request fetches.

--- a/libs/community/langchain_community/agent_toolkits/openapi/spec.py
+++ b/libs/community/langchain_community/agent_toolkits/openapi/spec.py
@@ -23,7 +23,9 @@ class ReducedOpenAPISpec:
     endpoints: List[Tuple[str, str, dict]]
 
 
-def reduce_openapi_spec(spec: dict, dereference: bool = True) -> ReducedOpenAPISpec:
+def reduce_openapi_spec(
+    spec: dict, dereference: bool = True, remove_optional: bool = False
+) -> ReducedOpenAPISpec:
     """Simplify/distill/minify a spec somehow.
 
     I want a smaller target for retrieval and (more importantly)
@@ -63,7 +65,7 @@ def reduce_openapi_spec(spec: dict, dereference: bool = True) -> ReducedOpenAPIS
             out["parameters"] = [
                 parameter
                 for parameter in docs.get("parameters", [])
-                if parameter.get("required")
+                if not remove_optional or parameter.get("required")
             ]
         if "200" in docs["responses"]:
             out["responses"] = docs["responses"]["200"]

--- a/libs/community/langchain_community/tools/requests/tool.py
+++ b/libs/community/langchain_community/tools/requests/tool.py
@@ -4,6 +4,7 @@
 import json
 from typing import Any, Dict, Optional, Union
 
+from aiohttp.hdrs import DATE
 from pydantic import BaseModel
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
@@ -51,24 +52,36 @@ class RequestsGetTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
     """Tool for making a GET request to an API endpoint."""
 
     name: str = "requests_get"
-    description: str = """A portal to the internet. Use this when you need to get specific
-    content from a website. Input should be a  url (i.e. https://www.google.com).
+    description: str = """
+    A portal to the internet. Use this when you need to get specific
+    content from a website.
+    Input should be a json string with two keys: "url" and "headers".
+    The value of "url" should be a string, and the value of "headers" should be a dictionary of
+    key-value pairs you want to PUT to the url.
+    "headers" are optional. Headers are merged with the default headers of the request wrapper.
+    Be careful to always use double quotes for strings in the json string.
     The output will be the text response of the GET request.
     """
 
     def _run(
-        self, url: str, run_manager: Optional[CallbackManagerForToolRun] = None
+        self, text: str, run_manager: Optional[CallbackManagerForToolRun] = None
     ) -> Union[str, Dict[str, Any]]:
         """Run the tool."""
-        return self.requests_wrapper.get(_clean_url(url))
+        data = _parse_input(text)
+        return self.requests_wrapper.get(
+            _clean_url(data["url"]), headers=data.get("headers", {})
+        )
 
     async def _arun(
         self,
-        url: str,
+        text: str,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> Union[str, Dict[str, Any]]:
         """Run the tool asynchronously."""
-        return await self.requests_wrapper.aget(_clean_url(url))
+        data = _parse_input(text)
+        return await self.requests_wrapper.aget(
+            _clean_url(data["url"]), headers=data.get("headers", {})
+        )
 
 
 class RequestsPostTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
@@ -76,9 +89,10 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
 
     name: str = "requests_post"
     description: str = """Use this when you want to POST to a website.
-    Input should be a json string with two keys: "url" and "data".
-    The value of "url" should be a string, and the value of "data" should be a dictionary of 
+    Input should be a json string with two keys: "url", "data" and "headers".
+    The value of "url" should be a string, and the value of "data" and "headers" should be a dictionary of
     key-value pairs you want to POST to the url.
+    "headers" are optional. Headers are merged with the default headers of the request wrapper.
     Be careful to always use double quotes for strings in the json string
     The output will be the text response of the POST request.
     """
@@ -89,7 +103,9 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return self.requests_wrapper.post(_clean_url(data["url"]), data["data"])
+            return self.requests_wrapper.post(
+                _clean_url(data["url"]), data["data"], data.get("headers", {})
+            )
         except Exception as e:
             return repr(e)
 
@@ -102,7 +118,7 @@ class RequestsPostTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
         try:
             data = _parse_input(text)
             return await self.requests_wrapper.apost(
-                _clean_url(data["url"]), data["data"]
+                _clean_url(data["url"]), data["data"], data.get("headers", {})
             )
         except Exception as e:
             return repr(e)
@@ -113,9 +129,10 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
 
     name: str = "requests_patch"
     description: str = """Use this when you want to PATCH to a website.
-    Input should be a json string with two keys: "url" and "data".
-    The value of "url" should be a string, and the value of "data" should be a dictionary of 
+    Input should be a json string with two keys: "url", "data" and "headers".
+    The value of "url" should be a string, and the value of "data" and "headers" should be a dictionary of
     key-value pairs you want to PATCH to the url.
+    "headers" are optional. Headers are merged with the default headers of the request wrapper.
     Be careful to always use double quotes for strings in the json string
     The output will be the text response of the PATCH request.
     """
@@ -126,7 +143,9 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return self.requests_wrapper.patch(_clean_url(data["url"]), data["data"])
+            return self.requests_wrapper.patch(
+                _clean_url(data["url"]), data["data"], data.get("headers", {})
+            )
         except Exception as e:
             return repr(e)
 
@@ -139,7 +158,7 @@ class RequestsPatchTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
         try:
             data = _parse_input(text)
             return await self.requests_wrapper.apatch(
-                _clean_url(data["url"]), data["data"]
+                _clean_url(data["url"]), data["data"], data.get("headers", {})
             )
         except Exception as e:
             return repr(e)
@@ -150,9 +169,10 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
 
     name: str = "requests_put"
     description: str = """Use this when you want to PUT to a website.
-    Input should be a json string with two keys: "url" and "data".
-    The value of "url" should be a string, and the value of "data" should be a dictionary of 
+    Input should be a json string with two keys: "url", "data" and "headers".
+    The value of "url" should be a string, and the value of "data" and "headers" should be a dictionary of
     key-value pairs you want to PUT to the url.
+    "headers" are optional. Headers are merged with the default headers of the request wrapper.
     Be careful to always use double quotes for strings in the json string.
     The output will be the text response of the PUT request.
     """
@@ -163,7 +183,9 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
         """Run the tool."""
         try:
             data = _parse_input(text)
-            return self.requests_wrapper.put(_clean_url(data["url"]), data["data"])
+            return self.requests_wrapper.put(
+                _clean_url(data["url"]), data["data"], data.get("headers", {})
+            )
         except Exception as e:
             return repr(e)
 
@@ -176,7 +198,7 @@ class RequestsPutTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
         try:
             data = _parse_input(text)
             return await self.requests_wrapper.aput(
-                _clean_url(data["url"]), data["data"]
+                _clean_url(data["url"]), data["data"], data.get("headers", {})
             )
         except Exception as e:
             return repr(e)
@@ -186,24 +208,35 @@ class RequestsDeleteTool(BaseRequestsTool, BaseTool):  # type: ignore[override]
     """Tool for making a DELETE request to an API endpoint."""
 
     name: str = "requests_delete"
-    description: str = """A portal to the internet.
+    description: str = """
+    A portal to the internet.
     Use this when you need to make a DELETE request to a URL.
-    Input should be a specific url, and the output will be the text
-    response of the DELETE request.
+    Input should be a json string with two keys: "url" and "headers".
+    The value of "url" should be a string, and the value of "headers" should be a dictionary of
+    key-value pairs you want to PUT to the url.
+    "headers" are optional. Headers are merged with the default headers of the request wrapper.
+    Be careful to always use double quotes for strings in the json string.
+    The output will be the text response of the DELETE request.
     """
 
     def _run(
         self,
-        url: str,
+        text: str,
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> Union[str, Dict[str, Any]]:
         """Run the tool."""
-        return self.requests_wrapper.delete(_clean_url(url))
+        data = _parse_input(text)
+        return self.requests_wrapper.delete(
+            _clean_url(data["url"]), headers=data.get("headers", {})
+        )
 
     async def _arun(
         self,
-        url: str,
+        text: str,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> Union[str, Dict[str, Any]]:
         """Run the tool asynchronously."""
-        return await self.requests_wrapper.adelete(_clean_url(url))
+        data = _parse_input(text)
+        return await self.requests_wrapper.adelete(
+            _clean_url(data["url"]), headers=data.get("headers", {})
+        )

--- a/libs/community/tests/unit_tests/agents/test_tools.py
+++ b/libs/community/tests/unit_tests/agents/test_tools.py
@@ -95,7 +95,8 @@ def test_load_tools_with_callbacks_is_called() -> None:
         "langchain.requests.TextRequestsWrapper.get",
         return_value=Mock(text="Hello world!"),
     ):
-        result = tools[0].run("https://www.google.com")
+        input_data = '{"url": "https://www.google.com"}'
+        result = tools[0].run(input_data)
         assert result.text == "Hello world!"
     assert callbacks[0].tool_starts == 1
     assert callbacks[0].tool_ends == 1

--- a/libs/community/tests/unit_tests/chains/test_api.py
+++ b/libs/community/tests/unit_tests/chains/test_api.py
@@ -17,7 +17,7 @@ class FakeRequestsChain(TextRequestsWrapper):
 
     output: str
 
-    def get(self, url: str, **kwargs: Any) -> str:
+    def get(self, url: str, headers: dict = {}, **kwargs: Any) -> str:
         """Just return the specified output."""
         return self.output
 

--- a/libs/community/tests/unit_tests/tools/requests/test_tool.py
+++ b/libs/community/tests/unit_tests/tools/requests/test_tool.py
@@ -20,44 +20,56 @@ from langchain_community.utilities.requests import (
 
 class _MockTextRequestsWrapper(TextRequestsWrapper):
     @staticmethod
-    def get(url: str, **kwargs: Any) -> str:
-        return "get_response"
+    def get(url: str, headers: Dict[str, str] = {}, **kwargs: Any) -> str:
+        return f"get_response {headers}"
 
     @staticmethod
-    async def aget(url: str, **kwargs: Any) -> str:
-        return "aget_response"
+    async def aget(url: str, headers: Dict[str, str] = {}, **kwargs: Any) -> str:
+        return f"aget_response {headers}"
 
     @staticmethod
-    def post(url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        return f"post {str(data)}"
+    def post(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> str:
+        return f"post {str(data)} {headers}"
 
     @staticmethod
-    async def apost(url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        return f"apost {str(data)}"
+    async def apost(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> str:
+        return f"apost {str(data)} {headers}"
 
     @staticmethod
-    def patch(url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        return f"patch {str(data)}"
+    def patch(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> str:
+        return f"patch {str(data)} {headers}"
 
     @staticmethod
-    async def apatch(url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        return f"apatch {str(data)}"
+    async def apatch(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> str:
+        return f"apatch {str(data)} {headers}"
 
     @staticmethod
-    def put(url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        return f"put {str(data)}"
+    def put(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> str:
+        return f"put {str(data)} {headers}"
 
     @staticmethod
-    async def aput(url: str, data: Dict[str, Any], **kwargs: Any) -> str:
-        return f"aput {str(data)}"
+    async def aput(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> str:
+        return f"aput {str(data)} {headers}"
 
     @staticmethod
-    def delete(url: str, **kwargs: Any) -> str:
-        return "delete_response"
+    def delete(url: str, headers: Dict[str, str] = {}, **kwargs: Any) -> str:
+        return f"delete_response {headers}"
 
     @staticmethod
-    async def adelete(url: str, **kwargs: Any) -> str:
-        return "adelete_response"
+    async def adelete(url: str, headers: Dict[str, str] = {}, **kwargs: Any) -> str:
+        return f"adelete_response {headers}"
 
 
 @pytest.fixture
@@ -66,8 +78,16 @@ def mock_requests_wrapper() -> TextRequestsWrapper:
 
 
 def test_parse_input() -> None:
-    input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    expected_output = {"url": "https://example.com", "data": {"key": "value"}}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    expected_output = {
+        "url": "https://example.com",
+        "data": {"key": "value"},
+        "headers": {"Key": "Value"},
+    }
     assert _parse_input(input_text) == expected_output
 
 
@@ -75,8 +95,33 @@ def test_requests_get_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
     tool = RequestsGetTool(
         requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
     )
-    assert tool.run("https://example.com") == "get_response"
-    assert asyncio.run(tool.arun("https://example.com")) == "aget_response"
+    input_text = '{"url": "https://example.com"}'
+    assert tool.run(input_text) == "get_response {}"
+    assert asyncio.run(tool.arun(input_text)) == "aget_response {}"
+
+
+def test_requests_get_tool_with_headers(
+    mock_requests_wrapper: TextRequestsWrapper,
+) -> None:
+    tool = RequestsGetTool(
+        requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = '{"url": "https://example.com", "headers": {"Key": "Value"}}'
+    assert tool.run(input_text) == f"get_response {headers}"
+    assert asyncio.run(tool.arun(input_text)) == f"aget_response {headers}"
+
+
+def test_requests_get_tool_with_headers_merge(
+    mock_requests_wrapper: TextRequestsWrapper,
+) -> None:
+    tool = RequestsGetTool(
+        requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = '{"url": "https://example.com", "headers": {"Key": "Value"}}'
+    assert tool.run(input_text) == f"get_response {headers}"
+    assert asyncio.run(tool.arun(input_text)) == f"aget_response {headers}"
 
 
 def test_requests_post_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
@@ -84,8 +129,24 @@ def test_requests_post_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
         requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
     )
     input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    assert tool.run(input_text) == "post {'key': 'value'}"
-    assert asyncio.run(tool.arun(input_text)) == "apost {'key': 'value'}"
+    assert tool.run(input_text) == "post {'key': 'value'} {}"
+    assert asyncio.run(tool.arun(input_text)) == "apost {'key': 'value'} {}"
+
+
+def test_requests_post_tool_with_headers(
+    mock_requests_wrapper: TextRequestsWrapper,
+) -> None:
+    tool = RequestsPostTool(
+        requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    assert tool.run(input_text) == f"post {{'key': 'value'}} {headers}"
+    assert asyncio.run(tool.arun(input_text)) == f"apost {{'key': 'value'}} {headers}"
 
 
 def test_requests_patch_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
@@ -93,8 +154,24 @@ def test_requests_patch_tool(mock_requests_wrapper: TextRequestsWrapper) -> None
         requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
     )
     input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    assert tool.run(input_text) == "patch {'key': 'value'}"
-    assert asyncio.run(tool.arun(input_text)) == "apatch {'key': 'value'}"
+    assert tool.run(input_text) == "patch {'key': 'value'} {}"
+    assert asyncio.run(tool.arun(input_text)) == "apatch {'key': 'value'} {}"
+
+
+def test_requests_patch_tool_with_headers(
+    mock_requests_wrapper: TextRequestsWrapper,
+) -> None:
+    tool = RequestsPatchTool(
+        requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    assert tool.run(input_text) == f"patch {{'key': 'value'}} {headers}"
+    assert asyncio.run(tool.arun(input_text)) == f"apatch {{'key': 'value'}} {headers}"
 
 
 def test_requests_put_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
@@ -102,58 +179,103 @@ def test_requests_put_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
         requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
     )
     input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    assert tool.run(input_text) == "put {'key': 'value'}"
-    assert asyncio.run(tool.arun(input_text)) == "aput {'key': 'value'}"
+    assert tool.run(input_text) == "put {'key': 'value'} {}"
+    assert asyncio.run(tool.arun(input_text)) == "aput {'key': 'value'} {}"
+
+
+def test_requests_put_tool_with_headers(
+    mock_requests_wrapper: TextRequestsWrapper,
+) -> None:
+    tool = RequestsPutTool(
+        requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    assert tool.run(input_text) == f"put {{'key': 'value'}} {headers}"
+    assert asyncio.run(tool.arun(input_text)) == f"aput {{'key': 'value'}} {headers}"
 
 
 def test_requests_delete_tool(mock_requests_wrapper: TextRequestsWrapper) -> None:
     tool = RequestsDeleteTool(
         requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
     )
-    assert tool.run("https://example.com") == "delete_response"
-    assert asyncio.run(tool.arun("https://example.com")) == "adelete_response"
+    input_text = '{"url": "https://example.com"}'
+    assert tool.run(input_text) == "delete_response {}"
+    assert asyncio.run(tool.arun(input_text)) == "adelete_response {}"
+
+
+def test_requests_delete_tool_with_headers(
+    mock_requests_wrapper: TextRequestsWrapper,
+) -> None:
+    tool = RequestsDeleteTool(
+        requests_wrapper=mock_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = '{"url": "https://example.com", "headers": {"Key": "Value"}}'
+    assert tool.run(input_text) == f"delete_response {headers}"
+    assert asyncio.run(tool.arun(input_text)) == f"adelete_response {headers}"
 
 
 class _MockJsonRequestsWrapper(JsonRequestsWrapper):
     @staticmethod
-    def get(url: str, **kwargs: Any) -> Dict[str, Any]:
-        return {"response": "get_response"}
+    def get(url: str, headers: Dict[str, str] = {}, **kwargs: Any) -> Dict[str, Any]:
+        return {"response": f"get_response {headers}"}
 
     @staticmethod
-    async def aget(url: str, **kwargs: Any) -> Dict[str, Any]:
-        return {"response": "aget_response"}
+    async def aget(
+        url: str, headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"aget_response {headers}"}
 
     @staticmethod
-    def post(url: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        return {"response": f"post {json.dumps(data)}"}
+    def post(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"post {json.dumps(data)} {headers}"}
 
     @staticmethod
-    async def apost(url: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        return {"response": f"apost {json.dumps(data)}"}
+    async def apost(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"apost {json.dumps(data)} {headers}"}
 
     @staticmethod
-    def patch(url: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        return {"response": f"patch {json.dumps(data)}"}
+    def patch(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"patch {json.dumps(data)} {headers}"}
 
     @staticmethod
-    async def apatch(url: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        return {"response": f"apatch {json.dumps(data)}"}
+    async def apatch(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"apatch {json.dumps(data)} {headers}"}
 
     @staticmethod
-    def put(url: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        return {"response": f"put {json.dumps(data)}"}
+    def put(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"put {json.dumps(data)} {headers}"}
 
     @staticmethod
-    async def aput(url: str, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
-        return {"response": f"aput {json.dumps(data)}"}
+    async def aput(
+        url: str, data: Dict[str, Any], headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"aput {json.dumps(data)} {headers}"}
 
     @staticmethod
-    def delete(url: str, **kwargs: Any) -> Dict[str, Any]:
-        return {"response": "delete_response"}
+    def delete(url: str, headers: Dict[str, str] = {}, **kwargs: Any) -> Dict[str, Any]:
+        return {"response": f"delete_response {headers}"}
 
     @staticmethod
-    async def adelete(url: str, **kwargs: Any) -> Dict[str, Any]:
-        return {"response": "adelete_response"}
+    async def adelete(
+        url: str, headers: Dict[str, str] = {}, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {"response": f"adelete_response {headers}"}
 
 
 @pytest.fixture
@@ -167,9 +289,22 @@ def test_requests_get_tool_json(
     tool = RequestsGetTool(
         requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
     )
-    assert tool.run("https://example.com") == {"response": "get_response"}
-    assert asyncio.run(tool.arun("https://example.com")) == {
-        "response": "aget_response"
+    input_text = '{"url": "https://example.com"}'
+    assert tool.run(input_text) == {"response": "get_response {}"}
+    assert asyncio.run(tool.arun(input_text)) == {"response": "aget_response {}"}
+
+
+def test_requests_get_tool_json_with_headers(
+    mock_json_requests_wrapper: JsonRequestsWrapper,
+) -> None:
+    tool = RequestsGetTool(
+        requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = '{"url": "https://example.com", "headers": {"Key": "Value"}}'
+    assert tool.run(input_text) == {"response": f"get_response {headers}"}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": f"aget_response {headers}"
     }
 
 
@@ -180,8 +315,28 @@ def test_requests_post_tool_json(
         requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
     )
     input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    assert tool.run(input_text) == {"response": 'post {"key": "value"}'}
-    assert asyncio.run(tool.arun(input_text)) == {"response": 'apost {"key": "value"}'}
+    assert tool.run(input_text) == {"response": 'post {"key": "value"} {}'}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": 'apost {"key": "value"} {}'
+    }
+
+
+def test_requests_post_tool_json_with_headers(
+    mock_json_requests_wrapper: JsonRequestsWrapper,
+) -> None:
+    tool = RequestsPostTool(
+        requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    assert tool.run(input_text) == {"response": f'post {{"key": "value"}} {headers}'}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": f'apost {{"key": "value"}} {headers}'
+    }
 
 
 def test_requests_patch_tool_json(
@@ -191,8 +346,28 @@ def test_requests_patch_tool_json(
         requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
     )
     input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    assert tool.run(input_text) == {"response": 'patch {"key": "value"}'}
-    assert asyncio.run(tool.arun(input_text)) == {"response": 'apatch {"key": "value"}'}
+    assert tool.run(input_text) == {"response": 'patch {"key": "value"} {}'}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": 'apatch {"key": "value"} {}'
+    }
+
+
+def test_requests_patch_tool_json_with_headers(
+    mock_json_requests_wrapper: JsonRequestsWrapper,
+) -> None:
+    tool = RequestsPatchTool(
+        requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    assert tool.run(input_text) == {"response": f'patch {{"key": "value"}} {headers}'}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": f'apatch {{"key": "value"}} {headers}'
+    }
 
 
 def test_requests_put_tool_json(
@@ -202,8 +377,28 @@ def test_requests_put_tool_json(
         requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
     )
     input_text = '{"url": "https://example.com", "data": {"key": "value"}}'
-    assert tool.run(input_text) == {"response": 'put {"key": "value"}'}
-    assert asyncio.run(tool.arun(input_text)) == {"response": 'aput {"key": "value"}'}
+    assert tool.run(input_text) == {"response": 'put {"key": "value"} {}'}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": 'aput {"key": "value"} {}'
+    }
+
+
+def test_requests_put_tool_json_with_headers(
+    mock_json_requests_wrapper: JsonRequestsWrapper,
+) -> None:
+    tool = RequestsPutTool(
+        requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = (
+        '{"url": "https://example.com", '
+        '"data": {"key": "value"}, '
+        '"headers": {"Key": "Value"}}'
+    )
+    assert tool.run(input_text) == {"response": f'put {{"key": "value"}} {headers}'}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": f'aput {{"key": "value"}} {headers}'
+    }
 
 
 def test_requests_delete_tool_json(
@@ -212,7 +407,20 @@ def test_requests_delete_tool_json(
     tool = RequestsDeleteTool(
         requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
     )
-    assert tool.run("https://example.com") == {"response": "delete_response"}
-    assert asyncio.run(tool.arun("https://example.com")) == {
-        "response": "adelete_response"
+    input_text = '{"url": "https://example.com"}'
+    assert tool.run(input_text) == {"response": "delete_response {}"}
+    assert asyncio.run(tool.arun(input_text)) == {"response": "adelete_response {}"}
+
+
+def test_requests_delete_tool_json_with_headers(
+    mock_json_requests_wrapper: JsonRequestsWrapper,
+) -> None:
+    tool = RequestsDeleteTool(
+        requests_wrapper=mock_json_requests_wrapper, allow_dangerous_requests=True
+    )
+    headers = {"Key": "Value"}
+    input_text = '{"url": "https://example.com", "headers": {"Key": "Value"}}'
+    assert tool.run(input_text) == {"response": f"delete_response {headers}"}
+    assert asyncio.run(tool.arun(input_text)) == {
+        "response": f"adelete_response {headers}"
     }


### PR DESCRIPTION
- **Description:** Allow OpenAPI agent to use request headers. 
It adds the following:
   * request tool now supports passing of the headers parameter. Headers are optional not to introduce breaking changes. Request headers are merged with headers passed to RequestWrapper class overwriting duplicate names.
   * OpenAPI planner prompts were updated to support new parameter.
   * `reduce_openapi_spec` now has new optional parameter "remove_optional", which allows to control whether optional parameters will be added to reduced API specification. This is required for the API I am integrating langchain with and often needed in real world scenarios.
   * new functionality for requests tool covered with tests
   * docstrings updated
