### PR TITLE
community; allow to set gitlab url in gitlab tool in constrictor

### DIFF
--- a/libs/community/langchain_community/utilities/gitlab.py
+++ b/libs/community/langchain_community/utilities/gitlab.py
@@ -17,6 +17,8 @@ class GitLabAPIWrapper(BaseModel):
 
     gitlab: Any = None  #: :meta private:
     gitlab_repo_instance: Any = None  #: :meta private:
+    gitlab_url: Optional[str] = None
+    """The url of the GitLab instance."""
     gitlab_repository: Optional[str] = None
     """The name of the GitLab repository, in the form {username}/{repo-name}."""
     gitlab_personal_access_token: Optional[str] = None
@@ -76,6 +78,7 @@ class GitLabAPIWrapper(BaseModel):
 
         values["gitlab"] = g
         values["gitlab_repo_instance"] = g.projects.get(gitlab_repository)
+        values["gitlab_url"] = gitlab_url
         values["gitlab_repository"] = gitlab_repository
         values["gitlab_personal_access_token"] = gitlab_personal_access_token
         values["gitlab_branch"] = gitlab_branch


### PR DESCRIPTION
This pr, expands the gitlab url so it can also be set in a constructor, instead of only through env variables. 

This allows to do something like this. 
```
       # Create the GitLab API wrapper
        gitlab_api = GitLabAPIWrapper(
            gitlab_url=self.gitlab_url,
            gitlab_personal_access_token=self.gitlab_personal_access_token,
            gitlab_repository=self.gitlab_repository,
            gitlab_branch=self.gitlab_branch,
            gitlab_base_branch=self.gitlab_base_branch,
        )
```
Where before you could not set the url in the constructor. 
