### PR TITLE
groq[patch]: update model for integration tests

### DIFF
--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -29,14 +29,10 @@ class BaseTestGroq(ChatModelIntegrationTests):
         return True
 
 
-class TestGroqLlama(BaseTestGroq):
+class TestGroqGemma(BaseTestGroq):
     @property
     def chat_model_params(self) -> dict:
-        return {
-            "model": "llama-3.1-8b-instant",
-            "temperature": 0,
-            "rate_limiter": rate_limiter,
-        }
+        return {"model": "gemma2-9b-it", "rate_limiter": rate_limiter}
 
     @property
     def supports_json_mode(self) -> bool:


### PR DESCRIPTION
Llama-3.1 started failing consistently with
> groq.BadRequestError: Error code: 400 - ***'error': ***'message': "Failed to call a function. Please adjust your prompt. See 'failed_generation' for more details.", 'type': 'invalid_request_error', 'code': 'tool_use_failed', 'failed_generation': '<function=brave_search>***"query": "Hello!"***</function>'***