### PR TITLE
docs: Remove additional ` in heading

### DIFF
--- a/docs/docs/concepts/lcel.mdx
+++ b/docs/docs/concepts/lcel.mdx
@@ -140,7 +140,7 @@ is Equivalent to:
 chain = RunnableSequence([runnable1, runnable2])
 ```
 
-### The `.pipe` method`
+### The `.pipe` method
 
 If you have moral qualms with operator overloading, you can use the `.pipe` method instead. This is equivalent to the `|` operator.
 


### PR DESCRIPTION
Remove the additional ` in the pipe operator heading
