### PR TITLE
community: cube document loader - do not load non-public dimensions and measures

### DIFF
--- a/libs/community/langchain_community/document_loaders/cube_semantic.py
+++ b/libs/community/langchain_community/document_loaders/cube_semantic.py
@@ -152,6 +152,11 @@ class CubeSemanticLoader(BaseLoader):
                 item_name = str(item.get("name"))
                 item_type = str(item.get("type"))
 
+                is_public = bool(item.get("public"))
+                if not is_public:
+                    logger.info("Skipping %s because it is not public.", item_name)
+                    continue
+
                 if (
                     self.load_dimension_values
                     and column_member_type == "dimension"

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -66,7 +66,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
         self.assertEqual(len(documents), 1)
         self.assertEqual(documents[0].page_content, "Test Title, Test Description")
         self.assertEqual(documents[0].metadata["column_values"], ["value1", "value2"])
-        self.assertIn('Skipping hidden_dimension because it is not public.', cm.output)
+        self.assertIn('INFO:langchain_community.document_loaders.cube_semantic:Skipping hidden_dimension because it is not public.', cm.output)
 
 
 if __name__ == "__main__":

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
@@ -25,8 +26,10 @@ class TestCubeSemanticLoader(unittest.TestCase):
     @patch("requests.get")
     @patch(f"{MODULE_PATH}._get_dimension_values")
     def test_load(
-        self, mock_get_dimension_values: MagicMock, mock_get: MagicMock
+        self, mock_get_dimension_values: MagicMock, mock_get: MagicMock, caplog,
     ) -> None:
+        caplog.set_level(logging.INFO)
+
         # Mocking the response
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
@@ -43,6 +46,14 @@ class TestCubeSemanticLoader(unittest.TestCase):
                             "type": "string",
                             "title": "Test Title",
                             "description": "Test Description",
+                            "public": True,
+                        },
+                        {
+                            "name": "hidden_dimension",
+                            "type": "string",
+                            "title": "Hidden",
+                            "description": "Hidden",
+                            "public": False,
                         }
                     ],
                 }
@@ -56,6 +67,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
         self.assertEqual(len(documents), 1)
         self.assertEqual(documents[0].page_content, "Test Title, Test Description")
         self.assertEqual(documents[0].metadata["column_values"], ["value1", "value2"])
+        self.assertIn('Skipping hidden_dimension because it is not public.')
 
 
 if __name__ == "__main__":

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -66,7 +66,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
         self.assertEqual(len(documents), 1)
         self.assertEqual(documents[0].page_content, "Test Title, Test Description")
         self.assertEqual(documents[0].metadata["column_values"], ["value1", "value2"])
-        self.assertIn('INFO:langchain_community.document_loaders.cube_semantic:Skipping hidden_dimension because it is not public.', cm.output)
+        self.assertIn("INFO:langchain_community.document_loaders.cube_semantic:Skipping hidden_dimension because it is not public.", cm.output)
 
 
 if __name__ == "__main__":

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -60,7 +60,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
 
         mock_get_dimension_values.return_value = ["value1", "value2"]
 
-        with self.assertLogs(level='INFO') as cm:
+        with self.assertLogs(level="INFO") as cm:
             documents = self.loader.load()
 
         self.assertEqual(len(documents), 1)

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
@@ -26,10 +25,8 @@ class TestCubeSemanticLoader(unittest.TestCase):
     @patch("requests.get")
     @patch(f"{MODULE_PATH}._get_dimension_values")
     def test_load(
-        self, mock_get_dimension_values: MagicMock, mock_get: MagicMock, caplog,
+        self, mock_get_dimension_values: MagicMock, mock_get: MagicMock
     ) -> None:
-        caplog.set_level(logging.INFO)
-
         # Mocking the response
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
@@ -63,11 +60,13 @@ class TestCubeSemanticLoader(unittest.TestCase):
 
         mock_get_dimension_values.return_value = ["value1", "value2"]
 
-        documents = self.loader.load()
+        with self.assertLogs(level='INFO') as cm:
+            documents = self.loader.load()
+
         self.assertEqual(len(documents), 1)
         self.assertEqual(documents[0].page_content, "Test Title, Test Description")
         self.assertEqual(documents[0].metadata["column_values"], ["value1", "value2"])
-        self.assertIn('Skipping hidden_dimension because it is not public.')
+        self.assertIn('Skipping hidden_dimension because it is not public.', cm.output)
 
 
 if __name__ == "__main__":

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -51,7 +51,7 @@ class TestCubeSemanticLoader(unittest.TestCase):
                             "title": "Hidden",
                             "description": "Hidden",
                             "public": False,
-                        }
+                        },
                     ],
                 }
             ]

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -66,7 +66,8 @@ class TestCubeSemanticLoader(unittest.TestCase):
         self.assertEqual(len(documents), 1)
         self.assertEqual(documents[0].page_content, "Test Title, Test Description")
         self.assertEqual(documents[0].metadata["column_values"], ["value1", "value2"])
-        self.assertIn("INFO:langchain_community.document_loaders.cube_semantic:Skipping hidden_dimension because it is not public.", cm.output)
+        self.assertIn("INFO:langchain_community.document_loaders.cube_semantic:"
+                      "Skipping hidden_dimension because it is not public.", cm.output)
 
 
 if __name__ == "__main__":

--- a/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_cube_semantic.py
@@ -66,8 +66,11 @@ class TestCubeSemanticLoader(unittest.TestCase):
         self.assertEqual(len(documents), 1)
         self.assertEqual(documents[0].page_content, "Test Title, Test Description")
         self.assertEqual(documents[0].metadata["column_values"], ["value1", "value2"])
-        self.assertIn("INFO:langchain_community.document_loaders.cube_semantic:"
-                      "Skipping hidden_dimension because it is not public.", cm.output)
+        self.assertIn(
+            "INFO:langchain_community.document_loaders.cube_semantic:"
+            "Skipping hidden_dimension because it is not public.",
+            cm.output,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thank you for contributing to LangChain!

- [x] **PR title**: "package: description"
  - Where "package" is whichever of langchain, community, core, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "community: add foobar LLM"

- **Description:** Do not load non-public dimensions and measures (public: false) with Cube semantic loader

- **Issue:** Currently, non-public dimensions and measures are loaded by the Cube document loader which leads to downstream applications using these which is not allowed by Cube.


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.


- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
