### PR TITLE
docs: Fix incorrect import path for create_retrieval_chain in documentation #29560

### DIFF
--- a/docs/docs/integrations/document_loaders/docling.ipynb
+++ b/docs/docs/integrations/document_loaders/docling.ipynb
@@ -435,7 +435,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.chains import create_retrieval_chain\n",
+    "from langchain.chains.retrieval import create_retrieval_chain\n",
     "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
     "from langchain_huggingface import HuggingFaceEndpoint\n",
     "\n",


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "docs: Fix incorrect import path for `create_retrieval_chain` in documentation"

- [x] **PR message**:
    - **Description:**  
      The documentation example incorrectly imports `create_retrieval_chain` from `langchain.chains`, which results in an ImportError.  
      The correct import path is:  
      ```python
      from langchain.chains.retrieval import create_retrieval_chain
      ```
      This PR updates the documentation to reflect the correct import path and prevent confusion for users.  

    - **Issue:** Closes #29560 

    - **Dependencies:** None  

    - **Twitter handle:** https://x.com/AkmalJasmin

- [x] **Add tests and docs**:  
  - No new tests required, as this is a documentation fix.  

- [x] **Lint and test**:  
  - Ran `make format`, `make lint`, and `make test` to ensure compliance with contribution guidelines.  

---

This is a small but important fix to improve the accuracy of LangChain’s documentation. Looking forward to the review! 🚀
