### PR TITLE
(text-splitters): Small Fix in `_process_html` for HTMLSemanticPreservingSplitter to properly extract the metadata.

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -696,7 +696,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             placeholder_count: int,
         ) -> Tuple[List[Document], Dict[str, str], List[str], Dict[str, str], int]:
             for elem in element:
-                if elem.name.lower() in ["html", "body", "div"]:
+                if elem.name.lower() in ["html", "body", "div", "main"]:
                     children = elem.find_all(recursive=False)
                     (
                         documents,


### PR DESCRIPTION
- **Description:** Include `main` in the list of elements whose child elements needs to be processed for splitting the HTML.
- **Issue:** #29184
    