### PR TITLE
docs: Fix typo in code samples for max_tokens_for_prompt

### DIFF
--- a/libs/community/langchain_community/llms/openai.py
+++ b/libs/community/langchain_community/llms/openai.py
@@ -724,7 +724,7 @@ class BaseOpenAI(BaseLLM):
         Example:
             .. code-block:: python
 
-                max_tokens = openai.max_token_for_prompt("Tell me a joke.")
+                max_tokens = openai.max_tokens_for_prompt("Tell me a joke.")
         """
         num_tokens = self.get_num_tokens(prompt)
         return self.max_context_size - num_tokens

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -581,7 +581,7 @@ class BaseOpenAI(BaseLLM):
         Example:
             .. code-block:: python
 
-                max_tokens = openai.max_token_for_prompt("Tell me a joke.")
+                max_tokens = openai.max_tokens_for_prompt("Tell me a joke.")
         """
         num_tokens = self.get_num_tokens(prompt)
         return self.max_context_size - num_tokens


### PR DESCRIPTION
- **Description:** Fix typo in code samples for max_tokens_for_prompt. Code blocks had singular "token" but the method has plural "tokens".
- **Issue:** N/A
- **Dependencies:** N/A
- **Twitter handle:** N/A