### PR TITLE
langchain-huggingface: fixed reading of `self.model_id` before it is set in `_resolve_model_id()`

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -776,7 +776,7 @@ class ChatHuggingFace(BaseChatModel):
             from transformers import AutoTokenizer  # type: ignore[import]
 
             self.tokenizer = (
-                AutoTokenizer.from_pretrained(self.model_id)
+                AutoTokenizer.from_pretrained(self.llm.model_id)
                 if self.tokenizer is None
                 else self.tokenizer
             )


### PR DESCRIPTION
- [ ] **PR title**: "langchain-huggingface: fixed reading of `self.model_id` before it is set in `_resolve_model_id()`"


- [ ] **PR message**: 
    - **Description:** While resolving the `model_id` when HuggingFacePipeline is used, the code loads an AutoTokenizer using the value of `self.model_id` before it is set to `self.llm.model_id`. The value of `self.model_id` is currently `None` at this point and raises an exception. I changed the code to load the tokenizer value from `self.llm.model_id` instead.

