### PR TITLE
community: Fix attribute access for transcript text in YoutubeLoader (Fixes #30309)

### DIFF
--- a/libs/community/langchain_community/document_loaders/youtube.py
+++ b/libs/community/langchain_community/document_loaders/youtube.py
@@ -272,7 +272,14 @@ class YoutubeLoader(BaseLoader):
             transcript = transcript.translate(self.translation)
         transcript_object = transcript.fetch()
         if isinstance(transcript_object, FetchedTranscript):
-            transcript_pieces = [{"text": x.text} for x in transcript_object.snippets]
+            transcript_pieces = [
+                {
+                    "text": snippet.text,
+                    "start": snippet.start,
+                    "duration": snippet.duration,
+                }
+                for snippet in transcript_object.snippets
+            ]
         else:
             transcript_pieces: List[Dict[str, Any]] = transcript_object  # type: ignore[no-redef]
 

--- a/libs/community/tests/unit_tests/document_loaders/test_youtube.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_youtube.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 from langchain_core.documents import Document
 
@@ -218,28 +216,3 @@ def test__get_transcript_chunks() -> None:
         list(ytl._get_transcript_chunks(test_transcript_pieces))
         == test_transcript_chunks
     )
-
-
-@pytest.mark.requires("youtube_transcript_api")
-@patch("youtube_transcript_api.YouTubeTranscriptApi.get_transcript")
-def test_youtube_loader_with_transcript_formats(mock_get_transcript: MagicMock) -> None:
-    """Test that YoutubeLoader properly handles different transcript formats."""
-    transcript_list = [
-        {"text": "First part of transcript", "start": 0.0, "duration": 5.0},
-        {"text": "Second part of transcript", "start": 5.0, "duration": 5.0},
-    ]
-
-    mock_get_transcript.return_value = transcript_list
-
-    loader = YoutubeLoader.from_youtube_url("https://www.youtube.com/watch?v=fake_id")
-    documents = loader.load()
-    assert len(documents) == 1
-    assert "First part" in documents[0].page_content
-
-    loader_chunks = YoutubeLoader.from_youtube_url(
-        "https://www.youtube.com/watch?v=fake_id",
-        transcript_format=TranscriptFormat.CHUNKS,
-        chunk_size_seconds=10,
-    )
-    documents_chunks = loader_chunks.load()
-    assert len(documents_chunks) > 0

--- a/libs/community/tests/unit_tests/document_loaders/test_youtube.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_youtube.py
@@ -1,3 +1,6 @@
+from typing import List
+from unittest.mock import MagicMock, patch
+
 import pytest
 from langchain_core.documents import Document
 
@@ -216,3 +219,73 @@ def test__get_transcript_chunks() -> None:
         list(ytl._get_transcript_chunks(test_transcript_pieces))
         == test_transcript_chunks
     )
+
+
+@pytest.mark.requires("youtube_transcript_api")
+def test_youtube_loader_with_fetched_transcript() -> None:
+    """Test that YoutubeLoader correctly processes FetchedTranscript objects."""
+
+    class MockSnippet:
+        def __init__(self, text: str, start: float, duration: float) -> None:
+            self.text = text
+            self.start = start
+            self.duration = duration
+
+    class MockFetchedTranscript:
+        def __init__(self, snippets: List[MockSnippet]) -> None:
+            self.snippets = snippets
+
+    snippets = [
+        MockSnippet("First part of transcript", 0.0, 5.0),
+        MockSnippet("Second part of transcript", 5.0, 5.0),
+    ]
+
+    mock_transcript = MockFetchedTranscript(snippets)
+
+    with patch(
+        "youtube_transcript_api.YouTubeTranscriptApi.get_transcript",
+        return_value=mock_transcript,
+    ):
+        with patch(
+            "builtins.isinstance",
+            lambda obj, cls: (
+                obj is mock_transcript and str(cls).endswith("FetchedTranscript'>")
+            )
+            or isinstance(obj, cls),
+        ):
+            loader = YoutubeLoader.from_youtube_url(
+                "https://www.youtube.com/watch?v=fake_id"
+            )
+            documents = loader.load()
+
+            assert len(documents) == 1
+            assert "First part of transcript" in documents[0].page_content
+            assert "Second part of transcript" in documents[0].page_content
+
+            loader_chunks = YoutubeLoader.from_youtube_url(
+                "https://www.youtube.com/watch?v=fake_id",
+                transcript_format=TranscriptFormat.CHUNKS,
+                chunk_size_seconds=10,
+            )
+            documents_chunks = loader_chunks.load()
+
+            assert len(documents_chunks) > 0
+
+
+@pytest.mark.requires("youtube_transcript_api")
+@patch("youtube_transcript_api.YouTubeTranscriptApi.get_transcript")
+def test_youtube_loader_with_transcript(mock_get_transcript: MagicMock) -> None:
+    """Test that YoutubeLoader works correctly with transcript pieces that have all necessary keys."""  # noqa: E501
+    transcript_pieces = [
+        {"text": "First part of transcript", "start": 0.0, "duration": 5.0},
+        {"text": "Second part of transcript", "start": 5.0, "duration": 5.0},
+    ]
+
+    mock_get_transcript.return_value = transcript_pieces
+
+    loader = YoutubeLoader.from_youtube_url("https://www.youtube.com/watch?v=fake_id")
+    documents = loader.load()
+
+    assert len(documents) == 1
+    assert "First part of transcript" in documents[0].page_content
+    assert "Second part of transcript" in documents[0].page_content

--- a/libs/community/uv.lock
+++ b/libs/community/uv.lock
@@ -1492,7 +1492,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "0.3.21"
+version = "0.3.22"
 source = { editable = "../langchain" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
@@ -1747,7 +1747,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.47"
+version = "0.3.49"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1777,7 +1777,7 @@ dev = [
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
     { name = "setuptools", specifier = ">=67.6.1,<68.0.0" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.9.2,<1.0.0" }]
+lint = [{ name = "ruff", specifier = ">=0.11.2,<0.12.0" }]
 test = [
     { name = "blockbuster", specifier = "~=1.5.18" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -1805,7 +1805,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.15"
+version = "0.3.17"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
**Description:** 
Fixes a bug in the YoutubeLoader where FetchedTranscript objects were not properly processed. The loader was only extracting the 'text' attribute from FetchedTranscriptSnippet objects while ignoring 'start' and 'duration' attributes. This would cause a TypeError when the code later tried to access these missing keys, particularly when using the CHUNKS format or any code path that needed timestamp information.

This PR modifies the conversion of FetchedTranscriptSnippet objects to include all necessary attributes, ensuring that the loader works correctly with all transcript formats.

**Issue:** Fixes #30309

**Dependencies:** None

**Testing:**
- Tested the fix with multiple YouTube videos to confirm it resolves the issue
- Verified that both regular loading and CHUNKS format work correctly