### PR TITLE
docs: enable milvus in API ref build

### DIFF
--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -85,7 +85,6 @@ packages:
 - name: langchain-milvus
   path: libs/milvus
   repo: langchain-ai/langchain-milvus
-  disabled: true
   downloads: 207750
   downloads_updated_at: '2025-04-22T15:24:39.289813+00:00'
 - name: langchain-mistralai


### PR DESCRIPTION
Reverts langchain-ai/langchain#30996

Should be fixed following https://github.com/langchain-ai/langchain-milvus/pull/68