### PR TITLE
fix chatperplexity: remove 'stream' from params in _stream method

### DIFF
--- a/libs/community/langchain_community/chat_models/perplexity.py
+++ b/libs/community/langchain_community/chat_models/perplexity.py
@@ -217,11 +217,11 @@ class ChatPerplexity(BaseChatModel):
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
         default_chunk_class = AIMessageChunk
-
+        params.pop("stream", None)
         if stop:
             params["stop_sequences"] = stop
         stream_resp = self.client.chat.completions.create(
-            messages=message_dicts, stream=True, **params
+            messages=message_dicts,stream=True, **params
         )
         for chunk in stream_resp:
             if not isinstance(chunk, dict):

--- a/libs/community/langchain_community/chat_models/perplexity.py
+++ b/libs/community/langchain_community/chat_models/perplexity.py
@@ -221,7 +221,7 @@ class ChatPerplexity(BaseChatModel):
         if stop:
             params["stop_sequences"] = stop
         stream_resp = self.client.chat.completions.create(
-            messages=message_dicts,stream=True, **params
+            messages=message_dicts, stream=True, **params
         )
         for chunk in stream_resp:
             if not isinstance(chunk, dict):


### PR DESCRIPTION
quick fix chatperplexity: remove 'stream' from params in _stream method