### PR TITLE
community: change to uuid4 in cassandra message histories

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/cassandra.py
+++ b/libs/community/langchain_community/chat_message_histories/cassandra.py
@@ -103,7 +103,7 @@ class CassandraChatMessageHistory(BaseChatMessageHistory):
         Args:
             message: A message to write.
         """
-        this_row_id = uuid.uuid1()
+        this_row_id = uuid.uuid4()
         self.table.put(
             partition_id=self.session_id,
             row_id=this_row_id,
@@ -113,7 +113,7 @@ class CassandraChatMessageHistory(BaseChatMessageHistory):
 
     async def aadd_messages(self, messages: Sequence[BaseMessage]) -> None:
         for message in messages:
-            this_row_id = uuid.uuid1()
+            this_row_id = uuid.uuid4()
             await self.table.aput(
                 partition_id=self.session_id,
                 row_id=this_row_id,


### PR DESCRIPTION
this_row_id previously used UUID v1. However, since UUID v1 can be predicted if the MAC address and timestamp are known, it poses a potential security risk. Therefore, it has been changed to UUID v4.