### PR TITLE
community: Strip URLs from sitemap.

### DIFF
--- a/libs/community/langchain_community/document_loaders/sitemap.py
+++ b/libs/community/langchain_community/document_loaders/sitemap.py
@@ -185,7 +185,7 @@ class SitemapLoader(WebBaseLoader):
 
             els.append(
                 {
-                    tag: prop.text
+                    tag: prop.text.strip()
                     for tag in ["loc", "lastmod", "changefreq", "priority"]
                     if (prop := url.find(tag))
                 }


### PR DESCRIPTION
Fixes #30829

    - **Description:** Simply strips the loc value when building the element. 
    - **Issue:** Fixes #30829
