### PR TITLE
docs:Adding line breaks to better explain each step, also making sure that bulleting style is consistent with other docs.

### DIFF
--- a/docs/docs/concepts/tool_calling.mdx
+++ b/docs/docs/concepts/tool_calling.mdx
@@ -21,10 +21,10 @@ You will sometimes hear the term `function calling`. We use this term interchang
 
 ## Key concepts 
 
-**(1) Tool Creation:** Use the [@tool](https://python.langchain.com/api_reference/core/tools/langchain_core.tools.convert.tool.html) decorator to create a [tool](/docs/concepts/tools). A tool is an association between a function and its schema.
-**(2) Tool Binding:** The tool needs to be connected to a model that supports tool calling. This gives the model awareness of the tool and the associated input schema required by the tool.
-**(3) Tool Calling:** When appropriate, the model can decide to call a tool and ensure its response conforms to the tool's input schema.
-**(4) Tool Execution:** The tool can be executed using the arguments provided by the model.
+1. **Tool Creation:** Use the [@tool](https://python.langchain.com/api_reference/core/tools/langchain_core.tools.convert.tool.html) decorator to create a [tool](/docs/concepts/tools). A tool is an association between a function and its schema.<br/>
+2. **Tool Binding:** The tool needs to be connected to a model that supports tool calling. This gives the model awareness of the tool and the associated input schema required by the tool.<br/>
+3. **Tool Calling:** When appropriate, the model can decide to call a tool and ensure its response conforms to the tool's input schema.<br/>
+4. **Tool Execution:** The tool can be executed using the arguments provided by the model.
 
 ![Conceptual parts of tool calling](/img/tool_calling_components.png)
 


### PR DESCRIPTION
- **Description:** Added line-break for each of the step mentioned for a diagram in the doc.
- **Dependencies:** N/A
- **Twitter handle:** [mrityu___](https://x.com/mrityu___)

Before changes:
![image](https://github.com/user-attachments/assets/c9946aec-79c7-4ad5-a28e-06ea4c163ce5)


After Changes:
![image](https://github.com/user-attachments/assets/933db561-bea2-421e-88e8-f79cbb30856d)




The styling(non-bold of bullet) is consistent with [chat_models.mdx](https://github.com/langchain-ai/langchain/edit/master/docs/docs/concepts/chat_models.mdx) (SS below from same, take note that how bullet numbers are not bold).

![image](https://github.com/user-attachments/assets/958c1e25-e52c-4d6f-8b46-f59af3aa3d3b)
