### PR TITLE
community[fix]: override `_cosine_relevance_score_fn` to use cosine similarity (#30257)

### DIFF
--- a/libs/community/langchain_community/vectorstores/mongodb_atlas.py
+++ b/libs/community/langchain_community/vectorstores/mongodb_atlas.py
@@ -91,6 +91,22 @@ class MongoDBAtlasVectorSearch(VectorStore):
     @property
     def embeddings(self) -> Embeddings:
         return self._embedding
+    
+    @staticmethod
+    def _cosine_relevance_score_fn(distance: float) -> float:
+        """Return the raw cosine similarity score.
+    
+        This method overrides the default behavior in `VectorStore`, 
+        as MongoDB Atlas Vector Search provides scores directly in 
+        cosine similarity format. No normalization is required.
+    
+        Args:
+            distance (float): The cosine similarity score from MongoDB.
+    
+        Returns:
+            float: The raw cosine similarity score.
+        """
+        return distance 
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         if self._relevance_score_fn == "euclidean":


### PR DESCRIPTION

PR Title:
community: Fix incorrect similarity score calculation in MongoDBAtlasVectorSearch

PR Message:
Description:
This PR fixes an issue in MongoDBAtlasVectorSearch where _cosine_relevance_score_fn incorrectly applies 1 - distance normalization. Since MongoDB already returns cosine similarity scores, this normalization is unnecessary. The method is overridden to return distance directly.

Issue:
Fixes #30257

Dependencies:
No new dependencies introduced.
