### PR TITLE
perplexity[patch]: Fix #30767: Handle missing citations attribute in ChatPerplexity

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -375,8 +375,8 @@ class ChatPerplexity(BaseChatModel):
         else:
             usage_metadata = None
 
-        additional_kwargs = {"citations": response.citations}
-        for attr in ["images", "related_questions"]:
+        additional_kwargs = {}
+        for attr in ["citations", "images", "related_questions"]:
             if hasattr(response, attr):
                 additional_kwargs[attr] = getattr(response, attr)
 


### PR DESCRIPTION
This PR fixes an issue where ChatPerplexity would raise an AttributeError when the citations attribute was missing from the model response (e.g., when using offline models like r1-1776).

The fix checks for the presence of citations, images, and related_questions before attempting to access them, avoiding crashes in models that don't provide these fields.

Tested locally with models that omit citations, and the fix works as expected.