### PR TITLE
anthropic[patch]: allow structured output when thinking is enabled

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -26,6 +26,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
+from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
@@ -969,8 +970,9 @@ class ChatAnthropic(BaseChatModel):
         thinking_admonition = (
             "Anthropic structured output relies on forced tool calling, "
             "which is not supported when `thinking` is enabled. This method will raise "
-            "NotImplementedError if tool calls are not generated. Consider disabling "
-            "`thinking` or adjust your prompt to ensure the tool is called."
+            "langchain_core.exceptions.OutputParserException if tool calls are not "
+            "generated. Consider disabling `thinking` or adjust your prompt to ensure "
+            "the tool is called."
         )
         warnings.warn(thinking_admonition)
         llm = self.bind_tools(
@@ -980,7 +982,7 @@ class ChatAnthropic(BaseChatModel):
 
         def _raise_if_no_tool_calls(message: AIMessage) -> AIMessage:
             if not message.tool_calls:
-                raise NotImplementedError(thinking_admonition)
+                raise OutputParserException(thinking_admonition)
             return message
 
         return llm | _raise_if_no_tool_calls

--- a/libs/partners/anthropic/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_chat_models.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from anthropic import BadRequestError
 from langchain_core.callbacks import CallbackManager
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -740,7 +741,7 @@ def test_structured_output_thinking_enabled() -> None:
     response = structured_llm.invoke(query)
     assert isinstance(response, GenerateUsername)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(OutputParserException):
         structured_llm.invoke("Hello")
 
     # Test streaming


### PR DESCRIPTION
Structured output will currently always raise a BadRequestError when Claude 3.7 Sonnet's `thinking` is enabled, because we rely on forced tool use for structured output and this feature is not supported when `thinking` is enabled.

Here we:
- Emit a warning if `with_structured_output` is called when `thinking` is enabled.
- Raise `OutputParserException` if no tool calls are generated.

This is arguably preferable to raising an error in all cases.

```python
from langchain_anthropic import ChatAnthropic
from pydantic import BaseModel


class Person(BaseModel):
    name: str
    age: int


llm = ChatAnthropic(
    model="claude-3-7-sonnet-latest",
    max_tokens=5_000,
    thinking={"type": "enabled", "budget_tokens": 2_000},
)
structured_llm = llm.with_structured_output(Person)  # <-- this generates a warning
```

```python
structured_llm.invoke("Alice is 30.")  # <-- works
```

```python
structured_llm.invoke("Hello!")  # <-- raises OutputParserException
```