### PR TITLE
fix: Correct getpass usage in Google Generative AI Embedding docs (#29809)

### DIFF
--- a/docs/docs/integrations/text_embedding/google_generative_ai.ipynb
+++ b/docs/docs/integrations/text_embedding/google_generative_ai.ipynb
@@ -47,7 +47,7 @@
     "import os\n",
     "\n",
     "if \"GOOGLE_API_KEY\" not in os.environ:\n",
-    "    os.environ[\"GOOGLE_API_KEY\"] = getpass(\"Provide your Google API key here\")"
+    "    os.environ[\"GOOGLE_API_KEY\"] = getpass.getpass(\"Provide your Google API key here\")"
    ]
   },
   {


### PR DESCRIPTION
**fix: Correct getpass usage in Google Generative AI Embedding docs (#29809)**

- **Description:** Corrected the `getpass` usage in the Google Generative AI Embedding documentation by replacing `getpass()` with `getpass.getpass()` to fix the `TypeError`.  
- **Issue:** #29809  
- **Dependencies:** None  

**Additional Notes:**  
The change ensures compatibility with Google Colab and follows Python's `getpass` module usage standards.