### PR TITLE
Docs: Textract Integration Page  - Fixing a typo

### DIFF
--- a/docs/docs/integrations/document_loaders/amazon_textract.ipynb
+++ b/docs/docs/integrations/document_loaders/amazon_textract.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "## Sample 1\n",
     "\n",
-    "The first example uses a local file, which internally will be send to Amazon Textract sync API [DetectDocumentText](https://docs.aws.amazon.com/textract/latest/dg/API_DetectDocumentText.html). \n",
+    "The first example uses a local file, which internally will be sent to Amazon Textract sync API [DetectDocumentText](https://docs.aws.amazon.com/textract/latest/dg/API_DetectDocumentText.html). \n",
     "\n",
     "Local files or URL endpoints like HTTP:// are limited to one page documents for Textract.\n",
     "Multi-page documents have to reside on S3. This sample file is a jpeg."


### PR DESCRIPTION
Fixing a little typo in AWS textract integration page 