### PR TITLE
community: add missing format specifier in error log in CubeSemanticLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/cube_semantic.py
+++ b/libs/community/langchain_community/document_loaders/cube_semantic.py
@@ -92,7 +92,9 @@ class CubeSemanticLoader(BaseLoader):
                     ]
                     return dimension_values
             else:
-                logger.error("Request failed with status code: %s", response.status_code)
+                logger.error(
+                    "Request failed with status code: %s", response.status_code
+                )
                 break
 
         if retries == self.dimension_values_max_retries:

--- a/libs/community/langchain_community/document_loaders/cube_semantic.py
+++ b/libs/community/langchain_community/document_loaders/cube_semantic.py
@@ -92,7 +92,7 @@ class CubeSemanticLoader(BaseLoader):
                     ]
                     return dimension_values
             else:
-                logger.error("Request failed with status code:", response.status_code)
+                logger.error("Request failed with status code: %s", response.status_code)
                 break
 
         if retries == self.dimension_values_max_retries:


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"
  - Where "package" is whichever of langchain, community, core, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


- [x] **PR message**
    - **Description:** Add a missing format specifier in an an error log in `langchain_community.document_loaders.CubeSemanticLoader`
    - **Issue:** raises `TypeError: not all arguments converted during string formatting`


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
