### PR TITLE
Bug fix: "IndexError: list index out of range" in langchain_openai/embeddings

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -552,7 +552,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                 )
                 if not isinstance(average_embedded, dict):
                     average_embedded = average_embedded.model_dump()
-                _cached_empty_embedding = average_embedded["data"][0]["embedding"]
+                if (len(average_embedded["data"]) > 0):
+                    _cached_empty_embedding = average_embedded["data"][0]["embedding"]
+                else:
+                    raise ValueError(average_embedded["message"])
             return _cached_empty_embedding
 
         return [e if e is not None else await empty_embedding() for e in embeddings]


### PR DESCRIPTION
**PR Title**: `langchain_openai: Improve error handling in embeddings/base.py`

---

**Description**  
This PR fixes a bug in the `embeddings/base.py` file where API-related errors were not handled properly. Specifically:
- The old code raised an `IndexError: list index out of range` when the API key was expired or invalid.
- This issue has been resolved by implementing proper error handling that raises user-friendly exceptions.

New behavior:
- For an **expired API key**, it now raises:  
  `ValueError: Not enough available money, Please go to recharge.`
- For an **invalid API key**, it now raises:  
  `ValueError: Please check sk-************6GzDaH key from the platform and follow their guidelines.`

This ensures clearer and more descriptive error messages for users, and potentially improves handling for other API-related issues.

---

**Issue**  
No specific GitHub issue is referenced, but the PR addresses improper error handling in `embeddings/base.py`.

---

**Dependencies**  
No additional dependencies are required for this change.

---

**Testing Instructions**  
Please test the following code with the updated implementation:

```python
from langchain_community.vectorstores import FAISS
from langchain_openai.embeddings import OpenAIEmbeddings
import os

os.environ['OPENAI_API_BASE'] = "https://api.agicto.cn/v1"
# Test with an expired key (out of money):
# os.environ['OPENAI_API_KEY'] = "***"

# Test with an invalid key:
os.environ['OPENAI_API_KEY'] = "sk-8Dxxl7SxhIHU8J3M6GzDaH"

vectorstore = FAISS.from_texts(
    [
        "some text",
        "some more text"
    ],
    embedding=OpenAIEmbeddings(),
)
```

Expected results:
1. **Expired key**:  
   Raises: `ValueError: Not enough available money, Please go to recharge.`
2. **Invalid key**:  
   Raises: `ValueError: Please check sk-************6GzDaH key from the platform and follow their guidelines.`
