### PR TITLE
openai: fix streaming reasoning without summaries

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3411,14 +3411,16 @@ def _convert_responses_chunk_to_generation_chunk(
         )
     elif chunk.type == "response.refusal.done":
         additional_kwargs["refusal"] = chunk.refusal
+    elif chunk.type == "response.output_item.added" and chunk.item.type == "reasoning":
+        additional_kwargs["reasoning"] = chunk.item.model_dump(
+            exclude_none=True, mode="json"
+        )
     elif chunk.type == "response.reasoning_summary_part.added":
         additional_kwargs["reasoning"] = {
-            "type": "reasoning",
-            "id": chunk.item_id,
             # langchain-core uses the `index` key to aggregate text blocks.
             "summary": [
                 {"index": chunk.summary_index, "type": "summary_text", "text": ""}
-            ],
+            ]
         }
     elif chunk.type == "response.reasoning_summary_text.delta":
         additional_kwargs["reasoning"] = {


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/30909: need to retain "empty" reasoning output when streaming, e.g.,
```python
{'id': 'rs_...', 'summary': [], 'type': 'reasoning'}
```
Tested by existing integration tests, which are currently failing.