### PR TITLE
DOC: type checker complain on args_schema type hint when inheriting from BaseTool

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -492,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "1dad8f8e",
    "metadata": {
     "execution": {
@@ -504,13 +504,14 @@
    },
    "outputs": [],
    "source": [
-    "from typing import Optional, Type\n",
+    "from typing import Optional\n",
     "\n",
     "from langchain_core.callbacks import (\n",
     "    AsyncCallbackManagerForToolRun,\n",
     "    CallbackManagerForToolRun,\n",
     ")\n",
     "from langchain_core.tools import BaseTool\n",
+    "from langchain_core.tools.base import ArgsSchema\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
     "\n",
@@ -524,7 +525,7 @@
     "class CustomCalculatorTool(BaseTool):\n",
     "    name: str = \"Calculator\"\n",
     "    description: str = \"useful for when you need to answer questions about math\"\n",
-    "    args_schema: Type[BaseModel] = CalculatorInput\n",
+    "    args_schema: Optional[ArgsSchema] = CalculatorInput\n",
     "    return_direct: bool = True\n",
     "\n",
     "    def _run(\n",


### PR DESCRIPTION
Thank you for contributing to LangChain!

- **Description:** update docs to suppress type checker complain on args_schema type hint when inheriting from BaseTool
- **Issue:** #30142 
- **Dependencies:** N/A
- **Twitter handle:** N/A

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
