### PR TITLE
Docs: update huggingfacehub.ipynb

### DIFF
--- a/docs/docs/integrations/text_embedding/huggingfacehub.ipynb
+++ b/docs/docs/integrations/text_embedding/huggingfacehub.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade --quiet  langchain sentence_transformers"
+    "%pip install --upgrade --quiet  langchain-huggingface sentence_transformers"
    ]
   },
   {


### PR DESCRIPTION
langchain -> langchain-huggingface 



Updated the installation command from:
%pip install --upgrade --quiet langchain sentence_transformers to:
%pip install --upgrade --quiet langchain-huggingface sentence_transformers

This resolves an import error in the notebook when using `from langchain_huggingface.embeddings import HuggingFaceEmbeddings`.