### PR TITLE
community:Adding async support for AWS DocumentDB

### DIFF
--- a/libs/community/langchain_community/vectorstores/documentdb.py
+++ b/libs/community/langchain_community/vectorstores/documentdb.py
@@ -279,7 +279,7 @@ class DocumentDBVectorSearch(VectorStore):
     ) -> DocumentDBVectorSearch:
         if collection is None:
             raise ValueError("Must provide 'collection' named parameter.")
-        vectorstore = cls(collection, embedding, **kwargs)
+        vectorstore = cls(collection, embedding, **kwargs)  # type: ignore[arg-type]
         vectorstore.add_texts(texts, metadatas=metadatas)
         return vectorstore
 

--- a/libs/community/langchain_community/vectorstores/documentdb.py
+++ b/libs/community/langchain_community/vectorstores/documentdb.py
@@ -19,7 +19,6 @@ from langchain_core.vectorstores import VectorStore
 
 if TYPE_CHECKING:
     from langchain_core.embeddings import Embeddings
-    from motor.core import AgnosticClient, AgnosticCollection
     from pymongo.collection import Collection
 
 
@@ -54,8 +53,8 @@ class DocumentDBVectorSearch(VectorStore):
     Example:
         . code-block:: python
 
-            from langchain_aws.vectorstores import DocumentDBVectorSearch
-            from langchain_aws.embeddings.openai import OpenAIEmbeddings
+            from langchain_community.vectorstores import DocumentDBVectorSearch
+            from langchain_community.embeddings.openai import OpenAIEmbeddings
             from pymongo import MongoClient
 
             mongo_client = MongoClient("<YOUR-CONNECTION-STRING>")
@@ -72,8 +71,6 @@ class DocumentDBVectorSearch(VectorStore):
         index_name: str = "vectorSearchIndex",
         text_key: str = "textContent",
         embedding_key: str = "vectorContent",
-        is_async: bool = False,
-        async_collection: AgnosticCollection,
     ):
         """Constructor for DocumentDBVectorSearch
 
@@ -85,39 +82,17 @@ class DocumentDBVectorSearch(VectorStore):
                 for each document.
             embedding_key: MongoDB field that will contain the embedding
                 for each document.
-            is_async: Whether the collection is async or not.
-            async_collection: Async version of the collection.
-            NOTES:
-                * If `is_async` is True, `async_collection` must be provided.
-                * `collection` must be provided also when `is_async` is False.
         """
-        if collection is None:
-            raise ValueError("Must provide 'collection' named parameter.")
         self._collection = collection
         self._embedding = embedding
         self._index_name = index_name
         self._text_key = text_key
         self._embedding_key = embedding_key
         self._similarity_type = DocumentDBSimilarityType.COS
-        self.is_async = is_async
-        if is_async and async_collection is None:
-            raise ValueError(
-                f"Expecting `async_collection` when `is_async` is defined.\n \
-                    Go async_collection = `{async_collection}`"
-            )
-        self._async_collection = async_collection  # type: ignore[arg-type]
 
     @property
     def embeddings(self) -> Embeddings:
         return self._embedding
-
-    def validate_async(self) -> None:
-        if not self.is_async:
-            raise RuntimeError(
-                f"Async functions can only be called \n \
-                    when the object `is_async` flag is `True`.\n \
-                               is_async = `{self.is_async}`"
-            )
 
     def get_index_name(self) -> str:
         """Returns the index name
@@ -160,53 +135,6 @@ class DocumentDBVectorSearch(VectorStore):
         collection = client[db_name][collection_name]
         return cls(collection, embedding, **kwargs)
 
-    @classmethod
-    def afrom_connection_string(
-        cls,
-        connection_string: str,
-        namespace: str,
-        embedding: Embeddings,
-        **kwargs: Any,
-    ) -> "DocumentDBVectorSearch":
-        """Creates an Instance of DocumentDBVectorSearch from a Connection
-        String.
-
-        Args:
-            connection_string: The DocumentDB cluster endpoint connection string
-            namespace: The namespace (database.collection)
-            embedding: The embedding utility
-            **kwargs: Dynamic keyword arguments
-
-        Returns:
-            an instance of the vector store
-        """
-        try:
-            from pymongo import MongoClient
-        except ImportError:
-            raise ImportError(
-                "Could not import pymongo, please install it with "
-                "`pip install pymongo`."
-            )
-        client: MongoClient = MongoClient(connection_string)
-        try:
-            from motor.core import AgnosticClient  # noqa: F811 F401
-            from motor.motor_asyncio import AsyncIOMotorClient
-        except ImportError:
-            raise ImportError(
-                "Could not import motor, please install it with `pip install motor`."
-            )
-        async_client: AgnosticClient = AsyncIOMotorClient(connection_string)
-        db_name, collection_name = namespace.split(".")
-        collection = client[db_name][collection_name]
-        async_collection = async_client[db_name][collection_name]
-        return cls(
-            collection,
-            embedding,
-            is_async=True,
-            async_collection=async_collection,
-            **kwargs,
-        )
-
     def index_exists(self) -> bool:
         """Verifies if the specified index name during instance
             construction exists on the collection
@@ -225,38 +153,10 @@ class DocumentDBVectorSearch(VectorStore):
 
         return False
 
-    async def aindex_exists(self) -> bool:
-        """Verifies if the specified index name during instance construction
-        exists on the collection.
-
-        Returns:
-          Returns True on success and False if no such index exists
-            on the collection
-        """
-        self.validate_async()
-        cursor = self._async_collection.list_indexes()
-        index_name = self._index_name
-
-        async for res in cursor:
-            current_index_name = res.pop("name")
-            if current_index_name == index_name:
-                return True
-
-        return False
-
     def delete_index(self) -> None:
         """Deletes the index specified during instance construction if it exists"""
         if self.index_exists():
             self._collection.drop_index(self._index_name)
-            # Raises OperationFailure on an error (e.g. trying to drop
-            # an index that does not exist)
-
-    async def adelete_index(self) -> None:
-        """Deletes the index specified during instance construction if it
-        exists."""
-        self.validate_async()
-        if await self.aindex_exists():
-            await self._async_collection.drop_index(self._index_name)
             # Raises OperationFailure on an error (e.g. trying to drop
             # an index that does not exist)
 
@@ -275,6 +175,10 @@ class DocumentDBVectorSearch(VectorStore):
                 The maximum number of supported dimensions is 2000
 
             similarity: Similarity algorithm to use with the HNSW index.
+                 Possible options are:
+                    - DocumentDBSimilarityType.COS (cosine distance),
+                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
+                    - DocumentDBSimilarityType.DOT (dot product).
 
             m: Specifies the max number of connections for an HNSW index.
                 Large impact on memory consumption.
@@ -283,10 +187,6 @@ class DocumentDBVectorSearch(VectorStore):
                 for constructing the graph for HNSW index. Higher values lead
                 to more accurate results but slower indexing speed.
 
-                Possible options are:
-                    - DocumentDBSimilarityType.COS (cosine distance),
-                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
-                    - DocumentDBSimilarityType.DOT (dot product).
 
         Returns:
             An object describing the created index
@@ -322,68 +222,6 @@ class DocumentDBVectorSearch(VectorStore):
 
         return create_index_responses
 
-    async def acreate_index(
-        self,
-        dimensions: int = 1536,
-        similarity: DocumentDBSimilarityType = DocumentDBSimilarityType.COS,
-        m: int = 16,
-        ef_construction: int = 64,
-    ) -> dict[str, Any]:
-        """Creates an index using the index name specified at instance
-        construction.
-
-        Args:
-            dimensions: Number of dimensions for vector similarity.
-                The maximum number of supported dimensions is 2000
-
-            similarity: Similarity algorithm to use with the HNSW index.
-
-            m: Specifies the max number of connections for an HNSW index.
-                Large impact on memory consumption.
-
-            ef_construction: Specifies the size of the dynamic candidate list
-                for constructing the graph for HNSW index. Higher values lead
-                to more accurate results but slower indexing speed.
-
-                Possible options are:
-                    - DocumentDBSimilarityType.COS (cosine distance),
-                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
-                    - DocumentDBSimilarityType.DOT (dot product).
-
-        Returns:
-            An object describing the created index
-        """
-        self.validate_async()
-        self._similarity_type = similarity
-
-        # prepare the command
-        create_index_commands = {
-            "createIndexes": self._async_collection.name,
-            "indexes": [
-                {
-                    "name": self._index_name,
-                    "key": {self._embedding_key: "vector"},
-                    "vectorOptions": {
-                        "type": "hnsw",
-                        "similarity": similarity,
-                        "dimensions": dimensions,
-                        "m": m,
-                        "efConstruction": ef_construction,
-                    },
-                }
-            ],
-        }
-
-        # retrieve the database object
-        current_database = self._async_collection.database
-
-        # invoke the command from the database object
-        create_index_responses: dict[str, Any] = await current_database.command(
-            create_index_commands
-        )
-
-        return create_index_responses
-
     def add_texts(
         self,
         texts: Iterable[str],
@@ -405,57 +243,6 @@ class DocumentDBVectorSearch(VectorStore):
         if texts_batch:
             result_ids.extend(self._insert_texts(texts_batch, metadatas_batch))
         return result_ids
-
-    async def aadd_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[Dict[str, Any]]] = None,
-        **kwargs: Any,
-    ) -> List:
-        self.validate_async()
-        batch_size = kwargs.get("batch_size", DEFAULT_INSERT_BATCH_SIZE)
-        _metadatas: Union[List, Generator] = metadatas or ({} for _ in texts)
-        texts_batch = []
-        metadatas_batch = []
-        result_ids = []
-        for i, (text, metadata) in enumerate(zip(texts, _metadatas)):
-            texts_batch.append(text)
-            metadatas_batch.append(metadata)
-            if (i + 1) % batch_size == 0:
-                new_result_ids = await self._ainsert_texts(texts_batch, metadatas_batch)
-                result_ids.extend(new_result_ids)
-                texts_batch = []
-                metadatas_batch = []
-        if texts_batch:
-            new_result_ids = await self._ainsert_texts(texts_batch, metadatas_batch)
-            result_ids.extend(new_result_ids)
-        return result_ids
-
-    async def _ainsert_texts(
-        self, texts: List[str], metadatas: List[Dict[str, Any]]
-    ) -> List:
-        """Used to Load Documents into the collection.
-
-        Args:
-            texts: The list of documents strings to load
-            metadatas: The list of metadata objects associated with each document
-
-        Returns:
-        """
-        self.validate_async()
-        # If the text is empty, then exit early
-        if not texts:
-            return []
-
-        # Embed and create the documents
-        embeddings = self._embedding.embed_documents(texts)
-        to_insert = [
-            {self._text_key: t, self._embedding_key: embedding, **m}
-            for t, m, embedding in zip(texts, metadatas, embeddings)
-        ]
-        # insert the documents in DocumentDB
-        insert_result = await self._async_collection.insert_many(to_insert)  # type: ignore
-        return insert_result.inserted_ids
 
     def _insert_texts(self, texts: List[str], metadatas: List[Dict[str, Any]]) -> List:
         """Used to Load Documents into the collection
@@ -490,38 +277,10 @@ class DocumentDBVectorSearch(VectorStore):
         collection: Optional[Collection[DocumentDBDocumentType]] = None,
         **kwargs: Any,
     ) -> DocumentDBVectorSearch:
-        try:
-            assert isinstance(collection, Collection)
-        except AssertionError:
+        if collection is None:
             raise ValueError("Must provide 'collection' named parameter.")
         vectorstore = cls(collection, embedding, **kwargs)  # type: ignore[arg-type]
         vectorstore.add_texts(texts, metadatas=metadatas)
-        return vectorstore
-
-    @classmethod
-    async def afrom_texts(
-        cls,
-        texts: List[str],
-        embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
-        collection: Optional[Collection[DocumentDBDocumentType]] = None,
-        async_collection: Optional[AgnosticCollection] = None,
-        **kwargs: Any,
-    ) -> DocumentDBVectorSearch:
-        if collection is None or async_collection is None:
-            raise ValueError(
-                f"Must provide 'collection' and `async_collection` named parameters.\n \
-                    got collection: `{collection}`\n \
-                    async_collection: `{async_collection}`"
-            )
-        vectorstore = cls(
-            collection,  # type: ignore [arg-type]
-            embedding,
-            is_async=True,
-            async_collection=async_collection,  # type: ignore [arg-type]
-            **kwargs,
-        )
-        await vectorstore.aadd_texts(texts, metadatas=metadatas)
         return vectorstore
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
@@ -530,17 +289,6 @@ class DocumentDBVectorSearch(VectorStore):
 
         for document_id in ids:
             self.delete_document_by_id(document_id)
-        return True
-
-    async def adelete(
-        self, ids: Optional[List[str]] = None, **kwargs: Any
-    ) -> Optional[bool]:
-        self.validate_async()
-        if ids is None:
-            raise ValueError("No document ids provided to delete.")
-
-        for document_id in ids:
-            await self.adelete_document_by_id(document_id)
         return True
 
     def delete_document_by_id(self, document_id: Optional[str] = None) -> None:
@@ -559,24 +307,6 @@ class DocumentDBVectorSearch(VectorStore):
             raise ValueError("No document id provided to delete.")
 
         self._collection.delete_one({"_id": ObjectId(document_id)})
-
-    async def adelete_document_by_id(self, document_id: Optional[str] = None) -> None:
-        """Removes a Specific Document by Id.
-
-        Args:
-            document_id: The document identifier
-        """
-        self.validate_async()
-        try:
-            from bson.objectid import ObjectId
-        except ImportError as e:
-            raise ImportError(
-                "Unable to import bson, please install with `pip install bson`."
-            ) from e
-        if document_id is None:
-            raise ValueError("No document id provided to delete.")
-
-        await self._async_collection.delete_one({"_id": ObjectId(document_id)})
 
     def _similarity_search_without_score(
         self,
@@ -626,55 +356,6 @@ class DocumentDBVectorSearch(VectorStore):
 
         return docs
 
-    async def _asimilarity_search_without_score(
-        self,
-        embeddings: List[float],
-        k: int = 4,
-        ef_search: int = 40,
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> List[Document]:
-        """Returns a list of documents.
-
-        Args:
-            embeddings: The query vector
-            k: the number of documents to return
-            ef_search: Specifies the size of the dynamic candidate list
-                that HNSW index uses during search. A higher value of
-                efSearch provides better recall at cost of speed.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-        Returns:
-            A list of documents closest to the query vector
-        """
-        self.validate_async()
-        # $match can't be null, so intializes to {} when None to avoid
-        # "the match filter must be an expression in an object"
-        if not filter:
-            filter = {}
-        pipeline: List[dict[str, Any]] = [
-            {"$match": filter},
-            {
-                "$search": {
-                    "vectorSearch": {
-                        "vector": embeddings,
-                        "path": self._embedding_key,
-                        "similarity": self._similarity_type,
-                        "k": k,
-                        "efSearch": ef_search,
-                    },
-                },
-            },
-        ]
-
-        cursor = self._async_collection.aggregate(pipeline)
-
-        docs = []
-
-        async for res in cursor:
-            text = res.pop(self._text_key)
-            docs.append(Document(page_content=text, metadata=res))
-
-        return docs
-
     def similarity_search(
         self,
         query: str,
@@ -686,22 +367,6 @@ class DocumentDBVectorSearch(VectorStore):
     ) -> List[Document]:
         embeddings = self._embedding.embed_query(query)
         docs = self._similarity_search_without_score(
-            embeddings=embeddings, k=k, ef_search=ef_search, filter=filter
-        )
-        return [doc for doc in docs]
-
-    async def asimilarity_search(
-        self,
-        query: str,
-        k: int = 4,
-        ef_search: int = 40,
-        *,
-        filter: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
-        self.validate_async()
-        embeddings = self._embedding.embed_query(query)
-        docs = await self._asimilarity_search_without_score(
             embeddings=embeddings, k=k, ef_search=ef_search, filter=filter
         )
         return [doc for doc in docs]

--- a/libs/community/langchain_community/vectorstores/documentdb.py
+++ b/libs/community/langchain_community/vectorstores/documentdb.py
@@ -19,6 +19,7 @@ from langchain_core.vectorstores import VectorStore
 
 if TYPE_CHECKING:
     from langchain_core.embeddings import Embeddings
+    from motor.core import AgnosticClient, AgnosticCollection
     from pymongo.collection import Collection
 
 
@@ -53,8 +54,8 @@ class DocumentDBVectorSearch(VectorStore):
     Example:
         . code-block:: python
 
-            from langchain_community.vectorstores import DocumentDBVectorSearch
-            from langchain_community.embeddings.openai import OpenAIEmbeddings
+            from langchain_aws.vectorstores import DocumentDBVectorSearch
+            from langchain_aws.embeddings.openai import OpenAIEmbeddings
             from pymongo import MongoClient
 
             mongo_client = MongoClient("<YOUR-CONNECTION-STRING>")
@@ -71,6 +72,8 @@ class DocumentDBVectorSearch(VectorStore):
         index_name: str = "vectorSearchIndex",
         text_key: str = "textContent",
         embedding_key: str = "vectorContent",
+        is_async: bool = False,
+        async_collection: AgnosticCollection,
     ):
         """Constructor for DocumentDBVectorSearch
 
@@ -82,17 +85,39 @@ class DocumentDBVectorSearch(VectorStore):
                 for each document.
             embedding_key: MongoDB field that will contain the embedding
                 for each document.
+            is_async: Whether the collection is async or not.
+            async_collection: Async version of the collection.
+            NOTES:
+                * If `is_async` is True, `async_collection` must be provided.
+                * `collection` must be provided also when `is_async` is False.
         """
+        if collection is None:
+            raise ValueError("Must provide 'collection' named parameter.")
         self._collection = collection
         self._embedding = embedding
         self._index_name = index_name
         self._text_key = text_key
         self._embedding_key = embedding_key
         self._similarity_type = DocumentDBSimilarityType.COS
+        self.is_async = is_async
+        if is_async and async_collection is None:
+            raise ValueError(
+                f"Expecting `async_collection` when `is_async` is defined.\n \
+                    Go async_collection = `{async_collection}`"
+            )
+        self._async_collection = async_collection  # type: ignore[arg-type]
 
     @property
     def embeddings(self) -> Embeddings:
         return self._embedding
+
+    def validate_async(self) -> None:
+        if not self.is_async:
+            raise RuntimeError(
+                f"Async functions can only be called \n \
+                    when the object `is_async` flag is `True`.\n \
+                               is_async = `{self.is_async}`"
+            )
 
     def get_index_name(self) -> str:
         """Returns the index name
@@ -135,6 +160,53 @@ class DocumentDBVectorSearch(VectorStore):
         collection = client[db_name][collection_name]
         return cls(collection, embedding, **kwargs)
 
+    @classmethod
+    def afrom_connection_string(
+        cls,
+        connection_string: str,
+        namespace: str,
+        embedding: Embeddings,
+        **kwargs: Any,
+    ) -> "DocumentDBVectorSearch":
+        """Creates an Instance of DocumentDBVectorSearch from a Connection
+        String.
+
+        Args:
+            connection_string: The DocumentDB cluster endpoint connection string
+            namespace: The namespace (database.collection)
+            embedding: The embedding utility
+            **kwargs: Dynamic keyword arguments
+
+        Returns:
+            an instance of the vector store
+        """
+        try:
+            from pymongo import MongoClient
+        except ImportError:
+            raise ImportError(
+                "Could not import pymongo, please install it with "
+                "`pip install pymongo`."
+            )
+        client: MongoClient = MongoClient(connection_string)
+        try:
+            from motor.core import AgnosticClient  # noqa: F811 F401
+            from motor.motor_asyncio import AsyncIOMotorClient
+        except ImportError:
+            raise ImportError(
+                "Could not import motor, please install it with `pip install motor`."
+            )
+        async_client: AgnosticClient = AsyncIOMotorClient(connection_string)
+        db_name, collection_name = namespace.split(".")
+        collection = client[db_name][collection_name]
+        async_collection = async_client[db_name][collection_name]
+        return cls(
+            collection,
+            embedding,
+            is_async=True,
+            async_collection=async_collection,
+            **kwargs,
+        )
+
     def index_exists(self) -> bool:
         """Verifies if the specified index name during instance
             construction exists on the collection
@@ -153,10 +225,38 @@ class DocumentDBVectorSearch(VectorStore):
 
         return False
 
+    async def aindex_exists(self) -> bool:
+        """Verifies if the specified index name during instance construction
+        exists on the collection.
+
+        Returns:
+          Returns True on success and False if no such index exists
+            on the collection
+        """
+        self.validate_async()
+        cursor = self._async_collection.list_indexes()
+        index_name = self._index_name
+
+        async for res in cursor:
+            current_index_name = res.pop("name")
+            if current_index_name == index_name:
+                return True
+
+        return False
+
     def delete_index(self) -> None:
         """Deletes the index specified during instance construction if it exists"""
         if self.index_exists():
             self._collection.drop_index(self._index_name)
+            # Raises OperationFailure on an error (e.g. trying to drop
+            # an index that does not exist)
+
+    async def adelete_index(self) -> None:
+        """Deletes the index specified during instance construction if it
+        exists."""
+        self.validate_async()
+        if await self.aindex_exists():
+            await self._async_collection.drop_index(self._index_name)
             # Raises OperationFailure on an error (e.g. trying to drop
             # an index that does not exist)
 
@@ -175,10 +275,6 @@ class DocumentDBVectorSearch(VectorStore):
                 The maximum number of supported dimensions is 2000
 
             similarity: Similarity algorithm to use with the HNSW index.
-                 Possible options are:
-                    - DocumentDBSimilarityType.COS (cosine distance),
-                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
-                    - DocumentDBSimilarityType.DOT (dot product).
 
             m: Specifies the max number of connections for an HNSW index.
                 Large impact on memory consumption.
@@ -187,6 +283,10 @@ class DocumentDBVectorSearch(VectorStore):
                 for constructing the graph for HNSW index. Higher values lead
                 to more accurate results but slower indexing speed.
 
+                Possible options are:
+                    - DocumentDBSimilarityType.COS (cosine distance),
+                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
+                    - DocumentDBSimilarityType.DOT (dot product).
 
         Returns:
             An object describing the created index
@@ -222,6 +322,68 @@ class DocumentDBVectorSearch(VectorStore):
 
         return create_index_responses
 
+    async def acreate_index(
+        self,
+        dimensions: int = 1536,
+        similarity: DocumentDBSimilarityType = DocumentDBSimilarityType.COS,
+        m: int = 16,
+        ef_construction: int = 64,
+    ) -> dict[str, Any]:
+        """Creates an index using the index name specified at instance
+        construction.
+
+        Args:
+            dimensions: Number of dimensions for vector similarity.
+                The maximum number of supported dimensions is 2000
+
+            similarity: Similarity algorithm to use with the HNSW index.
+
+            m: Specifies the max number of connections for an HNSW index.
+                Large impact on memory consumption.
+
+            ef_construction: Specifies the size of the dynamic candidate list
+                for constructing the graph for HNSW index. Higher values lead
+                to more accurate results but slower indexing speed.
+
+                Possible options are:
+                    - DocumentDBSimilarityType.COS (cosine distance),
+                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
+                    - DocumentDBSimilarityType.DOT (dot product).
+
+        Returns:
+            An object describing the created index
+        """
+        self.validate_async()
+        self._similarity_type = similarity
+
+        # prepare the command
+        create_index_commands = {
+            "createIndexes": self._async_collection.name,
+            "indexes": [
+                {
+                    "name": self._index_name,
+                    "key": {self._embedding_key: "vector"},
+                    "vectorOptions": {
+                        "type": "hnsw",
+                        "similarity": similarity,
+                        "dimensions": dimensions,
+                        "m": m,
+                        "efConstruction": ef_construction,
+                    },
+                }
+            ],
+        }
+
+        # retrieve the database object
+        current_database = self._async_collection.database
+
+        # invoke the command from the database object
+        create_index_responses: dict[str, Any] = await current_database.command(
+            create_index_commands
+        )
+
+        return create_index_responses
+
     def add_texts(
         self,
         texts: Iterable[str],
@@ -243,6 +405,57 @@ class DocumentDBVectorSearch(VectorStore):
         if texts_batch:
             result_ids.extend(self._insert_texts(texts_batch, metadatas_batch))
         return result_ids
+
+    async def aadd_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+        **kwargs: Any,
+    ) -> List:
+        self.validate_async()
+        batch_size = kwargs.get("batch_size", DEFAULT_INSERT_BATCH_SIZE)
+        _metadatas: Union[List, Generator] = metadatas or ({} for _ in texts)
+        texts_batch = []
+        metadatas_batch = []
+        result_ids = []
+        for i, (text, metadata) in enumerate(zip(texts, _metadatas)):
+            texts_batch.append(text)
+            metadatas_batch.append(metadata)
+            if (i + 1) % batch_size == 0:
+                new_result_ids = await self._ainsert_texts(texts_batch, metadatas_batch)
+                result_ids.extend(new_result_ids)
+                texts_batch = []
+                metadatas_batch = []
+        if texts_batch:
+            new_result_ids = await self._ainsert_texts(texts_batch, metadatas_batch)
+            result_ids.extend(new_result_ids)
+        return result_ids
+
+    async def _ainsert_texts(
+        self, texts: List[str], metadatas: List[Dict[str, Any]]
+    ) -> List:
+        """Used to Load Documents into the collection.
+
+        Args:
+            texts: The list of documents strings to load
+            metadatas: The list of metadata objects associated with each document
+
+        Returns:
+        """
+        self.validate_async()
+        # If the text is empty, then exit early
+        if not texts:
+            return []
+
+        # Embed and create the documents
+        embeddings = self._embedding.embed_documents(texts)
+        to_insert = [
+            {self._text_key: t, self._embedding_key: embedding, **m}
+            for t, m, embedding in zip(texts, metadatas, embeddings)
+        ]
+        # insert the documents in DocumentDB
+        insert_result = await self._async_collection.insert_many(to_insert)  # type: ignore
+        return insert_result.inserted_ids
 
     def _insert_texts(self, texts: List[str], metadatas: List[Dict[str, Any]]) -> List:
         """Used to Load Documents into the collection
@@ -277,10 +490,38 @@ class DocumentDBVectorSearch(VectorStore):
         collection: Optional[Collection[DocumentDBDocumentType]] = None,
         **kwargs: Any,
     ) -> DocumentDBVectorSearch:
-        if collection is None:
+        try:
+            assert isinstance(collection, Collection)
+        except AssertionError:
             raise ValueError("Must provide 'collection' named parameter.")
-        vectorstore = cls(collection, embedding, **kwargs)
+        vectorstore = cls(collection, embedding, **kwargs)  # type: ignore[arg-type]
         vectorstore.add_texts(texts, metadatas=metadatas)
+        return vectorstore
+
+    @classmethod
+    async def afrom_texts(
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        collection: Optional[Collection[DocumentDBDocumentType]] = None,
+        async_collection: Optional[AgnosticCollection] = None,
+        **kwargs: Any,
+    ) -> DocumentDBVectorSearch:
+        if collection is None or async_collection is None:
+            raise ValueError(
+                f"Must provide 'collection' and `async_collection` named parameters.\n \
+                    got collection: `{collection}`\n \
+                    async_collection: `{async_collection}`"
+            )
+        vectorstore = cls(
+            collection,  # type: ignore [arg-type]
+            embedding,
+            is_async=True,
+            async_collection=async_collection,  # type: ignore [arg-type]
+            **kwargs,
+        )
+        await vectorstore.aadd_texts(texts, metadatas=metadatas)
         return vectorstore
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
@@ -289,6 +530,17 @@ class DocumentDBVectorSearch(VectorStore):
 
         for document_id in ids:
             self.delete_document_by_id(document_id)
+        return True
+
+    async def adelete(
+        self, ids: Optional[List[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
+        self.validate_async()
+        if ids is None:
+            raise ValueError("No document ids provided to delete.")
+
+        for document_id in ids:
+            await self.adelete_document_by_id(document_id)
         return True
 
     def delete_document_by_id(self, document_id: Optional[str] = None) -> None:
@@ -307,6 +559,24 @@ class DocumentDBVectorSearch(VectorStore):
             raise ValueError("No document id provided to delete.")
 
         self._collection.delete_one({"_id": ObjectId(document_id)})
+
+    async def adelete_document_by_id(self, document_id: Optional[str] = None) -> None:
+        """Removes a Specific Document by Id.
+
+        Args:
+            document_id: The document identifier
+        """
+        self.validate_async()
+        try:
+            from bson.objectid import ObjectId
+        except ImportError as e:
+            raise ImportError(
+                "Unable to import bson, please install with `pip install bson`."
+            ) from e
+        if document_id is None:
+            raise ValueError("No document id provided to delete.")
+
+        await self._async_collection.delete_one({"_id": ObjectId(document_id)})
 
     def _similarity_search_without_score(
         self,
@@ -356,6 +626,55 @@ class DocumentDBVectorSearch(VectorStore):
 
         return docs
 
+    async def _asimilarity_search_without_score(
+        self,
+        embeddings: List[float],
+        k: int = 4,
+        ef_search: int = 40,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Document]:
+        """Returns a list of documents.
+
+        Args:
+            embeddings: The query vector
+            k: the number of documents to return
+            ef_search: Specifies the size of the dynamic candidate list
+                that HNSW index uses during search. A higher value of
+                efSearch provides better recall at cost of speed.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+        Returns:
+            A list of documents closest to the query vector
+        """
+        self.validate_async()
+        # $match can't be null, so intializes to {} when None to avoid
+        # "the match filter must be an expression in an object"
+        if not filter:
+            filter = {}
+        pipeline: List[dict[str, Any]] = [
+            {"$match": filter},
+            {
+                "$search": {
+                    "vectorSearch": {
+                        "vector": embeddings,
+                        "path": self._embedding_key,
+                        "similarity": self._similarity_type,
+                        "k": k,
+                        "efSearch": ef_search,
+                    },
+                },
+            },
+        ]
+
+        cursor = self._async_collection.aggregate(pipeline)
+
+        docs = []
+
+        async for res in cursor:
+            text = res.pop(self._text_key)
+            docs.append(Document(page_content=text, metadata=res))
+
+        return docs
+
     def similarity_search(
         self,
         query: str,
@@ -367,6 +686,22 @@ class DocumentDBVectorSearch(VectorStore):
     ) -> List[Document]:
         embeddings = self._embedding.embed_query(query)
         docs = self._similarity_search_without_score(
+            embeddings=embeddings, k=k, ef_search=ef_search, filter=filter
+        )
+        return [doc for doc in docs]
+
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        ef_search: int = 40,
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        self.validate_async()
+        embeddings = self._embedding.embed_query(query)
+        docs = await self._asimilarity_search_without_score(
             embeddings=embeddings, k=k, ef_search=ef_search, filter=filter
         )
         return [doc for doc in docs]

--- a/libs/community/langchain_community/vectorstores/documentdb_async.py
+++ b/libs/community/langchain_community/vectorstores/documentdb_async.py
@@ -1,0 +1,706 @@
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+)
+
+from langchain_core.documents import Document
+from langchain_core.vectorstores import VectorStore
+
+if TYPE_CHECKING:
+    from langchain_core.embeddings import Embeddings
+    from motor.core import AgnosticClient, AgnosticCollection
+    from pymongo.collection import Collection
+
+
+# Before Python 3.11 native StrEnum is not available
+class DocumentDBSimilarityType(str, Enum):
+    """DocumentDB Similarity Type as enumerator."""
+
+    COS = "cosine"
+    """Cosine similarity"""
+    DOT = "dotProduct"
+    """Dot product"""
+    EUC = "euclidean"
+    """Euclidean distance"""
+
+
+DocumentDBDocumentType = TypeVar("DocumentDBDocumentType", bound=Dict[str, Any])
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INSERT_BATCH_SIZE = 128
+
+
+class DocumentDBVectorSearch(VectorStore):
+    """`Amazon DocumentDB (with MongoDB compatibility)` vector store.
+    Please refer to the official Vector Search documentation for more details:
+    https://docs.aws.amazon.com/documentdb/latest/developerguide/vector-search.html
+
+    To use, you should have both:
+    - the ``pymongo`` python package installed
+    - a connection string and credentials associated with a DocumentDB cluster
+
+    Example:
+        . code-block:: python
+
+            from langchain_aws.vectorstores import DocumentDBVectorSearch
+            from langchain_aws.embeddings.openai import OpenAIEmbeddings
+            from pymongo import MongoClient
+
+            mongo_client = MongoClient("<YOUR-CONNECTION-STRING>")
+            collection = mongo_client["<db_name>"]["<collection_name>"]
+            embeddings = OpenAIEmbeddings()
+            vectorstore = DocumentDBVectorSearch(collection, embeddings)
+    """
+
+    def __init__(
+        self,
+        collection: Collection[DocumentDBDocumentType],
+        embedding: Embeddings,
+        *,
+        index_name: str = "vectorSearchIndex",
+        text_key: str = "textContent",
+        embedding_key: str = "vectorContent",
+        is_async: bool = False,
+        async_collection: AgnosticCollection,
+    ):
+        """Constructor for DocumentDBVectorSearch
+
+        Args:
+            collection: MongoDB collection to add the texts to.
+            embedding: Text embedding model to use.
+            index_name: Name of the Vector Search index.
+            text_key: MongoDB field that will contain the text
+                for each document.
+            embedding_key: MongoDB field that will contain the embedding
+                for each document.
+            is_async: Whether the collection is async or not.
+            async_collection: Async version of the collection.
+            NOTES:
+                * If `is_async` is True, `async_collection` must be provided.
+                * `collection` must be provided also when `is_async` is False.
+        """
+        if collection is None:
+            raise ValueError("Must provide 'collection' named parameter.")
+        self._collection = collection
+        self._embedding = embedding
+        self._index_name = index_name
+        self._text_key = text_key
+        self._embedding_key = embedding_key
+        self._similarity_type = DocumentDBSimilarityType.COS
+        self.is_async = is_async
+        if is_async and async_collection is None:
+            raise ValueError(
+                f"Expecting `async_collection` when `is_async` is defined.\n \
+                    Go async_collection = `{async_collection}`"
+            )
+        self._async_collection = async_collection  # type: ignore[arg-type]
+
+    @property
+    def embeddings(self) -> Embeddings:
+        return self._embedding
+
+    def validate_async(self) -> None:
+        if not self.is_async:
+            raise RuntimeError(
+                f"Async functions can only be called \n \
+                    when the object `is_async` flag is `True`.\n \
+                               is_async = `{self.is_async}`"
+            )
+
+    def get_index_name(self) -> str:
+        """Returns the index name
+
+        Returns:
+            Returns the index name
+
+        """
+        return self._index_name
+
+    @classmethod
+    def from_connection_string(
+        cls,
+        connection_string: str,
+        namespace: str,
+        embedding: Embeddings,
+        **kwargs: Any,
+    ) -> DocumentDBVectorSearch:
+        """Creates an Instance of DocumentDBVectorSearch from a Connection String
+
+        Args:
+            connection_string: The DocumentDB cluster endpoint connection string
+            namespace: The namespace (database.collection)
+            embedding: The embedding utility
+            **kwargs: Dynamic keyword arguments
+
+        Returns:
+            an instance of the vector store
+
+        """
+        try:
+            from pymongo import MongoClient
+        except ImportError:
+            raise ImportError(
+                "Could not import pymongo, please install it with "
+                "`pip install pymongo`."
+            )
+        client: MongoClient = MongoClient(connection_string)
+        db_name, collection_name = namespace.split(".")
+        collection = client[db_name][collection_name]
+        return cls(collection, embedding, **kwargs)
+
+    @classmethod
+    def afrom_connection_string(
+        cls,
+        connection_string: str,
+        namespace: str,
+        embedding: Embeddings,
+        **kwargs: Any,
+    ) -> "DocumentDBVectorSearch":
+        """Creates an Instance of DocumentDBVectorSearch from a Connection
+        String.
+
+        Args:
+            connection_string: The DocumentDB cluster endpoint connection string
+            namespace: The namespace (database.collection)
+            embedding: The embedding utility
+            **kwargs: Dynamic keyword arguments
+
+        Returns:
+            an instance of the vector store
+        """
+        try:
+            from pymongo import MongoClient
+        except ImportError:
+            raise ImportError(
+                "Could not import pymongo, please install it with "
+                "`pip install pymongo`."
+            )
+        client: MongoClient = MongoClient(connection_string)
+        try:
+            from motor.core import AgnosticClient  # noqa: F811 F401
+            from motor.motor_asyncio import AsyncIOMotorClient
+        except ImportError:
+            raise ImportError(
+                "Could not import motor, please install it with `pip install motor`."
+            )
+        async_client: AgnosticClient = AsyncIOMotorClient(connection_string)
+        db_name, collection_name = namespace.split(".")
+        collection = client[db_name][collection_name]
+        async_collection = async_client[db_name][collection_name]
+        return cls(
+            collection,
+            embedding,
+            is_async=True,
+            async_collection=async_collection,
+            **kwargs,
+        )
+
+    def index_exists(self) -> bool:
+        """Verifies if the specified index name during instance
+            construction exists on the collection
+
+        Returns:
+          Returns True on success and False if no such index exists
+            on the collection
+        """
+        cursor = self._collection.list_indexes()
+        index_name = self._index_name
+
+        for res in cursor:
+            current_index_name = res.pop("name")
+            if current_index_name == index_name:
+                return True
+
+        return False
+
+    async def aindex_exists(self) -> bool:
+        """Verifies if the specified index name during instance construction
+        exists on the collection.
+
+        Returns:
+          Returns True on success and False if no such index exists
+            on the collection
+        """
+        self.validate_async()
+        cursor = self._async_collection.list_indexes()
+        index_name = self._index_name
+
+        async for res in cursor:
+            current_index_name = res.pop("name")
+            if current_index_name == index_name:
+                return True
+
+        return False
+
+    def delete_index(self) -> None:
+        """Deletes the index specified during instance construction if it exists"""
+        if self.index_exists():
+            self._collection.drop_index(self._index_name)
+            # Raises OperationFailure on an error (e.g. trying to drop
+            # an index that does not exist)
+
+    async def adelete_index(self) -> None:
+        """Deletes the index specified during instance construction if it
+        exists."""
+        self.validate_async()
+        if await self.aindex_exists():
+            await self._async_collection.drop_index(self._index_name)
+            # Raises OperationFailure on an error (e.g. trying to drop
+            # an index that does not exist)
+
+    def create_index(
+        self,
+        dimensions: int = 1536,
+        similarity: DocumentDBSimilarityType = DocumentDBSimilarityType.COS,
+        m: int = 16,
+        ef_construction: int = 64,
+    ) -> dict[str, Any]:
+        """Creates an index using the index name specified at
+            instance construction
+
+        Args:
+            dimensions: Number of dimensions for vector similarity.
+                The maximum number of supported dimensions is 2000
+
+            similarity: Similarity algorithm to use with the HNSW index.
+
+            m: Specifies the max number of connections for an HNSW index.
+                Large impact on memory consumption.
+
+            ef_construction: Specifies the size of the dynamic candidate list
+                for constructing the graph for HNSW index. Higher values lead
+                to more accurate results but slower indexing speed.
+
+                Possible options are:
+                    - DocumentDBSimilarityType.COS (cosine distance),
+                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
+                    - DocumentDBSimilarityType.DOT (dot product).
+
+        Returns:
+            An object describing the created index
+
+        """
+        self._similarity_type = similarity
+
+        # prepare the command
+        create_index_commands = {
+            "createIndexes": self._collection.name,
+            "indexes": [
+                {
+                    "name": self._index_name,
+                    "key": {self._embedding_key: "vector"},
+                    "vectorOptions": {
+                        "type": "hnsw",
+                        "similarity": similarity,
+                        "dimensions": dimensions,
+                        "m": m,
+                        "efConstruction": ef_construction,
+                    },
+                }
+            ],
+        }
+
+        # retrieve the database object
+        current_database = self._collection.database
+
+        # invoke the command from the database object
+        create_index_responses: dict[str, Any] = current_database.command(
+            create_index_commands
+        )
+
+        return create_index_responses
+
+    async def acreate_index(
+        self,
+        dimensions: int = 1536,
+        similarity: DocumentDBSimilarityType = DocumentDBSimilarityType.COS,
+        m: int = 16,
+        ef_construction: int = 64,
+    ) -> dict[str, Any]:
+        """Creates an index using the index name specified at instance
+        construction.
+
+        Args:
+            dimensions: Number of dimensions for vector similarity.
+                The maximum number of supported dimensions is 2000
+
+            similarity: Similarity algorithm to use with the HNSW index.
+
+            m: Specifies the max number of connections for an HNSW index.
+                Large impact on memory consumption.
+
+            ef_construction: Specifies the size of the dynamic candidate list
+                for constructing the graph for HNSW index. Higher values lead
+                to more accurate results but slower indexing speed.
+
+                Possible options are:
+                    - DocumentDBSimilarityType.COS (cosine distance),
+                    - DocumentDBSimilarityType.EUC (Euclidean distance), and
+                    - DocumentDBSimilarityType.DOT (dot product).
+
+        Returns:
+            An object describing the created index
+        """
+        self.validate_async()
+        self._similarity_type = similarity
+
+        # prepare the command
+        create_index_commands = {
+            "createIndexes": self._async_collection.name,
+            "indexes": [
+                {
+                    "name": self._index_name,
+                    "key": {self._embedding_key: "vector"},
+                    "vectorOptions": {
+                        "type": "hnsw",
+                        "similarity": similarity,
+                        "dimensions": dimensions,
+                        "m": m,
+                        "efConstruction": ef_construction,
+                    },
+                }
+            ],
+        }
+
+        # retrieve the database object
+        current_database = self._async_collection.database
+
+        # invoke the command from the database object
+        create_index_responses: dict[str, Any] = await current_database.command(
+            create_index_commands
+        )
+
+        return create_index_responses
+
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+        **kwargs: Any,
+    ) -> List:
+        batch_size = kwargs.get("batch_size", DEFAULT_INSERT_BATCH_SIZE)
+        _metadatas: Union[List, Generator] = metadatas or ({} for _ in texts)
+        texts_batch = []
+        metadatas_batch = []
+        result_ids = []
+        for i, (text, metadata) in enumerate(zip(texts, _metadatas)):
+            texts_batch.append(text)
+            metadatas_batch.append(metadata)
+            if (i + 1) % batch_size == 0:
+                result_ids.extend(self._insert_texts(texts_batch, metadatas_batch))
+                texts_batch = []
+                metadatas_batch = []
+        if texts_batch:
+            result_ids.extend(self._insert_texts(texts_batch, metadatas_batch))
+        return result_ids
+
+    async def aadd_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+        **kwargs: Any,
+    ) -> List:
+        self.validate_async()
+        batch_size = kwargs.get("batch_size", DEFAULT_INSERT_BATCH_SIZE)
+        _metadatas: Union[List, Generator] = metadatas or ({} for _ in texts)
+        texts_batch = []
+        metadatas_batch = []
+        result_ids = []
+        for i, (text, metadata) in enumerate(zip(texts, _metadatas)):
+            texts_batch.append(text)
+            metadatas_batch.append(metadata)
+            if (i + 1) % batch_size == 0:
+                new_result_ids = await self._ainsert_texts(texts_batch, metadatas_batch)
+                result_ids.extend(new_result_ids)
+                texts_batch = []
+                metadatas_batch = []
+        if texts_batch:
+            new_result_ids = await self._ainsert_texts(texts_batch, metadatas_batch)
+            result_ids.extend(new_result_ids)
+        return result_ids
+
+    async def _ainsert_texts(
+        self, texts: List[str], metadatas: List[Dict[str, Any]]
+    ) -> List:
+        """Used to Load Documents into the collection.
+
+        Args:
+            texts: The list of documents strings to load
+            metadatas: The list of metadata objects associated with each document
+
+        Returns:
+        """
+        self.validate_async()
+        # If the text is empty, then exit early
+        if not texts:
+            return []
+
+        # Embed and create the documents
+        embeddings = self._embedding.embed_documents(texts)
+        to_insert = [
+            {self._text_key: t, self._embedding_key: embedding, **m}
+            for t, m, embedding in zip(texts, metadatas, embeddings)
+        ]
+        # insert the documents in DocumentDB
+        insert_result = await self._async_collection.insert_many(to_insert)  # type: ignore
+        return insert_result.inserted_ids
+
+    def _insert_texts(self, texts: List[str], metadatas: List[Dict[str, Any]]) -> List:
+        """Used to Load Documents into the collection
+
+        Args:
+            texts: The list of documents strings to load
+            metadatas: The list of metadata objects associated with each document
+
+        Returns:
+
+        """
+        # If the text is empty, then exit early
+        if not texts:
+            return []
+
+        # Embed and create the documents
+        embeddings = self._embedding.embed_documents(texts)
+        to_insert = [
+            {self._text_key: t, self._embedding_key: embedding, **m}
+            for t, m, embedding in zip(texts, metadatas, embeddings)
+        ]
+        # insert the documents in DocumentDB
+        insert_result = self._collection.insert_many(to_insert)  # type: ignore
+        return insert_result.inserted_ids
+
+    @classmethod
+    def from_texts(
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        collection: Optional[Collection[DocumentDBDocumentType]] = None,
+        **kwargs: Any,
+    ) -> DocumentDBVectorSearch:
+        try:
+            assert isinstance(collection, Collection)
+        except AssertionError:
+            raise ValueError("Must provide 'collection' named parameter.")
+        vectorstore = cls(collection, embedding, **kwargs)  # type: ignore[arg-type]
+        vectorstore.add_texts(texts, metadatas=metadatas)
+        return vectorstore
+
+    @classmethod
+    async def afrom_texts(
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        collection: Optional[Collection[DocumentDBDocumentType]] = None,
+        async_collection: Optional[AgnosticCollection] = None,
+        **kwargs: Any,
+    ) -> DocumentDBVectorSearch:
+        if collection is None or async_collection is None:
+            raise ValueError(
+                f"Must provide 'collection' and `async_collection` named parameters.\n \
+                    got collection: `{collection}`\n \
+                    async_collection: `{async_collection}`"
+            )
+        vectorstore = cls(
+            collection,  # type: ignore [arg-type]
+            embedding,
+            is_async=True,
+            async_collection=async_collection,  # type: ignore [arg-type]
+            **kwargs,
+        )
+        await vectorstore.aadd_texts(texts, metadatas=metadatas)
+        return vectorstore
+
+    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
+        if ids is None:
+            raise ValueError("No document ids provided to delete.")
+
+        for document_id in ids:
+            self.delete_document_by_id(document_id)
+        return True
+
+    async def adelete(
+        self, ids: Optional[List[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
+        self.validate_async()
+        if ids is None:
+            raise ValueError("No document ids provided to delete.")
+
+        for document_id in ids:
+            await self.adelete_document_by_id(document_id)
+        return True
+
+    def delete_document_by_id(self, document_id: Optional[str] = None) -> None:
+        """Removes a Specific Document by Id
+
+        Args:
+            document_id: The document identifier
+        """
+        try:
+            from bson.objectid import ObjectId
+        except ImportError as e:
+            raise ImportError(
+                "Unable to import bson, please install with `pip install bson`."
+            ) from e
+        if document_id is None:
+            raise ValueError("No document id provided to delete.")
+
+        self._collection.delete_one({"_id": ObjectId(document_id)})
+
+    async def adelete_document_by_id(self, document_id: Optional[str] = None) -> None:
+        """Removes a Specific Document by Id.
+
+        Args:
+            document_id: The document identifier
+        """
+        self.validate_async()
+        try:
+            from bson.objectid import ObjectId
+        except ImportError as e:
+            raise ImportError(
+                "Unable to import bson, please install with `pip install bson`."
+            ) from e
+        if document_id is None:
+            raise ValueError("No document id provided to delete.")
+
+        await self._async_collection.delete_one({"_id": ObjectId(document_id)})
+
+    def _similarity_search_without_score(
+        self,
+        embeddings: List[float],
+        k: int = 4,
+        ef_search: int = 40,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Document]:
+        """Returns a list of documents.
+
+        Args:
+            embeddings: The query vector
+            k: the number of documents to return
+            ef_search: Specifies the size of the dynamic candidate list
+                that HNSW index uses during search. A higher value of
+                efSearch provides better recall at cost of speed.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+        Returns:
+            A list of documents closest to the query vector
+        """
+        # $match can't be null, so intializes to {} when None to avoid
+        # "the match filter must be an expression in an object"
+        if not filter:
+            filter = {}
+        pipeline: List[dict[str, Any]] = [
+            {"$match": filter},
+            {
+                "$search": {
+                    "vectorSearch": {
+                        "vector": embeddings,
+                        "path": self._embedding_key,
+                        "similarity": self._similarity_type,
+                        "k": k,
+                        "efSearch": ef_search,
+                    }
+                },
+            },
+        ]
+
+        cursor = self._collection.aggregate(pipeline)
+
+        docs = []
+
+        for res in cursor:
+            text = res.pop(self._text_key)
+            docs.append(Document(page_content=text, metadata=res))
+
+        return docs
+
+    async def _asimilarity_search_without_score(
+        self,
+        embeddings: List[float],
+        k: int = 4,
+        ef_search: int = 40,
+        filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Document]:
+        """Returns a list of documents.
+
+        Args:
+            embeddings: The query vector
+            k: the number of documents to return
+            ef_search: Specifies the size of the dynamic candidate list
+                that HNSW index uses during search. A higher value of
+                efSearch provides better recall at cost of speed.
+            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+        Returns:
+            A list of documents closest to the query vector
+        """
+        self.validate_async()
+        # $match can't be null, so intializes to {} when None to avoid
+        # "the match filter must be an expression in an object"
+        if not filter:
+            filter = {}
+        pipeline: List[dict[str, Any]] = [
+            {"$match": filter},
+            {
+                "$search": {
+                    "vectorSearch": {
+                        "vector": embeddings,
+                        "path": self._embedding_key,
+                        "similarity": self._similarity_type,
+                        "k": k,
+                        "efSearch": ef_search,
+                    },
+                },
+            },
+        ]
+        cursor = self._async_collection.aggregate(pipeline)
+
+        docs = []
+
+        async for res in cursor:
+            text = res.pop(self._text_key)
+            docs.append(Document(page_content=text, metadata=res))
+
+        return docs
+
+    def similarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        ef_search: int = 40,
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        embeddings = self._embedding.embed_query(query)
+        docs = self._similarity_search_without_score(
+            embeddings=embeddings, k=k, ef_search=ef_search, filter=filter
+        )
+        return [doc for doc in docs]
+
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        ef_search: int = 40,
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        self.validate_async()
+        embeddings = self._embedding.embed_query(query)
+        docs = await self._asimilarity_search_without_score(
+            embeddings=embeddings, k=k, ef_search=ef_search, filter=filter
+        )
+        return [doc for doc in docs]

--- a/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
@@ -4,7 +4,7 @@ import logging
 import os
 from asyncio import sleep as asyncio_sleep
 from time import sleep
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 import pytest
 from langchain_core.documents import Document

--- a/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
@@ -1,784 +1,784 @@
-"""Test DocumentDBVectorSearch functionality."""
-
-import logging
-import os
-from asyncio import sleep as asyncio_sleep
-from time import sleep
-from typing import Any, Optional, Tuple
-
-import pytest
-from langchain_core.documents import Document
-from motor.core import AgnosticCollection
-from pymongo.collection import Collection
-
-from langchain_community.embeddings import OpenAIEmbeddings
-from langchain_community.vectorstores.documentdb_async import (
-    DocumentDBSimilarityType,
-    DocumentDBVectorSearch,
-)
-
-logging.basicConfig(level=logging.DEBUG)
-
-model_deployment = os.getenv(
-    "OPENAI_EMBEDDINGS_DEPLOYMENT", "smart-agent-embedding-ada"
-)
-model_name = os.getenv("OPENAI_EMBEDDINGS_MODEL_NAME", "text-embedding-ada-002")
-
-INDEX_NAME = "langchain-test-index"
-NAMESPACE = "langchain_test_db.langchain_test_collection"
-CONNECTION_STRING = os.getenv("DOCUMENTDB_URI", "")
-DB_NAME, COLLECTION_NAME = NAMESPACE.split(".")
-
-dimensions = 1536
-similarity_algorithm = DocumentDBSimilarityType.COS
-
-
-def prepare_collection() -> Tuple[Collection, AgnosticCollection]:
-    from motor.core import AgnosticClient
-    from motor.motor_asyncio import AsyncIOMotorClient
-    from pymongo import MongoClient
-
-    test_client: MongoClient = MongoClient(CONNECTION_STRING)
-    test_async_client: AgnosticClient = AsyncIOMotorClient(CONNECTION_STRING)
-    return test_client[DB_NAME][COLLECTION_NAME], test_async_client[DB_NAME][
-        COLLECTION_NAME
-    ]
-
-
-@pytest.fixture()
-@pytest.mark.requires("pymongo")
-@pytest.mark.requires("motor")
-def collections() -> Any:
-    return prepare_collection()
-
-
-@pytest.fixture()
-@pytest.mark.requires("pymongo")
-@pytest.mark.requires("motor")
-def embedding_openai() -> Any:
-    openai_embeddings: OpenAIEmbeddings = OpenAIEmbeddings(
-        deployment=model_deployment, model=model_name, chunk_size=1
-    )
-    return openai_embeddings
-
-
-"""
-This is how to run the integration tests:
-
-cd libs/aws
-make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
-
-NOTE: You will first need to follow the contributor setup steps:
-https://python.langchain.com/docs/contributing/code. You will also need to install
-`pymongo` via `poetry`. You can also run the test directly using `pytest`, but please
-make sure to install all dependencies.
-"""
-
-
-class TestDocumentDBVectorSearch:
-    @classmethod
-    def setup_class(cls) -> None:
-        if not os.getenv("OPENAI_API_KEY"):
-            raise ValueError("OPENAI_API_KEY environment variable is not set")
-
-        # insure the test collection is empty
-        collection, async_collection = prepare_collection()
-        assert collection.count_documents({}) == 0  # type: ignore[index]  # noqa: E501
-
-    @classmethod
-    def teardown_class(cls) -> None:
-        collection, async_collection = prepare_collection()
-        # delete all the documents in the collection
-        collection.delete_many({})  # type: ignore[index]
-        collection.drop_indexes()
-
-    @pytest.fixture(autouse=True)
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def setup(self) -> None:
-        collection, async_collection = prepare_collection()
-        # delete all the documents in the collection
-        collection.delete_many({})  # type: ignore[index]
-        collection.drop_indexes()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_documents_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        """Test end to end construction and search."""
-        documents = [
-            Document(page_content="Dogs are tough.", metadata={"a": 1}),
-            Document(page_content="Cats have fluff.", metadata={"b": 1}),
-            Document(page_content="What is a sandwich?", metadata={"c": 1}),
-            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-        ]
-
-        collection = collections[0]
-        vectorstore = DocumentDBVectorSearch.from_documents(
-            documents,
-            embedding_openai,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-        sleep(1)  # waits for DocumentDB to save contents to the collection
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, similarity_algorithm)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_documents_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        """Test end to end construction and search."""
-        documents = [
-            Document(page_content="Dogs are tough.", metadata={"a": 1}),
-            Document(page_content="Cats have fluff.", metadata={"b": 1}),
-            Document(page_content="What is a sandwich?", metadata={"c": 1}),
-            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-        ]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_documents(
-            documents,
-            embedding_openai,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-        await asyncio_sleep(
-            1
-        )  # waits for DocumentDB to save contents to the collection
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, similarity_algorithm)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_documents_inner_product(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        """Test end to end construction and search."""
-        documents = [
-            Document(page_content="Dogs are tough.", metadata={"a": 1}),
-            Document(page_content="Cats have fluff.", metadata={"b": 1}),
-            Document(page_content="What is a sandwich?", metadata={"c": 1}),
-            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-        ]
-        collection = collections[0]
-        vectorstore = DocumentDBVectorSearch.from_documents(
-            documents,
-            embedding_openai,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-        sleep(1)  # waits for DocumentDB to save contents to the collection
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1, ef_search=100)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_documents_inner_product(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        """Test end to end construction and search."""
-        documents = [
-            Document(page_content="Dogs are tough.", metadata={"a": 1}),
-            Document(page_content="Cats have fluff.", metadata={"b": 1}),
-            Document(page_content="What is a sandwich?", metadata={"c": 1}),
-            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-        ]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_documents(
-            documents,
-            embedding_openai,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-        await asyncio_sleep(
-            1
-        )  # waits for DocumentDB to save contents to the collection
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=100)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_texts_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "That fence is purple.",
-        ]
-        collection = collections[0]
-        vectorstore = DocumentDBVectorSearch.from_texts(
-            texts,
-            embedding_openai,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, similarity_algorithm)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1)
-
-        assert output[0].page_content == "What is a sandwich?"
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_texts_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "That fence is purple.",
-        ]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_texts(
-            texts,
-            embedding_openai,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, similarity_algorithm)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-        assert output[0].page_content == "What is a sandwich?"
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_texts_with_metadatas_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        collection = collections[0]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        vectorstore = DocumentDBVectorSearch.from_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, similarity_algorithm)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_texts_with_metadatas_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, similarity_algorithm)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_texts_with_metadatas_delete_one(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        collection = collections[0]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        vectorstore = DocumentDBVectorSearch.from_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, similarity_algorithm)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-
-        first_document_id_object = output[0].metadata["_id"]
-        first_document_id = str(first_document_id_object)
-
-        vectorstore.delete_document_by_id(first_document_id)
-        sleep(2)  # waits for the index to be updated
-
-        output2 = vectorstore.similarity_search("Sandwich", k=1, ef_search=10)
-        assert output2
-        assert output2[0].page_content != "What is a sandwich?"
-
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_texts_with_metadatas_delete_one(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, similarity_algorithm)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-
-        first_document_id_object = output[0].metadata["_id"]
-        first_document_id = str(first_document_id_object)
-
-        await vectorstore.adelete_document_by_id(first_document_id)
-        await asyncio_sleep(2)  # waits for the index to be updated
-
-        output2 = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=10)
-        assert output2
-        assert output2[0].page_content != "What is a sandwich?"
-
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_texts_with_metadatas_delete_multiple(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        collection = collections[0]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        vectorstore = DocumentDBVectorSearch.from_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, similarity_algorithm)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=5)
-
-        first_document_id_object = output[0].metadata["_id"]
-        first_document_id = str(first_document_id_object)
-
-        output[1].metadata["_id"]
-        second_document_id = output[1].metadata["_id"]
-
-        output[2].metadata["_id"]
-        third_document_id = output[2].metadata["_id"]
-
-        document_ids = [first_document_id, second_document_id, third_document_id]
-        vectorstore.delete(document_ids)
-        sleep(2)  # waits for the index to be updated
-
-        output_2 = vectorstore.similarity_search("Sandwich", k=5)
-        assert output
-        assert output_2
-
-        assert len(output) == 4  # we should see all the four documents
-        assert (
-            len(output_2) == 1
-        )  # we should see only one document left after three have been deleted
-
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_texts_with_metadatas_delete_multiple(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, similarity_algorithm)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=5)
-
-        first_document_id_object = output[0].metadata["_id"]
-        first_document_id = str(first_document_id_object)
-
-        output[1].metadata["_id"]
-        second_document_id = output[1].metadata["_id"]
-
-        output[2].metadata["_id"]
-        third_document_id = output[2].metadata["_id"]
-
-        document_ids = [first_document_id, second_document_id, third_document_id]
-        await vectorstore.adelete(document_ids)
-        await asyncio_sleep(2)  # waits for the index to be updated
-
-        output_2 = await vectorstore.asimilarity_search("Sandwich", k=5)
-        assert output
-        assert output_2
-
-        assert len(output) == 4  # we should see all the four documents
-        assert (
-            len(output_2) == 1
-        )  # we should see only one document left after three have been deleted
-
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_texts_with_metadatas_inner_product(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        collection = collections[0]
-        vectorstore = DocumentDBVectorSearch.from_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_texts_with_metadatas_inner_product(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_from_texts_with_metadatas_euclidean_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        collection = collections[0]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        vectorstore = DocumentDBVectorSearch.from_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        vectorstore.create_index(dimensions, DocumentDBSimilarityType.EUC)
-        sleep(2)  # waits for the index to be set up
-
-        output = vectorstore.similarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        vectorstore.delete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_afrom_texts_with_metadatas_euclidean_distance(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        texts = [
-            "Dogs are tough.",
-            "Cats have fluff.",
-            "What is a sandwich?",
-            "The fence is purple.",
-        ]
-        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-        collection, async_collection = collections
-        vectorstore = await DocumentDBVectorSearch.afrom_texts(
-            texts,
-            embedding_openai,
-            metadatas=metadatas,
-            collection=collection,
-            async_collection=async_collection,
-            index_name=INDEX_NAME,
-        )
-
-        # Create the HNSW index that will be leveraged later for vector search
-        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.EUC)
-        await asyncio_sleep(2)  # waits for the index to be set up
-
-        output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-        assert output
-        assert output[0].page_content == "What is a sandwich?"
-        assert output[0].metadata["c"] == 1
-        await vectorstore.adelete_index()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def invoke_delete_with_no_args(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> Optional[bool]:
-        vectorstore: DocumentDBVectorSearch = (
-            DocumentDBVectorSearch.from_connection_string(
-                CONNECTION_STRING,
-                NAMESPACE,
-                embedding_openai,
-                index_name=INDEX_NAME,
-            )
-        )
-
-        return vectorstore.delete()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def ainvoke_delete_with_no_args(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> Optional[bool]:
-        vectorstore: DocumentDBVectorSearch = (
-            DocumentDBVectorSearch.afrom_connection_string(
-                CONNECTION_STRING,
-                NAMESPACE,
-                embedding_openai,
-                index_name=INDEX_NAME,
-            )
-        )
-
-        return await vectorstore.adelete()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def invoke_delete_by_id_with_no_args(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        vectorstore: DocumentDBVectorSearch = (
-            DocumentDBVectorSearch.from_connection_string(
-                CONNECTION_STRING,
-                NAMESPACE,
-                embedding_openai,
-                index_name=INDEX_NAME,
-            )
-        )
-
-        vectorstore.delete_document_by_id()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def ainvoke_delete_by_id_with_no_args(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        vectorstore: DocumentDBVectorSearch = (
-            DocumentDBVectorSearch.afrom_connection_string(
-                CONNECTION_STRING,
-                NAMESPACE,
-                embedding_openai,
-                index_name=INDEX_NAME,
-            )
-        )
-
-        await vectorstore.adelete_document_by_id()
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_invalid_arguments_to_delete(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        with pytest.raises(ValueError) as exception_info:
-            collection = collections[0]
-            self.invoke_delete_with_no_args(embedding_openai, collection)
-        assert str(exception_info.value) == "No document ids provided to delete."
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_ainvalid_arguments_to_delete(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        with pytest.raises(ValueError) as exception_info:
-            collection = collections[0]
-            await self.ainvoke_delete_with_no_args(embedding_openai, collection)
-        assert str(exception_info.value) == "No document ids provided to delete."
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    def test_no_arguments_to_delete_by_id(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        with pytest.raises(Exception) as exception_info:
-            collection = collections[0]
-            self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
-        assert str(exception_info.value) == "No document id provided to delete."
-
-    @pytest.mark.requires("pymongo")
-    @pytest.mark.requires("motor")
-    async def test_ano_arguments_to_delete_by_id(
-        self, embedding_openai: OpenAIEmbeddings, collections: Any
-    ) -> None:
-        with pytest.raises(Exception) as exception_info:
-            await self.ainvoke_delete_by_id_with_no_args(embedding_openai, collections)
-        assert str(exception_info.value) == "No document id provided to delete."
+# """Test DocumentDBVectorSearch functionality."""
+
+# import logging
+# import os
+# from asyncio import sleep as asyncio_sleep
+# from time import sleep
+# from typing import Any, Optional, Tuple
+
+# import pytest
+# from langchain_core.documents import Document
+# from motor.core import AgnosticCollection
+# from pymongo.collection import Collection
+
+# from langchain_community.embeddings import OpenAIEmbeddings
+# from langchain_community.vectorstores.documentdb_async import (
+#     DocumentDBSimilarityType,
+#     DocumentDBVectorSearch,
+# )
+
+# logging.basicConfig(level=logging.DEBUG)
+
+# model_deployment = os.getenv(
+#     "OPENAI_EMBEDDINGS_DEPLOYMENT", "smart-agent-embedding-ada"
+# )
+# model_name = os.getenv("OPENAI_EMBEDDINGS_MODEL_NAME", "text-embedding-ada-002")
+
+# INDEX_NAME = "langchain-test-index"
+# NAMESPACE = "langchain_test_db.langchain_test_collection"
+# CONNECTION_STRING = os.getenv("DOCUMENTDB_URI", "")
+# DB_NAME, COLLECTION_NAME = NAMESPACE.split(".")
+
+# dimensions = 1536
+# similarity_algorithm = DocumentDBSimilarityType.COS
+
+
+# def prepare_collection() -> Tuple[Collection, AgnosticCollection]:
+#     from motor.core import AgnosticClient
+#     from motor.motor_asyncio import AsyncIOMotorClient
+#     from pymongo import MongoClient
+
+#     test_client: MongoClient = MongoClient(CONNECTION_STRING)
+#     test_async_client: AgnosticClient = AsyncIOMotorClient(CONNECTION_STRING)
+#     return test_client[DB_NAME][COLLECTION_NAME], test_async_client[DB_NAME][
+#         COLLECTION_NAME
+#     ]
+
+
+# @pytest.fixture()
+# @pytest.mark.requires("pymongo")
+# @pytest.mark.requires("motor")
+# def collections() -> Any:
+#     return prepare_collection()
+
+
+# @pytest.fixture()
+# @pytest.mark.requires("pymongo")
+# @pytest.mark.requires("motor")
+# def embedding_openai() -> Any:
+#     openai_embeddings: OpenAIEmbeddings = OpenAIEmbeddings(
+#         deployment=model_deployment, model=model_name, chunk_size=1
+#     )
+#     return openai_embeddings
+
+
+# """
+# This is how to run the integration tests:
+
+# cd libs/aws
+# make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
+
+# NOTE: You will first need to follow the contributor setup steps:
+# https://python.langchain.com/docs/contributing/code. You will also need to install
+# `pymongo` via `poetry`. You can also run the test directly using `pytest`, but please
+# make sure to install all dependencies.
+# """
+
+
+# class TestDocumentDBVectorSearch:
+#     @classmethod
+#     def setup_class(cls) -> None:
+#         if not os.getenv("OPENAI_API_KEY"):
+#             raise ValueError("OPENAI_API_KEY environment variable is not set")
+
+#         # insure the test collection is empty
+#         collection, async_collection = prepare_collection()
+#         assert collection.count_documents({}) == 0  # type: ignore[index]  # noqa: E501
+
+#     @classmethod
+#     def teardown_class(cls) -> None:
+#         collection, async_collection = prepare_collection()
+#         # delete all the documents in the collection
+#         collection.delete_many({})  # type: ignore[index]
+#         collection.drop_indexes()
+
+#     @pytest.fixture(autouse=True)
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def setup(self) -> None:
+#         collection, async_collection = prepare_collection()
+#         # delete all the documents in the collection
+#         collection.delete_many({})  # type: ignore[index]
+#         collection.drop_indexes()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_documents_cosine_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         """Test end to end construction and search."""
+#         documents = [
+#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
+#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
+#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
+#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+#         ]
+
+#         collection = collections[0]
+#         vectorstore = DocumentDBVectorSearch.from_documents(
+#             documents,
+#             embedding_openai,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+#         sleep(1)  # waits for DocumentDB to save contents to the collection
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, similarity_algorithm)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_documents_cosine_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         """Test end to end construction and search."""
+#         documents = [
+#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
+#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
+#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
+#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+#         ]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_documents(
+#             documents,
+#             embedding_openai,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+#         await asyncio_sleep(
+#             1
+#         )  # waits for DocumentDB to save contents to the collection
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_documents_inner_product(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         """Test end to end construction and search."""
+#         documents = [
+#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
+#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
+#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
+#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+#         ]
+#         collection = collections[0]
+#         vectorstore = DocumentDBVectorSearch.from_documents(
+#             documents,
+#             embedding_openai,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+#         sleep(1)  # waits for DocumentDB to save contents to the collection
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1, ef_search=100)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_documents_inner_product(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         """Test end to end construction and search."""
+#         documents = [
+#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
+#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
+#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
+#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+#         ]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_documents(
+#             documents,
+#             embedding_openai,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+#         await asyncio_sleep(
+#             1
+#         )  # waits for DocumentDB to save contents to the collection
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=100)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_texts_cosine_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "That fence is purple.",
+#         ]
+#         collection = collections[0]
+#         vectorstore = DocumentDBVectorSearch.from_texts(
+#             texts,
+#             embedding_openai,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, similarity_algorithm)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1)
+
+#         assert output[0].page_content == "What is a sandwich?"
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_texts_cosine_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "That fence is purple.",
+#         ]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
+#             texts,
+#             embedding_openai,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+#         assert output[0].page_content == "What is a sandwich?"
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_texts_with_metadatas_cosine_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         collection = collections[0]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         vectorstore = DocumentDBVectorSearch.from_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, similarity_algorithm)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_texts_with_metadatas_cosine_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_texts_with_metadatas_delete_one(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         collection = collections[0]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         vectorstore = DocumentDBVectorSearch.from_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, similarity_algorithm)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+
+#         first_document_id_object = output[0].metadata["_id"]
+#         first_document_id = str(first_document_id_object)
+
+#         vectorstore.delete_document_by_id(first_document_id)
+#         sleep(2)  # waits for the index to be updated
+
+#         output2 = vectorstore.similarity_search("Sandwich", k=1, ef_search=10)
+#         assert output2
+#         assert output2[0].page_content != "What is a sandwich?"
+
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_texts_with_metadatas_delete_one(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+
+#         first_document_id_object = output[0].metadata["_id"]
+#         first_document_id = str(first_document_id_object)
+
+#         await vectorstore.adelete_document_by_id(first_document_id)
+#         await asyncio_sleep(2)  # waits for the index to be updated
+
+#         output2 = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=10)
+#         assert output2
+#         assert output2[0].page_content != "What is a sandwich?"
+
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_texts_with_metadatas_delete_multiple(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         collection = collections[0]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         vectorstore = DocumentDBVectorSearch.from_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, similarity_algorithm)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=5)
+
+#         first_document_id_object = output[0].metadata["_id"]
+#         first_document_id = str(first_document_id_object)
+
+#         output[1].metadata["_id"]
+#         second_document_id = output[1].metadata["_id"]
+
+#         output[2].metadata["_id"]
+#         third_document_id = output[2].metadata["_id"]
+
+#         document_ids = [first_document_id, second_document_id, third_document_id]
+#         vectorstore.delete(document_ids)
+#         sleep(2)  # waits for the index to be updated
+
+#         output_2 = vectorstore.similarity_search("Sandwich", k=5)
+#         assert output
+#         assert output_2
+
+#         assert len(output) == 4  # we should see all the four documents
+#         assert (
+#             len(output_2) == 1
+#         )  # we should see only one document left after three have been deleted
+
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_texts_with_metadatas_delete_multiple(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=5)
+
+#         first_document_id_object = output[0].metadata["_id"]
+#         first_document_id = str(first_document_id_object)
+
+#         output[1].metadata["_id"]
+#         second_document_id = output[1].metadata["_id"]
+
+#         output[2].metadata["_id"]
+#         third_document_id = output[2].metadata["_id"]
+
+#         document_ids = [first_document_id, second_document_id, third_document_id]
+#         await vectorstore.adelete(document_ids)
+#         await asyncio_sleep(2)  # waits for the index to be updated
+
+#         output_2 = await vectorstore.asimilarity_search("Sandwich", k=5)
+#         assert output
+#         assert output_2
+
+#         assert len(output) == 4  # we should see all the four documents
+#         assert (
+#             len(output_2) == 1
+#         )  # we should see only one document left after three have been deleted
+
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_texts_with_metadatas_inner_product(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         collection = collections[0]
+#         vectorstore = DocumentDBVectorSearch.from_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_texts_with_metadatas_inner_product(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_from_texts_with_metadatas_euclidean_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         collection = collections[0]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         vectorstore = DocumentDBVectorSearch.from_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         vectorstore.create_index(dimensions, DocumentDBSimilarityType.EUC)
+#         sleep(2)  # waits for the index to be set up
+
+#         output = vectorstore.similarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         vectorstore.delete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_afrom_texts_with_metadatas_euclidean_distance(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         texts = [
+#             "Dogs are tough.",
+#             "Cats have fluff.",
+#             "What is a sandwich?",
+#             "The fence is purple.",
+#         ]
+#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+#         collection, async_collection = collections
+#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
+#             texts,
+#             embedding_openai,
+#             metadatas=metadatas,
+#             collection=collection,
+#             async_collection=async_collection,
+#             index_name=INDEX_NAME,
+#         )
+
+#         # Create the HNSW index that will be leveraged later for vector search
+#         await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.EUC)
+#         await asyncio_sleep(2)  # waits for the index to be set up
+
+#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+#         assert output
+#         assert output[0].page_content == "What is a sandwich?"
+#         assert output[0].metadata["c"] == 1
+#         await vectorstore.adelete_index()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def invoke_delete_with_no_args(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> Optional[bool]:
+#         vectorstore: DocumentDBVectorSearch = (
+#             DocumentDBVectorSearch.from_connection_string(
+#                 CONNECTION_STRING,
+#                 NAMESPACE,
+#                 embedding_openai,
+#                 index_name=INDEX_NAME,
+#             )
+#         )
+
+#         return vectorstore.delete()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def ainvoke_delete_with_no_args(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> Optional[bool]:
+#         vectorstore: DocumentDBVectorSearch = (
+#             DocumentDBVectorSearch.afrom_connection_string(
+#                 CONNECTION_STRING,
+#                 NAMESPACE,
+#                 embedding_openai,
+#                 index_name=INDEX_NAME,
+#             )
+#         )
+
+#         return await vectorstore.adelete()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def invoke_delete_by_id_with_no_args(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         vectorstore: DocumentDBVectorSearch = (
+#             DocumentDBVectorSearch.from_connection_string(
+#                 CONNECTION_STRING,
+#                 NAMESPACE,
+#                 embedding_openai,
+#                 index_name=INDEX_NAME,
+#             )
+#         )
+
+#         vectorstore.delete_document_by_id()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def ainvoke_delete_by_id_with_no_args(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         vectorstore: DocumentDBVectorSearch = (
+#             DocumentDBVectorSearch.afrom_connection_string(
+#                 CONNECTION_STRING,
+#                 NAMESPACE,
+#                 embedding_openai,
+#                 index_name=INDEX_NAME,
+#             )
+#         )
+
+#         await vectorstore.adelete_document_by_id()
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_invalid_arguments_to_delete(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         with pytest.raises(ValueError) as exception_info:
+#             collection = collections[0]
+#             self.invoke_delete_with_no_args(embedding_openai, collection)
+#         assert str(exception_info.value) == "No document ids provided to delete."
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_ainvalid_arguments_to_delete(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         with pytest.raises(ValueError) as exception_info:
+#             collection = collections[0]
+#             await self.ainvoke_delete_with_no_args(embedding_openai, collection)
+#         assert str(exception_info.value) == "No document ids provided to delete."
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     def test_no_arguments_to_delete_by_id(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         with pytest.raises(Exception) as exception_info:
+#             collection = collections[0]
+#             self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
+#         assert str(exception_info.value) == "No document id provided to delete."
+
+#     @pytest.mark.requires("pymongo")
+#     @pytest.mark.requires("motor")
+#     async def test_ano_arguments_to_delete_by_id(
+#         self, embedding_openai: OpenAIEmbeddings, collections: Any
+#     ) -> None:
+#         with pytest.raises(Exception) as exception_info:
+#             await self.ainvoke_delete_by_id_with_no_args(embedding_openai, collections)
+#         assert str(exception_info.value) == "No document id provided to delete."

--- a/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
@@ -1,784 +1,782 @@
-# """Test DocumentDBVectorSearch functionality."""
-
-# import logging
-# import os
-# from asyncio import sleep as asyncio_sleep
-# from time import sleep
-# from typing import Any, Optional, Tuple
-
-# import pytest
-# from langchain_core.documents import Document
-# from motor.core import AgnosticCollection
-# from pymongo.collection import Collection
-
-# from langchain_community.embeddings import OpenAIEmbeddings
-# from langchain_community.vectorstores.documentdb_async import (
-#     DocumentDBSimilarityType,
-#     DocumentDBVectorSearch,
-# )
-
-# logging.basicConfig(level=logging.DEBUG)
-
-# model_deployment = os.getenv(
-#     "OPENAI_EMBEDDINGS_DEPLOYMENT", "smart-agent-embedding-ada"
-# )
-# model_name = os.getenv("OPENAI_EMBEDDINGS_MODEL_NAME", "text-embedding-ada-002")
-
-# INDEX_NAME = "langchain-test-index"
-# NAMESPACE = "langchain_test_db.langchain_test_collection"
-# CONNECTION_STRING = os.getenv("DOCUMENTDB_URI", "")
-# DB_NAME, COLLECTION_NAME = NAMESPACE.split(".")
-
-# dimensions = 1536
-# similarity_algorithm = DocumentDBSimilarityType.COS
-
-
-# def prepare_collection() -> Tuple[Collection, AgnosticCollection]:
-#     from motor.core import AgnosticClient
-#     from motor.motor_asyncio import AsyncIOMotorClient
-#     from pymongo import MongoClient
-
-#     test_client: MongoClient = MongoClient(CONNECTION_STRING)
-#     test_async_client: AgnosticClient = AsyncIOMotorClient(CONNECTION_STRING)
-#     return test_client[DB_NAME][COLLECTION_NAME], test_async_client[DB_NAME][
-#         COLLECTION_NAME
-#     ]
-
-
-# @pytest.fixture()
-# @pytest.mark.requires("pymongo")
-# @pytest.mark.requires("motor")
-# def collections() -> Any:
-#     return prepare_collection()
-
-
-# @pytest.fixture()
-# @pytest.mark.requires("pymongo")
-# @pytest.mark.requires("motor")
-# def embedding_openai() -> Any:
-#     openai_embeddings: OpenAIEmbeddings = OpenAIEmbeddings(
-#         deployment=model_deployment, model=model_name, chunk_size=1
-#     )
-#     return openai_embeddings
-
-
-# """
-# This is how to run the integration tests:
-
-# cd libs/aws
-# make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
-
-# NOTE: You will first need to follow the contributor setup steps:
-# https://python.langchain.com/docs/contributing/code. You will also need to install
-# `pymongo` via `poetry`. You can also run the test directly using `pytest`, but please
-# make sure to install all dependencies.
-# """
-
-
-# class TestDocumentDBVectorSearch:
-#     @classmethod
-#     def setup_class(cls) -> None:
-#         if not os.getenv("OPENAI_API_KEY"):
-#             raise ValueError("OPENAI_API_KEY environment variable is not set")
-
-#         # insure the test collection is empty
-#         collection, async_collection = prepare_collection()
-#         assert collection.count_documents({}) == 0  # type: ignore[index]  # noqa: E501
-
-#     @classmethod
-#     def teardown_class(cls) -> None:
-#         collection, async_collection = prepare_collection()
-#         # delete all the documents in the collection
-#         collection.delete_many({})  # type: ignore[index]
-#         collection.drop_indexes()
-
-#     @pytest.fixture(autouse=True)
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def setup(self) -> None:
-#         collection, async_collection = prepare_collection()
-#         # delete all the documents in the collection
-#         collection.delete_many({})  # type: ignore[index]
-#         collection.drop_indexes()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_documents_cosine_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         """Test end to end construction and search."""
-#         documents = [
-#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
-#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
-#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
-#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-#         ]
-
-#         collection = collections[0]
-#         vectorstore = DocumentDBVectorSearch.from_documents(
-#             documents,
-#             embedding_openai,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-#         sleep(1)  # waits for DocumentDB to save contents to the collection
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, similarity_algorithm)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_documents_cosine_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         """Test end to end construction and search."""
-#         documents = [
-#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
-#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
-#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
-#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-#         ]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_documents(
-#             documents,
-#             embedding_openai,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-#         await asyncio_sleep(
-#             1
-#         )  # waits for DocumentDB to save contents to the collection
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_documents_inner_product(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         """Test end to end construction and search."""
-#         documents = [
-#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
-#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
-#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
-#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-#         ]
-#         collection = collections[0]
-#         vectorstore = DocumentDBVectorSearch.from_documents(
-#             documents,
-#             embedding_openai,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-#         sleep(1)  # waits for DocumentDB to save contents to the collection
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1, ef_search=100)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_documents_inner_product(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         """Test end to end construction and search."""
-#         documents = [
-#             Document(page_content="Dogs are tough.", metadata={"a": 1}),
-#             Document(page_content="Cats have fluff.", metadata={"b": 1}),
-#             Document(page_content="What is a sandwich?", metadata={"c": 1}),
-#             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-#         ]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_documents(
-#             documents,
-#             embedding_openai,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-#         await asyncio_sleep(
-#             1
-#         )  # waits for DocumentDB to save contents to the collection
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=100)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_texts_cosine_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "That fence is purple.",
-#         ]
-#         collection = collections[0]
-#         vectorstore = DocumentDBVectorSearch.from_texts(
-#             texts,
-#             embedding_openai,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, similarity_algorithm)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1)
-
-#         assert output[0].page_content == "What is a sandwich?"
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_texts_cosine_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "That fence is purple.",
-#         ]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
-#             texts,
-#             embedding_openai,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-#         assert output[0].page_content == "What is a sandwich?"
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_texts_with_metadatas_cosine_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         collection = collections[0]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         vectorstore = DocumentDBVectorSearch.from_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, similarity_algorithm)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_texts_with_metadatas_cosine_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_texts_with_metadatas_delete_one(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         collection = collections[0]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         vectorstore = DocumentDBVectorSearch.from_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, similarity_algorithm)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-
-#         first_document_id_object = output[0].metadata["_id"]
-#         first_document_id = str(first_document_id_object)
-
-#         vectorstore.delete_document_by_id(first_document_id)
-#         sleep(2)  # waits for the index to be updated
-
-#         output2 = vectorstore.similarity_search("Sandwich", k=1, ef_search=10)
-#         assert output2
-#         assert output2[0].page_content != "What is a sandwich?"
-
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_texts_with_metadatas_delete_one(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-
-#         first_document_id_object = output[0].metadata["_id"]
-#         first_document_id = str(first_document_id_object)
-
-#         await vectorstore.adelete_document_by_id(first_document_id)
-#         await asyncio_sleep(2)  # waits for the index to be updated
-
-#         output2 = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=10)
-#         assert output2
-#         assert output2[0].page_content != "What is a sandwich?"
-
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_texts_with_metadatas_delete_multiple(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         collection = collections[0]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         vectorstore = DocumentDBVectorSearch.from_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, similarity_algorithm)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=5)
-
-#         first_document_id_object = output[0].metadata["_id"]
-#         first_document_id = str(first_document_id_object)
-
-#         output[1].metadata["_id"]
-#         second_document_id = output[1].metadata["_id"]
-
-#         output[2].metadata["_id"]
-#         third_document_id = output[2].metadata["_id"]
-
-#         document_ids = [first_document_id, second_document_id, third_document_id]
-#         vectorstore.delete(document_ids)
-#         sleep(2)  # waits for the index to be updated
-
-#         output_2 = vectorstore.similarity_search("Sandwich", k=5)
-#         assert output
-#         assert output_2
-
-#         assert len(output) == 4  # we should see all the four documents
-#         assert (
-#             len(output_2) == 1
-#         )  # we should see only one document left after three have been deleted
-
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_texts_with_metadatas_delete_multiple(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, similarity_algorithm)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=5)
-
-#         first_document_id_object = output[0].metadata["_id"]
-#         first_document_id = str(first_document_id_object)
-
-#         output[1].metadata["_id"]
-#         second_document_id = output[1].metadata["_id"]
-
-#         output[2].metadata["_id"]
-#         third_document_id = output[2].metadata["_id"]
-
-#         document_ids = [first_document_id, second_document_id, third_document_id]
-#         await vectorstore.adelete(document_ids)
-#         await asyncio_sleep(2)  # waits for the index to be updated
-
-#         output_2 = await vectorstore.asimilarity_search("Sandwich", k=5)
-#         assert output
-#         assert output_2
-
-#         assert len(output) == 4  # we should see all the four documents
-#         assert (
-#             len(output_2) == 1
-#         )  # we should see only one document left after three have been deleted
-
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_texts_with_metadatas_inner_product(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         collection = collections[0]
-#         vectorstore = DocumentDBVectorSearch.from_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_texts_with_metadatas_inner_product(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_from_texts_with_metadatas_euclidean_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         collection = collections[0]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         vectorstore = DocumentDBVectorSearch.from_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         vectorstore.create_index(dimensions, DocumentDBSimilarityType.EUC)
-#         sleep(2)  # waits for the index to be set up
-
-#         output = vectorstore.similarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         vectorstore.delete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_afrom_texts_with_metadatas_euclidean_distance(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         texts = [
-#             "Dogs are tough.",
-#             "Cats have fluff.",
-#             "What is a sandwich?",
-#             "The fence is purple.",
-#         ]
-#         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
-#         collection, async_collection = collections
-#         vectorstore = await DocumentDBVectorSearch.afrom_texts(
-#             texts,
-#             embedding_openai,
-#             metadatas=metadatas,
-#             collection=collection,
-#             async_collection=async_collection,
-#             index_name=INDEX_NAME,
-#         )
-
-#         # Create the HNSW index that will be leveraged later for vector search
-#         await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.EUC)
-#         await asyncio_sleep(2)  # waits for the index to be set up
-
-#         output = await vectorstore.asimilarity_search("Sandwich", k=1)
-
-#         assert output
-#         assert output[0].page_content == "What is a sandwich?"
-#         assert output[0].metadata["c"] == 1
-#         await vectorstore.adelete_index()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def invoke_delete_with_no_args(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> Optional[bool]:
-#         vectorstore: DocumentDBVectorSearch = (
-#             DocumentDBVectorSearch.from_connection_string(
-#                 CONNECTION_STRING,
-#                 NAMESPACE,
-#                 embedding_openai,
-#                 index_name=INDEX_NAME,
-#             )
-#         )
-
-#         return vectorstore.delete()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def ainvoke_delete_with_no_args(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> Optional[bool]:
-#         vectorstore: DocumentDBVectorSearch = (
-#             DocumentDBVectorSearch.afrom_connection_string(
-#                 CONNECTION_STRING,
-#                 NAMESPACE,
-#                 embedding_openai,
-#                 index_name=INDEX_NAME,
-#             )
-#         )
-
-#         return await vectorstore.adelete()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def invoke_delete_by_id_with_no_args(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         vectorstore: DocumentDBVectorSearch = (
-#             DocumentDBVectorSearch.from_connection_string(
-#                 CONNECTION_STRING,
-#                 NAMESPACE,
-#                 embedding_openai,
-#                 index_name=INDEX_NAME,
-#             )
-#         )
-
-#         vectorstore.delete_document_by_id()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def ainvoke_delete_by_id_with_no_args(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         vectorstore: DocumentDBVectorSearch = (
-#             DocumentDBVectorSearch.afrom_connection_string(
-#                 CONNECTION_STRING,
-#                 NAMESPACE,
-#                 embedding_openai,
-#                 index_name=INDEX_NAME,
-#             )
-#         )
-
-#         await vectorstore.adelete_document_by_id()
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_invalid_arguments_to_delete(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         with pytest.raises(ValueError) as exception_info:
-#             collection = collections[0]
-#             self.invoke_delete_with_no_args(embedding_openai, collection)
-#         assert str(exception_info.value) == "No document ids provided to delete."
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_ainvalid_arguments_to_delete(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         with pytest.raises(ValueError) as exception_info:
-#             collection = collections[0]
-#             await self.ainvoke_delete_with_no_args(embedding_openai, collection)
-#         assert str(exception_info.value) == "No document ids provided to delete."
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     def test_no_arguments_to_delete_by_id(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         with pytest.raises(Exception) as exception_info:
-#             collection = collections[0]
-#             self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
-#         assert str(exception_info.value) == "No document id provided to delete."
-
-#     @pytest.mark.requires("pymongo")
-#     @pytest.mark.requires("motor")
-#     async def test_ano_arguments_to_delete_by_id(
-#         self, embedding_openai: OpenAIEmbeddings, collections: Any
-#     ) -> None:
-#         with pytest.raises(Exception) as exception_info:
-#             await self.ainvoke_delete_by_id_with_no_args(embedding_openai, collections)
-#         assert str(exception_info.value) == "No document id provided to delete."
+"""Test DocumentDBVectorSearch functionality."""
+
+import logging
+import os
+from asyncio import sleep as asyncio_sleep
+from time import sleep
+from typing import Any, Optional, Tuple
+
+import pytest
+from langchain_core.documents import Document
+
+from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores.documentdb_async import (
+    DocumentDBSimilarityType,
+    DocumentDBVectorSearch,
+)
+
+logging.basicConfig(level=logging.DEBUG)
+
+model_deployment = os.getenv(
+    "OPENAI_EMBEDDINGS_DEPLOYMENT", "smart-agent-embedding-ada"
+)
+model_name = os.getenv("OPENAI_EMBEDDINGS_MODEL_NAME", "text-embedding-ada-002")
+
+INDEX_NAME = "langchain-test-index"
+NAMESPACE = "langchain_test_db.langchain_test_collection"
+CONNECTION_STRING = os.getenv("DOCUMENTDB_URI", "")
+DB_NAME, COLLECTION_NAME = NAMESPACE.split(".")
+
+dimensions = 1536
+similarity_algorithm = DocumentDBSimilarityType.COS
+
+
+def prepare_collection() -> Any:
+    from motor.core import AgnosticClient
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from pymongo import MongoClient
+
+    test_client: MongoClient = MongoClient(CONNECTION_STRING)
+    test_async_client: AgnosticClient = AsyncIOMotorClient(CONNECTION_STRING)
+    return test_client[DB_NAME][COLLECTION_NAME], test_async_client[DB_NAME][
+        COLLECTION_NAME
+    ]
+
+
+@pytest.fixture()
+@pytest.mark.requires("pymongo")
+@pytest.mark.requires("motor")
+def collections() -> Any:
+    return prepare_collection()
+
+
+@pytest.fixture()
+@pytest.mark.requires("pymongo")
+@pytest.mark.requires("motor")
+def embedding_openai() -> Any:
+    openai_embeddings: OpenAIEmbeddings = OpenAIEmbeddings(
+        deployment=model_deployment, model=model_name, chunk_size=1
+    )
+    return openai_embeddings
+
+
+"""
+This is how to run the integration tests:
+
+cd libs/aws
+make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
+
+NOTE: You will first need to follow the contributor setup steps:
+https://python.langchain.com/docs/contributing/code. You will also need to install
+`pymongo` via `uv`. You can also run the test directly using `pytest`, but please
+make sure to install all dependencies.
+"""
+
+
+class TestDocumentDBVectorSearch:
+    @classmethod
+    def setup_class(cls) -> None:
+        if not os.getenv("OPENAI_API_KEY"):
+            raise ValueError("OPENAI_API_KEY environment variable is not set")
+
+        # insure the test collection is empty
+        collection, async_collection = prepare_collection()
+        assert collection.count_documents({}) == 0  # type: ignore[index]  # noqa: E501
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        collection, async_collection = prepare_collection()
+        # delete all the documents in the collection
+        collection.delete_many({})  # type: ignore[index]
+        collection.drop_indexes()
+
+    @pytest.fixture(autouse=True)
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def setup(self) -> None:
+        collection, async_collection = prepare_collection()
+        # delete all the documents in the collection
+        collection.delete_many({})  # type: ignore[index]
+        collection.drop_indexes()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_documents_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+        sleep(1)  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_documents_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+        await asyncio_sleep(
+            1
+        )  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_documents_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+        sleep(1)  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1, ef_search=100)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_documents_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+        await asyncio_sleep(
+            1
+        )  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=100)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_texts_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "That fence is purple.",
+        ]
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output[0].page_content == "What is a sandwich?"
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_texts_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "That fence is purple.",
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output[0].page_content == "What is a sandwich?"
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_texts_with_metadatas_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_texts_with_metadatas_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_texts_with_metadatas_delete_one(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        vectorstore.delete_document_by_id(first_document_id)
+        sleep(2)  # waits for the index to be updated
+
+        output2 = vectorstore.similarity_search("Sandwich", k=1, ef_search=10)
+        assert output2
+        assert output2[0].page_content != "What is a sandwich?"
+
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_texts_with_metadatas_delete_one(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        await vectorstore.adelete_document_by_id(first_document_id)
+        await asyncio_sleep(2)  # waits for the index to be updated
+
+        output2 = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=10)
+        assert output2
+        assert output2[0].page_content != "What is a sandwich?"
+
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_texts_with_metadatas_delete_multiple(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=5)
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        output[1].metadata["_id"]
+        second_document_id = output[1].metadata["_id"]
+
+        output[2].metadata["_id"]
+        third_document_id = output[2].metadata["_id"]
+
+        document_ids = [first_document_id, second_document_id, third_document_id]
+        vectorstore.delete(document_ids)
+        sleep(2)  # waits for the index to be updated
+
+        output_2 = vectorstore.similarity_search("Sandwich", k=5)
+        assert output
+        assert output_2
+
+        assert len(output) == 4  # we should see all the four documents
+        assert (
+            len(output_2) == 1
+        )  # we should see only one document left after three have been deleted
+
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_texts_with_metadatas_delete_multiple(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=5)
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        output[1].metadata["_id"]
+        second_document_id = output[1].metadata["_id"]
+
+        output[2].metadata["_id"]
+        third_document_id = output[2].metadata["_id"]
+
+        document_ids = [first_document_id, second_document_id, third_document_id]
+        await vectorstore.adelete(document_ids)
+        await asyncio_sleep(2)  # waits for the index to be updated
+
+        output_2 = await vectorstore.asimilarity_search("Sandwich", k=5)
+        assert output
+        assert output_2
+
+        assert len(output) == 4  # we should see all the four documents
+        assert (
+            len(output_2) == 1
+        )  # we should see only one document left after three have been deleted
+
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_texts_with_metadatas_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_texts_with_metadatas_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_from_texts_with_metadatas_euclidean_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, DocumentDBSimilarityType.EUC)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_afrom_texts_with_metadatas_euclidean_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.EUC)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def invoke_delete_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> Optional[bool]:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.from_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        return vectorstore.delete()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def ainvoke_delete_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> Optional[bool]:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.afrom_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        return await vectorstore.adelete()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def invoke_delete_by_id_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.from_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        vectorstore.delete_document_by_id()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def ainvoke_delete_by_id_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.afrom_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        await vectorstore.adelete_document_by_id()
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_invalid_arguments_to_delete(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(ValueError) as exception_info:
+            collection = collections[0]
+            self.invoke_delete_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document ids provided to delete."
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_ainvalid_arguments_to_delete(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(ValueError) as exception_info:
+            collection = collections[0]
+            await self.ainvoke_delete_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document ids provided to delete."
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    def test_no_arguments_to_delete_by_id(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(Exception) as exception_info:
+            collection = collections[0]
+            self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document id provided to delete."
+
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
+    async def test_ano_arguments_to_delete_by_id(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(Exception) as exception_info:
+            await self.ainvoke_delete_by_id_with_no_args(embedding_openai, collections)
+        assert str(exception_info.value) == "No document id provided to delete."

--- a/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
@@ -1,0 +1,730 @@
+"""Test DocumentDBVectorSearch functionality."""
+
+import logging
+import os
+from asyncio import sleep as asyncio_sleep
+from time import sleep
+from typing import Any, Optional, Tuple
+
+import pytest
+from langchain_core.documents import Document
+from motor.core import AgnosticCollection
+from pymongo.collection import Collection
+
+from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores.documentdb_async import (
+    DocumentDBSimilarityType,
+    DocumentDBVectorSearch,
+)
+
+logging.basicConfig(level=logging.DEBUG)
+
+model_deployment = os.getenv(
+    "OPENAI_EMBEDDINGS_DEPLOYMENT", "smart-agent-embedding-ada"
+)
+model_name = os.getenv("OPENAI_EMBEDDINGS_MODEL_NAME", "text-embedding-ada-002")
+
+INDEX_NAME = "langchain-test-index"
+NAMESPACE = "langchain_test_db.langchain_test_collection"
+CONNECTION_STRING = os.getenv("DOCUMENTDB_URI", "")
+DB_NAME, COLLECTION_NAME = NAMESPACE.split(".")
+
+dimensions = 1536
+similarity_algorithm = DocumentDBSimilarityType.COS
+
+
+def prepare_collection() -> Tuple[Collection, AgnosticCollection]:
+    from motor.core import AgnosticClient
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from pymongo import MongoClient
+
+    test_client: MongoClient = MongoClient(CONNECTION_STRING)
+    test_async_client: AgnosticClient = AsyncIOMotorClient(CONNECTION_STRING)
+    return test_client[DB_NAME][COLLECTION_NAME], test_async_client[DB_NAME][
+        COLLECTION_NAME
+    ]
+
+
+@pytest.fixture()
+def collections() -> Any:
+    return prepare_collection()
+
+
+@pytest.fixture()
+def embedding_openai() -> Any:
+    openai_embeddings: OpenAIEmbeddings = OpenAIEmbeddings(
+        deployment=model_deployment, model=model_name, chunk_size=1
+    )
+    return openai_embeddings
+
+
+"""
+This is how to run the integration tests:
+
+cd libs/aws
+make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
+
+NOTE: You will first need to follow the contributor setup steps:
+https://python.langchain.com/docs/contributing/code. You will also need to install
+`pymongo` via `poetry`. You can also run the test directly using `pytest`, but please
+make sure to install all dependencies.
+"""
+
+
+class TestDocumentDBVectorSearch:
+    @classmethod
+    def setup_class(cls) -> None:
+        if not os.getenv("OPENAI_API_KEY"):
+            raise ValueError("OPENAI_API_KEY environment variable is not set")
+
+        # insure the test collection is empty
+        collection, async_collection = prepare_collection()
+        assert collection.count_documents({}) == 0  # type: ignore[index]  # noqa: E501
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        collection, async_collection = prepare_collection()
+        # delete all the documents in the collection
+        collection.delete_many({})  # type: ignore[index]
+        collection.drop_indexes()
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        collection, async_collection = prepare_collection()
+        # delete all the documents in the collection
+        collection.delete_many({})  # type: ignore[index]
+        collection.drop_indexes()
+
+    def test_from_documents_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+        sleep(1)  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    async def test_afrom_documents_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+        await asyncio_sleep(
+            1
+        )  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    def test_from_documents_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+        sleep(1)  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1, ef_search=100)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    async def test_afrom_documents_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+        await asyncio_sleep(
+            1
+        )  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=100)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    def test_from_texts_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "That fence is purple.",
+        ]
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output[0].page_content == "What is a sandwich?"
+        vectorstore.delete_index()
+
+    async def test_afrom_texts_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "That fence is purple.",
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output[0].page_content == "What is a sandwich?"
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        vectorstore.delete_index()
+
+    async def test_afrom_texts_with_metadatas_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_delete_one(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        vectorstore.delete_document_by_id(first_document_id)
+        sleep(2)  # waits for the index to be updated
+
+        output2 = vectorstore.similarity_search("Sandwich", k=1, ef_search=10)
+        assert output2
+        assert output2[0].page_content != "What is a sandwich?"
+
+        vectorstore.delete_index()
+
+    async def test_afrom_texts_with_metadatas_delete_one(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        await vectorstore.adelete_document_by_id(first_document_id)
+        await asyncio_sleep(2)  # waits for the index to be updated
+
+        output2 = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=10)
+        assert output2
+        assert output2[0].page_content != "What is a sandwich?"
+
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_delete_multiple(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, similarity_algorithm)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=5)
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        output[1].metadata["_id"]
+        second_document_id = output[1].metadata["_id"]
+
+        output[2].metadata["_id"]
+        third_document_id = output[2].metadata["_id"]
+
+        document_ids = [first_document_id, second_document_id, third_document_id]
+        vectorstore.delete(document_ids)
+        sleep(2)  # waits for the index to be updated
+
+        output_2 = vectorstore.similarity_search("Sandwich", k=5)
+        assert output
+        assert output_2
+
+        assert len(output) == 4  # we should see all the four documents
+        assert (
+            len(output_2) == 1
+        )  # we should see only one document left after three have been deleted
+
+        vectorstore.delete_index()
+
+    async def test_afrom_texts_with_metadatas_delete_multiple(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=5)
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        output[1].metadata["_id"]
+        second_document_id = output[1].metadata["_id"]
+
+        output[2].metadata["_id"]
+        third_document_id = output[2].metadata["_id"]
+
+        document_ids = [first_document_id, second_document_id, third_document_id]
+        await vectorstore.adelete(document_ids)
+        await asyncio_sleep(2)  # waits for the index to be updated
+
+        output_2 = await vectorstore.asimilarity_search("Sandwich", k=5)
+        assert output
+        assert output_2
+
+        assert len(output) == 4  # we should see all the four documents
+        assert (
+            len(output_2) == 1
+        )  # we should see only one document left after three have been deleted
+
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection = collections[0]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, DocumentDBSimilarityType.DOT)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    async def test_afrom_texts_with_metadatas_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_euclidean_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        vectorstore = DocumentDBVectorSearch.from_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        vectorstore.create_index(dimensions, DocumentDBSimilarityType.EUC)
+        sleep(2)  # waits for the index to be set up
+
+        output = vectorstore.similarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        vectorstore.delete_index()
+
+    async def test_afrom_texts_with_metadatas_euclidean_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.EUC)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    def invoke_delete_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> Optional[bool]:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.from_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        return vectorstore.delete()
+
+    async def ainvoke_delete_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> Optional[bool]:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.afrom_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        return await vectorstore.adelete()
+
+    def invoke_delete_by_id_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.from_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        vectorstore.delete_document_by_id()
+
+    async def ainvoke_delete_by_id_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.afrom_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        await vectorstore.adelete_document_by_id()
+
+    def test_invalid_arguments_to_delete(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(ValueError) as exception_info:
+            collection = collections[0]
+            self.invoke_delete_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document ids provided to delete."
+
+    async def test_ainvalid_arguments_to_delete(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(ValueError) as exception_info:
+            collection = collections[0]
+            await self.ainvoke_delete_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document ids provided to delete."
+
+    def test_no_arguments_to_delete_by_id(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(Exception) as exception_info:
+            collection = collections[0]
+            self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document id provided to delete."
+
+    async def test_ano_arguments_to_delete_by_id(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(Exception) as exception_info:
+            await self.ainvoke_delete_by_id_with_no_args(embedding_openai, collections)
+        assert str(exception_info.value) == "No document id provided to delete."

--- a/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_async_documentdb.py
@@ -46,11 +46,15 @@ def prepare_collection() -> Tuple[Collection, AgnosticCollection]:
 
 
 @pytest.fixture()
+@pytest.mark.requires("pymongo")
+@pytest.mark.requires("motor")
 def collections() -> Any:
     return prepare_collection()
 
 
 @pytest.fixture()
+@pytest.mark.requires("pymongo")
+@pytest.mark.requires("motor")
 def embedding_openai() -> Any:
     openai_embeddings: OpenAIEmbeddings = OpenAIEmbeddings(
         deployment=model_deployment, model=model_name, chunk_size=1
@@ -89,12 +93,16 @@ class TestDocumentDBVectorSearch:
         collection.drop_indexes()
 
     @pytest.fixture(autouse=True)
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def setup(self) -> None:
         collection, async_collection = prepare_collection()
         # delete all the documents in the collection
         collection.delete_many({})  # type: ignore[index]
         collection.drop_indexes()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_documents_cosine_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -126,6 +134,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_documents_cosine_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -159,6 +169,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_documents_inner_product(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -189,6 +201,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_documents_inner_product(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -222,6 +236,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_texts_cosine_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -248,6 +264,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].page_content == "What is a sandwich?"
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_texts_cosine_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -275,6 +293,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].page_content == "What is a sandwich?"
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_texts_with_metadatas_cosine_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -306,6 +326,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_texts_with_metadatas_cosine_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -338,6 +360,8 @@ class TestDocumentDBVectorSearch:
 
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_texts_with_metadatas_delete_one(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -379,6 +403,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_texts_with_metadatas_delete_one(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -421,6 +447,8 @@ class TestDocumentDBVectorSearch:
 
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_texts_with_metadatas_delete_multiple(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -470,6 +498,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_texts_with_metadatas_delete_multiple(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -520,6 +550,8 @@ class TestDocumentDBVectorSearch:
 
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_texts_with_metadatas_inner_product(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -550,6 +582,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_texts_with_metadatas_inner_product(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -581,6 +615,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_from_texts_with_metadatas_euclidean_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -611,6 +647,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_afrom_texts_with_metadatas_euclidean_distance(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -642,6 +680,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         await vectorstore.adelete_index()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def invoke_delete_with_no_args(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> Optional[bool]:
@@ -656,6 +696,8 @@ class TestDocumentDBVectorSearch:
 
         return vectorstore.delete()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def ainvoke_delete_with_no_args(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> Optional[bool]:
@@ -670,6 +712,8 @@ class TestDocumentDBVectorSearch:
 
         return await vectorstore.adelete()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def invoke_delete_by_id_with_no_args(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -684,6 +728,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_document_by_id()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def ainvoke_delete_by_id_with_no_args(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -698,6 +744,8 @@ class TestDocumentDBVectorSearch:
 
         await vectorstore.adelete_document_by_id()
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_invalid_arguments_to_delete(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -706,6 +754,8 @@ class TestDocumentDBVectorSearch:
             self.invoke_delete_with_no_args(embedding_openai, collection)
         assert str(exception_info.value) == "No document ids provided to delete."
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_ainvalid_arguments_to_delete(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -714,6 +764,8 @@ class TestDocumentDBVectorSearch:
             await self.ainvoke_delete_with_no_args(embedding_openai, collection)
         assert str(exception_info.value) == "No document ids provided to delete."
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     def test_no_arguments_to_delete_by_id(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
@@ -722,6 +774,8 @@ class TestDocumentDBVectorSearch:
             self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
         assert str(exception_info.value) == "No document id provided to delete."
 
+    @pytest.mark.requires("pymongo")
+    @pytest.mark.requires("motor")
     async def test_ano_arguments_to_delete_by_id(
         self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:

--- a/libs/community/tests/integration_tests/vectorstores/test_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_documentdb.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from asyncio import sleep as asyncio_sleep
 from time import sleep
 from typing import Any, Optional
 
@@ -30,15 +31,20 @@ dimensions = 1536
 similarity_algorithm = DocumentDBSimilarityType.COS
 
 
-def prepare_collection() -> Any:
+def prepare_collection() -> tuple:
+    from motor.core import AgnosticClient
+    from motor.motor_asyncio import AsyncIOMotorClient
     from pymongo import MongoClient
 
     test_client: MongoClient = MongoClient(CONNECTION_STRING)
-    return test_client[DB_NAME][COLLECTION_NAME]
+    test_async_client: AgnosticClient = AsyncIOMotorClient(CONNECTION_STRING)
+    return test_client[DB_NAME][COLLECTION_NAME], test_async_client[DB_NAME][
+        COLLECTION_NAME
+    ]
 
 
 @pytest.fixture()
-def collection() -> Any:
+def collection() -> tuple:
     return prepare_collection()
 
 
@@ -58,7 +64,8 @@ make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
 
 NOTE: You will first need to follow the contributor setup steps:
 https://python.langchain.com/docs/contributing/code. You will also need to install
-`pymongo` via `poetry`. You can also run the test directly using `pytest`, but please
+`pymongo>=4.6<5 and motor>=3.3<=3.4` via `poetry`.
+You can also run the test directly using `pytest`, but please
 make sure to install all dependencies.
 """
 
@@ -70,25 +77,25 @@ class TestDocumentDBVectorSearch:
             raise ValueError("OPENAI_API_KEY environment variable is not set")
 
         # insure the test collection is empty
-        collection = prepare_collection()
-        assert collection.count_documents({}) == 0  # type: ignore[index]
+        collection, async_collection = prepare_collection()
+        assert collection.count_documents({}) == 0  # type: ignore[index]  # noqa: E501
 
     @classmethod
     def teardown_class(cls) -> None:
-        collection = prepare_collection()
+        collection, async_collection = prepare_collection()
         # delete all the documents in the collection
         collection.delete_many({})  # type: ignore[index]
         collection.drop_indexes()
 
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
-        collection = prepare_collection()
+        collection, async_collection = prepare_collection()
         # delete all the documents in the collection
         collection.delete_many({})  # type: ignore[index]
         collection.drop_indexes()
 
     def test_from_documents_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         """Test end to end construction and search."""
         documents = [
@@ -98,6 +105,7 @@ class TestDocumentDBVectorSearch:
             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
         ]
 
+        collection = collections[0]
         vectorstore = DocumentDBVectorSearch.from_documents(
             documents,
             embedding_openai,
@@ -117,8 +125,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
-    def test_from_documents_inner_product(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+    async def test_afrom_documents_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         """Test end to end construction and search."""
         documents = [
@@ -127,7 +135,40 @@ class TestDocumentDBVectorSearch:
             Document(page_content="What is a sandwich?", metadata={"c": 1}),
             Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
         ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+        await asyncio_sleep(
+            1
+        )  # waits for DocumentDB to save contents to the collection
 
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    def test_from_documents_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection = collections[0]
         vectorstore = DocumentDBVectorSearch.from_documents(
             documents,
             embedding_openai,
@@ -147,8 +188,41 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
+    async def test_afrom_documents_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        """Test end to end construction and search."""
+        documents = [
+            Document(page_content="Dogs are tough.", metadata={"a": 1}),
+            Document(page_content="Cats have fluff.", metadata={"b": 1}),
+            Document(page_content="What is a sandwich?", metadata={"c": 1}),
+            Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_documents(
+            documents,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+        await asyncio_sleep(
+            1
+        )  # waits for DocumentDB to save contents to the collection
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=100)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
     def test_from_texts_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         texts = [
             "Dogs are tough.",
@@ -156,6 +230,7 @@ class TestDocumentDBVectorSearch:
             "What is a sandwich?",
             "That fence is purple.",
         ]
+        collection = collections[0]
         vectorstore = DocumentDBVectorSearch.from_texts(
             texts,
             embedding_openai,
@@ -172,8 +247,35 @@ class TestDocumentDBVectorSearch:
         assert output[0].page_content == "What is a sandwich?"
         vectorstore.delete_index()
 
+    async def test_afrom_texts_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "That fence is purple.",
+        ]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output[0].page_content == "What is a sandwich?"
+        await vectorstore.adelete_index()
+
     def test_from_texts_with_metadatas_cosine_distance(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         texts = [
             "Dogs are tough.",
@@ -181,6 +283,7 @@ class TestDocumentDBVectorSearch:
             "What is a sandwich?",
             "The fence is purple.",
         ]
+        collection = collections[0]
         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
         vectorstore = DocumentDBVectorSearch.from_texts(
             texts,
@@ -202,8 +305,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_index()
 
-    def test_from_texts_with_metadatas_delete_one(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+    async def test_afrom_texts_with_metadatas_cosine_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         texts = [
             "Dogs are tough.",
@@ -211,6 +314,39 @@ class TestDocumentDBVectorSearch:
             "What is a sandwich?",
             "The fence is purple.",
         ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_delete_one(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
         vectorstore = DocumentDBVectorSearch.from_texts(
             texts,
@@ -242,8 +378,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_index()
 
-    def test_from_texts_with_metadatas_delete_multiple(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+    async def test_afrom_texts_with_metadatas_delete_one(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         texts = [
             "Dogs are tough.",
@@ -251,6 +387,49 @@ class TestDocumentDBVectorSearch:
             "What is a sandwich?",
             "The fence is purple.",
         ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        await vectorstore.adelete_document_by_id(first_document_id)
+        await asyncio_sleep(2)  # waits for the index to be updated
+
+        output2 = await vectorstore.asimilarity_search("Sandwich", k=1, ef_search=10)
+        assert output2
+        assert output2[0].page_content != "What is a sandwich?"
+
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_delete_multiple(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
         vectorstore = DocumentDBVectorSearch.from_texts(
             texts,
@@ -290,8 +469,8 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_index()
 
-    def test_from_texts_with_metadatas_inner_product(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+    async def test_afrom_texts_with_metadatas_delete_multiple(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         texts = [
             "Dogs are tough.",
@@ -300,6 +479,57 @@ class TestDocumentDBVectorSearch:
             "The fence is purple.",
         ]
         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, similarity_algorithm)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=5)
+
+        first_document_id_object = output[0].metadata["_id"]
+        first_document_id = str(first_document_id_object)
+
+        output[1].metadata["_id"]
+        second_document_id = output[1].metadata["_id"]
+
+        output[2].metadata["_id"]
+        third_document_id = output[2].metadata["_id"]
+
+        document_ids = [first_document_id, second_document_id, third_document_id]
+        await vectorstore.adelete(document_ids)
+        await asyncio_sleep(2)  # waits for the index to be updated
+
+        output_2 = await vectorstore.asimilarity_search("Sandwich", k=5)
+        assert output
+        assert output_2
+
+        assert len(output) == 4  # we should see all the four documents
+        assert (
+            len(output_2) == 1
+        )  # we should see only one document left after three have been deleted
+
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection = collections[0]
         vectorstore = DocumentDBVectorSearch.from_texts(
             texts,
             embedding_openai,
@@ -319,8 +549,8 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
-    def test_from_texts_with_metadatas_euclidean_distance(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+    async def test_afrom_texts_with_metadatas_inner_product(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         texts = [
             "Dogs are tough.",
@@ -328,6 +558,38 @@ class TestDocumentDBVectorSearch:
             "What is a sandwich?",
             "The fence is purple.",
         ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.DOT)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
+    def test_from_texts_with_metadatas_euclidean_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        collection = collections[0]
         metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
         vectorstore = DocumentDBVectorSearch.from_texts(
             texts,
@@ -348,8 +610,39 @@ class TestDocumentDBVectorSearch:
         assert output[0].metadata["c"] == 1
         vectorstore.delete_index()
 
+    async def test_afrom_texts_with_metadatas_euclidean_distance(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        texts = [
+            "Dogs are tough.",
+            "Cats have fluff.",
+            "What is a sandwich?",
+            "The fence is purple.",
+        ]
+        metadatas = [{"a": 1}, {"b": 1}, {"c": 1}, {"d": 1, "e": 2}]
+        collection, async_collection = collections
+        vectorstore = await DocumentDBVectorSearch.afrom_texts(
+            texts,
+            embedding_openai,
+            metadatas=metadatas,
+            collection=collection,
+            async_collection=async_collection,
+            index_name=INDEX_NAME,
+        )
+
+        # Create the HNSW index that will be leveraged later for vector search
+        await vectorstore.acreate_index(dimensions, DocumentDBSimilarityType.EUC)
+        await asyncio_sleep(2)  # waits for the index to be set up
+
+        output = await vectorstore.asimilarity_search("Sandwich", k=1)
+
+        assert output
+        assert output[0].page_content == "What is a sandwich?"
+        assert output[0].metadata["c"] == 1
+        await vectorstore.adelete_index()
+
     def invoke_delete_with_no_args(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> Optional[bool]:
         vectorstore: DocumentDBVectorSearch = (
             DocumentDBVectorSearch.from_connection_string(
@@ -362,8 +655,22 @@ class TestDocumentDBVectorSearch:
 
         return vectorstore.delete()
 
+    async def ainvoke_delete_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> Optional[bool]:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.afrom_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        return await vectorstore.adelete()
+
     def invoke_delete_by_id_with_no_args(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         vectorstore: DocumentDBVectorSearch = (
             DocumentDBVectorSearch.from_connection_string(
@@ -376,16 +683,47 @@ class TestDocumentDBVectorSearch:
 
         vectorstore.delete_document_by_id()
 
+    async def ainvoke_delete_by_id_with_no_args(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        vectorstore: DocumentDBVectorSearch = (
+            DocumentDBVectorSearch.afrom_connection_string(
+                CONNECTION_STRING,
+                NAMESPACE,
+                embedding_openai,
+                index_name=INDEX_NAME,
+            )
+        )
+
+        await vectorstore.adelete_document_by_id()
+
     def test_invalid_arguments_to_delete(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         with pytest.raises(ValueError) as exception_info:
+            collection = collections[0]
             self.invoke_delete_with_no_args(embedding_openai, collection)
         assert str(exception_info.value) == "No document ids provided to delete."
 
+    async def test_ainvalid_arguments_to_delete(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(ValueError) as exception_info:
+            collection = collections[0]
+            await self.ainvoke_delete_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document ids provided to delete."
+
     def test_no_arguments_to_delete_by_id(
-        self, embedding_openai: OpenAIEmbeddings, collection: Any
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
     ) -> None:
         with pytest.raises(Exception) as exception_info:
+            collection = collections[0]
             self.invoke_delete_by_id_with_no_args(embedding_openai, collection)
+        assert str(exception_info.value) == "No document id provided to delete."
+
+    async def test_ano_arguments_to_delete_by_id(
+        self, embedding_openai: OpenAIEmbeddings, collections: Any
+    ) -> None:
+        with pytest.raises(Exception) as exception_info:
+            await self.ainvoke_delete_by_id_with_no_args(embedding_openai, collections)
         assert str(exception_info.value) == "No document id provided to delete."

--- a/libs/community/tests/integration_tests/vectorstores/test_documentdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_documentdb.py
@@ -58,7 +58,7 @@ make test TEST_FILE=tests/integration_tests/vectorstores/test_documentdb.py
 
 NOTE: You will first need to follow the contributor setup steps:
 https://python.langchain.com/docs/contributing/code. You will also need to install
-`pymongo` via `poetry`. You can also run the test directly using `pytest`, but please
+`pymongo` via `uv`. You can also run the test directly using `pytest`, but please
 make sure to install all dependencies.
 """
 


### PR DESCRIPTION
Changes to be committed:
-	new file:   libs/community/langchain_community/vectorstores/documentdb_async.py
-	new file:   libs/community/tests/integration_tests/vectorstores/test_documentdb_async.py

**Description**: Adding async support for AWS DocumentDB. I added it as a new file for backwards compatibility for current users of DocumentDBVectorSearch, as requiring them to install motor might break their code.
**Dependencies**: None, though users should install pymongo and motor if they wish to use.
**Twitter handle**:  @Sunshineallon


If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
