### PR TITLE
community:  Adding IN Operator to AzureCosmosDBNoSQLVectorStore

### DIFF
--- a/libs/community/langchain_community/vectorstores/azure_cosmos_db_no_sql.py
+++ b/libs/community/langchain_community/vectorstores/azure_cosmos_db_no_sql.py
@@ -845,6 +845,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
         operator_map = {
             "$eq": "=",
             "$ne": "!=",
+            "$in": "IN",
             "$lt": "<",
             "$lte": "<=",
             "$gt": ">",


### PR DESCRIPTION
- ** Description**: I have added a new operator in the operator map with key `$in` and value `IN`, so that you can define filters using lists as values. This was already contemplated but as IN operator was not in the map they cannot be used.
- **Issue**: Fixes #29804.
- **Dependencies**: No extra. 

