### PR TITLE
community: Update deeplake.py

### DIFF
--- a/libs/community/langchain_community/vectorstores/deeplake.py
+++ b/libs/community/langchain_community/vectorstores/deeplake.py
@@ -168,7 +168,7 @@ class DeepLake(VectorStore):
         if _DEEPLAKE_INSTALLED is False:
             raise ImportError(
                 "Could not import deeplake python package. "
-                "Please install it with `pip install deeplake[enterprise]`."
+                "Please install it with `pip install deeplake[enterprise]<4.0.0`."
             )
 
         if (


### PR DESCRIPTION
Deep Lake recently released version 4, which introduces significant architectural changes, including a new on-disk storage format, enhanced indexing mechanisms, and improved concurrency. However, LangChain's vector store integration currently does not support Deep Lake v4 due to breaking API changes.

Previously, the installation command was:
`pip install deeplake[enterprise]`
This installs the latest available version, which now defaults to Deep Lake v4. Since LangChain's vector store integration is still dependent on v3, this can lead to compatibility issues when using Deep Lake as a vector database within LangChain.

To ensure compatibility, the installation command has been updated to:
`pip install deeplake[enterprise]<4.0.0`
This constraint ensures that pip installs the latest available version of Deep Lake within the v3 series while avoiding the incompatible v4 update.