### PR TITLE
docs: fix typo in chat_history.ipynb

### DIFF
--- a/docs/docs/versions/migrating_memory/chat_history.ipynb
+++ b/docs/docs/versions/migrating_memory/chat_history.ipynb
@@ -16,7 +16,7 @@
     "* [Memory](https://langchain-ai.github.io/langgraph/concepts/agentic_concepts/#memory)\n",
     ":::\n",
     "\n",
-    "We recommend that new LangChain applications take advantage of the [built-in LangGraph peristence](https://langchain-ai.github.io/langgraph/concepts/persistence/) to implement memory.\n",
+    "We recommend that new LangChain applications take advantage of the [built-in LangGraph persistence](https://langchain-ai.github.io/langgraph/concepts/persistence/) to implement memory.\n",
     "\n",
     "In some situations, users may need to keep using an existing persistence solution for chat message history.\n",
     "\n",


### PR DESCRIPTION
`peristence` should be `persistence`
