### PR TITLE
openai[patch]: enable streaming for o1

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -511,15 +511,6 @@ class BaseChatOpenAI(BaseChatModel):
             values["temperature"] = 1
         return values
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_disable_streaming(cls, values: Dict[str, Any]) -> Any:
-        """Disable streaming if n > 1."""
-        model = values.get("model_name") or values.get("model") or ""
-        if model == "o1" and values.get("disable_streaming") is None:
-            values["disable_streaming"] = True
-        return values
-
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1189,16 +1189,6 @@ def test_o1(use_max_completion_tokens: bool) -> None:
 
 
 @pytest.mark.scheduled
-def test_o1_doesnt_stream() -> None:
-    """
-    When this starts failing, remove the `disable_streaming` validator in
-    `BaseChatOpenAI`
-    """
-    with pytest.raises(openai.BadRequestError):
-        list(ChatOpenAI(model="o1", disable_streaming=False).stream("how are you"))
-
-
-@pytest.mark.scheduled
 def test_o1_stream_default_works() -> None:
     result = list(ChatOpenAI(model="o1").stream("say 'hi'"))
     assert len(result) > 0


### PR DESCRIPTION
Verified streaming works for the `o1-2024-12-17` snapshot as well.