### PR TITLE
docs: Fix for broken links for Docling project sites

### DIFF
--- a/docs/docs/integrations/document_loaders/docling.ipynb
+++ b/docs/docs/integrations/document_loaders/docling.ipynb
@@ -521,9 +521,9 @@
    "source": [
     "## API reference\n",
     "\n",
-    "- [LangChain Docling integration GitHub](https://github.com/DS4SD/docling-langchain)\n",
-    "- [Docling GitHub](https://github.com/DS4SD/docling)\n",
-    "- [Docling docs](https://ds4sd.github.io/docling/)"
+    "- [LangChain Docling integration GitHub](https://github.com/docling-project/docling-langchain)\n",
+    "- [Docling GitHub](https://github.com/docling-project/docling)\n",
+    "- [Docling docs](https://docling-project.github.io/docling//)"
    ]
   },
   {


### PR DESCRIPTION
**Description:**: Updated Docling project URLs from ds4sd.github.io to docling-project.github.io/docling/
 **Issue:** #30312
 **Dependencies:** None
 **Twitter handle**: @lahoramaker