### PR TITLE
langchain_qdrant: fix showing the missing sparse vector name

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -1178,7 +1178,7 @@ class QdrantVectorStore(VectorStore):
         ):
             raise QdrantVectorStoreError(
                 f"Existing Qdrant collection {collection_name} does not "
-                f"contain sparse vectors named {sparse_vector_config}. "
+                f"contain sparse vectors named {sparse_vector_name}. "
                 f"If you want to recreate the collection, set `force_recreate` "
                 f"parameter to `True`."
             )


### PR DESCRIPTION
**Description:** The error message was supposed to display the missing vector name, but instead, it includes only the existing collection configs.

This simple PR just includes the correct variable name, so that the user knows the requested vector does not exist in the collection.

Additional guidelines:
- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to pyproject.toml files (even optional ones) unless they are required for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
- If you are adding something to community, do not re-import it in langchain.

If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
