### PR TITLE
[Core]: Passing config_factories in  `with_config` for RunnableBinding

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -5670,6 +5670,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):
             bound=self.bound,
             kwargs=self.kwargs,
             config=cast("RunnableConfig", {**self.config, **(config or {}), **kwargs}),
+            config_factories=self.config_factories,
             custom_input_type=self.custom_input_type,
             custom_output_type=self.custom_output_type,
         )


### PR DESCRIPTION
- **Description:**  We were not passing `config_factories` to `RunnableBinding`  method `with_config` which was causing the parent `config_factories` to be lost as shown in the issue but this has been fixed
- **Issue**:  #30531