### PR TITLE
core: Raise `AttributeError` (not `ModuleNotFoundError`) from`__getattr__`

### DIFF
--- a/libs/core/langchain_core/_api/__init__.py
+++ b/libs/core/langchain_core/_api/__init__.py
@@ -61,9 +61,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/_api/__init__.py
+++ b/libs/core/langchain_core/_api/__init__.py
@@ -64,12 +64,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -134,12 +134,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/callbacks/__init__.py
+++ b/libs/core/langchain_core/callbacks/__init__.py
@@ -131,9 +131,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/document_loaders/__init__.py
+++ b/libs/core/langchain_core/document_loaders/__init__.py
@@ -31,9 +31,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/document_loaders/__init__.py
+++ b/libs/core/langchain_core/document_loaders/__init__.py
@@ -34,12 +34,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/documents/__init__.py
+++ b/libs/core/langchain_core/documents/__init__.py
@@ -29,12 +29,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/documents/__init__.py
+++ b/libs/core/langchain_core/documents/__init__.py
@@ -26,9 +26,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/embeddings/__init__.py
+++ b/libs/core/langchain_core/embeddings/__init__.py
@@ -26,12 +26,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/embeddings/__init__.py
+++ b/libs/core/langchain_core/embeddings/__init__.py
@@ -23,9 +23,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/example_selectors/__init__.py
+++ b/libs/core/langchain_core/example_selectors/__init__.py
@@ -42,12 +42,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/example_selectors/__init__.py
+++ b/libs/core/langchain_core/example_selectors/__init__.py
@@ -39,9 +39,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/indexing/__init__.py
+++ b/libs/core/langchain_core/indexing/__init__.py
@@ -48,12 +48,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/indexing/__init__.py
+++ b/libs/core/langchain_core/indexing/__init__.py
@@ -45,9 +45,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/language_models/__init__.py
+++ b/libs/core/langchain_core/language_models/__init__.py
@@ -109,9 +109,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/language_models/__init__.py
+++ b/libs/core/langchain_core/language_models/__init__.py
@@ -112,12 +112,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/load/__init__.py
+++ b/libs/core/langchain_core/load/__init__.py
@@ -31,12 +31,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/load/__init__.py
+++ b/libs/core/langchain_core/load/__init__.py
@@ -28,9 +28,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -142,12 +142,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -139,9 +139,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/output_parsers/__init__.py
+++ b/libs/core/langchain_core/output_parsers/__init__.py
@@ -90,9 +90,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/output_parsers/__init__.py
+++ b/libs/core/langchain_core/output_parsers/__init__.py
@@ -93,12 +93,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/outputs/__init__.py
+++ b/libs/core/langchain_core/outputs/__init__.py
@@ -62,12 +62,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/outputs/__init__.py
+++ b/libs/core/langchain_core/outputs/__init__.py
@@ -59,9 +59,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/prompts/__init__.py
+++ b/libs/core/langchain_core/prompts/__init__.py
@@ -117,12 +117,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/prompts/__init__.py
+++ b/libs/core/langchain_core/prompts/__init__.py
@@ -114,9 +114,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -130,12 +130,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -127,9 +127,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/tools/__init__.py
+++ b/libs/core/langchain_core/tools/__init__.py
@@ -103,12 +103,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/tools/__init__.py
+++ b/libs/core/langchain_core/tools/__init__.py
@@ -100,9 +100,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/tracers/__init__.py
+++ b/libs/core/langchain_core/tracers/__init__.py
@@ -53,12 +53,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/tracers/__init__.py
+++ b/libs/core/langchain_core/tracers/__init__.py
@@ -50,9 +50,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/utils/__init__.py
+++ b/libs/core/langchain_core/utils/__init__.py
@@ -99,9 +99,15 @@ def __getattr__(attr_name: str) -> object:
     module_name = _dynamic_imports.get(attr_name)
     package = __spec__.parent
     if module_name == "__module__" or module_name is None:
-        result = import_module(f".{attr_name}", package=package)
+        try:
+            result = import_module(f".{attr_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
     else:
-        module = import_module(f".{module_name}", package=package)
+        try:
+            module = import_module(f".{module_name}", package=package)
+        except ModuleNotFoundError:
+            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result

--- a/libs/core/langchain_core/utils/__init__.py
+++ b/libs/core/langchain_core/utils/__init__.py
@@ -102,12 +102,14 @@ def __getattr__(attr_name: str) -> object:
         try:
             result = import_module(f".{attr_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '.' has no attribute {attr_name!r}")
+            message = f"module '.' has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
     else:
         try:
             module = import_module(f".{module_name}", package=package)
         except ModuleNotFoundError:
-            raise AttributeError(f"module '{module_name}' has no attribute {attr_name!r}")
+            message = f"module {module_name!r} has no attribute {attr_name!r}"
+            raise AttributeError(message) from None
         result = getattr(module, attr_name)
     globals()[attr_name] = result
     return result


### PR DESCRIPTION
- **Description:** Fixes downstream failures when using `self.assertWarns` caused by violation of `__getattr__` protocol in langchain
- **Issue:** https://github.com/langchain-ai/langchain/pull/30769
- **Dependencies:** None
