### PR TITLE
community: fix "confluence-loader" enable include_labels for documents loaded via CQL

### DIFF
--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -408,7 +408,7 @@ class ConfluenceLoader(BaseLoader):
                 include_restricted_content,
                 include_attachments,
                 include_comments,
-                False,  # labels are not included in the search results
+                include_labels,
                 content_format,
                 ocr_languages,
                 keep_markdown_format,


### PR DESCRIPTION
## Description
This PR enables label inclusion for documents loaded via CQL in the confluence-loader.

- Updated _lazy_load to pass the include_labels parameter instead of False in process_pages calls for documents loaded via CQL.
- Ensured that labels can now be fetched and added to the metadata for documents queried with cql.

## Related Modification History
This PR builds on the previous functionality introduced in [#28259](https://github.com/langchain-ai/langchain/pull/28259), which added support for including labels with the include_labels option. However, this functionality did not work as expected for CQL queries, and this PR fixes that issue.

If the False handling was intentional due to another issue, please let me know. I have verified with our Confluence instance that this change allows labels to be correctly fetched for documents loaded via CQL.

## Issue
Fixes #29088


## Dependencies
No changes.

## Twitter Handle
[@zenoengine](https://x.com/zenoengine)