### PR TITLE
infra: run old standard-tests on core releases

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -395,8 +395,11 @@ jobs:
 
           # Checkout the latest package files
           rm -rf $GITHUB_WORKSPACE/libs/partners/${{ matrix.partner }}/*
-          cd $GITHUB_WORKSPACE/libs/partners/${{ matrix.partner }}
-          git checkout "$LATEST_PACKAGE_TAG" -- .
+          rm -rf $GITHUB_WORKSPACE/libs/standard-tests/*
+          cd $GITHUB_WORKSPACE/libs/
+          git checkout "$LATEST_PACKAGE_TAG" -- standard-tests/
+          git checkout "$LATEST_PACKAGE_TAG" -- partners/${{ matrix.partner }}/
+          cd partners/${{ matrix.partner }}
 
           # Print as a sanity check
           echo "Version number from pyproject.toml: "


### PR DESCRIPTION
On core releases, we check out the latest published package for langchain-openai and langchain-anthropic and run their tests against the candidate version of langchain-core.

Because these packages have a local install of langchain-tests, we also need to check out the previous version of langchain-tests.