### PR TITLE
community: Made some Jira fields optional for agent to work correctly

### DIFF
--- a/libs/community/langchain_community/utilities/jira.py
+++ b/libs/community/langchain_community/utilities/jira.py
@@ -84,7 +84,10 @@ class JiraAPIWrapper(BaseModel):
             key = issue["key"]
             summary = issue["fields"]["summary"]
             created = issue["fields"]["created"][0:10]
-            priority = issue["fields"]["priority"]["name"]
+            if "priority" in issue["fields"]:
+                priority = issue["fields"]["priority"]["name"]
+            else:
+                priority = None
             status = issue["fields"]["status"]["name"]
             try:
                 assignee = issue["fields"]["assignee"]["displayName"]
@@ -121,15 +124,9 @@ class JiraAPIWrapper(BaseModel):
             key = project["key"]
             name = project["name"]
             type = project["projectTypeKey"]
-            style = project["style"]
+            style = project.get("style", None)
             parsed.append(
-                {
-                    "id": id,
-                    "key": key,
-                    "name": name,
-                    "type": type,
-                    "style": style,
-                }
+                {"id": id, "key": key, "name": name, "type": type, "style": style}
             )
         return parsed
 


### PR DESCRIPTION
**Description:** Two small changes have been proposed here:
(1)
Previous code assumes that every issue has a priority field. If an issue lacks this field, the code will raise a KeyError.
Now, the code checks if priority exists before accessing it. If priority is missing, it assigns None instead of crashing. This prevents runtime errors when processing issues without a priority.

(2)

Also If the "style" field is missing, the code throws a KeyError. `.get("style", None)` safely retrieves the value if present.

**Issue:** #29875 

**Dependencies:** N/A

