### PR TITLE
docs: Fix typo "tall" → "tool" in tools_human.ipynb

### DIFF
--- a/docs/docs/how_to/tools_human.ipynb
+++ b/docs/docs/how_to/tools_human.ipynb
@@ -161,7 +161,7 @@
    "source": [
     "## Adding human approval\n",
     "\n",
-    "Let's add a step in the chain that will ask a person to approve or reject the tall call request.\n",
+    "Let's add a step in the chain that will ask a person to approve or reject the tool call request.\n",
     "\n",
     "On rejection, the step will raise an exception which will stop execution of the rest of the chain."
    ]


### PR DESCRIPTION
This PR fixes a minor typo.

The word "tall" was mistakenly used instead of "tool." 

I have corrected it to "tool" for better clarity and accuracy.
