### PR TITLE
core: Fix variable rendering in HumanMessage for ChatPromptTemplate (Fixes #30598)

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1212,7 +1212,23 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         result = []
         for message_template in self.messages:
             if isinstance(message_template, BaseMessage):
-                result.extend([message_template])
+                content = message_template.content
+                if isinstance(content, str) and "{" in content and "}" in content:
+                    variables = get_template_variables(content, "f-string")
+
+                    if variables and all(var in kwargs for var in variables):
+                        formatted_content = PromptTemplate.from_template(
+                            content
+                        ).format(**kwargs)
+
+                        result.append(
+                            type(message_template)(
+                                content=formatted_content,
+                                additional_kwargs=message_template.additional_kwargs,
+                            )
+                        )
+                        continue
+                result.append(message_template)
             elif isinstance(
                 message_template, (BaseMessagePromptTemplate, BaseChatPromptTemplate)
             ):
@@ -1240,7 +1256,23 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         result = []
         for message_template in self.messages:
             if isinstance(message_template, BaseMessage):
-                result.extend([message_template])
+                content = message_template.content
+                if isinstance(content, str) and "{" in content and "}" in content:
+                    variables = get_template_variables(content, "f-string")
+
+                    if variables and all(var in kwargs for var in variables):
+                        formatted_content = await PromptTemplate.from_template(
+                            content
+                        ).aformat(**kwargs)
+
+                        result.append(
+                            type(message_template)(
+                                content=formatted_content,
+                                additional_kwargs=message_template.additional_kwargs,
+                            )
+                        )
+                        continue
+                result.append(message_template)
             elif isinstance(
                 message_template, (BaseMessagePromptTemplate, BaseChatPromptTemplate)
             ):


### PR DESCRIPTION
**Description:** 
Fixed an issue where variables inside `HumanMessage("{variable}")` weren't being properly rendered when formatting a ChatPromptTemplate. The fix allows direct use of template variables in BaseMessage objects by adding variable detection and substitution in both the synchronous and asynchronous format_messages methods.

**Issue:** Fixes #30598

**Dependencies:** None

**Testing:**
Verified that both methods of template specification now work correctly:
1. Using MessagePromptTemplate classes: `HumanMessage("{variable}")`
2. Using tuple notation: `("human", "{variable}")`