### PR TITLE
Fix template variable handling in ChatPromptTemplate BaseMessage objects #29034

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1219,7 +1219,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         """
         kwargs = self._merge_partial_and_user_variables(**kwargs)
         result = []
-        
+
         for message_template in self.messages:
             if isinstance(message_template, BaseMessage):
                 # Check if the content contains any template variables

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1244,11 +1244,15 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
                     # If no template variables, use original message
                     result.append(message_template)
                     
-            elif isinstance(message_template, (BaseMessagePromptTemplate, BaseChatPromptTemplate)):
+            elif isinstance(
+                message_template, 
+                (BaseMessagePromptTemplate, BaseChatPromptTemplate)
+            ):
                 message = message_template.format_messages(**kwargs)
                 result.extend(message)
             else:
-                raise ValueError(f"Unexpected input: {message_template}")
+                error_msg = "Unexpected input: " + str(message_template)
+                raise ValueError(error_msg)
         
         return result
 

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1243,9 +1243,9 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
                 else:
                     # If no template variables, use original message
                     result.append(message_template)
-                    
+
             elif isinstance(
-                message_template, 
+                message_template,
                 (BaseMessagePromptTemplate, BaseChatPromptTemplate)
             ):
                 message = message_template.format_messages(**kwargs)
@@ -1253,7 +1253,7 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
             else:
                 error_msg = "Unexpected input: " + str(message_template)
                 raise ValueError(error_msg)
-        
+
         return result
 
     async def aformat_messages(self, **kwargs: Any) -> list[BaseMessage]:


### PR DESCRIPTION
Title: core: Fix template variable handling in ChatPromptTemplate BaseMessage objects https://github.com/langchain-ai/langchain/issues/29034

Description:
Fixes a bug in ChatPromptTemplate where template variables in BaseMessage objects (like SystemMessage) were not being processed. Previously, template variables in direct BaseMessage instances would be left unformatted, while variables in MessagePromptTemplate instances were processed correctly. This PR modifies the format_messages method to properly handle template variables in all message types.

Example of the bug:

template = ChatPromptTemplate.from_messages([
    SystemMessage("Answer in {language}"),  # Variable not processed
    HumanMessagePromptTemplate.from_template("Hello")  # Works fine
])
Before fix:

result = template.invoke({"language": "English"})
# Output: SystemMessage(content='Answer in {language}')  # Variable not replaced
After fix:

result = template.invoke({"language": "English"})
# Output: SystemMessage(content='Answer in English')  # Variable properly replaced
The fix adds template variable processing for BaseMessage objects while maintaining backward compatibility and existing functionality for other message types.

Key changes:

Modified format_messages method to detect and process template variables in BaseMessage content
Added template variable processing using PromptTemplate for BaseMessage instances
Implemented proper error handling for missing variables or formatting failures
Added comprehensive tests for template variable processing in all message types
Maintained backward compatibility with existing usage patterns
Implementation details:

Uses PromptTemplate for consistent variable formatting
Only attempts formatting when template variables are detected
Preserves original message if formatting fails
Maintains all existing functionality for MessagePromptTemplate instances
@baskaryan, @efriis, @eyurtsev, @ccurme