### PR TITLE
community: add include_likes option to ConfluenceLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -651,7 +651,12 @@ class ConfluenceLoader(BaseLoader):
             ]
 
         if include_likes:
-            metadata["likes"] = page.get("metadata", {}).get("likes", {}).get("meta", {}).get("count", 0)
+            metadata["likes"] = (
+                page.get("metadata", {})
+                .get("likes", {})
+                .get("meta", {})
+                .get("count", 0)
+            )
 
         if "version" in page and "when" in page["version"]:
             metadata["when"] = page["version"]["when"]

--- a/libs/community/tests/unit_tests/document_loaders/test_confluence.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_confluence.py
@@ -283,7 +283,7 @@ class TestConfluenceLoader:
         include_labels: bool = False,
         include_likes: bool = False,
     ) -> Dict:
-        metadata = {}
+        metadata: Dict[str, Any] = {}
         if include_labels:
             metadata["labels"] = {
                 "results": [


### PR DESCRIPTION
## **Description:**

Enable `ConfluenceLoader` to include labels with `include_likes` option (`false` by default for backward compatibility). and the labels are set to `metadata` in the `Document`. e.g. `{"likes": 2}`

## Notes

Confluence API supports to get labels by providing `metadata.likes` to `expand` query parameter 

All of the following functions support `expand` in the same way:
- [confluence.get_page_by_id](https://github.com/atlassian-api/atlassian-python-api/blob/b3f6d77e17195a9b669cf4a693bb82764fb70cba/atlassian/confluence.py#L352) `rest/api/content/1234?expand=space,body.view,version,container`
- [confluence.get_all_pages_by_label](https://github.com/atlassian-api/atlassian-python-api/blob/b3f6d77e17195a9b669cf4a693bb82764fb70cba/atlassian/confluence.py#L556) `rest/api/content/search`
- [confluence.get_all_pages_from_space](https://github.com/atlassian-api/atlassian-python-api/blob/b3f6d77e17195a9b669cf4a693bb82764fb70cba/atlassian/confluence.py#L587) `rest/api/content`
- [cql](https://github.com/atlassian-api/atlassian-python-api/blob/b3f6d77e17195a9b669cf4a693bb82764fb70cba/atlassian/confluence.py#L2750) `rest/api/search`

## Ref

- https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content/#api-wiki-rest-api-content-search-get

v1 seems to not support include-likes

## **Issue:**

No issue related to this PR.

## **Dependencies:** 

No changes.

## **Twitter handle:** 

[@gymnstcs](https://x.com/gymnstcs)


- [x] **Add tests and docs**: If you're adding a new integration, please include
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/docs/integrations` directory.

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. See contribution guidelines for more: https://python.langchain.com/docs/contributing/


