### PR TITLE
docs: Fixed a typo in 'Google AI vs Google Cloud Vertex AI' section

### DIFF
--- a/docs/docs/integrations/chat/google_generative_ai.ipynb
+++ b/docs/docs/integrations/chat/google_generative_ai.ipynb
@@ -23,7 +23,7 @@
         "\n",
         ":::info Google AI vs Google Cloud Vertex AI\n",
         "\n",
-        "Google's Gemini models are accessible through Google AI and through Google Cloud Vertex AI. Using Google AI just requires a Google account and an API key. Using Google Cloud Vertex AI requires a Google Cloud account (with term agreements and billing) but offers enterprise features like customer encription key, virtual private cloud, and more.\n",
+        "Google's Gemini models are accessible through Google AI and through Google Cloud Vertex AI. Using Google AI just requires a Google account and an API key. Using Google Cloud Vertex AI requires a Google Cloud account (with term agreements and billing) but offers enterprise features like customer encryption key, virtual private cloud, and more.\n",
         "\n",
         "To learn more about the key features of the two APIs see the [Google docs](https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/migrate-google-ai#google-ai).\n",
         "\n",


### PR DESCRIPTION
**Description:** Corrected 'encription' spelling to 'encryption'
