### PR TITLE
docs: updated incorrect datatype for custom tool notebook

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -141,7 +141,7 @@
        "{'description': 'Multiply a by the maximum of b.',\n",
        " 'properties': {'a': {'description': 'scale factor',\n",
        "   'title': 'A',\n",
-       "   'type': 'string'},\n",
+       "   'type': 'integer'},\n",
        "  'b': {'description': 'list of ints over which to take maximum',\n",
        "   'items': {'type': 'integer'},\n",
        "   'title': 'B',\n",


### PR DESCRIPTION
- **Description:** `"string"` is given as the `"type"` for a custom tool argument, even though it is an `integer`. This can be validated from the Colab notebook output.
- **Issue:** N/A
- **Dependencies:** N/A
- **Twitter handle:** [mrityu___](https://x.com/mrityu___)

    
Current: 
![image](https://github.com/user-attachments/assets/403c04c5-ba35-4845-a8ce-9e9c584a57b8)

After Change:
![image](https://github.com/user-attachments/assets/c0af90c4-2039-4b92-9be3-7b77d08bae3d)

Colab Output:
![image](https://github.com/user-attachments/assets/9495c574-21bf-475d-8ede-a14cb2576ffa)




