### PR TITLE
docs: fix truncation of retriever descriptions in overview table

### DIFF
--- a/docs/docs/integrations/retrievers/index.mdx
+++ b/docs/docs/integrations/retrievers/index.mdx
@@ -34,4 +34,7 @@ The below retrievers will search over an external index (e.g., constructed from 
 
 ## All retrievers
 
+> **Note:** The descriptions in the table below are truncated for readability.  
+> To view the full description of a retriever, hover over the description or click the retriever name to visit its documentation page.
+
 <IndexTable />

--- a/docs/docs/integrations/retrievers/index.mdx
+++ b/docs/docs/integrations/retrievers/index.mdx
@@ -34,7 +34,6 @@ The below retrievers will search over an external index (e.g., constructed from 
 
 ## All retrievers
 
-> **Note:** The descriptions in the table below are truncated for readability.  
-> To view the full description of a retriever, hover over the description or click the retriever name to visit its documentation page.
+> **Note:** The descriptions in the table below are truncated for readability.
 
 <IndexTable />


### PR DESCRIPTION
### Description
Added a note above the retriever overview table to clarify that the descriptions are truncated for readability and how to view the full version (via hover or click).

### Issue
Fixes #31311 — Users were confused by incomplete retriever descriptions in the integration docs.

### Dependencies
None
