### PR TITLE
fix(pdf): Fix garbled text in PDF loaders

### DIFF
--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -197,7 +197,8 @@ class BasePDFLoader(BaseLoader, ABC):
         self._encoding_config = config
 
     def process_text(self, text: str) -> str:
-        """Process text using the configured text processor and encoding configuration."""
+        """Process text using the configured text processor and encoding
+        configuration."""
         return self._text_processor.process_text(text, self._encoding_config)
 
     def with_encoding(


### PR DESCRIPTION
Hi team,

This PR implements the first part of the fix for the garbled text issue (#29555), starting with PDF loaders. This is part of a larger effort to address encoding issues across multiple document loaders.

<img width="736" alt="スクリーンショット 2025-02-04 0 22 43" src="https://github.com/user-attachments/assets/a5f29413-b22d-4e88-b630-95809a7c50c7" />

## Changes
- Add `PDFEncoding` enum for standardized encoding options
- Implement `PDFEncodingConfig` for centralized encoding management
- Enhance `BasePDFLoader` with encoding configuration support
- Update `PDFMinerParser` to handle encoding properly
- Add fallback mechanism for encoding errors

## Next Steps
This PR focuses on PDF loaders as the first implementation. Similar fixes will be needed for:
- Docx2txtLoader
- PyPDFLoader
- TextLoader
- UnstructuredExcelLoader
- UnstructuredWordDocumentLoader

## Notes
- No breaking changes to existing API
- Default encoding remains UTF-8
- Users can now specify custom encoding configurations when needed
- Fixes regression introduced in o3 release for PDF loaders

## Environment
- Tested on Python 3.13.1
- Compatible with:
  - langchain 0.3.17
  - langchain_community 0.3.16
  - langchain_core 0.3.33

Related issue: #29555