### PR TITLE
openai[patch]: instantiate clients lazily

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -178,7 +178,7 @@ class ChatDeepSeek(BaseChatOpenAI):
             self.api_key and self.api_key.get_secret_value()
         ):
             raise ValueError("If using default api base, DEEPSEEK_API_KEY must be set.")
-        client_params: dict = {
+        self._client_params: dict = {
             k: v
             for k, v in {
                 "api_key": self.api_key.get_secret_value() if self.api_key else None,
@@ -191,16 +191,6 @@ class ChatDeepSeek(BaseChatOpenAI):
             if v is not None
         }
 
-        if not (self.client or None):
-            sync_specific: dict = {"http_client": self.http_client}
-            self.client = openai.OpenAI(
-                **client_params, **sync_specific
-            ).chat.completions
-        if not (self.async_client or None):
-            async_specific: dict = {"http_client": self.http_async_client}
-            self.async_client = openai.AsyncOpenAI(
-                **client_params, **async_specific
-            ).chat.completions
         return self
 
     def _create_chat_result(

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -660,7 +660,7 @@ class AzureChatOpenAI(BaseChatOpenAI):
         return self
 
     @property
-    def root_client(self) -> openai.AzureOpenAI:
+    def root_client(self) -> Any:
         if self._root_client is None:
             sync_specific = {"http_client": self.http_client}
             self._root_client = openai.AzureOpenAI(
@@ -669,8 +669,12 @@ class AzureChatOpenAI(BaseChatOpenAI):
             )
         return self._root_client
 
+    @root_client.setter
+    def root_client(self, value: openai.AzureOpenAI) -> None:
+        self._root_client = value
+
     @property
-    def root_async_client(self) -> openai.AsyncAzureOpenAI:
+    def root_async_client(self) -> Any:
         if self._root_async_client is None:
             async_specific = {"http_client": self.http_async_client}
             self._root_async_client = openai.AsyncAzureOpenAI(
@@ -678,6 +682,10 @@ class AzureChatOpenAI(BaseChatOpenAI):
                 **async_specific,  # type: ignore[call-overload]
             )
         return self._root_async_client
+
+    @root_async_client.setter
+    def root_async_client(self, value: openai.AsyncAzureOpenAI) -> None:
+        self._root_async_client = value
 
     @property
     def _identifying_params(self) -> Dict[str, Any]:

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-from functools import cached_property
 from typing import (
     Any,
     Awaitable,
@@ -660,35 +659,38 @@ class AzureChatOpenAI(BaseChatOpenAI):
 
         return self
 
-    @cached_property
+    @property
     def _root_client(self) -> openai.AzureOpenAI:
         if self.root_client is not None:
             return self.root_client
         sync_specific = {"http_client": self._http_client}
-        return openai.AzureOpenAI(**self._client_params, **sync_specific)  # type: ignore[call-overload]
+        self.root_client = openai.AzureOpenAI(**self._client_params, **sync_specific)  # type: ignore[call-overload]
+        return self.root_client
 
-    @cached_property
+    @property
     def _root_async_client(self) -> openai.AsyncAzureOpenAI:
         if self.root_async_client is not None:
             return self.root_async_client
         async_specific = {"http_client": self._http_async_client}
-
-        return openai.AsyncAzureOpenAI(
+        self.root_async_client = openai.AsyncAzureOpenAI(
             **self._client_params,
             **async_specific,  # type: ignore[call-overload]
         )
+        return self._root_async_client
 
-    @cached_property
+    @property
     def _client(self) -> Any:
         if self.client is not None:
             return self.client
-        return self._root_client.chat.completions
+        self.client = self._root_client.chat.completions
+        return self.client
 
-    @cached_property
+    @property
     def _async_client(self) -> Any:
         if self.async_client is not None:
             return self.async_client
-        return self._root_async_client.chat.completions
+        self.async_client = self._root_async_client.chat.completions
+        return self.async_client
 
     @property
     def _identifying_params(self) -> Dict[str, Any]:

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -680,18 +680,6 @@ class AzureChatOpenAI(BaseChatOpenAI):
         return self._root_async_client
 
     @property
-    def client(self) -> Any:
-        if self._client is None:
-            self._client = self.root_client.chat.completions
-        return self._client
-
-    @property
-    def async_client(self) -> Any:
-        if self._async_client is None:
-            self._async_client = self.root_async_client.chat.completions
-        return self._async_client
-
-    @property
     def _identifying_params(self) -> Dict[str, Any]:
         """Get the identifying parameters."""
         return {

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -660,37 +660,37 @@ class AzureChatOpenAI(BaseChatOpenAI):
         return self
 
     @property
-    def _root_client(self) -> openai.AzureOpenAI:
-        if self.root_client is not None:
-            return self.root_client
-        sync_specific = {"http_client": self._http_client}
-        self.root_client = openai.AzureOpenAI(**self._client_params, **sync_specific)  # type: ignore[call-overload]
-        return self.root_client
+    def root_client(self) -> openai.AzureOpenAI:
+        if self._root_client is not None:
+            return self._root_client
+        sync_specific = {"http_client": self.http_client}
+        self._root_client = openai.AzureOpenAI(**self._client_params, **sync_specific)  # type: ignore[call-overload]
+        return self._root_client
 
     @property
-    def _root_async_client(self) -> openai.AsyncAzureOpenAI:
-        if self.root_async_client is not None:
-            return self.root_async_client
-        async_specific = {"http_client": self._http_async_client}
-        self.root_async_client = openai.AsyncAzureOpenAI(
+    def root_async_client(self) -> openai.AsyncAzureOpenAI:
+        if self._root_async_client is not None:
+            return self._root_async_client
+        async_specific = {"http_client": self.http_async_client}
+        self._root_async_client = openai.AsyncAzureOpenAI(
             **self._client_params,
             **async_specific,  # type: ignore[call-overload]
         )
         return self._root_async_client
 
     @property
-    def _client(self) -> Any:
-        if self.client is not None:
-            return self.client
-        self.client = self._root_client.chat.completions
-        return self.client
+    def client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        self._client = self.root_client.chat.completions
+        return self._client
 
     @property
-    def _async_client(self) -> Any:
-        if self.async_client is not None:
-            return self.async_client
-        self.async_client = self._root_async_client.chat.completions
-        return self.async_client
+    def async_client(self) -> Any:
+        if self._async_client is not None:
+            return self._async_client
+        self._async_client = self.root_async_client.chat.completions
+        return self._async_client
 
     @property
     def _identifying_params(self) -> Dict[str, Any]:

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -661,35 +661,34 @@ class AzureChatOpenAI(BaseChatOpenAI):
 
     @property
     def root_client(self) -> openai.AzureOpenAI:
-        if self._root_client is not None:
-            return self._root_client
-        sync_specific = {"http_client": self.http_client}
-        self._root_client = openai.AzureOpenAI(**self._client_params, **sync_specific)  # type: ignore[call-overload]
+        if self._root_client is None:
+            sync_specific = {"http_client": self.http_client}
+            self._root_client = openai.AzureOpenAI(
+                **self._client_params,
+                **sync_specific,  # type: ignore[call-overload]
+            )
         return self._root_client
 
     @property
     def root_async_client(self) -> openai.AsyncAzureOpenAI:
-        if self._root_async_client is not None:
-            return self._root_async_client
-        async_specific = {"http_client": self.http_async_client}
-        self._root_async_client = openai.AsyncAzureOpenAI(
-            **self._client_params,
-            **async_specific,  # type: ignore[call-overload]
-        )
+        if self._root_async_client is None:
+            async_specific = {"http_client": self.http_async_client}
+            self._root_async_client = openai.AsyncAzureOpenAI(
+                **self._client_params,
+                **async_specific,  # type: ignore[call-overload]
+            )
         return self._root_async_client
 
     @property
     def client(self) -> Any:
-        if self._client is not None:
-            return self._client
-        self._client = self.root_client.chat.completions
+        if self._client is None:
+            self._client = self.root_client.chat.completions
         return self._client
 
     @property
     def async_client(self) -> Any:
-        if self._async_client is not None:
-            return self._async_client
-        self._async_client = self.root_async_client.chat.completions
+        if self._async_client is None:
+            self._async_client = self.root_async_client.chat.completions
         return self._async_client
 
     @property

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -634,7 +634,7 @@ class BaseChatOpenAI(BaseChatModel):
         return self._http_async_client
 
     @property
-    def root_client(self) -> openai.OpenAI:
+    def root_client(self) -> Any:
         if self._root_client is None:
             sync_specific = {"http_client": self.http_client}
             self._root_client = openai.OpenAI(
@@ -648,7 +648,7 @@ class BaseChatOpenAI(BaseChatModel):
         self._root_client = value
 
     @property
-    def root_async_client(self) -> openai.AsyncOpenAI:
+    def root_async_client(self) -> Any:
         if self._root_async_client is None:
             async_specific = {"http_client": self.http_async_client}
             self._root_async_client = openai.AsyncOpenAI(

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -641,6 +641,10 @@ class BaseChatOpenAI(BaseChatModel):
             )
         return self._root_client
 
+    @root_client.setter
+    def root_client(self, value: openai.OpenAI) -> None:
+        self._root_client = value
+
     @property
     def root_async_client(self) -> openai.AsyncOpenAI:
         if self._root_async_client is None:
@@ -651,17 +655,29 @@ class BaseChatOpenAI(BaseChatModel):
             )
         return self._root_async_client
 
+    @root_async_client.setter
+    def root_async_client(self, value: openai.AsyncOpenAI) -> None:
+        self._root_async_client = value
+
     @property
     def client(self) -> Any:
         if self._client is None:
             self._client = self.root_client.chat.completions
         return self._client
 
+    @client.setter
+    def client(self, value: Any) -> None:
+        self._client = value
+
     @property
     def async_client(self) -> Any:
         if self._async_client is None:
             self._async_client = self.root_async_client.chat.completions
         return self._async_client
+
+    @async_client.setter
+    def async_client(self, value: Any) -> None:
+        self._async_client = value
 
     @property
     def _default_params(self) -> Dict[str, Any]:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -611,6 +611,10 @@ class BaseChatOpenAI(BaseChatModel):
             )
         return self._http_client
 
+    @http_client.setter
+    def http_client(self, value: Optional[httpx.Client]) -> None:
+        self._http_client = value
+
     @property
     def http_async_client(self) -> Optional[httpx.AsyncClient]:
         """Optional httpx.AsyncClient. Only used for async invocations.
@@ -632,6 +636,10 @@ class BaseChatOpenAI(BaseChatModel):
                 proxy=self.openai_proxy, verify=global_ssl_context
             )
         return self._http_async_client
+
+    @http_async_client.setter
+    def http_async_client(self, value: Optional[httpx.AsyncClient]) -> None:
+        self._http_async_client = value
 
     @property
     def root_client(self) -> Any:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -33,6 +33,7 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import certifi
 import openai
 import tiktoken
 from langchain_core._api.deprecation import deprecated
@@ -109,7 +110,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-global_ssl_context = ssl.create_default_context()
+# This SSL context is equivelent to the default `verify=True`.
+global_ssl_context = ssl.create_default_context(cafile=certifi.where())
 
 
 def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -591,18 +591,17 @@ class BaseChatOpenAI(BaseChatModel):
         # Configure a custom httpx client. See the
         # [httpx documentation](https://www.python-httpx.org/api/#client) for more
         # details.
-        if self._http_client is not None:
-            return self._http_client
-        if not self.openai_proxy:
-            return None
-        try:
-            import httpx
-        except ImportError as e:
-            raise ImportError(
-                "Could not import httpx python package. "
-                "Please install it with `pip install httpx`."
-            ) from e
-        self._http_client = httpx.Client(proxy=self.openai_proxy)
+        if self._http_client is None:
+            if not self.openai_proxy:
+                return None
+            try:
+                import httpx
+            except ImportError as e:
+                raise ImportError(
+                    "Could not import httpx python package. "
+                    "Please install it with `pip install httpx`."
+                ) from e
+            self._http_client = httpx.Client(proxy=self.openai_proxy)
         return self._http_client
 
     @property
@@ -612,51 +611,49 @@ class BaseChatOpenAI(BaseChatModel):
         Must specify http_client as well if you'd like a custom client for sync
         invocations.
         """
-        if self._http_async_client is not None:
-            return self._http_async_client
-        if not self.openai_proxy:
-            return None
-        try:
-            import httpx
-        except ImportError as e:
-            raise ImportError(
-                "Could not import httpx python package. "
-                "Please install it with `pip install httpx`."
-            ) from e
-        self._http_async_client = httpx.AsyncClient(proxy=self.openai_proxy)
+        if self._http_async_client is None:
+            if not self.openai_proxy:
+                return None
+            try:
+                import httpx
+            except ImportError as e:
+                raise ImportError(
+                    "Could not import httpx python package. "
+                    "Please install it with `pip install httpx`."
+                ) from e
+            self._http_async_client = httpx.AsyncClient(proxy=self.openai_proxy)
         return self._http_async_client
 
     @property
     def root_client(self) -> openai.OpenAI:
-        if self._root_client is not None:
-            return self._root_client
-        sync_specific = {"http_client": self.http_client}
-        self._root_client = openai.OpenAI(**self._client_params, **sync_specific)  # type: ignore[arg-type]
+        if self._root_client is None:
+            sync_specific = {"http_client": self.http_client}
+            self._root_client = openai.OpenAI(
+                **self._client_params,
+                **sync_specific,  # type: ignore[arg-type]
+            )
         return self._root_client
 
     @property
     def root_async_client(self) -> openai.AsyncOpenAI:
-        if self._root_async_client is not None:
-            return self._root_async_client
-        async_specific = {"http_client": self.http_async_client}
-        self._root_async_client = openai.AsyncOpenAI(
-            **self._client_params,
-            **async_specific,  # type: ignore[arg-type]
-        )
+        if self._root_async_client is None:
+            async_specific = {"http_client": self.http_async_client}
+            self._root_async_client = openai.AsyncOpenAI(
+                **self._client_params,
+                **async_specific,  # type: ignore[arg-type]
+            )
         return self._root_async_client
 
     @property
     def client(self) -> Any:
-        if self._client is not None:
-            return self._client
-        self._client = self.root_client.chat.completions
+        if self._client is None:
+            self._client = self.root_client.chat.completions
         return self._client
 
     @property
     def async_client(self) -> Any:
-        if self._async_client is not None:
-            return self._async_client
-        self._async_client = self.root_async_client.chat.completions
+        if self._async_client is None:
+            self._async_client = self.root_async_client.chat.completions
         return self._async_client
 
     @property

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -6,6 +6,7 @@ import base64
 import json
 import logging
 import os
+import ssl
 import sys
 import warnings
 from io import BytesIO
@@ -107,6 +108,8 @@ if TYPE_CHECKING:
     import httpx
 
 logger = logging.getLogger(__name__)
+
+global_ssl_context = ssl.create_default_context()
 
 
 def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
@@ -601,7 +604,9 @@ class BaseChatOpenAI(BaseChatModel):
                     "Could not import httpx python package. "
                     "Please install it with `pip install httpx`."
                 ) from e
-            self._http_client = httpx.Client(proxy=self.openai_proxy)
+            self._http_client = httpx.Client(
+                proxy=self.openai_proxy, verify=global_ssl_context
+            )
         return self._http_client
 
     @property
@@ -621,7 +626,9 @@ class BaseChatOpenAI(BaseChatModel):
                     "Could not import httpx python package. "
                     "Please install it with `pip install httpx`."
                 ) from e
-            self._http_async_client = httpx.AsyncClient(proxy=self.openai_proxy)
+            self._http_async_client = httpx.AsyncClient(
+                proxy=self.openai_proxy, verify=global_ssl_context
+            )
         return self._http_async_client
 
     @property

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -676,6 +676,16 @@ def test_openai_proxy() -> None:
         assert proxy.host == b"localhost"
         assert proxy.port == 8080
 
+    http_async_client = httpx.AsyncClient(proxy="http://localhost:8081")
+    chat_openai = ChatOpenAI(http_async_client=http_async_client)
+    mounts = chat_openai.async_client._client._client._mounts
+    assert len(mounts) == 1
+    for key, value in mounts.items():
+        proxy = value._pool._proxy_url.origin
+        assert proxy.scheme == b"http"
+        assert proxy.host == b"localhost"
+        assert proxy.port == 8081
+
 
 def test_openai_response_headers() -> None:
     """Test ChatOpenAI response headers."""

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -660,9 +660,6 @@ def test_openai_structured_output(model: str) -> None:
 def test_openai_proxy() -> None:
     """Test ChatOpenAI with proxy."""
     chat_openai = ChatOpenAI(openai_proxy="http://localhost:8080")
-    assert chat_openai.client is None
-    _ = chat_openai._client  # force client to instantiate
-    assert chat_openai.client is not None
     mounts = chat_openai.client._client._client._mounts
     assert len(mounts) == 1
     for key, value in mounts.items():
@@ -671,9 +668,6 @@ def test_openai_proxy() -> None:
         assert proxy.host == b"localhost"
         assert proxy.port == 8080
 
-    assert chat_openai.async_client is None
-    _ = chat_openai._async_client  # force client to instantiate
-    assert chat_openai.async_client is not None
     async_client_mounts = chat_openai.async_client._client._client._mounts
     assert len(async_client_mounts) == 1
     for key, value in async_client_mounts.items():

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -660,6 +660,9 @@ def test_openai_structured_output(model: str) -> None:
 def test_openai_proxy() -> None:
     """Test ChatOpenAI with proxy."""
     chat_openai = ChatOpenAI(openai_proxy="http://localhost:8080")
+    assert chat_openai.client is None
+    _ = chat_openai._client  # force client to instantiate
+    assert chat_openai.client is not None
     mounts = chat_openai.client._client._client._mounts
     assert len(mounts) == 1
     for key, value in mounts.items():
@@ -668,6 +671,9 @@ def test_openai_proxy() -> None:
         assert proxy.host == b"localhost"
         assert proxy.port == 8080
 
+    assert chat_openai.async_client is None
+    _ = chat_openai._async_client  # force client to instantiate
+    assert chat_openai.async_client is not None
     async_client_mounts = chat_openai.async_client._client._client._mounts
     assert len(async_client_mounts) == 1
     for key, value in async_client_mounts.items():

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -14,6 +14,7 @@ def test_initialize_azure_openai() -> None:
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
         azure_endpoint="my-base-url",
+        http_client=None,
     )
     assert llm.deployment_name == "35-turbo-dev"
     assert llm.openai_api_version == "2023-05-15"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -541,6 +541,9 @@ def test_openai_invoke(mock_client: MagicMock) -> None:
         assert "headers" not in res.response_metadata
     assert mock_client.create.called
 
+    assert llm.root_client is None
+    assert llm.root_async_client is None
+
 
 async def test_openai_ainvoke(mock_async_client: AsyncMock) -> None:
     llm = ChatOpenAI()

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -298,7 +298,7 @@ async def test_glm4_astream(mock_glm4_completion: list) -> None:
     usage_chunk = mock_glm4_completion[-1]
 
     usage_metadata: Optional[UsageMetadata] = None
-    with patch.object(llm, "async_client", mock_client):
+    with patch.object(llm, "_async_client", mock_client):
         async for chunk in llm.astream("你的名字叫什么？只回答名字"):
             assert isinstance(chunk, AIMessageChunk)
             if chunk.usage_metadata is not None:
@@ -323,7 +323,7 @@ def test_glm4_stream(mock_glm4_completion: list) -> None:
     usage_chunk = mock_glm4_completion[-1]
 
     usage_metadata: Optional[UsageMetadata] = None
-    with patch.object(llm, "client", mock_client):
+    with patch.object(llm, "_client", mock_client):
         for chunk in llm.stream("你的名字叫什么？只回答名字"):
             assert isinstance(chunk, AIMessageChunk)
             if chunk.usage_metadata is not None:
@@ -378,7 +378,7 @@ async def test_deepseek_astream(mock_deepseek_completion: list) -> None:
     mock_client.create = mock_create
     usage_chunk = mock_deepseek_completion[-1]
     usage_metadata: Optional[UsageMetadata] = None
-    with patch.object(llm, "async_client", mock_client):
+    with patch.object(llm, "_async_client", mock_client):
         async for chunk in llm.astream("你的名字叫什么？只回答名字"):
             assert isinstance(chunk, AIMessageChunk)
             if chunk.usage_metadata is not None:
@@ -402,7 +402,7 @@ def test_deepseek_stream(mock_deepseek_completion: list) -> None:
     mock_client.create = mock_create
     usage_chunk = mock_deepseek_completion[-1]
     usage_metadata: Optional[UsageMetadata] = None
-    with patch.object(llm, "client", mock_client):
+    with patch.object(llm, "_client", mock_client):
         for chunk in llm.stream("你的名字叫什么？只回答名字"):
             assert isinstance(chunk, AIMessageChunk)
             if chunk.usage_metadata is not None:
@@ -446,7 +446,7 @@ async def test_openai_astream(mock_openai_completion: list) -> None:
     mock_client.create = mock_create
     usage_chunk = mock_openai_completion[-1]
     usage_metadata: Optional[UsageMetadata] = None
-    with patch.object(llm, "async_client", mock_client):
+    with patch.object(llm, "_async_client", mock_client):
         async for chunk in llm.astream("你的名字叫什么？只回答名字"):
             assert isinstance(chunk, AIMessageChunk)
             if chunk.usage_metadata is not None:
@@ -470,7 +470,7 @@ def test_openai_stream(mock_openai_completion: list) -> None:
     mock_client.create = mock_create
     usage_chunk = mock_openai_completion[-1]
     usage_metadata: Optional[UsageMetadata] = None
-    with patch.object(llm, "client", mock_client):
+    with patch.object(llm, "_client", mock_client):
         for chunk in llm.stream("你的名字叫什么？只回答名字"):
             assert isinstance(chunk, AIMessageChunk)
             if chunk.usage_metadata is not None:
@@ -533,7 +533,7 @@ def mock_async_client(mock_completion: dict) -> AsyncMock:
 def test_openai_invoke(mock_client: MagicMock) -> None:
     llm = ChatOpenAI()
 
-    with patch.object(llm, "client", mock_client):
+    with patch.object(llm, "_client", mock_client):
         res = llm.invoke("bar")
         assert res.content == "Bar Baz"
 
@@ -541,13 +541,13 @@ def test_openai_invoke(mock_client: MagicMock) -> None:
         assert "headers" not in res.response_metadata
     assert mock_client.create.called
 
-    assert llm.async_client is None
+    assert llm._async_client is None
 
 
 async def test_openai_ainvoke(mock_async_client: AsyncMock) -> None:
     llm = ChatOpenAI()
 
-    with patch.object(llm, "async_client", mock_async_client):
+    with patch.object(llm, "_async_client", mock_async_client):
         res = await llm.ainvoke("bar")
         assert res.content == "Bar Baz"
 
@@ -575,7 +575,7 @@ def test__get_encoding_model(model: str) -> None:
 def test_openai_invoke_name(mock_client: MagicMock) -> None:
     llm = ChatOpenAI()
 
-    with patch.object(llm, "client", mock_client):
+    with patch.object(llm, "_client", mock_client):
         messages = [HumanMessage(content="Foo", name="Katie")]
         res = llm.invoke(messages)
         call_args, call_kwargs = mock_client.create.call_args

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -541,8 +541,7 @@ def test_openai_invoke(mock_client: MagicMock) -> None:
         assert "headers" not in res.response_metadata
     assert mock_client.create.called
 
-    assert llm.root_client is None
-    assert llm.root_async_client is None
+    assert llm.async_client is None
 
 
 async def test_openai_ainvoke(mock_async_client: AsyncMock) -> None:


### PR DESCRIPTION
https://github.com/langchain-ai/langchain/issues/29925

Simplified version of the change below.

**Before**:
```python
from typing import Any, Optional

import openai
from pydantic import BaseModel, Field, SecretStr, model_validator
from typing_extensions import Self


class BaseChatOpenAI(BaseModel):
    client: Any = Field(default=None, exclude=True)
    async_client: Any = Field(default=None, exclude=True)
    my_special_api_key: Optional[SecretStr] = Field(alias="api_key")

    @model_validator(mode="after")
    def validate_environment(self) -> Self:
        client_params = {"api_key": self.my_special_api_key}
        if not self.client:
            self.client = openai.OpenAI(**client_params)  # type: ignore[arg-type]
        if not self.async_client:
            self.async_client = openai.AsyncOpenAI(**client_params)  # type: ignore[arg-type]
        return self
```

**After**:
```python
from typing import Any, Dict, Optional

import openai
from pydantic import BaseModel, Field, PrivateAttr, SecretStr, model_validator
from typing_extensions import Self

class BaseChatOpenAI(BaseModel):
    _client: Any = PrivateAttr(default=None)
    _async_client: Any = PrivateAttr(default=None)
    _client_params: Dict[str, Any] = PrivateAttr(default_factory=dict)
    my_special_api_key: Optional[SecretStr] = Field(alias="api_key")

    # Needed to support initializing the class with `client`
    def __init__(
        self, client: Any = None, async_client: Any = None, **kwargs: Any
    ) -> None:
        super().__init__(**kwargs)
        self._client = client
        self._async_client = async_client

    @model_validator(mode="after")
    def validate_environment(self) -> Self:
        self._client_params = {"api_key": self.my_special_api_key}
        return self

    @property
    def client(self) -> Any:
        if self._client is None:
            self._client = openai.OpenAI(**self._client_params)  # type: ignore[arg-type]
        return self._client

    @client.setter
    def client(self, value: Any) -> None:
        self._client = value

    @property
    def async_client(self) -> Any:
        if self._async_client is None:
            self._async_client = openai.AsyncOpenAI(**self._client_params)  # type: ignore[arg-type]
        return self._async_client

    @async_client.setter
    def async_client(self, value: Any) -> None:
        self._async_client = value
```

I'm not sure there is a way to do this that is not semver-breaking. One usage pattern I know breaks is subclasses of BaseChatOpenAI, most of which have unique names for their API keys and other attributes (e.g., `xai_api_key`, `together_api_key`, etc.). These subclasses have post init steps that look like:
```python
@model_validator(mode="after")
def validate_environment(self) -> Self:
    client_params = {"api_key": self.xai_api_key.get_secret_value()}
    if not self.client:  # <-- breaks
        self.client = openai.OpenAI(**client_params)
```
The check `if not self.client` breaks because we now try to instantiate the client in a property, and this requires that client params be accessible to the property.

Current plan is to update classes we control and explain how to update sub-classes in release notes. The update is simple but would be annoying.