### PR TITLE
[feat] Added options parameter to embed_documents and embed_query methods in OllamaEmbeddings

### DIFF
--- a/libs/partners/ollama/langchain_ollama/embeddings.py
+++ b/libs/partners/ollama/langchain_ollama/embeddings.py
@@ -3,10 +3,14 @@
 from typing import (
     List,
     Optional,
+    Union,
+    Mapping,
+    Any,
 )
 
 from langchain_core.embeddings import Embeddings
 from ollama import AsyncClient, Client
+from ollama._types import Options
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -156,14 +160,14 @@ class OllamaEmbeddings(BaseModel, Embeddings):
         self._async_client = AsyncClient(host=self.base_url, **client_kwargs)
         return self
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: List[str], options: Optional[Union[Mapping[str, Any], Options]] = None) -> List[List[float]]:
         """Embed search docs."""
-        embedded_docs = self._client.embed(self.model, texts)["embeddings"]
+        embedded_docs = self._client.embed(self.model, texts, options=options)["embeddings"]
         return embedded_docs
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str, options: Optional[Union[Mapping[str, Any], Options]] = None) -> List[float]:
         """Embed query text."""
-        return self.embed_documents([text])[0]
+        return self.embed_documents([text], options=options)[0]
 
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         """Embed search docs."""

--- a/libs/partners/ollama/langchain_ollama/embeddings.py
+++ b/libs/partners/ollama/langchain_ollama/embeddings.py
@@ -1,11 +1,11 @@
 """Ollama embeddings models."""
 
 from typing import (
+    Any,
     List,
+    Mapping,
     Optional,
     Union,
-    Mapping,
-    Any,
 )
 
 from langchain_core.embeddings import Embeddings
@@ -160,12 +160,20 @@ class OllamaEmbeddings(BaseModel, Embeddings):
         self._async_client = AsyncClient(host=self.base_url, **client_kwargs)
         return self
 
-    def embed_documents(self, texts: List[str], options: Optional[Union[Mapping[str, Any], Options]] = None) -> List[List[float]]:
+    def embed_documents(
+        self,
+        texts: List[str],
+        options: Optional[Union[Mapping[str, Any], Options]] = None,
+    ) -> List[List[float]]:
         """Embed search docs."""
-        embedded_docs = self._client.embed(self.model, texts, options=options)["embeddings"]
+        embedded_docs = self._client.embed(self.model, texts, options=options)[
+            "embeddings"
+        ]
         return embedded_docs
 
-    def embed_query(self, text: str, options: Optional[Union[Mapping[str, Any], Options]] = None) -> List[float]:
+    def embed_query(
+        self, text: str, options: Optional[Union[Mapping[str, Any], Options]] = None
+    ) -> List[float]:
         """Embed query text."""
         return self.embed_documents([text], options=options)[0]
 


### PR DESCRIPTION
- [feat ] **Added options parameter to embed_documents and embed_query methods in OllamaEmbeddings**: "langchain_ollama"
    - **Description:** Added options parameter to OllamaEmbeddings to set model configurations while creating embeddings
    - **Issue:** #29294 
    - **Dependencies:** None
    - **Twitter handle:** @BaqarAbbas2001

## Additional Information
Previously, `OllamaEmbeddings` from `langchain_community.embeddings` used to support the following options:
https://github.com/langchain-ai/langchain/blob/e9abe583b2efe80b4c38f4b7548a473bcca4dde5/libs/community/langchain_community/embeddings/ollama.py#L125-L139

However, in the new package `from langchain_ollama import OllamaEmbeddings`, there is no method to set these options. I have added an options parameters in `embed_query` and `embed_documents` to resolve this issue.

This issue was also discussed in https://github.com/langchain-ai/langchain/discussions/29113