### PR TITLE
make: add pyproject.toml check in create_api_rst.py 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ api_docs_quick_preview:
 api_docs_clean:
 	find ./docs/api_reference -name '*_api_reference.rst' -delete
 	git clean -fdX ./docs/api_reference
-	rm docs/api_reference/index.md
+	rm -f docs/api_reference/index.md
 	
 
 ## api_docs_linkcheck: Run linkchecker on the API Reference documentation.

--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -663,6 +663,7 @@ def main(dirs: Optional[list] = None) -> None:
             dir_
             for dir_ in os.listdir(ROOT_DIR / "libs")
             if dir_ not in ("cli", "partners", "packages.yml")
+            and "pyproject.toml" in os.listdir(ROOT_DIR / "libs" / dir_)
         ]
         dirs += [
             dir_


### PR DESCRIPTION
- **Description:** This PR extends the pyproject.toml check in ```docs/api_reference/create_api_rst.py``` to libs' sub-directories as well. without which the ```make api_docs_build``` command fails (see error).
- **Issue:** #31109
- **Dependencies:** none
- **Error:** 
uv run --no-group test python docs/api_reference/create_api_rst.py
Starting to build API reference files.
Building package: community
pyproject.toml not found in /langchain/libs/community.
You are either attempting to build a directory which is not a package or the package is missing a pyproject.toml file which should be added.Aborting the build.
make: *** [Makefile:35: api_docs_build] Error 1