### PR TITLE
community: add title, score and raw_content to tavily search results

### DIFF
--- a/libs/community/langchain_community/utilities/tavily_search.py
+++ b/libs/community/langchain_community/utilities/tavily_search.py
@@ -178,8 +178,11 @@ class TavilySearchAPIWrapper(BaseModel):
         for result in results:
             clean_results.append(
                 {
+                    "title": result["title"],
                     "url": result["url"],
                     "content": result["content"],
+                    "score": result["score"],
+                    "raw_content": result.get("raw_content"),
                 }
             )
         return clean_results

--- a/libs/community/langchain_community/utilities/tavily_search.py
+++ b/libs/community/langchain_community/utilities/tavily_search.py
@@ -176,13 +176,13 @@ class TavilySearchAPIWrapper(BaseModel):
         """Clean results from Tavily Search API."""
         clean_results = []
         for result in results:
-            clean_results.append(
-                {
-                    "title": result["title"],
-                    "url": result["url"],
-                    "content": result["content"],
-                    "score": result["score"],
-                    "raw_content": result.get("raw_content"),
-                }
-            )
+            clean_result = {
+                "title": result["title"],
+                "url": result["url"],
+                "content": result["content"],
+                "score": result["score"],
+            }
+            if raw_content := result.get("raw_content"):
+                clean_result["raw_content"] = raw_content
+            clean_results.append(clean_result)
         return clean_results


### PR DESCRIPTION
**Description:**

Tavily search results returned from API include useful information like title, score and (optionally) raw_content that is missed in wrapper although it's documented there properly. Add this data  to the result structure.
