### PR TITLE
core: enable true caching support for arbitrary message stacks in langgraph

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -46,7 +46,7 @@ from langchain_core.language_models.base import (
     LangSmithParams,
     LanguageModelInput,
 )
-from langchain_core.load import dumpd, dumps
+from langchain_core.load import dumpd, dumps, loads
 from langchain_core.messages import (
     AIMessage,
     AnyMessage,
@@ -1045,6 +1045,8 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
         check_cache = self.cache or self.cache is None
         if check_cache:
             if llm_cache:
+                for idx, message in enumerate(messages):
+                    message.id = f"cached_message_{idx}"
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 prompt = dumps(messages)
                 cache_val = await llm_cache.alookup(prompt, llm_string)
@@ -1100,6 +1102,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
                 **result.generations[0].message.response_metadata,
             }
         if check_cache and llm_cache:
+            result.generations = loads(dumps(result.generations))
             await llm_cache.aupdate(prompt, llm_string, result.generations)
         return result
 


### PR DESCRIPTION
**Description**: This PR introduces improvements to enable robust caching when using LangGraph or any arbitrary stack of messages. It addresses two core challenges:

**1. Stable Message IDs:**
For effective caching, message IDs must remain consistent across runs. Previously, these IDs were often generated using UUIDs or other random methods, causing cache misses. This fix ensures IDs are deterministically set before making an LLM request—especially important when using complex message stacks involving AIMessage, ToolMessage, etc.

**2. Cache Serialization Bug Fix:**
A subtle deserialization issue in cache stores (e.g., SQLite) caused cache mismatches due to key order changes in the tool_calls field of AIMessage. This fix enforces a deterministic key order during serialization, ensuring consistent cache lookups.

Issue: N/A (internal reliability improvement)

Dependencies: None

Twitter handle: N/A

PS: This PR is intended to highlight the current caching issues and demonstrate a straightforward fix. I’m happy to continue refining it and implement a more robust solution based on your feedback and suggestions.