### PR TITLE
core: fix aspect ratio calculation in _resize

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2875,22 +2875,26 @@ def _is_b64(s: str) -> bool:
 
 
 def _resize(width: int, height: int) -> tuple[int, int]:
-    # larger side must be <= 2048
+    """Resize an image while preserving the aspect ratio."""
+
+    # scale such that the larger side does not exceed 2048
     if width > 2048 or height > 2048:
         if width > height:
-            height = (height * 2048) // width
-            width = 2048
+            ratio = 2048 / width
         else:
-            width = (width * 2048) // height
-            height = 2048
-    # smaller side must be <= 768
+            ratio = 2048 / height
+        width = max(1, int(round(width * ratio)))
+        height = max(1, int(round(height * ratio)))
+
+    # scale such that the smaller side does not exceed 768
     if width > 768 and height > 768:
-        if width > height:
-            width = (width * 768) // height
-            height = 768
+        if width < height:
+            ratio = 768 / width
         else:
-            height = (height * 768) // width
-            width = 768
+            ratio = 768 / height
+        width = max(1, int(round(width * ratio)))
+        height = max(1, int(round(height * ratio)))
+
     return width, height
 
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2889,7 +2889,7 @@ def _resize(width: int, height: int) -> tuple[int, int]:
             width = (width * 768) // height
             height = 768
         else:
-            height = (width * 768) // height
+            height = (height * 768) // width
             width = 768
     return width, height
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
@@ -4,3 +4,8 @@ from langchain_openai.chat_models.base import _resize
 def test_resize_smaller_side_scaled_correctly() -> None:
     width, height = _resize(1000, 2000)
     assert width == 768 and height == 1536
+
+
+def test_resize_aspect_ratio_preserved() -> None:
+    width, height = _resize(3000, 1000)
+    assert width == 2048 and height == 683

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
@@ -1,0 +1,6 @@
+from langchain_openai.chat_models.base import _resize
+
+
+def test_resize_smaller_side_scaled_correctly() -> None:
+    width, height = _resize(1000, 2000)
+    assert width == 768 and height == 1536


### PR DESCRIPTION
### PR Title
`core: fix aspect ratio calculation in _resize`

### PR Message
**Description:**  
Corrected the aspect ratio calculation logic in the `_resize` function to ensure consistent and expected behaviour when resizing. This prevents distortion when the original dimensions have non-uniform scaling.

**Issue:**  
No linked issue.

**Dependencies:**  
None.

**Twitter handle:**  
N/A

### Testing
- Added a dedicated unit test in `libs/partners/openai/tests/unit_tests/chat_models/test_resize.py` to verify the corrected aspect ratio logic in `_resize`.
- Command attempted:  
  ```bash
  uv run pytest libs/partners/openai/tests/unit_tests/chat_models/test_resize.py
