### PR TITLE
langchain-tests: allow image specific params for image model tests

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -294,6 +294,18 @@ class ChatModelIntegrationTests(ChatModelTests):
             def supports_image_inputs(self) -> bool:
                 return True
 
+        If the model that supports images requires special initialization, override
+        the image_model_params property. This may happen if you need to pass a different
+        model name.
+
+        Example:
+
+        .. code-block:: python
+
+            @property
+            def image_model_params(self) -> dict:
+                return {"model": "image-model-001"}
+
     .. dropdown:: supports_video_inputs
 
         Boolean property indicating whether the chat model supports image inputs.
@@ -1769,7 +1781,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         result = model_with_tools.invoke(messages)
         assert isinstance(result, AIMessage)
 
-    def test_image_inputs(self, model: BaseChatModel) -> None:
+    def test_image_inputs(self, image_model: BaseChatModel) -> None:
         """Test that the model can process image inputs.
 
         This test should be skipped (see Configuration below) if the model does not
@@ -1805,6 +1817,9 @@ class ChatModelIntegrationTests(ChatModelTests):
             If this test fails, check that the model can correctly handle messages
             with image content blocks in OpenAI format, including base64-encoded
             images. Otherwise, set the ``supports_image_inputs`` property to False.
+
+            If you need to control the model used for this test, you can override
+            the ``image_model_params`` property on the test class.
         """
         if not self.supports_image_inputs:
             pytest.skip("Model does not support image message.")
@@ -1819,7 +1834,7 @@ class ChatModelIntegrationTests(ChatModelTests):
                 },
             ],
         )
-        model.invoke([message])
+        image_model.invoke([message])
 
     def test_image_tool_message(self, model: BaseChatModel) -> None:
         """Test that the model can process ToolMessages with image inputs.

--- a/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
@@ -86,6 +86,11 @@ class ChatModelTests(BaseStandardTests):
         return {}
 
     @property
+    def image_model_params(self) -> dict:
+        """Initialization parameters for the image model."""
+        return self.chat_model_params
+
+    @property
     def standard_chat_model_params(self) -> dict:
         """:private:"""
         return {
@@ -103,6 +108,16 @@ class ChatModelTests(BaseStandardTests):
             **{
                 **self.standard_chat_model_params,
                 **self.chat_model_params,
+            }
+        )
+
+    @pytest.fixture
+    def image_model(self) -> BaseChatModel:
+        """:private:"""
+        return self.chat_model_class(
+            **{
+                **self.standard_chat_model_params,
+                **self.image_model_params,
             }
         )
 


### PR DESCRIPTION
**Description:** allow image specific model params for image tests

this is important for ChatModels where model="a" may support all the chat features but not image messages, and model="a-vision" supports image messages but not all other chat features

those ChatModel test classes can override `image_model_params` similar to `chat_model_params`