### PR TITLE
rfc: support image generation in ChatOpenAI via client.images

### DIFF
--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 requires-python = "<4.0,>=3.9"
 dependencies = [
     "langchain-core<1.0.0,>=0.3.53",
-    "openai<2.0.0,>=1.68.2",
+    "openai<2.0.0,>=1.76.0",
     "tiktoken<1,>=0.7",
 ]
 name = "langchain-openai"

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -463,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.53"
+version = "0.3.55"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -571,7 +571,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", editable = "../../core" },
-    { name = "openai", specifier = ">=1.68.2,<2.0.0" },
+    { name = "openai", specifier = ">=1.76.0,<2.0.0" },
     { name = "tiktoken", specifier = ">=0.7,<1" },
 ]
 
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.68.2"
+version = "1.76.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -841,9 +841,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/6b/6b002d5d38794645437ae3ddb42083059d556558493408d39a0fcea608bc/openai-1.68.2.tar.gz", hash = "sha256:b720f0a95a1dbe1429c0d9bb62096a0d98057bcda82516f6e8af10284bdd5b19", size = 413429 }
+sdist = { url = "https://files.pythonhosted.org/packages/84/51/817969ec969b73d8ddad085670ecd8a45ef1af1811d8c3b8a177ca4d1309/openai-1.76.0.tar.gz", hash = "sha256:fd2bfaf4608f48102d6b74f9e11c5ecaa058b60dad9c36e409c12477dfd91fb2", size = 434660 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/34/cebce15f64eb4a3d609a83ac3568d43005cc9a1cba9d7fde5590fd415423/openai-1.68.2-py3-none-any.whl", hash = "sha256:24484cb5c9a33b58576fdc5acf0e5f92603024a4e39d0b99793dfa1eb14c2b36", size = 606073 },
+    { url = "https://files.pythonhosted.org/packages/59/aa/84e02ab500ca871eb8f62784426963a1c7c17a72fea3c7f268af4bbaafa5/openai-1.76.0-py3-none-any.whl", hash = "sha256:a712b50e78cf78e6d7b2a8f69c4978243517c2c36999756673e07a14ce37dc0a", size = 661201 },
 ]
 
 [[package]]


### PR DESCRIPTION
OpenAI released an image generation model `gpt-image-1` today. See [docs](https://platform.openai.com/docs/guides/image-generation?image-generation-model=gpt-image-1).

It features two methods:
- `client.images.generate` generates an image from a string prompt
- `client.images.edit` generates an image from a string prompt and a list of images

Here we hack this into a chat model interface, so that you can edit images in a conversational setting.

Example:
```python
from langchain.chat_models import init_chat_model

llm = init_chat_model("openai:gpt-image-1")

message_1 = "Make an image of a giraffe."
response_1 = llm.invoke([message_1])

# response_1 is:
# AIMessage(
#     content=[
#         {
#             "type": "image",
#             "source_type": "base64",
#             "data": "<base64 image data>",
#             "mime_type": "image/png",
#         },
#     ],
#     usage_metadata={"input_tokens": 14, "output_tokens": 6240, ...},
# )

message_2 = "Invert the colors in the image."
response_2 = llm.invoke([message_1, response_1, message_2])

# response_2 formatted similarly
```

Can inspect images locally with
```python
import base64

with open("/path/to/image.png", "wb") as f:
    f.write(base64.b64decode(response_1.content[0]["data"]))
```

Pros: maybe nice to support in a standard chat model interface. Easy to incorporate into a chatbot (e.g., using LangGraph persistence or similar).

Cons: abuse of `client.images`, will likely run into nonsensical usage patterns.