### PR TITLE
docs: Fix typos in pdfminer and pymupdf guides

### DIFF
--- a/docs/docs/integrations/document_loaders/pdfminer.ipynb
+++ b/docs/docs/integrations/document_loaders/pdfminer.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "### Credentials\n",
     "\n",
-    "No credentials are required to use PyMuPDFLoader"
+    "No credentials are required to use PDFMinerLoader"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "source": [
     "### Installation\n",
     "\n",
-    "Install **langchain_community** and **pymupdf**."
+    "Install **langchain_community** and **pdfminer**."
    ]
   },
   {
@@ -327,7 +327,7 @@
     "- By page\n",
     "- As a single text flow\n",
     "\n",
-    "By default PDFPlumberLoader will split the PDF by page."
+    "By default PDFMinerLoader will split the PDF by page."
    ]
   },
   {

--- a/docs/docs/integrations/document_loaders/pymupdf.ipynb
+++ b/docs/docs/integrations/document_loaders/pymupdf.ipynb
@@ -289,7 +289,7 @@
     "- By page\n",
     "- As a single text flow\n",
     "\n",
-    "By default PDFPlumberLoader will split the PDF by page."
+    "By default PyMuPDFLoader will split the PDF by page."
    ]
   },
   {


### PR DESCRIPTION
This pull request includes fixes in documentation for PDF loaders to correct the names of the loaders and the required installations. The most important changes include updating the loader names and installation instructions in the Jupyter notebooks.

Documentation fixes:

* [`docs/docs/integrations/document_loaders/pdfminer.ipynb`](diffhunk://#diff-a4a0561cd4a6e876ea34b7182de64a452060b921bb32d37b02e6a7980a41729bL34-R34): Changed references from `PyMuPDFLoader` to `PDFMinerLoader` and updated the installation instructions to replace `pymupdf` with `pdfminer`. [[1]](diffhunk://#diff-a4a0561cd4a6e876ea34b7182de64a452060b921bb32d37b02e6a7980a41729bL34-R34) [[2]](diffhunk://#diff-a4a0561cd4a6e876ea34b7182de64a452060b921bb32d37b02e6a7980a41729bL63-R63) [[3]](diffhunk://#diff-a4a0561cd4a6e876ea34b7182de64a452060b921bb32d37b02e6a7980a41729bL330-R330)

* [`docs/docs/integrations/document_loaders/pymupdf.ipynb`](diffhunk://#diff-8487995f457e33daa2a08fdcff3b42e144eca069eeadfad5651c7c08cce7a5cdL292-R292): Corrected the loader name from `PDFPlumberLoader` to `PyMuPDFLoader`.