### PR TITLE
docs: fix grammar in retrievers.mdx ("be built" → "build")

### DIFF
--- a/docs/docs/concepts/retrievers.mdx
+++ b/docs/docs/concepts/retrievers.mdx
@@ -57,7 +57,7 @@ Despite the flexibility of the retriever interface, a few common types of retrie
 ### Search apis
 
 It's important to note that retrievers don't need to actually *store* documents. 
-For example, we can be built retrievers on top of search APIs that simply return search results! 
+For example, we can build retrievers on top of search APIs that simply return search results! 
 See our retriever integrations with [Amazon Kendra](/docs/integrations/retrievers/amazon_kendra_retriever/) or [Wikipedia Search](/docs/integrations/retrievers/wikipedia/). 
 
 ### Relational or graph database


### PR DESCRIPTION
**Description:**  
Fixed a small grammatical error in the `retrievers.mdx` documentation.  
Replaced "we can be built retrievers on top of search APIs..." with  
"we can build retrievers on top of search APIs..." for clarity and correctness.

**Issue:**  
N/A

**Dependencies:**  
None

**Twitter handle:**  
@hassan_zameel
