### PR TITLE
docs(docs/how_to) : Fix the invalid URL link

### DIFF
--- a/docs/docs/how_to/tool_artifacts.ipynb
+++ b/docs/docs/how_to/tool_artifacts.ipynb
@@ -88,13 +88,6 @@
      "metadata": {},
      "output_type": "execute_result"
     },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Failed to batch ingest runs: LangSmithRateLimitError('Rate limit exceeded for https://api.smith.langchain.com/runs/batch. HTTPError(\\'429 Client Error: Too Many Requests for url: https://api.smith.langchain.com/runs/batch\\', \\'{\"detail\":\"Monthly unique traces usage limit exceeded\"}\\')')\n"
-     ]
-    }
    ],
    "source": [
     "generate_random_ints.invoke({\"min\": 0, \"max\": 9, \"size\": 10})"


### PR DESCRIPTION
update `custom_tools.ipynb` : Fix the invalid URL link