### PR TITLE
docs: update langchain-cloudflare repo/path on packages.yaml

### DIFF
--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -618,7 +618,7 @@ packages:
   downloads: 2114
   downloads_updated_at: '2025-04-22T15:25:24.644345+00:00'
 - name: langchain-cloudflare
-  path: .
+  path: libs/langchain-cloudflare
   repo: cloudflare/langchain-cloudflare
   downloads: 766
   downloads_updated_at: '2025-04-22T15:25:24.644345+00:00'


### PR DESCRIPTION
**Library Repo Path Update **: "langchain-cloudflare"

We recently changed our `langchain-cloudflare` repo to allow for future libraries.  
Created a `libs` folder to hold `langchain-cloudflare` python package.

https://github.com/cloudflare/langchain-cloudflare/tree/main/libs/langchain-cloudflare
 
On `langchain`, updating `packages.yaml` to point to new `libs/langchain-cloudflare` library folder.