### PR TITLE
core[fix]: Fix `__dir__` in `__init__.py` for `output_parsers` module

### DIFF
--- a/libs/core/langchain_core/output_parsers/__init__.py
+++ b/libs/core/langchain_core/output_parsers/__init__.py
@@ -99,4 +99,4 @@ def __getattr__(attr_name: str) -> object:
 
 
 def __dir__() -> list[str]:
-    return list(__all__)
+    return __all__


### PR DESCRIPTION
We have a `list.py` file which causes a namespace conflict with `list` from stdlib, unfortunately.

`__all__` is already a list, so no need to coerce.