### PR TITLE
docs: Fix llama.cpp GPU Installation in llamacpp.ipynb (Deprecated Env Variable)

### DIFF
--- a/docs/docs/integrations/llms/llamacpp.ipynb
+++ b/docs/docs/integrations/llms/llamacpp.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install llama-cpp-python"
+    "!CMAKE_ARGS=\"-DGGML_CUDA=on\" FORCE_CMAKE=1 pip install llama-cpp-python"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!CMAKE_ARGS=\"-DLLAMA_CUBLAS=on\" FORCE_CMAKE=1 pip install --upgrade --force-reinstall llama-cpp-python --no-cache-dir"
+    "!CMAKE_ARGS=\"-DGGML_CUDA=on\" FORCE_CMAKE=1 pip install --upgrade --force-reinstall llama-cpp-python --no-cache-dir"
    ]
   },
   {
@@ -149,9 +149,9 @@
     "\n",
     "```\n",
     "set FORCE_CMAKE=1\n",
-    "set CMAKE_ARGS=-DLLAMA_CUBLAS=OFF\n",
+    "set CMAKE_ARGS=-DGGML_CUDA=OFF\n",
     "```\n",
-    "If you have an NVIDIA GPU make sure `DLLAMA_CUBLAS` is set to `ON`\n",
+    "If you have an NVIDIA GPU make sure `DGGML_CUDA` is set to `ON`\n",
     "\n",
     "#### Compiling and installing\n",
     "\n",


### PR DESCRIPTION
- **Description:** The llamacpp.ipynb notebook used a deprecated environment variable, LLAMA_CUBLAS, for llama.cpp installation with GPU support. This commit updates the notebook to use the correct GGML_CUDA variable, fixing the installation error.
- **Issue:** none
-  **Dependencies:** none
