### PR TITLE
docs: Fixed broken link in google_generative_ai.ipynb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ docs/docs/templates
 
 prof
 virtualenv/
+.venv

--- a/docs/docs/integrations/chat/google_generative_ai.ipynb
+++ b/docs/docs/integrations/chat/google_generative_ai.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# ChatGoogleGenerativeAI\n",
     "\n",
-    "This docs will help you get started with Google AI [chat models](/docs/concepts/chat_models). For detailed documentation of all ChatGoogleGenerativeAI features and configurations head to the [API reference](https://python.langchain.com/api_reference/google_genai/chat_models/langchain_google_genai.chat_models.ChatGoogleGenerativeAI.html).\n",
+    "This docs will help you get started with Google AI [chat models](https://github.com/langchain-ai/langchain/blob/master/docs/docs/concepts/chat_models.mdx). For detailed documentation of all ChatGoogleGenerativeAI features and configurations head to the [API reference](https://python.langchain.com/api_reference/google_genai/chat_models/langchain_google_genai.chat_models.ChatGoogleGenerativeAI.html).\n",
     "\n",
     "Google AI offers a number of different chat models. For information on the latest models, their features, context windows, etc. head to the [Google AI docs](https://ai.google.dev/gemini-api/docs/models/gemini).\n",
     "\n",


### PR DESCRIPTION
- **Description:** Fixed the link for "chat models" in `google_generative_ai.ipynb`.  
  The previous relative link `/docs/concepts/chat_models` resulted in a 404 error.  
  I have updated the link to:  
  [Chat Models](https://github.com/langchain-ai/langchain/blob/master/docs/docs/concepts/chat_models.mdx)
- **Issue:** N/A  
- **Dependencies:** N/A  
- **Twitter handle:** [@ChaitanyaPoly_](https://twitter.com/ChaitanyaPoly_)
