### PR TITLE
docs: update readthedocs document loader options

### DIFF
--- a/docs/docs/integrations/document_loaders/readthedocs_documentation.ipynb
+++ b/docs/docs/integrations/document_loaders/readthedocs_documentation.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = ReadTheDocsLoader(\"rtdocs\", features=\"html.parser\")"
+    "loader = ReadTheDocsLoader(\"rtdocs\")"
    ]
   },
   {


### PR DESCRIPTION
Hi there!

This PR updates the documentation according to the code.
If we run the example as is, then it would result in the following error:
![image](https://github.com/user-attachments/assets/9c0a336c-775c-489c-a275-f1153d447ecb)

It seems that this part of the code already supplied the required argument to the BeautifulSoup4:
https://github.com/langchain-ai/langchain/blob/0c782ee5479f1eadf6cc532d7f27617bd2671fe9/libs/community/langchain_community/document_loaders/readthedocs.py#L87-L90

Since the example can only work by removing this argument, it also seems legit to remove it from the documentation.