### PR TITLE
core[patch]: make BaseMessage subscriptable

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -118,6 +118,9 @@ class BaseMessage(Serializable):
     def pretty_print(self) -> None:
         print(self.pretty_repr(html=is_interactive_env()))  # noqa: T201
 
+    def __getitem__(self, item: str) -> Any:
+        return self.model_dump()[item]
+
 
 def merge_content(
     first_content: Union[str, list[Union[str, dict]]],

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -119,7 +119,10 @@ class BaseMessage(Serializable):
         print(self.pretty_repr(html=is_interactive_env()))  # noqa: T201
 
     def __getitem__(self, item: str) -> Any:
-        return self.model_dump()[item]
+        if item in self.model_fields and hasattr(self, item):
+            return getattr(self, item)
+        else:
+            raise KeyError(item)
 
 
 def merge_content(

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1008,3 +1008,9 @@ def test_tool_message_tool_call_id() -> None:
     ToolMessage("foo", tool_call_id=uuid.uuid4())
     ToolMessage("foo", tool_call_id=1)
     ToolMessage("foo", tool_call_id=1.0)
+
+
+def test_message_getitem() -> None:
+    msg = BaseMessage(content="foo", role="bar", id=1, type="baz")
+    for k in msg.model_fields:
+        assert msg[k] == getattr(msg, k)


### PR DESCRIPTION
reduce cognitive overload for users of having to know when messages are dicts (usually as inputs) and when they're BaseMessages (usually as outputs)