### PR TITLE
anthropic: update streaming usage metadata

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1744,6 +1744,12 @@ def _make_message_chunk_from_anthropic_event(
     # See https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
         usage_metadata = _create_usage_metadata(event.message.usage)
+        # We pick up a cumulative count of output_tokens at the end of the stream,
+        # so here we zero out to avoid double counting.
+        usage_metadata["total_tokens"] = (
+            usage_metadata["total_tokens"] - usage_metadata["output_tokens"]
+        )
+        usage_metadata["output_tokens"] = 0
         if hasattr(event.message, "model"):
             response_metadata = {"model_name": event.message.model}
         else:

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1743,14 +1743,12 @@ def _make_message_chunk_from_anthropic_event(
     message_chunk: Optional[AIMessageChunk] = None
     # See https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
-        usage_metadata = _create_usage_metadata(event.message.usage)
         if hasattr(event.message, "model"):
             response_metadata = {"model_name": event.message.model}
         else:
             response_metadata = {}
         message_chunk = AIMessageChunk(
             content="" if coerce_content_to_string else [],
-            usage_metadata=usage_metadata,
             response_metadata=response_metadata,
         )
     elif (

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1743,12 +1743,14 @@ def _make_message_chunk_from_anthropic_event(
     message_chunk: Optional[AIMessageChunk] = None
     # See https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
+        usage_metadata = _create_usage_metadata(event.message.usage)
         if hasattr(event.message, "model"):
             response_metadata = {"model_name": event.message.model}
         else:
             response_metadata = {}
         message_chunk = AIMessageChunk(
             content="" if coerce_content_to_string else [],
+            usage_metadata=usage_metadata,
             response_metadata=response_metadata,
         )
     elif (

--- a/libs/partners/anthropic/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_chat_models.py
@@ -46,7 +46,7 @@ def test_stream() -> None:
         if token.usage_metadata is not None:
             if token.usage_metadata.get("input_tokens"):
                 chunks_with_input_token_counts += 1
-            elif token.usage_metadata.get("output_tokens"):
+            if token.usage_metadata.get("output_tokens"):
                 chunks_with_output_token_counts += 1
         chunks_with_model_name += int("model_name" in token.response_metadata)
     if chunks_with_input_token_counts != 1 or chunks_with_output_token_counts != 1:
@@ -85,7 +85,7 @@ async def test_astream() -> None:
         if token.usage_metadata is not None:
             if token.usage_metadata.get("input_tokens"):
                 chunks_with_input_token_counts += 1
-            elif token.usage_metadata.get("output_tokens"):
+            if token.usage_metadata.get("output_tokens"):
                 chunks_with_output_token_counts += 1
     if chunks_with_input_token_counts != 1 or chunks_with_output_token_counts != 1:
         raise AssertionError(


### PR DESCRIPTION
Anthropic updated how they report token counts during streaming today. See changes to `MessageDeltaUsage` in [this commit](https://github.com/anthropics/anthropic-sdk-python/commit/2da00f26c5f0bbf4f4039caec3c0500a2c2156bd#diff-1a396eba0cd9cd8952dcdb58049d3b13f6b7768ead1411888d66e28211f7bfc5).

It's clean and simple to grab these fields from the final `message_delta` event. However, some of them are typed as Optional, and language [here](https://github.com/anthropics/anthropic-sdk-python/blob/e42451ab3f14443c0ed8076b17032a6d8986b6bf/src/anthropic/lib/streaming/_messages.py#L462) suggests they may not always be present. So here we take the required field from the `message_delta` event as we were doing previously, and ignore the rest.