### PR TITLE
docs: replace initialize_agent with create_react_agent in edenai_tools.ipynb (part of #29277)

### DIFF
--- a/docs/docs/integrations/tools/edenai_tools.ipynb
+++ b/docs/docs/integrations/tools/edenai_tools.ipynb
@@ -74,8 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.agents import AgentType, initialize_agent\n",
     "from langchain_community.llms import EdenAI\n",
+    "from langgraph.prebuilt import create_react_agent\n",
     "\n",
     "llm = EdenAI(\n",
     "    feature=\"text\", provider=\"openai\", params={\"temperature\": 0.2, \"max_tokens\": 250}\n",
@@ -90,12 +90,10 @@
     "    EdenAiParsingIDTool(providers=[\"amazon\", \"klippa\"], language=\"en\"),\n",
     "    EdenAiParsingInvoiceTool(providers=[\"amazon\", \"google\"], language=\"en\"),\n",
     "]\n",
-    "agent_chain = initialize_agent(\n",
-    "    tools,\n",
-    "    llm,\n",
-    "    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,\n",
-    "    verbose=True,\n",
-    "    return_intermediate_steps=True,\n",
+    "agent_chain = create_react_agent(\n",
+    "    model=llm,\n",
+    "    tools=tools,\n",
+    "    debug=True\n",
     ")"
    ]
   },


### PR DESCRIPTION
## Description

This PR updates the `edenai_tools.ipynb` notebook to remove the deprecated `initialize_agent` method and replaces it with `langgraph.prebuilt.create_react_agent`.

- Removed `return_intermediate_steps=True` (not supported in LangGraph)

## Issue

Closes [#29277](https://github.com/langchain-ai/langchain/issues/29277)

## Dependencies

N/A

## Twitter Handle

N/A