### PR TITLE
anthropic: added model_name property to the ChatAnthropic class

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -601,6 +601,11 @@ class ChatAnthropic(BaseChatModel):
     """
 
     @property
+    def model_name(self) -> str:
+        """Alias for model"""
+        return self.model
+
+    @property
     def _llm_type(self) -> str:
         """Return type of chat model."""
         return "anthropic-chat"


### PR DESCRIPTION
**Description:** As model_name is used to retrieve the name of the model in other providers, it will be helpful to implement similar property into Anthropic package as well.

**Issue:** It was hectic to check for model or `model_name` existence before using it for multiple provider based application

```
from langchain_anthropic import ChatAnthropic
from langchain_openai import ChatOpenAI

openai_model = ChatOpenAI()
anthropic_model = ChatAnthropic()

openai_model.model_name  # gpt-4o-mini
anthropic_model.model  # claude-3-opus

# Let's say we choose provider by some settings,
chat_model = any of ChatOpenAI() or ChatAnthropic()

model_name = None
if 'model' in chat_model:
    model_name = chat_model.model
elif 'model_name' in chat_model:
    model_name = chat_model.model_name
```
The above `if...else` block can be eliminated with `model_name` property in the `ChatAnthropic` class

**Twitter handle:** @skanta_rath