### PR TITLE
docs: Fix old link to Unstructured package in document_loader_markdown.ipynb

### DIFF
--- a/docs/docs/how_to/document_loader_markdown.ipynb
+++ b/docs/docs/how_to/document_loader_markdown.ipynb
@@ -16,7 +16,7 @@
     "- Basic usage;\n",
     "- Parsing of Markdown into elements such as titles, list items, and text.\n",
     "\n",
-    "LangChain implements an [UnstructuredMarkdownLoader](https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.markdown.UnstructuredMarkdownLoader.html) object which requires the [Unstructured](https://unstructured-io.github.io/unstructured/) package. First we install it:"
+    "LangChain implements an [UnstructuredMarkdownLoader](https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.markdown.UnstructuredMarkdownLoader.html) object which requires the [Unstructured](https://docs.unstructured.io/welcome/) package. First we install it:"
    ]
   },
   {


### PR DESCRIPTION
Fixed a broken link in `document_loader_markdown.ipynb` to point to the updated documentation page for the Unstructured package.
Issue: N/A
Dependencies: None
