### PR TITLE
docs: correct groq description typo

### DIFF
--- a/docs/docs/integrations/providers/groq.mdx
+++ b/docs/docs/integrations/providers/groq.mdx
@@ -1,6 +1,6 @@
 # Groq
 
->[Groq](https://groq.com)developed the world's first Language Processing Unit™, or `LPU`. 
+>[Groq](https://groq.com) developed the world's first Language Processing Unit™, or `LPU`. 
 > The `Groq LPU` has a deterministic, single core streaming architecture that sets the standard 
 > for GenAI inference speed with predictable and repeatable performance for any given workload.
 >


### PR DESCRIPTION
**Description:** a space was missing between the words "Groq" and "developed" and has been added