### PR TITLE
langchain[patch]: remove explicit dependency on tenacity

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "requests<3,>=2",
     "PyYAML>=5.3",
     "aiohttp<4.0.0,>=3.8.3",
-    "tenacity!=8.4.0,<10,>=8.1.0",
     "numpy<2,>=1.26.4; python_version < \"3.12\"",
     "numpy<3,>=1.26.2; python_version >= \"3.12\"",
     "async-timeout<5.0.0,>=4.0.0; python_version < \"3.11\"",

--- a/libs/langchain/tests/unit_tests/test_dependencies.py
+++ b/libs/langchain/tests/unit_tests/test_dependencies.py
@@ -41,7 +41,6 @@ def test_required_dependencies(uv_conf: Mapping[str, Any]) -> None:
             "numpy",
             "pydantic",
             "requests",
-            "tenacity",
         ]
     )
 

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2254,7 +2254,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -2398,7 +2397,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.3" },
     { name = "requests", specifier = ">=2,<3" },
     { name = "sqlalchemy", specifier = ">=1.4,<3" },
-    { name = "tenacity", specifier = ">=8.1.0,!=8.4.0,<10" },
 ]
 
 [package.metadata.requires-dev]
@@ -2536,7 +2534,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.35"
+version = "0.3.39"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2713,7 +2711,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Not used anywhere in `langchain`, already a dependency of langchain-core.