### PR TITLE
[performance]: Use hard coded `langchain-core` version to avoid `importlib` import

### DIFF
--- a/.github/workflows/check_core_versions.yml
+++ b/.github/workflows/check_core_versions.yml
@@ -1,4 +1,4 @@
-name: Check Version Equality
+name: Check `langchain-core` version equality
 
 on:
   pull_request:

--- a/.github/workflows/check_core_versions.yml
+++ b/.github/workflows/check_core_versions.yml
@@ -1,0 +1,29 @@
+name: Check Version Equality
+
+on:
+  pull_request:
+    paths:
+      - 'libs/core/pyproject.toml'
+      - 'libs/core/langchain_core/version.py'
+
+jobs:
+  check_version_equality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version equality
+        run: |
+          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
+          VERSION_PY_VERSION=$(grep -Po '(?<=^VERSION = ")[^"]*' version.py)
+
+          # Compare the two versions
+          if [ "$PYPROJECT_VERSION" != "$VERSION_PY_VERSION" ]; then
+            echo "langchain-core versions in pyproject.toml and version.py do not match!"
+            echo "pyproject.toml version: $PYPROJECT_VERSION"
+            echo "version.py version: $VERSION_PY_VERSION"
+            exit 1
+          else
+            echo "Versions match: $PYPROJECT_VERSION"
+          fi

--- a/.github/workflows/check_core_versions.yml
+++ b/.github/workflows/check_core_versions.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Check version equality
         run: |
-          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
-          VERSION_PY_VERSION=$(grep -Po '(?<=^VERSION = ")[^"]*' version.py)
+          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' libs/core/pyproject.toml)
+          VERSION_PY_VERSION=$(grep -Po '(?<=^VERSION = ")[^"]*' libs/core/langchain_core/version.py)
 
           # Compare the two versions
           if [ "$PYPROJECT_VERSION" != "$VERSION_PY_VERSION" ]; then

--- a/libs/core/langchain_core/__init__.py
+++ b/libs/core/langchain_core/__init__.py
@@ -8,18 +8,13 @@ No third-party integrations are defined here. The dependencies are kept purposef
 very lightweight.
 """
 
-from importlib import metadata
-
 from langchain_core._api import (
     surface_langchain_beta_warnings,
     surface_langchain_deprecation_warnings,
 )
+from langchain_core.version import VERSION
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
+__version__ = VERSION
 
 surface_langchain_deprecation_warnings()
 surface_langchain_beta_warnings()

--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,0 +1,3 @@
+"""langchain-core version information and utilities."""
+
+VERSION = "0.3.51"

--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """langchain-core version information and utilities."""
 
-VERSION = "0.3.50"
+VERSION = "0.3.51"

--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """langchain-core version information and utilities."""
 
-VERSION = "0.3.51"
+VERSION = "0.3.50"


### PR DESCRIPTION
This PR aims to reduce import time of `langchain-core` tools by removing the `importlib.metadata` import previously used in `__init__.py`. This is the first in a sequence of PRs to reduce import time delays for `langchain-core` features and structures 🚀.

Because we're now hard coding the version, we need to make sure `version.py` and `pyproject.toml` stay in sync, so I've added a new CI job that runs whenever either of those files are modified. [This run](https://github.com/langchain-ai/langchain/actions/runs/14358012706/job/40251952044?pr=30744) demonstrates the failure that occurs whenever the version gets out of sync (thus blocking a PR).

Before, note the ~15% of time spent on the `importlib.metadata` /related imports

<img width="1081" alt="Screenshot 2025-04-09 at 9 06 15 AM" src="https://github.com/user-attachments/assets/59f405ec-ee8d-4473-89ff-45dea5befa31" />

After (note, lack of `importlib.metadata` time sink):

<img width="1245" alt="Screenshot 2025-04-09 at 9 01 23 AM" src="https://github.com/user-attachments/assets/9c32e77c-27ce-485e-9b88-e365193ed58d" />
