### PR TITLE
openai[patch]: relax Azure llm streaming callback test

### DIFF
--- a/libs/partners/openai/tests/integration_tests/llms/test_azure.py
+++ b/libs/partners/openai/tests/integration_tests/llms/test_azure.py
@@ -149,7 +149,7 @@ def test_openai_streaming_callback() -> None:
         verbose=True,
     )
     llm.invoke("Write me a sentence with 100 words.")
-    assert callback_handler.llm_streams == 12
+    assert callback_handler.llm_streams < 15
 
 
 @pytest.mark.scheduled
@@ -172,5 +172,5 @@ async def test_openai_async_streaming_callback() -> None:
         verbose=True,
     )
     result = await llm.agenerate(["Write me a sentence with 100 words."])
-    assert callback_handler.llm_streams == 12
+    assert callback_handler.llm_streams < 15
     assert isinstance(result, LLMResult)


### PR DESCRIPTION
Effectively reverts https://github.com/langchain-ai/langchain/pull/29302, but check that counts are "less than" instead of equal to an expected count.