### PR TITLE
Docs: Fixing a little typo in extraction tutorial

### DIFF
--- a/docs/docs/tutorials/extraction.ipynb
+++ b/docs/docs/tutorials/extraction.ipynb
@@ -135,7 +135,7 @@
     "2. Do not force the LLM to make up information! Above we used `Optional` for the attributes allowing the LLM to output `None` if it doesn't know the answer.\n",
     "\n",
     ":::important\n",
-    "For best performance, document the schema well and make sure the model isn't force to return results if there's no information to be extracted in the text.\n",
+    "For best performance, document the schema well and make sure the model isn't forced to return results if there's no information to be extracted in the text.\n",
     ":::\n",
     "\n",
     "## The Extractor\n",


### PR DESCRIPTION
Just a little typo: force should be forced