### PR TITLE
docs:Fix Imports for Document and BaseRetriever

### DIFF
--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -88,7 +88,8 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
 
         .. code-block:: python
 
-            from langchain_core import Document, BaseRetriever
+            from langchain_core.documents.base import Document
+            from langchain_core.retrievers import BaseRetriever
             from typing import List
 
             class SimpleRetriever(BaseRetriever):

--- a/libs/core/langchain_core/retrievers.py
+++ b/libs/core/langchain_core/retrievers.py
@@ -88,7 +88,7 @@ class BaseRetriever(RunnableSerializable[RetrieverInput, RetrieverOutput], ABC):
 
         .. code-block:: python
 
-            from langchain_core.documents.base import Document
+            from langchain_core.documents import Document
             from langchain_core.retrievers import BaseRetriever
             from typing import List
 


### PR DESCRIPTION
This pull request addresses an issue with import statements in the langchain_core/retrievers.py file. The following changes have been made:

Corrected the import for Document from langchain_core.documents.base.
Corrected the import for BaseRetriever from langchain_core.retrievers.
These changes ensure that the SimpleRetriever class can correctly reference the Document and BaseRetriever classes, improving code reliability and maintainability.
