### PR TITLE
 [langchain_community.llms.xinference]: Rewrite _stream() method and support stream() method in xinference.py

### DIFF
--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -85,21 +85,21 @@ class Xinference(LLM):
             prompt="Q: where can we visit in the capital of France? A:",
             generate_config={"max_tokens": 1024, "stream": True},
         )
-    
+
     Example:
 
     .. code-block:: python
-    
+
         from langchain_community.llms import Xinference
         from langchain.prompts import PromptTemplate
 
         llm = Xinference(
             server_url="http://0.0.0.0:9997",
-            model_uid = {model_uid}, # replace model_uid with the model UID return from launching the model
-            stream = True
+            model_uid={model_uid}, # replace model_uid with the model UID return from launching the model
+            stream=True
         )
         prompt = PromptTemplate(
-            input=['country'], 
+            input=['country'],
             template="Q: where can we visit in the capital of {country}? A:"
         )
         chain = prompt | llm
@@ -272,23 +272,17 @@ class Xinference(LLM):
                 yield chunk
 
     def _create_generate_stream(
-        self,
-        prompt: str,
-        generate_config: Optional[Dict[str, List[str]]] = None
+        self, prompt: str, generate_config: Optional[Dict[str, List[str]]] = None
     ) -> Iterator[str]:
         model = self.client.get_model(self.model_uid)
-        yield from self.create_stream(
-            model,
-            prompt,
-            generate_config,
-        )
+        yield from model.generate(prompt=prompt, generate_config=generate_config)
 
     @staticmethod
     def _stream_response_to_generation_chunk(
         stream_response: str,
     ) -> GenerationChunk:
         """Convert a stream response to a generation chunk."""
-        token = ''
+        token = ""
         if isinstance(stream_response, dict):
             choices = stream_response.get("choices", [])
             if choices:
@@ -306,11 +300,3 @@ class Xinference(LLM):
                 logprobs=stream_response["choices"][0].get("logprobs", None),
             ),
         )
-
-    @staticmethod
-    def create_stream(
-        model: Union["RESTfulGenerateModelHandle", "RESTfulChatModelHandle"],
-        prompt: str,
-        generate_config: Optional[Dict[str, List[str]]] = None
-    ) -> Iterator[str]:
-        return model.generate(prompt=prompt, generate_config=generate_config)

--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -281,7 +281,7 @@ class Xinference(LLM):
 
     @staticmethod
     def _stream_response_to_generation_chunk(
-        stream_response: Optional[Dict[Any, Any]],
+        stream_response: Optional[dict[Any, Any]],
     ) -> GenerationChunk:
         """Convert a stream response to a generation chunk."""
         token = ""

--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -281,7 +281,7 @@ class Xinference(LLM):
 
     @staticmethod
     def _stream_response_to_generation_chunk(
-        stream_response: Optional[Dict],
+        stream_response: Optional[Dict[Any, Any]],
     ) -> GenerationChunk:
         """Convert a stream response to a generation chunk."""
         token = ""
@@ -299,6 +299,8 @@ class Xinference(LLM):
                             logprobs=choice.get("logprobs", None),
                         ),
                     )
+                else:
+                    raise TypeError("choice type error!")
             else:
                 return GenerationChunk(text=token)
         else:

--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -281,7 +281,7 @@ class Xinference(LLM):
 
     @staticmethod
     def _stream_response_to_generation_chunk(
-        stream_response: Optional[dict[Any, Any]],
+        stream_response: str,
     ) -> GenerationChunk:
         """Convert a stream response to a generation chunk."""
         token = ""

--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -1,4 +1,16 @@
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Mapping, Optional, Union
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Union,
+)
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
@@ -72,6 +84,26 @@ class Xinference(LLM):
             prompt="Q: where can we visit in the capital of France? A:",
             generate_config={"max_tokens": 1024, "stream": True},
         )
+    
+    Example:
+
+    .. code-block:: python
+    
+        from langchain_community.llms import Xinference
+        from langchain.prompts import PromptTemplate
+
+        llm = Xinference(
+            server_url="http://0.0.0.0:9997",
+            model_uid = {model_uid}, # replace model_uid with the model UID return from launching the model
+            stream = True
+        )
+        prompt = PromptTemplate(
+            input=['country'], 
+            template="Q: where can we visit in the capital of {country}? A:"
+        )
+        chain = prompt | llm
+        chain.stream(input={'country': 'France'})
+
 
     To view all the supported builtin models, run:
 
@@ -216,3 +248,68 @@ class Xinference(LLM):
                                 token=token, verbose=self.verbose, log_probs=log_probs
                             )
                         yield token
+
+    def _stream(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Iterator[GenerationChunk]:
+        generate_config = kwargs.get("generate_config", {})
+        generate_config = {**self.model_kwargs, **generate_config}
+        if stop:
+            generate_config["stop"] = stop
+        for stream_resp in self._create_generate_stream(prompt, generate_config):
+            if stream_resp:
+                chunk = self._stream_response_to_generation_chunk(stream_resp)
+                if run_manager:
+                    run_manager.on_llm_new_token(
+                        chunk.text,
+                        verbose=self.verbose,
+                    )
+                yield chunk
+
+    def _create_generate_stream(
+        self,
+        prompt: str,
+        generate_config: Optional[Dict[str, List[str]]] = None
+    ) -> Iterator[str]:
+        model = self.client.get_model(self.model_uid)
+        yield from self.create_stream(
+            model,
+            prompt,
+            generate_config,
+        )
+
+    @staticmethod
+    def _stream_response_to_generation_chunk(
+        stream_response: str,
+    ) -> GenerationChunk:
+        """Convert a stream response to a generation chunk."""
+        token = ''
+        if isinstance(stream_response, dict):
+            choices = stream_response.get("choices", [])
+            if choices:
+                choice = choices[0]
+                if isinstance(choice, dict):
+                    token = choice.get("text", "")
+
+        if not stream_response["choices"]:
+            return GenerationChunk(text=token)
+
+        return GenerationChunk(
+            text=token,
+            generation_info=dict(
+                finish_reason=stream_response["choices"][0].get("finish_reason", None),
+                logprobs=stream_response["choices"][0].get("logprobs", None),
+            ),
+        )
+
+    @staticmethod
+    def create_stream(
+        model: Union["RESTfulGenerateModelHandle", "RESTfulChatModelHandle"],
+        prompt: str,
+        generate_config: Optional[Dict[str, List[str]]] = None
+    ) -> Iterator[str]:
+        return model.generate(prompt=prompt, generate_config=generate_config)

--- a/libs/community/langchain_community/llms/xinference.py
+++ b/libs/community/langchain_community/llms/xinference.py
@@ -14,6 +14,7 @@ from typing import (
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
+from langchain_core.outputs import GenerationChunk
 
 if TYPE_CHECKING:
     from xinference.client import RESTfulChatModelHandle, RESTfulGenerateModelHandle


### PR DESCRIPTION
- [ ] **PR title**:  [langchain_community.llms.xinference]: Rewrite _stream() method and support stream() method in xinference.py

- [ ] **PR message**:
- Rewrite the _stream method so that the chain.stream() can be used to return data streams.

        chain = prompt | llm
        chain.stream(input=user_input)

- [ ] **tests**:

       from langchain_community.llms import Xinference
       from langchain.prompts import PromptTemplate
       llm = Xinference(
         server_url="http://0.0.0.0:9997", # replace your xinference server url
         model_uid={model_uid}  # replace model_uid with the model UID return from launching the model
         stream=True
         )
       prompt = PromptTemplate(input=['country'], template="Q: where can we visit in the capital of {country}? A:")
       chain = prompt | llm
       chain.stream(input={'country': 'France'})