### PR TITLE
core: fix  AsyncCallbackManagerForToolRun JSON  is not serializable 

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -505,7 +505,7 @@ class BaseRunManager(RunManagerMixin):
             "parent_run_id": str(self.parent_run_id) if self.parent_run_id else None,
             "tags": self.tags.copy() if self.tags else [],
             "metadata": {k: v for k, v in self.metadata.items()
-                        if isinstance(v, (str, int, float, bool, 
+                        if isinstance(v, (str, int, float, bool,
                                           type(None), list, dict))},
             "type": self.__class__.__name__,
             # Exclude complex handler objects and only retain their quantity information

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -491,6 +491,7 @@ class BaseRunManager(RunManagerMixin):
             metadata={},
             inheritable_metadata={},
         )
+
     def _asdict(self) -> dict[str, Any]:
         """Return a dictionary representation of the run manager.
 
@@ -504,9 +505,11 @@ class BaseRunManager(RunManagerMixin):
             "run_id": str(self.run_id),
             "parent_run_id": str(self.parent_run_id) if self.parent_run_id else None,
             "tags": self.tags.copy() if self.tags else [],
-            "metadata": {k: v for k, v in self.metadata.items()
-                        if isinstance(v, (str, int, float, bool,
-                                          type(None), list, dict))},
+            "metadata": {
+                k: v
+                for k, v in self.metadata.items()
+                if isinstance(v, (str, int, float, bool, type(None), list, dict))
+            },
             "type": self.__class__.__name__,
             # Exclude complex handler objects and only retain their quantity information
             "handlers_count": len(self.handlers),

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -491,6 +491,26 @@ class BaseRunManager(RunManagerMixin):
             metadata={},
             inheritable_metadata={},
         )
+    def _asdict(self) -> dict[str, Any]:
+        """Return a dictionary representation of the run manager.
+        
+        This method provides a serializable representation of the run manager
+        that includes essential properties while excluding complex objects.
+        
+        Returns:
+            dict: A dictionary with serializable properties
+        """
+        return {
+            "run_id": str(self.run_id),
+            "parent_run_id": str(self.parent_run_id) if self.parent_run_id else None,
+            "tags": self.tags.copy() if self.tags else [],
+            "metadata": {k: v for k, v in self.metadata.items() 
+                        if isinstance(v, (str, int, float, bool, type(None), list, dict))},
+            "type": self.__class__.__name__,
+            # Exclude complex handler objects and only retain their quantity information
+            "handlers_count": len(self.handlers),
+            "inheritable_handlers_count": len(self.inheritable_handlers),
+        }
 
 
 class RunManager(BaseRunManager):

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -493,10 +493,10 @@ class BaseRunManager(RunManagerMixin):
         )
     def _asdict(self) -> dict[str, Any]:
         """Return a dictionary representation of the run manager.
-        
+
         This method provides a serializable representation of the run manager
         that includes essential properties while excluding complex objects.
-        
+
         Returns:
             dict: A dictionary with serializable properties
         """
@@ -504,8 +504,9 @@ class BaseRunManager(RunManagerMixin):
             "run_id": str(self.run_id),
             "parent_run_id": str(self.parent_run_id) if self.parent_run_id else None,
             "tags": self.tags.copy() if self.tags else [],
-            "metadata": {k: v for k, v in self.metadata.items() 
-                        if isinstance(v, (str, int, float, bool, type(None), list, dict))},
+            "metadata": {k: v for k, v in self.metadata.items()
+                        if isinstance(v, (str, int, float, bool, 
+                                          type(None), list, dict))},
             "type": self.__class__.__name__,
             # Exclude complex handler objects and only retain their quantity information
             "handlers_count": len(self.handlers),

--- a/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
+++ b/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
@@ -195,7 +195,7 @@ async def test_base_run_manager_asdict() -> None:
 
 async def test_callback_manager_json_serialization() -> None:
     """Test that AsyncCallbackManagerForToolRun can be properly JSON serialized."""
-    # Setup callback manager 
+    # Setup callback manager
     run_id = uuid4()
     manager = AsyncCallbackManagerForToolRun(
         run_id=run_id,
@@ -232,7 +232,8 @@ async def test_callback_manager_json_serialization() -> None:
 
 
 def test_callback_manager_pickle_serialization() -> None:
-    """Test callback managers can be pickled for msgpack serialization in checkpoints."""
+    """Test callback managers can be
+    pickled for msgpack serialization in checkpoints."""
     # Setup manager
     run_id = uuid4()
     manager = CallbackManagerForToolRun(

--- a/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
+++ b/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
@@ -164,7 +164,7 @@ async def test_base_run_manager_asdict() -> None:
     parent_run_id = uuid4()
     tags = ["test", "serialization"]
     metadata = {"simple": "value", "number": 42, "complex_obj": object()}
-    
+
     manager = BaseRunManager(
         run_id=run_id,
         parent_run_id=parent_run_id,
@@ -173,10 +173,10 @@ async def test_base_run_manager_asdict() -> None:
         handlers=[],  # Empty list of handlers
         inheritable_handlers=[],  # Empty list of inheritable handlers
     )
-    
+
     # Get dictionary representation
     result = manager._asdict()
-    
+
     # Verify all essential properties are included
     assert isinstance(result, dict)
     assert result["run_id"] == str(run_id)
@@ -187,7 +187,7 @@ async def test_base_run_manager_asdict() -> None:
     assert result["metadata"]["number"] == 42
     # Complex objects should be filtered out
     assert "complex_obj" not in result["metadata"]
-    
+
     # Should be JSON serializable
     serialized = json.dumps(result)
     assert isinstance(serialized, str)
@@ -205,14 +205,14 @@ async def test_callback_manager_json_serialization() -> None:
         handlers=[],  # Empty list of handlers
         inheritable_handlers=[],  # Empty list of inheritable handlers
     )
-    
+
     # Create tool arguments with the callback manager included
     tool_args = {
         "query": "test query",
         "run_manager": manager,
         "callbacks": manager.get_child()
     }
-    
+
     # Test JSON serialization
     try:
         serialized = json.dumps(
@@ -221,7 +221,7 @@ async def test_callback_manager_json_serialization() -> None:
         )
         # Successful serialization
         deserialized = json.loads(serialized)
-        
+
         # Verify contents were preserved
         assert "run_manager" in deserialized
         assert deserialized["run_manager"]["run_id"] == str(run_id)
@@ -242,12 +242,12 @@ def test_callback_manager_pickle_serialization() -> None:
         handlers=[],  # Empty list of handlers
         inheritable_handlers=[],  # Empty list of inheritable handlers
     )
-    
+
     # Test pickle serialization
     try:
         pickled = pickle.dumps(manager)
         unpickled = pickle.loads(pickled)
-        
+
         # Verify properties survived
         assert str(unpickled.run_id) == str(run_id)
         assert "pickle_test" in unpickled.tags

--- a/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
+++ b/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
@@ -157,6 +157,7 @@ async def test_inline_handlers_share_parent_context_multiple() -> None:
 
 # Serialization Tests
 
+
 async def test_base_run_manager_asdict() -> None:
     """Test that BaseRunManager._asdict() returns a properly serializable dictionary."""
     # Setup a manager with various types of metadata
@@ -210,14 +211,14 @@ async def test_callback_manager_json_serialization() -> None:
     tool_args = {
         "query": "test query",
         "run_manager": manager,
-        "callbacks": manager.get_child()
+        "callbacks": manager.get_child(),
     }
 
     # Test JSON serialization
     try:
         serialized = json.dumps(
             tool_args,
-            default=lambda obj: obj._asdict() if hasattr(obj, "_asdict") else str(obj)
+            default=lambda obj: obj._asdict() if hasattr(obj, "_asdict") else str(obj),
         )
         # Successful serialization
         deserialized = json.loads(serialized)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2668,7 +2668,6 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
     }
 
 
-
 def _lc_invalid_tool_call_to_openai_tool_call(
     invalid_tool_call: InvalidToolCall,
 ) -> dict:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2641,7 +2641,7 @@ def _is_pydantic_class(obj: Any) -> bool:
 
 # Resolve the issue of RunManager's inability to serialize
 def _lc_tool_call_to_openai_tool_call_encoder(obj):
-    try: 
+    try:
         if hasattr(obj, "dict") and callable(obj.dict):
             return obj.dict()
         if hasattr(obj, "_asdict") and callable(obj._asdict):
@@ -2661,9 +2661,10 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
         "function": {
             "name": tool_call["name"],
             # "arguments": json.dumps(tool_call["args"]),
-            "arguments": json.dumps(tool_call["args"],
-                         default=_lc_tool_call_to_openai_tool_call_encoder, 
-                         indent=4),
+            "arguments": json.dumps(
+                tool_call["args"],
+                default=_lc_tool_call_to_openai_tool_call_encoder,
+            ),
         },
     }
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2651,7 +2651,7 @@ def _lc_tool_call_to_openai_tool_call_encoder(obj):
             return str(obj)
     except Exception:
         # if failed, return None
-        return None 
+        return None
 
 
 def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
@@ -2662,8 +2662,7 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
             "name": tool_call["name"],
             # "arguments": json.dumps(tool_call["args"]),
             "arguments": json.dumps(
-                tool_call["args"],
-                default=_lc_tool_call_to_openai_tool_call_encoder,
+                tool_call["args"], default=_lc_tool_call_to_openai_tool_call_encoder
             ),
         },
     }

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2640,7 +2640,7 @@ def _is_pydantic_class(obj: Any) -> bool:
 
 
 # Resolve the issue of RunManager's inability to serialize
-def _lc_tool_call_to_openai_tool_call_encoder(obj) -> Any:
+def _lc_tool_call_to_openai_tool_call_encoder(obj: Any) -> Any:
     try:
         if hasattr(obj, "dict") and callable(obj.dict):
             return obj.dict()

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2640,7 +2640,7 @@ def _is_pydantic_class(obj: Any) -> bool:
 
 
 # Resolve the issue of RunManager's inability to serialize
-def _lc_tool_call_to_openai_tool_call_encoder(obj):
+def _lc_tool_call_to_openai_tool_call_encoder(obj) -> Any:
     try:
         if hasattr(obj, "dict") and callable(obj.dict):
             return obj.dict()


### PR DESCRIPTION
## Description
This PR fixes [issue #30441](https://github.com/langchain-ai/langchain/issues/30441) where async tools fail due to `AsyncCallbackManagerForToolRun` objects not being JSON serializable, causing errors when using with LangGraph.

## Issue
Fixes #30441

## Dependencies
None

## Implementation Details

I implemented two targeted changes to fix the serialization issues:

### 1. Enhanced BaseRunManager._asdict() method

Added a comprehensive dictionary representation that properly serializes all essential data:

```python
def _asdict(self) -> dict[str, Any]:
    """Return a dictionary representation of the run manager.
    
    This method provides a serializable representation of the run manager
    that includes essential properties while excluding complex objects.
    
    Returns:
        dict: A dictionary with serializable properties
    """
    return {
        "run_id": str(self.run_id),
        "parent_run_id": str(self.parent_run_id) if self.parent_run_id else None,
        "tags": self.tags.copy() if self.tags else [],
        "metadata": {k: v for k, v in self.metadata.items() 
                    if isinstance(v, (str, int, float, bool, type(None), list, dict))},
        "type": self.__class__.__name__,
        # Exclude complex handler objects and only retain their quantity information
        "handlers_count": len(self.handlers),
        "inheritable_handlers_count": len(self.inheritable_handlers),
    }
```

**Design considerations:** I chose to implement this in the `BaseRunManager` class rather than just in `AsyncCallbackManagerForToolRun` because:
1. The msgpack serialization issues affect multiple RunManager types beyond just the AsyncCallbackManagerForToolRun
2. This provides a consistent serialization approach across all manager classes
3. It's more maintainable as new manager classes inherit the same capability

### 2. Improved _lc_tool_call_to_openai_tool_call_encoder

Enhanced the encoder to properly handle serialization of complex objects:

```python
def _lc_tool_call_to_openai_tool_call_encoder(obj):
    try: 
        if hasattr(obj, "dict") and callable(obj.dict):
            return obj.dict()
        if hasattr(obj, "_asdict") and callable(obj._asdict):
            return obj._asdict()
        # transfer to string
        else:
            return str(obj)
    except Exception:
        # if failed, return None
        return None 
```

**Design considerations:** I initially considered simply filtering out non-serializable attributes (like run_manager), but chose this approach to preserve more information that could be useful during development and debugging. This provides better visibility while ensuring the code functions correctly.

## Testing

The fix has been tested with:
- Async tool invocations
- LangGraph workflows with checkpoints
- Both JSON and msgpack serialization contexts

This fix resolves both the JSON serialization errors and msgpack serialization issues without breaking existing functionality.