### PR TITLE
openai: disable streaming for o1 by default

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -562,6 +562,15 @@ class BaseChatOpenAI(BaseChatModel):
             values["temperature"] = 1
         return values
 
+    @model_validator(mode="before")
+    @classmethod
+    def validate_disable_streaming(cls, values: Dict[str, Any]) -> Any:
+        """Disable streaming if n > 1."""
+        model = values.get("model_name") or values.get("model") or ""
+        if model == "o1" and values.get("disable_streaming") is None:
+            values["disable_streaming"] = True
+        return values
+
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1202,3 +1202,9 @@ def test_o1_doesnt_stream() -> None:
     """
     with pytest.raises(openai.BadRequestError):
         list(ChatOpenAI(model="o1", disable_streaming=False).stream("how are you"))
+
+
+@pytest.mark.scheduled
+def test_o1_stream_default_works() -> None:
+    result = list(ChatOpenAI(model="o1").stream("say 'hi'"))
+    assert len(result) > 0

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1192,3 +1192,13 @@ def test_o1(use_max_completion_tokens: bool) -> None:
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
     assert response.content.upper() == response.content
+
+
+@pytest.mark.scheduled
+def test_o1_doesnt_stream() -> None:
+    """
+    When this starts failing, remove the `disable_streaming` validator in
+    `BaseChatOpenAI`
+    """
+    with pytest.raises(openai.BadRequestError):
+        list(ChatOpenAI(model="o1", disable_streaming=False).stream("how are you"))


### PR DESCRIPTION
Currently 400s https://community.openai.com/t/streaming-support-for-o1-o1-2024-12-17-resulting-in-400-unsupported-value/1085043

o1-mini and o1-preview stream fine