### PR TITLE
docs: fix vocabs and missing redirect links in concepts

### DIFF
--- a/docs/docs/concepts/agents.mdx
+++ b/docs/docs/concepts/agents.mdx
@@ -15,7 +15,7 @@ LangChain previously introduced the `AgentExecutor` as a runtime for agents.
 While it served as an excellent starting point, its limitations became apparent when dealing with more sophisticated and customized agents. 
 As a result, we're gradually phasing out `AgentExecutor` in favor of more flexible solutions in LangGraph.
 
-### Transitioning from AgentExecutor to langgraph
+### Transitioning from AgentExecutor to LangGraph
 
 If you're currently using `AgentExecutor`, don't worry! We've prepared resources to help you:
 

--- a/docs/docs/concepts/async.mdx
+++ b/docs/docs/concepts/async.mdx
@@ -9,7 +9,7 @@ LLM based applications often involve a lot of I/O-bound operations, such as maki
 
 :::note
 You are expected to be familiar with asynchronous programming in Python before reading this guide. If you are not, please find appropriate resources online to learn how to program asynchronously in Python.
-This guide specifically focuses on what you need to know to work with LangChain in an asynchronous context, assuming that you are already familiar with asynch
+This guide specifically focuses on what you need to know to work with LangChain in an asynchronous context, assuming that you are already familiar with asynchronous programming.
 :::
 
 ## Langchain asynchronous APIs

--- a/docs/docs/concepts/callbacks.mdx
+++ b/docs/docs/concepts/callbacks.mdx
@@ -6,7 +6,7 @@
 
 LangChain provides a callback system that allows you to hook into the various stages of your LLM application. This is useful for logging, monitoring, streaming, and other tasks.
 
-You can subscribe to these events by using the `callbacks` argument available throughout the API. This argument is list of handler objects, which are expected to implement one or more of the methods described below in more detail.
+You can subscribe to these events by using the `callbacks` argument available throughout the API. This argument is a list of handler objects, which are expected to implement one or more of the methods described below in more detail.
 
 ## Callback events
 

--- a/docs/docs/concepts/text_splitters.mdx
+++ b/docs/docs/concepts/text_splitters.mdx
@@ -3,8 +3,8 @@
 
 :::info[Prerequisites]
 
-* [Documents](/docs/docs/concepts/retrievers.mdx)
-* [Tokenization](/docs/docs/concepts/tokens.mdx)
+* [Documents](./retrievers.mdx)
+* [Tokenization](./tokens.mdx)
 :::
 
 ## Overview

--- a/docs/docs/concepts/text_splitters.mdx
+++ b/docs/docs/concepts/text_splitters.mdx
@@ -4,7 +4,7 @@
 :::info[Prerequisites]
 
 * [Documents](/docs/concepts/retrievers/#interface)
-* Tokenization(/docs/concepts/tokens)
+* [Tokenization](/docs/concepts/tokens)
 :::
 
 ## Overview

--- a/docs/docs/concepts/text_splitters.mdx
+++ b/docs/docs/concepts/text_splitters.mdx
@@ -3,8 +3,8 @@
 
 :::info[Prerequisites]
 
-* [Documents](/docs/concepts/retrievers/#interface)
-* [Tokenization](/docs/concepts/tokens)
+* [Documents](/docs/docs/concepts/retrievers.mdx)
+* [Tokenization](/docs/docs/concepts/tokens.mdx)
 :::
 
 ## Overview


### PR DESCRIPTION
### Description
Fix typo errors and missing redirect links in LangChain concepts documents.

### Issue
None

### Dependencies
None

