### PR TITLE
Fix incorrect import path for AzureAIChatCompletionsModel

### DIFF
--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -108,7 +108,7 @@ def init_chat_model(
             - 'openai'              -> langchain-openai
             - 'anthropic'           -> langchain-anthropic
             - 'azure_openai'        -> langchain-openai
-            - 'azure_ai             -> langchain-ai
+            - 'azure_ai'            -> langchain-azure-ai
             - 'google_vertexai'     -> langchain-google-vertexai
             - 'google_genai'        -> langchain-google-genai
             - 'bedrock'             -> langchain-aws

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -359,7 +359,7 @@ def _init_chat_model_helper(
         return AzureChatOpenAI(model=model, **kwargs)
     elif model_provider == "azure_ai":
         _check_pkg("langchain_azure_ai")
-        from langchain_azure_ai import AzureAIChatCompletionsModel
+        from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
 
         return AzureAIChatCompletionsModel(model=model, **kwargs)
     elif model_provider == "cohere":


### PR DESCRIPTION
Fixes #30416

Correct the import path for `AzureAIChatCompletionsModel` in the `_init_chat_model_helper` function.

* Update the import statement in `libs/langchain/langchain/chat_models/base.py` to `from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/langchain-ai/langchain/pull/30417?shareId=6ff6d5de-e3d1-4972-8d24-5e74838e9945).