### PR TITLE
docs: update typos in release_policy.mdx

### DIFF
--- a/docs/docs/versions/release_policy.mdx
+++ b/docs/docs/versions/release_policy.mdx
@@ -30,8 +30,6 @@ From time to time, we will version packages as **release candidates**. These are
 
 ### `langchain-community`
 
-`langchain-community` is currently on version `0.2.x`.
-
 Minor version increases will occur for:
 
 - Updates to the major/minor versions of required `langchain-x` dependencies. E.g., when updating the required version of `langchain-core` from `^0.2.x` to `0.3.0`.
@@ -49,7 +47,7 @@ However, if an external API makes a breaking change then breaking changes to the
 
 ### `langchain-experimental`
 
-`langchain-experimental` is currently on version `0.0.x`. All changes will be accompanied with patch version increases.
+All changes will be accompanied with patch version increases.
 
 ## Release cadence
 


### PR DESCRIPTION
Deleted two outdated phrases that were reflecting the current versions of packages at the time i.e.: 1-"langchain-community is currently on version 0.2.x." 2-langchain-"experimental is currently on version 0.0.x"