### PR TITLE
docs: dynamic copyright year in API ref

### DIFF
--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -11,8 +11,8 @@
 import json
 import os
 import sys
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 import toml
 from docutils import nodes

--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from datetime import datetime
 
 import toml
 from docutils import nodes
@@ -104,7 +105,7 @@ def skip_private_members(app, what, name, obj, skip, options):
 # -- Project information -----------------------------------------------------
 
 project = "🦜🔗 LangChain"
-copyright = "2023, LangChain Inc"
+copyright = f"{datetime.now().year}, LangChain Inc"
 author = "LangChain, Inc"
 
 html_favicon = "_static/img/brand/favicon.png"


### PR DESCRIPTION
- [x] **PR title:**  
`docs: make footer year dynamic in API reference docs`

- [x] **PR message:**

  - **Description:**  
  Update `docs/api_reference/conf.py` to make the copyright year dynamic  
  (on [https://python.langchain.com/api_reference/](https://python.langchain.com/api_reference/)).