### PR TITLE
core, openai[patch]: prefer provider-assigned IDs when aggregating message chunks

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -58,6 +58,7 @@ from langchain_core.messages import (
     is_data_content_block,
     message_chunk_to_message,
 )
+from langchain_core.messages.ai import _LC_ID_PREFIX
 from langchain_core.outputs import (
     ChatGeneration,
     ChatGenerationChunk,
@@ -493,7 +494,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 input_messages = _normalize_messages(messages)
                 for chunk in self._stream(input_messages, stop=stop, **kwargs):
                     if chunk.message.id is None:
-                        chunk.message.id = f"run-{run_manager.run_id}"
+                        chunk.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}"
                     chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)
                     run_manager.on_llm_new_token(
                         cast("str", chunk.message.content), chunk=chunk
@@ -583,7 +584,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 **kwargs,
             ):
                 if chunk.message.id is None:
-                    chunk.message.id = f"run-{run_manager.run_id}"
+                    chunk.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}"
                 chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)
                 await run_manager.on_llm_new_token(
                     cast("str", chunk.message.content), chunk=chunk
@@ -1001,7 +1002,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)
                 if run_manager:
                     if chunk.message.id is None:
-                        chunk.message.id = f"run-{run_manager.run_id}"
+                        chunk.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}"
                     run_manager.on_llm_new_token(
                         cast("str", chunk.message.content), chunk=chunk
                     )
@@ -1017,7 +1018,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         # Add response metadata to each generation
         for idx, generation in enumerate(result.generations):
             if run_manager and generation.message.id is None:
-                generation.message.id = f"run-{run_manager.run_id}-{idx}"
+                generation.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}-{idx}"
             generation.message.response_metadata = _gen_info_and_msg_metadata(
                 generation
             )
@@ -1073,7 +1074,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)
                 if run_manager:
                     if chunk.message.id is None:
-                        chunk.message.id = f"run-{run_manager.run_id}"
+                        chunk.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}"
                     await run_manager.on_llm_new_token(
                         cast("str", chunk.message.content), chunk=chunk
                     )
@@ -1089,7 +1090,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         # Add response metadata to each generation
         for idx, generation in enumerate(result.generations):
             if run_manager and generation.message.id is None:
-                generation.message.id = f"run-{run_manager.run_id}-{idx}"
+                generation.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}-{idx}"
             generation.message.response_metadata = _gen_info_and_msg_metadata(
                 generation
             )

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -36,6 +36,9 @@ from langchain_core.utils.usage import _dict_int_op
 logger = logging.getLogger(__name__)
 
 
+_LC_ID_PREFIX = "run-"
+
+
 class InputTokenDetails(TypedDict, total=False):
     """Breakdown of input token counts.
 
@@ -418,10 +421,19 @@ def add_ai_message_chunks(
         usage_metadata = None
 
     id = None
-    for id_ in [left.id] + [o.id for o in others]:
-        if id_:
+    candidates = [left.id] + [o.id for o in others]
+    # first pass: pick the first non‐run-* id
+    for id_ in candidates:
+        if id_ and not id_.startswith(_LC_ID_PREFIX):
             id = id_
             break
+    else:
+        # second pass: no provider-assigned id found, just take the first non‐null
+        for id_ in candidates:
+            if id_:
+                id = id_
+                break
+
     return left.__class__(
         example=left.example,
         content=content,

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -178,6 +178,22 @@ def test_message_chunks() -> None:
     assert AIMessageChunk(content="") + left == left
     assert right + AIMessageChunk(content="") == right
 
+    # Test ID order of precedence
+    null_id = AIMessageChunk(content="", id=None)
+    default_id = AIMessageChunk(
+        content="", id="run-abc123"
+    )  # LangChain-assigned run ID
+    meaningful_id = AIMessageChunk(content="", id="msg_def456")  # provider-assigned ID
+
+    assert (null_id + default_id).id == "run-abc123"
+    assert (default_id + null_id).id == "run-abc123"
+
+    assert (null_id + meaningful_id).id == "msg_def456"
+    assert (meaningful_id + null_id).id == "msg_def456"
+
+    assert (default_id + meaningful_id).id == "msg_def456"
+    assert (meaningful_id + default_id).id == "msg_def456"
+
 
 def test_chat_message_chunks() -> None:
     assert ChatMessageChunk(role="User", content="I am", id="ai4") + ChatMessageChunk(

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3095,52 +3095,6 @@ def _pop_summary_index_from_reasoning(reasoning: dict) -> dict:
     return new_reasoning
 
 
-def _explode_on_id(msg: dict[str, Any]) -> list[dict[str, Any]]:
-    """
-    Split a message dict into a list of message dicts, hoisting any `id`
-    that appears on a content block up to the outer level.
-
-    Consecutive content blocks that share the same non-None `id`
-    end up in the same outer block.
-    A content block **without** an `id` always goes into its *own* block.
-
-    Nothing else about the structure is assumed – every key except
-    `content` is copied unchanged into each resulting block.
-
-    The function avoids deepcopying large structures; only the small
-    pieces that actually change are copied.
-    """
-    base = {k: v for k, v in msg.items() if k != "content"}
-
-    out: list[dict[str, Any]] = []
-    current: Optional[dict[str, Any]] = None          # the block we’re filling
-    current_id: Optional[str] = None                  # id of that block
-
-    for part in msg.get("content", []):
-        pid = part.get("id")                          # may be None
-        stripped = {k: v for k, v in part.items() if k != "id"}
-
-        if pid is None:                               # always its own block #<-- TODO: fix this
-            if current is not None:                   # flush whatever we were building
-                out.append(current)
-                current = None
-            out.append({**base, "content": [stripped]})
-            continue
-
-        if pid != current_id:                         # start a new block
-            if current is not None:
-                out.append(current)
-            current_id = pid
-            current = {**base, "id": pid, "content": []}
-
-        current["content"].append(stripped)
-
-    if current is not None:                           # flush last block
-        out.append(current)
-
-    return out
-
-
 def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
     input_ = []
     for lc_msg in messages:
@@ -3220,7 +3174,6 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                                 "type": "output_text",
                                 "text": block["text"],
                                 "annotations": block.get("annotations") or [],
-                                "id": block.get("id"),
                             }
                         )
                     elif block["type"] in ("output_text", "refusal"):
@@ -3229,7 +3182,9 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                         pass
                 msg["content"] = new_blocks
             if msg["content"]:
-                input_.extend(_explode_on_id(msg))
+                if message_id := lc_msg.response_metadata.get("message_id"):
+                    msg["id"] = message_id
+                input_.append(msg)
             input_.extend(function_calls)
             input_.extend(computer_calls)
         elif msg["role"] == "user":
@@ -3314,14 +3269,14 @@ def _construct_lc_result_from_responses_api(
                             annotation.model_dump()
                             for annotation in content.annotations
                         ],
-                        "id": output.id,
                     }
                     content_blocks.append(block)
                     if hasattr(content, "parsed"):
                         additional_kwargs["parsed"] = content.parsed
                 if content.type == "refusal":
                     additional_kwargs["refusal"] = content.refusal
-            msg_id = output.id  # backward compatibility
+            msg_id = output.id
+            response_metadata["message_id"] = msg_id
         elif output.type == "function_call":
             try:
                 args = json.loads(output.arguments, strict=False)
@@ -3447,9 +3402,7 @@ def _convert_responses_chunk_to_generation_chunk(
             k: v for k, v in msg.response_metadata.items() if k != "id"
         }
     elif chunk.type == "response.output_item.added" and chunk.item.type == "message":
-        id = chunk.item.id  # backward compatibility
-    elif chunk.type == "response.content_part.done" and chunk.part.type == "output_text":
-        content.append({"type": "text", "text": "", "index": chunk.content_index, "id": chunk.item_id})
+        id = chunk.item.id
     elif (
         chunk.type == "response.output_item.added"
         and chunk.item.type == "function_call"

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3182,8 +3182,8 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                         pass
                 msg["content"] = new_blocks
             if msg["content"]:
-                if message_id := lc_msg.response_metadata.get("message_id"):
-                    msg["id"] = message_id
+                if lc_msg.id and lc_msg.id.startswith("msg_"):
+                    msg["id"] = lc_msg.id
                 input_.append(msg)
             input_.extend(function_calls)
             input_.extend(computer_calls)
@@ -3276,7 +3276,6 @@ def _construct_lc_result_from_responses_api(
                 if content.type == "refusal":
                     additional_kwargs["refusal"] = content.refusal
             msg_id = output.id
-            response_metadata["message_id"] = msg_id
         elif output.type == "function_call":
             try:
                 args = json.loads(output.arguments, strict=False)

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
@@ -270,7 +270,7 @@ def test_function_calling_and_structured_output() -> None:
         """return x * y"""
         return x * y
 
-    llm = ChatOpenAI(model=MODEL_NAME)
+    llm = ChatOpenAI(model=MODEL_NAME, use_responses_api=True)
     bound_llm = llm.bind_tools([multiply], response_format=Foo, strict=True)
     # Test structured output
     response = llm.invoke("how are ya", response_format=Foo)


### PR DESCRIPTION
When aggregating AIMessageChunks in a stream, core prefers the leftmost non-null ID. This is problematic because:
- Core assigns IDs when they are null to `f"run-{run_manager.run_id}"`
- The desired meaningful ID might not be available until midway through the stream, as is the case for the OpenAI Responses API.

For the OpenAI Responses API, we assign message IDs to the top-level `AIMessage.id`. This works in `.(a)invoke`, but during `.(a)stream` the IDs get overwritten by the defaults assigned in langchain-core. These IDs [must](https://community.openai.com/t/how-to-solve-badrequesterror-400-item-rs-of-type-reasoning-was-provided-without-its-required-following-item-error-in-responses-api/1151686/9) be available on the AIMessage object to support passing reasoning items back to the API (e.g., if not using OpenAI's `previous_response_id` feature). We could add them elsewhere, but seeing as we've already made the decision to store them in `.id` during `.(a)invoke`, addressing the issue in core lets us fix the problem with no interface changes.