### PR TITLE
wip: tinkering with codspeed settings

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   codspeed:
     name: Run benchmarks
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-benchmarks'))
-    runs-on: codspeed-macro
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-codspeed-benchmarks'))
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -6,6 +6,8 @@ on:
         - master
   pull_request:
     paths:
+      # right now, we only have core benchmarks, but in the future,
+      # we'd like to have benchmarks for partners and langchain
       - 'libs/core/**'
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.

--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -65,7 +65,7 @@ spell_fix:
 	uv run --all-groups codespell --toml pyproject.toml -w
 
 benchmark:
-	uv run pytest tests/benchmarks --codspeed
+	uv run pytest tests/benchmarks -m local_benchmark
 
 ######################
 # HELP

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -116,8 +116,18 @@ pydocstyle.ignore-var-parameters = true
 omit = [ "tests/*",]
 
 [tool.pytest.ini_options]
-addopts = "--snapshot-warn-unused --strict-markers --strict-config --durations=5"
-markers = [ "requires: mark tests as requiring a specific library", "compile: mark placeholder test used to compile integration tests without running them", ]
+addopts = [
+    "--snapshot-warn-unused",
+    "--strict-markers",
+    "--strict-config",
+    "--durations=5",
+    "-m", "not local_benchmark",
+]
+markers = [
+    "requires: mark tests as requiring a specific library", 
+    "compile: mark placeholder test used to compile integration tests without running them", 
+    "local_benchmark: mark benchmark as solely for local runs",
+]
 asyncio_mode = "auto"
 filterwarnings = [ "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning",]
 asyncio_default_fixture_loop_scope = "function"

--- a/libs/core/tests/benchmarks/test_async_callbacks.py
+++ b/libs/core/tests/benchmarks/test_async_callbacks.py
@@ -46,7 +46,7 @@ class MyCustomAsyncHandler(AsyncCallbackHandler):
 
 @pytest.mark.benchmark
 async def test_async_callbacks(benchmark: BenchmarkFixture) -> None:
-    infinite_cycle = cycle([AIMessage(content=" ".join(["hello", "goodbye"] * 1000))])
+    infinite_cycle = cycle([AIMessage(content=" ".join(["hello", "goodbye"] * 10))])
     model = GenericFakeChatModel(messages=infinite_cycle)
 
     @benchmark

--- a/libs/core/tests/benchmarks/test_imports.py
+++ b/libs/core/tests/benchmarks/test_imports.py
@@ -52,3 +52,10 @@ def test_import_time(benchmark: BenchmarkFixture, import_path: str) -> None:
     @benchmark
     def import_in_subprocess() -> None:
         subprocess.run([sys.executable, "-c", import_path], check=False)
+
+
+@pytest.mark.benchmark
+def test_import_no_process(benchmark) -> None:
+    @benchmark
+    def import_() -> None:
+        from langchain_core.messages import HumanMessage

--- a/libs/core/tests/benchmarks/test_imports.py
+++ b/libs/core/tests/benchmarks/test_imports.py
@@ -1,3 +1,17 @@
+"""
+Benchmarking import times for various langchain-core modules.
+
+Benchmarking import times is a bit tricky - in order to create reproducible results
+across runs, we need to avoid utilizing Python's import / modules cache.
+Thus, we run the import in a subprocess.
+
+At the moment, CodSpeed only supports [wall time](https://docs.codspeed.io/instruments/walltime/)
+metrics for this benchmark (not the standard trace generation, etc).
+
+Thus, we've temporarily marked this as a local only benchmark, though hopefully that
+changes in the short term.
+"""
+
 import subprocess
 import sys
 
@@ -5,6 +19,7 @@ import pytest
 from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore[import-untyped]
 
 
+@pytest.mark.local_benchmark
 @pytest.mark.parametrize(
     "import_path",
     [
@@ -52,10 +67,3 @@ def test_import_time(benchmark: BenchmarkFixture, import_path: str) -> None:
     @benchmark
     def import_in_subprocess() -> None:
         subprocess.run([sys.executable, "-c", import_path], check=False)
-
-
-@pytest.mark.benchmark
-def test_import_no_process(benchmark) -> None:
-    @benchmark
-    def import_() -> None:
-        from langchain_core.messages import HumanMessage


### PR DESCRIPTION
1. Fix label logic so that `codspeed` runs when `run-codspeed-benchmarks` is applied
2. Moved imports benchmarks to just run locally until we fix the walltime issue with invoking subprocesses (added a `local_benchmark` `pytest` marker, in case other folks want to use, which is disabled by default when `make benchmark` is run
3. Accelerated async callbacks benchmark so that it doesn't consume too much CI time

In the future, I think we should definitely add benchmarks for `langchain` and `partners`, at which point it will make sense to modify the `codspeed.yml` file to run these tests as well. We might also want different groups for benchmarks so that we can run based on relevant file changes. Not within the scope of this PR, though.