### PR TITLE
docs: fix typo in tool_results_pass_to_model.ipynb (how-to)

### DIFF
--- a/docs/docs/how_to/tool_results_pass_to_model.ipynb
+++ b/docs/docs/how_to/tool_results_pass_to_model.ipynb
@@ -16,7 +16,7 @@
     "\n",
     ":::\n",
     "\n",
-    "Some models are capable of [**tool calling**](/docs/concepts/tool_calling) - generating arguments that conform to a specific user-provided schema. This guide will demonstrate how to use those tool cals to actually call a function and properly pass the results back to the model.\n",
+    "Some models are capable of [**tool calling**](/docs/concepts/tool_calling) - generating arguments that conform to a specific user-provided schema. This guide will demonstrate how to use those tool calls to actually call a function and properly pass the results back to the model.\n",
     "\n",
     "![Diagram of a tool call invocation](/img/tool_invocation.png)\n",
     "\n",


### PR DESCRIPTION
Description: fix typo. change word from `cals` to `calls`
Issue: closes #29251 
Dependencies: None
Twitter handle: None