### PR TITLE
community: cube document loader - fix logging

### DIFF
--- a/libs/community/langchain_community/document_loaders/cube_semantic.py
+++ b/libs/community/langchain_community/document_loaders/cube_semantic.py
@@ -53,7 +53,7 @@ class CubeSemanticLoader(BaseLoader):
 
         These values can be used to achieve a more accurate filtering.
         """
-        logger.info("Loading dimension values for: {dimension_name}...")
+        logger.info("Loading dimension values for: %s ...", dimension_name)
 
         headers = {
             "Content-Type": "application/json",
@@ -122,13 +122,13 @@ class CubeSemanticLoader(BaseLoader):
             "Authorization": self.cube_api_token,
         }
 
-        logger.info(f"Loading metadata from {self.cube_api_url}...")
+        logger.info("Loading metadata from %s ...", self.cube_api_url)
         response = requests.get(f"{self.cube_api_url}/meta", headers=headers)
         response.raise_for_status()
         raw_meta_json = response.json()
         cube_data_objects = raw_meta_json.get("cubes", [])
 
-        logger.info(f"Found {len(cube_data_objects)} cube data objects in metadata.")
+        logger.info("Found %s cube data objects in metadata.", len(cube_data_objects))
 
         if not cube_data_objects:
             raise ValueError("No cubes found in metadata.")
@@ -140,10 +140,10 @@ class CubeSemanticLoader(BaseLoader):
             measures = cube_data_obj.get("measures", [])
             dimensions = cube_data_obj.get("dimensions", [])
 
-            logger.info(f"Processing {cube_data_obj_name}...")
+            logger.info("Processing %s ...", cube_data_obj_name)
 
             if not cube_data_obj_is_public:
-                logger.info(f"Skipping {cube_data_obj_name} because it is not public.")
+                logger.info("Skipping %s because it is not public.", cube_data_obj_name)
                 continue
 
             for item in measures + dimensions:


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"
  - Where "package" is whichever of langchain, community, core, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"

- **Description:** Fix bad log message on line#56 and replace f-string logs with format specifiers

- **Issue:** Log messages such as this one are emitted by cube document loader:
`INFO:langchain_community.document_loaders.cube_semantic:Loading dimension values for: {dimension_name}...`

- [ ] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
