### PR TITLE
langchain-tests: allow test_serdes for packages outside the default valid namespaces

### DIFF
--- a/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
@@ -683,4 +683,9 @@ class ChatModelUnitTests(ChatModelTests):
             with mock.patch.dict(os.environ, env_params):
                 ser = dumpd(model)
                 assert ser == snapshot(name="serialized")
-                assert model.dict() == load(dumpd(model)).dict()
+                assert (
+                    model.dict()
+                    == load(
+                        dumpd(model), valid_namespaces=model.get_lc_namespace()[:1]
+                    ).dict()
+                )


### PR DESCRIPTION
**Description:**

a third party package not listed in the default valid namespaces cannot pass test_serdes because the load() does not allow for extending the valid_namespaces.

test_serdes will fail with -
   ValueError: Invalid namespace: {'lc': 1, 'type': 'constructor', 'id': ['langchain_other', 'chat_models', 'ChatOther'], 'kwargs': {'model_name': '...', 'api_key': '...'}, 'name': 'ChatOther'}

this change has test_serdes automatically extend valid_namespaces based off the ChatModel under test's namespace.