### PR TITLE
core[patch]: Override __getitem__ in BaseMessage

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -118,6 +118,25 @@ class BaseMessage(Serializable):
     def pretty_print(self) -> None:
         print(self.pretty_repr(html=is_interactive_env()))  # noqa: T201
 
+    def __getitem__(self, item: str) -> Any:
+        """Get a field value using dict-like access.
+
+        This allows accessing attributes of the message as if it were a dictionary.
+        For example, `message["content"]` will return the `content` field.
+
+        Args:
+            item: The name of the field to access.
+
+        Returns:
+            The value of the specified field.
+
+        Raises:
+            KeyError: If the field does not exist in the message.
+        """
+        if hasattr(self, item) and item in self.model_fields:
+            return getattr(self, item)
+        raise KeyError(item)
+
 
 def merge_content(
     first_content: Union[str, list[Union[str, dict]]],

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -177,6 +177,19 @@ def test_message_chunks() -> None:
     assert right + AIMessageChunk(content="") == right
 
 
+def test_message_getitem() -> None:
+    msg = BaseMessage(content="foo", role="bar", id=1, type="baz")
+
+    # Test accessing valid fields
+    for k in msg.model_fields:
+        assert msg[k] == getattr(msg, k)
+
+    # Test KeyError for invalid field
+    invalid_key = "non_existent_field"
+    with pytest.raises(KeyError):
+        _ = msg[invalid_key]
+
+
 def test_chat_message_chunks() -> None:
     assert ChatMessageChunk(role="User", content="I am", id="ai4") + ChatMessageChunk(
         role="User", content=" indeed."


### PR DESCRIPTION
**Description:** Override __getitem__ in BaseMessage to enable dictionary-like access to its fields. This change allows using the [] syntax (e.g., msg["content"]) to access attributes of BaseMessage objects, preventing the TypeError: 'BaseMessage' object is not subscriptable error. It standardizes handling both input and output messages with the same syntax, simplifying the code and improving consistency across the system.
**Issue:** No issue #.