### PR TITLE
docs: tiny grammary fix to why_langchain.mdx

### DIFF
--- a/docs/docs/concepts/why_langchain.mdx
+++ b/docs/docs/concepts/why_langchain.mdx
@@ -31,7 +31,7 @@ This provides a standard way to interact with chat models, supporting important 
 
 ### Example: chat models 
 
-Many [model providers](/docs/concepts/chat_models/) support [tool calling](/docs/concepts/tool_calling/), a critical features for many applications (e.g., [agents](https://langchain-ai.github.io/langgraph/concepts/agentic_concepts/)), that allows a developer to request model responses that match a particular schema.
+Many [model providers](/docs/concepts/chat_models/) support [tool calling](/docs/concepts/tool_calling/), a critical feature for many applications (e.g., [agents](https://langchain-ai.github.io/langgraph/concepts/agentic_concepts/)), that allows a developer to request model responses that match a particular schema.
 The APIs for each provider differ. 
 LangChain's [chat model](/docs/concepts/chat_models/) interface provides a common way to bind [tools](/docs/concepts/tools) to a model in order to support [tool calling](/docs/concepts/tool_calling/):
 


### PR DESCRIPTION
Description: Tiny grammar fix to doc - why_langchain.mdx
