### PR TITLE
core: allow pydantic model as input of template

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -147,6 +147,9 @@ class BasePromptTemplate(
         )
 
     def _validate_input(self, inner_input: Any) -> dict:
+        if isinstance(inner_input, BaseModel):
+            inner_input = inner_input.model_dump()
+
         if not isinstance(inner_input, dict):
             if len(self.input_variables) == 1:
                 var_name = self.input_variables[0]


### PR DESCRIPTION
currently if you use langgraph's `create_react_agent` with a pydantic schema and the input of the graph invocation is such a pydantic object, the agent calls the chain with the prompt+model with the pydantic object as input.

This object is not well handled by the prompt template and so the chain does not work as expected.

It is very confusing to allow a pydantic schema in the graph, but then be obliged to invoke the graph with a dict.

This PR adds handling of pydantic objects in the template.