### PR TITLE
Langchain_community: Fix issue with missing backticks in arango client

### DIFF
--- a/libs/community/langchain_community/graphs/arangodb_graph.py
+++ b/libs/community/langchain_community/graphs/arangodb_graph.py
@@ -86,7 +86,7 @@ class ArangoGraph:
             limit_amount = ceil(sample_ratio * col_size) or 1
 
             aql = f"""
-                FOR doc in {col_name}
+                FOR doc in `{col_name}`
                     LIMIT {limit_amount}
                     RETURN doc
             """


### PR DESCRIPTION
    - **Description:** Adds backticks to generate_schema function in the arango graph client
    - **Issue:** We experienced an issue with the generate schema function when talking to our arango database where these backticks were missing
    - **Dependencies:** none
    - **Twitter handle:** @anangelofgrace