### PR TITLE
openai[patch]: compat with Bedrock Converse

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -195,7 +195,7 @@ def _format_message_content(content: Any) -> Any:
             if (
                 isinstance(block, dict)
                 and "type" in block
-                and block["type"] in ("tool_use", "thinking")
+                and block["type"] in ("tool_use", "thinking", "reasoning_content")
             ):
                 continue
             elif isinstance(block, dict) and is_data_content_block(block):

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1034,6 +1034,40 @@ def test__get_request_payload() -> None:
     }
     assert payload == expected
 
+    # Test we ignore reasoning blocks from other providers
+    reasoning_messages: list = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "reasoning_content", "reasoning_content": "reasoning..."},
+                {"type": "text", "text": "reasoned response"},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "thinking", "thinking": "thinking..."},
+                {"type": "text", "text": "thoughtful response"},
+            ],
+        },
+    ]
+    expected = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "reasoned response"}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "thoughtful response"}],
+            },
+        ],
+        "model": "o3-mini",
+        "stream": False,
+    }
+    payload = llm._get_request_payload(reasoning_messages)
+    assert payload == expected
+
 
 def test_init_o1() -> None:
     with pytest.warns(None) as record:  # type: ignore[call-overload]


### PR DESCRIPTION
ChatBedrockConverse passes through reasoning content blocks in [Bedrock Converse format](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html).

Similar to how we handle Anthropic thinking blocks, here we ensure these are filtered out of OpenAI request payloads.

Resolves https://github.com/langchain-ai/langchain/issues/31279.