### PR TITLE
openai[patch]: support optional fields in dict structured output with method="json_schema"

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2197,7 +2197,8 @@ def _resize(width: int, height: int) -> Tuple[int, int]:
 
 def _update_schema_with_optional_fields(input_dict: dict) -> dict:
     """Convert optional fields to required fields allowing 'null' type."""
-    def _update_properties(schema: dict):
+
+    def _update_properties(schema: dict) -> None:
         if schema.get("type") != "object":
             return
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2196,44 +2196,32 @@ def _resize(width: int, height: int) -> Tuple[int, int]:
 
 
 def _update_schema_with_optional_fields(input_dict: dict) -> dict:
-
+    """Convert optional fields to required fields allowing 'null' type."""
     def _update_properties(schema: dict):
-        if schema.get('type') != 'object':
+        if schema.get("type") != "object":
             return
 
-        properties = schema.get('properties', {})
-        required_fields = set(schema.get('required', []))
+        properties = schema.get("properties", {})
+        required_fields = schema.get("required", [])
 
         for field, field_schema in properties.items():
-            # Remove the 'default' key if it exists
-            field_schema.pop('default', None)
+            field_schema.pop("default", None)
 
-            if field_schema.get('type') == 'object':
+            if field_schema.get("type") == "object":
                 _update_properties(field_schema)
 
-            if 'allOf' in field_schema:
-                for sub_schema in field_schema['allOf']:
-                    if sub_schema.get('type') == 'object':
-                        _update_properties(sub_schema)
-
-            # if 'anyOf' in field_schema:
-            #     # Check if 'anyOf' contains a 'null' type
-            #     types = [sub_schema.get('type') for sub_schema in field_schema['anyOf']]
-            #     if 'null' not in types:
-            #         field_schema['anyOf'].append({'type': 'null'})
-
             if field not in required_fields:
-                original_type = field_schema.get('type')
+                original_type = field_schema.get("type")
                 if isinstance(original_type, str):
-                    field_schema['type'] = [original_type, 'null']
-                elif isinstance(original_type, list) and 'null' not in original_type:
-                    field_schema['type'].append('null')
+                    field_schema["type"] = [original_type, "null"]
+                elif isinstance(original_type, list) and "null" not in original_type:
+                    field_schema["type"].append("null")
 
-                required_fields.add(field)
+                required_fields.append(field)
 
-        schema['required'] = list(required_fields)
+        schema["required"] = required_fields
 
-    schema = input_dict.get('json_schema', {}).get('schema', {})
+    schema = input_dict.get("json_schema", {}).get("schema", {})
     _update_properties(schema)
 
     return input_dict

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -851,17 +851,19 @@ def test__convert_to_openai_response_format() -> None:
     assert expected == actual
 
     ## JSON Schema
-    class Entity(BaseModel):
+    class EntityModel(BaseModel):
         """Extracted entity."""
 
         animal: str = Field(description="The animal")
         color: Optional[str] = Field(default=None, description="The color")
 
-    actual = _convert_to_openai_response_format(Entity.model_json_schema(), strict=True)
+    actual = _convert_to_openai_response_format(
+        EntityModel.model_json_schema(), strict=True
+    )
     expected = {
         "type": "json_schema",
         "json_schema": {
-            "name": "Entity",
+            "name": "EntityModel",
             "description": "Extracted entity.",
             "strict": True,
             "schema": {

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -21,6 +21,7 @@ from langchain_core.utils.function_calling import tool_example_to_messages
 from pydantic import BaseModel, Field
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import Field as FieldV1
+from typing_extensions import Annotated, TypedDict
 
 from langchain_tests.unit_tests.chat_models import (
     ChatModelTests,
@@ -1293,6 +1294,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         if not self.has_tool_calling:
             pytest.skip("Test requires tool calling.")
 
+        # Pydantic
         class Joke(BaseModel):
             """Joke to tell user."""
 
@@ -1309,6 +1311,22 @@ class ChatModelIntegrationTests(ChatModelTests):
 
         joke_result = chat.invoke("Give me a joke about cats, include the punchline.")
         assert isinstance(joke_result, Joke)
+
+        # Schema
+        chat = model.with_structured_output(Joke.model_json_schema())
+        result = chat.invoke("Tell me a joke about cats.")
+        assert isinstance(result, dict)
+
+        # TypedDict
+        class JokeDict(TypedDict):
+            """Joke to tell user."""
+
+            setup: Annotated[str, ..., "question to set up a joke"]
+            punchline: Annotated[Optional[str], None, "answer to resolve the joke"]
+
+        chat = model.with_structured_output(JokeDict)
+        result = chat.invoke("Tell me a joke about cats.")
+        assert isinstance(result, dict)
 
     def test_json_mode(self, model: BaseChatModel) -> None:
         """Test structured output via `JSON mode. <https://python.langchain.com/docs/concepts/structured_outputs/#json-mode>`_


### PR DESCRIPTION
The `json_schema` method will currently error on the following:

Optional fields in TypedDict:
```python
class Entity(TypedDict):
    """Extracted entity."""

    animal: Annotated[str, ..., "The animal"]
    color: Annotated[Optional[str], None, "The color"]

structured_llm = llm.with_structured_output(Entity, method="json_schema")
structured_llm.invoke("black cat")
```

Optional fields in JSON schema generated from a Pydantic object:
```python
class Entity(BaseModel):
    """Extracted entity."""
    animal: str = Field(description="The animal")
    color: Optional[str] = Field(default=None, description="The color")

structured_llm = llm.with_structured_output(Entity.model_json_schema(), method="json_schema")
structured_llm.invoke("black cat")
```

Fields with any non-null default (Pydantic, TypedDict, or JSON schema):
```python
class Entity(BaseModel):
    """Extracted entity."""
    animal: str = Field(description="The animal")
    color: str = Field(default="blue", description="The color")

structured_llm = llm.with_structured_output(Entity, method="json_schema")
structured_llm.invoke("black cat")
```

Here, we update `_convert_to_openai_response_format` to update optional fields to be required with possible `'null'` type. This is a solution recommended in OpenAI's [docs](https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required).

Note that we make no changes to schemas specified as Pydantic models.

TODO:
- [ ]  support nested schemas for TypedDict, which also currently raise an error.
- [ ] run new standard test across providers