### PR TITLE
docs: fix missing 'self' reference in for-loop over documents

### DIFF
--- a/docs/docs/how_to/custom_retriever.ipynb
+++ b/docs/docs/how_to/custom_retriever.ipynb
@@ -98,7 +98,7 @@
     "    ) -> List[Document]:\n",
     "        \"\"\"Sync implementations for retriever.\"\"\"\n",
     "        matching_documents = []\n",
-    "        for document in documents:\n",
+    "        for document in self.documents:\n",
     "            if len(matching_documents) > self.k:\n",
     "                return matching_documents\n",
     "\n",


### PR DESCRIPTION
**Description:**  fix missing 'self' reference in for-loop over documents