### PR TITLE
core[patch]: add token counting callback handler

### DIFF
--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -43,10 +43,12 @@ from langchain_core.callbacks.manager import (
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_core.callbacks.usage import get_usage_metadata_callback
 
 __all__ = [
     "dispatch_custom_event",
     "adispatch_custom_event",
+    "get_usage_metadata_callback",
     "RetrieverManagerMixin",
     "LLMManagerMixin",
     "ChainManagerMixin",

--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -43,12 +43,11 @@ from langchain_core.callbacks.manager import (
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from langchain_core.callbacks.usage import get_usage_metadata_callback
+from langchain_core.callbacks.usage import get_usage_metadata_callback, UsageMetadataCallbackHandler
 
 __all__ = [
     "dispatch_custom_event",
     "adispatch_custom_event",
-    "get_usage_metadata_callback",
     "RetrieverManagerMixin",
     "LLMManagerMixin",
     "ChainManagerMixin",
@@ -79,4 +78,6 @@ __all__ = [
     "StdOutCallbackHandler",
     "StreamingStdOutCallbackHandler",
     "FileCallbackHandler",
+    "UsageMetadataCallbackHandler",
+    "get_usage_metadata_callback",
 ]

--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -43,7 +43,10 @@ from langchain_core.callbacks.manager import (
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from langchain_core.callbacks.usage import get_usage_metadata_callback, UsageMetadataCallbackHandler
+from langchain_core.callbacks.usage import (
+    UsageMetadataCallbackHandler,
+    get_usage_metadata_callback,
+)
 
 __all__ = [
     "dispatch_custom_event",

--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -30,11 +30,10 @@ class UsageMetadataCallbackHandler(BaseCallbackHandler):
     .. versionadded:: 0.3.49
     """
 
-    usage_metadata: Optional[UsageMetadata] = None
-
-    def __init__(self) -> None:
+    def __init__(self, usage_metadata: Optional[UsageMetadata] = None) -> None:
         super().__init__()
         self._lock = threading.Lock()
+        self.usage_metadata = usage_metadata
 
     def __repr__(self) -> str:
         return str(self.usage_metadata)

--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -1,4 +1,4 @@
-"""Callback Handler that prints to std out."""
+"""Callback Handler that tracks AIMessage.usage_metadata."""
 
 import threading
 from collections.abc import Generator
@@ -13,7 +13,22 @@ from langchain_core.outputs import ChatGeneration, LLMResult
 
 
 class UsageMetadataCallbackHandler(BaseCallbackHandler):
-    """Callback Handler that tracks AIMessage.usage_metadata."""
+    """Callback Handler that tracks AIMessage.usage_metadata.
+
+    Example:
+        .. code-block:: python
+
+            from langchain.chat_models import init_chat_model
+            from langchain_core.callbacks import UsageMetadataCallbackHandler
+
+            llm = init_chat_model(model="openai:gpt-4o-mini")
+
+            callback = UsageMetadataCallbackHandler()
+            results = llm.batch(["Hello", "Goodbye"], config={"callbacks": [callback]})
+            print(callback)
+
+    .. versionadded:: 0.3.49
+    """
 
     usage_metadata: Optional[UsageMetadata] = None
 
@@ -71,6 +86,8 @@ def get_usage_metadata_callback(
                 llm.invoke("...")
                 llm.invoke("...")
                 print(cb.usage_metadata)
+
+    .. versionadded:: 0.3.49
     """
     from langchain_core.tracers.context import register_configure_hook
 

--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -25,10 +25,14 @@ class UsageMetadataCallbackHandler(BaseCallbackHandler):
 
             callback = UsageMetadataCallbackHandler()
             results = llm.batch(["Hello", "Goodbye"], config={"callbacks": [callback]})
-            print(callback)
+            print(callback.usage_metadata)
+
+        .. code-block:: none
+
+            {'output_token_details': {'audio': 0, 'reasoning': 0}, 'input_tokens': 17, 'output_tokens': 31, 'total_tokens': 48, 'input_token_details': {'cache_read': 0, 'audio': 0}}
 
     .. versionadded:: 0.3.49
-    """
+    """  # noqa: E501
 
     def __init__(self) -> None:
         super().__init__()
@@ -82,12 +86,16 @@ def get_usage_metadata_callback(
             llm = init_chat_model(model="openai:gpt-4o-mini")
 
             with get_usage_metadata_callback() as cb:
-                llm.invoke("...")
-                llm.invoke("...")
+                llm.invoke("Hello")
+                llm.invoke("Goodbye")
                 print(cb.usage_metadata)
 
+        .. code-block:: none
+
+            {'output_token_details': {'audio': 0, 'reasoning': 0}, 'input_tokens': 17, 'output_tokens': 31, 'total_tokens': 48, 'input_token_details': {'cache_read': 0, 'audio': 0}}
+
     .. versionadded:: 0.3.49
-    """
+    """  # noqa: E501
     from langchain_core.tracers.context import register_configure_hook
 
     usage_metadata_callback_var: ContextVar[Optional[UsageMetadataCallbackHandler]] = (

--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -10,7 +10,6 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage
 from langchain_core.messages.ai import UsageMetadata, add_usage
 from langchain_core.outputs import ChatGeneration, LLMResult
-from langchain_core.tracers.context import register_configure_hook
 
 
 class UsageMetadataCallbackHandler(BaseCallbackHandler):
@@ -73,6 +72,8 @@ def get_usage_metadata_callback(
                 llm.invoke("...")
                 print(cb.usage_metadata)
     """
+    from langchain_core.tracers.context import register_configure_hook
+
     usage_metadata_callback_var: ContextVar[Optional[UsageMetadataCallbackHandler]] = (
         ContextVar(name, default=None)
     )

--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -30,10 +30,10 @@ class UsageMetadataCallbackHandler(BaseCallbackHandler):
     .. versionadded:: 0.3.49
     """
 
-    def __init__(self, usage_metadata: Optional[UsageMetadata] = None) -> None:
+    def __init__(self) -> None:
         super().__init__()
         self._lock = threading.Lock()
-        self.usage_metadata = usage_metadata
+        self.usage_metadata: Optional[UsageMetadata] = None
 
     def __repr__(self) -> str:
         return str(self.usage_metadata)

--- a/libs/core/tests/unit_tests/callbacks/test_imports.py
+++ b/libs/core/tests/unit_tests/callbacks/test_imports.py
@@ -33,6 +33,7 @@ EXPECTED_ALL = [
     "FileCallbackHandler",
     "adispatch_custom_event",
     "dispatch_custom_event",
+    "UsageMetadataCallbackHandler",
     "get_usage_metadata_callback",
 ]
 

--- a/libs/core/tests/unit_tests/callbacks/test_imports.py
+++ b/libs/core/tests/unit_tests/callbacks/test_imports.py
@@ -33,6 +33,7 @@ EXPECTED_ALL = [
     "FileCallbackHandler",
     "adispatch_custom_event",
     "dispatch_custom_event",
+    "get_usage_metadata_callback",
 ]
 
 

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -13,38 +13,39 @@ from langchain_core.messages.ai import (
     add_usage,
 )
 
+usage1 = UsageMetadata(
+    input_tokens=1,
+    output_tokens=2,
+    total_tokens=3,
+)
+usage2 = UsageMetadata(
+    input_tokens=4,
+    output_tokens=5,
+    total_tokens=9,
+)
+usage3 = UsageMetadata(
+    input_tokens=10,
+    output_tokens=20,
+    total_tokens=30,
+    input_token_details=InputTokenDetails(audio=5),
+    output_token_details=OutputTokenDetails(reasoning=10),
+)
+usage4 = UsageMetadata(
+    input_tokens=5,
+    output_tokens=10,
+    total_tokens=15,
+    input_token_details=InputTokenDetails(audio=3),
+    output_token_details=OutputTokenDetails(reasoning=5),
+)
+messages = [
+    AIMessage("Response 1", usage_metadata=usage1),
+    AIMessage("Response 2", usage_metadata=usage2),
+    AIMessage("Response 3", usage_metadata=usage3),
+    AIMessage("Response 4", usage_metadata=usage4),
+]
+
 
 def test_usage_callback() -> None:
-    usage1 = UsageMetadata(
-        input_tokens=1,
-        output_tokens=2,
-        total_tokens=3,
-    )
-    usage2 = UsageMetadata(
-        input_tokens=4,
-        output_tokens=5,
-        total_tokens=9,
-    )
-    usage3 = UsageMetadata(
-        input_tokens=10,
-        output_tokens=20,
-        total_tokens=30,
-        input_token_details=InputTokenDetails(audio=5),
-        output_token_details=OutputTokenDetails(reasoning=10),
-    )
-    usage4 = UsageMetadata(
-        input_tokens=5,
-        output_tokens=10,
-        total_tokens=15,
-        input_token_details=InputTokenDetails(audio=3),
-        output_token_details=OutputTokenDetails(reasoning=5),
-    )
-    messages = [
-        AIMessage("Response 1", usage_metadata=usage1),
-        AIMessage("Response 2", usage_metadata=usage2),
-        AIMessage("Response 3", usage_metadata=usage3),
-        AIMessage("Response 4", usage_metadata=usage4),
-    ]
     llm = GenericFakeChatModel(messages=cycle(messages))
 
     # Test context manager
@@ -61,4 +62,24 @@ def test_usage_callback() -> None:
     # Test via config
     callback = UsageMetadataCallbackHandler()
     _ = llm.batch(["Message 1", "Message 2"], config={"callbacks": [callback]})
+    assert callback.usage_metadata == total_1_2
+
+
+async def test_usage_callback_async() -> None:
+    llm = GenericFakeChatModel(messages=cycle(messages))
+
+    # Test context manager
+    with get_usage_metadata_callback() as cb:
+        _ = await llm.ainvoke("Message 1")
+        _ = await llm.ainvoke("Message 2")
+        total_1_2 = add_usage(usage1, usage2)
+        assert cb.usage_metadata == total_1_2
+        _ = await llm.ainvoke("Message 3")
+        _ = await llm.ainvoke("Message 4")
+        total_3_4 = add_usage(usage3, usage4)
+        assert cb.usage_metadata == add_usage(total_1_2, total_3_4)
+
+    # Test via config
+    callback = UsageMetadataCallbackHandler()
+    _ = await llm.abatch(["Message 1", "Message 2"], config={"callbacks": [callback]})
     assert callback.usage_metadata == total_1_2


### PR DESCRIPTION
Stripped-down version of [OpenAICallbackHandler](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/callbacks/openai_info.py) that just tracks `AIMessage.usage_metadata`.

```python
from langchain_core.callbacks import get_usage_metadata_callback
from langgraph.prebuilt import create_react_agent

def get_weather(location: str) -> str:
    """Get the weather at a location."""
    return "It's sunny."

tools = [get_weather]
agent = create_react_agent("openai:gpt-4o-mini", tools)

with get_usage_metadata_callback() as cb:
    result = await agent.ainvoke({"messages": "What's the weather in Boston?"})
    print(cb.usage_metadata)
```