### PR TITLE
langchain[patch]: update AgentType docstring with correct documentation URL

### DIFF
--- a/libs/langchain/langchain/agents/agent_types.py
+++ b/libs/langchain/langchain/agents/agent_types.py
@@ -15,7 +15,7 @@ from langchain._api.deprecation import AGENT_DEPRECATION_WARNING
 class AgentType(str, Enum):
     """An enum for agent types.
 
-    See documentation: https://python.langchain.com/docs/modules/agents/agent_types/
+    See documentation: https://python.langchain.com/api_reference/langchain/agents/langchain.agents.agent_types.AgentType.html
     """
 
     ZERO_SHOT_REACT_DESCRIPTION = "zero-shot-react-description"


### PR DESCRIPTION
### What does this PR do?

Updates the docstring for `AgentType` in the `langchain.agents.agent_types` module to reflect the current URL for the documentation.

### Why is this needed?

The existing URL (https://python.langchain.com/docs/modules/agents/agent_types/) returns "Page Moved" message. This fix improves developer experience by pointing to the correct API reference documentation.

### Reference

New link: https://python.langchain.com/api_reference/langchain/agents/langchain.agents.agent_types.AgentType.html
