### PR TITLE
docs: replace deprecated initialize_agent with create_react_agent in NASA toolkit example

### DIFF
--- a/docs/docs/integrations/tools/nasa.ipynb
+++ b/docs/docs/integrations/tools/nasa.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.agents import AgentType, initialize_agent\n",
+    "from langgraph.prebuilt import create_react_agent\n",
     "from langchain_community.agent_toolkits.nasa.toolkit import NasaToolkit\n",
     "from langchain_community.utilities.nasa import NasaAPIWrapper\n",
     "from langchain_openai import OpenAI\n",
@@ -47,9 +47,10 @@
     "llm = OpenAI(temperature=0, openai_api_key=\"\")\n",
     "nasa = NasaAPIWrapper()\n",
     "toolkit = NasaToolkit.from_nasa_api_wrapper(nasa)\n",
-    "agent = initialize_agent(\n",
-    "    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True\n",
-    ")"
+    "agent = create_react_agent(toolkit.get_tools(), llm)\n",
+    "\n",
+    "response = agent.invoke({\"input\": \"Show me the latest NASA news.\"})\n",
+    "print(response)"
    ]
   },
   {


### PR DESCRIPTION
**Description:**
This PR updates the NASA toolkit agent example in the documentation by replacing the deprecated `initialize_agent` with the recommended `create_react_agent` method from `langgraph.prebuilt`. 

**Issue:**
Part of #29277

**Dependencies:**
None


