### PR TITLE
langchain : set tool_choice="required" for Azure OpenAI compatibility and to make sure final response is always in required  format for with_structured_output

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1460,7 +1460,7 @@ class BaseChatModel(BaseLanguageModel[BaseMessage], ABC):
 
         llm = self.bind_tools(
             [schema],
-            tool_choice="any",
+            tool_choice="required",
             ls_structured_output_format={
                 "kwargs": {"method": "function_calling"},
                 "schema": schema,


### PR DESCRIPTION

**Description:**  
For with_structured_output , i have modified tool_choice to required becuase  it has to be called to make sure response is in right format. Current value of "any" was causing issue with Azure Open AI.

**Issue:**  
When using with_structured_output with Azure  Open AI , i am getting an error that "any" value for tool choice  is not supported.

**Dependencies:**  
None.

**Twitter handle:**  
N/A








