### PR TITLE
community: add init for `UnstructuredHTMLLoader` to solve pathlib paths

### DIFF
--- a/libs/community/langchain_community/document_loaders/html.py
+++ b/libs/community/langchain_community/document_loaders/html.py
@@ -1,4 +1,5 @@
-from typing import List
+from pathlib import Path
+from typing import Any, List, Union
 
 from langchain_community.document_loaders.unstructured import UnstructuredFileLoader
 
@@ -26,6 +27,23 @@ class UnstructuredHTMLLoader(UnstructuredFileLoader):
     ----------
     https://unstructured-io.github.io/unstructured/bricks.html#partition-html
     """
+
+    def __init__(
+        self,
+        file_path: Union[str, Path],
+        mode: str = "single",
+        **unstructured_kwargs: Any,
+    ):
+        """
+
+        Args:
+            file_path: The path to the HTML file to load.
+            mode: The mode to use when loading the file. Can be one of "single",
+                "multi", or "all". Default is "single".
+            **unstructured_kwargs: Any kwargs to pass to the unstructured.
+        """
+        file_path = str(file_path)
+        super().__init__(file_path=file_path, mode=mode, **unstructured_kwargs)
 
     def _get_elements(self) -> List:
         from unstructured.partition.html import partition_html


### PR DESCRIPTION
## Description
Add `__init__` for `UnstructuredHTMLLoader` to restrict the input type to `str` or `Path`, and transfer the `self.file_path` to `str` just like `UnstructuredXMLLoader` does.

## Issue
Fix #29090 

## Dependencies
No changes.

