### PR TITLE
groq[minor]: remove default model

### DIFF
--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -88,8 +88,6 @@ from typing_extensions import Self
 
 from langchain_groq.version import __version__
 
-WARNED_DEFAULT_MODEL = False
-
 
 class ChatGroq(BaseChatModel):
     """`Groq` Chat large language models API.
@@ -305,7 +303,7 @@ class ChatGroq(BaseChatModel):
 
     client: Any = Field(default=None, exclude=True)  #: :meta private:
     async_client: Any = Field(default=None, exclude=True)  #: :meta private:
-    model_name: str = Field(default="mixtral-8x7b-32768", alias="model")
+    model_name: str = Field(alias="model")
     """Model name to use."""
     temperature: float = 0.7
     """What sampling temperature to use."""
@@ -352,27 +350,6 @@ class ChatGroq(BaseChatModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def warn_default_model(cls, values: Dict[str, Any]) -> Any:
-        """Warning anticipating removal of default model."""
-        # TODO(ccurme): remove this warning in 0.3.0 when default model is removed
-        global WARNED_DEFAULT_MODEL
-        if (
-            "model" not in values
-            and "model_name" not in values
-            and not WARNED_DEFAULT_MODEL
-        ):
-            warnings.warn(
-                "Groq is retiring the default model for ChatGroq, mixtral-8x7b-32768, "
-                "on March 20, 2025. Requests with the default model will start failing "
-                "on that date. Version 0.3.0 of langchain-groq will remove the "
-                "default. Please specify `model` explicitly, e.g., "
-                "`model='mistral-saba-24b'` or `model='llama-3.3-70b-versatile'`.",
-            )
-            WARNED_DEFAULT_MODEL = True
-        return values
 
     @model_validator(mode="before")
     @classmethod

--- a/libs/partners/groq/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/unit_tests/test_chat_models.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import warnings
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -280,23 +279,3 @@ def test_groq_serialization() -> None:
 
     # Ensure a None was preserved
     assert llm.groq_api_base == llm2.groq_api_base
-
-
-def test_groq_warns_default_model() -> None:
-    """Test that a warning is raised if a default model is used."""
-
-    # Delete this test in 0.3 release, when the default model is removed.
-
-    # Test no warning if model is specified
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ChatGroq(model="foo")
-
-    # Test warns if default model is used
-    with pytest.warns(match="default model"):
-        ChatGroq()
-
-    # Test only warns once
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ChatGroq()


### PR DESCRIPTION
The default model for `ChatGroq`, `"mixtral-8x7b-32768"`, is being retired on March 20, 2025. Here we remove the default, such that model names must be explicitly specified (being explicit is a good practice here, and avoids the need for breaking changes down the line). This change will be released in a minor version bump to 0.3.

This follows https://github.com/langchain-ai/langchain/pull/30161 (released in version 0.2.5), where we began generating warnings to this effect.

![Screenshot 2025-03-18 at 10 33 27 AM](https://github.com/user-attachments/assets/f1e4b302-c62a-43b0-aa86-eaf9271e86cb)
