### PR TITLE
core[patch]: return empty list when ValueError is thrown on inspect.getclosurevars

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -423,7 +423,7 @@ def get_function_nonlocals(func: Callable) -> list[Any]:
                     else:
                         values.append(vv)
         return values
-    except (SyntaxError, TypeError, OSError, SystemError):
+    except (SyntaxError, TypeError, ValueError, OSError, SystemError):
         return []
 
 


### PR DESCRIPTION
In LangGraph the following error is thrown when attempting to get subgraph schema:

```
Traceback (most recent call last):
  File ".../.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File ".../.venv/lib/python3.12/site-packages/langgraph_api/route.py", line 33, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/langgraph_storage/retry.py", line 23, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/langgraph_api/api/assistants.py", line 144, in get_assistant_graph
    return ApiResponse(graph.get_graph(xray=xray).to_json())
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/langgraph/graph/graph.py", line 547, in get_graph
    subgraphs = {
                ^
  File ".../.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 426, in get_subgraphs
    graph = cast(Optional[Pregel], find_subgraph_pregel(node.bound))
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/langgraph/pregel/utils.py", line 49, in find_subgraph_pregel
    for nl in get_function_nonlocals(c.func)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/langchain_core/runnables/utils.py", line 408, in get_function_nonlocals
    closure = inspect.getclosurevars(func)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1622, in getclosurevars
    var : cell.cell_contents
          ^^^^^^^^^^^^^^^^^^
ValueError: Cell is empty
```

Used graph:

```
from langgraph.prebuilt import create_react_agent
from langchain_openai import ChatOpenAI

model = ChatOpenAI(model="gpt-4o-mini", temperature=0)
graph = create_react_agent(model, [])
```