### PR TITLE
openai[patch]: fix getting generation info when streaming with json_schema response format on Azure

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -732,7 +732,11 @@ class BaseChatOpenAI(BaseChatModel):
 
         if finish_reason := choice.get("finish_reason"):
             generation_info["finish_reason"] = finish_reason
-            if model_name := chunk.get("model"):
+            if model_name := (
+                chunk.get("model", [])
+                # from beta.chat.completions.stream
+                or chunk.get("chunk", {}).get("model", [])
+            ):
                 generation_info["model_name"] = model_name
             if system_fingerprint := chunk.get("system_fingerprint"):
                 generation_info["system_fingerprint"] = system_fingerprint


### PR DESCRIPTION
## Problem

When using Azure's chat completions API, with `json_schema` response format and streaming, the `LLMResult` response passed to callbacks doesn't contain `model_name`, just an empty string. (The support for streaming requests with json_schema response format was added in #29044.) 

The problem can be reproduced with the following minimal example (with env variables as described [here](https://python.langchain.com/docs/integrations/llms/azure_openai/#api-configuration)).

```python
from langchain_core.callbacks.base import BaseCallbackHandler
from langchain_openai import AzureChatOpenAI
from pydantic import BaseModel

class CustomCallbackHandler(BaseCallbackHandler):
    def on_llm_end(self, response, **kwargs):
        model_name = response.generations[0][0].generation_info["model_name"]
        print(f"{model_name=}")

llm = AzureChatOpenAI(
    azure_deployment="gpt-4o-2024-08-06",
    callbacks=[CustomCallbackHandler()],
)

class Answer(BaseModel):
    joke: str

response = llm.stream("Tell me a joke", response_format=Answer)
list(response)
```

**Observed output:**
```
model_name=''
```

**Expected output:**
```
model_name='gpt-4o-2024-08-06'
```

The output is as expected when changing `AzureChatOpenAI` to `ChatOpenAI` (and the corresponding OpenAI endpoint), and also when `function_calling` method for structured outputs is used instead of the default `json_schema`.

Package versions used:
```
langchain=0.3.24
langchain-openai=0.3.14
langchain-community=0.3.23
```

## Solution

This PR fixes the problem.

Similar approach is already used [a couple lines above](https://github.com/jjurm/langchain/blob/7e926520d5ff90f14325583a4088bb37532268d3/libs/partners/openai/langchain_openai/chat_models/base.py#L708-L712).