### PR TITLE
docs: Document Loader for the Outline collaborative knowledge base

### DIFF
--- a/docs/docs/integrations/document_loaders/outline.ipynb
+++ b/docs/docs/integrations/document_loaders/outline.ipynb
@@ -55,6 +55,7 @@
     "\n",
     "* outline_base_url: The URL of your outline instance (or it will be taken from the environment variable).\n",
     "* outline_api_key: Your API key for authenticating with your Outline instance (or it will be taken from the environment variable).\n",
+    "* outline_collection_id_list: List of collection ids to be retrieved. If None all will be retrieved.\n",
     "* page_size: Because the Outline API uses paginated results you can configure how many results (documents) per page will be retrieved per API request.  If this is not specified a default will be used."
    ]
   },
@@ -78,8 +79,7 @@
     "\n",
     "# Option 2: Passing parameters directly\n",
     "loader = OutlineLoader(\n",
-    "    outline_base_url=\"YOUR_OUTLINE_URL\",\n",
-    "    outline_api_key=\"YOUR_API_KEY\"\n",
+    "    outline_base_url=\"YOUR_OUTLINE_URL\", outline_api_key=\"YOUR_API_KEY\"\n",
     ")"
    ]
   },

--- a/docs/docs/integrations/document_loaders/outline.ipynb
+++ b/docs/docs/integrations/document_loaders/outline.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Outline Document Loader\n",
+    "\n",
+    ">[Outline](https://www.getoutline.com/) is an open-source collaborative knowledge base platform designed for team information sharing.\n",
+    "\n",
+    "This notebook shows how to obtain langchain Documents from your Outline collections."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "The [Outline Document Loader](https://github.com/10Pines/langchain-outline) can be used to load Outline collections as LangChain Documents for integration into Retrieval-Augmented Generation (RAG) workflows.\n",
+    "\n",
+    "This example demonstrates:\n",
+    "\n",
+    "* Setting up a Document Loader to load all documents from an Outline instance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup\n",
+    "Before starting, ensure you have the following environment variables set:\n",
+    "\n",
+    "* OUTLINE_API_KEY: Your API key for authenticating with your Outline instance (https://www.getoutline.com/developers#section/Authentication).\n",
+    "* OUTLINE_INSTANCE_URL: The URL (including protocol) of your Outline instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OUTLINE_API_KEY\"] = \"ol_api_xyz123\"\n",
+    "os.environ[\"OUTLINE_INSTANCE_URL\"] = \"https://app.getoutline.com\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "To initialize the OutlineLoader, you need the following parameters:\n",
+    "\n",
+    "* outline_base_url: The URL of your outline instance (or it will be taken from the environment variable).\n",
+    "* outline_api_key: Your API key for authenticating with your Outline instance (or it will be taken from the environment variable).\n",
+    "* page_size: Because the Outline API uses paginated results you can configure how many results (documents) per page will be retrieved per API request.  If this is not specified a default will be used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 1: Using environment variables (ensure they are set)\n",
+    "from langchain_outline.document_loaders.outline import OutlineLoader\n",
+    "\n",
+    "loader = OutlineLoader()\n",
+    "\n",
+    "# Option 2: Passing parameters directly\n",
+    "loader = OutlineLoader(\n",
+    "    outline_base_url=\"YOUR_OUTLINE_URL\",\n",
+    "    outline_api_key=\"YOUR_API_KEY\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load\n",
+    "To load and return all documents available in the Outline instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lazy Load\n",
+    "The lazy_load method allows you to iteratively load documents from the Outline collection, yielding each document as it is fetched:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader.lazy_load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For detailed documentation of all `Outline` features and configurations head to the API reference: https://www.getoutline.com/developers"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
**Description:**  Adds documentation on how to use `langchain-outline` document loader package.
**Issue:** None - document loader documentation
**Dependencies:** None
**Twitter handle:** `@10Pines`