### PR TITLE
community: Add cost per 1K tokens for fine-tuned model cached input

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -128,7 +128,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-3.5-turbo-1106-finetuned": 0.003,
     "gpt-3.5-turbo-0125-finetuned": 0.003,
     "gpt-4o-mini-2024-07-18-finetuned": 0.0003,
-    "gpt-4o-mini-2024-07-18-finetuned-cached":0.00015,
+    "gpt-4o-mini-2024-07-18-finetuned-cached": 0.00015,
     # Fine Tuned output
     "babbage-002-finetuned-completion": 0.0016,
     "davinci-002-finetuned-completion": 0.012,

--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -128,6 +128,7 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-3.5-turbo-1106-finetuned": 0.003,
     "gpt-3.5-turbo-0125-finetuned": 0.003,
     "gpt-4o-mini-2024-07-18-finetuned": 0.0003,
+    "gpt-4o-mini-2024-07-18-finetuned-cached":0.00015,
     # Fine Tuned output
     "babbage-002-finetuned-completion": 0.0016,
     "davinci-002-finetuned-completion": 0.012,


### PR DESCRIPTION
### Description

- Since there is no cost per 1k input tokens for a fine-tuned cached version of `gpt-4o-mini-2024-07-18` is not available when using the `OpenAICallbackHandler`, it raises an error when trying to make calls with such model.
- To add the price in the `MODEL_COST_PER_1K_TOKENS` dictionary

cc. @efriis 
