### PR TITLE
community: missing mandatory parameter partition_key for AzureCosmosDBNoSqlVectorSearch

### DIFF
--- a/libs/community/langchain_community/vectorstores/azure_cosmos_db_no_sql.py
+++ b/libs/community/langchain_community/vectorstores/azure_cosmos_db_no_sql.py
@@ -356,7 +356,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
             raise ValueError("No document ids provided to delete.")
 
         for document_id in ids:
-            self._container.delete_item(document_id)
+            self.delete_document_by_id(document_id)
         return True
 
     def delete_document_by_id(self, document_id: Optional[str] = None) -> None:


### PR DESCRIPTION
- **Description:** the `delete` function of AzureCosmosDBNoSqlVectorSearch  is using `self._container.delete_item(document_id)` which miss a mandatory parameter `partition_key`
We use the class function `delete_document_by_id` to provide a default `partition_key`
- **Issue:** #29372 
- **Dependencies:** None
- **Twitter handle:** None