### PR TITLE
openai: Update reasoning_effort arg documentation

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -439,7 +439,7 @@ class BaseChatOpenAI(BaseChatModel):
     reasoning_effort: Optional[str] = None
     """Constrains effort on reasoning for reasoning models. 
     
-    o1 models only.
+    Reasoning models only, like OpenAI o1 and o3-mini.
 
     Currently supported values are low, medium, and high. Reducing reasoning effort 
     can result in faster responses and fewer tokens used on reasoning in a response.


### PR DESCRIPTION
**Description:** Update docstring for `reasoning_effort` argument to specify that it applies to reasoning models only (e.g., OpenAI o1 and o3-mini), clarifying its supported models.
**Issue:** None
**Dependencies:** None