### PR TITLE
Docs: Amazon Textract Page - removing a redundancy and fixing a title

### DIFF
--- a/docs/docs/integrations/document_loaders/amazon_textract.ipynb
+++ b/docs/docs/integrations/document_loaders/amazon_textract.ipynb
@@ -247,7 +247,7 @@
    "id": "b3e41b4d-b159-4274-89be-80d8159134ef",
    "metadata": {},
    "source": [
-    "## Using the AmazonTextractPDFLoader in an LangChain chain (e. g. OpenAI)\n",
+    "## Using the AmazonTextractPDFLoader in a LangChain chain (e.g. OpenAI)\n",
     "\n",
     "The AmazonTextractPDFLoader can be used in a chain the same way the other loaders are used.\n",
     "Textract itself does have a [Query feature](https://docs.aws.amazon.com/textract/latest/dg/API_Query.html), which offers similar functionality to the QA chain in this sample, which is worth checking out as well."

--- a/docs/docs/integrations/document_loaders/amazon_textract.ipynb
+++ b/docs/docs/integrations/document_loaders/amazon_textract.ipynb
@@ -218,7 +218,7 @@
    "source": [
     "## Sample 4\n",
     "\n",
-    "You have the option to pass an additional parameter called `linearization_config` to the AmazonTextractPDFLoader which will determine how the the text output will be linearized by the parser after Textract runs."
+    "You have the option to pass an additional parameter called `linearization_config` to the AmazonTextractPDFLoader which will determine how the text output will be linearized by the parser after Textract runs."
    ]
   },
   {


### PR DESCRIPTION
- The second 'the' is redundant 
- Fixing the title grammatically 