### PR TITLE
community: fix extended testing

### DIFF
--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -64,7 +64,7 @@ pdfplumber>=0.11
 pgvector>=0.1.6,<0.2
 playwright>=1.48.0,<2
 praw>=7.7.1,<8
-premai>=0.3.25,<0.4
+premai>=0.3.25,<0.4,!=0.3.100
 psychicapi>=0.8.0,<0.9
 pydantic>=2.7.4,<3
 pytesseract>=0.3.13


### PR DESCRIPTION
v0.3.100 of premai sdk appears to break on import: https://github.com/premAI-io/prem-python-sdk/blob/89d9276cbff1aad8ea662e0efaae8126d5dacb08/premai/api/__init__.py#L230