### PR TITLE
[ci]: Quick `codspeed.yml` tweaks to enable comparisons with `master`

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,7 +1,12 @@
 name: CodSpeed
 
 on:
+  push:
+    branches:
+        - master
   pull_request:
+    paths:
+      - 'libs/core/**'
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:


### PR DESCRIPTION
* Only run codspeed logic when `libs/core` is changed (for now, we'll want to add other benchmarks later
* Also run on `master` so that we can get a reference :)