### PR TITLE
cookbook: fix typo in cookbook/mongodb-langchain-cache-memory.ipynb

### DIFF
--- a/cookbook/mongodb-langchain-cache-memory.ipynb
+++ b/cookbook/mongodb-langchain-cache-memory.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Ensure you have an HF_TOKEN in your development enviornment:\n",
+    "# Ensure you have an HF_TOKEN in your development environment:\n",
     "# access tokens can be created or copied from the Hugging Face platform (https://huggingface.co/docs/hub/en/security-tokens)\n",
     "\n",
     "# Load MongoDB's embedded_movies dataset from Hugging Face\n",


### PR DESCRIPTION
Description: fix "enviornment" into "environment". 
Issue: Typo
Dependencies: None
Twitter handle: zrwang01