### PR TITLE
infra: add UV_FROZEN to makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: all clean help docs_build docs_clean docs_linkcheck api_docs_build api_docs_clean api_docs_linkcheck spell_check spell_fix lint lint_package lint_tests format format_diff
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 ## help: Show this help info.
 help: Makefile
 	@printf "\n\033[1mUsage: make <TARGETS> ...\033[0m\n\n\033[1mTargets:\033[0m\n\n"

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -3,6 +3,9 @@
 # LINTING AND FORMATTING
 ######################
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for Python and notebook files.
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache

--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/

--- a/libs/partners/chroma/Makefile
+++ b/libs/partners/chroma/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE = tests/integration_tests/

--- a/libs/partners/deepseek/Makefile
+++ b/libs/partners/deepseek/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE = tests/integration_tests/

--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/fireworks/Makefile
+++ b/libs/partners/fireworks/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE = tests/integration_tests/

--- a/libs/partners/groq/Makefile
+++ b/libs/partners/groq/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/huggingface/Makefile
+++ b/libs/partners/huggingface/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 INTEGRATION_TEST_FILE ?= tests/integration_tests/

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test: TEST_FILE = tests/integration_tests/

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/pinecone/Makefile
+++ b/libs/partners/pinecone/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE = tests/integration_tests/

--- a/libs/partners/prompty/Makefile
+++ b/libs/partners/prompty/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/qdrant/Makefile
+++ b/libs/partners/qdrant/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/partners/voyageai/Makefile
+++ b/libs/partners/voyageai/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 integration_test integration_tests: TEST_FILE=tests/integration_tests/

--- a/libs/partners/xai/Makefile
+++ b/libs/partners/xai/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 

--- a/libs/standard-tests/Makefile
+++ b/libs/standard-tests/Makefile
@@ -3,6 +3,9 @@
 # Default target executed when no arguments are given to make.
 all: help
 
+.EXPORT_ALL_VARIABLES:
+UV_FROZEN = true
+
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 INTEGRATION_TEST_FILE ?= tests/integration_tests/


### PR DESCRIPTION
These are set in Github workflows, but forgot to add them to most makefiles for convenience when developing locally.

`uv run` will automatically sync the lock file. Because many of our development dependencies are local installs, it will pick up version changes and update the lock file. Passing `--frozen` or setting this environment variable disables the behavior.