### PR TITLE
add o1 and o3-mini to pricing

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -10,6 +10,22 @@ from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
 MODEL_COST_PER_1K_TOKENS = {
+    # OpenAI o1 input
+    "o1": 0.015,
+    "o1-2024-12-17": 0.015,
+    "o1-cached": 0.0075,
+    "o1-2024-12-17-cached": 0.0075,
+    # OpenAI o1 output
+    "o1-completion": 0.06,
+    "o1-2024-12-17-completion": 0.06,
+    # OpenAI o3-mini input
+    "o3-mini": 0.0011,
+    "o3-mini-2025-01-31": 0.0011,
+    "o3-mini-cached": 0.00055,
+    "o3-mini-2025-01-31-cached": 0.00055,
+    # OpenAI o3-mini output
+    "o3-mini-completion": 0.0044,
+    "o3-mini-2025-01-31-completion": 0.0044,
     # OpenAI o1-preview input
     "o1-preview": 0.015,
     "o1-preview-cached": 0.0075,


### PR DESCRIPTION
### PR Title:  
**community: add latest OpenAI models pricing**  

### Description:  
This PR updates the OpenAI model cost calculation mapping by adding the latest OpenAI models, **o1 (non-preview)** and **o3-mini**, based on the pricing listed on the [OpenAI pricing page](https://platform.openai.com/docs/pricing).  

### Changes:  
- Added pricing for `o1`, `o1-2024-12-17`, `o1-cached`, and `o1-2024-12-17-cached` for input tokens.  
- Added pricing for `o1-completion` and `o1-2024-12-17-completion` for output tokens.  
- Added pricing for `o3-mini`, `o3-mini-2025-01-31`, `o3-mini-cached`, and `o3-mini-2025-01-31-cached` for input tokens.  
- Added pricing for `o3-mini-completion` and `o3-mini-2025-01-31-completion` for output tokens.  

### Issue:  
N/A  

### Dependencies:  
None  

### Testing & Validation:  
- No functional changes outside of updating the cost mapping.  
- No tests were added or modified.  