### PR TITLE
infra: add to vercel overrides

### DIFF
--- a/docs/vercel_overrides.txt
+++ b/docs/vercel_overrides.txt
@@ -2,3 +2,4 @@ httpx
 grpcio
 aiohttp<3.11
 protobuf<3.21
+tenacity

--- a/docs/vercel_overrides.txt
+++ b/docs/vercel_overrides.txt
@@ -3,3 +3,4 @@ grpcio
 aiohttp<3.11
 protobuf<3.21
 tenacity
+urllib3


### PR DESCRIPTION
Incompatibility between langchain-redis and langchain-ai21 `tenacity` dep