### PR TITLE
core: remove unsupported keywords from pydantic schema

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -40,10 +40,26 @@ PYTHON_TO_JSON_TYPES = {
 }
 
 UNSUPPORTED_OPENAI_KEYWORDS = {
-    "title", "minLength", "maxLength", "pattern", "format", "minimum", "maximum",
-    "multipleOf", "patternProperties", "unevaluatedProperties", "propertyNames",
-    "minProperties", "maxProperties", "unevaluatedItems", "contains", "minContains",
-    "maxContains", "minItems", "maxItems", "uniqueItems"
+    "title",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "format",
+    "minimum",
+    "maximum",
+    "multipleOf",
+    "patternProperties",
+    "unevaluatedProperties",
+    "propertyNames",
+    "minProperties",
+    "maxProperties",
+    "unevaluatedItems",
+    "contains",
+    "minContains",
+    "maxContains",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
 }
 
 class FunctionDescription(TypedDict):

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -92,9 +92,6 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
                 and prev_key == "properties"
                 and len(UNSUPPORTED_OPENAI_KEYWORDS & v.keys()) > 0
             ):
-                 new_kv[k] = _rm_titles(v, k)
-             else:
-                 continue
                 new_kv[k] = _rm_titles(v, k)
             else:
                 continue

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -62,6 +62,7 @@ UNSUPPORTED_OPENAI_KEYWORDS = {
     "uniqueItems",
 }
 
+
 class FunctionDescription(TypedDict):
     """Representation of a callable function to send to an LLM."""
 
@@ -86,8 +87,14 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
     new_kv = {}
     for k, v in kv.items():
         if k in UNSUPPORTED_OPENAI_KEYWORDS:
-            if (isinstance(v, dict) and prev_key == "properties"
-            and len(UNSUPPORTED_OPENAI_KEYWORDS & v.keys()) > 0):
+            if (
+                isinstance(v, dict)
+                and prev_key == "properties"
+                and len(UNSUPPORTED_OPENAI_KEYWORDS & v.keys()) > 0
+            ):
+                 new_kv[k] = _rm_titles(v, k)
+             else:
+                 continue
                 new_kv[k] = _rm_titles(v, k)
             else:
                 continue

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -39,6 +39,12 @@ PYTHON_TO_JSON_TYPES = {
     "bool": "boolean",
 }
 
+UNSUPPORTED_OPENAI_KEYWORDS = {
+    'title', 'minLength', 'maxLength', 'pattern', 'format', 'minimum', 'maximum',
+    'multipleOf', 'patternProperties', 'unevaluatedProperties', 'propertyNames',
+    'minProperties', 'maxProperties', 'unevaluatedItems', 'contains', 'minContains',
+    'maxContains', 'minItems', 'maxItems', 'uniqueItems'
+}
 
 class FunctionDescription(TypedDict):
     """Representation of a callable function to send to an LLM."""
@@ -63,8 +69,8 @@ class ToolDescription(TypedDict):
 def _rm_titles(kv: dict, prev_key: str = "") -> dict:
     new_kv = {}
     for k, v in kv.items():
-        if k == "title":
-            if isinstance(v, dict) and prev_key == "properties" and "title" in v:
+        if k in UNSUPPORTED_OPENAI_KEYWORDS:
+            if isinstance(v, dict) and prev_key == "properties" and len(UNSUPPORTED_OPENAI_KEYWORDS & v.keys()) > 0:
                 new_kv[k] = _rm_titles(v, k)
             else:
                 continue

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -40,10 +40,10 @@ PYTHON_TO_JSON_TYPES = {
 }
 
 UNSUPPORTED_OPENAI_KEYWORDS = {
-    'title', 'minLength', 'maxLength', 'pattern', 'format', 'minimum', 'maximum',
-    'multipleOf', 'patternProperties', 'unevaluatedProperties', 'propertyNames',
-    'minProperties', 'maxProperties', 'unevaluatedItems', 'contains', 'minContains',
-    'maxContains', 'minItems', 'maxItems', 'uniqueItems'
+    "title", "minLength", "maxLength", "pattern", "format", "minimum", "maximum",
+    "multipleOf", "patternProperties", "unevaluatedProperties", "propertyNames",
+    "minProperties", "maxProperties", "unevaluatedItems", "contains", "minContains",
+    "maxContains", "minItems", "maxItems", "uniqueItems"
 }
 
 class FunctionDescription(TypedDict):
@@ -70,7 +70,8 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
     new_kv = {}
     for k, v in kv.items():
         if k in UNSUPPORTED_OPENAI_KEYWORDS:
-            if isinstance(v, dict) and prev_key == "properties" and len(UNSUPPORTED_OPENAI_KEYWORDS & v.keys()) > 0:
+            if (isinstance(v, dict) and prev_key == "properties"
+            and len(UNSUPPORTED_OPENAI_KEYWORDS & v.keys()) > 0):
                 new_kv[k] = _rm_titles(v, k)
             else:
                 continue

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -792,8 +792,6 @@ def test__convert_typed_dict_to_openai_function(
                         "type": "object",
                         "additionalProperties": {
                             "type": "array",
-                            "minItems": 2,
-                            "maxItems": 2,
                             "items": [
                                 {"type": "array", "items": {}},
                                 {
@@ -829,8 +827,6 @@ def test__convert_typed_dict_to_openai_function(
                 },
                 "arg8": {
                     "type": "array",
-                    "minItems": 1,
-                    "maxItems": 1,
                     "items": [
                         {
                             "title": "SubTool",

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -884,7 +884,6 @@ def test__convert_typed_dict_to_openai_function(
                             }
                         },
                     },
-                    "uniqueItems": True,
                 },
                 "arg12": {
                     "type": "object",


### PR DESCRIPTION
# Description

This modified the _rm_titles function to allow using `json_schema` method of structure output with `datetime.date` . The set of unsupported openai keywords includes the `title` key, as well as all the unsupported items listed here : https://platform.openai.com/docs/guides/structured-outputs#some-type-specific-keywords-are-not-yet-supported

# Issue

Resolves #29604
