### PR TITLE
convert agent observation to AIMessage (not HumanMessage)

### DIFF
--- a/libs/core/langchain_core/agents.py
+++ b/libs/core/langchain_core/agents.py
@@ -210,7 +210,7 @@ def _convert_agent_observation_to_messages(
             content = json.dumps(observation, ensure_ascii=False)
         except Exception:
             content = str(observation)
-    return [HumanMessage(content=content)]
+    return [AIMessage(content=content)]
 
 
 def _create_function_message(

--- a/libs/core/langchain_core/agents.py
+++ b/libs/core/langchain_core/agents.py
@@ -33,7 +33,6 @@ from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     FunctionMessage,
-    HumanMessage,
 )
 
 


### PR DESCRIPTION
- [X] **PR title**: "core: fix observation conversion to message"
 
- **Description:** agent observation is converted to HumanMessage instead of AIMessage


