### PR TITLE
community: add support for Azure CosmosDB NoSQL query_constructors

### DIFF
--- a/libs/community/langchain_community/query_constructors/cosmosdb_no_sql.py
+++ b/libs/community/langchain_community/query_constructors/cosmosdb_no_sql.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, Tuple
+
+from langchain_core.structured_query import (
+    Comparator,
+    Comparison,
+    Operation,
+    Operator,
+    StructuredQuery,
+    Visitor,
+)
+
+SQL_COMPARATOR = {
+    Comparator.EQ: "=",
+    Comparator.NE: "!=",
+    Comparator.GT: ">",
+    Comparator.GTE: ">=",
+    Comparator.LT: "<",
+    Comparator.LTE: "<=",
+    Comparator.LIKE: "LIKE",
+    Comparator.IN: "IN",
+    Comparator.NIN: "NOT IN",
+}
+
+SQL_OPERATOR = {
+    Operator.AND: "AND",
+    Operator.OR: "OR",
+    Operator.NOT: "NOT",
+}
+
+
+class AzureCosmosDbNoSQLTranslator(Visitor):
+    """
+    A visitor subclass that converts a StructuredQuery into an CosmosDB NO SQL query.
+    """
+
+    def __init__(self, table_name: str = "c") -> None:
+        self.table_name = table_name
+
+    def visit_comparison(self, comparison: Comparison) -> str:
+        """
+        Visit a comparison operation and convert it into an SQL condition.
+        """
+        operator = SQL_COMPARATOR.get(comparison.comparator)
+        value = comparison.value
+        field = f"{self.table_name}.{comparison.attribute}"
+
+        if operator is None:
+            raise ValueError(f"Unsupported operator: {comparison.comparator}")
+
+        # Correct value formatting
+        if isinstance(value, str):
+            value = f"'{value}'"
+        elif isinstance(value, (list, tuple)):  # Handle IN clause
+            if comparison.comparator not in [Comparator.IN, Comparator.NIN]:
+                raise ValueError(
+                    f"Invalid comparator for list value: {comparison.comparator}"
+                )
+            value = (
+                "("
+                + ", ".join(f"'{v}'" if isinstance(v, str) else str(v) for v in value)
+                + ")"
+            )
+
+        return f"{field} {operator} {value}"
+
+    def visit_operation(self, operation: Operation) -> str:
+        """
+        Visit logical operations and convert them into SQL expressions.
+        Uses parentheses to ensure correct precedence.
+        """
+        operator = SQL_OPERATOR.get(operation.operator)
+        if operator is None:
+            raise ValueError(f"Unsupported operator: {operation.operator}")
+
+        expressions = [arg.accept(self) for arg in operation.arguments]
+
+        if operation.operator == Operator.NOT:
+            return f"NOT ({expressions[0]})"
+
+        return f"({f' {operator} '.join(expressions)})"
+
+    def visit_structured_query(
+        self, structured_query: StructuredQuery
+    ) -> Tuple[str, Dict[str, Any]]:
+        if structured_query.filter is None:
+            kwargs = {}
+        else:
+            kwargs = {"where": structured_query.filter.accept(self)}
+        return structured_query.query, kwargs

--- a/libs/community/langchain_community/vectorstores/azure_cosmos_db_no_sql.py
+++ b/libs/community/langchain_community/vectorstores/azure_cosmos_db_no_sql.py
@@ -378,6 +378,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         with_embedding: bool = False,
         offset_limit: Optional[str] = None,
         *,
+        where: Optional[str] = None,
         projection_mapping: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
@@ -388,6 +389,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
             pre_filter=pre_filter,
             offset_limit=offset_limit,
             projection_mapping=projection_mapping,
+            where=where,
         )
 
         return self._execute_query(
@@ -407,6 +409,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         offset_limit: Optional[str] = None,
         *,
         projection_mapping: Optional[Dict[str, Any]] = None,
+        where: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         query, parameters = self._construct_query(
@@ -416,6 +419,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
             pre_filter=pre_filter,
             offset_limit=offset_limit,
             projection_mapping=projection_mapping,
+            where=where,
         )
 
         return self._execute_query(
@@ -437,6 +441,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         offset_limit: Optional[str] = None,
         *,
         projection_mapping: Optional[Dict[str, Any]] = None,
+        where: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         query, parameters = self._construct_query(
@@ -447,6 +452,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
             pre_filter=pre_filter,
             offset_limit=offset_limit,
             projection_mapping=projection_mapping,
+            where=where,
         )
         return self._execute_query(
             query=query,
@@ -464,6 +470,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         with_embedding: bool = False,
         query_type: CosmosDBQueryType = CosmosDBQueryType.VECTOR,
         offset_limit: Optional[str] = None,
+        where: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         embeddings = self._embedding.embed_query(query)
@@ -476,6 +483,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                 pre_filter=pre_filter,
                 with_embedding=with_embedding,
                 offset_limit=offset_limit,
+                where=where,
                 **kwargs,
             )
         elif query_type == CosmosDBQueryType.FULL_TEXT_SEARCH:
@@ -484,6 +492,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                 query_type=query_type,
                 pre_filter=pre_filter,
                 offset_limit=offset_limit,
+                where=where,
                 **kwargs,
             )
 
@@ -494,6 +503,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                 query_type=query_type,
                 pre_filter=pre_filter,
                 offset_limit=offset_limit,
+                where=where,
                 **kwargs,
             )
         elif query_type == CosmosDBQueryType.HYBRID:
@@ -505,6 +515,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                 pre_filter=pre_filter,
                 with_embedding=with_embedding,
                 offset_limit=offset_limit,
+                where=where,
                 **kwargs,
             )
         return docs_and_scores
@@ -517,6 +528,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         with_embedding: bool = False,
         query_type: CosmosDBQueryType = CosmosDBQueryType.VECTOR,
         offset_limit: Optional[str] = None,
+        where: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Document]:
         if query_type not in CosmosDBQueryType.__members__.values():
@@ -532,6 +544,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                 with_embedding=with_embedding,
                 query_type=query_type,
                 offset_limit=offset_limit,
+                where=where,
                 kwargs=kwargs,
             )
 
@@ -546,19 +559,16 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         query_type: CosmosDBQueryType = CosmosDBQueryType.VECTOR,
         pre_filter: Optional[PreFilter] = None,
         with_embedding: bool = False,
+        where: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Document]:
-        # Retrieves the docs with similarity scores
-        # if kwargs["pre_filter"]:
-        #     pre_filter = kwargs["pre_filter"]
-        # if kwargs["with_embedding"]:
-        #     with_embedding = kwargs["with_embedding"]
         docs = self._similarity_search_with_score(
             embeddings=embedding,
             k=fetch_k,
             query_type=query_type,
             pre_filter=pre_filter,
             with_embedding=with_embedding,
+            where=where,
         )
 
         # Re-ranks the docs using MMR
@@ -581,13 +591,11 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         query_type: CosmosDBQueryType = CosmosDBQueryType.VECTOR,
         pre_filter: Optional[PreFilter] = None,
         with_embedding: bool = False,
+        where: Optional[str] = None,
         **kwargs: Any,
     ) -> List[Document]:
         # compute the embeddings vector from the query string
-        # if kwargs["pre_filter"]:
-        #     pre_filter = kwargs["pre_filter"]
-        # if kwargs["with_embedding"]:
-        #     with_embedding = kwargs["with_embedding"]
+
         embeddings = self._embedding.embed_query(query)
 
         docs = self.max_marginal_relevance_search_by_vector(
@@ -598,6 +606,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
             pre_filter=pre_filter,
             query_type=query_type,
             with_embedding=with_embedding,
+            where=where,
         )
         return docs
 
@@ -610,6 +619,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         pre_filter: Optional[PreFilter] = None,
         offset_limit: Optional[str] = None,
         projection_mapping: Optional[Dict[str, Any]] = None,
+        where: Optional[str] = None,
     ) -> Tuple[str, List[Dict[str, Any]]]:
         if (
             query_type == CosmosDBQueryType.FULL_TEXT_RANK
@@ -627,6 +637,10 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         if pre_filter:
             where_clause = self._build_where_clause(pre_filter)
             query += f"""{where_clause}"""
+            if where:
+                raise ValueError("where clause cannot be used with pre_filter clause.")
+        if where:
+            query += f"""WHERE {where}"""
 
         # TODO: Update the code to use parameters once parametrized queries
         #  are allowed for these query functions

--- a/libs/community/tests/unit_tests/query_constructors/test_cosmosdb_no_sql.py
+++ b/libs/community/tests/unit_tests/query_constructors/test_cosmosdb_no_sql.py
@@ -1,0 +1,90 @@
+import pytest
+from langchain_core.structured_query import (
+    Comparator,
+    Comparison,
+    Operation,
+    Operator,
+    StructuredQuery,
+)
+
+from langchain_community.query_constructors.cosmosdb_no_sql import (
+    AzureCosmosDbNoSQLTranslator,
+)
+
+
+def test_visit_structured_query_basic() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    structured_query = StructuredQuery(query="my search terms", limit=None, filter=None)
+    query, filter = constructor.visit_structured_query(structured_query)
+    assert query == "my search terms"
+    assert filter == {}
+
+
+def test_visit_structured_query_with_limit() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator(table_name="t")
+    structured_query = StructuredQuery(query="my search terms", limit=10, filter=None)
+    query, filter = constructor.visit_structured_query(structured_query)
+    assert query == "my search terms"
+    assert filter == {}
+
+
+def test_visit_structured_query_with_filter() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    comparison = Comparison(attribute="age", comparator=Comparator.GT, value=30)
+    structured_query = StructuredQuery(query="my search", limit=None, filter=comparison)
+    query, filter = constructor.visit_structured_query(structured_query)
+    assert query == "my search"
+    assert filter == {"where": "c.age > 30"}
+
+
+def test_visit_comparison_basic() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    comparison = Comparison(attribute="age", comparator=Comparator.GT, value=30)
+    result = constructor.visit_comparison(comparison)
+    assert result == "c.age > 30"
+
+
+def test_visit_comparison_with_string() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    comparison = Comparison(attribute="name", comparator=Comparator.EQ, value="John")
+    result = constructor.visit_comparison(comparison)
+    assert result == "c.name = 'John'"
+
+
+def test_visit_comparison_with_list() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    comparison = Comparison(
+        attribute="age", comparator=Comparator.IN, value=[25, 30, 35]
+    )
+    result = constructor.visit_comparison(comparison)
+    assert result == "c.age IN (25, 30, 35)"
+
+
+def test_visit_comparison_unsupported_operator() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    comparison = Comparison(attribute="age", comparator=Comparator.CONTAIN, value=30)
+    with pytest.raises(ValueError, match="Unsupported operator"):
+        constructor.visit_comparison(comparison)
+
+
+def test_visit_operation_basic() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    operation = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(attribute="age", comparator=Comparator.GT, value=30),
+            Comparison(attribute="name", comparator=Comparator.EQ, value="John"),
+        ],
+    )
+    result = constructor.visit_operation(operation)
+    assert result == "(c.age > 30 AND c.name = 'John')"
+
+
+def test_visit_operation_not() -> None:
+    constructor = AzureCosmosDbNoSQLTranslator()
+    operation = Operation(
+        operator=Operator.NOT,
+        arguments=[Comparison(attribute="age", comparator=Comparator.GT, value=30)],
+    )
+    result = constructor.visit_operation(operation)
+    assert result == "NOT (c.age > 30)"

--- a/libs/langchain/langchain/retrievers/self_query/base.py
+++ b/libs/langchain/langchain/retrievers/self_query/base.py
@@ -34,6 +34,9 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
 
     from langchain_community.query_constructors.astradb import AstraDBTranslator
     from langchain_community.query_constructors.chroma import ChromaTranslator
+    from langchain_community.query_constructors.cosmosdb_no_sql import (
+        AzureCosmosDbNoSQLTranslator,
+    )
     from langchain_community.query_constructors.dashvector import DashvectorTranslator
     from langchain_community.query_constructors.databricks_vector_search import (
         DatabricksVectorSearchTranslator,
@@ -65,6 +68,7 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
     from langchain_community.query_constructors.weaviate import WeaviateTranslator
     from langchain_community.vectorstores import (
         AstraDB,
+        AzureCosmosDBNoSqlVectorSearch,
         DashVector,
         DatabricksVectorSearch,
         DeepLake,
@@ -97,6 +101,7 @@ def _get_builtin_translator(vectorstore: VectorStore) -> Visitor:
 
     BUILTIN_TRANSLATORS: Dict[Type[VectorStore], Type[Visitor]] = {
         AstraDB: AstraDBTranslator,
+        AzureCosmosDBNoSqlVectorSearch: AzureCosmosDbNoSQLTranslator,
         PGVector: PGVectorTranslator,
         CommunityPinecone: PineconeTranslator,
         CommunityChroma: ChromaTranslator,


### PR DESCRIPTION
Current metadata filter implementation in Azure CosmosDB NoSQL vectorstore uses custom objects, which are not native to CosmosDB nor to LangChain.
This PR adds the option in the vector store to filter with the more native "WHERE" sql clause as string.
It also adds a Translator class, so that in can be natively used with Structured Queries / Filter Expressions.

It adds another (more native) filtering syntax, but it is backwards compatible with current implementation. 