### PR TITLE
docs: Remove redundant "%"

### DIFF
--- a/docs/docs/tutorials/classification.ipynb
+++ b/docs/docs/tutorials/classification.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet langchain-core"
+    "pip install --upgrade --quiet langchain-core"
    ]
   },
   {


### PR DESCRIPTION
Before this commit, the copied command can't be used directly.

