### PR TITLE
docs: fix SQL-based metadata filter syntax, add link to BigQuery docs

### DIFF
--- a/docs/docs/integrations/vectorstores/google_bigquery_vector_search.ipynb
+++ b/docs/docs/integrations/vectorstores/google_bigquery_vector_search.ipynb
@@ -331,7 +331,7 @@
     "-   Dictionary-based Filters\n",
     "    -   You can pass a dictionary (dict) where the keys represent metadata fields and the values specify the filter condition. This method applies an equality filter between the key and the corresponding value. When multiple key-value pairs are provided, they are combined using a logical AND operation.\n",
     "-   SQL-based Filters\n",
-    "    -   Alternatively, you can provide a string representing an SQL WHERE clause to define more complex filtering conditions. This allows for greater flexibility, supporting SQL expressions such as comparison operators and logical operators."
+    "    -   Alternatively, you can provide a string representing an SQL WHERE clause to define more complex filtering conditions. This allows for greater flexibility, supporting SQL expressions such as comparison operators and logical operators. Learn more about [BigQuery operators](https://cloud.google.com/bigquery/docs/reference/standard-sql/operators)."
    ]
   },
   {

--- a/docs/docs/integrations/vectorstores/google_bigquery_vector_search.ipynb
+++ b/docs/docs/integrations/vectorstores/google_bigquery_vector_search.ipynb
@@ -356,7 +356,7 @@
    "source": [
     "# SQL-based Filters\n",
     "# This should return \"Banana\", \"Apples and oranges\" and \"Cars and airplanes\" documents.\n",
-    "docs = store.similarity_search_by_vector(query_vector, filter={\"len = 6 AND len > 17\"})\n",
+    "docs = store.similarity_search_by_vector(query_vector, filter=\"len = 6 AND len > 17\")\n",
     "print(docs)"
    ]
   },


### PR DESCRIPTION
Fix the syntax for SQL-based metadata filtering in the [Google BigQuery Vector Search docs](https://python.langchain.com/docs/integrations/vectorstores/google_bigquery_vector_search/#searching-documents-with-metadata-filters). Also add a link to learn more about BigQuery operators that can be used here.

I have been using this library, and have found that this is the correct syntax to use for the SQL-based filters.

**Issue**: no open issue.
**Dependencies**: none.
**Twitter handle**: none.

No tests as this is only a change to the documentation.

<!-- Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17. -->
