### PR TITLE
docs: Fixing typo: "chocalate" -> "chocolate".

### DIFF
--- a/docs/docs/concepts/vectorstores.mdx
+++ b/docs/docs/concepts/vectorstores.mdx
@@ -66,7 +66,7 @@ This API works with a list of [Document](https://python.langchain.com/api_refere
 from langchain_core.documents import Document
 
 document_1 = Document(
-    page_content="I had chocalate chip pancakes and scrambled eggs for breakfast this morning.",
+    page_content="I had chocolate chip pancakes and scrambled eggs for breakfast this morning.",
     metadata={"source": "tweet"},
 )
 

--- a/docs/docs/integrations/vectorstores/astradb.ipynb
+++ b/docs/docs/integrations/vectorstores/astradb.ipynb
@@ -231,7 +231,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/chroma.ipynb
+++ b/docs/docs/integrations/vectorstores/chroma.ipynb
@@ -402,7 +402,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "* I had chocalate chip pancakes and fried eggs for breakfast this morning. [{'source': 'tweet'}]\n"
+      "* I had chocolate chip pancakes and fried eggs for breakfast this morning. [{'source': 'tweet'}]\n"
      ]
     }
    ],

--- a/docs/docs/integrations/vectorstores/clickhouse.ipynb
+++ b/docs/docs/integrations/vectorstores/clickhouse.ipynb
@@ -144,7 +144,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/couchbase.ipynb
+++ b/docs/docs/integrations/vectorstores/couchbase.ipynb
@@ -301,7 +301,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",
@@ -492,7 +492,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "page_content='I had chocalate chip pancakes and scrambled eggs for breakfast this morning.' metadata={'source': 'tweet'}\n"
+      "page_content='I had chocolate chip pancakes and scrambled eggs for breakfast this morning.' metadata={'source': 'tweet'}\n"
      ]
     }
    ],

--- a/docs/docs/integrations/vectorstores/elasticsearch.ipynb
+++ b/docs/docs/integrations/vectorstores/elasticsearch.ipynb
@@ -255,7 +255,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/faiss.ipynb
+++ b/docs/docs/integrations/vectorstores/faiss.ipynb
@@ -150,7 +150,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/kinetica.ipynb
+++ b/docs/docs/integrations/vectorstores/kinetica.ipynb
@@ -138,7 +138,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/mongodb_atlas.ipynb
+++ b/docs/docs/integrations/vectorstores/mongodb_atlas.ipynb
@@ -206,7 +206,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/pinecone.ipynb
+++ b/docs/docs/integrations/vectorstores/pinecone.ipynb
@@ -206,7 +206,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",

--- a/docs/docs/integrations/vectorstores/ydb.ipynb
+++ b/docs/docs/integrations/vectorstores/ydb.ipynb
@@ -156,7 +156,7 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "document_1 = Document(\n",
-    "    page_content=\"I had chocalate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
+    "    page_content=\"I had chocolate chip pancakes and scrambled eggs for breakfast this morning.\",\n",
     "    metadata={\"source\": \"tweet\"},\n",
     ")\n",
     "\n",
@@ -356,7 +356,7 @@
      "output_type": "stream",
      "text": [
       "* [SIM=0.595] The weather forecast for tomorrow is cloudy and overcast, with a high of 62 degrees. [{'source': 'news'}]\n",
-      "* [SIM=0.212] I had chocalate chip pancakes and scrambled eggs for breakfast this morning. [{'source': 'tweet'}]\n",
+      "* [SIM=0.212] I had chocolate chip pancakes and scrambled eggs for breakfast this morning. [{'source': 'tweet'}]\n",
       "* [SIM=0.118] Wow! That was an amazing movie. I can't wait to see it again. [{'source': 'tweet'}]\n"
      ]
     }
@@ -387,7 +387,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "* I had chocalate chip pancakes and scrambled eggs for breakfast this morning. [{'source': 'tweet'}]\n",
+      "* I had chocolate chip pancakes and scrambled eggs for breakfast this morning. [{'source': 'tweet'}]\n",
       "* Wow! That was an amazing movie. I can't wait to see it again. [{'source': 'tweet'}]\n",
       "* Building an exciting new project with LangChain - come check it out! [{'source': 'tweet'}]\n",
       "* LangGraph is the best framework for building stateful, agentic applications! [{'source': 'tweet'}]\n"


### PR DESCRIPTION
Just fixing a typo that was making me anxious: "chocalate" -> "chocolate".