### PR TITLE
ollama: Add separate kwargs parameter for async client

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -436,14 +436,22 @@ class ChatOllama(BaseChatModel):
     """Base url the model is hosted under."""
 
     client_kwargs: Optional[dict] = {}
-    """Additional kwargs to pass to the httpx Client. 
-    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """Additional kwargs to pass to the httpx clients. 
+    These arguments are passed to both synchronous and async clients.
+    Use sync_client_kwargs and async_client_kwargs to pass different arguments
+    to synchronous and asynchronous clients.
     """
 
     async_client_kwargs: Optional[dict] = {}
     """Additional kwargs to merge with client_kwargs before
     passing to the httpx AsyncClient.
     For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
+    """
+
+    sync_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx Client.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
     """
 
     _client: Client = PrivateAttr(default=None)  # type: ignore
@@ -509,10 +517,16 @@ class ChatOllama(BaseChatModel):
     def _set_clients(self) -> Self:
         """Set clients to use for ollama."""
         client_kwargs = self.client_kwargs or {}
+
+        sync_client_kwargs = client_kwargs
+        if self.sync_client_kwargs:
+            sync_client_kwargs = {**sync_client_kwargs, **self.sync_client_kwargs}
+
         async_client_kwargs = client_kwargs
         if self.async_client_kwargs:
-            async_client_kwargs = {**client_kwargs, **self.async_client_kwargs}
-        self._client = Client(host=self.base_url, **client_kwargs)
+            async_client_kwargs = {**async_client_kwargs, **self.async_client_kwargs}
+
+        self._client = Client(host=self.base_url, **sync_client_kwargs)
         self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
         return self
 

--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -436,8 +436,14 @@ class ChatOllama(BaseChatModel):
     """Base url the model is hosted under."""
 
     client_kwargs: Optional[dict] = {}
-    """Additional kwargs to pass to the httpx Client.
-    For a full list of the params, see [this link](https://pydoc.dev/httpx/latest/httpx.Client.html)
+    """Additional kwargs to pass to the httpx Client. 
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """
+
+    async_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx AsyncClient.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
     """
 
     _client: Client = PrivateAttr(default=None)  # type: ignore
@@ -503,8 +509,11 @@ class ChatOllama(BaseChatModel):
     def _set_clients(self) -> Self:
         """Set clients to use for ollama."""
         client_kwargs = self.client_kwargs or {}
+        async_client_kwargs = client_kwargs
+        if self.async_client_kwargs:
+            async_client_kwargs = {**client_kwargs, **self.async_client_kwargs}
         self._client = Client(host=self.base_url, **client_kwargs)
-        self._async_client = AsyncClient(host=self.base_url, **client_kwargs)
+        self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
         return self
 
     def _convert_messages_to_ollama_messages(

--- a/libs/partners/ollama/langchain_ollama/embeddings.py
+++ b/libs/partners/ollama/langchain_ollama/embeddings.py
@@ -128,7 +128,13 @@ class OllamaEmbeddings(BaseModel, Embeddings):
 
     client_kwargs: Optional[dict] = {}
     """Additional kwargs to pass to the httpx Client. 
-    For a full list of the params, see [this link](https://pydoc.dev/httpx/latest/httpx.Client.html)
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """
+
+    async_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx AsyncClient.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
     """
 
     _client: Client = PrivateAttr(default=None)  # type: ignore
@@ -233,8 +239,11 @@ class OllamaEmbeddings(BaseModel, Embeddings):
     def _set_clients(self) -> Self:
         """Set clients to use for ollama."""
         client_kwargs = self.client_kwargs or {}
+        async_client_kwargs = client_kwargs
+        if self.async_client_kwargs:
+            async_client_kwargs = {**client_kwargs, **self.async_client_kwargs}
         self._client = Client(host=self.base_url, **client_kwargs)
-        self._async_client = AsyncClient(host=self.base_url, **client_kwargs)
+        self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
         return self
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:

--- a/libs/partners/ollama/langchain_ollama/embeddings.py
+++ b/libs/partners/ollama/langchain_ollama/embeddings.py
@@ -127,14 +127,22 @@ class OllamaEmbeddings(BaseModel, Embeddings):
     """Base url the model is hosted under."""
 
     client_kwargs: Optional[dict] = {}
-    """Additional kwargs to pass to the httpx Client. 
-    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """Additional kwargs to pass to the httpx clients. 
+    These arguments are passed to both synchronous and async clients.
+    Use sync_client_kwargs and async_client_kwargs to pass different arguments
+    to synchronous and asynchronous clients.
     """
 
     async_client_kwargs: Optional[dict] = {}
     """Additional kwargs to merge with client_kwargs before
     passing to the httpx AsyncClient.
     For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
+    """
+
+    sync_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx Client.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
     """
 
     _client: Client = PrivateAttr(default=None)  # type: ignore
@@ -239,10 +247,16 @@ class OllamaEmbeddings(BaseModel, Embeddings):
     def _set_clients(self) -> Self:
         """Set clients to use for ollama."""
         client_kwargs = self.client_kwargs or {}
+
+        sync_client_kwargs = client_kwargs
+        if self.sync_client_kwargs:
+            sync_client_kwargs = {**sync_client_kwargs, **self.sync_client_kwargs}
+
         async_client_kwargs = client_kwargs
         if self.async_client_kwargs:
-            async_client_kwargs = {**client_kwargs, **self.async_client_kwargs}
-        self._client = Client(host=self.base_url, **client_kwargs)
+            async_client_kwargs = {**async_client_kwargs, **self.async_client_kwargs}
+
+        self._client = Client(host=self.base_url, **sync_client_kwargs)
         self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
         return self
 

--- a/libs/partners/ollama/langchain_ollama/llms.py
+++ b/libs/partners/ollama/langchain_ollama/llms.py
@@ -114,7 +114,13 @@ class OllamaLLM(BaseLLM):
 
     client_kwargs: Optional[dict] = {}
     """Additional kwargs to pass to the httpx Client. 
-    For a full list of the params, see [this link](https://pydoc.dev/httpx/latest/httpx.Client.html)
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """
+
+    async_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx AsyncClient.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
     """
 
     _client: Client = PrivateAttr(default=None)  # type: ignore
@@ -189,8 +195,11 @@ class OllamaLLM(BaseLLM):
     def _set_clients(self) -> Self:
         """Set clients to use for ollama."""
         client_kwargs = self.client_kwargs or {}
+        async_client_kwargs = client_kwargs
+        if self.async_client_kwargs:
+            async_client_kwargs = {**client_kwargs, **self.async_client_kwargs}
         self._client = Client(host=self.base_url, **client_kwargs)
-        self._async_client = AsyncClient(host=self.base_url, **client_kwargs)
+        self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
         return self
 
     async def _acreate_generate_stream(

--- a/libs/partners/ollama/langchain_ollama/llms.py
+++ b/libs/partners/ollama/langchain_ollama/llms.py
@@ -113,14 +113,22 @@ class OllamaLLM(BaseLLM):
     """Base url the model is hosted under."""
 
     client_kwargs: Optional[dict] = {}
-    """Additional kwargs to pass to the httpx Client. 
-    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """Additional kwargs to pass to the httpx clients. 
+    These arguments are passed to both synchronous and async clients.
+    Use sync_client_kwargs and async_client_kwargs to pass different arguments
+    to synchronous and asynchronous clients.
     """
 
     async_client_kwargs: Optional[dict] = {}
     """Additional kwargs to merge with client_kwargs before
     passing to the httpx AsyncClient.
     For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
+    """
+
+    sync_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx Client.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
     """
 
     _client: Client = PrivateAttr(default=None)  # type: ignore
@@ -195,10 +203,16 @@ class OllamaLLM(BaseLLM):
     def _set_clients(self) -> Self:
         """Set clients to use for ollama."""
         client_kwargs = self.client_kwargs or {}
+
+        sync_client_kwargs = client_kwargs
+        if self.sync_client_kwargs:
+            sync_client_kwargs = {**sync_client_kwargs, **self.sync_client_kwargs}
+
         async_client_kwargs = client_kwargs
         if self.async_client_kwargs:
-            async_client_kwargs = {**client_kwargs, **self.async_client_kwargs}
-        self._client = Client(host=self.base_url, **client_kwargs)
+            async_client_kwargs = {**async_client_kwargs, **self.async_client_kwargs}
+
+        self._client = Client(host=self.base_url, **sync_client_kwargs)
         self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
         return self
 


### PR DESCRIPTION
**Description**:

Add a `async_client_kwargs` field to ollama chat/llm/embeddings adapters that is passed to async httpx client constructor.

**Motivation:**

In my use-case:
- chat/embedding model adapters may be created frequently, sometimes to be called just once or to never be called at all
- they may be used in bots sunc and async mode (not known at the moment they are created)

So, I want to keep a static transport instance maintaining connection pool, so model adapters can be created and destroyed freely. But that doesn't work when both sync and async functions are in use as I can only pass one transport instance for both sync and async client, while transport types must be different for them. So I can't make both sync and async calls use shared transport with current model adapter interfaces.

In this PR I add a separate `async_client_kwargs` that gets passed to async client constructor, so it will be possible to pass a separate transport instance. For sake of backwards compatibility, it is merged with `client_kwargs`, so nothing changes when it is not set.

I am unable to run linter right now, but the changes look ok.