### PR TITLE
langchain-core: Add image_generation tool to list of known openai tools

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -515,7 +515,7 @@ _WellKnownOpenAITools = (
     "computer_use_preview",
     "code_interpreter",
     "mcp",
-    "image_generation"
+    "image_generation",
 )
 
 

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -506,16 +506,17 @@ def convert_to_openai_function(
     return oai_function
 
 
-# List of well known tools supported by OpenAI's chat models or respones API.
+# List of well known tools supported by OpenAI's chat models or responses API.
 # These tools are not expected to be supported by other chat model providers
 # that conform to the OpenAI function-calling API.
 _WellKnownOpenAITools = (
+    "function",
     "file_search",
-    "web_search_preview",
     "computer_use_preview",
     "code_interpreter",
     "mcp",
     "image_generation",
+    "web_search_preview",
 )
 
 

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -574,7 +574,7 @@ def convert_to_openai_tool(
 
     .. versionchanged:: 0.3.63
 
-        Added support for OpenAI's image_generation built-in tool.
+        Added support for OpenAI's image generation built-in tool.
     """
     if isinstance(tool, dict):
         if tool.get("type") in _WellKnownOpenAITools:

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -506,6 +506,19 @@ def convert_to_openai_function(
     return oai_function
 
 
+# List of well known tools supported by OpenAI's chat models or respones API.
+# These tools are not expected to be supported by other chat model providers
+# that conform to the OpenAI function-calling API.
+_WellKnownOpenAITools = (
+    "file_search",
+    "web_search_preview",
+    "computer_use_preview",
+    "code_interpreter",
+    "mcp",
+    "image_generation"
+)
+
+
 def convert_to_openai_tool(
     tool: Union[dict[str, Any], type[BaseModel], Callable, BaseTool],
     *,
@@ -558,15 +571,13 @@ def convert_to_openai_tool(
     .. versionchanged:: 0.3.61
 
         Added support for OpenAI's built-in code interpreter and remote MCP tools.
+
+    .. versionchanged:: 0.3.63
+
+        Added support for OpenAI's image_generation built-in tool.
     """
     if isinstance(tool, dict):
-        if tool.get("type") in (
-            "function",
-            "file_search",
-            "computer_use_preview",
-            "code_interpreter",
-            "mcp",
-        ):
+        if tool.get("type") in _WellKnownOpenAITools:
             return tool
         # As of 03.12.25 can be "web_search_preview" or "web_search_preview_2025_03_11"
         if (tool.get("type") or "").startswith("web_search_preview"):


### PR DESCRIPTION
Add image generation tool to the list of well known tools. This is needed for changes in the ChatOpenAI client. TODO: Some of this logic needs to be moved from core directly into the client as changes in core should not be required to add a new tool to the openai chat client.