### PR TITLE
docs: Update BedrockEmbeddings import example in aws.mdx

### DIFF
--- a/docs/docs/integrations/providers/aws.mdx
+++ b/docs/docs/integrations/providers/aws.mdx
@@ -92,7 +92,7 @@ from langchain_aws import SagemakerEndpoint
 
 See a [usage example](/docs/integrations/text_embedding/bedrock).
 ```python
-from langchain_community.embeddings import BedrockEmbeddings
+from langchain_aws import BedrockEmbeddings
 ```
 
 ### SageMaker Endpoint


### PR DESCRIPTION
The `BedrockEmbeddings` class in `langchain-community` has been deprecated since v0.2.11:

https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/embeddings/bedrock.py#L14-L19

Updated the AWS docs for `BedRockEmbeddings` to use the new class in `langchain-aws`.