### PR TITLE
core: add sambanova chat models to load module mapping

### DIFF
--- a/libs/community/tests/unit_tests/load/test_serializable.py
+++ b/libs/community/tests/unit_tests/load/test_serializable.py
@@ -112,6 +112,16 @@ def test_serializable_mapping() -> None:
             "chat_models",
             "ChatGroq",
         ),
+        ("langchain_sambanova", "chat_models", "ChatSambaNovaCloud"): (
+            "langchain_sambanova",
+            "chat_models",
+            "ChatSambaNovaCloud",
+        ),
+        ("langchain_sambanova", "chat_models", "ChatSambaStudio"): (
+            "langchain_sambanova",
+            "chat_models",
+            "ChatSambaStudio",
+        ),
         # TODO(0.3): For now we're skipping the below two tests. Need to fix
         # so that it only runs when langchain-aws, langchain-google-genai
         # are installed.

--- a/libs/core/langchain_core/load/load.py
+++ b/libs/core/langchain_core/load/load.py
@@ -25,6 +25,7 @@ DEFAULT_NAMESPACES = [
     "langchain_mistralai",
     "langchain_fireworks",
     "langchain_xai",
+    "langchain_sambanova",
 ]
 # Namespaces for which only deserializing via the SERIALIZABLE_MAPPING is allowed.
 # Load by path is not allowed.

--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -528,6 +528,16 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "structured",
         "StructuredPrompt",
     ),
+    ("langchain_sambanova", "chat_models", "ChatSambaNovaCloud"): (
+        "langchain_sambanova",
+        "chat_models",
+        "ChatSambaNovaCloud",
+    ),
+    ("langchain_sambanova", "chat_models", "ChatSambaStudio"): (
+        "langchain_sambanova",
+        "chat_models",
+        "ChatSambaStudio",
+    ),
 }
 
 # Needed for backwards compatibility for old versions of LangChain where things


### PR DESCRIPTION
    - **Description:** add sambanova integration package chat models to load module mapping, to allow serialization and deserialization