### PR TITLE
community: Fix the problem of error reporting when OCR extracts text from PDF.

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -312,9 +312,9 @@ class PyPDFParser(BaseBlobParser):
                 elif xObject[obj]["/Filter"][1:] in _PDF_FILTER_WITH_LOSS:
                     images.append(xObject[obj].get_data())
                 elif (
-                        isinstance(xObject[obj]['/Filter'], list)
-                        and xObject[obj]['/Filter']
-                        and xObject[obj]['/Filter'][0][1:] in _PDF_FILTER_WITH_LOSS
+                    isinstance(xObject[obj]["/Filter"], list)
+                    and xObject[obj]["/Filter"]
+                    and xObject[obj]["/Filter"][0][1:] in _PDF_FILTER_WITH_LOSS
                 ):
                     images.append(xObject[obj].get_data())
                 else:

--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -313,8 +313,8 @@ class PyPDFParser(BaseBlobParser):
                     images.append(xObject[obj].get_data())
                 elif (
                         isinstance(xObject[obj]['/Filter'], list)
-                        and xObject[obj]['/Filter'] and
-                        xObject[obj]['/Filter'][0][1:] in _PDF_FILTER_WITH_LOSS
+                        and xObject[obj]['/Filter']
+                        and xObject[obj]['/Filter'][0][1:] in _PDF_FILTER_WITH_LOSS
                 ):
                     images.append(xObject[obj].get_data())
                 else:

--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -312,7 +312,8 @@ class PyPDFParser(BaseBlobParser):
                 elif xObject[obj]["/Filter"][1:] in _PDF_FILTER_WITH_LOSS:
                     images.append(xObject[obj].get_data())
                 elif (
-                        isinstance(xObject[obj]['/Filter'], list) and xObject[obj]['/Filter'] and
+                        isinstance(xObject[obj]['/Filter'], list)
+                        and xObject[obj]['/Filter'] and
                         xObject[obj]['/Filter'][0][1:] in _PDF_FILTER_WITH_LOSS
                 ):
                     images.append(xObject[obj].get_data())

--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -311,6 +311,11 @@ class PyPDFParser(BaseBlobParser):
                     )
                 elif xObject[obj]["/Filter"][1:] in _PDF_FILTER_WITH_LOSS:
                     images.append(xObject[obj].get_data())
+                elif (
+                        isinstance(xObject[obj]['/Filter'], list) and xObject[obj]['/Filter'] and
+                        xObject[obj]['/Filter'][0][1:] in _PDF_FILTER_WITH_LOSS
+                ):
+                    images.append(xObject[obj].get_data())
                 else:
                     warnings.warn("Unknown PDF Filter!")
         return extract_from_images_with_rapidocr(images)


### PR DESCRIPTION

- **Description:** The issue has been fixed where images could not be recognized from ```xObject[obj]["/Filter"]``` (whose value can be either a string or a list of strings) in the ```_extract_images_from_page()``` method. It also resolves the bug where vectorization by Faiss fails due to the failure of image extraction from a PDF containing only images```IndexError: list index out of range```.
![69a60f3f6bd474641b9126d74bb18f7e](https://github.com/user-attachments/assets/dc9e098d-2862-49f7-93b0-00f1056727dc)

- **Issue:** 
    Fix the following issues:
[#15227 ](https://github.com/langchain-ai/langchain/issues/15227) [#22892 ](https://github.com/langchain-ai/langchain/issues/22892) [#26652 ](https://github.com/langchain-ai/langchain-community/issues/187) [#27153 ](https://github.com/langchain-ai/langchain/issues/27153)
    Related issues:
[#7067 ](https://github.com/langchain-ai/langchain/issues/7067)

- **Dependencies:** None
- **Twitter handle:** None
