### PR TITLE
xai[minor]: release 0.2

### DIFF
--- a/libs/partners/xai/poetry.lock
+++ b/libs/partners/xai/poetry.lock
@@ -708,7 +708,7 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.27"
+version = "0.3.29"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.9,<4.0"
@@ -733,7 +733,7 @@ url = "../../core"
 
 [[package]]
 name = "langchain-openai"
-version = "0.2.13"
+version = "0.3.0"
 description = "An integration package connecting OpenAI and LangChain"
 optional = false
 python-versions = ">=3.9,<4.0"
@@ -741,8 +741,8 @@ files = []
 develop = true
 
 [package.dependencies]
-langchain-core = "^0.3.27"
-openai = "^1.55.3"
+langchain-core = "^0.3.29"
+openai = "^1.58.1"
 tiktoken = ">=0.7,<1"
 
 [package.source]
@@ -2122,4 +2122,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "ab1d2f38bf7404b05ad63b5ebfabd149d65760bbc0ee96c2d2f539912ac8f8ad"
+content-hash = "766771fc8e8ef0ccce3c46f92c24ff279934501821edb22f5ef9314316926c89"

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-xai"
-version = "0.1.1"
+version = "0.2.0"
 description = "An integration package connecting xAI and LangChain"
 authors = []
 readme = "README.md"
@@ -20,8 +20,8 @@ disallow_untyped_defs = "True"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-openai = ">=0.2,<0.3"
-langchain-core = "^0.3.27"
+langchain-openai = ">=0.3,<0.4"
+langchain-core = "^0.3.29"
 requests = ">=2,<3"
 aiohttp = ">=3.9.1,<4"
 


### PR DESCRIPTION
Update `langchain-openai` to 0.3. See [release notes](https://github.com/langchain-ai/langchain/releases/tag/langchain-openai%3D%3D0.3.0) for details. Should only impact default values of `temperature`, `n`, and `max_retries`.