### PR TITLE
infra: Restore Codespell execution in codespell.yml

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           skip: guide_imports.json,*.ambr,./cookbook/data/imdb_top_1000.csv,*.lock
           ignore_words_list: ${{ steps.extract_ignore_words.outputs.ignore_words_list }}
-          exclude_file: ./.github/workflows/codespell-exclude
+          exclude_file: ./.github/workflows/.codespell-exclude

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -27,9 +27,9 @@ jobs:
           python .github/workflows/extract_ignored_words_list.py
         id: extract_ignore_words
 
-#      - name: Codespell
-#        uses: codespell-project/actions-codespell@v2
-#        with:
-#          skip: guide_imports.json,*.ambr,./cookbook/data/imdb_top_1000.csv,*.lock
-#          ignore_words_list: ${{ steps.extract_ignore_words.outputs.ignore_words_list }}
-#          exclude_file: ./.github/workflows/codespell-exclude
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          skip: guide_imports.json,*.ambr,./cookbook/data/imdb_top_1000.csv,*.lock
+          ignore_words_list: ${{ steps.extract_ignore_words.outputs.ignore_words_list }}
+          exclude_file: ./.github/workflows/codespell-exclude

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -28,7 +28,7 @@ jobs:
         id: extract_ignore_words
 
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@v2.1
         with:
           skip: guide_imports.json,*.ambr,./cookbook/data/imdb_top_1000.csv,*.lock
           ignore_words_list: ${{ steps.extract_ignore_words.outputs.ignore_words_list }}


### PR DESCRIPTION
Reverts https://github.com/langchain-ai/langchain/pull/22097/files#diff-ce84a1b2c9eb4ab3ea22f610cad7111cb9a2f66365c3b24679901376a2a73ab2, otherwise suggest [disabling workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow#disabling-a-workflow) as it doesn't currently provide any checks