### PR TITLE
core[patch]: add model_kwargs to BaseChatModel

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -403,6 +403,40 @@ async def test_disable_streaming_no_streaming_model_async(
         break
 
 
+def test_model_kwargs() -> None:
+    llm = FakeListChatModel(
+        responses=["a", "b", "c"],
+        sleep=0.1,
+        disable_streaming=False,
+        model_kwargs={"foo": "bar"},
+    )
+    assert llm.responses == ["a", "b", "c"]
+    assert llm.sleep == 0.1
+    assert llm.disable_streaming is False
+    assert llm.model_kwargs == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = FakeListChatModel(
+            responses=["a", "b", "c"],
+            sleep=0.1,
+            disable_streaming=False,
+            foo="bar",  # type: ignore[call-arg]
+        )
+    assert llm.responses == ["a", "b", "c"]
+    assert llm.sleep == 0.1
+    assert llm.disable_streaming is False
+    assert llm.model_kwargs == {"foo": "bar"}
+
+    # Backward compatibility
+    with pytest.warns(match="should be specified explicitly"):
+        llm = FakeListChatModel(  # type: ignore[call-arg]
+            model_kwargs={"foo": "bar", "responses": ["a", "b", "c"], "sleep": 0.1},
+        )
+    assert llm.responses == ["a", "b", "c"]
+    assert llm.sleep == 0.1
+    assert llm.model_kwargs == {"foo": "bar"}
+
+
 class FakeChatModelStartTracer(FakeTracer):
     def __init__(self) -> None:
         super().__init__()

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -97,7 +97,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(responses=['foo, bar'])",
+          "repr": "FakeListChatModel(model_kwargs={}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -227,7 +227,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(responses=['baz, qux'])",
+          "repr": "FakeListChatModel(model_kwargs={}, responses=['baz, qux'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -346,7 +346,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(responses=['foo, bar'])",
+          "repr": "FakeListChatModel(model_kwargs={}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         },
         {
@@ -457,7 +457,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(responses=['baz, qux'])",
+          "repr": "FakeListChatModel(model_kwargs={}, responses=['baz, qux'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -1009,7 +1009,7 @@
 # name: test_prompt_with_chat_model
   '''
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
-  | FakeListChatModel(responses=['foo'])
+  | FakeListChatModel(model_kwargs={}, responses=['foo'])
   '''
 # ---
 # name: test_prompt_with_chat_model.1
@@ -1109,7 +1109,7 @@
           "fake_chat_models",
           "FakeListChatModel"
         ],
-        "repr": "FakeListChatModel(responses=['foo'])",
+        "repr": "FakeListChatModel(model_kwargs={}, responses=['foo'])",
         "name": "FakeListChatModel"
       }
     },
@@ -1220,7 +1220,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(responses=['foo, bar'])",
+          "repr": "FakeListChatModel(model_kwargs={}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -1249,7 +1249,7 @@
 # name: test_prompt_with_chat_model_async
   '''
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
-  | FakeListChatModel(responses=['foo'])
+  | FakeListChatModel(model_kwargs={}, responses=['foo'])
   '''
 # ---
 # name: test_prompt_with_chat_model_async.1
@@ -1349,7 +1349,7 @@
           "fake_chat_models",
           "FakeListChatModel"
         ],
-        "repr": "FakeListChatModel(responses=['foo'])",
+        "repr": "FakeListChatModel(model_kwargs={}, responses=['foo'])",
         "name": "FakeListChatModel"
       }
     },
@@ -13535,7 +13535,7 @@
     just_to_test_lambda: RunnableLambda(...)
   }
   | ChatPromptTemplate(input_variables=['documents', 'question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['documents', 'question'], input_types={}, partial_variables={}, template='Context:\n{documents}\n\nQuestion:\n{question}'), additional_kwargs={})])
-  | FakeListChatModel(responses=['foo, bar'])
+  | FakeListChatModel(model_kwargs={}, responses=['foo, bar'])
   | CommaSeparatedListOutputParser()
   '''
 # ---
@@ -13738,7 +13738,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(responses=['foo, bar'])",
+          "repr": "FakeListChatModel(model_kwargs={}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -13764,7 +13764,7 @@
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
   | RunnableLambda(...)
   | {
-      chat: FakeListChatModel(responses=["i'm a chatbot"]),
+      chat: FakeListChatModel(model_kwargs={}, responses=["i'm a chatbot"]),
       llm: FakeListLLM(responses=["i'm a textbot"])
     }
   '''
@@ -13890,7 +13890,7 @@
                 "fake_chat_models",
                 "FakeListChatModel"
               ],
-              "repr": "FakeListChatModel(responses=[\"i'm a chatbot\"])",
+              "repr": "FakeListChatModel(model_kwargs={}, responses=[\"i'm a chatbot\"])",
               "name": "FakeListChatModel"
             },
             "llm": {
@@ -14045,7 +14045,7 @@
                     "fake_chat_models",
                     "FakeListChatModel"
                   ],
-                  "repr": "FakeListChatModel(responses=[\"i'm a chatbot\"])",
+                  "repr": "FakeListChatModel(model_kwargs={}, responses=[\"i'm a chatbot\"])",
                   "name": "FakeListChatModel"
                 },
                 "kwargs": {


### PR DESCRIPTION
Most existing chat models implement a `model_kwargs` field. On init, fields that aren't recognized (by Pydantic) will be transferred to `model_kwargs`. Chat models then include these params in request payloads

Here we implement this mechanism on BaseChatModel. This just enables all chat models to be initialized with arbitrary params. We don't include the contents of `model_kwargs` in request payloads or otherwise do anything with them.