### PR TITLE
community: Add a BaseStore backed by OpenSearch

### DIFF
--- a/docs/docs/integrations/stores/opensearch.ipynb
+++ b/docs/docs/integrations/stores/opensearch.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "---\n",
+    "sidebar_label: OpenSearch\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenSearchStore\n",
+    "\n",
+    "This will help you get started with OpenSearch [key-value stores](/docs/concepts/key_value_stores). For detailed documentation of all `OpenSearchStore` features and configurations head to the [API reference](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.opensearch.OpenSearchStore.html).\n",
+    "\n",
+    "`OpenSearchStore` need the `opensearch-py` package to be installed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade --quiet  opensearch-py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Store takes the following parameters:\n",
+    "\n",
+    "* `host`: Your OpenSearch host API endpoint. Looks like `https://localhost:9200`\n",
+    "* `index_name`: The index name where stores inside OpenSearch.\n",
+    "* `username` : (Optional) OpenSearch username\n",
+    "* `password`: (Optional) OpenSearch password"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## OpenSearchStore\n",
+    "\n",
+    "The `OpenSearchStore` is an implementation of `BaseStore` that stores everything in your OpenSearch.\n",
+    "\n",
+    "### Integration details\n",
+    "\n",
+    "| Class | Package | Local | JS support | Package downloads | Package latest |\n",
+    "| :--- | :--- | :---: | :---: |  :---: | :---: |\n",
+    "| [OpenSearchStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.opensearch.OpenSearchStore.html) | [langchain_community](https://python.langchain.com/api_reference/community/index.html) | ❌ | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain_community?style=flat-square&label=%20) |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.storage import OpenSearchStore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docstore = OpenSearchStore(\n",
+    "    host=\"https://localhost:9200\",\n",
+    "    index_name=\"helloworld\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['v1', [0.1, 0.2, 0.3]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "docstore.mset([(\"k1\", \"v1\"), (\"k2\", [0.1, 0.2, 0.3])])\n",
+    "print(docstore.mget([\"k1\", \"k2\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And you can delete data using the `mdelete` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docstore.mdelete(\n",
+    "    [\n",
+    "        \"key1\",\n",
+    "        \"key2\",\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "docstore.mget(\n",
+    "    [\n",
+    "        \"key1\",\n",
+    "        \"key2\",\n",
+    "    ]\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/libs/community/langchain_community/storage/__init__.py
+++ b/libs/community/langchain_community/storage/__init__.py
@@ -36,6 +36,9 @@ if TYPE_CHECKING:
         UpstashRedisByteStore,
         UpstashRedisStore,
     )
+    from langchain_community.storage.opensearch import (
+        OpenSearchStore
+    )
 
 __all__ = [
     "AstraDBByteStore",
@@ -47,6 +50,7 @@ __all__ = [
     "SQLStore",
     "UpstashRedisByteStore",
     "UpstashRedisStore",
+    "OpenSearchStore"
 ]
 
 _module_lookup = {
@@ -59,6 +63,7 @@ _module_lookup = {
     "SQLStore": "langchain_community.storage.sql",
     "UpstashRedisByteStore": "langchain_community.storage.upstash_redis",
     "UpstashRedisStore": "langchain_community.storage.upstash_redis",
+    "OpenSearchStore": "langchain_community.storage.opensearch",
 }
 
 

--- a/libs/community/langchain_community/storage/opensearch.py
+++ b/libs/community/langchain_community/storage/opensearch.py
@@ -1,0 +1,117 @@
+from typing import Iterator, List, Optional, Sequence, Tuple
+from langchain_core.stores import BaseStore
+from langchain_core.documents import Document
+
+
+class OpenSearchStore(BaseStore[str, str]):
+    """BaseStore implementation using OpenSearch as the underlying store"""
+
+    def __init__(
+        self,
+        host: str,
+        index_name: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None
+    ) -> None:
+        """Initialize the OpenSearch client and set up the index.
+
+        Args:
+            host (str): The OpenSearch host URL.
+            index_name (str): The OpenSearch index name where data will be stored.
+            username (Optional[str]): Optional username for authentication.
+            password (Optional[str]): Optional password for authentication.
+        """
+
+        try:
+            from opensearchpy import OpenSearch
+        except (ImportError, ModuleNotFoundError):
+            raise ImportError(
+                "Could not import the opensearchpy package. "
+                "Please install it with `pip install opensearch-py`."
+            )
+
+        self.client = OpenSearch(
+            [host],
+            http_auth=(username, password) if username and password else None,
+            use_ssl=False,
+            verify_certs=False,
+            ssl_assert_hostname=False,
+            ssl_show_warn=False
+        )
+        self.index_name = index_name
+
+        if not self.client.indices.exists(index=self.index_name):
+            self.client.indices.create(index=self.index_name)
+
+    def _get_document(self, key: str) -> dict:
+        """Helper function to retrieve the document from OpenSearch by key."""
+        try:
+            response = self.client.get(index=self.index_name, id=key)
+            return response['_source']
+        except Exception as e:
+            return None
+
+    def mget(self, keys: Sequence[str]) -> List[Optional[str]]:
+        """Get the values associated with the given keys from OpenSearch.
+
+        Args:
+            keys (Sequence[str]): A sequence of keys to retrieve.
+
+        Returns:
+            A list of values (str) associated with the keys, or None if not found.
+        """
+        values: List[Optional[str]] = []
+        for key in keys:
+            doc = self._get_document(key)
+            if doc:
+                values.append(
+                    Document(
+                        page_content=doc["page_content"],
+                        metadata=doc["metadata"]
+                    )
+                )
+            else:
+                values.append(None)
+        return values
+
+    def mset(self, key_value_pairs: Sequence[Tuple[str, str]]) -> None:
+        """Set the values for the given keys in OpenSearch.
+
+        Args:
+            key_value_pairs (Sequence[Tuple[str, str]]):
+                Key-value pairs to store in OpenSearch.
+        """
+        for key, value in key_value_pairs:
+            document = value.dict()
+            self.client.index(index=self.index_name, id=key, body=document)
+
+    def mdelete(self, keys: Sequence[str]) -> None:
+        """Delete the given keys from OpenSearch.
+
+        Args:
+            keys (Sequence[str]): A sequence of keys to delete.
+        """
+        for key in keys:
+            self.client.delete(index=self.index_name, id=key)
+
+    def yield_keys(self, prefix: Optional[str] = None) -> Iterator[str]:
+        """Get an iterator over keys that match the given prefix from OpenSearch.
+
+        Args:
+            prefix (Optional[str]): The prefix to match.
+
+        Returns:
+            Iterator[str]: An iterator over keys that match the given prefix.
+        """
+
+        query = {
+            "query": {
+                "prefix": {
+                    "_id": prefix if prefix else ""
+                }
+            }
+        }
+        response = self.client.search(index=self.index_name, body=query)
+
+        for hit in response['hits']['hits']:
+            yield hit['_id']

--- a/libs/community/tests/integration_tests/storage/test_opensearch.py
+++ b/libs/community/tests/integration_tests/storage/test_opensearch.py
@@ -1,0 +1,96 @@
+"""Implement integration tests for OpenSearch storage."""
+
+import os
+from typing import Generator, TYPE_CHECKING
+import uuid
+
+import pytest
+
+from langchain_community.storage.opensearch import OpenSearchStore
+from langchain_core.documents import Document
+
+if TYPE_CHECKING:
+    from opensearchpy import OpenSearch
+
+pytest.importorskip("opensearchpy")
+
+
+@pytest.fixture
+def opensearch_client() -> OpenSearch:
+    """Yield OpenSearch client."""
+    from opensearchpy import OpenSearch
+
+    host = os.environ.get("OPENSEARCH_HOST", "localhost")
+    index_name = os.environ.get("OPENSEARCH_INDEX", f"test_index_{uuid.uuid4().hex}")
+    username = os.environ.get("OPENSEARCH_USERNAME")
+    password = os.environ.get("OPENSEARCH_PASSWORD")
+
+    client = OpenSearch(
+        [host],
+        http_auth=(username, password) if username else None,
+        use_ssl=False,
+        verify_certs=False,
+        ssl_assert_hostname=False,
+        ssl_show_warn=False,
+    )
+
+    yield client
+
+    client.indices.delete(index=index_name, ignore=[400, 404])
+
+
+@pytest.fixture
+def store(opensearch_client: OpenSearch) -> Generator[OpenSearchStore, None, None]:
+    """Yield an OpenSearchStore instance."""
+    index_name = os.environ.get("OPENSEARCH_INDEX", f"test_index_{uuid.uuid4().hex}")
+    store = OpenSearchStore(
+        host=os.environ.get("OPENSEARCH_HOST", "localhost"),
+        index_name=index_name,
+        username=os.environ.get("OPENSEARCH_USERNAME"),
+        password=os.environ.get("OPENSEARCH_PASSWORD"),
+    )
+    yield store
+    opensearch_client.indices.delete(index=index_name, ignore=[400, 404])
+
+
+def test_mget(store: OpenSearchStore) -> None:
+    """Test OpenSearchStore mget method."""
+    store.mset([
+        ("key1", Document(page_content="content1", metadata={"author": "Alice"})),
+        ("key2", Document(page_content="content2", metadata={"author": "Bob"}))
+    ])
+    result = store.mget(["key1", "key2"])
+    assert result[0].page_content == "content1"
+    assert result[1].page_content == "content2"
+
+
+def test_mset(store: OpenSearchStore) -> None:
+    """Test OpenSearchStore mset method."""
+    store.mset([
+        ("key1", Document(page_content="content1", metadata={"author": "Alice"}))
+    ])
+    result = store._get_document("key1")
+    assert result["page_content"] == "content1"
+    assert result["metadata"]["author"] == "Alice"
+
+
+def test_mdelete(store: OpenSearchStore) -> None:
+    """Test OpenSearchStore mdelete method."""
+    store.mset([
+        ("key1", Document(page_content="content1", metadata={})),
+        ("key2", Document(page_content="content2", metadata={}))
+    ])
+    store.mdelete(["key1", "key2"])
+    result = store.mget(["key1", "key2"])
+    assert result == [None, None]
+
+
+def test_yield_keys(store: OpenSearchStore) -> None:
+    """Test OpenSearchStore yield_keys method."""
+    store.mset([
+        ("key1", Document(page_content="content1", metadata={})),
+        ("key2", Document(page_content="content2", metadata={}))
+    ])
+    assert sorted(store.yield_keys()) == ["key1", "key2"]
+    assert sorted(store.yield_keys(prefix="key")) == ["key1", "key2"]
+    assert sorted(store.yield_keys(prefix="unknown")) == []

--- a/libs/community/tests/unit_tests/storage/test_imports.py
+++ b/libs/community/tests/unit_tests/storage/test_imports.py
@@ -10,6 +10,7 @@ EXPECTED_ALL = [
     "RedisStore",
     "UpstashRedisByteStore",
     "UpstashRedisStore",
+    "OpenSearchStore"
 ]
 
 


### PR DESCRIPTION
- Description: This PR adds a BaseStore implementation backed by OpenSearch. With this implementation, we can use OpenSearchStore as a docstore with others tools like ParentDocumentRetriver, below is the simple example:

```
retriever = ParentDocumentRetriever(
    vectorstore=vector_store,
    docstore=OpenSearchStore(host=OPENSEARCH_URL, index_name=index_name),
    child_splitter=small_chunk_spliter,
    parent_splitter=bic_chunk_spliter,
)
```


- Issue: (no related issue)

- Dependencies: opensearch-py

Thank you for a review!
Manu Chen