### PR TITLE
openai[patch]: warn on invalid reasoning model parameters

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -535,7 +535,6 @@ class BaseChatOpenAI(BaseChatModel):
         """Currently only o-series models support reasoning_effort."""
         model = values.get("model_name") or values.get("model") or ""
         if not re.match(r"^o\d", model) and values.get("reasoning_effort") is not None:
-            reasoning_effort = values.get("reasoning_effort")
             warnings.warn(
                 f"Reasoning effort is not supported for model '{model}'. Defaulting "
                 "to null."


### PR DESCRIPTION
```python
from langchain_openai import ChatOpenAI

llm = ChatOpenAI(model="o1-mini", temperature=0.5)  # raises warning
assert llm.temperature is None

llm = ChatOpenAI(model="gpt-4o-mini", reasoning_effort="low")  # raises warning
assert llm.reasoning_effort is None
```