### PR TITLE
community: add default value for `azure_search_key` parameter in Azure Search

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -288,9 +288,9 @@ class AzureSearch(VectorStore):
     def __init__(
         self,
         azure_search_endpoint: str,
-        azure_search_key: Optional[str],
         index_name: str,
         embedding_function: Union[Callable, Embeddings],
+        azure_search_key: Optional[str] = None,
         search_type: str = "hybrid",
         semantic_configuration_name: Optional[str] = None,
         fields: Optional[List[SearchField]] = None,


### PR DESCRIPTION
**Description:**
Add a default value for the `azure_search_key` parameter in the `__init__` function of the `AzureSearch` class.
Although PR #28873 made `azure_search_key` optional, no default value was assigned.
Issue #27536 explicitly mentioned the desire to set a default value for this parameter.
This change explicitly sets a default value to support scenarios using credentials or access tokens without providing a key (e.g., Managed Identity).

**Issue:** #27536

**Dependencies:**  None