### PR TITLE
community: add keep_newlines parameter to process_pages method

### DIFF
--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -448,6 +448,7 @@ class ConfluenceLoader(BaseLoader):
                     content_format,
                     ocr_languages,
                     keep_markdown_format,
+                    keep_newlines=keep_newlines,
                 )
 
     def load(self, **kwargs: Any) -> List[Document]:


### PR DESCRIPTION
- **Description:** Adding keep_newlines parameter to process_pages method with page_ids on Confluence document loader
- **Issue:** N/A (This is an enhancement rather than a bug fix)
- **Dependencies:** N/A
- **Twitter handle:** N/A
