### PR TITLE
Add TranscriptionGroq class to support Whisper audio transcription …

### DIFF
--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -31,7 +31,7 @@ codespell = ["codespell<3.0.0,>=2.2.0"]
 lint = ["ruff<1.0,>=0.5"]
 dev = ["langchain-core"]
 test_integration = ["langchain-core"]
-typing = ["mypy<2.0,>=1.10", "langchain-core"]
+typing = ["mypy<2.0,>=1.10", "langchain-core", "types-requests"]
 
 [tool.uv.sources]
 langchain-core = { path = "../../core", editable = true }


### PR DESCRIPTION
## What

Adds `TranscriptionGroq` to `langchain_groq`, allowing users to transcribe audio via any Groq-supported Whisper model.

## Why

- Enables Whisper transcription through Groq with flexible model selection
- Consistent with LangChain's partner model interfaces (e.g., `ChatGroq`)
- Useful for voice interfaces and agent audio workflows

## Highlights

- Supports model selection (default: `whisper-large-v3-turbo`)
- Optional language parameter
- Real-world test included
- Clean API with `.transcribe(audio_path)` method