### PR TITLE
doc:Updating doc with consistent bullet format.

### DIFF
--- a/docs/docs/concepts/structured_outputs.mdx
+++ b/docs/docs/concepts/structured_outputs.mdx
@@ -11,8 +11,8 @@ This need motivates the concept of structured output, where models can be instru
 
 ## Key concepts 
 
-**(1) Schema definition:** The output structure is represented as a schema, which can be defined in several ways. 
-**(2) Returning structured output:** The model is given this schema, and is instructed to return output that conforms to it.
+1. **Schema definition:** The output structure is represented as a schema, which can be defined in several ways.<br/>
+2. **Returning structured output:** The model is given this schema, and is instructed to return output that conforms to it.
 
 ## Recommended usage
 
@@ -109,11 +109,11 @@ ai_msg
 
 There are a few challenges when producing structured output with the above methods: 
 
-(1) When tool calling is used, tool call arguments needs to be parsed from a dictionary back to the original schema.  
+1. When tool calling is used, tool call arguments needs to be parsed from a dictionary back to the original schema.<br/>  
 
-(2) In addition, the model needs to be instructed to *always* use the tool when we want to enforce structured output, which is a provider specific setting. 
+2. In addition, the model needs to be instructed to *always* use the tool when we want to enforce structured output, which is a provider specific setting.<br/> 
 
-(3) When JSON mode is used, the output needs to be parsed into a JSON object. 
+3. When JSON mode is used, the output needs to be parsed into a JSON object. 
 
 With these challenges in mind, LangChain provides a helper function (`with_structured_output()`) to streamline the process.
 


### PR DESCRIPTION
Description: Added line-break for each of the step mentioned, also made bullet points consistent with other docs.
Dependencies: N/A
Twitter handle: [mrityu___](https://x.com/mrityu___)

Before Changes:
![image](https://github.com/user-attachments/assets/867b0c05-7ebd-418b-bfe4-e1cb6134baf2)

After Changes:
![image](https://github.com/user-attachments/assets/3ff5db49-a713-4bb0-b814-dc02b9dc6bb4)



The styling(non-bold of bullet) is consistent with [chat_models.mdx](https://github.com/langchain-ai/langchain/edit/master/docs/docs/concepts/chat_models.mdx) (SS below from same, take note that how bullet numbers are not bold).

![image](https://github.com/user-attachments/assets/712b1a73-85ca-45d0-86d6-aa1c0fb3f164)
