### PR TITLE
Update retrievers.ipynb

### DIFF
--- a/docs/docs/tutorials/retrievers.ipynb
+++ b/docs/docs/tutorials/retrievers.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "### Loading documents\n",
     "\n",
-    "Let's load a PDF into a sequence of `Document` objects. There is a sample PDF in the LangChain repo [here](https://github.com/langchain-ai/langchain/tree/master/docs/docs/example_data) -- a 10-k filing for Nike from 2023. We can consult the LangChain documentation for [available PDF document loaders](/docs/integrations/document_loaders/#pdfs). Let's select [PyPDFLoader](/docs/integrations/document_loaders/pypdfloader/), which is fairly lightweight."
+    "Let's load a PDF into a sequence of `Document` objects. There is a sample PDF [here](https://github.com/langchain-ai/langchain/tree/master/docs/docs/example_data) that you can add into your working directory inside an 'example_data' folder to make the following code work. The document is a 10-k filing for Nike from 2023. We can consult the LangChain documentation for [available PDF document loaders](/docs/integrations/document_loaders/#pdfs). Let's select [PyPDFLoader](/docs/integrations/document_loaders/pypdfloader/), which is fairly lightweight."
    ]
   },
   {
@@ -126,7 +126,7 @@
    "source": [
     "from langchain_community.document_loaders import PyPDFLoader\n",
     "\n",
-    "file_path = \"../example_data/nke-10k-2023.pdf\"\n",
+    "file_path = \"./example_data/nke-10k-2023.pdf\"\n",
     "loader = PyPDFLoader(file_path)\n",
     "\n",
     "docs = loader.load()\n",


### PR DESCRIPTION
Believe that langchain and the linked langchain-ai repository have diverged with the document to be loaded no longer residing in the downloaded library files.  There is no langchain/docs/docs/example_data/nke-10k-2023.pdf file anymore. Updated description to prompt user to download document themselves to make the tutorial code work.

Thank you for contributing to LangChain!

- [ ] **PR title**: "docs: update to solve missing tutorial referenced demo file in latest langchain release"


- [ ] **Description:** suggested user downloads file and stores in their working directory so that tutorial code works.
    - **Issue:** none
    - **Dependencies:** none


- [ ] **Add tests and docs**: n/a


- [ ] **Lint and test**: n/a

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
