### PR TITLE
Added ChatGrok extension to ChatXAI with grok_version support

### DIFF
--- a/libs/partners/xai/langchain_xai/__init__.py
+++ b/libs/partners/xai/langchain_xai/__init__.py
@@ -1,5 +1,5 @@
 """This package provides the xAI integration for LangChain."""
 
-from langchain_xai.chat_models import ChatXAI, ChatGrok
+from langchain_xai.chat_models import ChatGrok, ChatXAI
 
 __all__ = ["ChatXAI", "ChatGrok"]

--- a/libs/partners/xai/langchain_xai/__init__.py
+++ b/libs/partners/xai/langchain_xai/__init__.py
@@ -1,5 +1,5 @@
 """This package provides the xAI integration for LangChain."""
 
-from langchain_xai.chat_models import ChatXAI
+from langchain_xai.chat_models import ChatXAI, ChatGrok
 
-__all__ = ["ChatXAI"]
+__all__ = ["ChatXAI", "ChatGrok"]

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -1,19 +1,16 @@
 """Wrapper around xAI's Chat Completions API."""
 
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-)
-
+from typing import Any, Dict, List, Optional
 import openai
 from langchain_core.language_models.chat_models import LangSmithParams
 from langchain_core.utils import secret_from_env
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
-
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatResult, ChatGeneration
+from langchain_core.callbacks import CallbackManagerForLLMRun
+import os
 
 class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
     r"""ChatXAI chat model.
@@ -359,3 +356,67 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
                 **async_specific,
             )
         return self
+
+# Extension of ChatXAI optimized for Grok models (e.g., Grok 2, Grok 3)
+class ChatGrok(ChatXAI):
+    """An extended version of ChatXAI optimized for Grok models (e.g., Grok 2, Grok 3)."""
+
+    grok_version: Optional[str] = Field(default=None, description="Grok model version (e.g., '2', '3')")
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "grok-2",  # Default to Grok 2, adaptable to Grok 3 later
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        grok_version: Optional[str] = None,  # Hypothetical Grok-specific param
+        **kwargs
+    ):
+        # Fetch API key from env if not provided (ChatXAI handles SecretStr conversion)
+        api_key = api_key or os.environ.get("XAI_API_KEY")
+        if not api_key:
+            raise ValueError("XAI_API_KEY must be provided or set in environment.")
+
+        # Adjust model based on grok_version before passing to parent
+        if grok_version:
+            model = f"grok-{grok_version}"
+
+        # Pass to parent ChatXAI
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs
+        )
+
+        # Grok-specific customization
+        self.grok_version = grok_version
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs
+    ) -> ChatResult:
+        """Override to add Grok-specific tweaks if needed."""
+        print(f"Calling Grok model: {self.model_name}")  # Use model_name instead of model
+        # Delegate to BaseChatOpenAI's _generate, which returns ChatResult
+        result = super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        return result
+
+    @property
+    def _llm_type(self) -> str:
+        """Unique identifier for Grok-specific chat model."""
+        return "grok_chat"
+
+    def with_grok_config(self, grok_version: str) -> "ChatGrok":
+        """Convenience method to switch Grok versions."""
+        return ChatGrok(
+            api_key=self.xai_api_key.get_secret_value() if self.xai_api_key else None,
+            model=self.model_name,  # Use model_name here too
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            grok_version=grok_version
+        )

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -376,20 +376,18 @@ class ChatGrok(ChatXAI):
         self,
         api_key: Optional[str] = None,
         model: str = "grok-2",
-        temperature: float = 0.7,
+        temperature: Optional[float] = 0.7,
         max_tokens: Optional[int] = None,
         grok_version: Optional[str] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """Initialize ChatGrok with xAI API key and Grok version."""
-        api_key = api_key or os.environ.get("XAI_API_KEY")
-        if not api_key:
+        api_key_str = api_key or os.environ.get("XAI_API_KEY")
+        if not api_key_str:
             raise ValueError("XAI_API_KEY must be provided or set in environment.")
-        if grok_version:
-            model = f"grok-{grok_version}"
         super().__init__(
-            api_key=api_key,
-            model=model,
+            api_key=SecretStr(api_key_str) if api_key_str else None,
+            model=model if not grok_version else f"grok-{grok_version}",
             temperature=temperature,
             max_tokens=max_tokens,
             **kwargs,
@@ -401,7 +399,7 @@ class ChatGrok(ChatXAI):
         messages: List[BaseMessage],
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> ChatResult:
         """Generate a response using the specified Grok model."""
         print(f"Calling Grok model: {self.model_name}")

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -1,17 +1,16 @@
 """Wrapper around xAI's Chat Completions API."""
 
-import os
 from typing import Any, Dict, List, Optional
-
 import openai
-from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import LangSmithParams
-from langchain_core.messages import AIMessage, BaseMessage
-from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.utils import secret_from_env
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+from langchain_core.callbacks import CallbackManagerForLLMRun
+import os
 
 
 class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
@@ -362,7 +361,6 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
 
 # Extension of ChatXAI optimized for Grok models (e.g., Grok 2, Grok 3)
 class ChatGrok(ChatXAI):
-    """An extended version of ChatXAI optimized for Grok models (e.g., Grok 2, Grok 3)."""
 
     grok_version: Optional[str] = Field(
         default=None, description="Grok model version (e.g., '2', '3')"
@@ -380,7 +378,9 @@ class ChatGrok(ChatXAI):
         """Initialize ChatGrok with xAI API key and Grok version."""
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if not api_key:
-            raise ValueError("XAI_API_KEY must be provided or set in environment.")
+            raise ValueError(
+                "XAI_API_KEY must be provided or set "
+                "in environment.")
         if grok_version:
             model = f"grok-{grok_version}"
         super().__init__(

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -1,8 +1,9 @@
 """Wrapper around xAI's Chat Completions API."""
 
-import openai
 import os
 from typing import Any, Dict, List, Optional
+
+import openai
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import LangSmithParams
 from langchain_core.messages import BaseMessage
@@ -361,6 +362,11 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
 
 # Extension of ChatXAI optimized for Grok models (e.g., Grok 2, Grok 3)
 class ChatGrok(ChatXAI):
+    """Chat model for xAI's Grok, supporting versioned models like Grok 2 and 3.
+
+    This class extends ChatXAI to provide a convenient way to specify Grok model
+    versions using the `grok_version` parameter.
+    """
 
     grok_version: Optional[str] = Field(
         default=None, description="Grok model version (e.g., '2', '3')"
@@ -373,15 +379,12 @@ class ChatGrok(ChatXAI):
         temperature: float = 0.7,
         max_tokens: Optional[int] = None,
         grok_version: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         """Initialize ChatGrok with xAI API key and Grok version."""
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if not api_key:
-            raise ValueError(
-                "XAI_API_KEY must be provided or set "
-                "in environment."
-            )
+            raise ValueError("XAI_API_KEY must be provided or set in environment.")
         if grok_version:
             model = f"grok-{grok_version}"
         super().__init__(
@@ -389,7 +392,7 @@ class ChatGrok(ChatXAI):
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
-            **kwargs
+            **kwargs,
         )
         self.grok_version = grok_version
 
@@ -398,13 +401,11 @@ class ChatGrok(ChatXAI):
         messages: List[BaseMessage],
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
-        **kwargs
+        **kwargs,
     ) -> ChatResult:
         """Generate a response using the specified Grok model."""
         print(f"Calling Grok model: {self.model_name}")
-        return super()._generate(
-            messages, stop=stop, run_manager=run_manager, **kwargs
-        )
+        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
 
     @property
     def _llm_type(self) -> str:
@@ -414,9 +415,7 @@ class ChatGrok(ChatXAI):
     def with_grok_config(self, grok_version: str) -> "ChatGrok":
         """Return a new ChatGrok instance with updated Grok version."""
         return ChatGrok(
-            api_key=self.xai_api_key.get_secret_value()
-            if self.xai_api_key
-            else None,
+            api_key=self.xai_api_key.get_secret_value() if self.xai_api_key else None,
             model=self.model_name,
             temperature=self.temperature,
             max_tokens=self.max_tokens,

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -1,16 +1,16 @@
 """Wrapper around xAI's Chat Completions API."""
 
-from typing import Any, Dict, List, Optional
 import openai
+import os
+from typing import Any, Dict, List, Optional
+from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import LangSmithParams
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
 from langchain_core.utils import secret_from_env
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
-from langchain_core.messages import BaseMessage
-from langchain_core.outputs import ChatResult
-from langchain_core.callbacks import CallbackManagerForLLMRun
-import os
 
 
 class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
@@ -373,14 +373,15 @@ class ChatGrok(ChatXAI):
         temperature: float = 0.7,
         max_tokens: Optional[int] = None,
         grok_version: Optional[str] = None,
-        **kwargs,
+        **kwargs
     ):
         """Initialize ChatGrok with xAI API key and Grok version."""
         api_key = api_key or os.environ.get("XAI_API_KEY")
         if not api_key:
             raise ValueError(
                 "XAI_API_KEY must be provided or set "
-                "in environment.")
+                "in environment."
+            )
         if grok_version:
             model = f"grok-{grok_version}"
         super().__init__(
@@ -388,7 +389,7 @@ class ChatGrok(ChatXAI):
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
-            **kwargs,
+            **kwargs
         )
         self.grok_version = grok_version
 
@@ -397,11 +398,13 @@ class ChatGrok(ChatXAI):
         messages: List[BaseMessage],
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
-        **kwargs,
+        **kwargs
     ) -> ChatResult:
         """Generate a response using the specified Grok model."""
         print(f"Calling Grok model: {self.model_name}")
-        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+        return super()._generate(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        )
 
     @property
     def _llm_type(self) -> str:
@@ -411,7 +414,9 @@ class ChatGrok(ChatXAI):
     def with_grok_config(self, grok_version: str) -> "ChatGrok":
         """Return a new ChatGrok instance with updated Grok version."""
         return ChatGrok(
-            api_key=self.xai_api_key.get_secret_value() if self.xai_api_key else None,
+            api_key=self.xai_api_key.get_secret_value()
+            if self.xai_api_key
+            else None,
             model=self.model_name,
             temperature=self.temperature,
             max_tokens=self.max_tokens,

--- a/libs/partners/xai/tests/unit_tests/test_imports.py
+++ b/libs/partners/xai/tests/unit_tests/test_imports.py
@@ -1,6 +1,6 @@
 from langchain_xai import __all__
 
-EXPECTED_ALL = ["ChatXAI"]
+EXPECTED_ALL = ["ChatXAI", "ChatGrok"]
 
 
 def test_all_imports() -> None:


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [ ] **PR title**: "partners: add ChatGrok extension to ChatXAI with grok_version support"
  - Where "package" is whichever of langchain, community, core, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** This PR adds `ChatGrok`, a new class extending `ChatXAI` in the `langchain-xai` package. It introduces a `grok_version` parameter to easily specify Grok model versions (e.g., "grok-2", "grok-3"). The change is backwards compatible and leverages existing `BaseChatOpenAI` functionality.
    - **Issue:** NA
    - **Dependencies:** none
    - **Twitter handle:** @TiestVangool


- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.
