### PR TITLE
langchain_community: add error handling in HuggingFaceInferenceAPIEmbeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -436,7 +436,7 @@ class HuggingFaceInferenceAPIEmbeddings(BaseModel, Embeddings):
             "Authorization": f"Bearer {self.api_key.get_secret_value()}",
             **self.additional_headers,
         }
-    
+
     def _check_for_api_errors(self, response: requests.Response) -> None:
         """Check the API response for errors and raise exceptions with details."""
         try:

--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -437,7 +437,7 @@ class HuggingFaceInferenceAPIEmbeddings(BaseModel, Embeddings):
             **self.additional_headers,
         }
     
-    def _check_for_api_errors(self, response: requests.Response):
+    def _check_for_api_errors(self, response: requests.Response) -> None:
         """Check the API response for errors and raise exceptions with details."""
         try:
             json_response = response.json()

--- a/libs/community/tests/unit_tests/embeddings/test_huggingface.py
+++ b/libs/community/tests/unit_tests/embeddings/test_huggingface.py
@@ -1,3 +1,7 @@
+import pytest
+import requests
+
+from unittest.mock import MagicMock
 from langchain_community.embeddings.huggingface import HuggingFaceInferenceAPIEmbeddings
 
 
@@ -5,3 +9,43 @@ def test_hugginggface_inferenceapi_embedding_documents_init() -> None:
     """Test huggingface embeddings."""
     embedding = HuggingFaceInferenceAPIEmbeddings(api_key="abcd123")  # type: ignore[arg-type]
     assert "abcd123" not in repr(embedding)
+
+
+@pytest.fixture
+def embedding_component():
+    return HuggingFaceInferenceAPIEmbeddings(api_key="test-key",
+                                             api_url="https://api-inference.huggingface.co",
+                                             model_name="BAAI/bge-large-en-v1.5")
+
+
+def test_check_for_api_errors_no_error(embedding_component):
+    """Test that no error is raised when the API response is valid."""
+    response = MagicMock()
+    response.json.return_value = {"data": [0.1, 0.2, 0.3]}  # Mock a successful response
+
+    try:
+        embedding_component._check_for_api_errors(response)
+    except Exception:
+        pytest.fail("Unexpected exception raised for valid response")
+
+
+def test_check_for_api_errors_with_error(embedding_component):
+    """Test that the correct ValueError is raised for an API error response."""
+    response = MagicMock()
+    response.json.return_value = {
+        "error": "Input validation error: `inputs` cannot be empty",
+        "error_type": "Validation"
+    }
+
+    with pytest.raises(ValueError, match=r"HuggingFace API Error \[Validation\]: Input validation error: `inputs` cannot be empty"):
+        embedding_component._check_for_api_errors(response)
+
+
+def test_check_for_api_errors_invalid_json(embedding_component):
+    """Test that a ValueError is raised when the response contains invalid JSON."""
+    response = MagicMock()
+    response.json.side_effect = requests.JSONDecodeError("Invalid JSON", "", 0)  # Simulate invalid JSON
+
+    with pytest.raises(requests.JSONDecodeError):
+        embedding_component._check_for_api_errors(response)
+

--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -343,8 +343,8 @@ packages:
   downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
 - name: langchain-lindorm-integration
   path: .
-  provider_page: lindorm
   repo: AlwaysBluer/langchain-lindorm-integration
+  provider_page: lindorm
   downloads: 79
   downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
 - name: langchain-hyperbrowser
@@ -424,3 +424,8 @@ packages:
   provider_page: graph_rag
   downloads: 2093
   downloads_updated_at: '2025-02-13T20:32:23.744801+00:00'
+- name: langchain-xai
+  path: libs/partners/xai
+  repo: langchain-ai/langchain
+  downloads: 9521
+  downloads_updated_at: '2025-02-13T23:35:48.490391+00:00'

--- a/libs/partners/groq/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/integration_tests/test_chat_models.py
@@ -13,7 +13,6 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.outputs import ChatGeneration, LLMResult
-from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
 from langchain_groq import ChatGroq
@@ -392,42 +391,6 @@ def test_json_mode_structured_output() -> None:
     assert type(result) is Joke
     assert len(result.setup) != 0
     assert len(result.punchline) != 0
-
-
-def test_tool_calling_no_arguments() -> None:
-    # Note: this is a variant of a test in langchain_tests
-    # that as of 2024-08-19 fails with "Failed to call a function. Please
-    # adjust your prompt." when `tool_choice="any"` is specified, but
-    # passes when `tool_choice` is not specified.
-    model = ChatGroq(model="llama-3.3-70b-versatile", temperature=0)  # type: ignore[call-arg]
-
-    @tool
-    def magic_function_no_args() -> int:
-        """Calculates a magic function."""
-        return 5
-
-    model_with_tools = model.bind_tools([magic_function_no_args])
-    query = "What is the value of magic_function()? Use the tool."
-    result = model_with_tools.invoke(query)
-    assert isinstance(result, AIMessage)
-    assert len(result.tool_calls) == 1
-    tool_call = result.tool_calls[0]
-    assert tool_call["name"] == "magic_function_no_args"
-    assert tool_call["args"] == {}
-    assert tool_call["id"] is not None
-    assert tool_call["type"] == "tool_call"
-
-    # Test streaming
-    full: Optional[BaseMessageChunk] = None
-    for chunk in model_with_tools.stream(query):
-        full = chunk if full is None else full + chunk  # type: ignore
-    assert isinstance(full, AIMessage)
-    assert len(full.tool_calls) == 1
-    tool_call = full.tool_calls[0]
-    assert tool_call["name"] == "magic_function_no_args"
-    assert tool_call["args"] == {}
-    assert tool_call["id"] is not None
-    assert tool_call["type"] == "tool_call"
 
 
 # Groq does not currently support N > 1

--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -48,26 +48,3 @@ class TestGroqLlama(BaseTestGroq):
     @property
     def supports_json_mode(self) -> bool:
         return False  # Not supported in streaming mode
-
-    @pytest.mark.xfail(
-        reason=("Fails with 'Failed to call a function. Please adjust your prompt.'")
-    )
-    def test_tool_calling_with_no_arguments(self, model: BaseChatModel) -> None:
-        super().test_tool_calling_with_no_arguments(model)
-
-    @pytest.mark.xfail(
-        reason=("Fails with 'Failed to call a function. Please adjust your prompt.'")
-    )
-    def test_tool_message_histories_string_content(
-        self, model: BaseChatModel, my_adder_tool: BaseTool
-    ) -> None:
-        super().test_tool_message_histories_string_content(model, my_adder_tool)
-
-    @pytest.mark.xfail(
-        reason=(
-            "Sometimes fails with 'Failed to call a function. "
-            "Please adjust your prompt.'"
-        )
-    )
-    def test_bind_runnables_as_tools(self, model: BaseChatModel) -> None:
-        super().test_bind_runnables_as_tools(model)

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -1122,7 +1122,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         model_with_tools = model.bind_tools(
             [magic_function_no_args], tool_choice=tool_choice
         )
-        query = "What is the value of magic_function()? Use the tool."
+        query = "What is the value of magic_function_no_args()? Use the tool."
         result = model_with_tools.invoke(query)
         _validate_tool_call_message_no_args(result)
 

--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Erick Friis", email = "erick@langchain.dev" }]
 license = { text = "MIT" }
 requires-python = "<4.0,>=3.9"
 dependencies = [
-    "langchain-core<1.0.0,>=0.3.34",
+    "langchain-core<1.0.0,>=0.3.35",
     "pytest<9,>=7",
     "pytest-asyncio<1,>=0.20",
     "httpx<1,>=0.25.0",
@@ -17,7 +17,7 @@ dependencies = [
     "numpy<3,>=1.26.2; python_version >= \"3.12\"",
 ]
 name = "langchain-tests"
-version = "0.3.11"
+version = "0.3.12"
 description = "Standard tests for LangChain implementations"
 readme = "README.md"
 

--- a/libs/standard-tests/uv.lock
+++ b/libs/standard-tests/uv.lock
@@ -345,7 +345,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.11"
+version = "0.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
When using a custom HuggingFace API Endpoint there can be an error in the JSON response. I propose added two checks when calling the `embed_documents` method of the `HuggingFaceInferenceAPIEmbeddings` class:

1. Add a check for a `JSONDecodeError`
2. Add a check within the JSON response for an error

While working with the `HuggingFaceInferenceAPIEmbeddings` class, I sometimes receive a nebulous error `ValueError: could not convert string to float: 'e'`
![Screenshot 2025-02-13 at 5 04 36 PM](https://github.com/user-attachments/assets/0901728a-a865-432a-88d4-9477ef12d8db)

This results because the `embed_documents` method, which is called during the execution of the `add_documents` method of a vector store, can return a JSON response like the following: `{'error': 'Input validation error: `inputs` cannot be empty', 'error_type': 'Validation'}`

The initial `ValueError` raised from `add_documents` is misleading because it makes the underlying error returned in the JSON response. I propose surfacing this error by adding a check during `embed_documents` to return the JSON error in a Pythonic manner.

I have detailed [this request in the discussions](https://github.com/langchain-ai/langchain/discussions/29791#discussion-7962964).

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
