### PR TITLE
docs: update clickhouse version in notebook example

### DIFF
--- a/docs/docs/integrations/vectorstores/clickhouse.ipynb
+++ b/docs/docs/integrations/vectorstores/clickhouse.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! docker run -d -p 8123:8123 -p9000:9000 --name langchain-clickhouse-server --ulimit nofile=262144:262144 clickhouse/clickhouse-server:23.4.2.11"
+    "! docker run -d -p 8123:8123 -p9000:9000 --name langchain-clickhouse-server --ulimit nofile=262144:262144 clickhouse/clickhouse-server:24.7.6.8"
    ]
   },
   {


### PR DESCRIPTION
update clickhouse docker version tag in notebook example to avoid compatibility issues with clickhouse-connect.