### PR TITLE
langchain: release 0.3.23

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -7,7 +7,7 @@ authors = []
 license = { text = "MIT" }
 requires-python = "<4.0,>=3.9"
 dependencies = [
-    "langchain-core<1.0.0,>=0.3.49",
+    "langchain-core<1.0.0,>=0.3.51",
     "langchain-text-splitters<1.0.0,>=0.3.7",
     "langsmith<0.4,>=0.1.17",
     "pydantic<3.0.0,>=2.7.4",
@@ -17,7 +17,7 @@ dependencies = [
     "async-timeout<5.0.0,>=4.0.0; python_version < \"3.11\"",
 ]
 name = "langchain"
-version = "0.3.22"
+version = "0.3.23"
 description = "Building applications with LLMs through composability"
 readme = "README.md"
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 requires-python = "<4.0,>=3.9"
 dependencies = [
     "langchain-core<1.0.0,>=0.3.51",
-    "langchain-text-splitters<1.0.0,>=0.3.7",
+    "langchain-text-splitters<1.0.0,>=0.3.8",
     "langsmith<0.4,>=0.1.17",
     "pydantic<3.0.0,>=2.7.4",
     "SQLAlchemy<3,>=1.4",

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2345,7 +2345,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "0.3.22"
+version = "0.3.23"
 source = { editable = "." }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.50"
+version = "0.3.51"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2939,7 +2939,7 @@ typing = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "../text-splitters" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
* Bump `text-splitters` min version
* Bump `langchain-core` min version
* Bump `langchain` version 🚀 