### PR TITLE
infra: Extend pyproject.toml check in create_api_rst.py to langchain/libs folder

### DIFF
--- a/docs/api_reference/create_api_rst.py
+++ b/docs/api_reference/create_api_rst.py
@@ -663,6 +663,7 @@ def main(dirs: Optional[list] = None) -> None:
             dir_
             for dir_ in os.listdir(ROOT_DIR / "libs")
             if dir_ not in ("cli", "partners", "packages.yml")
+            and "pyproject.toml" in os.listdir(ROOT_DIR / "libs" / dir_)
         ]
         dirs += [
             dir_


### PR DESCRIPTION
- **Description:** The file  ```docs/api_reference/create_api_rst.py``` uses a pyproject.toml check to remove partners which don't have a valid pyproject.toml. This PR extends that check to ```/langchain/libs/*``` sub-directories as well. Without this the ```make api_docs_build``` command fails (see error).
- **Issue:** #31109
- **Dependencies:** none
- **Error Traceback:** 
uv run --no-group test python docs/api_reference/create_api_rst.py
Starting to build API reference files.
Building package: community
pyproject.toml not found in /langchain/libs/community.
You are either attempting to build a directory which is not a package or the package is missing a pyproject.toml file which should be added.Aborting the build.
make: *** [Makefile:35: api_docs_build] Error 1