### PR TITLE
community[patch]: `Redundant` Parser checker for Webbaseloader

### DIFF
--- a/libs/community/langchain_community/document_loaders/web_base.py
+++ b/libs/community/langchain_community/document_loaders/web_base.py
@@ -367,9 +367,6 @@ class WebBaseLoader(BaseLoader):
     def scrape(self, parser: Union[str, None] = None) -> Any:
         """Scrape data from webpage and return it in BeautifulSoup format."""
 
-        if parser is None:
-            parser = self.default_parser
-
         return self._scrape(self.web_path, parser=parser, bs_kwargs=self.bs_kwargs)
 
     def lazy_load(self) -> Iterator[Document]:


### PR DESCRIPTION
- **Description:** We do not need to set parser in `scrape` since it is already been done in `_scrape`
- **Issue:** #30629, not directly related but makes sure xml parser is used


