### PR TITLE
core, openai[patch]: support serialization of pydantic models in messages

### DIFF
--- a/libs/core/langchain_core/load/dump.py
+++ b/libs/core/langchain_core/load/dump.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any
 
+from pydantic import BaseModel
+
 from langchain_core.load.serializable import Serializable, to_json_not_implemented
 
 
@@ -18,6 +20,23 @@ def default(obj: Any) -> Any:
         return obj.to_json()
     else:
         return to_json_not_implemented(obj)
+
+
+def _dump_pydantic_models(obj: Any) -> Any:
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration
+
+    if (
+        isinstance(obj, ChatGeneration)
+        and isinstance(obj.message, AIMessage)
+        and (parsed := obj.message.additional_kwargs.get("parsed"))
+        and isinstance(parsed, BaseModel)
+    ):
+        obj_copy = obj.model_copy(deep=True)
+        obj_copy.message.additional_kwargs["parsed"] = parsed.model_dump()
+        return obj_copy
+    else:
+        return obj
 
 
 def dumps(obj: Any, *, pretty: bool = False, **kwargs: Any) -> str:
@@ -40,6 +59,7 @@ def dumps(obj: Any, *, pretty: bool = False, **kwargs: Any) -> str:
         msg = "`default` should not be passed to dumps"
         raise ValueError(msg)
     try:
+        obj = _dump_pydantic_models(obj)
         if pretty:
             indent = kwargs.pop("indent", 2)
             return json.dumps(obj, default=default, indent=indent, **kwargs)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1,11 +1,13 @@
 """Test OpenAI Chat API wrapper."""
 
 import json
+from functools import partial
 from types import TracebackType
 from typing import Any, Dict, List, Literal, Optional, Type, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.load import dumps, loads
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -17,6 +19,8 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langchain_core.messages.ai import UsageMetadata
+from langchain_core.outputs import ChatGeneration
+from langchain_core.runnables import RunnableLambda
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
@@ -27,6 +31,7 @@ from langchain_openai.chat_models.base import (
     _convert_to_openai_response_format,
     _create_usage_metadata,
     _format_message_content,
+    _oai_structured_outputs_parser,
 )
 
 
@@ -899,3 +904,21 @@ def test_structured_output_old_model() -> None:
     # assert tool calling was used instead of json_schema
     assert "tools" in llm.steps[0].kwargs  # type: ignore
     assert "response_format" not in llm.steps[0].kwargs  # type: ignore
+
+
+def test_structured_outputs_parser() -> None:
+    parsed_response = GenerateUsername(name="alice", hair_color="black")
+    llm_output = ChatGeneration(
+        message=AIMessage(
+            content='{"name": "alice", "hair_color": "black"}',
+            additional_kwargs={"parsed": parsed_response},
+        )
+    )
+    output_parser = RunnableLambda(
+        partial(_oai_structured_outputs_parser, schema=GenerateUsername)
+    )
+    serialized = dumps(llm_output)
+    deserialized = loads(serialized)
+    assert isinstance(deserialized, ChatGeneration)
+    result = output_parser.invoke(deserialized.message)
+    assert result == parsed_response


### PR DESCRIPTION
Resolves https://github.com/langchain-ai/langchain/issues/29003, https://github.com/langchain-ai/langchain/issues/27264
Related: https://github.com/langchain-ai/langchain-redis/issues/52

```python
from langchain.chat_models import init_chat_model
from langchain.globals import set_llm_cache
from langchain_community.cache import SQLiteCache
from pydantic import BaseModel

cache = SQLiteCache()

set_llm_cache(cache)

class Temperature(BaseModel):
    value: int
    city: str

llm = init_chat_model("openai:gpt-4o-mini")
structured_llm = llm.with_structured_output(Temperature)
```
```python
# 681 ms
response = structured_llm.invoke("What is the average temperature of Rome in May?")
```
```python
# 6.98 ms
response = structured_llm.invoke("What is the average temperature of Rome in May?")
```