### PR TITLE
fix: resolve issue #29513 - cannot retrieve reasoning_content while s…

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -287,6 +287,9 @@ def _convert_delta_to_message_chunk(
         except KeyError:
             pass
 
+    if _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = _dict["reasoning_content"]
+
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content, id=id_)
     elif role == "assistant" or default_class == AIMessageChunk:


### PR DESCRIPTION

Extract reasoning_content in the _convert_delta_to_message_chunk function


- [ ] **PR title**: "langchain_openai: add reasoning_content to stream response when using deepseek-reasoner"
  
- [ ] **PR message**: 
    - **Description:** Add reasoning_content to stream response
    - **Issue:** the issue #29513 
    - **Dependencies:** no dependencies

