### PR TITLE
docs: Update flashrank-reranker.ipynb

### DIFF
--- a/docs/docs/integrations/retrievers/flashrank-reranker.ipynb
+++ b/docs/docs/integrations/retrievers/flashrank-reranker.ipynb
@@ -365,7 +365,7 @@
    ],
    "source": [
     "from langchain.retrievers import ContextualCompressionRetriever\n",
-    "from langchain.retrievers.document_compressors import FlashrankRerank\n",
+    "from langchain_community.document_compressors import FlashrankRerank\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",
     "llm = ChatOpenAI(temperature=0)\n",


### PR DESCRIPTION

- **Description:** Fix import in doc, `FlashrankRerank` has been moved to `langchain_community`


