### PR TITLE
langchain: Fix error in LLMListwiseRerank when Document list is empty

### DIFF
--- a/libs/langchain/langchain/retrievers/document_compressors/listwise_rerank.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/listwise_rerank.py
@@ -24,7 +24,7 @@ def _get_prompt_input(input_: dict) -> dict[str, Any]:
     context = ""
     for index, doc in enumerate(documents):
         context += f"Document ID: {index}\n```{doc.page_content}```\n\n"
-    document_range = ""
+    document_range = "empty list"
     if len(documents) > 0:
         document_range = f"Document ID: 0, ..., Document ID: {len(documents) - 1}"
     context += f"Documents = [{document_range}]"

--- a/libs/langchain/langchain/retrievers/document_compressors/listwise_rerank.py
+++ b/libs/langchain/langchain/retrievers/document_compressors/listwise_rerank.py
@@ -24,7 +24,10 @@ def _get_prompt_input(input_: dict) -> dict[str, Any]:
     context = ""
     for index, doc in enumerate(documents):
         context += f"Document ID: {index}\n```{doc.page_content}```\n\n"
-    context += f"Documents = [Document ID: 0, ..., Document ID: {len(documents) - 1}]"
+    document_range = ""
+    if len(documents) > 0:
+        document_range = f"Document ID: 0, ..., Document ID: {len(documents) - 1}"
+    context += f"Documents = [{document_range}]"
     return {"query": input_["query"], "context": context}
 
 


### PR DESCRIPTION
**Description:**
This PR fixes an `IndexError` that occurs when `LLMListwiseRerank` is called with an empty list of documents.

Earlier, the code assumed the presence of at least one document and attempted to construct the context string based on `len(documents) - 1`, which raises an error when documents is an empty list.

The fix works with gpt-4o-mini if I make the list empty, but fails occasionally with gpt-3.5-turbo. In case of empty list, setting the string to "empty list" seems to have the expected response.

**Issue:**  #31192 