### PR TITLE
infra: remove use of --vcr-record=none

### DIFF
--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -14,7 +14,7 @@ test tests:
 	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -vvv --timeout 30 $(TEST_FILE) --vcr-record=none
+	uv run --group test --group test_integration pytest -vvv --timeout 30 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -24,7 +24,7 @@ test tests:
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE) --vcr-record=none
+	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -661,12 +661,6 @@ class ChatModelIntegrationTests(ChatModelTests):
 
             You can then commit the cassette to your repository. Subsequent test runs
             will use the cassette instead of making HTTP calls.
-
-            .. tip::
-                Adding ``--vcr-record=none`` to the pytest command will ensure that
-                no new cassettes are recorded, and only existing cassettes are used.
-                Consider adding this to your CI configuration (e.g., modify relevant
-                Makefile commands).
     """  # noqa: E501
 
     @property

--- a/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
@@ -763,13 +763,6 @@ class ChatModelUnitTests(ChatModelTests):
             You can then commit the cassette to your repository. Subsequent test runs
             will use the cassette instead of making HTTP calls.
 
-            .. tip::
-                Adding ``--vcr-record=none`` to the pytest command will ensure that
-                no new cassettes are recorded, and only existing cassettes are used.
-                Consider adding this to your CI configuration (e.g., modify relevant
-                Makefile commands).
-
-
     Testing initialization from environment variables
         Some unit tests may require testing initialization from environment variables.
         These tests can be enabled by overriding the ``init_from_env_params``


### PR DESCRIPTION
This option is specific to `pytest-vcr`. `pytest-recording` runs in this mode by default.