### PR TITLE
core: Propagate config_factories in RunnableBinding

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -5766,6 +5766,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):
         return self.__class__(
             bound=self.bound,
             config=self.config,
+            config_factories=self.config_factories,
             kwargs={**self.kwargs, **kwargs},
             custom_input_type=self.custom_input_type,
             custom_output_type=self.custom_output_type,
@@ -5782,6 +5783,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):
             bound=self.bound,
             kwargs=self.kwargs,
             config=cast("RunnableConfig", {**self.config, **(config or {}), **kwargs}),
+            config_factories=self.config_factories,
             custom_input_type=self.custom_input_type,
             custom_output_type=self.custom_output_type,
         )
@@ -5817,22 +5819,23 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):
         """
         from langchain_core.tracers.root_listeners import RootListenersTracer
 
+        def listener_config_factory(config: RunnableConfig) -> RunnableConfig:
+            return {
+                "callbacks": [
+                    RootListenersTracer(
+                        config=config,
+                        on_start=on_start,
+                        on_end=on_end,
+                        on_error=on_error,
+                    )
+                ],
+            }
+
         return self.__class__(
             bound=self.bound,
             kwargs=self.kwargs,
             config=self.config,
-            config_factories=[
-                lambda config: {
-                    "callbacks": [
-                        RootListenersTracer(
-                            config=config,
-                            on_start=on_start,
-                            on_end=on_end,
-                            on_error=on_error,
-                        )
-                    ],
-                }
-            ],
+            config_factories=[listener_config_factory] + self.config_factories,
             custom_input_type=self.custom_input_type,
             custom_output_type=self.custom_output_type,
         )
@@ -5847,6 +5850,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):
             bound=self.bound,
             kwargs=self.kwargs,
             config=self.config,
+            config_factories=self.config_factories,
             custom_input_type=(
                 input_type if input_type is not None else self.custom_input_type
             ),
@@ -5861,6 +5865,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):
             bound=self.bound.with_retry(**kwargs),
             kwargs=self.kwargs,
             config=self.config,
+            config_factories=self.config_factories,
         )
 
     @override

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -1712,6 +1712,72 @@ async def test_with_listeners_async(mocker: MockerFixture) -> None:
     assert mock_end.call_count == 1
 
 
+def test_with_listener_propagation(mocker: MockerFixture) -> None:
+    prompt = (
+        SystemMessagePromptTemplate.from_template("You are a nice assistant.")
+        + "{question}"
+    )
+    chat = FakeListChatModel(responses=["foo"])
+    chain: Runnable = prompt | chat
+    mock_start = mocker.Mock()
+    mock_end = mocker.Mock()
+    chain_with_listeners = chain.with_listeners(on_start=mock_start, on_end=mock_end)
+
+    chain_with_listeners.with_retry().invoke({"question": "Who are you?"})
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+
+    mock_start.reset_mock()
+    mock_end.reset_mock()
+
+    chain_with_listeners.with_types(output_type=str).invoke(
+        {"question": "Who are you?"}
+    )
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+
+    mock_start.reset_mock()
+    mock_end.reset_mock()
+
+    chain_with_listeners.with_config({"tags": ["foo"]}).invoke(
+        {"question": "Who are you?"}
+    )
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+
+    mock_start.reset_mock()
+    mock_end.reset_mock()
+
+    chain_with_listeners.bind(stop=["foo"]).invoke({"question": "Who are you?"})
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+
+    mock_start.reset_mock()
+    mock_end.reset_mock()
+
+    mock_start_inner = mocker.Mock()
+    mock_end_inner = mocker.Mock()
+
+    chain_with_listeners.with_listeners(
+        on_start=mock_start_inner, on_end=mock_end_inner
+    ).invoke({"question": "Who are you?"})
+
+    assert mock_start.call_count == 1
+    assert mock_start.call_args[0][0].name == "RunnableSequence"
+    assert mock_end.call_count == 1
+    assert mock_start_inner.call_count == 1
+    assert mock_start_inner.call_args[0][0].name == "RunnableSequence"
+    assert mock_end_inner.call_count == 1
+
+
 @freeze_time("2023-01-01")
 def test_prompt_with_chat_model(
     mocker: MockerFixture,


### PR DESCRIPTION
  - **Description:** Propagates config_factories when calling decoration methods for RunnableBinding--e.g. bind, with_config, with_types, with_retry, and with_listeners. This ensures that configs attached to the original RunnableBinding are kept when creating the new RunnableBinding and the configs are merged during invocation. Picks up where #30551  left off.
  - **Issue:** #30531 
