### PR TITLE
langchain[patch]: Remove proxy imports to langchain_experimental

### DIFF
--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -380,7 +380,9 @@ def _load_sql_database_chain(config: dict, **kwargs: Any) -> Any:
         "SQLDatabaseChain is not available through LangChain anymore. "
         "The relevant code can be found in langchain_experimental, "
         "but it is not appropriate for production usage due to security "
-        "concerns. Please refer to langchain-experimental repository for more details."
+        "concerns. Please refer to langchain-experimental repository for more details, "
+        "or refer to this tutorial for best practices: "
+        "https://python.langchain.com/docs/tutorials/sql_qa/"
     )
 
 

--- a/libs/langchain/langchain/chains/loading.py
+++ b/libs/langchain/langchain/chains/loading.py
@@ -219,33 +219,13 @@ def _load_reduce_documents_chain(config: dict, **kwargs: Any) -> ReduceDocuments
 
 
 def _load_llm_bash_chain(config: dict, **kwargs: Any) -> Any:
-    from langchain_experimental.llm_bash.base import LLMBashChain
-
-    llm_chain = None
-    if "llm_chain" in config:
-        llm_chain_config = config.pop("llm_chain")
-        llm_chain = load_chain_from_config(llm_chain_config, **kwargs)
-    elif "llm_chain_path" in config:
-        llm_chain = load_chain(config.pop("llm_chain_path"), **kwargs)
-    # llm attribute is deprecated in favor of llm_chain, here to support old configs
-    elif "llm" in config:
-        llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config, **kwargs)
-    # llm_path attribute is deprecated in favor of llm_chain_path,
-    # its to support old configs
-    elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"), **kwargs)
-    else:
-        raise ValueError("One of `llm_chain` or `llm_chain_path` must be present.")
-    if "prompt" in config:
-        prompt_config = config.pop("prompt")
-        prompt = load_prompt_from_config(prompt_config)
-    elif "prompt_path" in config:
-        prompt = load_prompt(config.pop("prompt_path"))
-    if llm_chain:
-        return LLMBashChain(llm_chain=llm_chain, prompt=prompt, **config)
-    else:
-        return LLMBashChain(llm=llm, prompt=prompt, **config)
+    """Load LLM Bash chain from config dict"""
+    raise NotImplementedError(
+        "LLMBash Chain is not available through LangChain anymore. "
+        "The relevant code can be found in langchain_experimental, "
+        "but it is not appropriate for production usage due to security "
+        "concerns. Please refer to langchain-experimental repository for more details."
+    )
 
 
 def _load_llm_checker_chain(config: dict, **kwargs: Any) -> LLMCheckerChain:
@@ -336,16 +316,12 @@ def _load_map_rerank_documents_chain(
 
 
 def _load_pal_chain(config: dict, **kwargs: Any) -> Any:
-    from langchain_experimental.pal_chain import PALChain
-
-    if "llm_chain" in config:
-        llm_chain_config = config.pop("llm_chain")
-        llm_chain = load_chain_from_config(llm_chain_config, **kwargs)
-    elif "llm_chain_path" in config:
-        llm_chain = load_chain(config.pop("llm_chain_path"), **kwargs)
-    else:
-        raise ValueError("One of `llm_chain` or `llm_chain_path` must be present.")
-    return PALChain(llm_chain=llm_chain, **config)
+    raise NotImplementedError(
+        "PALChain is not available through LangChain anymore. "
+        "The relevant code can be found in langchain_experimental, "
+        "but it is not appropriate for production usage due to security "
+        "concerns. Please refer to langchain-experimental repository for more details."
+    )
 
 
 def _load_refine_documents_chain(config: dict, **kwargs: Any) -> RefineDocumentsChain:
@@ -399,30 +375,13 @@ def _load_qa_with_sources_chain(config: dict, **kwargs: Any) -> QAWithSourcesCha
 
 
 def _load_sql_database_chain(config: dict, **kwargs: Any) -> Any:
-    from langchain_experimental.sql import SQLDatabaseChain
-
-    if "database" in kwargs:
-        database = kwargs.pop("database")
-    else:
-        raise ValueError("`database` must be present.")
-    if "llm_chain" in config:
-        llm_chain_config = config.pop("llm_chain")
-        chain = load_chain_from_config(llm_chain_config, **kwargs)
-        return SQLDatabaseChain(llm_chain=chain, database=database, **config)
-    if "llm" in config:
-        llm_config = config.pop("llm")
-        llm = load_llm_from_config(llm_config, **kwargs)
-    elif "llm_path" in config:
-        llm = load_llm(config.pop("llm_path"), **kwargs)
-    else:
-        raise ValueError("One of `llm` or `llm_path` must be present.")
-    if "prompt" in config:
-        prompt_config = config.pop("prompt")
-        prompt = load_prompt_from_config(prompt_config)
-    else:
-        prompt = None
-
-    return SQLDatabaseChain.from_llm(llm, database, prompt=prompt, **config)
+    """Load SQL Database chain from config dict."""
+    raise NotImplementedError(
+        "SQLDatabaseChain is not available through LangChain anymore. "
+        "The relevant code can be found in langchain_experimental, "
+        "but it is not appropriate for production usage due to security "
+        "concerns. Please refer to langchain-experimental repository for more details."
+    )
 
 
 def _load_vector_db_qa_with_sources_chain(


### PR DESCRIPTION
Remove proxy imports to langchain_experimental.

Previously, these imports would work if a user manually installed langchain_experimental. However, we want to drop support even for that as langchain_experimental is generally not recommended to be run in production.