### PR TITLE
text-splitters: fix bug in TextSplitter's create_documents method 

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/base.py
+++ b/libs/text-splitters/langchain_text_splitters/base.py
@@ -82,7 +82,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
                     offset = index + previous_chunk_len - self._chunk_overlap
                     index = text.find(chunk, max(0, offset))
                     metadata["start_index"] = index
-                    previous_chunk_len = len(chunk)
+                    previous_chunk_len = self.length_function(chunk)
                 new_doc = Document(page_content=chunk, metadata=metadata)
                 documents.append(new_doc)
         return documents

--- a/libs/text-splitters/langchain_text_splitters/base.py
+++ b/libs/text-splitters/langchain_text_splitters/base.py
@@ -82,7 +82,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
                     offset = index + previous_chunk_len - self._chunk_overlap
                     index = text.find(chunk, max(0, offset))
                     metadata["start_index"] = index
-                    previous_chunk_len = self.length_function(chunk)
+                    previous_chunk_len = self._length_function(chunk)
                 new_doc = Document(page_content=chunk, metadata=metadata)
                 documents.append(new_doc)
         return documents


### PR DESCRIPTION
Description:
Fixed a bug in the `TextSplitter` class within the `create_documents` method. When `_add_start_index` is set to `True`, the length of the chunk was measured using the `len()` function (which counts characters) instead of the user-defined` self.length_function()`. This inconsistency could lead to incorrect values in `metadata['start_index']`.

Solution:
Replaced `len(chunk)` with `self.length_function(chunk)` to ensure that the chunk length is measured consistently using the user-provided function, thereby maintaining the correctness of `metadata['start_index']`.