### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/docs/how_to/document_loader_pdf.ipynb
+++ b/docs/docs/how_to/document_loader_pdf.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "LangChain integrates with a host of PDF parsers. Some are simple and relatively low-level; others will support OCR and image-processing, or perform advanced document layout analysis. The right choice will depend on your needs. Below we enumerate the possibilities.\n",
     "\n",
-    "We will demonstrate these approaches on a [sample file](https://github.com/langchain-ai/langchain/blob/master/libs/community/tests/integration_tests/examples/layout-parser-paper.pdf):"
+    "We will demonstrate these approaches on a [sample file](https://github.com/langchain-ai/langchain-community/blob/main/libs/community/tests/examples/layout-parser-paper.pdf):"
    ]
   },
   {


### PR DESCRIPTION
As stated [here](https://github.com/langchain-ai/langchain/blob/master/libs/community/README.md) this package has moved, hence the broken link
