### PR TITLE
core: release 0.3.63

### DIFF
--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """langchain-core version information and utilities."""
 
-VERSION = "0.3.62"
+VERSION = "0.3.63"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic>=2.7.4",
 ]
 name = "langchain-core"
-version = "0.3.62"
+version = "0.3.63"
 description = "Building applications with LLMs through composability"
 readme = "README.md"
 

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -943,7 +943,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.62"
+version = "0.3.63"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Release core 0.3.63

Small update just to expand the list of well known tools. This is necessary while the logic lives in langchain-core.