### PR TITLE
docs: Fix typo in retrievers documentation: 'An vectorstore' -> 'A vectorstore'

### DIFF
--- a/docs/docs/concepts/retrievers.mdx
+++ b/docs/docs/concepts/retrievers.mdx
@@ -90,7 +90,7 @@ LangChain has retrievers for many popular lexical search algorithms / engines.
 ### Vector store 
 
 [Vector stores](/docs/concepts/vectorstores/) are a powerful and efficient way to index and retrieve unstructured data. 
-A vector store can be used as a retriever by calling the `as_retriever()` method.
+A vectorstore can be used as a retriever by calling the `as_retriever()` method.
 
 ```python
 vectorstore = MyVectorStore()

--- a/docs/docs/concepts/retrievers.mdx
+++ b/docs/docs/concepts/retrievers.mdx
@@ -90,7 +90,7 @@ LangChain has retrievers for many popular lexical search algorithms / engines.
 ### Vector store 
 
 [Vector stores](/docs/concepts/vectorstores/) are a powerful and efficient way to index and retrieve unstructured data. 
-An vectorstore can be used as a retriever by calling the `as_retriever()` method.
+A vector store can be used as a retriever by calling the `as_retriever()` method.
 
 ```python
 vectorstore = MyVectorStore()


### PR DESCRIPTION
- [x] **PR title**: "docs: Fix typo in documentation"

- [x] **PR message**:
    - **Description:** Fixed a typo in the documentation, changing "An vectorstore" to "A vector store" for grammatical accuracy.
    - **Issue:** N/A (no issue filed for this typo fix)
    - **Dependencies:** None
    - **Twitter handle:** N/A


- [x] **Add tests and docs**: This is a minor documentation fix that doesn't require additional tests or example notebooks.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/
