### PR TITLE
community: update perplexity documentation

### DIFF
--- a/docs/docs/integrations/chat/perplexity.ipynb
+++ b/docs/docs/integrations/chat/perplexity.ipynb
@@ -251,11 +251,8 @@
    ],
    "source": [
     "chat = ChatPerplexity(temperature=0.7, model=\"llama-3.1-sonar-small-128k-online\")\n",
-    "prompt = ChatPromptTemplate.from_messages(\n",
-    "    [(\"human\", \"Give me a list of famous tourist attractions in Pakistan\")]\n",
-    ")\n",
-    "chain = prompt | chat\n",
-    "for chunk in chain.stream({}):\n",
+    "\n",
+    "for chunk in chat.stream(\"Give me a list of famous tourist attractions in Pakistan\"):\n",
     "    print(chunk.content, end=\"\", flush=True)"
    ]
   },
@@ -269,8 +266,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8a05c153",
+   "execution_count": 6,
+   "id": "1bae9b80-394a-4340-9c30-612c136b742a",
    "metadata": {},
    "outputs": [
     {
@@ -279,7 +276,7 @@
        "AnswerFormat(first_name='Michael', last_name='Jordan', year_of_birth=1963, num_seasons_in_nba=15)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,9 +294,11 @@
     "\n",
     "chat = ChatPerplexity(temperature=0.7, model=\"sonar-pro\")\n",
     "structured_chat = chat.with_structured_output(AnswerFormat)\n",
-    "prompt = ChatPromptTemplate.from_messages([(\"human\", \"Tell me about Michael Jordan. \")])\n",
-    "chain = prompt | structured_chat\n",
-    "response = chain.invoke({})\n",
+    "response = structured_chat.invoke(\n",
+    "    \"Tell me about Michael Jordan. Return your answer \"\n",
+    "    \"as JSON with keys first_name (str), last_name (str), \"\n",
+    "    \"year_of_birth (int), and num_seasons_in_nba (int).\"\n",
+    ")\n",
     "response"
    ]
   }
@@ -320,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/chat/perplexity.ipynb
+++ b/docs/docs/integrations/chat/perplexity.ipynb
@@ -175,6 +175,39 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7f8f61b",
+   "metadata": {},
+   "source": [
+    "## Using Perplexity-specific parameters through `ChatPerplexity`\n",
+    "\n",
+    "You can also use Perplexity-specific parameters through the `ChatPerplexity` class. For example, parameters like `search_domain_filter`, `return_images`, `return_related_questions` or `search_recency_filter` using the `extra_body` parameter as shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73960f51",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AIMessage(content='Why are cats bad storytellers? Because they only have one tale[2].', additional_kwargs={'citations': ['https://www.youtube.com/watch?v=70x-HzObdiQ', 'https://onelinefun.com/oneliner-4110/', 'https://cheezburger.com/6231813/18-naughty-cats-who-are-just-begging-to-be-shamed', 'https://www.tiktok.com/@donttellcomedy/video/7484017503065083179', 'https://www.youtube.com/watch?v=JaguuzmGSQo']}, response_metadata={}, id='run-a22488c0-da19-402b-bf0c-7c18b6fad559-0', usage_metadata={'input_tokens': 6, 'output_tokens': 16, 'total_tokens': 22})"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat = ChatPerplexity(temperature=0.7, model=\"sonar-pro\")\n",
+    "response = chat.invoke(\"Tell me a joke about cats\", extra_body={\"search_recency_filter\": \"week\"})\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "13d93dc4",
    "metadata": {},
    "source": [
@@ -222,6 +255,50 @@
     "chain = prompt | chat\n",
     "for chunk in chain.stream({}):\n",
     "    print(chunk.content, end=\"\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "397c43de",
+   "metadata": {},
+   "source": [
+    "## `ChatPerplexity` also supports structured outputs for users with at least Tier 3 API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a05c153",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnswerFormat(first_name='Michael', last_name='Jordan', year_of_birth=1963, num_seasons_in_nba=15)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pydantic import BaseModel\n",
+    "\n",
+    "class AnswerFormat(BaseModel):\n",
+    "    first_name: str\n",
+    "    last_name: str\n",
+    "    year_of_birth: int\n",
+    "    num_seasons_in_nba: int\n",
+    "\n",
+    "chat = ChatPerplexity(temperature=0.7, model=\"sonar-pro\")\n",
+    "structured_chat = chat.with_structured_output(AnswerFormat)\n",
+    "prompt = ChatPromptTemplate.from_messages(\n",
+    "    [(\"human\", \"Tell me about Michael Jordan. \")]\n",
+    ")\n",
+    "chain = prompt | structured_chat\n",
+    "response = chain.invoke({})\n",
+    "response"
    ]
   }
  ],

--- a/docs/docs/integrations/chat/perplexity.ipynb
+++ b/docs/docs/integrations/chat/perplexity.ipynb
@@ -180,7 +180,7 @@
    "source": [
     "## Using Perplexity-specific parameters through `ChatPerplexity`\n",
     "\n",
-    "You can also use Perplexity-specific parameters through the `ChatPerplexity` class. For example, parameters like `search_domain_filter`, `return_images`, `return_related_questions` or `search_recency_filter` using the `extra_body` parameter as shown below:"
+    "You can also use Perplexity-specific parameters through the ChatPerplexity class. For example, parameters like search_domain_filter, return_images, return_related_questions or search_recency_filter using the extra_body parameter as shown below:"
    ]
   },
   {
@@ -262,7 +262,7 @@
    "id": "397c43de",
    "metadata": {},
    "source": [
-    "## `ChatPerplexity` also supports structured outputs for users with at least Tier 3 API"
+    "## `ChatPerplexity` Supports Structured Outputs for Tier 3+ Users"
    ]
   },
   {

--- a/docs/docs/integrations/chat/perplexity.ipynb
+++ b/docs/docs/integrations/chat/perplexity.ipynb
@@ -202,7 +202,9 @@
    ],
    "source": [
     "chat = ChatPerplexity(temperature=0.7, model=\"sonar-pro\")\n",
-    "response = chat.invoke(\"Tell me a joke about cats\", extra_body={\"search_recency_filter\": \"week\"})\n",
+    "response = chat.invoke(\n",
+    "    \"Tell me a joke about cats\", extra_body={\"search_recency_filter\": \"week\"}\n",
+    ")\n",
     "response"
    ]
   },
@@ -285,17 +287,17 @@
    "source": [
     "from pydantic import BaseModel\n",
     "\n",
+    "\n",
     "class AnswerFormat(BaseModel):\n",
     "    first_name: str\n",
     "    last_name: str\n",
     "    year_of_birth: int\n",
     "    num_seasons_in_nba: int\n",
     "\n",
+    "\n",
     "chat = ChatPerplexity(temperature=0.7, model=\"sonar-pro\")\n",
     "structured_chat = chat.with_structured_output(AnswerFormat)\n",
-    "prompt = ChatPromptTemplate.from_messages(\n",
-    "    [(\"human\", \"Tell me about Michael Jordan. \")]\n",
-    ")\n",
+    "prompt = ChatPromptTemplate.from_messages([(\"human\", \"Tell me about Michael Jordan. \")])\n",
     "chain = prompt | structured_chat\n",
     "response = chain.invoke({})\n",
     "response"

--- a/docs/docs/integrations/chat/perplexity.ipynb
+++ b/docs/docs/integrations/chat/perplexity.ipynb
@@ -192,20 +192,20 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='Why are cats bad storytellers? Because they only have one tale[2].', additional_kwargs={'citations': ['https://www.youtube.com/watch?v=70x-HzObdiQ', 'https://onelinefun.com/oneliner-4110/', 'https://cheezburger.com/6231813/18-naughty-cats-who-are-just-begging-to-be-shamed', 'https://www.tiktok.com/@donttellcomedy/video/7484017503065083179', 'https://www.youtube.com/watch?v=JaguuzmGSQo']}, response_metadata={}, id='run-a22488c0-da19-402b-bf0c-7c18b6fad559-0', usage_metadata={'input_tokens': 6, 'output_tokens': 16, 'total_tokens': 22})"
+       "\"Sure, here's a cat joke for you:\\n\\nWhy are cats bad storytellers?\\n\\nBecause they only have one tale. (Pun alert!)\\n\\nSource: OneLineFun.com [4]\""
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "chat = ChatPerplexity(temperature=0.7, model=\"sonar-pro\")\n",
+    "chat = ChatPerplexity(temperature=0.7, model=\"llama-3.1-sonar-small-128k-online\")\n",
     "response = chat.invoke(\n",
     "    \"Tell me a joke about cats\", extra_body={\"search_recency_filter\": \"week\"}\n",
     ")\n",
-    "response"
+    "response.content"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes updates to the `docs/docs/integrations/chat/perplexity.ipynb` file to enhance the documentation for `ChatPerplexity`. The changes focus on demonstrating the use of Perplexity-specific parameters and supporting structured outputs for Tier 3+ users.

Enhancements to documentation:

* Added a new markdown cell explaining the use of Perplexity-specific parameters through the `ChatPerplexity` class, including parameters like `search_domain_filter`, `return_images`, `return_related_questions`, and `search_recency_filter` using the `extra_body` parameter.
* Added a new code cell demonstrating how to invoke `ChatPerplexity` with the `extra_body` parameter to filter search recency.

Support for structured outputs:

* Added a new markdown cell explaining that `ChatPerplexity` supports structured outputs for Tier 3+ users.
* Added a new code cell demonstrating how to use `ChatPerplexity` with structured outputs by defining a `BaseModel` class and invoking the chat with structured output.[Copilot is generating a summary...]Thank you for contributing to LangChain!