### PR TITLE
docs: fix import path and update LiteLLM integration docs

### DIFF
--- a/docs/docs/integrations/chat/litellm.ipynb
+++ b/docs/docs/integrations/chat/litellm.ipynb
@@ -121,7 +121,7 @@
    },
    "outputs": [],
    "source": [
-    "from langchain_litellm.chat_models import ChatLiteLLM\n",
+    "from langchain_litellm import ChatLiteLLM\n",
     "\n",
     "llm = ChatLiteLLM(model=\"gpt-3.5-turbo\")"
    ]

--- a/docs/docs/integrations/providers/litellm.mdx
+++ b/docs/docs/integrations/providers/litellm.mdx
@@ -10,7 +10,7 @@ pip install langchain-litellm
 
 ## Chat Models
 ```python
-from langchain_litellm.chat_models import ChatLiteLLM
+from langchain_litellm import ChatLiteLLM
 ```
 See more detail in the guide [here](/docs/integrations/chat/litellm).
 


### PR DESCRIPTION
- [x] **PR title**: "docs: Update import path and LiteLLM integration docs"
- Update the old import path for `ChatLiteLLM` to reflect the new export from [`__init__.py`](https://github.com/Akshay-Dongare/langchain-litellm/blob/main/langchain_litellm/__init__.py) in [`langchain-litellm`](https://github.com/Akshay-Dongare/langchain-litellm) package

- [x] **PR message**:
    - **Description:** 
    - 🔗 **Follow-up to**: PR #30637
    - 🔧 **Fixes**: #30368
    - 💬 **Based on this comment from** @ccurme: https://github.com/langchain-ai/langchain/pull/30637#discussion_r2029084320
 


- [x] **About me**
🔗 LinkedIn: [akshay-dongare](https://www.linkedin.com/in/akshay-dongare/)