### PR TITLE
docs: Updated link to current Unstructured docs

### DIFF
--- a/docs/docs/how_to/document_loader_html.ipynb
+++ b/docs/docs/how_to/document_loader_html.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "This covers how to load `HTML` documents into a LangChain [Document](https://python.langchain.com/api_reference/core/documents/langchain_core.documents.base.Document.html#langchain_core.documents.base.Document) objects that we can use downstream.\n",
     "\n",
-    "Parsing HTML files often requires specialized tools. Here we demonstrate parsing via [Unstructured](https://unstructured-io.github.io/unstructured/) and [BeautifulSoup4](https://beautiful-soup-4.readthedocs.io/en/latest/), which can be installed via pip. Head over to the integrations page to find integrations with additional services, such as [Azure AI Document Intelligence](/docs/integrations/document_loaders/azure_document_intelligence) or [FireCrawl](/docs/integrations/document_loaders/firecrawl).\n",
+    "Parsing HTML files often requires specialized tools. Here we demonstrate parsing via [Unstructured](https://docs.unstructured.io) and [BeautifulSoup4](https://beautiful-soup-4.readthedocs.io/en/latest/), which can be installed via pip. Head over to the integrations page to find integrations with additional services, such as [Azure AI Document Intelligence](/docs/integrations/document_loaders/azure_document_intelligence) or [FireCrawl](/docs/integrations/document_loaders/firecrawl).\n",
     "\n",
     "## Loading HTML with Unstructured"
    ]


### PR DESCRIPTION
 The former link led to a site that explains that the docs have moved, but did not redirect the user to the actual site automatically. I just copied the provided url, checked that it works and updated the link to the current version.


**Description:** Updated the link to Unstructured Docs at https://docs.unstructured.io
**Issue:** #30315 
**Dependencies:** None
**Twitter handle:** @lahoramaker
