### PR TITLE
perf[core]: remove generations summation from hot loop

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -494,9 +494,10 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
 
             try:
                 input_messages = _normalize_messages(messages)
+                run_id = "-".join((_LC_ID_PREFIX, str(run_manager.run_id)))
                 for chunk in self._stream(input_messages, stop=stop, **kwargs):
                     if chunk.message.id is None:
-                        chunk.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}"
+                        chunk.message.id = run_id
                     chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)
                     run_manager.on_llm_new_token(
                         cast("str", chunk.message.content), chunk=chunk
@@ -586,13 +587,14 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
 
         try:
             input_messages = _normalize_messages(messages)
+            run_id = "-".join((_LC_ID_PREFIX, str(run_manager.run_id)))
             async for chunk in self._astream(
                 input_messages,
                 stop=stop,
                 **kwargs,
             ):
                 if chunk.message.id is None:
-                    chunk.message.id = f"{_LC_ID_PREFIX}-{run_manager.run_id}"
+                    chunk.message.id = run_id
                 chunk.message.response_metadata = _gen_info_and_msg_metadata(chunk)
                 await run_manager.on_llm_new_token(
                     cast("str", chunk.message.content), chunk=chunk

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Union
+from typing import Literal, Union
 
 from pydantic import model_validator
+from typing_extensions import Self
 
 from langchain_core.messages import BaseMessage, BaseMessageChunk
 from langchain_core.outputs.generation import Generation
 from langchain_core.utils._merge import merge_dicts
-
-if TYPE_CHECKING:
-    from typing_extensions import Self
 
 
 class ChatGeneration(Generation):
@@ -115,3 +113,16 @@ class ChatGenerationChunk(ChatGeneration):
             )
         msg = f"unsupported operand type(s) for +: '{type(self)}' and '{type(other)}'"
         raise TypeError(msg)
+
+
+def merge_chat_generation_chunks(
+    chunks: list[ChatGenerationChunk],
+) -> Union[ChatGenerationChunk, None]:
+    """Merge a list of ChatGenerationChunks into a single ChatGenerationChunk."""
+    if not chunks:
+        return None
+
+    if len(chunks) == 1:
+        return chunks[0]
+
+    return chunks[0] + chunks[1:]

--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -98,7 +98,7 @@ def _get_jinja2_variables_from_template(template: str) -> set[str]:
         raise ImportError(msg) from e
     env = Environment()  # noqa: S701
     ast = env.parse(template)
-    return meta.find_undeclared_variables(ast)
+    return meta.find_undeclared_variables(ast)  # type: ignore[no-untyped-call]
 
 
 def mustache_formatter(template: str, /, **kwargs: Any) -> str:

--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -98,7 +98,7 @@ def _get_jinja2_variables_from_template(template: str) -> set[str]:
         raise ImportError(msg) from e
     env = Environment()  # noqa: S701
     ast = env.parse(template)
-    return meta.find_undeclared_variables(ast)  # type: ignore[no-untyped-call]
+    return meta.find_undeclared_variables(ast)
 
 
 def mustache_formatter(template: str, /, **kwargs: Any) -> str:


### PR DESCRIPTION
1. Removes summation of `ChatGenerationChunk` from hot loops in `stream` and `astream`
2. Removes run id gen from loop as well (minor impact)

Again, benchmarking on processing ~200k chunks (a poem about broccoli).

Before: ~4.2s

Blue circle is all the time spent adding up gen chunks

<img width="1345" alt="Screenshot 2025-05-14 at 7 48 33 AM" src="https://github.com/user-attachments/assets/08a59d78-134d-4cd3-9d54-214de689df51" />

After: ~2.4s

Blue circle is remaining time spent on adding chunks, which can be minimized in a future PR by optimizing the `merge_content`, `merge_dicts`, and `merge_lists` utilities.

<img width="1353" alt="Screenshot 2025-05-14 at 7 50 08 AM" src="https://github.com/user-attachments/assets/df6b3506-929e-4b6d-b198-7c4e992c6d34" />