### PR TITLE
feat(openai): add `skip_tokenization` option to OpenAIEmbeddings

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -239,8 +239,9 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     API but with different models. In those cases, in order to avoid erroring
     when tiktoken is called, you can specify a model name to use here."""
     skip_tokenization: bool = False
-    """Set this to True to skip tokenization entirely and pass texts directly to the API.
-    Use this for OpenAI-compatible APIs that don't support tiktoken or huggingface tokenizers."""
+    """Whether to skip tokenization entirely and pass texts directly to the API.
+    Use this for OpenAI-compatible APIs that don't support tiktoken or
+    huggingface tokenizers."""
     show_progress_bar: bool = False
     """Whether to show a progress bar when embedding."""
     model_kwargs: Dict[str, Any] = Field(default_factory=dict)
@@ -403,7 +404,8 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     "Could not import transformers python package. "
                     "This is needed for OpenAIEmbeddings to work without "
                     "`tiktoken`. Please install it with `pip install transformers`. "
-                    "Alternatively, set `skip_tokenization=True` to bypass tokenization entirely."
+                    "Alternatively, set `skip_tokenization=True` to bypass "
+                    "tokenization entirely."
                 )
 
             tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
**Description:** 
Added a new `skip_tokenization` parameter to `OpenAIEmbeddings` to fix compatibility issues with OpenAI-like embedding servers. Previously, the class would always try to tokenize inputs using either tiktoken or HuggingFace tokenizers, causing errors or incorrect embeddings with servers that don't support these tokenizers (like vLLM). The fix allows completely bypassing the tokenization process, passing raw text directly to the embedding API.

**Issue:** Fixes #30574

**Dependencies:** None

**Testing:**
Verified the fix with a test script that simulates the issue:
1. Without the fix: Different embeddings between OpenAI client and LangChain OpenAIEmbeddings
2. With `skip_tokenization=True`: Identical embeddings between OpenAI client and LangChain