### PR TITLE
Docs: Fixing a typo in retrievers concepts page 

### DIFF
--- a/docs/docs/concepts/retrievers.mdx
+++ b/docs/docs/concepts/retrievers.mdx
@@ -32,7 +32,7 @@ The only requirement for a retriever is the ability to accepts a query and retur
 In particular, [LangChain's retriever class](https://python.langchain.com/api_reference/core/retrievers/langchain_core.retrievers.BaseRetriever.html#) only requires that the `_get_relevant_documents` method is implemented, which takes a `query: str` and returns a list of [Document](https://python.langchain.com/api_reference/core/documents/langchain_core.documents.base.Document.html) objects that are most relevant to the query.
 The underlying logic used to get relevant documents is specified by the retriever and can be whatever is most useful for the application.
 
-A LangChain retriever is a [runnable](/docs/how_to/lcel_cheatsheet/), which is a standard interface is for LangChain components. 
+A LangChain retriever is a [runnable](/docs/how_to/lcel_cheatsheet/), which is a standard interface for LangChain components. 
 This means that it has a few common methods, including `invoke`, that are used to interact with it. A retriever can be invoked with a query:
 
 ```python


### PR DESCRIPTION
The second 'is` is redundant, it makes the meaning confusing 