### PR TITLE
core, openai, standard-tests: improve OpenAI compatibility with Anthropic content blocks

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1191,6 +1191,8 @@ def convert_to_openai_messages(
                                 },
                             }
                         )
+                    elif block.get("type") == "thinking":
+                        content.append(block)
                     else:
                         err = (
                             f"Unrecognized content block at "

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -832,6 +832,18 @@ def test_convert_to_openai_messages_anthropic() -> None:
     ]
     assert result == expected
 
+    # Test thinking blocks (pass through)
+    thinking_block = {
+        "signature": "abc123",
+        "thinking": "Thinking text.",
+        "type": "thinking",
+    }
+    text_block = {"text": "Response text.", "type": "text"}
+    messages = [AIMessage([thinking_block, text_block])]
+    result = convert_to_openai_messages(messages)
+    expected = [{"role": "assistant", "content": [thinking_block, text_block]}]
+    assert result == expected
+
 
 def test_convert_to_openai_messages_bedrock_converse_image() -> None:
     image_data = create_image_data()

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -186,15 +186,37 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
 def _format_message_content(content: Any) -> Any:
     """Format message content."""
     if content and isinstance(content, list):
-        # Remove unexpected block types
         formatted_content = []
         for block in content:
+            # Remove unexpected block types
             if (
                 isinstance(block, dict)
                 and "type" in block
-                and block["type"] == "tool_use"
+                and block["type"] in ("tool_use", "thinking")
             ):
                 continue
+            # Anthropic image blocks
+            elif (
+                isinstance(block, dict)
+                and block.get("type") == "image"
+                and (source := block.get("source"))
+            ):
+                if source.get("type") == "base64" and (
+                    (media_type := source.get("media_type"))
+                    and (data := source.get("data"))
+                ):
+                    formatted_content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:{media_type};base64,{data}"},
+                        }
+                    )
+                elif source.get("type") == "url" and (url := source.get("url")):
+                    formatted_content.append(
+                        {"type": "image_url", "image_url": {"url": url}}
+                    )
+                else:
+                    continue
             else:
                 formatted_content.append(block)
     else:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -200,6 +200,7 @@ def _format_message_content(content: Any) -> Any:
                 isinstance(block, dict)
                 and block.get("type") == "image"
                 and (source := block.get("source"))
+                and isinstance(source, dict)
             ):
                 if source.get("type") == "base64" and (
                     (media_type := source.get("media_type"))

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base_standard.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base_standard.py
@@ -30,6 +30,10 @@ class TestOpenAIStandard(ChatModelIntegrationTests):
         return True
 
     @property
+    def supports_anthropic_inputs(self) -> bool:
+        return True
+
+    @property
     def supported_usage_metadata_details(
         self,
     ) -> Dict[


### PR DESCRIPTION
- Support thinking blocks in core's `convert_to_openai_messages` (pass through instead of error)
- Ignore thinking blocks in ChatOpenAI (instead of error)
- Support Anthropic-style image blocks in ChatOpenAI

---

Standard integration tests include a `supports_anthropic_inputs` property which is currently enabled only for tests on `ChatAnthropic`. This test enforces compatibility with message histories of the form:
```
- system message
- human message
- AI message with tool calls specified only through `tool_use` content blocks
- human message containing `tool_result` and an additional `text` block
```
It additionally checks support for Anthropic-style image inputs if `supports_image_inputs` is enabled.

Here we change this test, such that if you enable `supports_anthropic_inputs`:
- You support AI messages with text and `tool_use` content blocks
- You support Anthropic-style image inputs (if `supports_image_inputs` is enabled)
- You support thinking content blocks.

That is, we add a test case for thinking content blocks, but we also remove the requirement of handling tool results within HumanMessages (motivated by existing agent abstractions, which should all return ToolMessage). We move that requirement to a ChatAnthropic-specific test.