### PR TITLE
standard-tests: Fix ToolsIntegrationTests to correctly handle "content_and_artifact" tools

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/tools.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/tools.py
@@ -29,15 +29,10 @@ class ToolsIntegrationTests(ToolsTests):
         )
         result = tool.invoke(tool_call)
 
-        if tool.response_format == "content":
-            tool_message = result
-        elif tool.response_format == "content_and_artifact":
-            # should be (content, artifact)
-            assert isinstance(result, tuple)
-            assert len(result) == 2
-            tool_message, artifact = result
-
-            assert artifact  # artifact can be anything, but shouldn't be none
+        tool_message = result
+        if tool.response_format == "content_and_artifact":
+            # artifact can be anything, except none
+            assert tool_message.artifact is not None
 
         # check content is a valid ToolMessage content
         assert isinstance(tool_message.content, (str, list))
@@ -59,15 +54,10 @@ class ToolsIntegrationTests(ToolsTests):
         )
         result = await tool.ainvoke(tool_call)
 
-        if tool.response_format == "content":
-            tool_message = result
-        elif tool.response_format == "content_and_artifact":
-            # should be (content, artifact)
-            assert isinstance(result, tuple)
-            assert len(result) == 2
-            tool_message, artifact = result
-
-            assert artifact  # artifact can be anything, but shouldn't be none
+        tool_message = result
+        if tool.response_format == "content_and_artifact":
+            # artifact can be anything, except none
+            assert tool_message.artifact is not None
 
         # check content is a valid ToolMessage content
         assert isinstance(tool_message.content, (str, list))

--- a/libs/standard-tests/tests/unit_tests/test_basic_tool.py
+++ b/libs/standard-tests/tests/unit_tests/test_basic_tool.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Literal, Type
 
 from langchain_core.tools import BaseTool
 
@@ -14,6 +14,17 @@ class ParrotMultiplyTool(BaseTool):  # type: ignore
 
     def _run(self, a: int, b: int) -> int:
         return a * b + 80
+
+
+class ParrotMultiplyArtifactTool(BaseTool):  # type: ignore
+    name: str = "ParrotMultiplyArtifactTool"
+    description: str = (
+        "Multiply two numbers like a parrot. Parrots always add eighty for their matey."
+    )
+    response_format: Literal["content_and_artifact"] = "content_and_artifact"
+
+    def _run(self, a: int, b: int) -> tuple[int, str]:
+        return a * b + 80, "parrot artifact"
 
 
 class TestParrotMultiplyToolUnit(ToolsUnitTests):
@@ -43,6 +54,29 @@ class TestParrotMultiplyToolIntegration(ToolsIntegrationTests):
     @property
     def tool_constructor(self) -> Type[ParrotMultiplyTool]:
         return ParrotMultiplyTool
+
+    @property
+    def tool_constructor_params(self) -> dict:
+        # if your tool constructor instead required initialization arguments like
+        # `def __init__(self, some_arg: int):`, you would return those here
+        # as a dictionary, e.g.: `return {'some_arg': 42}`
+        return {}
+
+    @property
+    def tool_invoke_params_example(self) -> dict:
+        """
+        Returns a dictionary representing the "args" of an example tool call.
+
+        This should NOT be a ToolCall dict - i.e. it should not
+        have {"name", "id", "args"} keys.
+        """
+        return {"a": 2, "b": 3}
+
+
+class TestParrotMultiplyArtifactToolIntegration(ToolsIntegrationTests):
+    @property
+    def tool_constructor(self) -> Type[ParrotMultiplyArtifactTool]:
+        return ParrotMultiplyArtifactTool
 
     @property
     def tool_constructor_params(self) -> dict:


### PR DESCRIPTION
**Description:**

The response from `tool.invoke()` is always a ToolMessage, with content and artifact fields, not a tuple.
The tuple is converted to a ToolMessage here
https://github.com/langchain-ai/langchain/blob/b6ae7ca91dd0f54f58475463804540ad25eeea7d/libs/core/langchain_core/tools/base.py#L726

**Issue:**

Currently `ToolsIntegrationTests` requires `invoke()` to return a tuple and so standard tests fail for "content_and_artifact" tools. This fixes that to check the returned ToolMessage.

This PR also adds a test that now passes.
