### PR TITLE
langchain[patch]: remove aiohttp

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "SQLAlchemy<3,>=1.4",
     "requests<3,>=2",
     "PyYAML>=5.3",
-    "aiohttp<4.0.0,>=3.8.3",
     "numpy<2,>=1.26.4; python_version < \"3.12\"",
     "numpy<3,>=1.26.2; python_version >= \"3.12\"",
     "async-timeout<5.0.0,>=4.0.0; python_version < \"3.11\"",

--- a/libs/langchain/tests/unit_tests/test_dependencies.py
+++ b/libs/langchain/tests/unit_tests/test_dependencies.py
@@ -33,7 +33,6 @@ def test_required_dependencies(uv_conf: Mapping[str, Any]) -> None:
         [
             "PyYAML",
             "SQLAlchemy",
-            "aiohttp",
             "async-timeout",
             "langchain-core",
             "langchain-text-splitters",

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2243,7 +2243,6 @@ name = "langchain"
 version = "0.3.19"
 source = { editable = "." }
 dependencies = [
-    { name = "aiohttp" },
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "langchain-core" },
     { name = "langchain-text-splitters" },
@@ -2371,7 +2370,6 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.8.3,<4.0.0" },
     { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5.0.0" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-aws", marker = "extra == 'aws'" },


### PR DESCRIPTION
My guess is this was left over from when `community` was in langchain.