### PR TITLE
using getattr and default value to prevent 'OpenSearchVectorSearch' has no attribute 'bulk_size'

### DIFF
--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -1350,7 +1350,7 @@ class OpenSearchVectorSearch(VectorStore):
 
         """
         embeddings = embedding.embed_documents(texts)
-        bulk_size = bulk_size if bulk_size is not None else cls.bulk_size
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         return cls.from_embeddings(
             embeddings,
             texts,
@@ -1416,7 +1416,7 @@ class OpenSearchVectorSearch(VectorStore):
 
         """
         embeddings = await embedding.aembed_documents(texts)
-        bulk_size = bulk_size if bulk_size is not None else cls.bulk_size
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         return await cls.afrom_embeddings(
             embeddings,
             texts,
@@ -1503,7 +1503,7 @@ class OpenSearchVectorSearch(VectorStore):
             "max_chunk_bytes",
             "is_aoss",
         ]
-        bulk_size = bulk_size if bulk_size is not None else cls.bulk_size
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
         # Get the index name from either from kwargs or ENV Variable
@@ -1636,7 +1636,7 @@ class OpenSearchVectorSearch(VectorStore):
             "max_chunk_bytes",
             "is_aoss",
         ]
-        bulk_size = bulk_size if bulk_size is not None else cls.bulk_size
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
         # Get the index name from either from kwargs or ENV Variable

--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -1350,7 +1350,9 @@ class OpenSearchVectorSearch(VectorStore):
 
         """
         embeddings = embedding.embed_documents(texts)
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        bulk_size = (
+            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        )
         return cls.from_embeddings(
             embeddings,
             texts,
@@ -1416,7 +1418,9 @@ class OpenSearchVectorSearch(VectorStore):
 
         """
         embeddings = await embedding.aembed_documents(texts)
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        bulk_size = (
+            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        )
         return await cls.afrom_embeddings(
             embeddings,
             texts,
@@ -1503,7 +1507,9 @@ class OpenSearchVectorSearch(VectorStore):
             "max_chunk_bytes",
             "is_aoss",
         ]
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        bulk_size = (
+            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        )
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
         # Get the index name from either from kwargs or ENV Variable
@@ -1636,7 +1642,9 @@ class OpenSearchVectorSearch(VectorStore):
             "max_chunk_bytes",
             "is_aoss",
         ]
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        bulk_size = (
+            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+        )
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
         # Get the index name from either from kwargs or ENV Variable

--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -1350,7 +1350,7 @@ class OpenSearchVectorSearch(VectorStore):
 
         """
         embeddings = embedding.embed_documents(texts)
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
         return cls.from_embeddings(
             embeddings,
             texts,
@@ -1416,7 +1416,7 @@ class OpenSearchVectorSearch(VectorStore):
 
         """
         embeddings = await embedding.aembed_documents(texts)
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
         return await cls.afrom_embeddings(
             embeddings,
             texts,
@@ -1503,7 +1503,7 @@ class OpenSearchVectorSearch(VectorStore):
             "max_chunk_bytes",
             "is_aoss",
         ]
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
         # Get the index name from either from kwargs or ENV Variable
@@ -1636,7 +1636,7 @@ class OpenSearchVectorSearch(VectorStore):
             "max_chunk_bytes",
             "is_aoss",
         ]
-        bulk_size = bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
+        bulk_size = bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
         # Get the index name from either from kwargs or ENV Variable

--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -1351,7 +1351,7 @@ class OpenSearchVectorSearch(VectorStore):
         """
         embeddings = embedding.embed_documents(texts)
         bulk_size = (
-            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+            bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         )
         return cls.from_embeddings(
             embeddings,
@@ -1419,7 +1419,7 @@ class OpenSearchVectorSearch(VectorStore):
         """
         embeddings = await embedding.aembed_documents(texts)
         bulk_size = (
-            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+            bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         )
         return await cls.afrom_embeddings(
             embeddings,
@@ -1508,7 +1508,7 @@ class OpenSearchVectorSearch(VectorStore):
             "is_aoss",
         ]
         bulk_size = (
-            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+            bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         )
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])
@@ -1643,7 +1643,7 @@ class OpenSearchVectorSearch(VectorStore):
             "is_aoss",
         ]
         bulk_size = (
-            bulk_size if bulk_size is not None else getattr(cls,"bulk_size",500)
+            bulk_size if bulk_size is not None else getattr(cls, "bulk_size", 500)
         )
         _validate_embeddings_and_bulk_size(len(embeddings), bulk_size)
         dim = len(embeddings[0])


### PR DESCRIPTION
- Description: Adding getattr methods and set default value 500 to cls.bulk_size, it can prevent the error below:
  Error: type object 'OpenSearchVectorSearch' has no attribute 'bulk_size'

- Issue: https://github.com/langchain-ai/langchain/issues/29071