### PR TITLE
xai[patch]: support dedicated structured output feature

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -348,9 +348,14 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
             self.client = openai.OpenAI(
                 **client_params, **sync_specific
             ).chat.completions
+            self.root_client = openai.OpenAI(**client_params, **sync_specific)
         if not (self.async_client or None):
             async_specific: dict = {"http_client": self.http_async_client}
             self.async_client = openai.AsyncOpenAI(
                 **client_params, **async_specific
             ).chat.completions
+            self.root_async_client = openai.AsyncOpenAI(
+                **client_params,
+                **async_specific,
+            )
         return self


### PR DESCRIPTION
https://docs.x.ai/docs/guides/structured-outputs

Interface appears identical to OpenAI's.
```python
from langchain.chat_models import init_chat_model
from pydantic import BaseModel

class Joke(BaseModel):
    setup: str
    punchline: str

llm = init_chat_model("xai:grok-2").with_structured_output(
    Joke, method="json_schema"
)
llm.invoke("Tell me a joke about cats.")
```