### PR TITLE
docs: fix partner package table build for packages with no download stats

### DIFF
--- a/docs/scripts/partner_pkg_table.py
+++ b/docs/scripts/partner_pkg_table.py
@@ -93,7 +93,7 @@ packages_n = [_enrich_package(p) for p in data["packages"]]
 packages = [p for p in packages_n if p is not None]
 
 # sort by downloads
-packages_sorted = sorted(packages, key=lambda p: p["downloads"], reverse=True)
+packages_sorted = sorted(packages, key=lambda p: p.get("downloads", 0), reverse=True)
 
 
 def package_row(p: dict) -> str:


### PR DESCRIPTION
The build in #29867 is currently broken because `langchain-cli` didn't add download stats to the provider file.

This change gracefully handles sorting packages with missing download counts. I initially updated the build to fetch download counts on every run, but pypistats [requests](https://pypistats.org/api/) that users not fetch stats like this via CI.