### PR TITLE
community: Add siliconflow embeddings integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,3 @@ docs/docs/templates
 
 prof
 virtualenv/
- # Local development overrides
- !/.gitignore
- .aider/

--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,3 @@ docs/docs/templates
 
 prof
 virtualenv/
-.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ docs/docs/templates
 
 prof
 virtualenv/
+.aider*

--- a/docs/docs/integrations/text_embedding/siliconflow.ipynb
+++ b/docs/docs/integrations/text_embedding/siliconflow.ipynb
@@ -1,31 +1,15 @@
 {
  "cells": [
   {
-   "cell_type": "raw",
-   "id": "afaf8039",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "sidebar_label: SiliconFlow\n",
-    "keywords: [siliconflowembeddings]\n",
-    "---"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "9a3d6f34",
    "metadata": {},
    "source": [
     "# SiliconFlowEmbeddings\n",
     "\n",
-    "This guide will help you get started with SiliconFlow embedding models using LangChain. SiliconFlow provides fast, affordable and high-quality embedding services.\n",
+    "This guide will help you get started with SiliconFlow embedding models using LangChain. [SiliconFlow](https://www.siliconflow.cn/) provides free embedding model like BAAI series(bge-m3, bge-large-zh-v1.5, bge-large-en-v1.5).\n",
     "\n",
     "## Overview\n",
-    "### Integration details\n",
-    "\n",
-    "| Provider | Package |\n",
-    "|:--------:|:-------:|\n",
-    "| [SiliconFlow](https://www.siliconflow.cn/) | [langchain-community](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html) |\n",
     "\n",
     "## Setup\n",
     "\n",
@@ -71,34 +55,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9664366",
-   "metadata": {},
-   "source": [
-    "### Installation\n",
-    "\n",
-    "The SiliconFlow integration is included in LangChain community package:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "64853226",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install -qU langchain-community"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "45dd1724",
    "metadata": {},
    "source": [
@@ -109,15 +65,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9ea7a09b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'SiliconFlowEmbeddings' from 'langchain_community.embeddings' (d:\\py311\\.venv\\Lib\\site-packages\\langchain_community\\embeddings\\__init__.py)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[2], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mlangchain_community\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01membeddings\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m SiliconFlowEmbeddings\n\u001b[0;32m      3\u001b[0m embeddings \u001b[38;5;241m=\u001b[39m SiliconFlowEmbeddings(\n\u001b[0;32m      4\u001b[0m     model\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBAAI/bge-m3\u001b[39m\u001b[38;5;124m\"\u001b[39m,  \u001b[38;5;66;03m# Default model\u001b[39;00m\n\u001b[0;32m      5\u001b[0m     encoding_format\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfloat\u001b[39m\u001b[38;5;124m\"\u001b[39m  \u001b[38;5;66;03m# Can also use \"base64\" for compact representation\u001b[39;00m\n\u001b[0;32m      6\u001b[0m )\n",
+      "\u001b[1;31mImportError\u001b[0m: cannot import name 'SiliconFlowEmbeddings' from 'langchain_community.embeddings' (d:\\py311\\.venv\\Lib\\site-packages\\langchain_community\\embeddings\\__init__.py)"
+     ]
+    }
+   ],
    "source": [
     "from langchain_community.embeddings import SiliconFlowEmbeddings\n",
     "\n",
     "embeddings = SiliconFlowEmbeddings(\n",
-    "    model=\"BAAI/bge-large-zh-v1.5\",  # Default model optimized for Chinese\n",
+    "    model=\"BAAI/bge-m3\",  # Default model\n",
     "    encoding_format=\"float\"  # Can also use \"base64\" for compact representation\n",
     ")"
    ]
@@ -248,7 +216,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -262,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/docs/docs/integrations/text_embedding/siliconflow.ipynb
+++ b/docs/docs/integrations/text_embedding/siliconflow.ipynb
@@ -1,0 +1,268 @@
+{
+  "cells": [
+    {
+      "cell_type": "raw",
+      "id": "afaf8039",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "sidebar_label: SiliconFlow\n",
+        "keywords: [siliconflowembeddings]\n",
+        "---"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9a3d6f34",
+      "metadata": {},
+      "source": [
+        "# SiliconFlowEmbeddings\n",
+        "\n",
+        "This guide will help you get started with SiliconFlow embedding models using LangChain. SiliconFlow provides fast, affordable and high-quality embedding services.\n",
+        "\n",
+        "## Overview\n",
+        "### Integration details\n",
+        "\n",
+        "| Provider | Package |\n",
+        "|:--------:|:-------:|\n",
+        "| [SiliconFlow](https://www.siliconflow.cn/) | [langchain-community](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html) |\n",
+        "\n",
+        "## Setup\n",
+        "\n",
+        "To access SiliconFlow embedding models you'll need to get an API key and install the required package.\n",
+        "\n",
+        "### Credentials\n",
+        "\n",
+        "Sign up at [SiliconFlow](https://www.siliconflow.cn/) to get an API key. Then set the SILICONFLOW_API_KEY environment variable:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "36521c2a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import getpass\n",
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"SILICONFLOW_API_KEY\"):\n",
+        "    os.environ[\"SILICONFLOW_API_KEY\"] = getpass.getpass(\"Enter your SiliconFlow API key: \")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c84fb993",
+      "metadata": {},
+      "source": "To enable automated tracing of your model calls, set your [LangSmith](https://docs.smith.langchain.com/) API key:"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "39a4953b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+        "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d9664366",
+      "metadata": {},
+      "source": [
+        "### Installation\n",
+        "\n",
+        "The SiliconFlow integration is included in LangChain community package:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "64853226",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install -qU langchain-community"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "45dd1724",
+      "metadata": {},
+      "source": [
+        "## Instantiation\n",
+        "\n",
+        "Now we can instantiate our embedding model:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "9ea7a09b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_community.embeddings import SiliconFlowEmbeddings\n",
+        "\n",
+        "embeddings = SiliconFlowEmbeddings(\n",
+        "    model=\"BAAI/bge-large-zh-v1.5\",  # Default model optimized for Chinese\n",
+        "    encoding_format=\"float\"  # Can also use \"base64\" for compact representation\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "77d271b6",
+      "metadata": {},
+      "source": [
+        "## Indexing and Retrieval\n",
+        "\n",
+        "Here's how to use SiliconFlow embeddings with a vector store for retrieval:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "d817716b",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'LangChain is the framework for building context-aware reasoning applications'"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Create a vector store with a sample text\n",
+        "from langchain_core.vectorstores import InMemoryVectorStore\n",
+        "\n",
+        "text = \"LangChain is the framework for building context-aware reasoning applications\"\n",
+        "\n",
+        "vectorstore = InMemoryVectorStore.from_texts(\n",
+        "    [text],\n",
+        "    embedding=embeddings,\n",
+        ")\n",
+        "\n",
+        "# Use the vectorstore as a retriever\n",
+        "retriever = vectorstore.as_retriever()\n",
+        "\n",
+        "# Retrieve the most similar text\n",
+        "retrieved_documents = retriever.invoke(\"What is LangChain?\")\n",
+        "\n",
+        "# show the retrieved document's content\n",
+        "retrieved_documents[0].page_content"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e02b9855",
+      "metadata": {},
+      "source": [
+        "## Direct Usage\n",
+        "\n",
+        "You can directly call embedding methods for your own use cases.\n",
+        "\n",
+        "### Embed single texts\n",
+        "\n",
+        "Embed single texts with `embed_query`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "0d2befcd",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n"
+          ]
+        }
+      ],
+      "source": [
+        "single_vector = embeddings.embed_query(text)\n",
+        "print(str(single_vector)[:100])  # Show the first 100 characters of the vector"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1b5a7d03",
+      "metadata": {},
+      "source": [
+        "### Embed multiple texts\n",
+        "\n",
+        "Embed multiple texts with `embed_documents`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "2f4d6e97",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n",
+            "[0.0083934665, 0.037985895, -0.06684559, -0.039616987, 0.015481004, -0.023952313, 0.016464233, 0.00924\n"
+          ]
+        }
+      ],
+      "source": [
+        "text2 = \"SiliconFlow provides fast and affordable embedding services\"\n",
+        "two_vectors = embeddings.embed_documents([text, text2])\n",
+        "for vector in two_vectors:\n",
+        "    print(str(vector)[:100])  # Show the first 100 characters of the vector"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "98785c12",
+      "metadata": {},
+      "source": [
+        "## API Reference\n",
+        "\n",
+        "For detailed documentation on `SiliconFlowEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html).\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/docs/docs/integrations/text_embedding/siliconflow.ipynb
+++ b/docs/docs/integrations/text_embedding/siliconflow.ipynb
@@ -65,22 +65,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "9ea7a09b",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'SiliconFlowEmbeddings' from 'langchain_community.embeddings' (d:\\py311\\.venv\\Lib\\site-packages\\langchain_community\\embeddings\\__init__.py)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[2], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mlangchain_community\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01membeddings\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m SiliconFlowEmbeddings\n\u001b[0;32m      3\u001b[0m embeddings \u001b[38;5;241m=\u001b[39m SiliconFlowEmbeddings(\n\u001b[0;32m      4\u001b[0m     model\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBAAI/bge-m3\u001b[39m\u001b[38;5;124m\"\u001b[39m,  \u001b[38;5;66;03m# Default model\u001b[39;00m\n\u001b[0;32m      5\u001b[0m     encoding_format\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfloat\u001b[39m\u001b[38;5;124m\"\u001b[39m  \u001b[38;5;66;03m# Can also use \"base64\" for compact representation\u001b[39;00m\n\u001b[0;32m      6\u001b[0m )\n",
-      "\u001b[1;31mImportError\u001b[0m: cannot import name 'SiliconFlowEmbeddings' from 'langchain_community.embeddings' (d:\\py311\\.venv\\Lib\\site-packages\\langchain_community\\embeddings\\__init__.py)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain_community.embeddings import SiliconFlowEmbeddings\n",
     "\n",
@@ -102,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "d817716b",
    "metadata": {},
    "outputs": [
@@ -112,7 +100,7 @@
        "'LangChain is the framework for building context-aware reasoning applications'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "0d2befcd",
    "metadata": {},
    "outputs": [
@@ -162,7 +150,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n"
+      "[-0.016242882, -0.011639526, 0.0041511594, -0.011476736, -0.017753216, -0.05202063, 0.019100761, 0.0\n"
      ]
     }
    ],
@@ -183,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "2f4d6e97",
    "metadata": {},
    "outputs": [
@@ -191,8 +179,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n",
-      "[0.0083934665, 0.037985895, -0.06684559, -0.039616987, 0.015481004, -0.023952313, 0.016464233, 0.00924\n"
+      "[-0.016259937, -0.011620699, 0.004207417, -0.011457919, -0.017770175, -0.051908806, 0.019063374, 0.0\n",
+      "[-0.053298924, 0.035305943, -0.0028303568, -0.018856792, 0.007829429, -0.04366836, -0.0026994068, 0.\n"
      ]
     }
    ],

--- a/docs/docs/integrations/text_embedding/siliconflow.ipynb
+++ b/docs/docs/integrations/text_embedding/siliconflow.ipynb
@@ -190,16 +190,6 @@
     "for vector in two_vectors:\n",
     "    print(str(vector)[:100])  # Show the first 100 characters of the vector"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98785c12",
-   "metadata": {},
-   "source": [
-    "## API Reference\n",
-    "\n",
-    "For detailed documentation on `SiliconFlowEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html).\n"
-   ]
   }
  ],
  "metadata": {

--- a/docs/docs/integrations/text_embedding/siliconflow.ipynb
+++ b/docs/docs/integrations/text_embedding/siliconflow.ipynb
@@ -1,268 +1,270 @@
 {
-  "cells": [
-    {
-      "cell_type": "raw",
-      "id": "afaf8039",
-      "metadata": {},
-      "source": [
-        "---\n",
-        "sidebar_label: SiliconFlow\n",
-        "keywords: [siliconflowembeddings]\n",
-        "---"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9a3d6f34",
-      "metadata": {},
-      "source": [
-        "# SiliconFlowEmbeddings\n",
-        "\n",
-        "This guide will help you get started with SiliconFlow embedding models using LangChain. SiliconFlow provides fast, affordable and high-quality embedding services.\n",
-        "\n",
-        "## Overview\n",
-        "### Integration details\n",
-        "\n",
-        "| Provider | Package |\n",
-        "|:--------:|:-------:|\n",
-        "| [SiliconFlow](https://www.siliconflow.cn/) | [langchain-community](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html) |\n",
-        "\n",
-        "## Setup\n",
-        "\n",
-        "To access SiliconFlow embedding models you'll need to get an API key and install the required package.\n",
-        "\n",
-        "### Credentials\n",
-        "\n",
-        "Sign up at [SiliconFlow](https://www.siliconflow.cn/) to get an API key. Then set the SILICONFLOW_API_KEY environment variable:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "36521c2a",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import getpass\n",
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"SILICONFLOW_API_KEY\"):\n",
-        "    os.environ[\"SILICONFLOW_API_KEY\"] = getpass.getpass(\"Enter your SiliconFlow API key: \")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c84fb993",
-      "metadata": {},
-      "source": "To enable automated tracing of your model calls, set your [LangSmith](https://docs.smith.langchain.com/) API key:"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "39a4953b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
-        "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d9664366",
-      "metadata": {},
-      "source": [
-        "### Installation\n",
-        "\n",
-        "The SiliconFlow integration is included in LangChain community package:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "64853226",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        }
-      ],
-      "source": [
-        "%pip install -qU langchain-community"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "45dd1724",
-      "metadata": {},
-      "source": [
-        "## Instantiation\n",
-        "\n",
-        "Now we can instantiate our embedding model:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "9ea7a09b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from langchain_community.embeddings import SiliconFlowEmbeddings\n",
-        "\n",
-        "embeddings = SiliconFlowEmbeddings(\n",
-        "    model=\"BAAI/bge-large-zh-v1.5\",  # Default model optimized for Chinese\n",
-        "    encoding_format=\"float\"  # Can also use \"base64\" for compact representation\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "77d271b6",
-      "metadata": {},
-      "source": [
-        "## Indexing and Retrieval\n",
-        "\n",
-        "Here's how to use SiliconFlow embeddings with a vector store for retrieval:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "d817716b",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'LangChain is the framework for building context-aware reasoning applications'"
-            ]
-          },
-          "execution_count": 5,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Create a vector store with a sample text\n",
-        "from langchain_core.vectorstores import InMemoryVectorStore\n",
-        "\n",
-        "text = \"LangChain is the framework for building context-aware reasoning applications\"\n",
-        "\n",
-        "vectorstore = InMemoryVectorStore.from_texts(\n",
-        "    [text],\n",
-        "    embedding=embeddings,\n",
-        ")\n",
-        "\n",
-        "# Use the vectorstore as a retriever\n",
-        "retriever = vectorstore.as_retriever()\n",
-        "\n",
-        "# Retrieve the most similar text\n",
-        "retrieved_documents = retriever.invoke(\"What is LangChain?\")\n",
-        "\n",
-        "# show the retrieved document's content\n",
-        "retrieved_documents[0].page_content"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e02b9855",
-      "metadata": {},
-      "source": [
-        "## Direct Usage\n",
-        "\n",
-        "You can directly call embedding methods for your own use cases.\n",
-        "\n",
-        "### Embed single texts\n",
-        "\n",
-        "Embed single texts with `embed_query`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "0d2befcd",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n"
-          ]
-        }
-      ],
-      "source": [
-        "single_vector = embeddings.embed_query(text)\n",
-        "print(str(single_vector)[:100])  # Show the first 100 characters of the vector"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1b5a7d03",
-      "metadata": {},
-      "source": [
-        "### Embed multiple texts\n",
-        "\n",
-        "Embed multiple texts with `embed_documents`:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "2f4d6e97",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n",
-            "[0.0083934665, 0.037985895, -0.06684559, -0.039616987, 0.015481004, -0.023952313, 0.016464233, 0.00924\n"
-          ]
-        }
-      ],
-      "source": [
-        "text2 = \"SiliconFlow provides fast and affordable embedding services\"\n",
-        "two_vectors = embeddings.embed_documents([text, text2])\n",
-        "for vector in two_vectors:\n",
-        "    print(str(vector)[:100])  # Show the first 100 characters of the vector"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "98785c12",
-      "metadata": {},
-      "source": [
-        "## API Reference\n",
-        "\n",
-        "For detailed documentation on `SiliconFlowEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html).\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.3"
-    }
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "afaf8039",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: SiliconFlow\n",
+    "keywords: [siliconflowembeddings]\n",
+    "---"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "9a3d6f34",
+   "metadata": {},
+   "source": [
+    "# SiliconFlowEmbeddings\n",
+    "\n",
+    "This guide will help you get started with SiliconFlow embedding models using LangChain. SiliconFlow provides fast, affordable and high-quality embedding services.\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "| Provider | Package |\n",
+    "|:--------:|:-------:|\n",
+    "| [SiliconFlow](https://www.siliconflow.cn/) | [langchain-community](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html) |\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To access SiliconFlow embedding models you'll need to get an API key and install the required package.\n",
+    "\n",
+    "### Credentials\n",
+    "\n",
+    "Sign up at [SiliconFlow](https://www.siliconflow.cn/) to get an API key. Then set the SILICONFLOW_API_KEY environment variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "36521c2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"SILICONFLOW_API_KEY\"):\n",
+    "    os.environ[\"SILICONFLOW_API_KEY\"] = getpass.getpass(\"Enter your SiliconFlow API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c84fb993",
+   "metadata": {},
+   "source": [
+    "To enable automated tracing of your model calls, set your [LangSmith](https://docs.smith.langchain.com/) API key:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "39a4953b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9664366",
+   "metadata": {},
+   "source": [
+    "### Installation\n",
+    "\n",
+    "The SiliconFlow integration is included in LangChain community package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "64853226",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -qU langchain-community"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45dd1724",
+   "metadata": {},
+   "source": [
+    "## Instantiation\n",
+    "\n",
+    "Now we can instantiate our embedding model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9ea7a09b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.embeddings import SiliconFlowEmbeddings\n",
+    "\n",
+    "embeddings = SiliconFlowEmbeddings(\n",
+    "    model=\"BAAI/bge-large-zh-v1.5\",  # Default model optimized for Chinese\n",
+    "    encoding_format=\"float\"  # Can also use \"base64\" for compact representation\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77d271b6",
+   "metadata": {},
+   "source": [
+    "## Indexing and Retrieval\n",
+    "\n",
+    "Here's how to use SiliconFlow embeddings with a vector store for retrieval:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d817716b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'LangChain is the framework for building context-aware reasoning applications'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a vector store with a sample text\n",
+    "from langchain_core.vectorstores import InMemoryVectorStore\n",
+    "\n",
+    "text = \"LangChain is the framework for building context-aware reasoning applications\"\n",
+    "\n",
+    "vectorstore = InMemoryVectorStore.from_texts(\n",
+    "    [text],\n",
+    "    embedding=embeddings,\n",
+    ")\n",
+    "\n",
+    "# Use the vectorstore as a retriever\n",
+    "retriever = vectorstore.as_retriever()\n",
+    "\n",
+    "# Retrieve the most similar text\n",
+    "retrieved_documents = retriever.invoke(\"What is LangChain?\")\n",
+    "\n",
+    "# show the retrieved document's content\n",
+    "retrieved_documents[0].page_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e02b9855",
+   "metadata": {},
+   "source": [
+    "## Direct Usage\n",
+    "\n",
+    "You can directly call embedding methods for your own use cases.\n",
+    "\n",
+    "### Embed single texts\n",
+    "\n",
+    "Embed single texts with `embed_query`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0d2befcd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n"
+     ]
+    }
+   ],
+   "source": [
+    "single_vector = embeddings.embed_query(text)\n",
+    "print(str(single_vector)[:100])  # Show the first 100 characters of the vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b5a7d03",
+   "metadata": {},
+   "source": [
+    "### Embed multiple texts\n",
+    "\n",
+    "Embed multiple texts with `embed_documents`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2f4d6e97",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.003832892, -0.049372625, 0.035413884, 0.019301128, -0.0068899863, -0.01248398, 0.022153955, -0.0066\n",
+      "[0.0083934665, 0.037985895, -0.06684559, -0.039616987, 0.015481004, -0.023952313, 0.016464233, 0.00924\n"
+     ]
+    }
+   ],
+   "source": [
+    "text2 = \"SiliconFlow provides fast and affordable embedding services\"\n",
+    "two_vectors = embeddings.embed_documents([text, text2])\n",
+    "for vector in two_vectors:\n",
+    "    print(str(vector)[:100])  # Show the first 100 characters of the vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98785c12",
+   "metadata": {},
+   "source": [
+    "## API Reference\n",
+    "\n",
+    "For detailed documentation on `SiliconFlowEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/community/embeddings/langchain_community.embeddings.siliconflow.SiliconFlowEmbeddings.html).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/libs/community/langchain_community/embeddings/__init__.py
+++ b/libs/community/langchain_community/embeddings/__init__.py
@@ -246,6 +246,9 @@ if TYPE_CHECKING:
     from langchain_community.embeddings.zhipuai import (
         ZhipuAIEmbeddings,
     )
+    from langchain_community.embeddings.siliconflow import (
+        SiliconFlowEmbeddings,
+    )
 
 __all__ = [
     "AlephAlphaAsymmetricSemanticEmbedding",
@@ -331,6 +334,7 @@ __all__ = [
     "YandexGPTEmbeddings",
     "ZhipuAIEmbeddings",
     "HunyuanEmbeddings",
+    "SiliconFlowEmbeddings",
 ]
 
 _module_lookup = {
@@ -417,6 +421,7 @@ _module_lookup = {
     "AscendEmbeddings": "langchain_community.embeddings.ascend",
     "ZhipuAIEmbeddings": "langchain_community.embeddings.zhipuai",
     "HunyuanEmbeddings": "langchain_community.embeddings.hunyuan",
+    "SiliconFlowEmbeddings": "langchain_community.embeddings.siliconflow",
 }
 
 

--- a/libs/community/langchain_community/embeddings/siliconflow.py
+++ b/libs/community/langchain_community/embeddings/siliconflow.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_dict_or_env
 from pydantic import BaseModel, Field, model_validator

--- a/libs/community/langchain_community/embeddings/siliconflow.py
+++ b/libs/community/langchain_community/embeddings/siliconflow.py
@@ -17,7 +17,7 @@ class SiliconFlowEmbeddings(BaseModel, Embeddings):
 
     Key init args:
         model: str
-            Name of the embedding model to use. Default is "BAAI/bge-large-zh-v1.5".
+            Name of the embedding model to use. Default is "BAAI/bge-m3".
         api_key: str
             Automatically inferred from env var `SILICONFLOW_API_KEY` if not provided.
         encoding_format: str
@@ -29,7 +29,7 @@ class SiliconFlowEmbeddings(BaseModel, Embeddings):
             from your_module import SiliconFlowEmbeddings
 
             embed = SiliconFlowEmbeddings(
-                model="BAAI/bge-large-zh-v1.5",
+                model="BAAI/bge-m3",
                 # api_key="...",  # Optional, will use env var if not provided
             )
 

--- a/libs/community/langchain_community/embeddings/siliconflow.py
+++ b/libs/community/langchain_community/embeddings/siliconflow.py
@@ -71,7 +71,9 @@ class SiliconFlowEmbeddings(BaseModel, Embeddings):
     @classmethod
     def validate_environment(cls, values: Dict) -> Any:
         """Validate that API key exists in environment or provided explicitly."""
-        values["api_key"] = get_from_dict_or_env(values, "api_key", "SILICONFLOW_API_KEY")
+        values["api_key"] = get_from_dict_or_env(
+            values, "api_key", "SILICONFLOW_API_KEY"
+        )
         return values
 
     def _embed(self, texts: List[str]) -> List[List[float]]:

--- a/libs/community/langchain_community/embeddings/siliconflow.py
+++ b/libs/community/langchain_community/embeddings/siliconflow.py
@@ -1,0 +1,126 @@
+from typing import Any, Dict, List, Optional
+from langchain_core.embeddings import Embeddings
+from langchain_core.utils import get_from_dict_or_env
+from pydantic import BaseModel, Field, model_validator
+import requests
+
+class SiliconFlowEmbeddings(BaseModel, Embeddings):
+    """
+    SiliconFlow embedding model integration.
+
+    Setup:
+        To use, you should set the environment variable ``SILICONFLOW_API_KEY`` with your API key.
+
+        .. code-block:: bash
+
+            export SILICONFLOW_API_KEY="your-api-key"
+
+    Key init args:
+        model: str
+            Name of the embedding model to use. Default is "BAAI/bge-large-zh-v1.5".
+        api_key: str
+            Automatically inferred from env var `SILICONFLOW_API_KEY` if not provided.
+        encoding_format: str
+            The encoding format for embeddings. Default is "float". Available options: "float", "base64".
+
+    Instantiate:
+        .. code-block:: python
+
+            from your_module import SiliconFlowEmbeddings
+
+            embed = SiliconFlowEmbeddings(
+                model="BAAI/bge-large-zh-v1.5",
+                # api_key="...",  # Optional, will use env var if not provided
+            )
+
+    Embed single text:
+        .. code-block:: python
+
+            input_text = "Silicon flow embedding online: fast, affordable, and high-quality embedding services."
+            embed.embed_query(input_text)
+
+        .. code-block:: python
+
+            [0.003832892, -0.049372625, 0.035413884, ...]
+
+    Embed multiple texts:
+        .. code-block:: python
+
+            input_texts = ["This is a test query1.", "This is a test query2."]
+            embed.embed_documents(input_texts)
+
+        .. code-block:: python
+
+            [
+                [0.0083934665, 0.037985895, -0.06684559, ...],
+                [-0.02713102, -0.005470169, 0.032321047, ...]
+            ]
+    """  # noqa: E501
+
+    client: Any = Field(default=None, exclude=True)  #: :meta private:
+    model: str = Field(default="BAAI/bge-large-zh-v1.5")
+    """Model name"""
+    api_key: str
+    """Automatically inferred from env var `SILICONFLOW_API_KEY` if not provided."""
+    encoding_format: str = Field(default="float")
+    """The encoding format for embeddings."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_environment(cls, values: Dict) -> Any:
+        """Validate that API key exists in environment or provided explicitly."""
+        values["api_key"] = get_from_dict_or_env(values, "api_key", "SILICONFLOW_API_KEY")
+        return values
+
+    def _embed(self, texts: List[str]) -> List[List[float]]:
+        """
+        Internal method to send embedding requests to SiliconFlow API.
+
+        Args:
+            texts: A list of text documents to embed.
+
+        Returns:
+            A list of embeddings for each document in the input list.
+        """
+        url = "https://api.siliconflow.cn/v1/embeddings"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "model": self.model,
+            "input": texts,
+            "encoding_format": self.encoding_format
+        }
+
+        response = requests.post(url, json=payload, headers=headers)
+        if response.status_code != 200:
+            raise ValueError(f"Error in embedding request: {response.text}")
+
+        data = response.json()
+        embeddings = [item["embedding"] for item in data.get("data", [])]
+        return embeddings
+
+    def embed_query(self, text: str) -> List[float]:
+        """
+        Embeds a single text.
+
+        Args:
+            text: A text to embed.
+
+        Returns:
+            The embedding of the input text as a list of floats.
+        """
+        return self._embed([text])[0]
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """
+        Embeds a list of text documents.
+
+        Args:
+            texts: A list of text documents to embed.
+
+        Returns:
+            A list of embeddings for each document in the input list.
+        """
+        return self._embed(texts)

--- a/libs/community/langchain_community/embeddings/siliconflow.py
+++ b/libs/community/langchain_community/embeddings/siliconflow.py
@@ -58,7 +58,7 @@ class SiliconFlowEmbeddings(BaseModel, Embeddings):
     """  # noqa: E501
 
     client: Any = Field(default=None, exclude=True)  #: :meta private:
-    model: str = Field(default="BAAI/bge-large-zh-v1.5")
+    model: str = Field(default="BAAI/bge-m3")
     """Model name"""
     api_key: str
     """Automatically inferred from env var `SILICONFLOW_API_KEY` if not provided."""

--- a/libs/community/langchain_community/embeddings/siliconflow.py
+++ b/libs/community/langchain_community/embeddings/siliconflow.py
@@ -1,8 +1,10 @@
 from typing import Any, Dict, List, Optional
+
+import requests
+from pydantic import BaseModel, Field, model_validator
+
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_dict_or_env
-from pydantic import BaseModel, Field, model_validator
-import requests
 
 class SiliconFlowEmbeddings(BaseModel, Embeddings):
     """


### PR DESCRIPTION
 - Adds `SiliconFlowEmbeddings` as a new text embedding provider(see **langchain\libs\community\langchain_community\embeddings\siliconflow.py**)

 - No additional dependencies
 - Docs: Added quickstart notebook in **langchain\docs\docs\integrations\text_embedding\siliconflow.ipynb**