### PR TITLE
infra: Suppress error in make api_docs_clean if index.md is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ api_docs_quick_preview:
 api_docs_clean:
 	find ./docs/api_reference -name '*_api_reference.rst' -delete
 	git clean -fdX ./docs/api_reference
-	rm docs/api_reference/index.md
+	rm -f docs/api_reference/index.md
 	
 
 ## api_docs_linkcheck: Run linkchecker on the API Reference documentation.


### PR DESCRIPTION
- **Description:** Added -f flag to rm when calling ```make api_docs_clean``` to suppress error by make if index.md doesn't exist.
- **Dependencies:** none

On calling ```make api_docs_clean```

Behavior without this PR:
```
find ./docs/api_reference -name '*_api_reference.rst' -delete
git clean -fdX ./docs/api_reference
rm docs/api_reference/index.md
rm: cannot remove 'docs/api_reference/index.md': No such file or directory
make: *** [Makefile:51: api_docs_clean] Error 1
```
After this PR:

```
find ./docs/api_reference -name '*_api_reference.rst' -delete
git clean -fdX ./docs/api_reference
rm -f docs/api_reference/index.md
```