### PR TITLE
community: fix auto-detection of non-RGB images.

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/images.py
+++ b/libs/community/langchain_community/document_loaders/parsers/images.py
@@ -48,7 +48,8 @@ class BaseImageBlobParser(BaseBlobParser):
 
             with blob.as_bytes_io() as buf:
                 if blob.mimetype == "application/x-npy":
-                    img = Img.fromarray(numpy.load(buf))
+                    array = numpy.load(buf)
+                    img = Img.fromarray(numpy.squeeze(array))
                 else:
                     img = Img.open(buf)
                 content = self._analyze_image(img)


### PR DESCRIPTION
**Description:** Fixes loading non-RGB images, e.g. grayscale.
**Issue:** Closes #29586 
**Dependencies:** none
**Twitter handle:** none