### PR TITLE
Handled a bug around empty query results differently

### DIFF
--- a/libs/community/langchain_community/vectorstores/kinetica.py
+++ b/libs/community/langchain_community/vectorstores/kinetica.py
@@ -430,16 +430,18 @@ class Kinetica(VectorStore):
     ) -> List[Tuple[Document, float]]:
         # from gpudb import GPUdbException
 
+        results = []
         resp: Dict = self.__query_collection(embedding, k, filter)
-        if resp and resp["status_info"]["status"] == "OK" and "records" in resp:
-            records: OrderedDict = resp["records"]
-            results = list(zip(*list(records.values())))
+        if resp and resp["status_info"]["status"] == "OK":
+            total_records = resp["total_number_of_records"]
+            if total_records > 0:
+                records: OrderedDict = resp["records"]
+                results = list(zip(*list(records.values())))
 
-            return self._results_to_docs_and_scores(results)
-
-        self.logger.error(resp["status_info"]["message"])
-        # raise GPUdbException(resp["status_info"]["message"])
-        return []
+                return self._results_to_docs_and_scores(results)
+            else:
+                self.logger.warning(f"No records found; status: {resp['status_info']['status']}")
+        return results
 
     def similarity_search_by_vector(
         self,

--- a/libs/community/langchain_community/vectorstores/kinetica.py
+++ b/libs/community/langchain_community/vectorstores/kinetica.py
@@ -440,7 +440,8 @@ class Kinetica(VectorStore):
 
                 return self._results_to_docs_and_scores(results)
             else:
-                self.logger.warning(f"No records found; status: {resp['status_info']['status']}")
+                self.logger.warning(f"No records found; "
+                                    f"status: {resp['status_info']['status']}")
         return results
 
     def similarity_search_by_vector(

--- a/libs/community/langchain_community/vectorstores/kinetica.py
+++ b/libs/community/langchain_community/vectorstores/kinetica.py
@@ -440,8 +440,9 @@ class Kinetica(VectorStore):
 
                 return self._results_to_docs_and_scores(results)
             else:
-                self.logger.warning(f"No records found; "
-                                    f"status: {resp['status_info']['status']}")
+                self.logger.warning(
+                    f"No records found; status: {resp['status_info']['status']}"
+                )
         return results
 
     def similarity_search_by_vector(


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **Handled query records properly**: "community: vectorstores/kinetica"

- [ ] **Bugfix for empty query results handling**: 
    - **Description:** checked for the number of records returned by a query before processing further
    - **Issue:** resulted in an `AttributeError` earlier which has now been fixed

@efriis 