### PR TITLE
[performance]: Use dynamic versioning with `pdm` to avoid `importlib.metadata` import

### DIFF
--- a/libs/core/langchain_core/__init__.py
+++ b/libs/core/langchain_core/__init__.py
@@ -8,18 +8,12 @@ No third-party integrations are defined here. The dependencies are kept purposef
 very lightweight.
 """
 
-from importlib import metadata
-
 from langchain_core._api import (
     surface_langchain_beta_warnings,
     surface_langchain_deprecation_warnings,
 )
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
+__version__ = "0.3.51"
 
 surface_langchain_deprecation_warnings()
 surface_langchain_beta_warnings()

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -17,9 +17,9 @@ dependencies = [
     "pydantic<3.0.0,>=2.7.4; python_full_version >= \"3.12.4\"",
 ]
 name = "langchain-core"
-version = "0.3.51"
 description = "Building applications with LLMs through composability"
 readme = "README.md"
+dynamic = ['version']
 
 [project.urls]
 "Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/core"
@@ -62,10 +62,13 @@ test = [
 ]
 test_integration = []
 
+[tool.pdm.version]
+source = "file"
+path = "langchain_core/__init__.py"
+
 [tool.uv.sources]
 langchain-tests = { path = "../standard-tests" }
 langchain-text-splitters = { path = "../text-splitters" }
-
 
 [tool.mypy]
 exclude = [ "notebooks", "examples", "example_data", "langchain_core/pydantic", "tests/unit_tests/utils/test_function_calling.py",]

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -938,7 +938,6 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.51"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Alternative to https://github.com/langchain-ai/langchain/pull/30744, let's see what the benchmarks think :)

Removes the need for the unnecessary `importlib.metadata` import slowing basically all of our `langchain-core` imports down. Surprised we're not seeing more benchmark movement here honestly - this should impact all of the core imports (as seen on `tuna` flamegraphs). Basically, we're dropping ~.5 seconds on import time.

Before:

<img width="1218" alt="Screenshot 2025-04-10 at 1 16 29 PM" src="https://github.com/user-attachments/assets/3a0e8f32-fe8f-441b-a50b-ed522bd1ee12" />

After:

<img width="1213" alt="Screenshot 2025-04-10 at 1 17 14 PM" src="https://github.com/user-attachments/assets/a499ea39-43b0-4c9d-8591-571aa0c5d2a6" />