### PR TITLE
[VectorStores]: issue a warning if np.nan or np.inf are in _cosine_similarity argument Matrices

### DIFF
--- a/libs/core/langchain_core/vectorstores/utils.py
+++ b/libs/core/langchain_core/vectorstores/utils.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Union
 
+import warnings
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -46,6 +48,17 @@ def _cosine_similarity(x: Matrix, y: Matrix) -> np.ndarray:
 
     x = np.array(x)
     y = np.array(y)
+    
+    # Check for NaN
+    if np.any(np.isnan(x)) or np.any(np.isnan(y)):
+        warnings.warn('NaN found in input arrays, unexpected return might follow', 
+                    category=RuntimeWarning)
+    
+    # Check for Inf
+    if np.any(np.isinf(x)) or np.any(np.isinf(y)):
+        warnings.warn('Inf found in input arrays, unexpected return might follow',
+                    category=RuntimeWarning)
+
     if x.shape[1] != y.shape[1]:
         msg = (
             f"Number of columns in X and Y must be the same. X has shape {x.shape} "


### PR DESCRIPTION
- **Description:** issues a warning if inf and nan are passed as inputs to langchain_core.vectorstores.utils._cosine_similarity
- **Issue:** #31496
- **Dependencies:** no external dependencies added, only warnings module imported
