### PR TITLE
community: Fix attribute access for transcript text in YoutubeLoader (Fixes #30309)

### DIFF
--- a/libs/community/langchain_community/document_loaders/youtube.py
+++ b/libs/community/langchain_community/document_loaders/youtube.py
@@ -279,7 +279,7 @@ class YoutubeLoader(BaseLoader):
         if self.transcript_format == TranscriptFormat.TEXT:
             transcript = " ".join(
                 map(
-                    lambda transcript_piece: transcript_piece["text"].strip(" "),
+                    lambda transcript_piece: transcript_piece.text.strip(" "),
                     transcript_pieces,
                 )
             )

--- a/libs/community/uv.lock
+++ b/libs/community/uv.lock
@@ -1492,7 +1492,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "0.3.21"
+version = "0.3.22"
 source = { editable = "../langchain" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
@@ -1747,7 +1747,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.47"
+version = "0.3.49"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1777,7 +1777,7 @@ dev = [
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
     { name = "setuptools", specifier = ">=67.6.1,<68.0.0" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.9.2,<1.0.0" }]
+lint = [{ name = "ruff", specifier = ">=0.11.2,<0.12.0" }]
 test = [
     { name = "blockbuster", specifier = "~=1.5.18" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -1805,7 +1805,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.15"
+version = "0.3.17"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
**Description:** Fixed the YouTube transcript loader by changing subscript notation (square brackets) to attribute access (dot notation) when accessing transcript text. The current implementation causes errors when accessing transcript data.

**Issue:** Fixes #30309

**Dependencies:** None

I encountered issues running the automated test suite due to pytest plugin conflicts, but I've verified the fix works through manual testing.