### PR TITLE
Tinkering with CodSpeed CI settings

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   codspeed:
     name: Run benchmarks
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-benchmarks'))
-    runs-on: codspeed-macro
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-codspeed-benchmarks'))
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -41,3 +41,4 @@ jobs:
           run: |
             cd libs/core
             uv run --no-sync pytest ./tests/benchmarks --codspeed
+          mode: walltime

--- a/libs/core/tests/benchmarks/test_async_callbacks.py
+++ b/libs/core/tests/benchmarks/test_async_callbacks.py
@@ -46,7 +46,7 @@ class MyCustomAsyncHandler(AsyncCallbackHandler):
 
 @pytest.mark.benchmark
 async def test_async_callbacks_in_sync(benchmark: BenchmarkFixture) -> None:
-    infinite_cycle = cycle([AIMessage(content=" ".join(["hello", "goodbye"] * 500))])
+    infinite_cycle = cycle([AIMessage(content=" ".join(["hello", "goodbye"] * 5))])
     model = GenericFakeChatModel(messages=infinite_cycle)
 
     @benchmark  # type: ignore[misc]


### PR DESCRIPTION
Fix CI to trigger benchmarks on `run-codspeed-benchmarks` label addition

Reduce scope of async benchmark to save time on CI

Waiting to merge this PR until we figure out how to use walltime on local runners.