### PR TITLE
docs: Fix link to deprecation alternative for ConversationChain in docs

### DIFF
--- a/libs/langchain/langchain/chains/conversation/base.py
+++ b/libs/langchain/langchain/chains/conversation/base.py
@@ -13,10 +13,7 @@ from langchain.memory.buffer import ConversationBufferMemory
 
 @deprecated(
     since="0.2.7",
-    alternative=(
-        "RunnableWithMessageHistory: "
-        "https://python.langchain.com/v0.2/api_reference/core/runnables/langchain_core.runnables.history.RunnableWithMessageHistory.html"  # noqa: E501
-    ),
+    alternative="langchain_core.runnables.history.RunnableWithMessageHistory",
     removal="1.0",
 )
 class ConversationChain(LLMChain):


### PR DESCRIPTION
**Description:** ConversationChain has been deprecated, and the documentation says to use RunnableWithMessageHistory in its place, but the link at the top of the page to RunnableWithMessageHistory is broken (it's rendering as "html()"). See here at the top of the page: https://python.langchain.com/api_reference/langchain/chains/langchain.chains.conversation.base.ConversationChain.html. This PR fixes the link.
**Issue**: N/A
**Dependencies**: N/A
**Twitter handle:**: If you're on Bluesky, I'm @vikramsaraph.com
