### PR TITLE
ollama[patch]: add model_name to response metadata

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -743,6 +743,10 @@ class ChatOllama(BaseChatModel):
                         dict(stream_resp) if stream_resp.get("done") is True else None
                     ),
                 )
+                if chunk.generation_info and (
+                    model := chunk.generation_info.get("model")
+                ):
+                    chunk.generation_info["model_name"] = model  # backwards compat
                 if self.extract_reasoning:
                     message, is_thinking = self._extract_reasoning(
                         chunk.message, is_thinking
@@ -791,6 +795,10 @@ class ChatOllama(BaseChatModel):
                         dict(stream_resp) if stream_resp.get("done") is True else None
                     ),
                 )
+                if chunk.generation_info and (
+                    model := chunk.generation_info.get("model")
+                ):
+                    chunk.generation_info["model_name"] = model  # backwards compat
                 if self.extract_reasoning:
                     message, is_thinking = self._extract_reasoning(
                         chunk.message, is_thinking


### PR DESCRIPTION
Fixes [this standard test](https://python.langchain.com/api_reference/standard_tests/integration_tests/langchain_tests.integration_tests.chat_models.ChatModelIntegrationTests.html#langchain_tests.integration_tests.chat_models.ChatModelIntegrationTests.test_usage_metadata).