### PR TITLE
dosc: Fix typo in get_separators_for_language method section

### DIFF
--- a/docs/docs/how_to/code_splitter.ipynb
+++ b/docs/docs/how_to/code_splitter.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "To view the list of separators for a given language, pass a value from this enum into\n",
     "```python\n",
-    "RecursiveCharacterTextSplitter.get_separators_for_language`\n",
+    "RecursiveCharacterTextSplitter.get_separators_for_language\n",
     "```\n",
     "\n",
     "To instantiate a splitter that is tailored for a specific language, pass a value from the enum into\n",


### PR DESCRIPTION
Fix typo