### PR TITLE
openai[patch]: fix missing f-string modifier in oai structured output parsing error

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2485,8 +2485,8 @@ def _oai_structured_outputs_parser(ai_msg: AIMessage) -> PydanticBaseModel:
         raise OpenAIRefusalError(ai_msg.additional_kwargs["refusal"])
     else:
         raise ValueError(
-            f"Structured Output response does not have a 'parsed' field nor a "
-            f"'refusal' field. Received message:\n\n{ai_msg}"
+            "Structured Output response does not have a 'parsed' field nor a 'refusal' "
+            f"field. Received message:\n\n{ai_msg}"
         )
 
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2485,8 +2485,8 @@ def _oai_structured_outputs_parser(ai_msg: AIMessage) -> PydanticBaseModel:
         raise OpenAIRefusalError(ai_msg.additional_kwargs["refusal"])
     else:
         raise ValueError(
-            f"Structured Output response does not have a 'parsed' field nor a 'refusal' "
-            f"field. Received message:\n\n{ai_msg}"
+            f"Structured Output response does not have a 'parsed' field nor a "
+            f"'refusal' field. Received message:\n\n{ai_msg}"
         )
 
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2485,8 +2485,8 @@ def _oai_structured_outputs_parser(ai_msg: AIMessage) -> PydanticBaseModel:
         raise OpenAIRefusalError(ai_msg.additional_kwargs["refusal"])
     else:
         raise ValueError(
-            "Structured Output response does not have a 'parsed' field nor a 'refusal' "
-            "field. Received message:\n\n{ai_msg}"
+            f"Structured Output response does not have a 'parsed' field nor a 'refusal' "
+            f"field. Received message:\n\n{ai_msg}"
         )
 
 


### PR DESCRIPTION
- **Description:** The ValueError raised on certain structured-outputs parsing errors, in langchain openai community integration, was missing a f-string modifier and so didn't produce useful outputs. This is a 2-line, 2-character change.
- **Issue:** None open that this fixes
- **Dependencies:** Nothing changed
- **Twitter handle:** None

- [X] **Add tests and docs**: There's nothing to add for.
- [-] **Lint and test**: Happy to run this if you deem it necessary.