### PR TITLE
Docs: Fix SAP HANA Cloud docs - remove pip output, update vectorstore link, rename provider

### DIFF
--- a/docs/docs/integrations/providers/sap.mdx
+++ b/docs/docs/integrations/providers/sap.mdx
@@ -15,7 +15,7 @@ pip install langchain-hana
 
 ## Vectorstore
 
->[SAP HANA Cloud Vector Engine](https://www.sap.com/events/teched/news-guide/ai.html#article8) is 
+>[SAP HANA Cloud Vector Engine](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-vector-engine-guide/sap-hana-cloud-sap-hana-database-vector-engine-guide) is 
 > a vector store fully integrated into the `SAP HANA Cloud` database.
 
 See a [usage example](/docs/integrations/vectorstores/sap_hanavector).

--- a/docs/docs/integrations/vectorstores/sap_hanavector.ipynb
+++ b/docs/docs/integrations/vectorstores/sap_hanavector.ipynb
@@ -20,19 +20,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install -qU langchain-hana"
    ]
@@ -1425,9 +1417,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lc3",
+   "display_name": "dev311",
    "language": "python",
-   "name": "your_env_name"
+   "name": "dev311"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1439,7 +1431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -646,7 +646,7 @@ packages:
 - name: langchain-hana
   path: .
   repo: SAP/langchain-integration-for-sap-hana-cloud
-  name_title: SAP HANA
+  name_title: SAP HANA Cloud
   provider_page: sap
   downloads: 315
   downloads_updated_at: '2025-04-27T19:45:43.938924+00:00'


### PR DESCRIPTION
This PR includes the following documentation fixes for the SAP HANA Cloud vector store integration:
- Removed stale output from the `%pip install` code cell.
- Replaced an unrelated vectorstore documentation link on the provider overview page.
- Renamed the provider from "SAP HANA" to "SAP HANA Cloud"