### PR TITLE
infra: temporarily drop OpenAI from core release test matrix

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [anthropic]
       fail-fast: false  # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
As part of core releases we run tests on the last released version of some packages (including langchain-openai) using the new version of langchain-core. We run langchain-openai's test suite as it was when it was last released.

OpenAI has since updated their API— relaxing constraints on what schemas are supported when `strict=True`— causing these tests to break. They have since been fixed. But the old tests will continue to fail.

Will revert this change after we release OpenAI today.