### PR TITLE
Core , openai: add reasoning content to solve issues #30067

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -164,6 +164,11 @@ class AIMessage(BaseMessage):
     This is a standard representation of token usage that is consistent across models.
     """
 
+    """
+    reasoning message space for reasoning message like deepseek / o3-mini etc. 
+    """
+    reasoning_message:str = None 
+
     type: Literal["ai"] = "ai"
     """The type of the message (used for deserialization). Defaults to "ai"."""
 

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -164,11 +164,6 @@ class AIMessage(BaseMessage):
     This is a standard representation of token usage that is consistent across models.
     """
 
-    """
-    reasoning message space for reasoning message like deepseek / o3-mini etc. 
-    """
-    reasoning_message:str = None 
-
     type: Literal["ai"] = "ai"
     """The type of the message (used for deserialization). Defaults to "ai"."""
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -129,6 +129,7 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Fix for azure
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
+        reasoning_content = _dict.get("reasoning_content") or ""
         additional_kwargs: Dict = {}
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
@@ -152,6 +153,7 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
             id=id_,
             tool_calls=tool_calls,
             invalid_tool_calls=invalid_tool_calls,
+            reasoning_content = reasoning_content
         )
     elif role in ("system", "developer"):
         if role == "developer":

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -130,9 +130,9 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         reasoning_content = _dict.get("reasoning_content") or ""
-        if reasoning_content != "":
-            content = content[:] + reasoning_content[:]
         additional_kwargs: Dict = {}
+        if reasoning_content != "":
+            additional_kwargs["reasoning_content"] = reasoning_content
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -130,6 +130,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         reasoning_content = _dict.get("reasoning_content") or ""
+        if reasoning_content != "":
+            content = content[:] + reasoning_content[:]
         additional_kwargs: Dict = {}
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
@@ -152,8 +154,7 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
             name=name,
             id=id_,
             tool_calls=tool_calls,
-            invalid_tool_calls=invalid_tool_calls,
-            reasoning_content = reasoning_content
+            invalid_tool_calls=invalid_tool_calls
         )
     elif role in ("system", "developer"):
         if role == "developer":

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -154,7 +154,7 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
             name=name,
             id=id_,
             tool_calls=tool_calls,
-            invalid_tool_calls=invalid_tool_calls
+            invalid_tool_calls=invalid_tool_calls,
         )
     elif role in ("system", "developer"):
         if role == "developer":


### PR DESCRIPTION
The pull request addresses the issue of not having reasoning content when using ChatOpenAI with the DeepSeek reasoner. The issue is resolved by modifying the cover dictionary to the message, adding reasoning content to the content if it exist. There are no changes to other parts of the code, and it is believed that there will be no side effects from adding the reasoning content. 

#30067 