### PR TITLE
docs: Update ordering of cloudflare integration examples in providers page

### DIFF
--- a/docs/docs/integrations/providers/cloudflare.mdx
+++ b/docs/docs/integrations/providers/cloudflare.mdx
@@ -8,20 +8,12 @@
 > learning models, on the `Cloudflare` network, from your code via REST API.
 
 
-## LLMs
-
-See [installation instructions and usage example](/docs/integrations/llms/cloudflare_workersai).
-
-```python
-from langchain_community.llms.cloudflare_workersai import CloudflareWorkersAI
-```
-
 ## ChatModels
 
 See [installation instructions and usage example](/docs/integrations/chat/cloudflare_workersai).
 
 ```python
-from langchain_cloudflare.chat_models import ChatCloudflareWorkersAI
+from langchain_cloudflare import ChatCloudflareWorkersAI
 ```
 
 ## VectorStore
@@ -29,7 +21,7 @@ from langchain_cloudflare.chat_models import ChatCloudflareWorkersAI
 See [installation instructions and usage example](/docs/integrations/vectorstores/cloudflare_vectorize).
 
 ```python
-from langchain_cloudflare.vectorstores import CloudflareVectorize
+from langchain_cloudflare import CloudflareVectorize
 ```
 
 ## Embeddings
@@ -37,5 +29,13 @@ from langchain_cloudflare.vectorstores import CloudflareVectorize
 See [installation instructions and usage example](/docs/integrations/text_embedding/cloudflare_workersai).
 
 ```python
-from langchain_cloudflare.embeddings import CloudflareWorkersAIEmbeddings
+from langchain_cloudflare import CloudflareWorkersAIEmbeddings
+```
+
+## LLMs
+
+See [installation instructions and usage example](/docs/integrations/llms/cloudflare_workersai).
+
+```python
+from langchain_community.llms.cloudflare_workersai import CloudflareWorkersAI
 ```


### PR DESCRIPTION
Updated the ordering of cloudflare integrations and updated import examples. Follow up from https://github.com/langchain-ai/langchain/pull/30749

