### PR TITLE
community: support usage_metadata for litellm streaming calls

### DIFF
--- a/libs/community/tests/integration_tests/chat_models/test_litellm_standard.py
+++ b/libs/community/tests/integration_tests/chat_models/test_litellm_standard.py
@@ -2,7 +2,6 @@
 
 from typing import Type
 
-import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_tests.integration_tests import ChatModelIntegrationTests
 
@@ -16,8 +15,8 @@ class TestLiteLLMStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "ollama/mistral"}
-
-    @pytest.mark.xfail(reason="Not yet implemented.")
-    def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
-        super().test_usage_metadata_streaming(model)
+        return {
+            "model": "ollama/mistral",
+            # Needed to get the usage object when streaming. See https://docs.litellm.ai/docs/completion/usage#streaming-usage
+            "model_kwargs": {"stream_options": {"include_usage": True}},
+        }


### PR DESCRIPTION
Support "usage_metadata" for LiteLLM streaming calls.

This is a follow-up to https://github.com/langchain-ai/langchain/pull/30625, which tackled non-streaming calls.

If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
