### PR TITLE
Fix typo in with_structured_output function of class BaseChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1501,7 +1501,7 @@ class BaseChatOpenAI(BaseChatModel):
         Returns:
             A Runnable that takes same inputs as a :class:`langchain_core.language_models.chat.BaseChatModel`.
 
-            | If ``include_raw`` is False and ``schema`` is a Pydantic class, Runnable outputs an instance of ``schema`` (i.e., a Pydantic object). Otherwise, if ``include_raw`` is False then Runnable outputs a dict.
+            | If ``include_raw`` is False and ``schema`` is a Pydantic class, Runnable outputs an instance of ``schema`` (i.e., a Pydantic object). Otherwise, if ``include_raw`` is True then Runnable outputs a dict.
 
             | If ``include_raw`` is True, then Runnable outputs a dict with keys:
 


### PR DESCRIPTION
docs: Correct description of 'include_raw' parameter in Runnable outputs

**Description:** Corrected the description of the 'include_raw' parameter in Runnable outputs. Changed "Otherwise, if ``include_raw`` is False then Runnable outputs a dict." to "Otherwise, if ``include_raw`` is True then Runnable outputs a dict." to align with the correct information mentioned on the following line.

**Issue:** N/A

**Dependencies:** None