### PR TITLE
docs: Add Google Calendar documentation

### DIFF
--- a/docs/docs/integrations/tools/google_calendar.ipynb
+++ b/docs/docs/integrations/tools/google_calendar.ipynb
@@ -30,24 +30,6 @@
     "1. Have a Google account with access to Google Calendar.\n",
     "2. Set up your credentials as explained in the [Google Calendar API docs](https://developers.google.com/calendar/api/quickstart/python#authorize_credentials_for_a_desktop_application). Once you've downloaded the `credentials.json` file, you can start using the Google Calendar API.\n",
     "\n",
-    "### Installation\n",
-    "\n",
-    "This toolkit lives in the `langchain-google-community` package. We'll need the `calendar` extra:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -qU langchain-google-community\\[calendar\\]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "To enable automated tracing of individual tools, set your [LangSmith](https://docs.smith.langchain.com/) API key:"
    ]
   },
@@ -65,6 +47,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Installation\n",
+    "\n",
+    "This toolkit lives in the `langchain-google-community` package of the [langchain-google](https://github.com/langchain-ai/langchain-google) repository. We'll need the `calendar` extra:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-google-community\\[calendar\\]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Instantiation\n",
     "\n",
     "By default the toolkit reads the local `credentials.json` file. You can also manually provide a `Credentials` object."
@@ -72,17 +72,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=69722697557-n13nrkrq7t630sthrt70fucdcmn19hsl.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A50658%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar&state=zthpYhQllTXO5ninRupAeupTSuzC1I&access_type=offline\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain_google_community import CalendarToolkit\n",
     "\n",
@@ -100,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,6 +103,7 @@
     ")\n",
     "\n",
     "# Can review scopes here: https://developers.google.com/calendar/api/auth\n",
+    "# For instance, readonly scope is https://www.googleapis.com/auth/calendar.readonly\n",
     "credentials = get_google_credentials(\n",
     "    token_file=\"token.json\",\n",
     "    scopes=[\"https://www.googleapis.com/auth/calendar\"],\n",
@@ -125,8 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Invocation\n",
-    "### Tools\n",
+    "## Tools\n",
     "View available tools:"
    ]
   },
@@ -168,6 +160,52 @@
     "- [CalendarMoveEvent](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.move_event.CalendarMoveEvent.html)\n",
     "- [CalendarDeleteEvent](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.delete_event.CalendarDeleteEvent.html)\n",
     "- [GetCurrentDatetime](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.current_datetime.GetCurrentDatetime.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Invocation\n",
+    "\n",
+    "### [Invoke directly with args](/docs/concepts/tools/#use-the-tool-directly)\n",
+    "\n",
+    "You can invoke the tool directly by passing the required arguments in a dictionary format. Here is an example of creating a new event using the `CalendarCreateEvent` tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Event created: https://www.google.com/calendar/event?eid=amoxdjVsM2UzMW51Yjk2czc4ajhvaGdkcGcgam9yZ2VhbmczM0Bt'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from langchain_google_community.calendar.create_event import CalendarCreateEvent\n",
+    "\n",
+    "tool = CalendarCreateEvent()\n",
+    "tool.invoke(\n",
+    "    {\n",
+    "        \"summary\": \"Calculus exam\",\n",
+    "        \"start_datetime\": \"2025-07-11 11:00:00\",\n",
+    "        \"end_datetime\": \"2025-07-11 13:00:00\",\n",
+    "        \"timezone\": \"America/Mexico_City\",\n",
+    "        \"location\": \"UAM Cuajimalpa\",\n",
+    "        \"description\": \"Event created from the LangChain toolkit\",\n",
+    "        \"reminders\": [{\"method\": \"popup\", \"minutes\": 60}],\n",
+    "        \"conference_data\": True,\n",
+    "        \"color_id\": \"5\",\n",
+    "    }\n",
+    ")"
    ]
   },
   {
@@ -268,7 +306,8 @@
    "source": [
     "## API reference\n",
     "\n",
-    "Refer to the [Google Calendar API overview](https://developers.google.com/calendar/api/guides/overview) for more details."
+    "- Refer to the [Google Calendar API overview](https://developers.google.com/calendar/api/guides/overview) for more details from Google Calendar API.\n",
+    "- For detailed documentation of all Google Calendar Toolkit features and configurations head to the [calendar documentation](https://python.langchain.com/api_reference/google_community/calendar.html)."
    ]
   }
  ],

--- a/docs/docs/integrations/tools/google_calendar.ipynb
+++ b/docs/docs/integrations/tools/google_calendar.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "# Google Calendar Toolkit\n",
+    "\n",
+    "> [Google Calendar](https://workspace.google.com/intl/en-419/products/calendar/) is a product of Google Workspace that allows users to organize their schedules and events. It is a cloud-based calendar that allows users to create, edit, and delete events. It also allows users to share their calendars with others.\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "This notebook will help you get started with the Google Calendar Toolkit. This toolkit interacts with the Google Calendar API to perform various operations on the calendar. It allows you to:\n",
+    "\n",
+    "- Create events.\n",
+    "- Search events.\n",
+    "- Update events.\n",
+    "- Move events between different calendars.\n",
+    "- Delete events.\n",
+    "- List events.\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To use this toolkit, you will need to:\n",
+    "\n",
+    "1. Have a Google account with access to Google Calendar.\n",
+    "2. Set up your credentials as explained in the [Google Calendar API docs](https://developers.google.com/calendar/api/quickstart/python#authorize_credentials_for_a_desktop_application). Once you've downloaded the `credentials.json` file, you can start using the Google Calendar API.\n",
+    "\n",
+    "### Installation\n",
+    "\n",
+    "This toolkit lives in the `langchain-google-community` package. We'll need the `calendar` extra:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-google-community\\[calendar\\]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To enable automated tracing of individual tools, set your [LangSmith](https://docs.smith.langchain.com/) API key:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiation\n",
+    "\n",
+    "By default the toolkit reads the local `credentials.json` file. You can also manually provide a `Credentials` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=69722697557-n13nrkrq7t630sthrt70fucdcmn19hsl.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A50658%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar&state=zthpYhQllTXO5ninRupAeupTSuzC1I&access_type=offline\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_google_community import CalendarToolkit\n",
+    "\n",
+    "toolkit = CalendarToolkit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Customizing Authentication\n",
+    "\n",
+    "Behind the scenes, a `googleapi` resource is created using the following methods. you can manually build a `googleapi` resource for more auth control."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_google_community import CalendarToolkit\n",
+    "from langchain_google_community.calendar.utils import (\n",
+    "    build_resource_service,\n",
+    "    get_google_credentials,\n",
+    ")\n",
+    "\n",
+    "# Can review scopes here: https://developers.google.com/calendar/api/auth\n",
+    "credentials = get_google_credentials(\n",
+    "    token_file=\"token.json\",\n",
+    "    scopes=[\"https://www.googleapis.com/auth/calendar\"],\n",
+    "    client_secrets_file=\"credentials.json\",\n",
+    ")\n",
+    "\n",
+    "api_resource = build_resource_service(credentials=credentials)\n",
+    "toolkit = CalendarToolkit(api_resource=api_resource)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tools\n",
+    "\n",
+    "View available tools:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[CalendarCreateEvent(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>),\n",
+       " CalendarSearchEvents(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>),\n",
+       " CalendarUpdateEvent(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>),\n",
+       " GetCalendarsInfo(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>),\n",
+       " CalendarMoveEvent(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>),\n",
+       " CalendarDeleteEvent(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>),\n",
+       " GetCurrentDatetime(api_resource=<googleapiclient.discovery.Resource object at 0x10ad13fb0>)]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tools = toolkit.get_tools()\n",
+    "tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- [CalendarCreateEvent](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.create_event.CalendarCreateEvent.html)\n",
+    "- [CalendarSearchEvents](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.search_events.CalendarSearchEvents.html)\n",
+    "- [CalendarUpdateEvent](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.update_event.CalendarUpdateEvent.html)\n",
+    "- [GetCalendarsInfo](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.get_calendars_info.GetCalendarsInfo.html)\n",
+    "- [CalendarMoveEvent](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.move_event.CalendarMoveEvent.html)\n",
+    "- [CalendarDeleteEvent](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.delete_event.CalendarDeleteEvent.html)\n",
+    "- [GetCurrentDatetime](https://python.langchain.com/api_reference/google_community/calendar/langchain_google_community.calendar.current_datetime.GetCurrentDatetime.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use within an agent\n",
+    "\n",
+    "Below we show how to incorporate the toolkit into an [agent](/docs/tutorials/agents).\n",
+    "\n",
+    "We will need a LLM or chat model:\n",
+    "\n",
+    "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",
+    "\n",
+    "<ChatModelTabs customVarName=\"llm\" />"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# | output: false\n",
+    "# | echo: false\n",
+    "\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "agent_executor = create_react_agent(llm, tools)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Create a green event for this afternoon to go for a 30-minute run.\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  get_current_datetime (call_drHRRhm6pdvcAuqagONUEKs5)\n",
+      " Call ID: call_drHRRhm6pdvcAuqagONUEKs5\n",
+      "  Args:\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: get_current_datetime\n",
+      "\n",
+      "Time zone: America/Mexico_City, Date and time: 2025-04-02 19:07:30\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  create_calendar_event (call_p60zSVMmmjTy5Ctezzmlb9zD)\n",
+      " Call ID: call_p60zSVMmmjTy5Ctezzmlb9zD\n",
+      "  Args:\n",
+      "    summary: Run\n",
+      "    start_datetime: 2025-04-02 19:30:00\n",
+      "    end_datetime: 2025-04-02 20:00:00\n",
+      "    timezone: America/Mexico_City\n",
+      "    color_id: 2\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: create_calendar_event\n",
+      "\n",
+      "Event created: https://www.google.com/calendar/event?eid=czZyZHVpcG43ajNiY241dmJmNWwycjE0NWsgam9yZ2VhbmczM0Bt\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I have created a green event for your run this afternoon. You can view it [here](https://www.google.com/calendar/event?eid=czZyZHVpcG43ajNiY241dmJmNWwycjE0NWsgam9yZ2VhbmczM0Bt). Enjoy your run!\n"
+     ]
+    }
+   ],
+   "source": [
+    "example_query = \"Create a green event for this afternoon to go for a 30-minute run.\"\n",
+    "\n",
+    "events = agent_executor.stream(\n",
+    "    {\"messages\": [(\"user\", example_query)]},\n",
+    "    stream_mode=\"values\",\n",
+    ")\n",
+    "for event in events:\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "Refer to the [Google Calendar API overview](https://developers.google.com/calendar/api/guides/overview) for more details."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/docs/integrations/tools/google_calendar.ipynb
+++ b/docs/docs/integrations/tools/google_calendar.ipynb
@@ -125,8 +125,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Tools\n",
-    "\n",
+    "## Invocation\n",
+    "### Tools\n",
     "View available tools:"
    ]
   },


### PR DESCRIPTION
## Docs: Add Google Calendar Toolkit Documentation

### Description:
This PR adds documentation for the Google Calendar Toolkit as part of the `langchain-google` repository. Refer to the related PR: [community: Add Google Calendar Toolkit](https://github.com/langchain-ai/langchain-google/pull/688).

### Issue:
N/A 

### Twitter handle:
@jorgejrzz