### PR TITLE
openai[patch]: update embeddings to use .model_dump() when `check_embedding_ctx_length=False`

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -565,7 +565,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     input=texts[i : i + chunk_size_], **self._invocation_params
                 )
                 if not isinstance(response, dict):
-                    response = response.dict()
+                    response = response.model_dump()
                 embeddings.extend(r["embedding"] for r in response["data"])
             return embeddings
 
@@ -597,7 +597,7 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     input=texts[i : i + chunk_size_], **self._invocation_params
                 )
                 if not isinstance(response, dict):
-                    response = response.dict()
+                    response = response.model_dump()
                 embeddings.extend(r["embedding"] for r in response["data"])
             return embeddings
 


### PR DESCRIPTION
**What does this PR do?**
This PR replaces deprecated usages of ```.dict()``` with ```.model_dump()``` to ensure compatibility with Pydantic v2 and prepare for v3, addressing the deprecation warning ```PydanticDeprecatedSince20``` as required in  [Issue# 31103](https://github.com/langchain-ai/langchain/issues/31103).

**Changes made:**
* Replaced ```.dict()``` with ```.model_dump()``` in multiple locations
* Ensured consistency with Pydantic v2 migration guidelines
* Verified compatibility across affected modules

**Notes**
* This is a code maintenance and compatibility update
* Tested locally with Pydantic v2.11
* No functional logic changes; only internal method replacements to prevent deprecation issues

