### PR TITLE
fixes#30182: update tool names to match OpenAI function name pattern

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/jira/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/jira/toolkit.py
@@ -43,27 +43,27 @@ class JiraToolkit(BaseToolkit):
         operations: List[Dict] = [
             {
                 "mode": "jql",
-                "name": "JQL Query",
+                "name": "jql_query",
                 "description": JIRA_JQL_PROMPT,
             },
             {
                 "mode": "get_projects",
-                "name": "Get Projects",
+                "name": "get_projects",
                 "description": JIRA_GET_ALL_PROJECTS_PROMPT,
             },
             {
                 "mode": "create_issue",
-                "name": "Create Issue",
+                "name": "create_issue",
                 "description": JIRA_ISSUE_CREATE_PROMPT,
             },
             {
                 "mode": "other",
-                "name": "Catch all Jira API call",
+                "name": "catch_all_jira_api",
                 "description": JIRA_CATCH_ALL_PROMPT,
             },
             {
                 "mode": "create_page",
-                "name": "Create confluence page",
+                "name": "create_confluence_page",
                 "description": JIRA_CONFLUENCE_PAGE_CREATE_PROMPT,
             },
         ]


### PR DESCRIPTION
The OpenAI API requires function names to match the pattern '^[a-zA-Z0-9_-]+$'. This updates the JIRA toolkit's tool names to use underscores instead of spaces to comply with this requirement and prevent BadRequestError when using the tools with OpenAI functions.

Error fixed:
```
File "langgraph-bug-fix/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1023, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.", 'type': 'invalid_request_error', 'param': 'tools[0].function.name', 'code': 'invalid_value'}}
During task with name 'agent' and id 'aedd7537-e8d5-6678-d0c5-98129586d3ac'
```

Issue:#30182