### PR TITLE
docs: refine milvus server description

### DIFF
--- a/docs/docs/integrations/vectorstores/milvus.ipynb
+++ b/docs/docs/integrations/vectorstores/milvus.ipynb
@@ -115,13 +115,13 @@
    "id": "df34e8f4",
    "metadata": {},
    "source": [
-    "### Milvus Standalone\n",
+    "### Milvus Server\n",
     "\n",
     "If you have a large amount of data (e.g., more than a million vectors), we recommend setting up a more performant Milvus server on [Docker](https://milvus.io/docs/install_standalone-docker.md#Start-Milvus) or [Kubernetes](https://milvus.io/docs/install_cluster-milvusoperator.md).\n",
     "\n",
-    "Milvus Standalone also supports different [indexes](https://milvus.io/docs/index.md?tab=floating), if you want to improve retrieval functionality.\n",
+    "The Milvus server offers support for a variety of [indexes](https://milvus.io/docs/index.md?tab=floating). Leveraging these different indexes can significantly enhance the retrieval capabilities and expedite the retrieval process, tailored to your specific requirements.\n",
     "\n",
-    "To launch the Docker container, run:"
+    "As an illustration, consider the case of Milvus Standalone. To initiate the Docker container, you can run the following command:"
    ]
   },
   {


### PR DESCRIPTION
Document refinement: optimize milvus server description. The description of "milvus standalone", and "milvus server" is confusing, so I clarify it with a detailed description.