### PR TITLE
docs: Fix deprecated initialize agent in memorize.ipynb

### DIFF
--- a/docs/docs/integrations/tools/memorize.ipynb
+++ b/docs/docs/integrations/tools/memorize.ipynb
@@ -115,17 +115,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = initialize_agent(\n",
-    "    tools,\n",
-    "    llm,\n",
-    "    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,\n",
-    "    verbose=True,\n",
-    "    # memory=ConversationBufferMemory(memory_key=\"chat_history\", return_messages=True),\n",
-    ")"
+    "agent = create_react_agent(model=llm, tools=tools)"
    ]
   },
   {

--- a/docs/docs/integrations/tools/memorize.ipynb
+++ b/docs/docs/integrations/tools/memorize.ipynb
@@ -29,7 +29,8 @@
     "from langchain.agents import AgentExecutor, load_tools\n",
     "from langchain.chains import LLMChain\n",
     "from langchain.memory import ConversationBufferMemory\n",
-    "from langchain_community.llms import GradientLLM"
+    "from langchain_community.llms import GradientLLM\n",
+    "from langgraph.prebuilt import create_react_agent"
    ]
   },
   {

--- a/docs/docs/integrations/tools/memorize.ipynb
+++ b/docs/docs/integrations/tools/memorize.ipynb
@@ -20,13 +20,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
-    "from langchain.agents import AgentExecutor, AgentType, initialize_agent, load_tools\n",
+    "from langchain.agents import AgentExecutor, load_tools\n",
     "from langchain.chains import LLMChain\n",
     "from langchain.memory import ConversationBufferMemory\n",
     "from langchain_community.llms import GradientLLM"


### PR DESCRIPTION
  - **Description:** Replace the deprecated method of creating agents by:

    1. Remove the imports and code for the initialize_agent function
    2. Add the correct import and code for create_react_agent function from langgraph  

  - **Issue:** #29277
  - **Dependencies:** N/A
  - **Twitter handle:** N/A

