### PR TITLE
docs: revise option of TFIDFRetriever.load_local() in tf_idf.ipynb

### DIFF
--- a/docs/docs/integrations/retrievers/tf_idf.ipynb
+++ b/docs/docs/integrations/retrievers/tf_idf.ipynb
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retriever_copy = TFIDFRetriever.load_local(\"testing.pkl\")"
+    "retriever_copy = TFIDFRetriever.load_local(\"testing.pkl\", allow_dangerous_deserialization=True)"
    ]
   },
   {


### PR DESCRIPTION
**Description:**
Revise option of TFIDFRetriever.load_local()

Why we need option allow_dangerous_deserialization?
Because the de-serialization of this retriever is based on .joblib and .pkl files. Such files can be modified to deliver a malicious payload that results in execution of arbitrary code on your machine. So we would set allow_dangerous_deserialization as a guard, to emphasize the real security risk. Here is a simple example to simulate a malicious payload. Please check following references for detail.

Example: simulate a malicious payload
```python
>>> import pickle, pickletools
>>> pickle.loads(b"cos\nsystem\n(S'echo hello world'\ntR.")
hello world
0
>>> pickletools.dis(b"cos\nsystem\n(S'echo hello world'\ntR.")
    0: c    GLOBAL     'os system'
   11: (    MARK
   12: S        STRING     'echo hello world'
   32: t        TUPLE      (MARK at 11)
   33: R    REDUCE
   34: .    STOP
highest protocol among opcodes = 0
>>>
```

References:
pickle — Python object serialization
https://docs.python.org/3/library/pickle.html
Insecurity and Python pickles
https://lwn.net/Articles/964392/
Pickles are for delis
https://lwn.net/Articles/595352

**Issue:**
ValueError: The de-serialization of this retriever is based on .joblib and .pkl files.Such files can be modified to deliver a malicious payload that results in execution of arbitrary code on your machine.You will need to set `allow_dangerous_deserialization` to `True` to load this retriever. If you do this, make sure you trust the source of the file, and you are responsible for validating the file came from a trusted source.

**Dependencies:**
N/A