### PR TITLE
docs:Add SWI-Prolog for langchain-prolog

### DIFF
--- a/docs/docs/integrations/providers/prolog.md
+++ b/docs/docs/integrations/providers/prolog.md
@@ -4,7 +4,7 @@ SWI-Prolog offers a comprehensive free Prolog environment.
 
 ## Installation and Setup
 
-Install lanchain-prolog using pip:
+Once SWI-Prolog has been installed, install lanchain-prolog using pip:
 ```bash
 pip install langchain-prolog
 ```


### PR DESCRIPTION
Some users have complained that t is not clear that SWI-Prolog must be installed before installing langchain-prolog.
