### PR TITLE
docs: fix qa_per_user.ipynb

### DIFF
--- a/docs/docs/how_to/qa_per_user.ipynb
+++ b/docs/docs/how_to/qa_per_user.ipynb
@@ -228,7 +228,7 @@
     "# highlight-next-line\n",
     "def retrieve(state: State, config: RunnableConfig):\n",
     "    # highlight-next-line\n",
-    "    retrieved_docs = configurable_retriever.invoke(state[\"question\"])\n",
+    "    retrieved_docs = configurable_retriever.invoke(state[\"question\"], config)\n",
     "    return {\"context\": retrieved_docs}\n",
     "\n",
     "\n",


### PR DESCRIPTION
# Description
The `config` option was not passed to `configurable_retriever.invoke()`. Screenshot below. Fixed.
 
<img width="731" alt="Screenshot 2025-01-18 at 11 59 28 AM" src="https://github.com/user-attachments/assets/21f30739-2abd-4150-b3ad-626ea9e3f96c" />


