### PR TITLE
langchain: return attachments in _get_response

### DIFF
--- a/libs/langchain/langchain/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain/agents/openai_assistant/base.py
@@ -584,6 +584,9 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
             answer: Any = [
                 msg_content for msg in new_messages for msg_content in msg.content
             ]
+            attachments = [
+                attachment for msg in new_messages for attachment in msg.attachments
+            ]
             if all(
                 (
                     isinstance(content, openai.types.beta.threads.TextContentBlock)
@@ -601,6 +604,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     "output": answer,
                     "thread_id": run.thread_id,
                     "run_id": run.id,
+                    "attachments": attachments,
                 },
                 log="",
                 run_id=run.id,


### PR DESCRIPTION
This is a PR to return the message attachments in _get_response, as when files are generated these attachments are not returned thus generated files cannot be retrieved

Fixes issue: https://github.com/langchain-ai/langchain/issues/30851
