### PR TITLE
core[patch]: check "tool_call_id" existence to prevent KeyError (#27249)

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -129,7 +129,7 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
         else:
             pass
 
-        tool_call_id = values["tool_call_id"]
+        tool_call_id = values.get("tool_call_id")
         if isinstance(tool_call_id, (UUID, int, float)):
             values["tool_call_id"] = str(tool_call_id)
         return values


### PR DESCRIPTION
**Description:** Fixes a bug where a `KeyError` is thrown when `tool_call_id` is not found, by calling `values.get("tool_call_id")` instead of `values["tool_call_id"]`. This error happens when running an agent using a `RemoteRunnable` from `langserve` like [in this langserve agent with history implementation example](https://github.com/langchain-ai/langserve/blob/main/examples/agent_with_history/client.ipynb).

**Issue:** Fixes #27249

**Dependencies:** none