### PR TITLE
deepinfra: add chat model openai based

### DIFF
--- a/docs/docs/integrations/chat/deepinfra_openai.ipynb
+++ b/docs/docs/integrations/chat/deepinfra_openai.ipynb
@@ -18,7 +18,7 @@
     "# ChatDeepInfra\n",
     "\n",
     "\n",
-    "This will help you getting started with ChatDeepInfra [chat models](/docs/concepts/#chat-models). For detailed documentation of all ChatDeepInfra features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html).\n",
+    "This will help you getting started with ChatDeepInfra [chat models](/docs/concepts/#chat-models). For detailed documentation of all ChatDeepInfra features and configurations head to the [API reference](https://python.langchain.com/api_reference/deepinfra/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html).\n",
     "\n",
     "[DeepInfra](https://deepinfra.com/) offers an API to query [OpenAI API](https://deepinfra.com/docs/openai_api)\n",
     "\n",
@@ -28,7 +28,7 @@
     "\n",
     "| Class | Package | Local | Serializable | [JS support](https://js.langchain.com/docs/integrations/chat/deepinfra_openai) | Package downloads | Package latest |\n",
     "| :--- | :--- | :---: | :---: |  :---: | :---: | :---: |\n",
-    "| [ChatDeepInfra](https://api.python.langchain.com/en/latest/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html) | [langchain-deepinfra](https://api.python.langchain.com/en/latest/deepinfra_api_reference.html) | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-deepinfra?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-deepinfra?style=flat-square&label=%20) |\n",
+    "| [ChatDeepInfra](https://python.langchain.com/api_reference/deepinfra/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html) | [langchain-deepinfra](https://python.langchain.com/api_reference/deepinfra_api_reference.html) | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-deepinfra?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-deepinfra?style=flat-square&label=%20) |\n",
     "\n",
     "### Model features\n",
     "| [Tool calling](/docs/how_to/tool_calling) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
@@ -238,7 +238,7 @@
    "source": [
     "## API reference\n",
     "\n",
-    "For detailed documentation of all ChatDeepInfra features and configurations head to the API reference: https://api.python.langchain.com/en/latest/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html"
+    "For detailed documentation of all ChatDeepInfra features and configurations head to the API reference: https://python.langchain.com/api_reference/deepinfra/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html"
    ]
   }
  ],

--- a/docs/docs/integrations/chat/deepinfra_openai.ipynb
+++ b/docs/docs/integrations/chat/deepinfra_openai.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "afaf8039",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: ChatDeepInfra\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e49f1e0d",
+   "metadata": {},
+   "source": [
+    "# ChatDeepInfra\n",
+    "\n",
+    "\n",
+    "This will help you getting started with ChatDeepInfra [chat models](/docs/concepts/#chat-models). For detailed documentation of all ChatDeepInfra features and configurations head to the [API reference](https://api.python.langchain.com/en/latest/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html).\n",
+    "\n",
+    "[DeepInfra](https://deepinfra.com/) offers an API to query [OpenAI API](https://deepinfra.com/docs/openai_api)\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "\n",
+    "| Class | Package | Local | Serializable | [JS support](https://js.langchain.com/docs/integrations/chat/deepinfra_openai) | Package downloads | Package latest |\n",
+    "| :--- | :--- | :---: | :---: |  :---: | :---: | :---: |\n",
+    "| [ChatDeepInfra](https://api.python.langchain.com/en/latest/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html) | [langchain-deepinfra](https://api.python.langchain.com/en/latest/deepinfra_api_reference.html) | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-deepinfra?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-deepinfra?style=flat-square&label=%20) |\n",
+    "\n",
+    "### Model features\n",
+    "| [Tool calling](/docs/how_to/tool_calling) | [Structured output](/docs/how_to/structured_output/) | JSON mode | [Image input](/docs/how_to/multimodal_inputs/) | Audio input | Video input | [Token-level streaming](/docs/how_to/chat_streaming/) | Native async | [Token usage](/docs/how_to/chat_token_usage_tracking/) | [Logprobs](/docs/how_to/logprobs/) |\n",
+    "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
+    "| ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | \n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To access DeepInfra models you'll need to create a DeepInfra account, get an API key, and install the `langchain-deepinfra` integration package.\n",
+    "\n",
+    "### Credentials\n",
+    "\n",
+    "Head to [this page](https://deepinfra.com/dash) to sign up to DeepInfra and generate an API key. Once you've done this set the DEEPINFRA_API_TOKEN environment variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "433e8d2b-9519-4b49-b2c4-7ab65b046c94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"DEEPINFRA_API_TOKEN\"):\n",
+    "    os.environ[\"DEEPINFRA_API_TOKEN\"] = getpass.getpass(\n",
+    "        \"Enter your DeepInfra API key: \"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72ee0c4b-9764-423a-9dbf-95129e185210",
+   "metadata": {},
+   "source": [
+    "If you want to get automated tracing of your model calls you can also set your [LangSmith](https://docs.smith.langchain.com/) API key by uncommenting below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a15d341e-3e26-4ca3-830b-5aab30ed66de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0730d6a1-c893-4840-9817-5e5251676d5d",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "The LangChain DeepInfra integration lives in the `langchain-deepinfra` package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "652d6238-1f87-422a-b135-f5abbb8652fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-deepinfra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a38cde65-254d-4219-a441-068766c0d4b5",
+   "metadata": {},
+   "source": [
+    "## Instantiation\n",
+    "\n",
+    "Now we can instantiate our model object and generate chat completions:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb09c344-1836-4e0c-acf8-11d13ac1dbae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_deepinfra import ChatDeepInfra\n",
+    "\n",
+    "llm = ChatDeepInfra(\n",
+    "    model=\"meta-llama/Meta-Llama-3.1-8B-Instruct\",\n",
+    "    temperature=0,\n",
+    "    max_tokens=None,\n",
+    "    timeout=None,\n",
+    "    max_retries=2,\n",
+    "    # other params...\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b4f3e15",
+   "metadata": {},
+   "source": [
+    "## Invocation\n",
+    "\n",
+    "- TODO: Run cells so output can be seen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62e0dbc3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "messages = [\n",
+    "    (\n",
+    "        \"system\",\n",
+    "        \"You are a helpful assistant that translates English to French. Translate the user sentence.\",\n",
+    "    ),\n",
+    "    (\"human\", \"I love programming.\"),\n",
+    "]\n",
+    "ai_msg = llm.invoke(messages)\n",
+    "ai_msg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40ab8481",
+   "metadata": {},
+   "source": [
+    "AIMessage(content=\"J'adore la programmation.\", response_metadata={'token_usage': {'completion_tokens': 9, 'prompt_tokens': 35, 'total_tokens': 44}, 'model_name': 'meta-llama/Llama-3-70b-chat-hf', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-eabcbe33-cdd8-45b8-ab0b-f90b6e7dfad8-0', usage_metadata={'input_tokens': 35, 'output_tokens': 9, 'total_tokens': 44})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d86145b3-bfef-46e8-b227-4dda5c9c2705",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ai_msg.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feb0fd90",
+   "metadata": {},
+   "source": [
+    "J'adore la programmation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18e2bfc0-7e78-4528-a73f-499ac150dca8",
+   "metadata": {},
+   "source": [
+    "## Chaining\n",
+    "\n",
+    "We can [chain](/docs/how_to/sequence/) our model with a prompt template like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e197d1d7-a070-4c96-9f8a-a0e86d046e0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "prompt = ChatPromptTemplate(\n",
+    "    [\n",
+    "        (\n",
+    "            \"system\",\n",
+    "            \"You are a helpful assistant that translates {input_language} to {output_language}.\",\n",
+    "        ),\n",
+    "        (\"human\", \"{input}\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "chain = prompt | llm\n",
+    "chain.invoke(\n",
+    "    {\n",
+    "        \"input_language\": \"English\",\n",
+    "        \"output_language\": \"German\",\n",
+    "        \"input\": \"I love programming.\",\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6883b38",
+   "metadata": {},
+   "source": [
+    "AIMessage(content='Ich liebe das Programmieren.', response_metadata={'token_usage': {'completion_tokens': 7, 'prompt_tokens': 30, 'total_tokens': 37}, 'model_name': 'meta-llama/Llama-3-70b-chat-hf', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-a249aa24-ee31-46ba-9bf9-f4eb135b0a95-0', usage_metadata={'input_tokens': 30, 'output_tokens': 7, 'total_tokens': 37})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a5bb5ca-c3ae-4a58-be67-2cd18574b9a3",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For detailed documentation of all ChatDeepInfra features and configurations head to the API reference: https://api.python.langchain.com/en/latest/chat_models/langchain_deepinfra.chat_models.ChatDeepInfra.html"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/integrations/providers/deepinfra_openai.ipynb
+++ b/docs/docs/integrations/providers/deepinfra_openai.ipynb
@@ -17,9 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain_deepinfra import ChatDeepInfra\n",
-    "from langchain_deepinfra import DeepInfraLLM\n",
-    "from langchain_deepinfra import DeepInfraVectorStore"
+    "from langchain_deepinfra import ChatDeepInfra, DeepInfraLLM, DeepInfraVectorStore"
    ]
   }
  ],

--- a/docs/docs/integrations/providers/deepinfra_openai.ipynb
+++ b/docs/docs/integrations/providers/deepinfra_openai.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DeepInfra\n",
+    "\n",
+    "DeepInfra is a platform that offers..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "y8ku6X96sebl"
+   },
+   "outputs": [],
+   "source": [
+    "from langchain_deepinfra import ChatDeepInfra\n",
+    "from langchain_deepinfra import DeepInfraLLM\n",
+    "from langchain_deepinfra import DeepInfraVectorStore"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/docs/docs/integrations/text_embedding/deepinfra_openai.ipynb
+++ b/docs/docs/integrations/text_embedding/deepinfra_openai.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "afaf8039",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "---\n",
+    "sidebar_label: DeepInfra\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a3d6f34",
+   "metadata": {},
+   "source": [
+    "# DeepInfraEmbeddings\n",
+    "\n",
+    "This will help you get started with DeepInfra embedding models using LangChain. For detailed documentation on `DeepInfraEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/deepinfra/embeddings/langchain_deepinfra.embeddings.DeepInfraEmbeddings.html).\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "import { ItemTable } from \"@theme/FeatureTables\";\n",
+    "\n",
+    "<ItemTable category=\"text_embedding\" item=\"DeepInfra\" />\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To access DeepInfra embedding models you'll need to create a/an DeepInfra account, get an API key, and install the `langchain-deepinfra` integration package.\n",
+    "\n",
+    "### Credentials\n",
+    "\n",
+    "Head to [https://deepinfra.com/dash](https://deepinfra.com/dash/) to sign up to DeepInfra and generate an API key. Once you've done this set the DEEPINFRA_API_TOKEN environment variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "36521c2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"DEEPINFRA_API_TOKEN\"):\n",
+    "    os.environ[\"DEEPINFRA_API_TOKEN\"] = getpass.getpass(\n",
+    "        \"Enter your DeepInfra API key: \"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c84fb993",
+   "metadata": {},
+   "source": [
+    "If you want to get automated tracing of your model calls you can also set your [LangSmith](https://docs.smith.langchain.com/) API key by uncommenting below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "39a4953b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9664366",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "The LangChain DeepInfra integration lives in the `langchain-deepinfra` package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "64853226",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.0\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython -m pip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -qU langchain-deepinfra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45dd1724",
+   "metadata": {},
+   "source": [
+    "## Instantiation\n",
+    "\n",
+    "Now we can instantiate our model object and generate chat completions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9ea7a09b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_deepinfra import DeepInfraEmbeddings\n",
+    "\n",
+    "embeddings = DeepInfraEmbeddings(\n",
+    "    model=\"BAAI/bge-base-en-v1.5\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77d271b6",
+   "metadata": {},
+   "source": [
+    "## Indexing and Retrieval\n",
+    "\n",
+    "Embedding models are often used in retrieval-augmented generation (RAG) flows, both as part of indexing data as well as later retrieving it. For more detailed instructions, please see our [RAG tutorials](/docs/tutorials/).\n",
+    "\n",
+    "Below, see how to index and retrieve data using the `embeddings` object we initialized above. In this example, we will index and retrieve a sample document in the `InMemoryVectorStore`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d817716b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'LangChain is the framework for building context-aware reasoning applications'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a vector store with a sample text\n",
+    "from langchain_core.vectorstores import InMemoryVectorStore\n",
+    "\n",
+    "text = \"LangChain is the framework for building context-aware reasoning applications\"\n",
+    "\n",
+    "vectorstore = InMemoryVectorStore.from_texts(\n",
+    "    [text],\n",
+    "    embedding=embeddings,\n",
+    ")\n",
+    "\n",
+    "# Use the vectorstore as a retriever\n",
+    "retriever = vectorstore.as_retriever()\n",
+    "\n",
+    "# Retrieve the most similar text\n",
+    "retrieved_documents = retriever.invoke(\"What is LangChain?\")\n",
+    "\n",
+    "# show the retrieved document's content\n",
+    "retrieved_documents[0].page_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e02b9855",
+   "metadata": {},
+   "source": [
+    "## Direct Usage\n",
+    "\n",
+    "Under the hood, the vectorstore and retriever implementations are calling `embeddings.embed_documents(...)` and `embeddings.embed_query(...)` to create embeddings for the text(s) used in `from_texts` and retrieval `invoke` operations, respectively.\n",
+    "\n",
+    "You can directly call these methods to get embeddings for your own use cases.\n",
+    "\n",
+    "### Embed single texts\n",
+    "\n",
+    "You can embed single texts or documents with `embed_query`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0d2befcd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.3812227, -0.052848946, -0.10564975, 0.03480297, 0.2878488, 0.0084609175, 0.11605915, 0.05303011, \n"
+     ]
+    }
+   ],
+   "source": [
+    "single_vector = embeddings.embed_query(text)\n",
+    "print(str(single_vector)[:100])  # Show the first 100 characters of the vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b5a7d03",
+   "metadata": {},
+   "source": [
+    "### Embed multiple texts\n",
+    "\n",
+    "You can embed multiple texts with `embed_documents`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2f4d6e97",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.3812227, -0.052848946, -0.10564975, 0.03480297, 0.2878488, 0.0084609175, 0.11605915, 0.05303011, \n",
+      "[0.066308185, -0.032866564, 0.115751594, 0.19082588, 0.14017, -0.26976448, -0.056340694, -0.26923394\n"
+     ]
+    }
+   ],
+   "source": [
+    "text2 = (\n",
+    "    \"LangGraph is a library for building stateful, multi-actor applications with LLMs\"\n",
+    ")\n",
+    "two_vectors = embeddings.embed_documents([text, text2])\n",
+    "for vector in two_vectors:\n",
+    "    print(str(vector)[:100])  # Show the first 100 characters of the vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98785c12",
+   "metadata": {},
+   "source": [
+    "## API Reference\n",
+    "\n",
+    "For detailed documentation on `DeepInfraEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/deepinfra/embeddings/langchain_deepinfra.embeddings.DeepInfraEmbeddings.html).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -2,475 +2,480 @@
 # it is EXPERIMENTAL and may be removed in the future
 
 packages:
-- name: langchain-core
-  path: libs/core
-  repo: langchain-ai/langchain
-  downloads: 27722594
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-text-splitters
-  path: libs/text-splitters
-  repo: langchain-ai/langchain
-  downloads: 12866727
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain
-  path: libs/langchain
-  repo: langchain-ai/langchain
-  downloads: 32917727
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-community
-  path: libs/community
-  repo: langchain-ai/langchain
-  downloads: 21967466
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-experimental
-  path: libs/experimental
-  repo: langchain-ai/langchain-experimental
-  downloads: 1960508
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-cli
-  path: libs/cli
-  repo: langchain-ai/langchain
-  downloads: 84415
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-ai21
-  path: libs/ai21
-  repo: langchain-ai/langchain-ai21
-  downloads: 13100
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-anthropic
-  path: libs/partners/anthropic
-  repo: langchain-ai/langchain
-  js: '@langchain/anthropic'
-  downloads: 1549411
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-chroma
-  path: libs/partners/chroma
-  repo: langchain-ai/langchain
-  downloads: 553991
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-exa
-  path: libs/partners/exa
-  repo: langchain-ai/langchain
-  provider_page: exa_search
-  js: '@langchain/exa'
-  downloads: 5817
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-fireworks
-  path: libs/partners/fireworks
-  repo: langchain-ai/langchain
-  downloads: 264866
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-groq
-  path: libs/partners/groq
-  repo: langchain-ai/langchain
-  js: '@langchain/groq'
-  downloads: 452801
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-huggingface
-  path: libs/partners/huggingface
-  repo: langchain-ai/langchain
-  downloads: 403346
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-ibm
-  path: libs/ibm
-  repo: langchain-ai/langchain-ibm
-  js: '@langchain/ibm'
-  downloads: 95572
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-localai
-  path: libs/localai
-  repo: mkhludnev/langchain-localai
-  downloads: 306
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-milvus
-  path: libs/milvus
-  repo: langchain-ai/langchain-milvus
-  downloads: 162619
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-mistralai
-  path: libs/partners/mistralai
-  repo: langchain-ai/langchain
-  js: '@langchain/mistralai'
-  downloads: 315149
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-mongodb
-  path: libs/langchain-mongodb
-  repo: langchain-ai/langchain-mongodb
-  provider_page: mongodb_atlas
-  js: '@langchain/mongodb'
-  downloads: 160711
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-nomic
-  path: libs/partners/nomic
-  repo: langchain-ai/langchain
-  js: '@langchain/nomic'
-  downloads: 10335
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-openai
-  path: libs/partners/openai
-  repo: langchain-ai/langchain
-  js: '@langchain/openai'
-  downloads: 9823331
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-pinecone
-  path: libs/pinecone
-  repo: langchain-ai/langchain-pinecone
-  js: '@langchain/pinecone'
-  downloads: 393153
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-prompty
-  path: libs/partners/prompty
-  repo: langchain-ai/langchain
-  provider_page: microsoft
-  downloads: 1216
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-qdrant
-  path: libs/partners/qdrant
-  repo: langchain-ai/langchain
-  js: '@langchain/qdrant'
-  downloads: 125551
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-scrapegraph
-  path: .
-  repo: ScrapeGraphAI/langchain-scrapegraph
-  downloads: 851
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-sema4
-  path: libs/sema4
-  repo: langchain-ai/langchain-sema4
-  provider_page: robocorp
-  downloads: 1647
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-together
-  path: libs/together
-  repo: langchain-ai/langchain-together
-  downloads: 53987
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-upstage
-  path: libs/upstage
-  repo: langchain-ai/langchain-upstage
-  downloads: 29553
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-voyageai
-  path: libs/partners/voyageai
-  repo: langchain-ai/langchain
-  downloads: 17269
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-aws
-  name_title: AWS
-  path: libs/aws
-  repo: langchain-ai/langchain-aws
-  js: '@langchain/aws'
-  downloads: 2133380
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-astradb
-  path: libs/astradb
-  repo: langchain-ai/langchain-datastax
-  downloads: 83037
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-google-genai
-  name_title: Google Generative AI
-  path: libs/genai
-  repo: langchain-ai/langchain-google
-  provider_page: google
-  js: '@langchain/google-genai'
-  downloads: 1019707
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-google-vertexai
-  path: libs/vertexai
-  repo: langchain-ai/langchain-google
-  provider_page: google
-  js: '@langchain/google-vertexai'
-  downloads: 13033464
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-google-community
-  path: libs/community
-  repo: langchain-ai/langchain-google
-  provider_page: google
-  downloads: 3787822
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-weaviate
-  path: libs/weaviate
-  repo: langchain-ai/langchain-weaviate
-  js: '@langchain/weaviate'
-  downloads: 31199
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-cohere
-  path: libs/cohere
-  repo: langchain-ai/langchain-cohere
-  js: '@langchain/cohere'
-  downloads: 653329
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-elasticsearch
-  path: libs/elasticsearch
-  repo: langchain-ai/langchain-elastic
-  downloads: 137212
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-nvidia-ai-endpoints
-  path: libs/ai-endpoints
-  repo: langchain-ai/langchain-nvidia
-  provider_page: nvidia
-  downloads: 157267
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-postgres
-  path: .
-  repo: langchain-ai/langchain-postgres
-  provider_page: pgvector
-  downloads: 320831
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-redis
-  path: libs/redis
-  repo: langchain-ai/langchain-redis
-  js: '@langchain/redis'
-  downloads: 22787
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-unstructured
-  path: libs/unstructured
-  repo: langchain-ai/langchain-unstructured
-  downloads: 118888
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-azure-ai
-  path: libs/azure-ai
-  repo: langchain-ai/langchain-azure
-  provider_page: azure_ai
-  downloads: 5835
-  js: '@langchain/openai'
-- name: langchain-azure-dynamic-sessions
-  path: libs/azure-dynamic-sessions
-  repo: langchain-ai/langchain-azure
-  provider_page: microsoft
-  js: '@langchain/azure-dynamic-sessions'
-  downloads: 7401
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-sqlserver
-  path: libs/sqlserver
-  repo: langchain-ai/langchain-azure
-  provider_page: microsoft
-  downloads: 2298
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-cerebras
-  path: libs/cerebras
-  repo: langchain-ai/langchain-cerebras
-  downloads: 26690
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-snowflake
-  path: libs/snowflake
-  repo: langchain-ai/langchain-snowflake
-  downloads: 1905
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: databricks-langchain
-  name_title: Databricks
-  path: integrations/langchain
-  repo: databricks/databricks-ai-bridge
-  provider_page: databricks
-  downloads: 36221
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-couchbase
-  path: .
-  repo: Couchbase-Ecosystem/langchain-couchbase
-  downloads: 725
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-ollama
-  path: libs/partners/ollama
-  repo: langchain-ai/langchain
-  js: '@langchain/ollama'
-  downloads: 623011
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-box
-  path: libs/box
-  repo: box-community/langchain-box
-  downloads: 730
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-tests
-  path: libs/standard-tests
-  repo: langchain-ai/langchain
-  downloads: 180354
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-neo4j
-  path: libs/neo4j
-  repo: langchain-ai/langchain-neo4j
-  downloads: 30320
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-linkup
-  path: .
-  repo: LinkupPlatform/langchain-linkup
-  downloads: 532
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-yt-dlp
-  path: .
-  repo: aqib0770/langchain-yt-dlp
-  downloads: 461
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-oceanbase
-  path: .
-  repo: oceanbase/langchain-oceanbase
-  downloads: 58
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-predictionguard
-  path: .
-  repo: predictionguard/langchain-predictionguard
-  downloads: 422
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-cratedb
-  path: .
-  repo: crate/langchain-cratedb
-  downloads: 417
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-modelscope
-  path: .
-  repo: modelscope/langchain-modelscope
-  downloads: 131
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-falkordb
-  path: .
-  repo: kingtroga/langchain-falkordb
-  downloads: 178
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-dappier
-  path: .
-  repo: DappierAI/langchain-dappier
-  downloads: 353
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-pull-md
-  path: .
-  repo: chigwell/langchain-pull-md
-  downloads: 161
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-kuzu
-  path: .
-  repo: kuzudb/langchain-kuzu
-  downloads: 426
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-docling
-  path: .
-  repo: DS4SD/docling-langchain
-  downloads: 6800
-  downloads_updated_at: '2025-02-13T20:29:06.035211+00:00'
-- name: langchain-lindorm-integration
-  path: .
-  repo: AlwaysBluer/langchain-lindorm-integration
-  provider_page: lindorm
-  downloads: 79
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-hyperbrowser
-  path: .
-  repo: hyperbrowserai/langchain-hyperbrowser
-  downloads: 371
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-fmp-data
-  path: .
-  repo: MehdiZare/langchain-fmp-data
-  downloads: 366
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: tilores-langchain
-  name_title: Tilores
-  path: .
-  repo: tilotech/tilores-langchain
-  provider_page: tilores
-  downloads: 121
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-pipeshift
-  path: .
-  repo: pipeshift-org/langchain-pipeshift
-  downloads: 133
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-payman-tool
-  path: .
-  repo: paymanai/langchain-payman-tool
-  downloads: 685
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-sambanova
-  path: .
-  repo: sambanova/langchain-sambanova
-  downloads: 1313
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-deepseek
-  path: libs/partners/deepseek
-  repo: langchain-ai/langchain
-  provider_page: deepseek
-  js: '@langchain/deepseek'
-  downloads: 6871
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-jenkins
-  path: .
-  repo: Amitgb14/langchain_jenkins
-  downloads: 386
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-goodfire
-  path: .
-  repo: keenanpepper/langchain-goodfire
-  downloads: 585
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-nimble
-  path: .
-  repo: Nimbleway/langchain-nimble
-  downloads: 388
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-apify
-  path: .
-  repo: apify/langchain-apify
-  downloads: 443
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langfair
-  name_title: LangFair
-  path: .
-  repo: cvs-health/langfair
-  downloads: 901
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-abso
-  path: .
-  repo: lunary-ai/langchain-abso
-  downloads: 0
-  downloads_updated_at: '2025-02-13T20:30:13.814314+00:00'
-- name: langchain-graph-retriever
-  name_title: Graph RAG
-  path: packages/langchain-graph-retriever
-  repo: datastax/graph-rag
-  provider_page: graph_rag
-  downloads: 2093
-  downloads_updated_at: '2025-02-13T20:32:23.744801+00:00'
-- name: langchain-xai
-  path: libs/partners/xai
-  repo: langchain-ai/langchain
-  downloads: 9521
-  downloads_updated_at: '2025-02-13T23:35:48.490391+00:00'
-- name: langchain-salesforce
-  path: .
-  repo: colesmcintosh/langchain-salesforce
-  downloads: 0
-  downloads_updated_at: '2025-02-13T23:35:48.490391+00:00'
-- name: langchain-discord-shikenso
-  path: .
-  repo: Shikenso-Analytics/langchain-discord
-  downloads: 1
-  downloads_updated_at: '2025-02-15T16:00:00.000000+00:00'
-- name: langchain-vdms
-  repo: IntelLabs/langchain-vdms
-  path: .
-  name_title: VDMS
-- name: langchain-deeplake
-  path: .
-  repo: activeloopai/langchain-deeplake
-- name: langchain-cognee
-  repo: topoteretes/langchain-cognee
-  path: .
-- name: langchain-prolog
-  path: .
-  repo: apisani1/langchain-prolog
-  downloads: 0
-  downloads_updated_at: '2025-02-15T16:00:00.000000+00:00'
-- name: langchain-permit
-  path: .
-  repo: permitio/langchain-permit
-- name: langchain-pymupdf4llm
-  path: .
-  repo: lakinduboteju/langchain-pymupdf4llm
-- name: langchain-writer
-  path: .
-  repo: writer/langchain-writer
-  downloads: 0
-  downloads_updated_at: '2025-02-24T13:19:19.816059+00:00'
-- name: langchain-taiga
-  name_title: Taiga
-  path: .
-  repo: Shikenso-Analytics/langchain-taiga
+  - name: langchain-core
+    path: libs/core
+    repo: langchain-ai/langchain
+    downloads: 27722594
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-text-splitters
+    path: libs/text-splitters
+    repo: langchain-ai/langchain
+    downloads: 12866727
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain
+    path: libs/langchain
+    repo: langchain-ai/langchain
+    downloads: 32917727
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-community
+    path: libs/community
+    repo: langchain-ai/langchain
+    downloads: 21967466
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-experimental
+    path: libs/experimental
+    repo: langchain-ai/langchain-experimental
+    downloads: 1960508
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-cli
+    path: libs/cli
+    repo: langchain-ai/langchain
+    downloads: 84415
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-ai21
+    path: libs/ai21
+    repo: langchain-ai/langchain-ai21
+    downloads: 13100
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-anthropic
+    path: libs/partners/anthropic
+    repo: langchain-ai/langchain
+    js: "@langchain/anthropic"
+    downloads: 1549411
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-chroma
+    path: libs/partners/chroma
+    repo: langchain-ai/langchain
+    downloads: 553991
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-exa
+    path: libs/partners/exa
+    repo: langchain-ai/langchain
+    provider_page: exa_search
+    js: "@langchain/exa"
+    downloads: 5817
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-fireworks
+    path: libs/partners/fireworks
+    repo: langchain-ai/langchain
+    downloads: 264866
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-groq
+    path: libs/partners/groq
+    repo: langchain-ai/langchain
+    js: "@langchain/groq"
+    downloads: 452801
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-huggingface
+    path: libs/partners/huggingface
+    repo: langchain-ai/langchain
+    downloads: 403346
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-ibm
+    path: libs/ibm
+    repo: langchain-ai/langchain-ibm
+    js: "@langchain/ibm"
+    downloads: 95572
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-localai
+    path: libs/localai
+    repo: mkhludnev/langchain-localai
+    downloads: 306
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-milvus
+    path: libs/milvus
+    repo: langchain-ai/langchain-milvus
+    downloads: 162619
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-mistralai
+    path: libs/partners/mistralai
+    repo: langchain-ai/langchain
+    js: "@langchain/mistralai"
+    downloads: 315149
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-mongodb
+    path: libs/langchain-mongodb
+    repo: langchain-ai/langchain-mongodb
+    provider_page: mongodb_atlas
+    js: "@langchain/mongodb"
+    downloads: 160711
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-nomic
+    path: libs/partners/nomic
+    repo: langchain-ai/langchain
+    js: "@langchain/nomic"
+    downloads: 10335
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-openai
+    path: libs/partners/openai
+    repo: langchain-ai/langchain
+    js: "@langchain/openai"
+    downloads: 9823331
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-pinecone
+    path: libs/pinecone
+    repo: langchain-ai/langchain-pinecone
+    js: "@langchain/pinecone"
+    downloads: 393153
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-prompty
+    path: libs/partners/prompty
+    repo: langchain-ai/langchain
+    provider_page: microsoft
+    downloads: 1216
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-qdrant
+    path: libs/partners/qdrant
+    repo: langchain-ai/langchain
+    js: "@langchain/qdrant"
+    downloads: 125551
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-scrapegraph
+    path: .
+    repo: ScrapeGraphAI/langchain-scrapegraph
+    downloads: 851
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-sema4
+    path: libs/sema4
+    repo: langchain-ai/langchain-sema4
+    provider_page: robocorp
+    downloads: 1647
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-together
+    path: libs/together
+    repo: langchain-ai/langchain-together
+    downloads: 53987
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-deepinfra
+    path: libs/deepinfra
+    repo: zulnabil/langchain-deepinfra
+    downloads: 1
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-upstage
+    path: libs/upstage
+    repo: langchain-ai/langchain-upstage
+    downloads: 29553
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-voyageai
+    path: libs/partners/voyageai
+    repo: langchain-ai/langchain
+    downloads: 17269
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-aws
+    name_title: AWS
+    path: libs/aws
+    repo: langchain-ai/langchain-aws
+    js: "@langchain/aws"
+    downloads: 2133380
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-astradb
+    path: libs/astradb
+    repo: langchain-ai/langchain-datastax
+    downloads: 83037
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-google-genai
+    name_title: Google Generative AI
+    path: libs/genai
+    repo: langchain-ai/langchain-google
+    provider_page: google
+    js: "@langchain/google-genai"
+    downloads: 1019707
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-google-vertexai
+    path: libs/vertexai
+    repo: langchain-ai/langchain-google
+    provider_page: google
+    js: "@langchain/google-vertexai"
+    downloads: 13033464
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-google-community
+    path: libs/community
+    repo: langchain-ai/langchain-google
+    provider_page: google
+    downloads: 3787822
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-weaviate
+    path: libs/weaviate
+    repo: langchain-ai/langchain-weaviate
+    js: "@langchain/weaviate"
+    downloads: 31199
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-cohere
+    path: libs/cohere
+    repo: langchain-ai/langchain-cohere
+    js: "@langchain/cohere"
+    downloads: 653329
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-elasticsearch
+    path: libs/elasticsearch
+    repo: langchain-ai/langchain-elastic
+    downloads: 137212
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-nvidia-ai-endpoints
+    path: libs/ai-endpoints
+    repo: langchain-ai/langchain-nvidia
+    provider_page: nvidia
+    downloads: 157267
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-postgres
+    path: .
+    repo: langchain-ai/langchain-postgres
+    provider_page: pgvector
+    downloads: 320831
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-redis
+    path: libs/redis
+    repo: langchain-ai/langchain-redis
+    js: "@langchain/redis"
+    downloads: 22787
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-unstructured
+    path: libs/unstructured
+    repo: langchain-ai/langchain-unstructured
+    downloads: 118888
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-azure-ai
+    path: libs/azure-ai
+    repo: langchain-ai/langchain-azure
+    provider_page: azure_ai
+    downloads: 5835
+    js: "@langchain/openai"
+  - name: langchain-azure-dynamic-sessions
+    path: libs/azure-dynamic-sessions
+    repo: langchain-ai/langchain-azure
+    provider_page: microsoft
+    js: "@langchain/azure-dynamic-sessions"
+    downloads: 7401
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-sqlserver
+    path: libs/sqlserver
+    repo: langchain-ai/langchain-azure
+    provider_page: microsoft
+    downloads: 2298
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-cerebras
+    path: libs/cerebras
+    repo: langchain-ai/langchain-cerebras
+    downloads: 26690
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-snowflake
+    path: libs/snowflake
+    repo: langchain-ai/langchain-snowflake
+    downloads: 1905
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: databricks-langchain
+    name_title: Databricks
+    path: integrations/langchain
+    repo: databricks/databricks-ai-bridge
+    provider_page: databricks
+    downloads: 36221
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-couchbase
+    path: .
+    repo: Couchbase-Ecosystem/langchain-couchbase
+    downloads: 725
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-ollama
+    path: libs/partners/ollama
+    repo: langchain-ai/langchain
+    js: "@langchain/ollama"
+    downloads: 623011
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-box
+    path: libs/box
+    repo: box-community/langchain-box
+    downloads: 730
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-tests
+    path: libs/standard-tests
+    repo: langchain-ai/langchain
+    downloads: 180354
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-neo4j
+    path: libs/neo4j
+    repo: langchain-ai/langchain-neo4j
+    downloads: 30320
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-linkup
+    path: .
+    repo: LinkupPlatform/langchain-linkup
+    downloads: 532
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-yt-dlp
+    path: .
+    repo: aqib0770/langchain-yt-dlp
+    downloads: 461
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-oceanbase
+    path: .
+    repo: oceanbase/langchain-oceanbase
+    downloads: 58
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-predictionguard
+    path: .
+    repo: predictionguard/langchain-predictionguard
+    downloads: 422
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-cratedb
+    path: .
+    repo: crate/langchain-cratedb
+    downloads: 417
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-modelscope
+    path: .
+    repo: modelscope/langchain-modelscope
+    downloads: 131
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-falkordb
+    path: .
+    repo: kingtroga/langchain-falkordb
+    downloads: 178
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-dappier
+    path: .
+    repo: DappierAI/langchain-dappier
+    downloads: 353
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-pull-md
+    path: .
+    repo: chigwell/langchain-pull-md
+    downloads: 161
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-kuzu
+    path: .
+    repo: kuzudb/langchain-kuzu
+    downloads: 426
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-docling
+    path: .
+    repo: DS4SD/docling-langchain
+    downloads: 6800
+    downloads_updated_at: "2025-02-13T20:29:06.035211+00:00"
+  - name: langchain-lindorm-integration
+    path: .
+    repo: AlwaysBluer/langchain-lindorm-integration
+    provider_page: lindorm
+    downloads: 79
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-hyperbrowser
+    path: .
+    repo: hyperbrowserai/langchain-hyperbrowser
+    downloads: 371
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-fmp-data
+    path: .
+    repo: MehdiZare/langchain-fmp-data
+    downloads: 366
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: tilores-langchain
+    name_title: Tilores
+    path: .
+    repo: tilotech/tilores-langchain
+    provider_page: tilores
+    downloads: 121
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-pipeshift
+    path: .
+    repo: pipeshift-org/langchain-pipeshift
+    downloads: 133
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-payman-tool
+    path: .
+    repo: paymanai/langchain-payman-tool
+    downloads: 685
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-sambanova
+    path: .
+    repo: sambanova/langchain-sambanova
+    downloads: 1313
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-deepseek
+    path: libs/partners/deepseek
+    repo: langchain-ai/langchain
+    provider_page: deepseek
+    js: "@langchain/deepseek"
+    downloads: 6871
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-jenkins
+    path: .
+    repo: Amitgb14/langchain_jenkins
+    downloads: 386
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-goodfire
+    path: .
+    repo: keenanpepper/langchain-goodfire
+    downloads: 585
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-nimble
+    path: .
+    repo: Nimbleway/langchain-nimble
+    downloads: 388
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-apify
+    path: .
+    repo: apify/langchain-apify
+    downloads: 443
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langfair
+    name_title: LangFair
+    path: .
+    repo: cvs-health/langfair
+    downloads: 901
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-abso
+    path: .
+    repo: lunary-ai/langchain-abso
+    downloads: 0
+    downloads_updated_at: "2025-02-13T20:30:13.814314+00:00"
+  - name: langchain-graph-retriever
+    name_title: Graph RAG
+    path: packages/langchain-graph-retriever
+    repo: datastax/graph-rag
+    provider_page: graph_rag
+    downloads: 2093
+    downloads_updated_at: "2025-02-13T20:32:23.744801+00:00"
+  - name: langchain-xai
+    path: libs/partners/xai
+    repo: langchain-ai/langchain
+    downloads: 9521
+    downloads_updated_at: "2025-02-13T23:35:48.490391+00:00"
+  - name: langchain-salesforce
+    path: .
+    repo: colesmcintosh/langchain-salesforce
+    downloads: 0
+    downloads_updated_at: "2025-02-13T23:35:48.490391+00:00"
+  - name: langchain-discord-shikenso
+    path: .
+    repo: Shikenso-Analytics/langchain-discord
+    downloads: 1
+    downloads_updated_at: "2025-02-15T16:00:00.000000+00:00"
+  - name: langchain-vdms
+    repo: IntelLabs/langchain-vdms
+    path: .
+    name_title: VDMS
+  - name: langchain-deeplake
+    path: .
+    repo: activeloopai/langchain-deeplake
+  - name: langchain-cognee
+    repo: topoteretes/langchain-cognee
+    path: .
+  - name: langchain-prolog
+    path: .
+    repo: apisani1/langchain-prolog
+    downloads: 0
+    downloads_updated_at: "2025-02-15T16:00:00.000000+00:00"
+  - name: langchain-permit
+    path: .
+    repo: permitio/langchain-permit
+  - name: langchain-pymupdf4llm
+    path: .
+    repo: lakinduboteju/langchain-pymupdf4llm
+  - name: langchain-writer
+    path: .
+    repo: writer/langchain-writer
+    downloads: 0
+    downloads_updated_at: "2025-02-24T13:19:19.816059+00:00"
+  - name: langchain-taiga
+    name_title: Taiga
+    path: .
+    repo: Shikenso-Analytics/langchain-taiga


### PR DESCRIPTION
Description: Adding deepinfra chat model open ai based
Dependencies: [langchain-deepinfra](https://pypi.org/project/langchain-deepinfra/)


## Installation and Setup

Install the LangChain partner package

```bash
pip install -U langchain-deepinfra
```

Get your DeepInfra api key from the [DeepInfra Dashboard](https://deepinfra.com/dash/api_keys) and set it as an environment variable (`DEEPINFRA_API_TOKEN`)

```bash
export DEEPINFRA_API_TOKEN=<api_key>
```

## Chat Completions

This package contains the `ChatDeepInfra` class, which is the recommended way to interface with DeepInfra chat models.

```python
from langchain_deepinfra import ChatDeepInfra

chat = ChatDeepInfra(model="meta-llama/Meta-Llama-3.1-8B-Instruct")
chat.invoke("Who is the first president of Indonesia?")
```

## Embeddings

`DeepInfraEmbeddings` class exposes the DeepInfra embedding API.

```python
from langchain_deepinfra import DeepInfraEmbeddings

embeddings = DeepInfraEmbeddings(model="BAAI/bge-base-en-v1.5")
embeddings.embed_query("Who is the first president of Indonesia?")
```

## LLM

`DeepInfra` class exposes the DeepInfra LLM API.

```python
from langchain_deepinfra import DeepInfra

llm = DeepInfra(model="meta-llama/Meta-Llama-3.1-8B-Instruct")
llm.invoke("Who is the first president of Indonesia?")
```

