### PR TITLE
docs: Fix `model_id` on EmbeddingTabs page

### DIFF
--- a/docs/src/theme/EmbeddingTabs.js
+++ b/docs/src/theme/EmbeddingTabs.js
@@ -48,7 +48,7 @@ export default function EmbeddingTabs(props) {
     const nvidiaParamsOrDefault = nvidiaParams ?? `model="NV-Embed-QA"`;
     const voyageaiParamsOrDefault = voyageaiParams ?? `model="voyage-3"`;
     const ibmParamsOrDefault = ibmParams ?? 
-      `\n    model_id="ibm/slate-125m-english-rtrvr,\n    url="https://us-south.ml.cloud.ibm.com",\n    project_id="<WATSONX PROJECT_ID>",\n`;
+      `\n    model_id="ibm/slate-125m-english-rtrvr",\n    url="https://us-south.ml.cloud.ibm.com",\n    project_id="<WATSONX PROJECT_ID>",\n`;
     const fakeEmbeddingParamsOrDefault = fakeEmbeddingParams ?? `size=4096`;
 
     const embeddingVarName = customVarName ?? "embeddings";


### PR DESCRIPTION
Thank you for contributing to LangChain!

Fix `model_id` in IBM provider on EmbeddingTabs page

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

