### PR TITLE
docs: fix typo in local_llms.ipynb

### DIFF
--- a/docs/docs/how_to/local_llms.ipynb
+++ b/docs/docs/how_to/local_llms.ipynb
@@ -314,7 +314,7 @@
    "source": [
     "%env CMAKE_ARGS=\"-DLLAMA_METAL=on\"\n",
     "%env FORCE_CMAKE=1\n",
-    "%pip install --upgrade --quiet  llama-cpp-python --no-cache-dirclear"
+    "%pip install --upgrade --quiet  llama-cpp-python --no-cache-dir"
    ]
   },
   {


### PR DESCRIPTION
change `--no-cache-dirclear` -> `--no-cache-dir`.

pip throws `no such option: --no-cache-dirclear` since its invalid. `--no-cache-dir` is the correct one.