### PR TITLE
docs: add UQLM as a provider

### DIFF
--- a/docs/docs/integrations/providers/uqlm.mdx
+++ b/docs/docs/integrations/providers/uqlm.mdx
@@ -54,7 +54,7 @@ results.to_df()
   <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/black_box_output4.png" />
 </p>
 
-Above, `use_best=True` implements mitigation so that the uncertainty-minimized responses is selected. Note that although we use `ChatVertexAI` in this example, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used. For a more detailed demo, refer to our [Black-Box UQ Demo](./examples/black_box_demo.ipynb).
+Above, `use_best=True` implements mitigation so that the uncertainty-minimized responses is selected. Note that although we use `ChatVertexAI` in this example, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used. For a more detailed demo, refer to our [Black-Box UQ Demo](https://github.com/cvs-health/uqlm/blob/main/examples/black_box_demo.ipynb).
 
 
 **Available Scorers:**
@@ -91,7 +91,7 @@ results.to_df()
   <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/white_box_output2.png" />
 </p>
 
-Again, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used in place of `ChatVertexAI`. For a more detailed demo, refer to our [White-Box UQ Demo](./examples/white_box_demo.ipynb).
+Again, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used in place of `ChatVertexAI`. For a more detailed demo, refer to our [White-Box UQ Demo](https://github.com/cvs-health/uqlm/blob/main/examples/white_box_demo.ipynb).
 
 
 **Available Scorers:**
@@ -126,7 +126,7 @@ results.to_df()
   <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/panel_output2.png" />
 </p>
 
-Note that although we use `ChatVertexAI` in this example, we can use any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) as judges. For a more detailed demo illustrating how to customize a panel of LLM judges, refer to our [LLM-as-a-Judge Demo](./examples/judges_demo.ipynb).
+Note that although we use `ChatVertexAI` in this example, we can use any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) as judges. For a more detailed demo illustrating how to customize a panel of LLM judges, refer to our [LLM-as-a-Judge Demo](https://github.com/cvs-health/uqlm/blob/main/examples/judges_demo.ipynb).
 
 
 **Available Scorers:**
@@ -175,7 +175,7 @@ results.to_df()
   <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/uqensemble_output2.png" />
 </p>
 
-As with the other examples, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used in place of `ChatVertexAI`. For more detailed demos, refer to our [Off-the-Shelf Ensemble Demo](./examples/ensemble_off_the_shelf_demo.ipynb) (quick start) or our [Ensemble Tuning Demo](./examples/ensemble_tuning_demo.ipynb) (advanced).
+As with the other examples, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used in place of `ChatVertexAI`. For more detailed demos, refer to our [Off-the-Shelf Ensemble Demo](https://github.com/cvs-health/uqlm/blob/main/examples/ensemble_off_the_shelf_demo.ipynb) (quick start) or our [Ensemble Tuning Demo](https://github.com/cvs-health/uqlm/blob/main/examples/ensemble_tuning_demo.ipynb) (advanced).
 
 
 **Available Scorers:**

--- a/docs/docs/integrations/providers/uqlm.mdx
+++ b/docs/docs/integrations/providers/uqlm.mdx
@@ -1,0 +1,184 @@
+# UQLM: Uncertainty Quantification for Language Models
+
+UQLM is a Python library for generation-time, zero-resource LLM hallucination detection using state-of-the-art uncertainty quantification techniques.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/uqlm_flow_ds.png" />
+</p>
+
+
+## Installation
+The latest version can be installed from PyPI:
+
+```bash
+pip install uqlm
+```
+
+## Hallucination Detection
+UQLM provides a suite of response-level scorers for quantifying the uncertainty of Large Language Model (LLM) outputs. Each scorer returns a confidence score between 0 and 1, where higher scores indicate a lower likelihood of errors or hallucinations.  We categorize these scorers into four main types:
+
+
+
+| Scorer Type            | Added Latency                                      | Added Cost                               | Compatibility                                             | Off-the-Shelf / Effort                                  |
+|------------------------|----------------------------------------------------|------------------------------------------|-----------------------------------------------------------|---------------------------------------------------------|
+| [Black-Box Scorers](#black-box-scorers-consistency-based)      | ⏱️ Medium-High (multiple generations & comparisons)           | 💸 High (multiple LLM calls)             | 🌍 Universal (works with any LLM)                         | ✅ Off-the-shelf |
+| [White-Box Scorers](#white-box-scorers-token-probability-based)      | ⚡ Minimal (token probabilities already returned)   | ✔️ None (no extra LLM calls)             | 🔒 Limited (requires access to token probabilities)       | ✅ Off-the-shelf            |
+| [LLM-as-a-Judge Scorers](#llm-as-a-judge-scorers) | ⏳ Low-Medium (additional judge calls add latency)    | 💵 Low-High (depends on number of judges)| 🌍 Universal (any LLM can serve as judge)                     |✅  Off-the-shelf        |
+| [Ensemble Scorers](#ensemble-scorers)       | 🔀 Flexible (combines various scorers)       | 🔀 Flexible (combines various scorers)      | 🔀 Flexible (combines various scorers)                    | ✅  Off-the-shelf (beginner-friendly); 🛠️ Can be tuned (best for advanced users)    |
+
+
+Below we provide illustrative code snippets and details about available scorers for each type.
+
+### Black-Box Scorers (Consistency-Based)
+
+These scorers assess uncertainty by measuring the consistency of multiple responses generated from the same prompt. They are compatible with any LLM, intuitive to use, and don't require access to internal model states or token probabilities.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/black_box_graphic.png" />
+</p>
+
+**Example Usage:**
+Below is a sample of code illustrating how to use the `BlackBoxUQ` class to conduct hallucination detection.
+
+```python
+from langchain_google_vertexai import ChatVertexAI
+llm = ChatVertexAI(model='gemini-pro')
+
+from uqlm import BlackBoxUQ
+bbuq = BlackBoxUQ(llm=llm, scorers=["semantic_negentropy"], use_best=True)
+
+results = await bbuq.generate_and_score(prompts=prompts, num_responses=5)
+results.to_df()
+```
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/black_box_output4.png" />
+</p>
+
+Above, `use_best=True` implements mitigation so that the uncertainty-minimized responses is selected. Note that although we use `ChatVertexAI` in this example, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used. For a more detailed demo, refer to our [Black-Box UQ Demo](./examples/black_box_demo.ipynb).
+
+
+**Available Scorers:**
+
+*   Non-Contradiction Probability ([Chen & Mueller, 2023](https://arxiv.org/abs/2308.16175); [Lin et al., 2024](https://arxiv.org/abs/2305.19187); [Manakul et al., 2023](https://arxiv.org/abs/2303.08896))
+*   Semantic Entropy ([Farquhar et al., 2024](https://www.nature.com/articles/s41586-024-07421-0); [Kuhn et al., 2023](https://arxiv.org/abs/2302.09664))
+*   Exact Match ([Cole et al., 2023](https://arxiv.org/abs/2305.14613); [Chen & Mueller, 2023](https://arxiv.org/abs/2308.16175))
+*   BERT-score ([Manakul et al., 2023](https://arxiv.org/abs/2303.08896); [Zheng et al., 2020](https://arxiv.org/abs/1904.09675))
+*   BLUERT-score ([Sellam et al., 2020](https://arxiv.org/abs/2004.04696))
+*   Cosine Similarity ([Shorinwa et al., 2024](https://arxiv.org/abs/2412.05563); [HuggingFace](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2))
+
+### White-Box Scorers (Token-Probability-Based)
+
+These scorers leverage token probabilities to estimate uncertainty.  They are significantly faster and cheaper than black-box methods, but require access to the LLM's internal probabilities, meaning they are not necessarily compatible with all LLMs/APIs.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/white_box_graphic.png" />
+</p>
+
+**Example Usage:**
+Below is a sample of code illustrating how to use the `WhiteBoxUQ` class to conduct hallucination detection. 
+
+```python
+from langchain_google_vertexai import ChatVertexAI
+llm = ChatVertexAI(model='gemini-pro')
+
+from uqlm import WhiteBoxUQ
+wbuq = WhiteBoxUQ(llm=llm, scorers=["min_probability"])
+
+results = await wbuq.generate_and_score(prompts=prompts)
+results.to_df()
+```
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/white_box_output2.png" />
+</p>
+
+Again, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used in place of `ChatVertexAI`. For a more detailed demo, refer to our [White-Box UQ Demo](./examples/white_box_demo.ipynb).
+
+
+**Available Scorers:**
+
+*   Minimum token probability ([Manakul et al., 2023](https://arxiv.org/abs/2303.08896))
+*   Length-Normalized Joint Token Probability ([Malinin & Gales, 2021](https://arxiv.org/abs/2002.07650))
+
+### LLM-as-a-Judge Scorers
+
+These scorers use one or more LLMs to evaluate the reliability of the original LLM's response.  They offer high customizability through prompt engineering and the choice of judge LLM(s).
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/judges_graphic.png" />
+</p>
+
+**Example Usage:**
+Below is a sample of code illustrating how to use the `LLMPanel` class to conduct hallucination detection using a panel of LLM judges. 
+
+```python
+from langchain_google_vertexai import ChatVertexAI
+llm1 = ChatVertexAI(model='gemini-1.0-pro')
+llm2 = ChatVertexAI(model='gemini-1.5-flash-001')
+llm3 = ChatVertexAI(model='gemini-1.5-pro-001')
+
+from uqlm import LLMPanel
+panel = LLMPanel(llm=llm1, judges=[llm1, llm2, llm3])
+
+results = await panel.generate_and_score(prompts=prompts)
+results.to_df()
+```
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/panel_output2.png" />
+</p>
+
+Note that although we use `ChatVertexAI` in this example, we can use any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) as judges. For a more detailed demo illustrating how to customize a panel of LLM judges, refer to our [LLM-as-a-Judge Demo](./examples/judges_demo.ipynb).
+
+
+**Available Scorers:**
+
+*   Categorical LLM-as-a-Judge ([Manakul et al., 2023](https://arxiv.org/abs/2303.08896); [Chen & Mueller, 2023](https://arxiv.org/abs/2308.16175); [Luo et al., 2023](https://arxiv.org/abs/2303.15621))
+*   Continuous LLM-as-a-Judge ([Xiong et al., 2024](https://arxiv.org/abs/2306.13063))
+*   Panel of LLM Judges ([Verga et al., 2024](https://arxiv.org/abs/2404.18796))
+
+### Ensemble Scorers
+
+These scorers leverage a weighted average of multiple individual scorers to provide a more robust uncertainty/confidence estimate. They offer high flexibility and customizability, allowing you to tailor the ensemble to specific use cases.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/uqensemble_generate_score.png" />
+</p>
+
+**Example Usage:**
+Below is a sample of code illustrating how to use the `UQEnsemble` class to conduct hallucination detection. 
+
+```python
+from langchain_google_vertexai import ChatVertexAI
+llm = ChatVertexAI(model='gemini-pro')
+
+from uqlm import UQEnsemble
+## ---Option 1: Off-the-Shelf Ensemble---
+# uqe = UQEnsemble(llm=llm)
+# results = await uqe.generate_and_score(prompts=prompts, num_responses=5)
+
+## ---Option 2: Tuned Ensemble---
+scorers = [ # specify which scorers to include
+    "exact_match", "noncontradiction", # black-box scorers
+    "min_probability", # white-box scorer
+    llm # use same LLM as a judge
+]
+uqe = UQEnsemble(llm=llm, scorers=scorers)
+
+# Tune on tuning prompts with provided ground truth answers
+tune_results = await uqe.tune(
+    prompts=tuning_prompts, ground_truth_answers=ground_truth_answers
+)
+# ensemble is now tuned - generate responses on new prompts
+results = await uqe.generate_and_score(prompts=prompts)
+results.to_df()
+```
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cvs-health/uqlm/develop/assets/images/uqensemble_output2.png" />
+</p>
+
+As with the other examples, any [LangChain Chat Model](https://js.langchain.com/docs/integrations/chat/) may be used in place of `ChatVertexAI`. For more detailed demos, refer to our [Off-the-Shelf Ensemble Demo](./examples/ensemble_off_the_shelf_demo.ipynb) (quick start) or our [Ensemble Tuning Demo](./examples/ensemble_tuning_demo.ipynb) (advanced).
+
+
+**Available Scorers:**
+
+*   BS Detector ([Chen & Mueller, 2023](https://arxiv.org/abs/2308.16175))
+*   Generalized UQ Ensemble ([Bouchard & Chauhan, 2025](https://arxiv.org/abs/2504.19254))

--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -662,3 +662,6 @@ packages:
 - name: langchain-brightdata
   repo: luminati-io/langchain-brightdata
   path: .
+- name: uqlm
+  repo: cvs-health/uqlm
+  path: .


### PR DESCRIPTION
**Description:**
We would like to add [UQLM](https://github.com/cvs-health/uqlm) (Uncertainty Quantification for Language Models), to the list of providers. UQLM is a Python library for generation-time, zero-resource hallucination detection using state-of-the-art uncertainty quantification techniques. It is built on top of LangChain. 

The following changes are made:
- Add docs/docs/providers/uqlm.mdx
- Register uqlm in libs/packages.yml

**Twitter handle:** @uqlm

**Tests and docs**

1. Integration tests not needed as this PR only adds a .mdx file to docs.