### PR TITLE
langchain_community/vectorstores/weaviate: refine code to support weaviate with SemanticSimilarityExampleSelector

### DIFF
--- a/libs/community/langchain_community/vectorstores/weaviate.py
+++ b/libs/community/langchain_community/vectorstores/weaviate.py
@@ -458,14 +458,25 @@ class Weaviate(VectorStore):
                 "Please install it with `pip install weaviate-client`"
             ) from e
 
-        client = client or _create_weaviate_client(
-            url=weaviate_url,
-            api_key=weaviate_api_key,
+        # SemanticSimilarityExampleSelector.from_examples need to init client
+        # here could keep client instance in vectorstore_cls_kwargs
+        client = (
+            client
+            or kwargs["vectorstore_cls_kwargs"]["client"]
+            or _create_weaviate_client(
+                url=weaviate_url,
+                api_key=weaviate_api_key,
+            )
         )
         if batch_size:
             client.batch.configure(batch_size=batch_size)
 
-        index_name = index_name or f"LangChain_{uuid4().hex}"
+        index_name = (
+            index_name
+            or kwargs["vectorstore_cls_kwargs"]["index_name"]
+            or f"LangChain_{uuid4().hex}"
+        )
+        text_key = text_key or kwargs["vectorstore_cls_kwargs"]["text_key"]
         schema = _default_schema(index_name, text_key)
         # check whether the index already exists
         if not client.schema.exists(index_name):


### PR DESCRIPTION
```python
with weaviate.connect_to_embedded() as client:
    client.is_ready()
    example_selector = SemanticSimilarityExampleSelector.from_examples(
        examples=examples,
        embeddings=embeddings,
        vectorstore_cls= Weaviate,
        vectorstore_cls_kwargs={"index_name": "example_index", "text_key": "answer", "client": client},
        k=1,
    )
```

above code, using SemanticSimilarityExampleSelector.from_examples method but can not correct get Weaviate client, so support init weaviate client outside and pass by vectorstore_cls_kwargs.