### PR TITLE
langchain: infer Perplexity provider for sonar model prefix

### DIFF
--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -133,6 +133,7 @@ def init_chat_model(
             - 'mistral...'                      -> 'mistralai'
             - 'deepseek...'                     -> 'deepseek'
             - 'grok...'                         -> 'xai'
+            - 'sonar...'                        -> 'perplexity'
         configurable_fields: Which model parameters are
             configurable:
 
@@ -504,6 +505,8 @@ def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
         return "deepseek"
     elif model_name.startswith("grok"):
         return "xai"
+    elif model_name.startswith("sonar"):
+        return "perplexity"
     else:
         return None
 


### PR DESCRIPTION
**Description:** This PR adds provider inference logic to `init_chat_model` for Perplexity models that use the "sonar..." prefix (`sonar`, `sonar-pro`, `sonar-reasoning`, `sonar-reasoning-pro` or `sonar-deep-research`).

This allows users to initialize these models by simply passing the model name, without needing to explicitly set `model_provider="perplexity"`.

The docstring for `init_chat_model` has also been updated to reflect this new inference rule.