### PR TITLE
langchain: support the situation when action_input is null in json output_parser

### DIFF
--- a/libs/langchain/langchain/agents/output_parsers/json.py
+++ b/libs/langchain/langchain/agents/output_parsers/json.py
@@ -50,9 +50,10 @@ class JSONAgentOutputParser(AgentOutputParser):
             if response["action"] == "Final Answer":
                 return AgentFinish({"output": response["action_input"]}, text)
             else:
-                return AgentAction(
-                    response["action"], response.get("action_input", {}), text
-                )
+                action_input = response.get("action_input", {})
+                if action_input is None:
+                    action_input = {}
+                return AgentAction(response["action"], action_input, text)
         except Exception as e:
             raise OutputParserException(f"Could not parse LLM output: {text}") from e
 


### PR DESCRIPTION
Description:
This PR fixes handling of null action_input in [langchain.agents.output_parser]. Previously, passing null to action_input could cause OutputParserException with unclear error message which cause LLM don't know how to modify the action. The changes include:

Added null-check validation before processing action_input
Implemented proper fallback behavior with default values
Maintained backward compatibility with existing implementations

Error Examples:
```
{
  "action":"some action",
  "action_input":null
}
```

Issue:
None

Dependencies:
None