### PR TITLE
docs: Update MongoDB feature status

### DIFF
--- a/docs/scripts/vectorstore_feat_table.py
+++ b/docs/scripts/vectorstore_feat_table.py
@@ -190,7 +190,7 @@ def get_vectorstore_table():
             "similarity_search_by_vector": True,
             "similarity_search_with_score": True,
             "asearch": True,
-            "Passes Standard Tests": False,
+            "Passes Standard Tests": True,
             "Multi Tenancy": False,
             "Local/Cloud": "Local",
             "IDs in add Documents": True,


### PR DESCRIPTION
 **Description:** a description of the change

Update the MongoDBAtlasVectorSearch feature status.

As of https://github.com/langchain-ai/langchain-mongodb/pull/98,  MongoDBAtlasVectorSearch is using the standard test suite.

