### PR TITLE
docs: Add upstage document parse loader to pdf loaders

### DIFF
--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -883,6 +883,13 @@ const FEATURE_TABLES = {
                 source: "Load PDF files using PDFMiner",
                 api: "Package",
                 apiLink: "https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.pdf.PDFMinerLoader.html"
+            },
+            {
+                name: "Upstage Document Parse Loader",
+                link: "upstage",
+                source: "Load PDF files using UpstageDocumentParseLoader",
+                api: "Package",
+                apiLink: "https://python.langchain.com/api_reference/upstage/document_parse/langchain_upstage.document_parse.UpstageDocumentParseLoader.html"
             }
         ]
     },


### PR DESCRIPTION
Add upstage document parse loader to pdf loaders

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
