### PR TITLE
core: allow for `tool_choice` in `with_structured_output` to be overriden by client wrappers

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1193,6 +1193,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         schema: Union[typing.Dict, type],  # noqa: UP006
         *,
         include_raw: bool = False,
+        tool_choice: Optional[str] = "any",
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, Union[typing.Dict, BaseModel]]:  # noqa: UP006
         """Model wrapper that returns outputs formatted to match the given schema.
@@ -1312,7 +1313,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
 
         llm = self.bind_tools(
             [schema],
-            tool_choice="any",
+            tool_choice=tool_choice,
             structured_output_format={"kwargs": {}, "schema": schema},
         )
         if isinstance(schema, type) and is_basemodel_subclass(schema):


### PR DESCRIPTION
### Description

This change allows for wrappers around `BaseChatModel` to change the `tool_choice` parameter.  This will default to what is was set prior to this change, however, if client libraries want to change it, they can now do so.

## Issue
When using a custom wrapper with `BaseChatModel`, i encountered an issue where there was an incompatibility. 	The default implemantation of `with_structured_output`, hard coded an `any` key, when that key can be other values. 

With my wrapper, it uses the OpenAI spec, and in the spec [`any` is not a valid option for the `tool_choice` parameter](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice)

### Dependencies
None

### Twitter handle
@christian_arty

### Additional request
Could this change, if approved, be backported to 0.2.* (e.g. 0.2.44). 