### PR TITLE
core: Fix output of convert_messages when called with BaseMessage.model_dump()

### DIFF
--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -23,7 +23,7 @@ test_watch:
 	-u LANGCHAIN_API_KEY \
 	-u LANGSMITH_TRACING \
 	-u LANGCHAIN_PROJECT \
-	uv run --group test ptw --snapshot-update --now . --disable-socket --allow-unix-socket -- -vv $(TEST_FILE)
+	uv run --group test ptw --snapshot-update --now . --disable-socket --allow-unix-socket -vv -- $(TEST_FILE)
 
 test_profile:
 	uv run --group test pytest -vv tests/unit_tests/ --profile-svg

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -236,7 +236,10 @@ def _create_message_from_message_type(
     if tool_call_id is not None:
         kwargs["tool_call_id"] = tool_call_id
     if additional_kwargs:
+        if response_metadata := additional_kwargs.pop("response_metadata", None):
+            kwargs["response_metadata"] = response_metadata
         kwargs["additional_kwargs"] = additional_kwargs  # type: ignore[assignment]
+        additional_kwargs.update(additional_kwargs.pop("additional_kwargs", {}))
     if id is not None:
         kwargs["id"] = id
     if tool_calls is not None:
@@ -258,8 +261,12 @@ def _create_message_from_message_type(
             else:
                 kwargs["tool_calls"].append(tool_call)
     if message_type in ("human", "user"):
+        if example := kwargs.get("additional_kwargs", {}).pop("example", False):
+            kwargs["example"] = example
         message: BaseMessage = HumanMessage(content=content, **kwargs)
     elif message_type in ("ai", "assistant"):
+        if example := kwargs.get("additional_kwargs", {}).pop("example", False):
+            kwargs["example"] = example
         message = AIMessage(content=content, **kwargs)
     elif message_type in ("system", "developer"):
         if message_type == "developer":

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -738,6 +738,15 @@ def test_convert_to_messages() -> None:
                 "artifact": {"foo": 123},
             },
             {"role": "remove", "id": "message_to_remove", "content": ""},
+            {
+                "content": "Now the turn for Larry to ask a question about the book!",
+                "additional_kwargs": {"metadata": {"speaker_name": "Presenter"}},
+                "response_metadata": {},
+                "type": "human",
+                "name": None,
+                "id": "1",
+                "example": False,
+            },
         ]
     )
     expected = [
@@ -762,6 +771,13 @@ def test_convert_to_messages() -> None:
         ToolMessage(tool_call_id="tool_id", content="Hi!"),
         ToolMessage(tool_call_id="tool_id2", content="Bye!", artifact={"foo": 123}),
         RemoveMessage(id="message_to_remove"),
+        HumanMessage(
+            content="Now the turn for Larry to ask a question about the book!",
+            additional_kwargs={"metadata": {"speaker_name": "Presenter"}},
+            response_metadata={},
+            id="1",
+            example=False,
+        ),
     ]
     assert expected == actual
 

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1026,7 +1026,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.10"
+version = "0.3.11"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },
@@ -1042,7 +1042,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.25.0,<1" },
-    { name = "langchain-core", specifier = ">=0.3.33,<1.0.0" },
+    { name = "langchain-core", specifier = ">=0.3.34,<1.0.0" },
     { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.24.0,<2.0.0" },
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = ">=1.26.2,<3" },
     { name = "pytest", specifier = ">=7,<9" },
@@ -1063,14 +1063,14 @@ typing = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "0.3.5"
+version = "0.3.6"
 source = { directory = "../text-splitters" }
 dependencies = [
     { name = "langchain-core" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "langchain-core", specifier = ">=0.3.33,<1.0.0" }]
+requires-dist = [{ name = "langchain-core", specifier = ">=0.3.34,<1.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION


- additional_kwargs was being nested twice
- example, response_metadata was placed inside additional_kwargs
